### PR TITLE
Run the app tests without watch mode when using lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lint": "lerna run lint --parallel",
     "start": "lerna run start --parallel",
     "release": "cd packages/app && yarn release",
-    "test": "lerna run test --parallel",
+    "test": "lerna run test --parallel -- --watchAll=false",
     "coverage": "lerna run test --parallel -- --coverage"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #154

Change the `package.json` `test` script entry so it doesn't run tests in interactive watch mode by default, so lerna doesn't hang (waiting for a user input).