### PR TITLE
Display an error on API failure

### DIFF
--- a/packages/app/src/components/ErrorMessage.tsx
+++ b/packages/app/src/components/ErrorMessage.tsx
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+
+function ErrorMessage(errorMessage: string | undefined) {
+  return (
+    <div css={styles.errorMessage}>
+      <p>{errorMessage || "Erreur"}</p>
+    </div>
+  );
+}
+
+const styles = {
+  errorMessage: css({
+    margin: "auto",
+    alignSelf: "center"
+  })
+};
+
+export default ErrorMessage;

--- a/packages/app/src/containers/Simulateur.tsx
+++ b/packages/app/src/containers/Simulateur.tsx
@@ -10,6 +10,7 @@ import { getIndicatorsDatas, putIndicatorsDatas } from "../utils/api";
 import { useDebounceEffect } from "../utils/hooks";
 
 import ActivityIndicator from "../components/ActivityIndicator";
+import ErrorMessage from "../components/ErrorMessage";
 
 import HomeSimulateur from "../views/HomeSimulateur";
 import Effectif from "../views/Effectif";
@@ -41,7 +42,8 @@ function Simulateur({ code, state, dispatch }: Props) {
       .catch(error => {
         setLoading(false);
         const errorMessage =
-          (error.jsonBody && error.jsonBody.message) || "Erreur";
+          (error.jsonBody && error.jsonBody.message) ||
+          "Erreur lors de la récupération des données";
         setErrorMessage(errorMessage);
       });
   }, [code, dispatch]);
@@ -51,18 +53,20 @@ function Simulateur({ code, state, dispatch }: Props) {
     2000,
     debouncedState => {
       if (debouncedState) {
-        putIndicatorsDatas(code, debouncedState);
+        putIndicatorsDatas(code, debouncedState).catch(error => {
+          setLoading(false);
+          const errorMessage =
+            (error.jsonBody && error.jsonBody.message) ||
+            "Erreur lors de la sauvegarde des données";
+          setErrorMessage(errorMessage);
+        });
       }
     },
     [code]
   );
 
   if (!loading && errorMessage) {
-    return (
-      <div css={styles.viewLoading}>
-        <p>{errorMessage}</p>
-      </div>
-    );
+    return ErrorMessage(errorMessage);
   }
 
   if (loading || !state) {

--- a/packages/app/src/views/Home.tsx
+++ b/packages/app/src/views/Home.tsx
@@ -9,6 +9,7 @@ import { postIndicatorsDatas } from "../utils/api";
 import Page from "../components/Page";
 import ButtonAction from "../components/ButtonAction";
 import Button from "../components/Button";
+import ErrorMessage from "../components/ErrorMessage";
 import globalStyles from "../utils/globalStyles";
 
 interface Props extends RouteComponentProps {
@@ -17,19 +18,32 @@ interface Props extends RouteComponentProps {
 
 function Home({ history, location, dispatch }: Props) {
   const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(undefined);
 
   const onClick = () => {
     setLoading(true);
     dispatch({ type: "resetState" });
 
-    postIndicatorsDatas({}).then(({ jsonBody: { id } }) => {
-      setLoading(false);
-      history.push(`/simulateur/${id}`, {
-        ...(location.state && location.state),
-        openModalEmail: true
+    postIndicatorsDatas({})
+      .then(({ jsonBody: { id } }) => {
+        setLoading(false);
+        history.push(`/simulateur/${id}`, {
+          ...(location.state && location.state),
+          openModalEmail: true
+        });
+      })
+      .catch(error => {
+        setLoading(false);
+        const errorMessage =
+          (error.jsonBody && error.jsonBody.message) ||
+          "Erreur lors de la récupération du code";
+        setErrorMessage(errorMessage);
       });
-    });
   };
+
+  if (!loading && errorMessage) {
+    return ErrorMessage(errorMessage);
+  }
 
   return (
     <Page


### PR DESCRIPTION
Fixes #152

This is very crude at the moment, but at least we get some feedback on API failures:

Failure when getting the code:
<img width="936" alt="Capture d’écran 2019-10-06 à 20 27 55" src="https://user-images.githubusercontent.com/167767/66274298-6421bf00-e87d-11e9-9341-c8c23fccf612.png">

Failure when sending the email:
<img width="679" alt="Capture d’écran 2019-10-06 à 20 28 56" src="https://user-images.githubusercontent.com/167767/66274300-6f74ea80-e87d-11e9-863b-88277ff8456f.png">

Failure when getting the data associated with the code
<img width="942" alt="Capture d’écran 2019-10-06 à 20 29 43" src="https://user-images.githubusercontent.com/167767/66274305-7ac81600-e87d-11e9-85d8-0d4e17dae924.png">

Failure when saving the data
<img width="939" alt="Capture d’écran 2019-10-06 à 20 31 56" src="https://user-images.githubusercontent.com/167767/66274307-8287ba80-e87d-11e9-9c1a-35608e22d931.png">


There are not tests for it (yet?) as we would need to test the rendering and some events (clicking on buttons, entering emails, data...) and it seems we have nothing in place right now for that.
We might want to use [the react testing library](https://testing-library.com/) (also used on the "code du travail numérique").

@tglatt thoughts?