### PR TITLE
Remove indicators numbers

### DIFF
--- a/packages/app/src/components/Menu.tsx
+++ b/packages/app/src/components/Menu.tsx
@@ -110,31 +110,31 @@ function Menu({
               />
               <CustomNavLink
                 to={`/simulateur/${code}/indicateur1`}
-                title="indicateur 1"
+                title="indicateur"
                 label="écart de rémunérations"
                 valid={indicateurUnFormValidated}
               />
               <CustomNavLink
                 to={`/simulateur/${code}/indicateur2`}
-                title="indicateur 2"
+                title="indicateur"
                 label="écart de taux d'augmentations"
                 valid={indicateurDeuxFormValidated}
               />
               <CustomNavLink
                 to={`/simulateur/${code}/indicateur3`}
-                title="indicateur 3"
+                title="indicateur"
                 label="écart de taux de promotions"
                 valid={indicateurTroisFormValidated}
               />
               <CustomNavLink
                 to={`/simulateur/${code}/indicateur4`}
-                title="indicateur 4"
+                title="indicateur"
                 label="retour congé maternité"
                 valid={indicateurQuatreFormValidated}
               />
               <CustomNavLink
                 to={`/simulateur/${code}/indicateur5`}
-                title="indicateur 5"
+                title="indicateur"
                 label="hautes rémunérations"
                 valid={indicateurCinqFormValidated}
               />

--- a/packages/app/src/data/faq.tsx
+++ b/packages/app/src/data/faq.tsx
@@ -260,7 +260,7 @@ export const faqData: FAQPart = {
     ]
   },
   indicateur1: {
-    title: "indicateur 1 - écart de rémunération",
+    title: "indicateur - écart de rémunération",
     qr: [
       {
         question:
@@ -300,7 +300,7 @@ export const faqData: FAQPart = {
         question:
           "Dans quels cas l’employeur doit-il obligatoirement consulter le comité social et économique (CSE) ?",
         reponse: [
-          "La consultation du CSE mentionnée au paragraphe 4.1. des annexes du décret du 8 janvier 2019 est obligatoire si l’employeur choisit une catégorisation par niveau ou coefficient hiérarchique en application de la classification de branche, ou d’une autre méthode de cotation des postes. La consultation du CSE n’est en revanche pas obligatoire dans le cas d’une répartition des salariés par CSP ou s’il choisit de regrouper entre elles une des 4 CSP existantes. Par exemple : le calcul de l’indicateur 1, avec 2 catégories cadres / non cadres (comprenant ouvriers / employés / techniciens-agents de maitrise) est possible sans consultation (avec un seuil de pertinence de 5% et non 2%).",
+          "La consultation du CSE mentionnée au paragraphe 4.1. des annexes du décret du 8 janvier 2019 est obligatoire si l’employeur choisit une catégorisation par niveau ou coefficient hiérarchique en application de la classification de branche, ou d’une autre méthode de cotation des postes. La consultation du CSE n’est en revanche pas obligatoire dans le cas d’une répartition des salariés par CSP ou s’il choisit de regrouper entre elles une des 4 CSP existantes. Par exemple : le calcul de l’indicateur écart de rémunérations, avec 2 catégories cadres / non cadres (comprenant ouvriers / employés / techniciens-agents de maitrise) est possible sans consultation (avec un seuil de pertinence de 5% et non 2%).",
           "Une entreprise ayant déjà informé ses IRP par le passé sur la méthode de cotation des postes devra procéder à une nouvelle consultation dans le cadre du calcul de l’Index."
         ]
       },
@@ -341,8 +341,7 @@ export const faqData: FAQPart = {
     ]
   },
   indicateur2et3: {
-    title:
-      "indicateurs 2 et 3 - écart de taux d’augmentations et de promotions",
+    title: "indicateurs - écart de taux d’augmentations et de promotions",
     qr: [
       {
         question:
@@ -353,22 +352,22 @@ export const faqData: FAQPart = {
       },
       {
         question:
-          "Pour les indicateurs 2 et 3, est-il possible, comme pour l’indicateur 1, de répartir les salariés par niveau ou coefficient hiérarchique ?",
+          "Pour les indicateurs écart de taux d'augmentations et écart de taux de promotions, est-il possible, comme pour l’indicateur écart de rémunérations, de répartir les salariés par niveau ou coefficient hiérarchique ?",
         reponse: [
           "Non. La répartition des salariés, après consultation du comité social et économique, par niveau ou coefficient hiérarchique, en application de la classification de branche ou d’une autre méthode de cotation des postes n’est possible que pour le calcul du 1er indicateur relatif à l’écart de rémunération.",
-          "S’agissant des indicateurs 2 et 3, pour les entreprises de plus de 250 salariés, les salariés sont répartis selon les 4 catégories socioprofessionnelles définies en annexe du décret (ouvriers ; employés ; techniciens et agents de maîtrise ; ingénieurs et cadres)."
+          "S’agissant des indicateurs écart de taux d'augmentations et écart de taux de promotions, pour les entreprises de plus de 250 salariés, les salariés sont répartis selon les 4 catégories socioprofessionnelles définies en annexe du décret (ouvriers ; employés ; techniciens et agents de maîtrise ; ingénieurs et cadres)."
         ]
       }
     ]
   },
   indicateur2: {
-    title: "indicateur 2 - écart de taux d’augmentations",
+    title: "indicateur - écart de taux d’augmentations",
     qr: [
       {
         question:
           'Les "écarts de taux d’augmentations individuelles" correspondent-ils à des écarts de montants d’augmentations ou à des écarts de nombres de bénéficiaires d’augmentation ?',
         reponse: [
-          "La notion d’ « écarts de taux d’augmentations individuelles » renvoie à l’écart des taux de bénéficiaires d’augmentations individuelles. Ainsi, l’indicateur 2° est calculé en comparant le pourcentage de salariés augmentés parmi les hommes à celui de salariées augmentées parmi les femmes pour chacun des quatre groupes de CSP comptant 10 salariés ou plus de l’un et de l’autre sexe. Il en va de même pour l’écart de taux de promotions."
+          "La notion d’ « écarts de taux d’augmentations individuelles » renvoie à l’écart des taux de bénéficiaires d’augmentations individuelles. Ainsi, l’indicateur écart de taux d'augmentations est calculé en comparant le pourcentage de salariés augmentés parmi les hommes à celui de salariées augmentées parmi les femmes pour chacun des quatre groupes de CSP comptant 10 salariés ou plus de l’un et de l’autre sexe. Il en va de même pour l’écart de taux de promotions."
         ]
       },
       {
@@ -381,14 +380,14 @@ export const faqData: FAQPart = {
     ]
   },
   indicateur3: {
-    title: "indicateur  3 - écart de taux de promotions",
+    title: "indicateur - écart de taux de promotions",
     qr: [
       {
         question:
           'Pour les "écarts de taux de promotions", quelle est la définition d’une "promotion" au sens du décret ?',
         reponse: [
           "La notion de promotion est définie en annexe du décret comme le passage à un niveau de classification ou coefficient supérieur, dans la classification de branche ou dans le système de cotation choisi par l’entreprise.",
-          "À noter que le passage à un niveau de classification ou coefficient supérieur n’est pas lié au choix retenu pour la répartition des salariés dans les catégories de postes pour le calcul de l’indicateur 1.",
+          "À noter que le passage à un niveau de classification ou coefficient supérieur n’est pas lié au choix retenu pour la répartition des salariés dans les catégories de postes pour le calcul de l’indicateur écart de rémunérations.",
           "Il est conseillé à l’entreprise d’être la plus transparente possible sur la méthode de promotion, afin que les salariés et les représentants élus au CSE puissent identifier clairement la notion de promotion."
         ]
       },
@@ -409,11 +408,11 @@ export const faqData: FAQPart = {
     ]
   },
   indicateur4: {
-    title: "indicateur 4 - congé maternité",
+    title: "indicateur - congé maternité",
     qr: [
       {
         question:
-          "Concernant l’indicateur 4.3, comment interpréter « l’année suivant » le retour de congé maternité ?",
+          "Concernant l’indicateur retour de congé maternité, comment interpréter « l’année suivant » le retour de congé maternité ?",
         reponse: [
           "L’indicateur concerne les salariées qui sont revenues de congé maternité au cours de la période annuelle de référence. Parmi ces salariées, seules sont prises en compte, pour le calcul de l’indicateur, celles ayant eu un congé maternité durant lequel des augmentations salariales (générales ou individuelles) ont eu lieu. Pour elles, comme le prévoit la loi depuis 2006, il faut procéder à une réévaluation de leur rémunération.",
           "Ainsi, si une salariée revient en décembre de congé maternité et que des augmentations ont été versées pendant la période de ce congé, elle devra avoir une augmentation à son retour avant la fin de l’année (si l’année civile est la période de référence).",
@@ -435,16 +434,16 @@ export const faqData: FAQPart = {
           "Oui, les salariées revenues de congé maternité pendant la période de référence et qui ont été absentes plus de 6 mois pendant cette même période, doivent être prises en compte uniquement pour le calcul de l’indicateur"
         ]
       },
-       {
+      {
         question:
-          "En évaluant la période de référence du 1er janvier au 31 décembre 2018, si une salariée revient de congé maternité au 31 août 2018 et qu’elle est augmentée au 1er janvier 2019, alors que ses collègues ont été revalorisés au 1er juillet 2018, celle-ci est-elle considérée comme augmentée ou non au titre de l’indicateur 4?",
+          "En évaluant la période de référence du 1er janvier au 31 décembre 2018, si une salariée revient de congé maternité au 31 août 2018 et qu’elle est augmentée au 1er janvier 2019, alors que ses collègues ont été revalorisés au 1er juillet 2018, celle-ci est-elle considérée comme augmentée ou non au titre de l’indicateur retour congé maternité ?",
         reponse: [
           "Non, elle n’est pas considérée comme augmentée, car le respect de l’obligation est apprécié sur l’année de référence, soit dans cet exemple sur l'année civile 2018."
         ]
       },
       {
         question:
-          "Les augmentations salariales des salariées en congé maternité, accordées durant ce congé (et non au retour de la salariée) sont-elles prises en compte pour le calcul de l’indicateur 4 ?",
+          "Les augmentations salariales des salariées en congé maternité, accordées durant ce congé (et non au retour de la salariée) sont-elles prises en compte pour le calcul de l’indicateur retour congé maternité ?",
         reponse: [
           "Oui. L’indicateur a pour objet de déterminer le pourcentage de salariées ayant bénéficié d’une augmentation à leur retour de congé maternité si des augmentations sont intervenues durant la durée de leur congé maternité. Or en pratique, beaucoup d’entreprises procèdent aux augmentations prévues par l’article L.1225-26 du code du travail simultanément aux augmentations générales prévues pour l’ensemble des salariés. Ces augmentations peuvent donc être effectives pendant le congé maternité et non à l’issue de celui-ci. Il est logique et conforme à l’esprit du texte de prendre en compte l’augmentation que les femmes ont connue au cours de leur congé de maternité si elle se situe pendant la période de référence pour le calcul de l’indicateur."
         ]
@@ -459,14 +458,14 @@ export const faqData: FAQPart = {
       },
       {
         question:
-          "Le congé d’adoption est-il pris en compte pour le calcul de l’indicateur 4 ?",
+          "Le congé d’adoption est-il pris en compte pour le calcul de l’indicateur retour congé maternité ?",
         reponse: [
           "Oui, le congé d’adoption est pris en compte dans le calcul de l’indicateur, au même titre que le congé de maternité."
         ]
       },
       {
         question:
-          "Obtient-on nécessairement 0 à l’indicateur 4 dans le cas où seules 2 salariées n’ont pas bénéficié d’une augmentation durant l’année 2018 alors qu’elles étaient absentes pour congé maternité à l’occasion de l’exercice annuel de revalorisation, étant donné que ces deux salariées avaient bénéficié toutes deux d’une augmentation au second semestre 2017 ?",
+          "Obtient-on nécessairement 0 à l’indicateur retour congé maternité dans le cas où seules 2 salariées n’ont pas bénéficié d’une augmentation durant l’année 2018 alors qu’elles étaient absentes pour congé maternité à l’occasion de l’exercice annuel de revalorisation, étant donné que ces deux salariées avaient bénéficié toutes deux d’une augmentation au second semestre 2017 ?",
         reponse: [
           "Le calcul de l’Index étant basé sur une période de référence annuelle, si la période choisie est l’année 2018, il n’est pas possible de déroger à la règle posée par le décret n° 2019-15 du 8 janvier 2019, car les deux salariées concernées ont bénéficié d’une revalorisation au second semestre de l’année 2017."
         ]
@@ -563,23 +562,23 @@ export const faqSections: FAQSection = {
     parts: ["periodeReference", "effectifs"]
   },
   indicateur1: {
-    title: "indicateur 1 - écart de rémunération",
+    title: "indicateur - écart de rémunération",
     parts: ["remuneration", "indicateur1"]
   },
   indicateur2: {
-    title: "indicateur 2 - écart d’augmentations",
+    title: "indicateur - écart d’augmentations",
     parts: ["indicateur2", "indicateur2et3"]
   },
   indicateur3: {
-    title: "indicateur 3 - écart de promotions",
+    title: "indicateur - écart de promotions",
     parts: ["indicateur3", "indicateur2et3"]
   },
   indicateur4: {
-    title: "indicateur 4 - congé maternité",
+    title: "indicateur - congé maternité",
     parts: ["indicateur4"]
   },
   indicateur5: {
-    title: "indicateur 5 - hautes rémunérations",
+    title: "indicateur - hautes rémunérations",
     parts: []
   },
   resultat: {

--- a/packages/app/src/views/Effectif/Effectif.tsx
+++ b/packages/app/src/views/Effectif/Effectif.tsx
@@ -87,7 +87,7 @@ function Effectif({ state, dispatch }: Props) {
                     <Fragment>
                       <TextSimulatorLink
                         to="/indicateur1"
-                        label="aller à l'indicateur 1"
+                        label="aller à l'indicateur écart de rémunérations"
                       />
                       &emsp;
                     </Fragment>
@@ -96,7 +96,7 @@ function Effectif({ state, dispatch }: Props) {
                     <Fragment>
                       <TextSimulatorLink
                         to="/indicateur2"
-                        label="aller à l'indicateur 2"
+                        label="aller à l'indicateur écart de taux d'augmentations"
                       />
                       &emsp;
                     </Fragment>
@@ -104,7 +104,7 @@ function Effectif({ state, dispatch }: Props) {
                   {state.indicateurTrois.formValidated === "Invalid" && (
                     <TextSimulatorLink
                       to="/indicateur3"
-                      label="aller à l'indicateur 3"
+                      label="aller à l'indicateur écart de taux de promotions"
                     />
                   )}
                 </span>

--- a/packages/app/src/views/Indicateur1/IndicateurUn.tsx
+++ b/packages/app/src/views/Indicateur1/IndicateurUn.tsx
@@ -79,7 +79,7 @@ function IndicateurUn({ state, dispatch }: Props) {
 function PageIndicateurUn({ children }: { children: ReactNode }) {
   return (
     <Page
-      title="Indicateur 1, écart de rémunération"
+      title="Indicateur écart de rémunération"
       tagline={[
         "Les rémunérations annuelles moyennes des femmes et des hommes doivent être renseignées par catégorie de postes équivalents (soit par CSP, soit par niveau ou coefficient hiérarchique en application de la classification de branche ou d’une autre méthode de cotation des postes après consultation du CSE ) et par tranche d’âge."
       ]}

--- a/packages/app/src/views/Indicateur2/IndicateurDeux.tsx
+++ b/packages/app/src/views/Indicateur2/IndicateurDeux.tsx
@@ -141,7 +141,7 @@ function IndicateurDeux({ state, dispatch }: Props) {
 function PageIndicateurDeux({ children }: { children: ReactNode }) {
   return (
     <Page
-      title="Indicateur 2, écart de taux d’augmentations individuelles hors promotion"
+      title="Indicateur écart de taux d’augmentations individuelles hors promotion"
       tagline="Le pourcentage de femmes et d’hommes ayant été augmentés durant la période de référence, doit être renseigné par CSP."
     >
       {children}

--- a/packages/app/src/views/Indicateur3/IndicateurTrois.tsx
+++ b/packages/app/src/views/Indicateur3/IndicateurTrois.tsx
@@ -144,7 +144,7 @@ function IndicateurTrois({ state, dispatch }: Props) {
 function PageIndicateurTrois({ children }: { children: ReactNode }) {
   return (
     <Page
-      title="Indicateur 3, écart de taux de promotions"
+      title="Indicateur écart de taux de promotions"
       tagline="Le pourcentage de femmes et d’hommes ayant été promus durant la période de référence, doit être renseigné par CSP."
     >
       {children}

--- a/packages/app/src/views/Indicateur4/IndicateurQuatre.tsx
+++ b/packages/app/src/views/Indicateur4/IndicateurQuatre.tsx
@@ -100,7 +100,7 @@ function IndicateurQuatre({ state, dispatch }: Props) {
 function PageIndicateurQuatre({ children }: { children: ReactNode }) {
   return (
     <Page
-      title="Indicateur 4, pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
+      title="Indicateur pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
       tagline="Renseignez le taux de salariées en congès maternité durant la période de référence ayant reçu une augmentation à leur retour."
     >
       {children}

--- a/packages/app/src/views/Indicateur5/IndicateurCinq.tsx
+++ b/packages/app/src/views/Indicateur5/IndicateurCinq.tsx
@@ -72,7 +72,7 @@ function IndicateurCinq({ state, dispatch }: Props) {
 function PageIndicateurCinq({ children }: { children: ReactNode }) {
   return (
     <Page
-      title="Indicateur 5, nombre de salariés du sexe sous-représenté parmi les 10 plus hautes rémunérations"
+      title="Indicateur nombre de salariés du sexe sous-représenté parmi les 10 plus hautes rémunérations"
       tagline="Renseignez le nombre de femmes et d'hommes parmi les 10 plus hautes rémunérations durant la période de référence."
     >
       {children}

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurCinq.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurCinq.tsx
@@ -25,7 +25,7 @@ function RecapitulatifIndicateurCinq({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 5, nombre de salariés du sexe sous-représenté parmi les 10 plus hautes rémunérations"
+          title="Indicateur nombre de salariés du sexe sous-représenté parmi les 10 plus hautes rémunérations"
           text={
             <Fragment>
               <span>
@@ -55,7 +55,7 @@ function RecapitulatifIndicateurCinq({
   return (
     <div css={styles.container}>
       <RecapBloc
-        title="Indicateur 5, nombre de salariés du sexe sous-représenté parmi les 10 plus hautes rémunérations"
+        title="Indicateur nombre de salariés du sexe sous-représenté parmi les 10 plus hautes rémunérations"
         resultBubble={{
           firstLineLabel: "votre résultat final est",
           firstLineData:

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeux.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeux.tsx
@@ -43,7 +43,7 @@ function RecapitulatifIndicateurDeux({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 2, écart de taux d’augmentations entre les femmes et les hommes"
+          title="Indicateur écart de taux d’augmentations entre les femmes et les hommes"
           text="Malheureusement votre indicateur n’est pas calculable car l’ensemble des groupes valables (c’est-à-dire comptant au moins 10 femmes et 10 hommes), représentent moins de 40% des effectifs."
         />
       </div>
@@ -54,7 +54,7 @@ function RecapitulatifIndicateurDeux({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 2, écart de taux d’augmentations entre les femmes et les hommes"
+          title="Indicateur écart de taux d’augmentations entre les femmes et les hommes"
           text={
             <Fragment>
               <span>
@@ -76,7 +76,7 @@ function RecapitulatifIndicateurDeux({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 2, écart de taux d’augmentations entre les femmes et les hommes"
+          title="Indicateur écart de taux d’augmentations entre les femmes et les hommes"
           text="Malheureusement votre indicateur n’est pas calculable  car il n’y a pas eu d’augmentation durant la période de référence"
         />
       </div>
@@ -86,7 +86,7 @@ function RecapitulatifIndicateurDeux({
   return (
     <div css={styles.container}>
       <RecapBloc
-        title="Indicateur 2, écart de taux d’augmentations entre les femmes et les hommes"
+        title="Indicateur écart de taux d’augmentations entre les femmes et les hommes"
         resultBubble={{
           firstLineLabel: "votre résultat final est",
           firstLineData:

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurQuatre.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurQuatre.tsx
@@ -27,7 +27,7 @@ function RecapitulatifIndicateurQuatre({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 4, pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
+          title="Indicateur pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
           text={
             <Fragment>
               <span>
@@ -49,7 +49,7 @@ function RecapitulatifIndicateurQuatre({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 4, pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
+          title="Indicateur pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
           text="Malheureusement votre indicateur n’est pas calculable  car il n’y a pas eu de retour de congé maternité durant la période de référence"
         />
       </div>
@@ -59,7 +59,7 @@ function RecapitulatifIndicateurQuatre({
   return (
     <div css={styles.container}>
       <RecapBloc
-        title="Indicateur 4, pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
+        title="Indicateur pourcentage de salariées augmentées dans l'année suivant leur retour de congé maternité"
         resultBubble={{
           firstLineLabel: "votre résultat final est",
           firstLineData:

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurTrois.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurTrois.tsx
@@ -43,7 +43,7 @@ function RecapitulatifIndicateurTrois({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 3, écart de taux de promotions entre les femmes et les hommes"
+          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
           text="Malheureusement votre indicateur n’est pas calculable car l’ensemble des groupes valables (c’est-à-dire comptant au moins 10 femmes et 10 hommes), représentent moins de 40% des effectifs."
         />
       </div>
@@ -54,7 +54,7 @@ function RecapitulatifIndicateurTrois({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 3, écart de taux de promotions entre les femmes et les hommes"
+          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
           text={
             <Fragment>
               <span>
@@ -76,7 +76,7 @@ function RecapitulatifIndicateurTrois({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 3, écart de taux de promotions entre les femmes et les hommes"
+          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
           text="Malheureusement votre indicateur n’est pas calculable  car il n’y a pas eu de promotion durant la période de référence"
         />
       </div>
@@ -86,7 +86,7 @@ function RecapitulatifIndicateurTrois({
   return (
     <div css={styles.container}>
       <RecapBloc
-        title="Indicateur 3, écart de taux de promotions entre les femmes et les hommes"
+        title="Indicateur écart de taux de promotions entre les femmes et les hommes"
         resultBubble={{
           firstLineLabel: "votre résultat final est",
           firstLineData:

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
@@ -43,7 +43,7 @@ function RecapitulatifIndicateurUn({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 1, écart de rémunération entre les femmes et les hommes"
+          title="Indicateur écart de rémunération entre les femmes et les hommes"
           text="Malheureusement votre indicateur n’est pas calculable car l’ensemble des groupes valables (c’est-à-dire comptant au moins 3 femmes et 3 hommes), représentent moins de 40% des effectifs."
         />
       </div>
@@ -54,7 +54,7 @@ function RecapitulatifIndicateurUn({
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur 1, écart de rémunération entre les femmes et les hommes"
+          title="Indicateur écart de rémunération entre les femmes et les hommes"
           text={
             <Fragment>
               <span>
@@ -97,7 +97,7 @@ function RecapitulatifIndicateurUn({
   return (
     <div css={styles.container}>
       <RecapBloc
-        title="Indicateur 1, écart de rémunération entre les femmes et les hommes"
+        title="Indicateur écart de rémunération entre les femmes et les hommes"
         resultBubble={{
           firstLineLabel: "votre résultat final est",
           firstLineData:


### PR DESCRIPTION
Fixes #159

This renames all the indicators by either removing their number
- in the left menu
![Capture d’écran 2019-10-07 à 15 02 40](https://user-images.githubusercontent.com/167767/66314022-aa296200-e913-11e9-85c8-de506b6ca676.png)
- in the page titles
![Capture d’écran 2019-10-07 à 15 02 46](https://user-images.githubusercontent.com/167767/66314154-e6f55900-e913-11e9-9c07-043546a0b70f.png)
- in the FAQ titles
![Capture d’écran 2019-10-07 à 15 05 09](https://user-images.githubusercontent.com/167767/66314189-f7a5cf00-e913-11e9-821a-f5cade5d7617.png)

Or replacing the number by the full indicator name
- in the FAQ content
![Capture d’écran 2019-10-07 à 15 02 51](https://user-images.githubusercontent.com/167767/66314243-09877200-e914-11e9-8751-a0821fd20fff.png)
- in the recap page
![Capture d’écran 2019-10-07 à 15 06 09](https://user-images.githubusercontent.com/167767/66314303-1ad07e80-e914-11e9-99fb-d9f5c5f01ae5.png)
