### PR TITLE
Nouvelle page indicateur 2 et 3 écart de taux d'augmentations et de promotions

### DIFF
--- a/packages/app/src/AppReducer.test.tsx
+++ b/packages/app/src/AppReducer.test.tsx
@@ -554,6 +554,32 @@ describe("updateIndicateurTrois", () => {
   });
 });
 
+describe("updateIndicateurDeuxTrois", () => {
+  const action = {
+    type: "updateIndicateurDeuxTrois" as "updateIndicateurDeuxTrois",
+    data: {
+      presenceAugmentationPromotion: true,
+      nombreAugmentationPromotionFemmes: 3,
+      nombreAugmentationPromotionHommes: 4,
+      memePeriodeReference: true,
+      periodeReferenceDebut: "2018-11-01",
+      periodeReferenceFin: "2019-10-31"
+    }
+  };
+
+  test("nothing undefined state", () => {
+    expect(AppReducer(stateUndefined, action)).toMatchSnapshot();
+  });
+
+  test("change default state", () => {
+    expect(AppReducer(stateDefault, action)).toMatchSnapshot();
+  });
+
+  test("change complete state", () => {
+    expect(AppReducer(stateComplete, action)).toMatchSnapshot();
+  });
+});
+
 describe("updateIndicateurQuatre", () => {
   const action = {
     type: "updateIndicateurQuatre" as "updateIndicateurQuatre",
@@ -767,6 +793,25 @@ describe("validateIndicateurDeux", () => {
 describe("validateIndicateurTrois", () => {
   const action = {
     type: "validateIndicateurTrois" as "validateIndicateurTrois",
+    valid: "Valid" as FormState
+  };
+
+  test("nothing undefined state", () => {
+    expect(AppReducer(stateUndefined, action)).toMatchSnapshot();
+  });
+
+  test("change default state", () => {
+    expect(AppReducer(stateDefault, action)).toMatchSnapshot();
+  });
+
+  test("change complete state", () => {
+    expect(AppReducer(stateComplete, action)).toMatchSnapshot();
+  });
+});
+
+describe("validateIndicateurDeuxTrois", () => {
+  const action = {
+    type: "validateIndicateurDeuxTrois" as "validateIndicateurDeuxTrois",
     valid: "Valid" as FormState
   };
 

--- a/packages/app/src/AppReducer.test.tsx
+++ b/packages/app/src/AppReducer.test.tsx
@@ -1,4 +1,9 @@
-import { CategorieSocioPro, TranchesAges, FormState } from "./globals.d";
+import {
+  CategorieSocioPro,
+  TranchesAges,
+  FormState,
+  PeriodeDeclaration
+} from "./globals.d";
 
 import AppReducer from "./AppReducer";
 
@@ -561,9 +566,7 @@ describe("updateIndicateurDeuxTrois", () => {
       presenceAugmentationPromotion: true,
       nombreAugmentationPromotionFemmes: 3,
       nombreAugmentationPromotionHommes: 4,
-      memePeriodeReference: true,
-      periodeReferenceDebut: "2018-11-01",
-      periodeReferenceFin: "2019-10-31"
+      periodeDeclaration: "deuxPeriodesReference" as PeriodeDeclaration
     }
   };
 

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -61,15 +61,6 @@ const dataIndicateurTrois = mapEnum(
   })
 );
 
-const dataIndicateurDeuxTrois = mapEnum(
-  CategorieSocioPro,
-  (categorieSocioPro: CategorieSocioPro) => ({
-    categorieSocioPro,
-    tauxAugmentationPromotionFemmes: undefined,
-    tauxAugmentationPromotionHommes: undefined
-  })
-);
-
 const defaultState: AppState = {
   effectif: {
     formValidated: "None",
@@ -96,7 +87,11 @@ const defaultState: AppState = {
   indicateurDeuxTrois: {
     formValidated: "None",
     presenceAugmentationPromotion: true,
-    tauxAugmentationPromotion: dataIndicateurDeuxTrois
+    nombreAugmentationPromotionFemmes: undefined,
+    nombreAugmentationPromotionHommes: undefined,
+    memePeriodeReference: true,
+    periodeReferenceDebut: "",
+    periodeReferenceFin: ""
   },
   indicateurQuatre: {
     formValidated: "None",
@@ -153,7 +148,7 @@ function AppReducer(
               ? { ...state.indicateurTrois, formValidated: "Invalid" }
               : state.indicateurTrois,
           indicateurDeuxTrois:
-            state.indicateurTrois.formValidated === "Valid"
+            state.indicateurDeuxTrois.formValidated === "Valid"
               ? { ...state.indicateurDeuxTrois, formValidated: "Invalid" }
               : state.indicateurDeuxTrois
         };
@@ -291,15 +286,23 @@ function AppReducer(
     }
     case "updateIndicateurDeuxTrois": {
       const {
-        tauxAugmentationPromotion,
-        presenceAugmentationPromotion
+        presenceAugmentationPromotion,
+        nombreAugmentationPromotionFemmes,
+        nombreAugmentationPromotionHommes,
+        memePeriodeReference,
+        periodeReferenceDebut,
+        periodeReferenceFin
       } = action.data;
       return {
         ...state,
         indicateurDeuxTrois: {
           ...state.indicateurDeuxTrois,
           presenceAugmentationPromotion,
-          tauxAugmentationPromotion
+          nombreAugmentationPromotionFemmes,
+          nombreAugmentationPromotionHommes,
+          memePeriodeReference,
+          periodeReferenceDebut,
+          periodeReferenceFin
         }
       };
     }

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -61,6 +61,15 @@ const dataIndicateurTrois = mapEnum(
   })
 );
 
+const dataIndicateurDeuxTrois = mapEnum(
+  CategorieSocioPro,
+  (categorieSocioPro: CategorieSocioPro) => ({
+    categorieSocioPro,
+    tauxAugmentationPromotionFemmes: undefined,
+    tauxAugmentationPromotionHommes: undefined
+  })
+);
+
 const defaultState: AppState = {
   effectif: {
     formValidated: "None",
@@ -83,6 +92,11 @@ const defaultState: AppState = {
     formValidated: "None",
     presencePromotion: true,
     tauxPromotion: dataIndicateurTrois
+  },
+  indicateurDeuxTrois: {
+    formValidated: "None",
+    presenceAugmentationPromotion: true,
+    tauxAugmentationPromotion: dataIndicateurDeuxTrois
   },
   indicateurQuatre: {
     formValidated: "None",
@@ -137,7 +151,11 @@ function AppReducer(
           indicateurTrois:
             state.indicateurTrois.formValidated === "Valid"
               ? { ...state.indicateurTrois, formValidated: "Invalid" }
-              : state.indicateurTrois
+              : state.indicateurTrois,
+          indicateurDeuxTrois:
+            state.indicateurTrois.formValidated === "Valid"
+              ? { ...state.indicateurDeuxTrois, formValidated: "Invalid" }
+              : state.indicateurDeuxTrois
         };
       }
       return {
@@ -265,8 +283,31 @@ function AppReducer(
     case "validateIndicateurTrois": {
       return {
         ...state,
-        indicateurTrois: {
-          ...state.indicateurTrois,
+        indicateurDeuxTrois: {
+          ...state.indicateurDeuxTrois,
+          formValidated: action.valid
+        }
+      };
+    }
+    case "updateIndicateurDeuxTrois": {
+      const {
+        tauxAugmentationPromotion,
+        presenceAugmentationPromotion
+      } = action.data;
+      return {
+        ...state,
+        indicateurDeuxTrois: {
+          ...state.indicateurDeuxTrois,
+          presenceAugmentationPromotion,
+          tauxAugmentationPromotion
+        }
+      };
+    }
+    case "validateIndicateurDeuxTrois": {
+      return {
+        ...state,
+        indicateurDeuxTrois: {
+          ...state.indicateurDeuxTrois,
           formValidated: action.valid
         }
       };

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -3,7 +3,8 @@ import {
   AppState,
   ActionType,
   CategorieSocioPro,
-  TranchesAges
+  TranchesAges,
+  PeriodeDeclaration
 } from "./globals.d";
 import mapEnum from "./utils/mapEnum";
 import { overwriteMerge, combineMerge } from "./utils/merge";
@@ -89,9 +90,7 @@ const defaultState: AppState = {
     presenceAugmentationPromotion: true,
     nombreAugmentationPromotionFemmes: undefined,
     nombreAugmentationPromotionHommes: undefined,
-    memePeriodeReference: true,
-    periodeReferenceDebut: "",
-    periodeReferenceFin: ""
+    periodeDeclaration: "unePeriodeReference" as PeriodeDeclaration
   },
   indicateurQuatre: {
     formValidated: "None",
@@ -289,9 +288,7 @@ function AppReducer(
         presenceAugmentationPromotion,
         nombreAugmentationPromotionFemmes,
         nombreAugmentationPromotionHommes,
-        memePeriodeReference,
-        periodeReferenceDebut,
-        periodeReferenceFin
+        periodeDeclaration
       } = action.data;
       return {
         ...state,
@@ -300,9 +297,7 @@ function AppReducer(
           presenceAugmentationPromotion,
           nombreAugmentationPromotionFemmes,
           nombreAugmentationPromotionHommes,
-          memePeriodeReference,
-          periodeReferenceDebut,
-          periodeReferenceFin
+          periodeDeclaration
         }
       };
     }

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -277,8 +277,8 @@ function AppReducer(
     case "validateIndicateurTrois": {
       return {
         ...state,
-        indicateurDeuxTrois: {
-          ...state.indicateurDeuxTrois,
+        indicateurTrois: {
+          ...state.indicateurTrois,
           formValidated: action.valid
         }
       };

--- a/packages/app/src/__fixtures__/stateComplete.tsx
+++ b/packages/app/src/__fixtures__/stateComplete.tsx
@@ -359,6 +359,18 @@ const actionUpdateIndicateurTrois = {
   }
 };
 
+const actionUpdateIndicateurDeuxTrois = {
+  type: "updateIndicateurDeuxTrois" as "updateIndicateurDeuxTrois",
+  data: {
+    presenceAugmentationPromotion: false,
+    nombreAugmentationPromotionFemmes: 1,
+    nombreAugmentationPromotionHommes: 2,
+    memePeriodeReference: false,
+    periodeReferenceDebut: "2017-11-01",
+    periodeReferenceFin: "2018-10-31"
+  }
+};
+
 const actionUpdateIndicateurQuatre = {
   type: "updateIndicateurQuatre" as "updateIndicateurQuatre",
   data: {
@@ -387,22 +399,25 @@ const stateDefault = AppReducer(
               AppReducer(
                 AppReducer(
                   AppReducer(
-                    AppReducer(undefined, actionInitiateState),
-                    actionUpdateEffectif
+                    AppReducer(
+                      AppReducer(undefined, actionInitiateState),
+                      actionUpdateEffectif
+                    ),
+                    actionUpdateIndicateurUnCsp
                   ),
-                  actionUpdateIndicateurUnCsp
+                  actionUpdateIndicateurUnCoefAddGroup
                 ),
-                actionUpdateIndicateurUnCoefAddGroup
+                actionUpdateIndicateurUnCoefName
               ),
-              actionUpdateIndicateurUnCoefName
+              actionUpdateIndicateurUnCoefNombreSalaries
             ),
-            actionUpdateIndicateurUnCoefNombreSalaries
+            actionUpdateIndicateurUnCoefRemuneration
           ),
-          actionUpdateIndicateurUnCoefRemuneration
+          actionUpdateIndicateurDeux
         ),
-        actionUpdateIndicateurDeux
+        actionUpdateIndicateurTrois
       ),
-      actionUpdateIndicateurTrois
+      actionUpdateIndicateurDeuxTrois
     ),
     actionUpdateIndicateurQuatre
   ),

--- a/packages/app/src/__fixtures__/stateComplete.tsx
+++ b/packages/app/src/__fixtures__/stateComplete.tsx
@@ -1,4 +1,8 @@
-import { CategorieSocioPro, TranchesAges } from "../globals.d";
+import {
+  CategorieSocioPro,
+  PeriodeDeclaration,
+  TranchesAges
+} from "../globals.d";
 import AppReducer from "../AppReducer";
 
 const actionInitiateState = {
@@ -365,9 +369,7 @@ const actionUpdateIndicateurDeuxTrois = {
     presenceAugmentationPromotion: false,
     nombreAugmentationPromotionFemmes: 1,
     nombreAugmentationPromotionHommes: 2,
-    memePeriodeReference: false,
-    periodeReferenceDebut: "2017-11-01",
-    periodeReferenceFin: "2018-10-31"
+    periodeDeclaration: "unePeriodeReference" as PeriodeDeclaration
   }
 };
 

--- a/packages/app/src/__fixtures__/stateCompleteAndValidate.tsx
+++ b/packages/app/src/__fixtures__/stateCompleteAndValidate.tsx
@@ -33,6 +33,11 @@ const actionValidateIndicateurTrois = {
   valid: "Valid" as FormState
 };
 
+const actionValidateIndicateurDeuxTrois = {
+  type: "validateIndicateurDeuxTrois" as "validateIndicateurDeuxTrois",
+  valid: "Valid" as FormState
+};
+
 const actionValidateIndicateurQuatre = {
   type: "validateIndicateurQuatre" as "validateIndicateurQuatre",
   valid: "Valid" as FormState
@@ -51,16 +56,19 @@ const stateDefault = AppReducer(
         AppReducer(
           AppReducer(
             AppReducer(
-              AppReducer(stateComplete, actionValidateEffectif),
-              actionValidateIndicateurUnCoefGroup
+              AppReducer(
+                AppReducer(stateComplete, actionValidateEffectif),
+                actionValidateIndicateurUnCoefGroup
+              ),
+              actionValidateIndicateurUnCoefEffectif
             ),
-            actionValidateIndicateurUnCoefEffectif
+            actionValidateIndicateurUn
           ),
-          actionValidateIndicateurUn
+          actionValidateIndicateurDeux
         ),
-        actionValidateIndicateurDeux
+        actionValidateIndicateurTrois
       ),
-      actionValidateIndicateurTrois
+      actionValidateIndicateurDeuxTrois
     ),
     actionValidateIndicateurQuatre
   ),

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -146,12 +146,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -471,12 +471,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -1089,12 +1089,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -1707,12 +1707,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -2325,12 +2325,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -2803,7 +2803,7 @@ Object {
 
 exports[`updateIndicateurDeux nothing undefined state 1`] = `undefined`;
 
-exports[`updateIndicateurQuatre change complete state 1`] = `
+exports[`updateIndicateurDeuxTrois change complete state 1`] = `
 Object {
   "effectif": Object {
     "formValidated": "None",
@@ -2944,11 +2944,629 @@ Object {
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
     "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "nombreAugmentationPromotionFemmes": 3,
+    "nombreAugmentationPromotionHommes": 4,
+    "periodeReferenceDebut": "2018-11-01",
+    "periodeReferenceFin": "2019-10-31",
     "presenceAugmentationPromotion": true,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": 7,
+    "nombreSalarieesPeriodeAugmentation": 7,
+    "presenceCongeMat": false,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": false,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": 1.1,
+        "tauxPromotionHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": 0.3,
+        "tauxPromotionHommes": 2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": 2,
+        "tauxPromotionHommes": 3,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": 4,
+        "tauxPromotionHommes": 5.55,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [
+      Object {
+        "name": "Business Developers",
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 4,
+            "remunerationAnnuelleBrutFemmes": 25000,
+            "remunerationAnnuelleBrutHommes": 24000,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 2,
+            "nombreSalariesHommes": 6,
+            "remunerationAnnuelleBrutFemmes": 32000,
+            "remunerationAnnuelleBrutHommes": 32000,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 41000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 1,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 49000,
+            "remunerationAnnuelleBrutHommes": 51500,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 25500,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27500,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 31000,
+            "remunerationAnnuelleBrutHommes": 33000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 39000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 26000,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27000,
+            "remunerationAnnuelleBrutHommes": 29000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 34000,
+            "remunerationAnnuelleBrutHommes": 36000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 42000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 36000,
+            "remunerationAnnuelleBrutHommes": 38000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 37000,
+            "remunerationAnnuelleBrutHommes": 39000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 44000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 52000,
+            "remunerationAnnuelleBrutHommes": 56000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`updateIndicateurDeuxTrois change default state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": undefined,
+    "nombreSalariesHommes": undefined,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": true,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": 3,
+    "nombreAugmentationPromotionHommes": 4,
+    "periodeReferenceDebut": "2018-11-01",
+    "periodeReferenceFin": "2019-10-31",
+    "presenceAugmentationPromotion": true,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": undefined,
+    "nombreSalarieesPeriodeAugmentation": undefined,
+    "presenceCongeMat": true,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": true,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`updateIndicateurDeuxTrois nothing undefined state 1`] = `undefined`;
+
+exports[`updateIndicateurQuatre change complete state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 23,
+            "nombreSalariesHommes": 32,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 12,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 34,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 21,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 63,
+            "nombreSalariesHommes": 25,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 52,
+            "nombreSalariesHommes": 62,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 18,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 27,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 14,
+            "nombreSalariesHommes": 15,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 4,
+            "nombreSalariesHommes": 5,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 6,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 10,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 13,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": 4,
+    "nombreSalariesHommes": 6,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": false,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": 2.2,
+        "tauxAugmentationHommes": 3.5,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": 1.3,
+        "tauxAugmentationHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": 8.02,
+        "tauxAugmentationHommes": 6.92,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": 12.15,
+        "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -3561,12 +4179,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -4179,12 +4797,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -4831,12 +5449,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -5483,12 +6101,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -6135,12 +6753,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -6820,12 +7438,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -7404,12 +8022,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -8022,12 +8640,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -8640,12 +9258,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Invalid",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -8965,12 +9583,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -9290,12 +9908,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Invalid",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -9615,12 +10233,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -10233,12 +10851,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -10851,12 +11469,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -11329,6 +11947,624 @@ Object {
 
 exports[`validateIndicateurDeux nothing undefined state 1`] = `undefined`;
 
+exports[`validateIndicateurDeuxTrois change complete state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 23,
+            "nombreSalariesHommes": 32,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 12,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 34,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 21,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 63,
+            "nombreSalariesHommes": 25,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 52,
+            "nombreSalariesHommes": 62,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 18,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 27,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 14,
+            "nombreSalariesHommes": 15,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 4,
+            "nombreSalariesHommes": 5,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 6,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 10,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 13,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": 4,
+    "nombreSalariesHommes": 6,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": false,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": 2.2,
+        "tauxAugmentationHommes": 3.5,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": 1.3,
+        "tauxAugmentationHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": 8.02,
+        "tauxAugmentationHommes": 6.92,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": 12.15,
+        "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": 7,
+    "nombreSalarieesPeriodeAugmentation": 7,
+    "presenceCongeMat": false,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": false,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": 1.1,
+        "tauxPromotionHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": 0.3,
+        "tauxPromotionHommes": 2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": 2,
+        "tauxPromotionHommes": 3,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": 4,
+        "tauxPromotionHommes": 5.55,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [
+      Object {
+        "name": "Business Developers",
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 4,
+            "remunerationAnnuelleBrutFemmes": 25000,
+            "remunerationAnnuelleBrutHommes": 24000,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 2,
+            "nombreSalariesHommes": 6,
+            "remunerationAnnuelleBrutFemmes": 32000,
+            "remunerationAnnuelleBrutHommes": 32000,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 41000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 1,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 49000,
+            "remunerationAnnuelleBrutHommes": 51500,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 25500,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27500,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 31000,
+            "remunerationAnnuelleBrutHommes": 33000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 39000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 26000,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27000,
+            "remunerationAnnuelleBrutHommes": 29000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 34000,
+            "remunerationAnnuelleBrutHommes": 36000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 42000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 36000,
+            "remunerationAnnuelleBrutHommes": 38000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 37000,
+            "remunerationAnnuelleBrutHommes": 39000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 44000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 52000,
+            "remunerationAnnuelleBrutHommes": 56000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`validateIndicateurDeuxTrois change default state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": undefined,
+    "nombreSalariesHommes": undefined,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": true,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
+    "presenceAugmentationPromotion": true,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": undefined,
+    "nombreSalarieesPeriodeAugmentation": undefined,
+    "presenceCongeMat": true,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": true,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`validateIndicateurDeuxTrois nothing undefined state 1`] = `undefined`;
+
 exports[`validateIndicateurQuatre change complete state 1`] = `
 Object {
   "effectif": Object {
@@ -11469,12 +12705,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -12087,12 +13323,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -12705,12 +13941,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -13323,12 +14559,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -13648,12 +14884,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -14266,12 +15502,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -14591,12 +15827,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
-    "nombreAugmentationPromotionFemmes": undefined,
-    "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
-    "presenceAugmentationPromotion": true,
+    "memePeriodeReference": false,
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeReferenceDebut": "2017-11-01",
+    "periodeReferenceFin": "2018-10-31",
+    "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
     "formValidated": "None",

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -481,7 +481,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Valid",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -9212,7 +9212,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Invalid",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -9535,7 +9535,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Valid",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -9858,7 +9858,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Invalid",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -13238,7 +13238,7 @@ Object {
     ],
   },
   "indicateurDeuxTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
     "periodeDeclaration": "unePeriodeReference",
@@ -13251,7 +13251,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Valid",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -13561,7 +13561,7 @@ Object {
     ],
   },
   "indicateurDeuxTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
     "periodeDeclaration": "unePeriodeReference",
@@ -13574,7 +13574,7 @@ Object {
     "presenceCongeMat": true,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Valid",
     "presencePromotion": true,
     "tauxPromotion": Array [
       Object {
@@ -14479,7 +14479,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Valid",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -15416,7 +15416,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "None",
+    "formValidated": "Valid",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -146,29 +146,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -488,29 +471,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -830,29 +796,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -1140,29 +1089,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -1482,29 +1414,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -1792,29 +1707,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -2134,29 +2032,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -2444,29 +2325,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -2786,29 +2650,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -3096,29 +2943,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -3438,29 +3268,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -3748,29 +3561,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -4090,29 +3886,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -4400,29 +4179,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -4742,29 +4504,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -5086,29 +4831,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -5428,29 +5156,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -5772,29 +5483,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -6114,29 +5808,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -6458,29 +6135,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -6833,29 +6493,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -7177,29 +6820,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -7485,29 +7111,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -7795,29 +7404,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -8137,29 +7729,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -8447,29 +8022,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -8789,29 +8347,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -9098,30 +8639,13 @@ Object {
     ],
   },
   "indicateurDeuxTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "Invalid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -9441,29 +8965,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -9782,30 +9289,13 @@ Object {
     ],
   },
   "indicateurDeuxTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "Invalid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -10125,29 +9615,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -10467,29 +9940,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -10777,29 +10233,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -11119,29 +10558,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -11429,29 +10851,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -11771,29 +11176,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -12081,29 +11469,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -12423,29 +11794,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -12733,29 +12087,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -13075,29 +12412,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -13385,29 +12705,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -13727,29 +13030,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -14037,29 +13323,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -14379,29 +13648,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -14721,29 +13973,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -15031,29 +14266,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
@@ -15373,29 +14591,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",
@@ -15715,29 +14916,12 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
+    "memePeriodeReference": true,
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeReferenceDebut": "",
+    "periodeReferenceFin": "",
     "presenceAugmentationPromotion": true,
-    "tauxAugmentationPromotion": Array [
-      Object {
-        "categorieSocioPro": 0,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 1,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 2,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-      Object {
-        "categorieSocioPro": 3,
-        "tauxAugmentationPromotionFemmes": undefined,
-        "tauxAugmentationPromotionHommes": undefined,
-      },
-    ],
   },
   "indicateurQuatre": Object {
     "formValidated": "None",

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -144,6 +144,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": 7,
@@ -460,6 +486,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
     "nombreSalarieesAugmentees": 7,
@@ -467,7 +519,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -776,6 +828,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -1057,6 +1135,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -1376,6 +1480,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -1657,6 +1787,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -1976,6 +2132,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -2257,6 +2439,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 10.05,
         "tauxAugmentationHommes": 10.06,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -2576,6 +2784,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -2857,6 +3091,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -3176,6 +3436,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": 5,
@@ -3457,6 +3743,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -3776,6 +4088,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -4057,6 +4395,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -4373,6 +4737,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": undefined,
         "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -4694,6 +5084,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": 7,
@@ -5007,6 +5423,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": undefined,
         "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -5328,6 +5770,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": 7,
@@ -5641,6 +6109,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": undefined,
         "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -5959,6 +6453,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -6311,6 +6831,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -6629,6 +7175,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": 7,
@@ -6908,6 +7480,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": undefined,
         "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -7192,6 +7790,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -7511,6 +8135,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -7792,6 +8442,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -8111,6 +8787,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -8395,6 +9097,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
     "nombreSalarieesAugmentees": 7,
@@ -8402,7 +9130,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "Invalid",
+    "formValidated": "None",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -8711,6 +9439,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
     "nombreSalarieesAugmentees": 7,
@@ -8718,7 +9472,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -9027,6 +9781,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
     "nombreSalarieesAugmentees": 7,
@@ -9034,7 +9814,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "Invalid",
+    "formValidated": "None",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -9340,6 +10120,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -9659,6 +10465,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -9940,6 +10772,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -10259,6 +11117,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -10540,6 +11424,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -10859,6 +11769,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -11140,6 +12076,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -11459,6 +12421,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
     "nombreSalarieesAugmentees": undefined,
@@ -11743,6 +12731,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": 7,
@@ -11750,7 +12764,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -12059,6 +13073,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -12066,7 +13106,7 @@ Object {
     "presenceCongeMat": true,
   },
   "indicateurTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "presencePromotion": true,
     "tauxPromotion": Array [
       Object {
@@ -12340,6 +13380,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -12659,6 +13725,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -12943,6 +14035,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
     "nombreSalarieesAugmentees": 7,
@@ -12950,7 +14068,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -13256,6 +14374,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -13575,6 +14719,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "None",
     "nombreSalarieesAugmentees": undefined,
@@ -13859,6 +15029,32 @@ Object {
       },
     ],
   },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "Valid",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+    ],
+  },
   "indicateurQuatre": Object {
     "formValidated": "Valid",
     "nombreSalarieesAugmentees": 7,
@@ -13866,7 +15062,7 @@ Object {
     "presenceCongeMat": false,
   },
   "indicateurTrois": Object {
-    "formValidated": "Valid",
+    "formValidated": "None",
     "presencePromotion": false,
     "tauxPromotion": Array [
       Object {
@@ -14172,6 +15368,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": 12.15,
         "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },
@@ -14488,6 +15710,32 @@ Object {
         "categorieSocioPro": 3,
         "tauxAugmentationFemmes": undefined,
         "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "presenceAugmentationPromotion": true,
+    "tauxAugmentationPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationPromotionFemmes": undefined,
+        "tauxAugmentationPromotionHommes": undefined,
       },
     ],
   },

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -146,11 +146,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -471,11 +469,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -796,11 +792,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -1089,11 +1083,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -1414,11 +1406,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -1707,11 +1697,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -2032,11 +2020,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -2325,11 +2311,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -2650,11 +2634,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -2943,11 +2925,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": 3,
     "nombreAugmentationPromotionHommes": 4,
-    "periodeReferenceDebut": "2018-11-01",
-    "periodeReferenceFin": "2019-10-31",
+    "periodeDeclaration": "deuxPeriodesReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -3268,11 +3248,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": 3,
     "nombreAugmentationPromotionHommes": 4,
-    "periodeReferenceDebut": "2018-11-01",
-    "periodeReferenceFin": "2019-10-31",
+    "periodeDeclaration": "deuxPeriodesReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -3561,11 +3539,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -3886,11 +3862,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -4179,11 +4153,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -4504,11 +4476,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -4797,11 +4767,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -5122,11 +5090,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -5449,11 +5415,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -5774,11 +5738,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -6101,11 +6063,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -6426,11 +6386,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -6753,11 +6711,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -7111,11 +7067,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -7438,11 +7392,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -7729,11 +7681,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -8022,11 +7972,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -8347,11 +8295,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -8640,11 +8586,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -8965,11 +8909,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -9258,11 +9200,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Invalid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -9583,11 +9523,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -9908,11 +9846,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Invalid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -10233,11 +10169,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -10558,11 +10492,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -10851,11 +10783,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -11176,11 +11106,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -11469,11 +11397,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -11794,11 +11720,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -12087,11 +12011,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -12412,11 +12334,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -12705,11 +12625,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -13030,11 +12948,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -13323,11 +13239,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -13648,11 +13562,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -13941,11 +13853,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -14266,11 +14176,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -14559,11 +14467,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -14884,11 +14790,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -15209,11 +15113,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {
@@ -15502,11 +15404,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "Valid",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -15827,11 +15727,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": false,
     "nombreAugmentationPromotionFemmes": 1,
     "nombreAugmentationPromotionHommes": 2,
-    "periodeReferenceDebut": "2017-11-01",
-    "periodeReferenceFin": "2018-10-31",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": false,
   },
   "indicateurQuatre": Object {
@@ -16152,11 +16050,9 @@ Object {
   },
   "indicateurDeuxTrois": Object {
     "formValidated": "None",
-    "memePeriodeReference": true,
     "nombreAugmentationPromotionFemmes": undefined,
     "nombreAugmentationPromotionHommes": undefined,
-    "periodeReferenceDebut": "",
-    "periodeReferenceFin": "",
+    "periodeDeclaration": "unePeriodeReference",
     "presenceAugmentationPromotion": true,
   },
   "indicateurQuatre": Object {

--- a/packages/app/src/components/Menu.tsx
+++ b/packages/app/src/components/Menu.tsx
@@ -64,6 +64,7 @@ interface Props {
   indicateurUnFormValidated: FormState;
   indicateurDeuxFormValidated: FormState;
   indicateurTroisFormValidated: FormState;
+  indicateurDeuxTroisFormValidated: FormState;
   indicateurQuatreFormValidated: FormState;
   indicateurCinqFormValidated: FormState;
 }
@@ -72,6 +73,7 @@ function Menu({
   effectifFormValidated,
   indicateurUnFormValidated,
   indicateurDeuxFormValidated,
+  indicateurDeuxTroisFormValidated,
   indicateurTroisFormValidated,
   indicateurQuatreFormValidated,
   indicateurCinqFormValidated
@@ -125,6 +127,12 @@ function Menu({
                 title="indicateur"
                 label="écart de taux de promotions"
                 valid={indicateurTroisFormValidated}
+              />
+              <CustomNavLink
+                to={`/simulateur/${code}/indicateur2et3`}
+                title="indicateur"
+                label="écart de taux d'augmentations et de promotions"
+                valid={indicateurDeuxTroisFormValidated}
               />
               <CustomNavLink
                 to={`/simulateur/${code}/indicateur4`}

--- a/packages/app/src/components/RadioButtons.tsx
+++ b/packages/app/src/components/RadioButtons.tsx
@@ -1,0 +1,108 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { ReactNode } from "react";
+import { useField } from "react-final-form";
+
+import globalStyles from "../utils/globalStyles";
+
+function RadioField({
+  fieldName,
+  label,
+  value,
+  choiceValue,
+  disabled
+}: {
+  fieldName: string;
+  label: ReactNode;
+  value: string;
+  choiceValue: string;
+  disabled: boolean;
+}) {
+  const { input } = useField(fieldName, { type: "radio", value: choiceValue });
+  return (
+    <label css={styles.label}>
+      <input css={styles.radio} {...input} disabled={disabled} />
+      <div css={[styles.fakeRadio, input.checked && styles.fakeRadioChecked]} />
+      <span css={styles.labelText}>{label}</span>
+    </label>
+  );
+}
+
+export type RadioButtonChoice = {
+  label: string;
+  value: string;
+};
+
+interface Props {
+  readOnly: boolean;
+  fieldName: string;
+  label: string;
+  value: string;
+  choices: RadioButtonChoice[];
+}
+
+function RadioButtons({ readOnly, fieldName, label, value, choices }: Props) {
+  return (
+    <div css={styles.container}>
+      <p>{label}</p>
+      {choices.map(({ label: choiceLabel, value: choiceValue }) => (
+        <div
+          key={choiceLabel}
+          css={[
+            styles.radioField,
+            readOnly && value !== choiceValue && styles.radioFieldDisabled
+          ]}
+        >
+          <RadioField
+            fieldName={fieldName}
+            label={choiceLabel}
+            value={value}
+            choiceValue={choiceValue}
+            disabled={readOnly}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const styles = {
+  container: css({
+    display: "flex",
+    flexDirection: "column"
+  }),
+  radioField: css({
+    marginTop: 9,
+    "&:first-child": {
+      marginTop: 0
+    }
+  }),
+  label: css({
+    display: "flex",
+    fontSize: 14,
+    cursor: "pointer"
+  }),
+  labelText: css({
+    lineHeight: "16px"
+  }),
+  radio: css({
+    display: "none"
+  }),
+  fakeRadio: css({
+    width: 16,
+    height: 16,
+    flexShrink: 0,
+    marginRight: 6,
+    borderRadius: 8,
+    backgroundColor: "white",
+    border: `solid ${globalStyles.colors.default} 1px`
+  }),
+  fakeRadioChecked: css({
+    backgroundImage: `radial-gradient(${globalStyles.colors.default} 0%, ${globalStyles.colors.default} 3px, #FFF 3px)`
+  }),
+  radioFieldDisabled: css({
+    visibility: "hidden"
+  })
+};
+
+export default RadioButtons;

--- a/packages/app/src/components/RadioButtons.tsx
+++ b/packages/app/src/components/RadioButtons.tsx
@@ -73,7 +73,7 @@ const styles = {
   }),
   radioField: css({
     marginTop: 9,
-    "&:first-child": {
+    "&:first-of-type": {
       marginTop: 0
     }
   }),

--- a/packages/app/src/containers/MainScrollView.tsx
+++ b/packages/app/src/containers/MainScrollView.tsx
@@ -31,6 +31,9 @@ function MainScrollView({ children, state, location }: Props) {
       indicateurTroisFormValidated={
         state ? state.indicateurTrois.formValidated : "None"
       }
+      indicateurDeuxTroisFormValidated={
+        state ? state.indicateurDeuxTrois.formValidated : "None"
+      }
       indicateurQuatreFormValidated={
         state ? state.indicateurQuatre.formValidated : "None"
       }

--- a/packages/app/src/containers/Simulateur.tsx
+++ b/packages/app/src/containers/Simulateur.tsx
@@ -17,6 +17,7 @@ import Effectif from "../views/Effectif";
 import IndicateurUn from "../views/Indicateur1";
 import IndicateurDeux from "../views/Indicateur2";
 import IndicateurTrois from "../views/Indicateur3";
+import IndicateurDeuxTrois from "../views/Indicateur2et3";
 import IndicateurQuatre from "../views/Indicateur4";
 import IndicateurCinq from "../views/Indicateur5";
 import Recapitulatif from "../views/Recapitulatif";
@@ -106,6 +107,12 @@ function Simulateur({ code, state, dispatch }: Props) {
         path="/simulateur/:code/indicateur3"
         render={props => (
           <IndicateurTrois {...props} state={state} dispatch={dispatch} />
+        )}
+      />
+      <Route
+        path="/simulateur/:code/indicateur2et3"
+        render={props => (
+          <IndicateurDeuxTrois {...props} state={state} dispatch={dispatch} />
         )}
       />
       <Route

--- a/packages/app/src/globals.d.ts
+++ b/packages/app/src/globals.d.ts
@@ -21,6 +21,11 @@ export type AppState = {
     presencePromotion: boolean;
     tauxPromotion: Array<GroupeIndicateurTrois>;
   };
+  indicateurDeuxTrois: {
+    formValidated: FormState;
+    presenceAugmentationPromotion: boolean;
+    tauxAugmentationPromotion: Array<GroupeIndicateurDeuxTrois>;
+  };
   indicateurQuatre: {
     formValidated: FormState;
     presenceCongeMat: boolean;
@@ -100,6 +105,14 @@ export type ActionType =
       valid: FormState;
     }
   | {
+      type: "updateIndicateurDeuxTrois";
+      data: ActionIndicateurDeuxTroisData;
+    }
+  | {
+      type: "validateIndicateurDeuxTrois";
+      valid: FormState;
+    }
+  | {
       type: "updateIndicateurQuatre";
       data: ActionIndicateurQuatreData;
     }
@@ -147,6 +160,11 @@ export type ActionIndicateurDeuxData = {
 export type ActionIndicateurTroisData = {
   presencePromotion: boolean;
   tauxPromotion: Array<GroupeIndicateurTrois>;
+};
+
+export type ActionIndicateurDeuxTroisData = {
+  presenceAugmentationPromotion: boolean;
+  tauxAugmentationPromotion: Array<GroupeIndicateurDeuxTrois>;
 };
 
 export type ActionIndicateurQuatreData = {
@@ -223,6 +241,12 @@ export interface GroupeIndicateurTrois {
   tauxPromotionHommes: number | undefined;
 }
 
+export interface GroupeIndicateurDeuxTrois {
+  categorieSocioPro: CategorieSocioPro;
+  tauxAugmentationPromotionFemmes: number | undefined;
+  tauxAugmentationPromotionHommes: number | undefined;
+}
+
 ////////////
 
 export type FAQPartType =
@@ -241,7 +265,7 @@ export type FAQPart = {
   [key in FAQPartType]: {
     title: string;
     qr: Array<{ question: string; reponse: Array<string> }>;
-  }
+  };
 };
 
 export type FAQSectionType =
@@ -258,7 +282,7 @@ export type FAQSection = {
   [key in FAQSectionType]: {
     title: string;
     parts: Array<FAQPartType>;
-  }
+  };
 };
 
 ////////////

--- a/packages/app/src/globals.d.ts
+++ b/packages/app/src/globals.d.ts
@@ -26,9 +26,7 @@ export type AppState = {
     presenceAugmentationPromotion: boolean;
     nombreAugmentationPromotionFemmes: number | undefined;
     nombreAugmentationPromotionHommes: number | undefined;
-    memePeriodeReference: boolean;
-    periodeReferenceDebut: string;
-    periodeReferenceFin: string;
+    periodeDeclaration: PeriodeDeclaration;
   };
   indicateurQuatre: {
     formValidated: FormState;
@@ -42,6 +40,11 @@ export type AppState = {
     nombreSalariesFemmes: number | undefined;
   };
 };
+
+export type PeriodeDeclaration =
+  | "unePeriodeReference"
+  | "deuxPeriodesReference"
+  | "troisPeriodesReference";
 
 export type FormState = "None" | "Valid" | "Invalid";
 
@@ -170,9 +173,7 @@ export type ActionIndicateurDeuxTroisData = {
   presenceAugmentationPromotion: boolean;
   nombreAugmentationPromotionFemmes: number | undefined;
   nombreAugmentationPromotionHommes: number | undefined;
-  memePeriodeReference: boolean;
-  periodeReferenceDebut: string;
-  periodeReferenceFin: string;
+  periodeDeclaration: PeriodeDeclaration;
 };
 
 export type DateInterval = {

--- a/packages/app/src/globals.d.ts
+++ b/packages/app/src/globals.d.ts
@@ -24,7 +24,11 @@ export type AppState = {
   indicateurDeuxTrois: {
     formValidated: FormState;
     presenceAugmentationPromotion: boolean;
-    tauxAugmentationPromotion: Array<GroupeIndicateurDeuxTrois>;
+    nombreAugmentationPromotionFemmes: number | undefined;
+    nombreAugmentationPromotionHommes: number | undefined;
+    memePeriodeReference: boolean;
+    periodeReferenceDebut: string;
+    periodeReferenceFin: string;
   };
   indicateurQuatre: {
     formValidated: FormState;
@@ -164,7 +168,16 @@ export type ActionIndicateurTroisData = {
 
 export type ActionIndicateurDeuxTroisData = {
   presenceAugmentationPromotion: boolean;
-  tauxAugmentationPromotion: Array<GroupeIndicateurDeuxTrois>;
+  nombreAugmentationPromotionFemmes: number | undefined;
+  nombreAugmentationPromotionHommes: number | undefined;
+  memePeriodeReference: boolean;
+  periodeReferenceDebut: string;
+  periodeReferenceFin: string;
+};
+
+export type DateInterval = {
+  start: Date;
+  end: Date;
 };
 
 export type ActionIndicateurQuatreData = {

--- a/packages/app/src/globals.d.ts
+++ b/packages/app/src/globals.d.ts
@@ -254,12 +254,6 @@ export interface GroupeIndicateurTrois {
   tauxPromotionHommes: number | undefined;
 }
 
-export interface GroupeIndicateurDeuxTrois {
-  categorieSocioPro: CategorieSocioPro;
-  tauxAugmentationPromotionFemmes: number | undefined;
-  tauxAugmentationPromotionHommes: number | undefined;
-}
-
 ////////////
 
 export type FAQPartType =

--- a/packages/app/src/utils/__snapshots__/calculsEgaProIndicateurDeuxTrois.test.tsx.snap
+++ b/packages/app/src/utils/__snapshots__/calculsEgaProIndicateurDeuxTrois.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test calculIndicateurDeuxTrois test data 1`] = `
+Object {
+  "indicateurCalculable": true,
+  "indicateurEcartAugmentationPromotion": 11.1905,
+  "indicateurEcartNombreEquivalentSalaries": 3.1,
+  "indicateurSexeSurRepresente": "hommes",
+  "noteIndicateurDeuxTrois": 25,
+}
+`;

--- a/packages/app/src/utils/__snapshots__/calculsEgaProIndicateurDeuxTrois.test.tsx.snap
+++ b/packages/app/src/utils/__snapshots__/calculsEgaProIndicateurDeuxTrois.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`test calculIndicateurDeuxTrois test data 1`] = `
 Object {
+  "correctionMeasure": false,
   "indicateurCalculable": true,
   "indicateurEcartAugmentationPromotion": 11.1905,
   "indicateurEcartNombreEquivalentSalaries": 3.1,

--- a/packages/app/src/utils/__snapshots__/calculsEgaProIndicateurDeuxTrois.test.tsx.snap
+++ b/packages/app/src/utils/__snapshots__/calculsEgaProIndicateurDeuxTrois.test.tsx.snap
@@ -3,10 +3,14 @@
 exports[`test calculIndicateurDeuxTrois test data 1`] = `
 Object {
   "correctionMeasure": false,
+  "effectifsIndicateurCalculable": true,
   "indicateurCalculable": true,
   "indicateurEcartAugmentationPromotion": 11.1905,
   "indicateurEcartNombreEquivalentSalaries": 3.1,
   "indicateurSexeSurRepresente": "hommes",
   "noteIndicateurDeuxTrois": 25,
+  "plusPetitNombreSalaries": "femmes",
+  "tauxAugmentationPromotionFemmes": 0.06666666666666667,
+  "tauxAugmentationPromotionHommes": 0.17857142857142858,
 }
 `;

--- a/packages/app/src/utils/calculsEgaPro.tsx
+++ b/packages/app/src/utils/calculsEgaPro.tsx
@@ -38,6 +38,7 @@ export const calculEcartsPonderesParGroupe = (
     ecartApresApplicationSeuilPertinence?: number | undefined;
     ecartTauxAugmentation?: number | undefined;
     ecartTauxPromotion?: number | undefined;
+    ecartTauxAugmentationPromotion?: number | undefined;
   }) => number | undefined
 ) => (
   groupEffectifEtEcart: Array<{
@@ -46,6 +47,7 @@ export const calculEcartsPonderesParGroupe = (
     ecartApresApplicationSeuilPertinence?: number | undefined;
     ecartTauxAugmentation?: number | undefined;
     ecartTauxPromotion?: number | undefined;
+    ecartTauxAugmentationPromotion?: number | undefined;
   }>,
   totalEffectifsValides: number
 ) =>

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
@@ -1,7 +1,7 @@
 import stateComplete from "../__fixtures__/stateComplete";
 import { calculBarem, calculNote } from "./calculsEgaProIndicateurDeuxTrois";
 import calculIndicateurDeuxTrois from "./calculsEgaProIndicateurDeuxTrois";
-import { AppState } from "../globals";
+import { AppState, PeriodeDeclaration } from "../globals";
 
 ///////////////////////
 // INDICATEUR 2 et 3 //
@@ -85,7 +85,7 @@ describe("calculNote", () => {
 });
 
 describe("test calculIndicateurDeuxTrois", () => {
-  const state: AppState = {
+  const state = {
     ...stateComplete,
     effectif: {
       formValidated: "Valid",
@@ -194,14 +194,12 @@ describe("test calculIndicateurDeuxTrois", () => {
     },
     indicateurDeuxTrois: {
       formValidated: "Valid",
-      memePeriodeReference: true,
+      periodeDeclaration: "unePeriodeReference" as PeriodeDeclaration,
       nombreAugmentationPromotionFemmes: 2,
       nombreAugmentationPromotionHommes: 5,
-      presenceAugmentationPromotion: true,
-      periodeReferenceDebut: "",
-      periodeReferenceFin: ""
+      presenceAugmentationPromotion: true
     }
-  };
+  } as AppState;
   test("test data", () => {
     expect(calculIndicateurDeuxTrois(state)).toMatchSnapshot();
   });

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
@@ -1,169 +1,157 @@
-import { calculNote } from "./calculsEgaProIndicateurDeuxTrois";
+import stateComplete from "../__fixtures__/stateComplete";
+import { calculBarem, calculNote } from "./calculsEgaProIndicateurDeuxTrois";
+import calculIndicateurDeuxTrois from "./calculsEgaProIndicateurDeuxTrois";
+import { AppState } from "../globals";
 
-//////////////////
+///////////////////////
 // INDICATEUR 2 et 3 //
-//////////////////
+///////////////////////
 
-// Most of functions are directly imported from 2nd indicator
-// So no duplicated tests here
+describe("calculBarem", () => {
+  test("test barem", () => {
+    expect(calculBarem(0)).toEqual(35);
+    expect(calculBarem(2)).toEqual(35);
+    expect(calculBarem(2.1)).toEqual(25);
+    expect(calculBarem(5)).toEqual(25);
+    expect(calculBarem(5.1)).toEqual(15);
+    expect(calculBarem(10)).toEqual(15);
+    expect(calculBarem(10.1)).toEqual(0);
+    expect(calculBarem(100)).toEqual(0);
+  });
+});
 
 describe("calculNote", () => {
   test("cant calcul note", () => {
-    expect(calculNote(undefined, undefined, undefined, undefined)).toEqual({
-      note: undefined,
-      correctionMeasure: false
-    });
+    expect(calculNote(undefined, undefined)).toEqual(undefined);
+    expect(calculNote(1, undefined)).toEqual(undefined);
+    expect(calculNote(undefined, 1)).toEqual(undefined);
   });
 
-  test("test some valid data", () => {
-    expect(calculNote(-2, undefined, undefined, undefined)).toEqual({
-      note: 15,
-      correctionMeasure: false
-    });
-    expect(calculNote(-0.5, undefined, undefined, undefined)).toEqual({
-      note: 15,
-      correctionMeasure: false
-    });
-    expect(calculNote(0, undefined, undefined, undefined)).toEqual({
-      note: 15,
-      correctionMeasure: false
-    });
-    expect(calculNote(0.1, undefined, undefined, undefined)).toEqual({
-      note: 15,
-      correctionMeasure: false
-    });
-    expect(calculNote(0.5, undefined, undefined, undefined)).toEqual({
-      note: 15,
-      correctionMeasure: false
-    });
-    expect(calculNote(1, undefined, undefined, undefined)).toEqual({
-      note: 15,
-      correctionMeasure: false
-    });
-    expect(calculNote(2, undefined, undefined, undefined)).toEqual({
-      note: 15,
-      correctionMeasure: false
-    });
-    expect(calculNote(2.1, undefined, undefined, undefined)).toEqual({
-      note: 10,
-      correctionMeasure: false
-    });
-    expect(calculNote(3.2, undefined, undefined, undefined)).toEqual({
-      note: 10,
-      correctionMeasure: false
-    });
-    expect(calculNote(4, undefined, undefined, undefined)).toEqual({
-      note: 10,
-      correctionMeasure: false
-    });
-    expect(calculNote(5, undefined, undefined, undefined)).toEqual({
-      note: 10,
-      correctionMeasure: false
-    });
-    expect(calculNote(5.1, undefined, undefined, undefined)).toEqual({
-      note: 5,
-      correctionMeasure: false
-    });
-    expect(calculNote(7, undefined, undefined, undefined)).toEqual({
-      note: 5,
-      correctionMeasure: false
-    });
-    expect(calculNote(7.1, undefined, undefined, undefined)).toEqual({
-      note: 5,
-      correctionMeasure: false
-    });
-    expect(calculNote(8, undefined, undefined, undefined)).toEqual({
-      note: 5,
-      correctionMeasure: false
-    });
-    expect(calculNote(10, undefined, undefined, undefined)).toEqual({
-      note: 5,
-      correctionMeasure: false
-    });
-    expect(calculNote(10.1, undefined, undefined, undefined)).toEqual({
-      note: 0,
-      correctionMeasure: false
-    });
-    expect(calculNote(13.2, undefined, undefined, undefined)).toEqual({
-      note: 0,
-      correctionMeasure: false
-    });
-    expect(calculNote(50.5, undefined, undefined, undefined)).toEqual({
-      note: 0,
-      correctionMeasure: false
-    });
+  test("test max of both notes", () => {
+    expect(calculNote(15, 0)).toEqual(35);
+    expect(calculNote(0, 15)).toEqual(35);
   });
+});
 
-  describe("test round to 1 number after comma", () => {
-    test("round to 2.1", () => {
-      expect(calculNote(2.1, undefined, undefined, undefined)).toEqual({
-        note: 10,
-        correctionMeasure: false
-      });
-      expect(calculNote(2.09, undefined, undefined, undefined)).toEqual({
-        note: 10,
-        correctionMeasure: false
-      });
-      expect(calculNote(2.06, undefined, undefined, undefined)).toEqual({
-        note: 10,
-        correctionMeasure: false
-      });
-      expect(calculNote(2.05, undefined, undefined, undefined)).toEqual({
-        note: 10,
-        correctionMeasure: false
-      });
-    });
-
-    test("round to 2.0", () => {
-      expect(calculNote(2.04, undefined, undefined, undefined)).toEqual({
-        note: 15,
-        correctionMeasure: false
-      });
-      expect(calculNote(2.01, undefined, undefined, undefined)).toEqual({
-        note: 15,
-        correctionMeasure: false
-      });
-      expect(calculNote(2.0, undefined, undefined, undefined)).toEqual({
-        note: 15,
-        correctionMeasure: false
-      });
-    });
-  });
-
-  describe("correction measure from indicateur 1", () => {
-    test("note indicator 1 is 40 so not correction measure", () => {
-      expect(calculNote(2.1, 40, "femmes", "hommes")).toEqual({
-        note: 10,
-        correctionMeasure: false
-      });
-    });
-
-    test("overrepresented sex is same on indicator 1 & 2 so not correction measure", () => {
-      expect(calculNote(8.1, 36, "hommes", "hommes")).toEqual({
-        note: 5,
-        correctionMeasure: false
-      });
-    });
-
-    test("correction measure for men", () => {
-      expect(calculNote(2.1, 39, "femmes", "hommes")).toEqual({
-        note: 15,
-        correctionMeasure: true
-      });
-    });
-
-    test("correction measure for women", () => {
-      expect(calculNote(8.1, 36, "hommes", "femmes")).toEqual({
-        note: 15,
-        correctionMeasure: true
-      });
-    });
-
-    test("note indicator 1 is 0", () => {
-      expect(calculNote(8.1, 0, "hommes", "femmes")).toEqual({
-        note: 15,
-        correctionMeasure: true
-      });
-    });
+describe("test calculIndicateurDeuxTrois", () => {
+  const state: AppState = {
+    ...stateComplete,
+    effectif: {
+      formValidated: "Valid",
+      nombreSalaries: [
+        {
+          categorieSocioPro: 0,
+          tranchesAges: [
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 2,
+              trancheAge: 0
+            },
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 1,
+              trancheAge: 1
+            },
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 0,
+              trancheAge: 2
+            },
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 1,
+              trancheAge: 3
+            }
+          ]
+        },
+        {
+          categorieSocioPro: 1,
+          tranchesAges: [
+            {
+              nombreSalariesFemmes: 9,
+              nombreSalariesHommes: 4,
+              trancheAge: 0
+            },
+            {
+              nombreSalariesFemmes: 8,
+              nombreSalariesHommes: 3,
+              trancheAge: 1
+            },
+            {
+              nombreSalariesFemmes: 4,
+              nombreSalariesHommes: 3,
+              trancheAge: 2
+            },
+            {
+              nombreSalariesFemmes: 2,
+              nombreSalariesHommes: 1,
+              trancheAge: 3
+            }
+          ]
+        },
+        {
+          categorieSocioPro: 2,
+          tranchesAges: [
+            {
+              nombreSalariesFemmes: 2,
+              nombreSalariesHommes: 1,
+              trancheAge: 0
+            },
+            {
+              nombreSalariesFemmes: 2,
+              nombreSalariesHommes: 2,
+              trancheAge: 1
+            },
+            {
+              nombreSalariesFemmes: 3,
+              nombreSalariesHommes: 6,
+              trancheAge: 2
+            },
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 2,
+              trancheAge: 3
+            }
+          ]
+        },
+        {
+          categorieSocioPro: 3,
+          tranchesAges: [
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 1,
+              trancheAge: 0
+            },
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 1,
+              trancheAge: 1
+            },
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 0,
+              trancheAge: 2
+            },
+            {
+              nombreSalariesFemmes: 0,
+              nombreSalariesHommes: 0,
+              trancheAge: 3
+            }
+          ]
+        }
+      ]
+    },
+    indicateurDeuxTrois: {
+      formValidated: "Valid",
+      memePeriodeReference: true,
+      nombreAugmentationPromotionFemmes: 2,
+      nombreAugmentationPromotionHommes: 5,
+      presenceAugmentationPromotion: true,
+      periodeReferenceDebut: "",
+      periodeReferenceFin: ""
+    }
+  };
+  test("test data", () => {
+    expect(calculIndicateurDeuxTrois(state)).toMatchSnapshot();
   });
 });

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
@@ -21,15 +21,66 @@ describe("calculBarem", () => {
 });
 
 describe("calculNote", () => {
-  test("cant calcul note", () => {
-    expect(calculNote(undefined, undefined)).toEqual(undefined);
-    expect(calculNote(1, undefined)).toEqual(undefined);
-    expect(calculNote(undefined, 1)).toEqual(undefined);
+  test("can't calcul note", () => {
+    expect(
+      calculNote(undefined, undefined, undefined, undefined, undefined)
+    ).toEqual({ node: undefined, correctionMeasure: false });
+    expect(calculNote(1, undefined, undefined, undefined, undefined)).toEqual({
+      note: undefined,
+      correctionMeasure: false
+    });
+    expect(calculNote(undefined, 1, undefined, undefined, undefined)).toEqual({
+      note: undefined,
+      correctionMeasure: false
+    });
   });
 
   test("test max of both notes", () => {
-    expect(calculNote(15, 0)).toEqual(35);
-    expect(calculNote(0, 15)).toEqual(35);
+    expect(calculNote(15, 0, undefined, undefined, undefined)).toEqual({
+      note: 35,
+      correctionMeasure: false
+    });
+    expect(calculNote(0, 15, undefined, undefined, undefined)).toEqual({
+      note: 35,
+      correctionMeasure: false
+    });
+  });
+
+  describe("correction measure from indicateur 1", () => {
+    test("note indicator 1 is 40 so no correction measure", () => {
+      expect(calculNote(2.1, 2.1, 40, "femmes", "hommes")).toEqual({
+        note: 25,
+        correctionMeasure: false
+      });
+    });
+
+    test("overrepresented sex is same on indicator 1 & 2et3 so no correction measure", () => {
+      expect(calculNote(8.1, 8.1, 36, "hommes", "hommes")).toEqual({
+        note: 15,
+        correctionMeasure: false
+      });
+    });
+
+    test("correction measure for men", () => {
+      expect(calculNote(2.1, 2.1, 39, "femmes", "hommes")).toEqual({
+        note: 35,
+        correctionMeasure: true
+      });
+    });
+
+    test("correction measure for women", () => {
+      expect(calculNote(8.1, 8.1, 36, "hommes", "femmes")).toEqual({
+        note: 35,
+        correctionMeasure: true
+      });
+    });
+
+    test("note indicator 1 is 0", () => {
+      expect(calculNote(8.1, 8.1, 0, "hommes", "femmes")).toEqual({
+        note: 35,
+        correctionMeasure: true
+      });
+    });
   });
 });
 

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.test.tsx
@@ -1,0 +1,169 @@
+import { calculNote } from "./calculsEgaProIndicateurDeuxTrois";
+
+//////////////////
+// INDICATEUR 2 et 3 //
+//////////////////
+
+// Most of functions are directly imported from 2nd indicator
+// So no duplicated tests here
+
+describe("calculNote", () => {
+  test("cant calcul note", () => {
+    expect(calculNote(undefined, undefined, undefined, undefined)).toEqual({
+      note: undefined,
+      correctionMeasure: false
+    });
+  });
+
+  test("test some valid data", () => {
+    expect(calculNote(-2, undefined, undefined, undefined)).toEqual({
+      note: 15,
+      correctionMeasure: false
+    });
+    expect(calculNote(-0.5, undefined, undefined, undefined)).toEqual({
+      note: 15,
+      correctionMeasure: false
+    });
+    expect(calculNote(0, undefined, undefined, undefined)).toEqual({
+      note: 15,
+      correctionMeasure: false
+    });
+    expect(calculNote(0.1, undefined, undefined, undefined)).toEqual({
+      note: 15,
+      correctionMeasure: false
+    });
+    expect(calculNote(0.5, undefined, undefined, undefined)).toEqual({
+      note: 15,
+      correctionMeasure: false
+    });
+    expect(calculNote(1, undefined, undefined, undefined)).toEqual({
+      note: 15,
+      correctionMeasure: false
+    });
+    expect(calculNote(2, undefined, undefined, undefined)).toEqual({
+      note: 15,
+      correctionMeasure: false
+    });
+    expect(calculNote(2.1, undefined, undefined, undefined)).toEqual({
+      note: 10,
+      correctionMeasure: false
+    });
+    expect(calculNote(3.2, undefined, undefined, undefined)).toEqual({
+      note: 10,
+      correctionMeasure: false
+    });
+    expect(calculNote(4, undefined, undefined, undefined)).toEqual({
+      note: 10,
+      correctionMeasure: false
+    });
+    expect(calculNote(5, undefined, undefined, undefined)).toEqual({
+      note: 10,
+      correctionMeasure: false
+    });
+    expect(calculNote(5.1, undefined, undefined, undefined)).toEqual({
+      note: 5,
+      correctionMeasure: false
+    });
+    expect(calculNote(7, undefined, undefined, undefined)).toEqual({
+      note: 5,
+      correctionMeasure: false
+    });
+    expect(calculNote(7.1, undefined, undefined, undefined)).toEqual({
+      note: 5,
+      correctionMeasure: false
+    });
+    expect(calculNote(8, undefined, undefined, undefined)).toEqual({
+      note: 5,
+      correctionMeasure: false
+    });
+    expect(calculNote(10, undefined, undefined, undefined)).toEqual({
+      note: 5,
+      correctionMeasure: false
+    });
+    expect(calculNote(10.1, undefined, undefined, undefined)).toEqual({
+      note: 0,
+      correctionMeasure: false
+    });
+    expect(calculNote(13.2, undefined, undefined, undefined)).toEqual({
+      note: 0,
+      correctionMeasure: false
+    });
+    expect(calculNote(50.5, undefined, undefined, undefined)).toEqual({
+      note: 0,
+      correctionMeasure: false
+    });
+  });
+
+  describe("test round to 1 number after comma", () => {
+    test("round to 2.1", () => {
+      expect(calculNote(2.1, undefined, undefined, undefined)).toEqual({
+        note: 10,
+        correctionMeasure: false
+      });
+      expect(calculNote(2.09, undefined, undefined, undefined)).toEqual({
+        note: 10,
+        correctionMeasure: false
+      });
+      expect(calculNote(2.06, undefined, undefined, undefined)).toEqual({
+        note: 10,
+        correctionMeasure: false
+      });
+      expect(calculNote(2.05, undefined, undefined, undefined)).toEqual({
+        note: 10,
+        correctionMeasure: false
+      });
+    });
+
+    test("round to 2.0", () => {
+      expect(calculNote(2.04, undefined, undefined, undefined)).toEqual({
+        note: 15,
+        correctionMeasure: false
+      });
+      expect(calculNote(2.01, undefined, undefined, undefined)).toEqual({
+        note: 15,
+        correctionMeasure: false
+      });
+      expect(calculNote(2.0, undefined, undefined, undefined)).toEqual({
+        note: 15,
+        correctionMeasure: false
+      });
+    });
+  });
+
+  describe("correction measure from indicateur 1", () => {
+    test("note indicator 1 is 40 so not correction measure", () => {
+      expect(calculNote(2.1, 40, "femmes", "hommes")).toEqual({
+        note: 10,
+        correctionMeasure: false
+      });
+    });
+
+    test("overrepresented sex is same on indicator 1 & 2 so not correction measure", () => {
+      expect(calculNote(8.1, 36, "hommes", "hommes")).toEqual({
+        note: 5,
+        correctionMeasure: false
+      });
+    });
+
+    test("correction measure for men", () => {
+      expect(calculNote(2.1, 39, "femmes", "hommes")).toEqual({
+        note: 15,
+        correctionMeasure: true
+      });
+    });
+
+    test("correction measure for women", () => {
+      expect(calculNote(8.1, 36, "hommes", "femmes")).toEqual({
+        note: 15,
+        correctionMeasure: true
+      });
+    });
+
+    test("note indicator 1 is 0", () => {
+      expect(calculNote(8.1, 0, "hommes", "femmes")).toEqual({
+        note: 15,
+        correctionMeasure: true
+      });
+    });
+  });
+});

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
@@ -1,0 +1,285 @@
+import {
+  AppState,
+  CategorieSocioPro,
+  GroupeEffectif,
+  GroupeIndicateurDeuxTrois
+} from "../globals.d";
+
+import { roundDecimal } from "./helpers";
+
+import {
+  calculEcartsPonderesParGroupe,
+  calculTotalEcartPondere,
+  calculTotalEffectifs,
+  calculEffectifsIndicateurCalculable,
+  rowEffectifsParCategorieSocioPro,
+  effectifGroup
+} from "./calculsEgaPro";
+
+import {
+  calculValiditeGroupe,
+  calculEcartTauxAugmentation,
+  calculIndicateurCalculable,
+  calculIndicateurEcartAugmentation,
+  calculIndicateurSexeSurRepresente,
+  calculIndicateurEcartAugmentationAbsolute
+} from "../utils/calculsEgaProIndicateurDeux";
+import calculIndicateurUn from "./calculsEgaProIndicateurUn";
+
+const baremEcartAugmentationPromotion = [
+  15,
+  15,
+  15,
+  10,
+  10,
+  10,
+  5,
+  5,
+  5,
+  5,
+  5,
+  0
+];
+
+//////////////////
+// COMMON ////////
+//////////////////
+
+export {
+  calculValiditeGroupe, // VG
+  calculTotalEcartPondere, // TEV
+  calculEffectifsIndicateurCalculable, // IC
+  calculIndicateurCalculable // IC
+};
+
+//////////////////
+// INDICATEUR 3 //
+//////////////////
+
+// ETP
+export const calculEcartTauxAugmentationPromotion = calculEcartTauxAugmentation;
+
+export interface effectifEtEcartAugmentationPromotionGroup
+  extends effectifGroup {
+  categorieSocioPro: CategorieSocioPro;
+  tauxAugmentationPromotionFemmes: number | undefined;
+  tauxAugmentationPromotionHommes: number | undefined;
+  ecartTauxAugmentationPromotion: number | undefined;
+}
+
+export const calculEffectifsEtEcartAugmentationPromotionParCategorieSocioPro = (
+  dataEffectif: Array<GroupeEffectif>,
+  dataIndicateurDeuxTrois: Array<GroupeIndicateurDeuxTrois>
+): Array<effectifEtEcartAugmentationPromotionGroup> => {
+  return dataEffectif.map(
+    ({ categorieSocioPro, tranchesAges }: GroupeEffectif) => {
+      const effectifs = rowEffectifsParCategorieSocioPro(
+        tranchesAges,
+        calculValiditeGroupe
+      );
+
+      const dataPromo = dataIndicateurDeuxTrois.find(
+        ({ categorieSocioPro: csp }) => csp === categorieSocioPro
+      );
+
+      const tauxAugmentationPromotionFemmes =
+        dataPromo && dataPromo.tauxAugmentationPromotionFemmes;
+      const tauxAugmentationPromotionHommes =
+        dataPromo && dataPromo.tauxAugmentationPromotionHommes;
+
+      // ETA
+      const ecartTauxAugmentationPromotion = calculEcartTauxAugmentationPromotion(
+        tauxAugmentationPromotionFemmes,
+        tauxAugmentationPromotionHommes
+      );
+
+      return {
+        ...effectifs,
+        categorieSocioPro,
+        tauxAugmentationPromotionFemmes,
+        tauxAugmentationPromotionHommes,
+        ecartTauxAugmentationPromotion
+      };
+    }
+  );
+};
+
+export const calculTotalEffectifsEtTauxAugmentationPromotion = (
+  groupEffectifEtEcartAugment: Array<effectifEtEcartAugmentationPromotionGroup>
+) => {
+  const {
+    totalNombreSalariesFemmes,
+    totalNombreSalariesHommes,
+    totalNombreSalaries,
+    totalEffectifsValides
+  } = calculTotalEffectifs(groupEffectifEtEcartAugment);
+
+  const {
+    sommeProduitTauxAugmentationPromotionFemmes,
+    sommeProduitTauxAugmentationPromotionHommes
+  } = groupEffectifEtEcartAugment.reduce(
+    (
+      {
+        sommeProduitTauxAugmentationPromotionFemmes,
+        sommeProduitTauxAugmentationPromotionHommes
+      },
+      {
+        nombreSalariesFemmes,
+        nombreSalariesHommes,
+        tauxAugmentationPromotionFemmes,
+        tauxAugmentationPromotionHommes
+      }
+    ) => {
+      return {
+        sommeProduitTauxAugmentationPromotionFemmes:
+          sommeProduitTauxAugmentationPromotionFemmes +
+          (tauxAugmentationPromotionFemmes || 0) * nombreSalariesFemmes,
+        sommeProduitTauxAugmentationPromotionHommes:
+          sommeProduitTauxAugmentationPromotionHommes +
+          (tauxAugmentationPromotionHommes || 0) * nombreSalariesHommes
+      };
+    },
+    {
+      sommeProduitTauxAugmentationPromotionFemmes: 0,
+      sommeProduitTauxAugmentationPromotionHommes: 0
+    }
+  );
+
+  // TTPF
+  const totalTauxAugmentationPromotionFemmes =
+    sommeProduitTauxAugmentationPromotionFemmes / totalNombreSalariesFemmes;
+
+  // TTPH
+  const totalTauxAugmentationPromotionHommes =
+    sommeProduitTauxAugmentationPromotionHommes / totalNombreSalariesHommes;
+
+  return {
+    totalNombreSalaries,
+    totalEffectifsValides,
+    totalTauxAugmentationPromotionFemmes,
+    totalTauxAugmentationPromotionHommes
+  };
+};
+
+export const calculEcartsPonderesParCategorieSocioPro = calculEcartsPonderesParGroupe(
+  ({ ecartTauxAugmentationPromotion }) => ecartTauxAugmentationPromotion
+);
+
+// IEP
+export const calculIndicateurEcartAugmentationPromotion = calculIndicateurEcartAugmentation;
+
+export const calculIndicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationAbsolute;
+
+// NOTE
+export const calculNote = (
+  indicateurEcartAugmentationPromotion: number | undefined,
+  noteIndicateurUn: number | undefined,
+  indicateurUnSexeSurRepresente: "hommes" | "femmes" | undefined,
+  indicateurDeuxSexeSurRepresente: "hommes" | "femmes" | undefined
+): { note: number | undefined; correctionMeasure: boolean } => {
+  if (
+    noteIndicateurUn !== undefined &&
+    noteIndicateurUn < 40 &&
+    indicateurUnSexeSurRepresente &&
+    indicateurDeuxSexeSurRepresente &&
+    indicateurUnSexeSurRepresente !== indicateurDeuxSexeSurRepresente
+  ) {
+    return {
+      note: baremEcartAugmentationPromotion[0],
+      correctionMeasure: true
+    };
+  }
+  const note =
+    indicateurEcartAugmentationPromotion !== undefined
+      ? baremEcartAugmentationPromotion[
+          Math.min(
+            baremEcartAugmentationPromotion.length - 1,
+            Math.ceil(
+              Math.max(0, roundDecimal(indicateurEcartAugmentationPromotion, 1))
+            )
+          )
+        ]
+      : undefined;
+  return { note, correctionMeasure: false };
+};
+
+/////////
+// ALL //
+/////////
+
+export default function calculIndicateurDeuxTrois(state: AppState) {
+  const effectifEtEcartAugmentationPromotionParGroupe = calculEffectifsEtEcartAugmentationPromotionParCategorieSocioPro(
+    state.effectif.nombreSalaries,
+    state.indicateurDeuxTrois.tauxAugmentationPromotion
+  );
+
+  const {
+    totalNombreSalaries,
+    totalEffectifsValides,
+    totalTauxAugmentationPromotionFemmes,
+    totalTauxAugmentationPromotionHommes
+  } = calculTotalEffectifsEtTauxAugmentationPromotion(
+    effectifEtEcartAugmentationPromotionParGroupe
+  );
+
+  const ecartsPonderesByRow = calculEcartsPonderesParCategorieSocioPro(
+    effectifEtEcartAugmentationPromotionParGroupe,
+    totalEffectifsValides
+  );
+
+  // TEP
+  const totalEcartPondere = calculTotalEcartPondere(ecartsPonderesByRow);
+
+  // IC
+  const effectifsIndicateurCalculable = calculEffectifsIndicateurCalculable(
+    totalNombreSalaries,
+    totalEffectifsValides
+  );
+
+  // IC
+  const indicateurCalculable = calculIndicateurCalculable(
+    state.indicateurDeuxTrois.presenceAugmentationPromotion,
+    totalNombreSalaries,
+    totalEffectifsValides,
+    totalTauxAugmentationPromotionFemmes,
+    totalTauxAugmentationPromotionHommes
+  );
+
+  // IEA
+  const indicateurEcartAugmentationPromotion = calculIndicateurEcartAugmentationPromotion(
+    indicateurCalculable,
+    totalEcartPondere
+  );
+
+  const indicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationPromotionAbsolute(
+    indicateurEcartAugmentationPromotion
+  );
+
+  const indicateurDeuxTroisSexeSurRepresente = calculIndicateurSexeSurRepresente(
+    indicateurEcartAugmentationPromotion
+  );
+
+  // Mesures correction indicateur 1
+  const {
+    indicateurSexeSurRepresente: indicateurUnSexeSurRepresente,
+    noteIndicateurUn
+  } = calculIndicateurUn(state);
+
+  // NOTE
+  const { note: noteIndicateurDeuxTrois, correctionMeasure } = calculNote(
+    indicateurEcartAugmentationPromotionAbsolute,
+    noteIndicateurUn,
+    indicateurUnSexeSurRepresente,
+    indicateurDeuxTroisSexeSurRepresente
+  );
+
+  return {
+    effectifsIndicateurCalculable,
+    effectifEtEcartAugmentationPromotionParGroupe,
+    indicateurCalculable,
+    indicateurEcartAugmentationPromotion: indicateurEcartAugmentationPromotionAbsolute,
+    indicateurSexeSurRepresente: indicateurDeuxTroisSexeSurRepresente,
+    noteIndicateurDeuxTrois,
+    correctionMeasure
+  };
+}

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
@@ -1,298 +1,154 @@
-import {
-  AppState,
-  CategorieSocioPro,
-  GroupeEffectif,
-  GroupeIndicateurDeuxTrois
-} from "../globals.d";
+import { AppState } from "../globals.d";
 
 import { roundDecimal } from "./helpers";
+import totalNombreSalaries from "./totalNombreSalaries";
 
 import {
-  calculEcartsPonderesParGroupe,
-  calculTotalEcartPondere,
-  calculTotalEffectifs,
-  calculEffectifsIndicateurCalculable,
-  rowEffectifsParCategorieSocioPro,
-  effectifGroup
-} from "./calculsEgaPro";
-
-import {
-  calculValiditeGroupe,
   calculEcartTauxAugmentation,
-  calculIndicateurCalculable,
   calculIndicateurEcartAugmentation,
-  // calculIndicateurSexeSurRepresente,
+  calculIndicateurSexeSurRepresente,
   calculIndicateurEcartAugmentationAbsolute
 } from "../utils/calculsEgaProIndicateurDeux";
-// import calculIndicateurUn from "./calculsEgaProIndicateurUn";
 
-const baremEcartAugmentationPromotion = [
-  15,
-  15,
-  15,
-  10,
-  10,
-  10,
-  5,
-  5,
-  5,
-  5,
-  5,
-  0
-];
+const barem = [35, 35, 35, 25, 25, 25, 15, 15, 15, 15, 15, 0];
 
-//////////////////
-// COMMON ////////
-//////////////////
+///////////////////////
+// INDICATEUR 2 ET 3 //
+///////////////////////
 
-export {
-  calculValiditeGroupe, // VG
-  calculTotalEcartPondere, // TEV
-  calculEffectifsIndicateurCalculable, // IC
-  calculIndicateurCalculable // IC
-};
-
-//////////////////
-// INDICATEUR 3 //
-//////////////////
-
-// ETP
+// // ETP
 export const calculEcartTauxAugmentationPromotion = calculEcartTauxAugmentation;
 
-export interface effectifEtEcartAugmentationPromotionGroup
-  extends effectifGroup {
-  categorieSocioPro: CategorieSocioPro;
-  tauxAugmentationPromotionFemmes: number | undefined;
-  tauxAugmentationPromotionHommes: number | undefined;
-  ecartTauxAugmentationPromotion: number | undefined;
-}
-
-export const calculEffectifsEtEcartAugmentationPromotionParCategorieSocioPro = (
-  dataEffectif: Array<GroupeEffectif>,
-  dataIndicateurDeuxTrois: Array<GroupeIndicateurDeuxTrois>
-): Array<effectifEtEcartAugmentationPromotionGroup> => {
-  return dataEffectif.map(
-    ({ categorieSocioPro, tranchesAges }: GroupeEffectif) => {
-      const effectifs = rowEffectifsParCategorieSocioPro(
-        tranchesAges,
-        calculValiditeGroupe
-      );
-
-      const dataPromo = dataIndicateurDeuxTrois.find(
-        ({ categorieSocioPro: csp }) => csp === categorieSocioPro
-      );
-
-      const tauxAugmentationPromotionFemmes =
-        dataPromo && dataPromo.tauxAugmentationPromotionFemmes;
-      const tauxAugmentationPromotionHommes =
-        dataPromo && dataPromo.tauxAugmentationPromotionHommes;
-
-      // ETA
-      const ecartTauxAugmentationPromotion = calculEcartTauxAugmentationPromotion(
-        tauxAugmentationPromotionFemmes,
-        tauxAugmentationPromotionHommes
-      );
-
-      return {
-        ...effectifs,
-        categorieSocioPro,
-        tauxAugmentationPromotionFemmes,
-        tauxAugmentationPromotionHommes,
-        ecartTauxAugmentationPromotion
-      };
-    }
-  );
-};
-
-export const calculTotalEffectifsEtTauxAugmentationPromotion = (
-  groupEffectifEtEcartAugment: Array<effectifEtEcartAugmentationPromotionGroup>
-) => {
-  const {
-    totalNombreSalariesFemmes,
-    totalNombreSalariesHommes,
-    totalNombreSalaries,
-    totalEffectifsValides
-  } = calculTotalEffectifs(groupEffectifEtEcartAugment);
-
-  const {
-    sommeProduitTauxAugmentationPromotionFemmes,
-    sommeProduitTauxAugmentationPromotionHommes
-  } = groupEffectifEtEcartAugment.reduce(
-    (
-      {
-        sommeProduitTauxAugmentationPromotionFemmes,
-        sommeProduitTauxAugmentationPromotionHommes
-      },
-      {
-        nombreSalariesFemmes,
-        nombreSalariesHommes,
-        tauxAugmentationPromotionFemmes,
-        tauxAugmentationPromotionHommes
-      }
-    ) => {
-      return {
-        sommeProduitTauxAugmentationPromotionFemmes:
-          sommeProduitTauxAugmentationPromotionFemmes +
-          (tauxAugmentationPromotionFemmes || 0) * nombreSalariesFemmes,
-        sommeProduitTauxAugmentationPromotionHommes:
-          sommeProduitTauxAugmentationPromotionHommes +
-          (tauxAugmentationPromotionHommes || 0) * nombreSalariesHommes
-      };
-    },
-    {
-      sommeProduitTauxAugmentationPromotionFemmes: 0,
-      sommeProduitTauxAugmentationPromotionHommes: 0
-    }
-  );
-
-  // TTPF
-  const totalTauxAugmentationPromotionFemmes =
-    sommeProduitTauxAugmentationPromotionFemmes / totalNombreSalariesFemmes;
-
-  // TTPH
-  const totalTauxAugmentationPromotionHommes =
-    sommeProduitTauxAugmentationPromotionHommes / totalNombreSalariesHommes;
-
-  return {
-    totalNombreSalaries,
-    totalEffectifsValides,
-    totalTauxAugmentationPromotionFemmes,
-    totalTauxAugmentationPromotionHommes
-  };
-};
-
-export const calculEcartsPonderesParCategorieSocioPro = calculEcartsPonderesParGroupe(
-  ({ ecartTauxAugmentationPromotion }) => ecartTauxAugmentationPromotion
-);
-
-// IEP
+// // IEP
 export const calculIndicateurEcartAugmentationPromotion = calculIndicateurEcartAugmentation;
 
 export const calculIndicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationAbsolute;
 
-// NOTE
+// // IC
+export const calculIndicateurCalculable = (
+  totalNombreSalariesHommes: number | undefined,
+  totalNombreSalariesFemmes: number | undefined
+): boolean => {
+  return (
+    totalNombreSalariesHommes !== undefined &&
+    totalNombreSalariesFemmes !== undefined &&
+    totalNombreSalariesHommes >= 5 &&
+    totalNombreSalariesFemmes >= 5
+  );
+};
+
+export const calculTaux = (
+  nombreSalaries: number | undefined,
+  totalNombreSalaries: number | undefined
+): number | undefined =>
+  nombreSalaries !== undefined &&
+  totalNombreSalaries !== undefined &&
+  totalNombreSalaries > 0
+    ? nombreSalaries / totalNombreSalaries
+    : undefined;
+
+export const calculIndicateurEcartNombreEquivalentSalaries = (
+  indicateurEcartAugmentationPromotionAbsolute: number | undefined,
+  totalNombreSalariesHommes: number | undefined,
+  totalNombreSalariesFemmes: number | undefined
+): number | undefined => {
+  return indicateurEcartAugmentationPromotionAbsolute !== undefined &&
+    totalNombreSalariesHommes !== undefined &&
+    totalNombreSalariesFemmes !== undefined
+    ? roundDecimal(
+        (indicateurEcartAugmentationPromotionAbsolute *
+          Math.min(totalNombreSalariesHommes, totalNombreSalariesFemmes)) /
+          100,
+        1
+      )
+    : undefined;
+};
+
+// // NOTE
+
+export const calculBarem = (indicateur: number): number => {
+  return barem[
+    Math.min(
+      barem.length - 1,
+      Math.ceil(Math.max(0, roundDecimal(indicateur, 1)))
+    )
+  ];
+};
+
 export const calculNote = (
-  indicateurEcartAugmentationPromotion: number | undefined,
-  noteIndicateurUn: number | undefined,
-  indicateurUnSexeSurRepresente: "hommes" | "femmes" | undefined,
-  indicateurDeuxSexeSurRepresente: "hommes" | "femmes" | undefined
-): { note: number | undefined; correctionMeasure: boolean } => {
-  if (
-    noteIndicateurUn !== undefined &&
-    noteIndicateurUn < 40 &&
-    indicateurUnSexeSurRepresente &&
-    indicateurDeuxSexeSurRepresente &&
-    indicateurUnSexeSurRepresente !== indicateurDeuxSexeSurRepresente
-  ) {
-    return {
-      note: baremEcartAugmentationPromotion[0],
-      correctionMeasure: true
-    };
+  ecartTaux: number | undefined,
+  ecartNombreSalaries: number | undefined
+): number | undefined => {
+  if (ecartTaux === undefined || ecartNombreSalaries === undefined) {
+    return undefined;
   }
-  const note =
-    indicateurEcartAugmentationPromotion !== undefined
-      ? baremEcartAugmentationPromotion[
-          Math.min(
-            baremEcartAugmentationPromotion.length - 1,
-            Math.ceil(
-              Math.max(0, roundDecimal(indicateurEcartAugmentationPromotion, 1))
-            )
-          )
-        ]
-      : undefined;
-  return { note, correctionMeasure: false };
+  const noteEcartTaux = calculBarem(ecartTaux);
+  const noteEcartNombreSalaries = calculBarem(ecartNombreSalaries);
+
+  return Math.max(noteEcartTaux, noteEcartNombreSalaries);
 };
 
 /////////
 // ALL //
 /////////
 
-// TODO: complete the computation
-// export default function calculIndicateurDeuxTrois(state: AppState) {
-//   const effectifEtEcartAugmentationPromotionParGroupe = calculEffectifsEtEcartAugmentationPromotionParCategorieSocioPro(
-//     state.effectif.nombreSalaries,
-//     state.indicateurDeuxTrois.tauxAugmentationPromotion
-//   );
-
-//   const {
-//     totalNombreSalaries,
-//     totalEffectifsValides,
-//     totalTauxAugmentationPromotionFemmes,
-//     totalTauxAugmentationPromotionHommes
-//   } = calculTotalEffectifsEtTauxAugmentationPromotion(
-//     effectifEtEcartAugmentationPromotionParGroupe
-//   );
-
-//   const ecartsPonderesByRow = calculEcartsPonderesParCategorieSocioPro(
-//     effectifEtEcartAugmentationPromotionParGroupe,
-//     totalEffectifsValides
-//   );
-
-//   // TEP
-//   const totalEcartPondere = calculTotalEcartPondere(ecartsPonderesByRow);
-
-//   // IC
-//   const effectifsIndicateurCalculable = calculEffectifsIndicateurCalculable(
-//     totalNombreSalaries,
-//     totalEffectifsValides
-//   );
-
-//   // IC
-//   const indicateurCalculable = calculIndicateurCalculable(
-//     state.indicateurDeuxTrois.presenceAugmentationPromotion,
-//     totalNombreSalaries,
-//     totalEffectifsValides,
-//     totalTauxAugmentationPromotionFemmes,
-//     totalTauxAugmentationPromotionHommes
-//   );
-
-//   // IEA
-//   const indicateurEcartAugmentationPromotion = calculIndicateurEcartAugmentationPromotion(
-//     indicateurCalculable,
-//     totalEcartPondere
-//   );
-
-//   const indicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationPromotionAbsolute(
-//     indicateurEcartAugmentationPromotion
-//   );
-
-//   const indicateurDeuxTroisSexeSurRepresente = calculIndicateurSexeSurRepresente(
-//     indicateurEcartAugmentationPromotion
-//   );
-
-//   // Mesures correction indicateur 1
-//   const {
-//     indicateurSexeSurRepresente: indicateurUnSexeSurRepresente,
-//     noteIndicateurUn
-//   } = calculIndicateurUn(state);
-
-//   // NOTE
-//   const { note: noteIndicateurDeuxTrois, correctionMeasure } = calculNote(
-//     indicateurEcartAugmentationPromotionAbsolute,
-//     noteIndicateurUn,
-//     indicateurUnSexeSurRepresente,
-//     indicateurDeuxTroisSexeSurRepresente
-//   );
-
-//   return {
-//     effectifsIndicateurCalculable,
-//     effectifEtEcartAugmentationPromotionParGroupe,
-//     indicateurCalculable,
-//     indicateurEcartAugmentationPromotion: indicateurEcartAugmentationPromotionAbsolute,
-//     indicateurSexeSurRepresente: indicateurDeuxTroisSexeSurRepresente,
-//     noteIndicateurDeuxTrois,
-//     correctionMeasure
-//   };
-// }
 export default function calculIndicateurDeuxTrois(state: AppState) {
-  const indicateurSexeSurRepresente: "hommes" | "femmes" | undefined = "hommes";
+  const {
+    totalNombreSalariesHomme: totalNombreSalariesHommes,
+    totalNombreSalariesFemme: totalNombreSalariesFemmes
+  } = totalNombreSalaries(state.effectif.nombreSalaries);
+
+  const indicateurCalculable = calculIndicateurCalculable(
+    totalNombreSalariesHommes,
+    totalNombreSalariesFemmes
+  );
+
+  const tauxAugmentationPromotionHommes = calculTaux(
+    state.indicateurDeuxTrois.nombreAugmentationPromotionHommes,
+    totalNombreSalariesHommes
+  );
+  const tauxAugmentationPromotionFemmes = calculTaux(
+    state.indicateurDeuxTrois.nombreAugmentationPromotionFemmes,
+    totalNombreSalariesFemmes
+  );
+
+  // // IEA
+  const ecartTauxAugmentationPromotion = calculEcartTauxAugmentationPromotion(
+    tauxAugmentationPromotionFemmes,
+    tauxAugmentationPromotionHommes
+  );
+
+  const indicateurEcartAugmentationPromotion = calculIndicateurEcartAugmentationPromotion(
+    indicateurCalculable,
+    ecartTauxAugmentationPromotion
+  );
+
+  const indicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationPromotionAbsolute(
+    indicateurEcartAugmentationPromotion
+  );
+
+  const indicateurSexeSurRepresente = calculIndicateurSexeSurRepresente(
+    indicateurEcartAugmentationPromotion
+  );
+
+  // // Ecart en nombre équivalent de salariés
+  const indicateurEcartNombreEquivalentSalaries = calculIndicateurEcartNombreEquivalentSalaries(
+    indicateurEcartAugmentationPromotionAbsolute,
+    totalNombreSalariesHommes,
+    totalNombreSalariesFemmes
+  );
+
+  // // NOTE
+  const noteIndicateurDeuxTrois = calculNote(
+    indicateurEcartAugmentationPromotionAbsolute,
+    indicateurEcartNombreEquivalentSalaries
+  );
+
   return {
-    effectifsIndicateurCalculable: 10,
-    effectifEtEcartAugmentationPromotionParGroupe: 0,
-    indicateurCalculable: true,
-    indicateurEcartAugmentationPromotion: 0,
-    indicateurSexeSurRepresente: indicateurSexeSurRepresente,
-    noteIndicateurDeuxTrois: 0,
-    correctionMeasure: false
+    indicateurCalculable,
+    indicateurEcartAugmentationPromotion: indicateurEcartAugmentationPromotionAbsolute,
+    indicateurEcartNombreEquivalentSalaries,
+    indicateurSexeSurRepresente,
+    noteIndicateurDeuxTrois
   };
 }

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
@@ -26,7 +26,7 @@ export const calculIndicateurEcartAugmentationPromotion = calculIndicateurEcartA
 export const calculIndicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationAbsolute;
 
 // // IC
-export const calculIndicateurCalculable = (
+export const calculEffectifsIndicateurCalculable = (
   totalNombreSalariesHommes: number | undefined,
   totalNombreSalariesFemmes: number | undefined
 ): boolean => {
@@ -38,6 +38,13 @@ export const calculIndicateurCalculable = (
   );
 };
 
+export const calculIndicateurCalculable = (
+  presenceAugmentationPromotion: boolean,
+  effectifsIndicateurCalculable: boolean
+): boolean => {
+  return presenceAugmentationPromotion && effectifsIndicateurCalculable;
+};
+
 export const calculTaux = (
   nombreSalaries: number | undefined,
   totalNombreSalaries: number | undefined
@@ -47,6 +54,22 @@ export const calculTaux = (
   totalNombreSalaries > 0
     ? nombreSalaries / totalNombreSalaries
     : undefined;
+
+export const calculPlusPetitNombreSalaries = (
+  totalNombreSalariesHommes: number | undefined,
+  totalNombreSalariesFemmes: number | undefined
+): "hommes" | "femmes" | undefined => {
+  if (
+    totalNombreSalariesFemmes === totalNombreSalariesHommes ||
+    totalNombreSalariesFemmes === undefined ||
+    totalNombreSalariesHommes === undefined
+  ) {
+    return undefined;
+  }
+  return totalNombreSalariesHommes > totalNombreSalariesFemmes
+    ? "hommes"
+    : "femmes";
+};
 
 export const calculIndicateurEcartNombreEquivalentSalaries = (
   indicateurEcartAugmentationPromotionAbsolute: number | undefined,
@@ -112,9 +135,19 @@ export default function calculIndicateurDeuxTrois(state: AppState) {
     totalNombreSalariesFemme: totalNombreSalariesFemmes
   } = totalNombreSalaries(state.effectif.nombreSalaries);
 
-  const indicateurCalculable = calculIndicateurCalculable(
+  const plusPetitNombreSalaries = calculPlusPetitNombreSalaries(
     totalNombreSalariesHommes,
     totalNombreSalariesFemmes
+  );
+
+  const effectifsIndicateurCalculable = calculEffectifsIndicateurCalculable(
+    totalNombreSalariesHommes,
+    totalNombreSalariesFemmes
+  );
+
+  const indicateurCalculable = calculIndicateurCalculable(
+    state.indicateurDeuxTrois.presenceAugmentationPromotion,
+    effectifsIndicateurCalculable
   );
 
   const tauxAugmentationPromotionHommes = calculTaux(
@@ -168,11 +201,15 @@ export default function calculIndicateurDeuxTrois(state: AppState) {
   );
 
   return {
+    effectifsIndicateurCalculable,
     indicateurCalculable,
     indicateurEcartAugmentationPromotion: indicateurEcartAugmentationPromotionAbsolute,
     indicateurEcartNombreEquivalentSalaries,
     indicateurSexeSurRepresente,
     noteIndicateurDeuxTrois,
-    correctionMeasure
+    correctionMeasure,
+    tauxAugmentationPromotionHommes,
+    tauxAugmentationPromotionFemmes,
+    plusPetitNombreSalaries
   };
 }

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
@@ -1,5 +1,6 @@
 import { AppState } from "../globals.d";
 
+import calculIndicateurUn from "./calculsEgaProIndicateurUn";
 import { roundDecimal } from "./helpers";
 import totalNombreSalaries from "./totalNombreSalaries";
 
@@ -77,15 +78,28 @@ export const calculBarem = (indicateur: number): number => {
 
 export const calculNote = (
   ecartTaux: number | undefined,
-  ecartNombreSalaries: number | undefined
-): number | undefined => {
+  ecartNombreSalaries: number | undefined,
+  noteIndicateurUn: number | undefined,
+  indicateurUnSexeSurRepresente: "hommes" | "femmes" | undefined,
+  indicateurDeuxTroisSexeSurRepresente: "hommes" | "femmes" | undefined
+): { note: number | undefined; correctionMeasure: boolean } => {
+  if (
+    noteIndicateurUn !== undefined &&
+    noteIndicateurUn < 40 &&
+    indicateurUnSexeSurRepresente &&
+    indicateurDeuxTroisSexeSurRepresente &&
+    indicateurUnSexeSurRepresente !== indicateurDeuxTroisSexeSurRepresente
+  ) {
+    return { note: barem[0], correctionMeasure: true };
+  }
   if (ecartTaux === undefined || ecartNombreSalaries === undefined) {
-    return undefined;
+    return { note: undefined, correctionMeasure: false };
   }
   const noteEcartTaux = calculBarem(ecartTaux);
   const noteEcartNombreSalaries = calculBarem(ecartNombreSalaries);
 
-  return Math.max(noteEcartTaux, noteEcartNombreSalaries);
+  const note = Math.max(noteEcartTaux, noteEcartNombreSalaries);
+  return { note, correctionMeasure: false };
 };
 
 /////////
@@ -138,10 +152,19 @@ export default function calculIndicateurDeuxTrois(state: AppState) {
     totalNombreSalariesFemmes
   );
 
+  // Mesures correction indicateur 1
+  const {
+    indicateurSexeSurRepresente: indicateurUnSexeSurRepresente,
+    noteIndicateurUn
+  } = calculIndicateurUn(state);
+
   // // NOTE
-  const noteIndicateurDeuxTrois = calculNote(
+  const { note: noteIndicateurDeuxTrois, correctionMeasure } = calculNote(
     indicateurEcartAugmentationPromotionAbsolute,
-    indicateurEcartNombreEquivalentSalaries
+    indicateurEcartNombreEquivalentSalaries,
+    noteIndicateurUn,
+    indicateurUnSexeSurRepresente,
+    indicateurSexeSurRepresente
   );
 
   return {
@@ -149,6 +172,7 @@ export default function calculIndicateurDeuxTrois(state: AppState) {
     indicateurEcartAugmentationPromotion: indicateurEcartAugmentationPromotionAbsolute,
     indicateurEcartNombreEquivalentSalaries,
     indicateurSexeSurRepresente,
-    noteIndicateurDeuxTrois
+    noteIndicateurDeuxTrois,
+    correctionMeasure
   };
 }

--- a/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
+++ b/packages/app/src/utils/calculsEgaProIndicateurDeuxTrois.tsx
@@ -21,10 +21,10 @@ import {
   calculEcartTauxAugmentation,
   calculIndicateurCalculable,
   calculIndicateurEcartAugmentation,
-  calculIndicateurSexeSurRepresente,
+  // calculIndicateurSexeSurRepresente,
   calculIndicateurEcartAugmentationAbsolute
 } from "../utils/calculsEgaProIndicateurDeux";
-import calculIndicateurUn from "./calculsEgaProIndicateurUn";
+// import calculIndicateurUn from "./calculsEgaProIndicateurUn";
 
 const baremEcartAugmentationPromotion = [
   15,
@@ -207,79 +207,92 @@ export const calculNote = (
 // ALL //
 /////////
 
+// TODO: complete the computation
+// export default function calculIndicateurDeuxTrois(state: AppState) {
+//   const effectifEtEcartAugmentationPromotionParGroupe = calculEffectifsEtEcartAugmentationPromotionParCategorieSocioPro(
+//     state.effectif.nombreSalaries,
+//     state.indicateurDeuxTrois.tauxAugmentationPromotion
+//   );
+
+//   const {
+//     totalNombreSalaries,
+//     totalEffectifsValides,
+//     totalTauxAugmentationPromotionFemmes,
+//     totalTauxAugmentationPromotionHommes
+//   } = calculTotalEffectifsEtTauxAugmentationPromotion(
+//     effectifEtEcartAugmentationPromotionParGroupe
+//   );
+
+//   const ecartsPonderesByRow = calculEcartsPonderesParCategorieSocioPro(
+//     effectifEtEcartAugmentationPromotionParGroupe,
+//     totalEffectifsValides
+//   );
+
+//   // TEP
+//   const totalEcartPondere = calculTotalEcartPondere(ecartsPonderesByRow);
+
+//   // IC
+//   const effectifsIndicateurCalculable = calculEffectifsIndicateurCalculable(
+//     totalNombreSalaries,
+//     totalEffectifsValides
+//   );
+
+//   // IC
+//   const indicateurCalculable = calculIndicateurCalculable(
+//     state.indicateurDeuxTrois.presenceAugmentationPromotion,
+//     totalNombreSalaries,
+//     totalEffectifsValides,
+//     totalTauxAugmentationPromotionFemmes,
+//     totalTauxAugmentationPromotionHommes
+//   );
+
+//   // IEA
+//   const indicateurEcartAugmentationPromotion = calculIndicateurEcartAugmentationPromotion(
+//     indicateurCalculable,
+//     totalEcartPondere
+//   );
+
+//   const indicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationPromotionAbsolute(
+//     indicateurEcartAugmentationPromotion
+//   );
+
+//   const indicateurDeuxTroisSexeSurRepresente = calculIndicateurSexeSurRepresente(
+//     indicateurEcartAugmentationPromotion
+//   );
+
+//   // Mesures correction indicateur 1
+//   const {
+//     indicateurSexeSurRepresente: indicateurUnSexeSurRepresente,
+//     noteIndicateurUn
+//   } = calculIndicateurUn(state);
+
+//   // NOTE
+//   const { note: noteIndicateurDeuxTrois, correctionMeasure } = calculNote(
+//     indicateurEcartAugmentationPromotionAbsolute,
+//     noteIndicateurUn,
+//     indicateurUnSexeSurRepresente,
+//     indicateurDeuxTroisSexeSurRepresente
+//   );
+
+//   return {
+//     effectifsIndicateurCalculable,
+//     effectifEtEcartAugmentationPromotionParGroupe,
+//     indicateurCalculable,
+//     indicateurEcartAugmentationPromotion: indicateurEcartAugmentationPromotionAbsolute,
+//     indicateurSexeSurRepresente: indicateurDeuxTroisSexeSurRepresente,
+//     noteIndicateurDeuxTrois,
+//     correctionMeasure
+//   };
+// }
 export default function calculIndicateurDeuxTrois(state: AppState) {
-  const effectifEtEcartAugmentationPromotionParGroupe = calculEffectifsEtEcartAugmentationPromotionParCategorieSocioPro(
-    state.effectif.nombreSalaries,
-    state.indicateurDeuxTrois.tauxAugmentationPromotion
-  );
-
-  const {
-    totalNombreSalaries,
-    totalEffectifsValides,
-    totalTauxAugmentationPromotionFemmes,
-    totalTauxAugmentationPromotionHommes
-  } = calculTotalEffectifsEtTauxAugmentationPromotion(
-    effectifEtEcartAugmentationPromotionParGroupe
-  );
-
-  const ecartsPonderesByRow = calculEcartsPonderesParCategorieSocioPro(
-    effectifEtEcartAugmentationPromotionParGroupe,
-    totalEffectifsValides
-  );
-
-  // TEP
-  const totalEcartPondere = calculTotalEcartPondere(ecartsPonderesByRow);
-
-  // IC
-  const effectifsIndicateurCalculable = calculEffectifsIndicateurCalculable(
-    totalNombreSalaries,
-    totalEffectifsValides
-  );
-
-  // IC
-  const indicateurCalculable = calculIndicateurCalculable(
-    state.indicateurDeuxTrois.presenceAugmentationPromotion,
-    totalNombreSalaries,
-    totalEffectifsValides,
-    totalTauxAugmentationPromotionFemmes,
-    totalTauxAugmentationPromotionHommes
-  );
-
-  // IEA
-  const indicateurEcartAugmentationPromotion = calculIndicateurEcartAugmentationPromotion(
-    indicateurCalculable,
-    totalEcartPondere
-  );
-
-  const indicateurEcartAugmentationPromotionAbsolute = calculIndicateurEcartAugmentationPromotionAbsolute(
-    indicateurEcartAugmentationPromotion
-  );
-
-  const indicateurDeuxTroisSexeSurRepresente = calculIndicateurSexeSurRepresente(
-    indicateurEcartAugmentationPromotion
-  );
-
-  // Mesures correction indicateur 1
-  const {
-    indicateurSexeSurRepresente: indicateurUnSexeSurRepresente,
-    noteIndicateurUn
-  } = calculIndicateurUn(state);
-
-  // NOTE
-  const { note: noteIndicateurDeuxTrois, correctionMeasure } = calculNote(
-    indicateurEcartAugmentationPromotionAbsolute,
-    noteIndicateurUn,
-    indicateurUnSexeSurRepresente,
-    indicateurDeuxTroisSexeSurRepresente
-  );
-
+  const indicateurSexeSurRepresente: "hommes" | "femmes" | undefined = "hommes";
   return {
-    effectifsIndicateurCalculable,
-    effectifEtEcartAugmentationPromotionParGroupe,
-    indicateurCalculable,
-    indicateurEcartAugmentationPromotion: indicateurEcartAugmentationPromotionAbsolute,
-    indicateurSexeSurRepresente: indicateurDeuxTroisSexeSurRepresente,
-    noteIndicateurDeuxTrois,
-    correctionMeasure
+    effectifsIndicateurCalculable: 10,
+    effectifEtEcartAugmentationPromotionParGroupe: 0,
+    indicateurCalculable: true,
+    indicateurEcartAugmentationPromotion: 0,
+    indicateurSexeSurRepresente: indicateurSexeSurRepresente,
+    noteIndicateurDeuxTrois: 0,
+    correctionMeasure: false
   };
 }

--- a/packages/app/src/utils/formHelpers.tsx
+++ b/packages/app/src/utils/formHelpers.tsx
@@ -1,4 +1,5 @@
 import { fractionToPercentage, percentageToFraction } from "./helpers";
+import { PeriodeDeclaration } from "../globals.d";
 
 // INT PARSE
 
@@ -35,6 +36,21 @@ export const parseFloatStateValue = (value: number | undefined) =>
 export const parseBooleanFormValue = (value: string) => value === "true";
 
 export const parseBooleanStateValue = (value: boolean) => String(value);
+
+// PeriodeDeclaration PARSE
+
+export const parsePeriodeDeclarationFormValue = (
+  value: string
+): PeriodeDeclaration => {
+  switch (value) {
+    case "deuxPeriodesReference":
+      return "deuxPeriodesReference" as PeriodeDeclaration;
+    case "troisPeriodesReference":
+      return "troisPeriodesReference" as PeriodeDeclaration;
+    default:
+      return "unePeriodeReference" as PeriodeDeclaration;
+  }
+};
 
 // VALIDATION
 

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -44,7 +44,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
   );
 
   const {
-    indicateurCalculable,
+    effectifsIndicateurCalculable,
     indicateurEcartAugmentationPromotion,
     indicateurEcartNombreEquivalentSalaries,
     indicateurSexeSurRepresente,
@@ -70,7 +70,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
   }
 
   // les effectifs ne permettent pas de calculer l'indicateur
-  if (!indicateurCalculable) {
+  if (!effectifsIndicateurCalculable) {
     return (
       <PageIndicateurDeuxTrois>
         <div>
@@ -89,8 +89,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
   // formulaire indicateur validé mais données renseignées ne permettent pas de calculer l'indicateur
   if (
     state.indicateurDeuxTrois.formValidated === "Valid" &&
-    (!state.indicateurDeuxTrois.presenceAugmentationPromotion &&
-      state.indicateurDeuxTrois.periodeDeclaration === "unePeriodeReference")
+    !state.indicateurDeuxTrois.presenceAugmentationPromotion
   ) {
     return (
       <PageIndicateurDeuxTrois>

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -44,13 +44,11 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
   );
 
   const {
-    effectifsIndicateurCalculable,
-    // effectifEtEcartAugmentationPromotionParGroupe,
     indicateurCalculable,
     indicateurEcartAugmentationPromotion,
+    indicateurEcartNombreEquivalentSalaries,
     indicateurSexeSurRepresente,
-    noteIndicateurDeuxTrois,
-    correctionMeasure
+    noteIndicateurDeuxTrois
   } = calculIndicateurDeuxTrois(state);
 
   // le formulaire d'effectif n'est pas validé
@@ -71,15 +69,13 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
   }
 
   // les effectifs ne permettent pas de calculer l'indicateur
-  if (!effectifsIndicateurCalculable) {
+  if (!indicateurCalculable) {
     return (
       <PageIndicateurDeuxTrois>
         <div>
           <InfoBloc
             title="Malheureusement votre indicateur n’est pas calculable"
-            text="car l’ensemble des groupes valables (c’est-à-dire comptant au
-                moins 10 femmes et 10 hommes), représentent moins de 40% des
-                effectifs."
+            text="car les effectifs comprennent moins de 5 femmes ou moins de 5 hommes."
           />
           <ActionBar>
             <ButtonSimulatorLink to="/indicateur4" label="suivant" />
@@ -92,7 +88,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
   // formulaire indicateur validé mais données renseignées ne permettent pas de calculer l'indicateur
   if (
     state.indicateurDeuxTrois.formValidated === "Valid" &&
-    !indicateurCalculable
+    !state.indicateurDeuxTrois.presenceAugmentationPromotion
   ) {
     return (
       <PageIndicateurDeuxTrois>
@@ -146,9 +142,11 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
               indicateurEcartAugmentationPromotion={
                 indicateurEcartAugmentationPromotion
               }
+              indicateurEcartNombreEquivalentSalaries={
+                indicateurEcartNombreEquivalentSalaries
+              }
               indicateurSexeSurRepresente={indicateurSexeSurRepresente}
               noteIndicateurDeuxTrois={noteIndicateurDeuxTrois}
-              correctionMeasure={correctionMeasure}
               validateIndicateurDeuxTrois={validateIndicateurDeuxTrois}
             />
           )

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -1,0 +1,162 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { useCallback, ReactNode } from "react";
+import { RouteComponentProps } from "react-router-dom";
+
+import {
+  AppState,
+  FormState,
+  ActionType,
+  ActionIndicateurDeuxTroisData
+} from "../../globals";
+
+import calculIndicateurDeuxTrois from "../../utils/calculsEgaProIndicateurDeuxTrois";
+
+import Page from "../../components/Page";
+import LayoutFormAndResult from "../../components/LayoutFormAndResult";
+import InfoBloc from "../../components/InfoBloc";
+import ActionBar from "../../components/ActionBar";
+import ActionLink from "../../components/ActionLink";
+import {
+  ButtonSimulatorLink,
+  TextSimulatorLink
+} from "../../components/SimulatorLink";
+
+import IndicateurDeuxTroisForm from "./IndicateurDeuxTroisForm";
+import IndicateurDeuxTroisResult from "./IndicateurDeuxTroisResult";
+
+interface Props extends RouteComponentProps {
+  state: AppState;
+  dispatch: (action: ActionType) => void;
+}
+
+function IndicateurDeuxTrois({ state, dispatch }: Props) {
+  const updateIndicateurDeuxTrois = useCallback(
+    (data: ActionIndicateurDeuxTroisData) =>
+      dispatch({ type: "updateIndicateurDeuxTrois", data }),
+    [dispatch]
+  );
+
+  const validateIndicateurDeuxTrois = useCallback(
+    (valid: FormState) =>
+      dispatch({ type: "validateIndicateurDeuxTrois", valid }),
+    [dispatch]
+  );
+
+  const {
+    effectifsIndicateurCalculable,
+    effectifEtEcartAugmentationPromotionParGroupe,
+    indicateurCalculable,
+    indicateurEcartAugmentationPromotion,
+    indicateurSexeSurRepresente,
+    noteIndicateurDeuxTrois,
+    correctionMeasure
+  } = calculIndicateurDeuxTrois(state);
+
+  // le formulaire d'effectif n'est pas validé
+  if (state.effectif.formValidated !== "Valid") {
+    return (
+      <PageIndicateurDeuxTrois>
+        <InfoBloc
+          title="vous devez renseignez vos effectifs avant d’avoir accès à cet indicateur"
+          text={
+            <TextSimulatorLink
+              to="/effectifs"
+              label="renseigner les effectifs"
+            />
+          }
+        />
+      </PageIndicateurDeuxTrois>
+    );
+  }
+
+  // les effectifs ne permettent pas de calculer l'indicateur
+  if (!effectifsIndicateurCalculable) {
+    return (
+      <PageIndicateurDeuxTrois>
+        <div>
+          <InfoBloc
+            title="Malheureusement votre indicateur n’est pas calculable"
+            text="car l’ensemble des groupes valables (c’est-à-dire comptant au
+                moins 10 femmes et 10 hommes), représentent moins de 40% des
+                effectifs."
+          />
+          <ActionBar>
+            <ButtonSimulatorLink to="/indicateur4" label="suivant" />
+          </ActionBar>
+        </div>
+      </PageIndicateurDeuxTrois>
+    );
+  }
+
+  // formulaire indicateur validé mais données renseignées ne permettent pas de calculer l'indicateur
+  if (
+    state.indicateurDeuxTrois.formValidated === "Valid" &&
+    !indicateurCalculable
+  ) {
+    return (
+      <PageIndicateurDeuxTrois>
+        <div>
+          <InfoBloc
+            title="Malheureusement votre indicateur n’est pas calculable"
+            text="car il n’y a pas eu de promotion durant la période de référence."
+          />
+          <ActionBar>
+            <ActionLink onClick={() => validateIndicateurDeuxTrois("None")}>
+              modifier les données saisies
+            </ActionLink>
+          </ActionBar>
+          <ActionBar>
+            <ButtonSimulatorLink to="/indicateur4" label="suivant" />
+          </ActionBar>
+        </div>
+      </PageIndicateurDeuxTrois>
+    );
+  }
+
+  return (
+    <PageIndicateurDeuxTrois>
+      <LayoutFormAndResult
+        childrenForm={
+          <IndicateurDeuxTroisForm
+            ecartPromoParCategorieSocioPro={
+              effectifEtEcartAugmentationPromotionParGroupe
+            }
+            presenceAugmentationPromotion={
+              state.indicateurDeuxTrois.presenceAugmentationPromotion
+            }
+            readOnly={state.indicateurDeuxTrois.formValidated === "Valid"}
+            updateIndicateurDeuxTrois={updateIndicateurDeuxTrois}
+            validateIndicateurDeuxTrois={validateIndicateurDeuxTrois}
+          />
+        }
+        childrenResult={
+          state.indicateurDeuxTrois.formValidated === "Valid" && (
+            <IndicateurDeuxTroisResult
+              indicateurEcartAugmentationPromotion={
+                indicateurEcartAugmentationPromotion
+              }
+              indicateurSexeSurRepresente={indicateurSexeSurRepresente}
+              noteIndicateurDeuxTrois={noteIndicateurDeuxTrois}
+              correctionMeasure={correctionMeasure}
+              validateIndicateurDeuxTrois={validateIndicateurDeuxTrois}
+            />
+          )
+        }
+      />
+    </PageIndicateurDeuxTrois>
+  );
+}
+
+function PageIndicateurDeuxTrois({ children }: { children: ReactNode }) {
+  return (
+    <Page
+      title="Indicateur écart de taux d'augmenations et de promotions"
+      tagline="Le pourcentage de femmes et d’hommes ayant été augmentés ou promus durant la période de référence, doit être renseigné par CSP."
+    >
+      {children}
+    </Page>
+  );
+}
+
+export default IndicateurDeuxTrois;

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -48,7 +48,8 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
     indicateurEcartAugmentationPromotion,
     indicateurEcartNombreEquivalentSalaries,
     indicateurSexeSurRepresente,
-    noteIndicateurDeuxTrois
+    noteIndicateurDeuxTrois,
+    correctionMeasure
   } = calculIndicateurDeuxTrois(state);
 
   // le formulaire d'effectif n'est pas validé
@@ -147,6 +148,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
               }
               indicateurSexeSurRepresente={indicateurSexeSurRepresente}
               noteIndicateurDeuxTrois={noteIndicateurDeuxTrois}
+              correctionMeasure={correctionMeasure}
               validateIndicateurDeuxTrois={validateIndicateurDeuxTrois}
             />
           )

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -89,7 +89,8 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
   // formulaire indicateur validé mais données renseignées ne permettent pas de calculer l'indicateur
   if (
     state.indicateurDeuxTrois.formValidated === "Valid" &&
-    !state.indicateurDeuxTrois.presenceAugmentationPromotion
+    (!state.indicateurDeuxTrois.presenceAugmentationPromotion &&
+      state.indicateurDeuxTrois.periodeDeclaration === "unePeriodeReference")
   ) {
     return (
       <PageIndicateurDeuxTrois>
@@ -125,13 +126,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
             nombreAugmentationPromotionHommes={
               state.indicateurDeuxTrois.nombreAugmentationPromotionHommes
             }
-            memePeriodeReference={
-              state.indicateurDeuxTrois.memePeriodeReference
-            }
-            periodeReferenceDebut={
-              state.indicateurDeuxTrois.periodeReferenceDebut
-            }
-            periodeReferenceFin={state.indicateurDeuxTrois.periodeReferenceFin}
+            periodeDeclaration={state.indicateurDeuxTrois.periodeDeclaration}
             readOnly={state.indicateurDeuxTrois.formValidated === "Valid"}
             updateIndicateurDeuxTrois={updateIndicateurDeuxTrois}
             validateIndicateurDeuxTrois={validateIndicateurDeuxTrois}

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -45,7 +45,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
 
   const {
     effectifsIndicateurCalculable,
-    effectifEtEcartAugmentationPromotionParGroupe,
+    // effectifEtEcartAugmentationPromotionParGroupe,
     indicateurCalculable,
     indicateurEcartAugmentationPromotion,
     indicateurSexeSurRepresente,
@@ -119,12 +119,22 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
       <LayoutFormAndResult
         childrenForm={
           <IndicateurDeuxTroisForm
-            ecartPromoParCategorieSocioPro={
-              effectifEtEcartAugmentationPromotionParGroupe
-            }
             presenceAugmentationPromotion={
               state.indicateurDeuxTrois.presenceAugmentationPromotion
             }
+            nombreAugmentationPromotionFemmes={
+              state.indicateurDeuxTrois.nombreAugmentationPromotionFemmes
+            }
+            nombreAugmentationPromotionHommes={
+              state.indicateurDeuxTrois.nombreAugmentationPromotionHommes
+            }
+            memePeriodeReference={
+              state.indicateurDeuxTrois.memePeriodeReference
+            }
+            periodeReferenceDebut={
+              state.indicateurDeuxTrois.periodeReferenceDebut
+            }
+            periodeReferenceFin={state.indicateurDeuxTrois.periodeReferenceFin}
             readOnly={state.indicateurDeuxTrois.formValidated === "Valid"}
             updateIndicateurDeuxTrois={updateIndicateurDeuxTrois}
             validateIndicateurDeuxTrois={validateIndicateurDeuxTrois}
@@ -151,8 +161,8 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
 function PageIndicateurDeuxTrois({ children }: { children: ReactNode }) {
   return (
     <Page
-      title="Indicateur écart de taux d'augmenations et de promotions"
-      tagline="Le pourcentage de femmes et d’hommes ayant été augmentés ou promus durant la période de référence, doit être renseigné par CSP."
+      title="Indicateur écart de taux d'augmentations et de promotions"
+      tagline="Le nombre de femmes et d’hommes ayant été augmentés ou promus durant la période de référence, ou pendant les deux ou trois dernières années."
     >
       {children}
     </Page>

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
@@ -1,0 +1,201 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { Form } from "react-final-form";
+import { FormState, ActionIndicateurDeuxTroisData } from "../../globals.d";
+
+import {
+  // calculTotalEffectifsEtTauxAugmentationPromotion,
+  // calculEcartTauxAugmentationPromotion,
+  effectifEtEcartAugmentationPromotionGroup
+} from "../../utils/calculsEgaProIndicateurDeuxTrois";
+
+import BlocForm from "../../components/BlocForm";
+import FieldInputsMenWomen from "../../components/FieldInputsMenWomen";
+import RadiosBoolean from "../../components/RadiosBoolean";
+import ActionBar from "../../components/ActionBar";
+import FormAutoSave from "../../components/FormAutoSave";
+import FormSubmit from "../../components/FormSubmit";
+import { ButtonSimulatorLink } from "../../components/SimulatorLink";
+
+import {
+  parseFloatFormValue,
+  parseFloatStateValue,
+  parseBooleanFormValue,
+  parseBooleanStateValue
+} from "../../utils/formHelpers";
+import {
+  displayNameCategorieSocioPro
+  // displayFractionPercent
+} from "../../utils/helpers";
+
+interface Props {
+  ecartPromoParCategorieSocioPro: Array<
+    effectifEtEcartAugmentationPromotionGroup
+  >;
+  presenceAugmentationPromotion: boolean;
+  readOnly: boolean;
+  updateIndicateurDeuxTrois: (data: ActionIndicateurDeuxTroisData) => void;
+  validateIndicateurDeuxTrois: (valid: FormState) => void;
+}
+
+function IndicateurDeuxTroisForm({
+  ecartPromoParCategorieSocioPro,
+  presenceAugmentationPromotion,
+  readOnly,
+  updateIndicateurDeuxTrois,
+  validateIndicateurDeuxTrois
+}: Props) {
+  const initialValues = {
+    presenceAugmentationPromotion: parseBooleanStateValue(
+      presenceAugmentationPromotion
+    ),
+    tauxAugmentationPromotion: ecartPromoParCategorieSocioPro.map(
+      ({
+        tauxAugmentationPromotionFemmes,
+        tauxAugmentationPromotionHommes,
+        ...otherProps
+      }: any) => ({
+        ...otherProps,
+        tauxAugmentationPromotionFemmes: parseFloatStateValue(
+          tauxAugmentationPromotionFemmes
+        ),
+        tauxAugmentationPromotionHommes: parseFloatStateValue(
+          tauxAugmentationPromotionHommes
+        )
+      })
+    )
+  };
+
+  const saveForm = (formData: any) => {
+    const presenceAugmentationPromotion = parseBooleanFormValue(
+      formData.presenceAugmentationPromotion
+    );
+    const tauxAugmentationPromotion = formData.tauxAugmentationPromotion.map(
+      ({
+        categorieSocioPro,
+        tauxAugmentationPromotionFemmes,
+        tauxAugmentationPromotionHommes
+      }: any) => ({
+        categorieSocioPro,
+        tauxAugmentationPromotionFemmes: parseFloatFormValue(
+          tauxAugmentationPromotionFemmes
+        ),
+        tauxAugmentationPromotionHommes: parseFloatFormValue(
+          tauxAugmentationPromotionHommes
+        )
+      })
+    );
+    updateIndicateurDeuxTrois({
+      tauxAugmentationPromotion,
+      presenceAugmentationPromotion
+    });
+  };
+
+  const onSubmit = (formData: any) => {
+    saveForm(formData);
+    validateIndicateurDeuxTrois("Valid");
+  };
+
+  // Only for Total with updated values
+  // const ecartPromoParCategorieSocioProPourTotal = ecartPromoParCategorieSocioPro.map(
+  //   (groupAugment, index) => {
+  //     const infoField = infoFields[index];
+  //     const tauxAugmentationPromotionFemmes = parseFloatFormValue(
+  //       values[infoField.tauxAugmentationPromotionFemmesName]
+  //     );
+  //     const tauxAugmentationPromotionHommes = parseFloatFormValue(
+  //       values[infoField.tauxAugmentationPromotionHommesName]
+  //     );
+  //     const ecartTauxAugmentationPromotion = calculEcartTauxAugmentationPromotion(
+  //       tauxAugmentationPromotionFemmes,
+  //       tauxAugmentationPromotionHommes
+  //     );
+  //     return {
+  //       ...groupAugment,
+  //       tauxAugmentationPromotionFemmes,
+  //       tauxAugmentationPromotionHommes,
+  //       ecartTauxAugmentationPromotion
+  //     };
+  //   }
+  // );
+  // const {
+  //   totalTauxAugmentationPromotionFemmes,
+  //   totalTauxAugmentationPromotionHommes
+  // } = calculTotalEffectifsEtTauxAugmentationPromotion(
+  //   ecartPromoParCategorieSocioProPourTotal
+  // );
+
+  return (
+    <Form
+      onSubmit={onSubmit}
+      initialValues={initialValues}
+      // mandatory to not change user inputs
+      // because we want to keep wrong string inside the input
+      // we don't want to block string value
+      initialValuesEqual={() => true}
+    >
+      {({ handleSubmit, values, hasValidationErrors, submitFailed }) => (
+        <form onSubmit={handleSubmit} css={styles.container}>
+          <FormAutoSave saveForm={saveForm} />
+          <RadiosBoolean
+            fieldName="presenceAugmentationPromotion"
+            value={values.presenceAugmentationPromotion}
+            readOnly={readOnly}
+            labelTrue="il y a eu des augmentations ou des promotions durant la période de référence"
+            labelFalse="il n’y a pas eu d'augmentations ou de promotions durant la période de référence"
+          />
+
+          {values.presenceAugmentationPromotion === "true" && (
+            <BlocForm
+              label="% de salariés augmentés ou promus"
+              // footer={[
+              //   displayFractionPercent(totalTauxAugmentationPromotionFemmes),
+              //   displayFractionPercent(totalTauxAugmentationPromotionHommes)
+              // ]}
+            >
+              {ecartPromoParCategorieSocioPro.map(
+                ({ categorieSocioPro, validiteGroupe }, index) => {
+                  return (
+                    <FieldInputsMenWomen
+                      key={categorieSocioPro}
+                      name={displayNameCategorieSocioPro(categorieSocioPro)}
+                      readOnly={readOnly}
+                      calculable={validiteGroupe}
+                      calculableNumber={10}
+                      mask="percent"
+                      femmeFieldName={`tauxAugmentationPromotion.${index}.tauxAugmentationPromotionFemmes`}
+                      hommeFieldName={`tauxAugmentationPromotion.${index}.tauxAugmentationPromotionHommes`}
+                    />
+                  );
+                }
+              )}
+            </BlocForm>
+          )}
+
+          {readOnly ? (
+            <ActionBar>
+              <ButtonSimulatorLink to="/indicateur4" label="suivant" />
+            </ActionBar>
+          ) : (
+            <ActionBar>
+              <FormSubmit
+                hasValidationErrors={hasValidationErrors}
+                submitFailed={submitFailed}
+                errorMessage="L’indicateur ne peut pas être validé si tous les champs ne sont pas remplis."
+              />
+            </ActionBar>
+          )}
+        </form>
+      )}
+    </Form>
+  );
+}
+
+const styles = {
+  container: css({
+    display: "flex",
+    flexDirection: "column"
+  })
+};
+
+export default IndicateurDeuxTroisForm;

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
@@ -117,18 +117,15 @@ function IndicateurDeuxTroisForm({
 
           <div css={styles.spacer} />
 
-          {values.periodeDeclaration === "unePeriodeReference" && (
-            <RadiosBoolean
-              fieldName="presenceAugmentationPromotion"
-              value={values.presenceAugmentationPromotion}
-              readOnly={readOnly}
-              labelTrue="il y a eu des augmentations ou des promotions durant la période de déclaration"
-              labelFalse="il n’y a pas eu d'augmentations ou de promotions durant la période de déclaration"
-            />
-          )}
+          <RadiosBoolean
+            fieldName="presenceAugmentationPromotion"
+            value={values.presenceAugmentationPromotion}
+            readOnly={readOnly}
+            labelTrue="il y a eu des augmentations ou des promotions durant la période de déclaration"
+            labelFalse="il n’y a pas eu d'augmentations ou de promotions durant la période de déclaration"
+          />
 
-          {(values.presenceAugmentationPromotion === "true" ||
-            values.periodeDeclaration !== "unePeriodeReference") && (
+          {values.presenceAugmentationPromotion === "true" && (
             <BlocForm>
               <FieldInputsMenWomen
                 name="nombre de salariés augmentés ou promus"

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
@@ -1,17 +1,16 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
-import { Field, Form } from "react-final-form";
-import { FormState, ActionIndicateurDeuxTroisData } from "../../globals.d";
-
-// import {
-//   // calculTotalEffectifsEtTauxAugmentationPromotion,
-//   // calculEcartTauxAugmentationPromotion,
-//   effectifEtEcartAugmentationPromotionGroup
-// } from "../../utils/calculsEgaProIndicateurDeuxTrois";
+import { Form } from "react-final-form";
+import {
+  FormState,
+  ActionIndicateurDeuxTroisData,
+  PeriodeDeclaration
+} from "../../globals.d";
 
 import { BlocFormLight } from "../../components/BlocForm";
 import FieldInputsMenWomen from "../../components/FieldInputsMenWomen";
 import RadiosBoolean from "../../components/RadiosBoolean";
+import RadioButtons from "../../components/RadioButtons";
 import ActionBar from "../../components/ActionBar";
 import FormAutoSave from "../../components/FormAutoSave";
 import FormSubmit from "../../components/FormSubmit";
@@ -21,20 +20,15 @@ import {
   parseIntFormValue,
   parseIntStateValue,
   parseBooleanFormValue,
-  parseBooleanStateValue
+  parseBooleanStateValue,
+  parsePeriodeDeclarationFormValue
 } from "../../utils/formHelpers";
-// import {
-//   displayNameCategorieSocioPro
-//   // displayFractionPercent
-// } from "../../utils/helpers";
 
 interface Props {
   presenceAugmentationPromotion: boolean;
   nombreAugmentationPromotionFemmes: number | undefined;
   nombreAugmentationPromotionHommes: number | undefined;
-  memePeriodeReference: boolean;
-  periodeReferenceDebut: string;
-  periodeReferenceFin: string;
+  periodeDeclaration: PeriodeDeclaration;
   readOnly: boolean;
   updateIndicateurDeuxTrois: (data: ActionIndicateurDeuxTroisData) => void;
   validateIndicateurDeuxTrois: (valid: FormState) => void;
@@ -44,9 +38,7 @@ function IndicateurDeuxTroisForm({
   presenceAugmentationPromotion,
   nombreAugmentationPromotionFemmes,
   nombreAugmentationPromotionHommes,
-  memePeriodeReference,
-  periodeReferenceDebut,
-  periodeReferenceFin,
+  periodeDeclaration,
   readOnly,
   updateIndicateurDeuxTrois,
   validateIndicateurDeuxTrois
@@ -61,9 +53,7 @@ function IndicateurDeuxTroisForm({
     nombreAugmentationPromotionHommes: parseIntStateValue(
       nombreAugmentationPromotionHommes
     ),
-    memePeriodeReference: parseBooleanStateValue(memePeriodeReference),
-    periodeReferenceDebut: periodeReferenceDebut,
-    periodeReferenceFin: periodeReferenceFin
+    periodeDeclaration: periodeDeclaration
   };
 
   const saveForm = (formData: any) => {
@@ -76,16 +66,14 @@ function IndicateurDeuxTroisForm({
     const nombreAugmentationPromotionHommes = parseIntFormValue(
       formData.nombreAugmentationPromotionHommes
     );
-    const memePeriodeReference = parseBooleanFormValue(
-      formData.memePeriodeReference
+    const periodeDeclaration = parsePeriodeDeclarationFormValue(
+      formData.periodeDeclaration
     );
     updateIndicateurDeuxTrois({
       presenceAugmentationPromotion,
       nombreAugmentationPromotionFemmes,
       nombreAugmentationPromotionHommes,
-      memePeriodeReference,
-      periodeReferenceDebut: formData.periodeReferenceDebut,
-      periodeReferenceFin: formData.periodeReferenceFin
+      periodeDeclaration
     });
   };
 
@@ -106,44 +94,41 @@ function IndicateurDeuxTroisForm({
       {({ handleSubmit, values, hasValidationErrors, submitFailed }) => (
         <form onSubmit={handleSubmit} css={styles.container}>
           <FormAutoSave saveForm={saveForm} />
-          <RadiosBoolean
-            fieldName="memePeriodeReference"
-            value={values.memePeriodeReference}
+          <RadioButtons
+            fieldName="periodeDeclaration"
+            label="je déclare sur"
+            value={values.periodeDeclaration}
             readOnly={readOnly}
-            labelTrue="je déclare sur la période de référence allant du XX/XX/XX au XX/XX/XX"
-            labelFalse="je souhaite déclarer sur une autre période de référence"
+            choices={[
+              {
+                label: "la dernière période de référence",
+                value: "unePeriodeReference"
+              },
+              {
+                label: "les deux dernières périodes de référence",
+                value: "deuxPeriodesReference"
+              },
+              {
+                label: "les trois dernières périodes de référence",
+                value: "troisPeriodesReference"
+              }
+            ]}
           />
 
-          {values.memePeriodeReference === "false" && (
-            <div>
-              <Field
-                name="periodeReferenceDebut"
-                label="Date de début"
-                readOnly={readOnly}
-                render={props => {
-                  return <input {...props.input} type="date" />;
-                }}
-              />
-              <Field
-                name="periodeReferenceFin"
-                label="Date de fin"
-                readOnly={readOnly}
-                render={props => {
-                  return <input {...props.input} type="date" />;
-                }}
-              />
-            </div>
+          <div css={styles.spacer} />
+
+          {values.periodeDeclaration === "unePeriodeReference" && (
+            <RadiosBoolean
+              fieldName="presenceAugmentationPromotion"
+              value={values.presenceAugmentationPromotion}
+              readOnly={readOnly}
+              labelTrue="il y a eu des augmentations ou des promotions durant la période de déclaration"
+              labelFalse="il n’y a pas eu d'augmentations ou de promotions durant la période de déclaration"
+            />
           )}
 
-          <RadiosBoolean
-            fieldName="presenceAugmentationPromotion"
-            value={values.presenceAugmentationPromotion}
-            readOnly={readOnly}
-            labelTrue="il y a eu des augmentations ou des promotions durant la période de référence"
-            labelFalse="il n’y a pas eu d'augmentations ou de promotions durant la période de référence"
-          />
-
-          {values.presenceAugmentationPromotion === "true" && (
+          {(values.presenceAugmentationPromotion === "true" ||
+            values.periodeDeclaration !== "unePeriodeReference") && (
             <BlocFormLight>
               <FieldInputsMenWomen
                 name="nombre de salariés augmentés ou promus"
@@ -180,6 +165,9 @@ const styles = {
   container: css({
     display: "flex",
     flexDirection: "column"
+  }),
+  spacer: css({
+    marginTop: "2em"
   })
 };
 

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
@@ -7,7 +7,7 @@ import {
   PeriodeDeclaration
 } from "../../globals.d";
 
-import { BlocFormLight } from "../../components/BlocForm";
+import BlocForm from "../../components/BlocForm";
 import FieldInputsMenWomen from "../../components/FieldInputsMenWomen";
 import RadiosBoolean from "../../components/RadiosBoolean";
 import RadioButtons from "../../components/RadioButtons";
@@ -129,7 +129,7 @@ function IndicateurDeuxTroisForm({
 
           {(values.presenceAugmentationPromotion === "true" ||
             values.periodeDeclaration !== "unePeriodeReference") && (
-            <BlocFormLight>
+            <BlocForm>
               <FieldInputsMenWomen
                 name="nombre de salariés augmentés ou promus"
                 readOnly={readOnly}
@@ -139,7 +139,7 @@ function IndicateurDeuxTroisForm({
                 femmeFieldName="nombreAugmentationPromotionFemmes"
                 hommeFieldName="nombreAugmentationPromotionHommes"
               />
-            </BlocFormLight>
+            </BlocForm>
           )}
 
           {readOnly ? (

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
@@ -1,15 +1,15 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
-import { Form } from "react-final-form";
+import { Field, Form } from "react-final-form";
 import { FormState, ActionIndicateurDeuxTroisData } from "../../globals.d";
 
-import {
-  // calculTotalEffectifsEtTauxAugmentationPromotion,
-  // calculEcartTauxAugmentationPromotion,
-  effectifEtEcartAugmentationPromotionGroup
-} from "../../utils/calculsEgaProIndicateurDeuxTrois";
+// import {
+//   // calculTotalEffectifsEtTauxAugmentationPromotion,
+//   // calculEcartTauxAugmentationPromotion,
+//   effectifEtEcartAugmentationPromotionGroup
+// } from "../../utils/calculsEgaProIndicateurDeuxTrois";
 
-import BlocForm from "../../components/BlocForm";
+import { BlocFormLight } from "../../components/BlocForm";
 import FieldInputsMenWomen from "../../components/FieldInputsMenWomen";
 import RadiosBoolean from "../../components/RadiosBoolean";
 import ActionBar from "../../components/ActionBar";
@@ -18,29 +18,35 @@ import FormSubmit from "../../components/FormSubmit";
 import { ButtonSimulatorLink } from "../../components/SimulatorLink";
 
 import {
-  parseFloatFormValue,
-  parseFloatStateValue,
+  parseIntFormValue,
+  parseIntStateValue,
   parseBooleanFormValue,
   parseBooleanStateValue
 } from "../../utils/formHelpers";
-import {
-  displayNameCategorieSocioPro
-  // displayFractionPercent
-} from "../../utils/helpers";
+// import {
+//   displayNameCategorieSocioPro
+//   // displayFractionPercent
+// } from "../../utils/helpers";
 
 interface Props {
-  ecartPromoParCategorieSocioPro: Array<
-    effectifEtEcartAugmentationPromotionGroup
-  >;
   presenceAugmentationPromotion: boolean;
+  nombreAugmentationPromotionFemmes: number | undefined;
+  nombreAugmentationPromotionHommes: number | undefined;
+  memePeriodeReference: boolean;
+  periodeReferenceDebut: string;
+  periodeReferenceFin: string;
   readOnly: boolean;
   updateIndicateurDeuxTrois: (data: ActionIndicateurDeuxTroisData) => void;
   validateIndicateurDeuxTrois: (valid: FormState) => void;
 }
 
 function IndicateurDeuxTroisForm({
-  ecartPromoParCategorieSocioPro,
   presenceAugmentationPromotion,
+  nombreAugmentationPromotionFemmes,
+  nombreAugmentationPromotionHommes,
+  memePeriodeReference,
+  periodeReferenceDebut,
+  periodeReferenceFin,
   readOnly,
   updateIndicateurDeuxTrois,
   validateIndicateurDeuxTrois
@@ -49,45 +55,37 @@ function IndicateurDeuxTroisForm({
     presenceAugmentationPromotion: parseBooleanStateValue(
       presenceAugmentationPromotion
     ),
-    tauxAugmentationPromotion: ecartPromoParCategorieSocioPro.map(
-      ({
-        tauxAugmentationPromotionFemmes,
-        tauxAugmentationPromotionHommes,
-        ...otherProps
-      }: any) => ({
-        ...otherProps,
-        tauxAugmentationPromotionFemmes: parseFloatStateValue(
-          tauxAugmentationPromotionFemmes
-        ),
-        tauxAugmentationPromotionHommes: parseFloatStateValue(
-          tauxAugmentationPromotionHommes
-        )
-      })
-    )
+    nombreAugmentationPromotionFemmes: parseIntStateValue(
+      nombreAugmentationPromotionFemmes
+    ),
+    nombreAugmentationPromotionHommes: parseIntStateValue(
+      nombreAugmentationPromotionHommes
+    ),
+    memePeriodeReference: parseBooleanStateValue(memePeriodeReference),
+    periodeReferenceDebut: periodeReferenceDebut,
+    periodeReferenceFin: periodeReferenceFin
   };
 
   const saveForm = (formData: any) => {
     const presenceAugmentationPromotion = parseBooleanFormValue(
       formData.presenceAugmentationPromotion
     );
-    const tauxAugmentationPromotion = formData.tauxAugmentationPromotion.map(
-      ({
-        categorieSocioPro,
-        tauxAugmentationPromotionFemmes,
-        tauxAugmentationPromotionHommes
-      }: any) => ({
-        categorieSocioPro,
-        tauxAugmentationPromotionFemmes: parseFloatFormValue(
-          tauxAugmentationPromotionFemmes
-        ),
-        tauxAugmentationPromotionHommes: parseFloatFormValue(
-          tauxAugmentationPromotionHommes
-        )
-      })
+    const nombreAugmentationPromotionFemmes = parseIntFormValue(
+      formData.nombreAugmentationPromotionFemmes
+    );
+    const nombreAugmentationPromotionHommes = parseIntFormValue(
+      formData.nombreAugmentationPromotionHommes
+    );
+    const memePeriodeReference = parseBooleanFormValue(
+      formData.memePeriodeReference
     );
     updateIndicateurDeuxTrois({
-      tauxAugmentationPromotion,
-      presenceAugmentationPromotion
+      presenceAugmentationPromotion,
+      nombreAugmentationPromotionFemmes,
+      nombreAugmentationPromotionHommes,
+      memePeriodeReference,
+      periodeReferenceDebut: formData.periodeReferenceDebut,
+      periodeReferenceFin: formData.periodeReferenceFin
     });
   };
 
@@ -95,35 +93,6 @@ function IndicateurDeuxTroisForm({
     saveForm(formData);
     validateIndicateurDeuxTrois("Valid");
   };
-
-  // Only for Total with updated values
-  // const ecartPromoParCategorieSocioProPourTotal = ecartPromoParCategorieSocioPro.map(
-  //   (groupAugment, index) => {
-  //     const infoField = infoFields[index];
-  //     const tauxAugmentationPromotionFemmes = parseFloatFormValue(
-  //       values[infoField.tauxAugmentationPromotionFemmesName]
-  //     );
-  //     const tauxAugmentationPromotionHommes = parseFloatFormValue(
-  //       values[infoField.tauxAugmentationPromotionHommesName]
-  //     );
-  //     const ecartTauxAugmentationPromotion = calculEcartTauxAugmentationPromotion(
-  //       tauxAugmentationPromotionFemmes,
-  //       tauxAugmentationPromotionHommes
-  //     );
-  //     return {
-  //       ...groupAugment,
-  //       tauxAugmentationPromotionFemmes,
-  //       tauxAugmentationPromotionHommes,
-  //       ecartTauxAugmentationPromotion
-  //     };
-  //   }
-  // );
-  // const {
-  //   totalTauxAugmentationPromotionFemmes,
-  //   totalTauxAugmentationPromotionHommes
-  // } = calculTotalEffectifsEtTauxAugmentationPromotion(
-  //   ecartPromoParCategorieSocioProPourTotal
-  // );
 
   return (
     <Form
@@ -138,6 +107,35 @@ function IndicateurDeuxTroisForm({
         <form onSubmit={handleSubmit} css={styles.container}>
           <FormAutoSave saveForm={saveForm} />
           <RadiosBoolean
+            fieldName="memePeriodeReference"
+            value={values.memePeriodeReference}
+            readOnly={readOnly}
+            labelTrue="je déclare sur la période de référence allant du XX/XX/XX au XX/XX/XX"
+            labelFalse="je souhaite déclarer sur une autre période de référence"
+          />
+
+          {values.memePeriodeReference === "false" && (
+            <div>
+              <Field
+                name="periodeReferenceDebut"
+                label="Date de début"
+                readOnly={readOnly}
+                render={props => {
+                  return <input {...props.input} type="date" />;
+                }}
+              />
+              <Field
+                name="periodeReferenceFin"
+                label="Date de fin"
+                readOnly={readOnly}
+                render={props => {
+                  return <input {...props.input} type="date" />;
+                }}
+              />
+            </div>
+          )}
+
+          <RadiosBoolean
             fieldName="presenceAugmentationPromotion"
             value={values.presenceAugmentationPromotion}
             readOnly={readOnly}
@@ -146,30 +144,17 @@ function IndicateurDeuxTroisForm({
           />
 
           {values.presenceAugmentationPromotion === "true" && (
-            <BlocForm
-              label="% de salariés augmentés ou promus"
-              // footer={[
-              //   displayFractionPercent(totalTauxAugmentationPromotionFemmes),
-              //   displayFractionPercent(totalTauxAugmentationPromotionHommes)
-              // ]}
-            >
-              {ecartPromoParCategorieSocioPro.map(
-                ({ categorieSocioPro, validiteGroupe }, index) => {
-                  return (
-                    <FieldInputsMenWomen
-                      key={categorieSocioPro}
-                      name={displayNameCategorieSocioPro(categorieSocioPro)}
-                      readOnly={readOnly}
-                      calculable={validiteGroupe}
-                      calculableNumber={10}
-                      mask="percent"
-                      femmeFieldName={`tauxAugmentationPromotion.${index}.tauxAugmentationPromotionFemmes`}
-                      hommeFieldName={`tauxAugmentationPromotion.${index}.tauxAugmentationPromotionHommes`}
-                    />
-                  );
-                }
-              )}
-            </BlocForm>
+            <BlocFormLight>
+              <FieldInputsMenWomen
+                name="nombre de salariés augmentés ou promus"
+                readOnly={readOnly}
+                calculable={true} // TODO: the total number of women and men must be above 5.
+                calculableNumber={5} // TODO: this calculable number applies to the "effectif" entered in the first step
+                mask="number"
+                femmeFieldName="nombreAugmentationPromotionFemmes"
+                hommeFieldName="nombreAugmentationPromotionHommes"
+              />
+            </BlocFormLight>
           )}
 
           {readOnly ? (

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
@@ -1,0 +1,70 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+
+import { FormState } from "../../globals.d";
+import { displayPercent } from "../../utils/helpers";
+
+import ResultBubble from "../../components/ResultBubble";
+import ActionLink from "../../components/ActionLink";
+
+interface Props {
+  indicateurEcartAugmentationPromotion: number | undefined;
+  indicateurSexeSurRepresente: "hommes" | "femmes" | undefined;
+  noteIndicateurDeuxTrois: number | undefined;
+  correctionMeasure: boolean;
+  validateIndicateurDeuxTrois: (valid: FormState) => void;
+}
+
+function IndicateurDeuxTroisResult({
+  indicateurEcartAugmentationPromotion,
+  indicateurSexeSurRepresente,
+  noteIndicateurDeuxTrois,
+  correctionMeasure,
+  validateIndicateurDeuxTrois
+}: Props) {
+  return (
+    <div css={styles.container}>
+      <ResultBubble
+        firstLineLabel="votre résultat final est"
+        firstLineData={
+          indicateurEcartAugmentationPromotion !== undefined
+            ? displayPercent(indicateurEcartAugmentationPromotion)
+            : "--"
+        }
+        firstLineInfo={`écart favorable aux ${indicateurSexeSurRepresente}`}
+        secondLineLabel="votre note obtenue est"
+        secondLineData={
+          (noteIndicateurDeuxTrois !== undefined
+            ? noteIndicateurDeuxTrois
+            : "--") + "/15"
+        }
+        secondLineInfo={
+          correctionMeasure
+            ? "mesures de correction prises en compte"
+            : undefined
+        }
+        indicateurSexeSurRepresente={indicateurSexeSurRepresente}
+      />
+
+      <p css={styles.edit}>
+        <ActionLink onClick={() => validateIndicateurDeuxTrois("None")}>
+          modifier les données saisies
+        </ActionLink>
+      </p>
+    </div>
+  );
+}
+
+const styles = {
+  container: css({
+    maxWidth: 250,
+    marginTop: 64
+  }),
+  edit: css({
+    marginTop: 14,
+    marginBottom: 14,
+    textAlign: "center"
+  })
+};
+
+export default IndicateurDeuxTroisResult;

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
@@ -12,6 +12,7 @@ interface Props {
   indicateurEcartNombreEquivalentSalaries: number | undefined;
   indicateurSexeSurRepresente: "hommes" | "femmes" | undefined;
   noteIndicateurDeuxTrois: number | undefined;
+  correctionMeasure: boolean;
   validateIndicateurDeuxTrois: (valid: FormState) => void;
 }
 
@@ -20,6 +21,7 @@ function IndicateurDeuxTroisResult({
   indicateurEcartNombreEquivalentSalaries,
   indicateurSexeSurRepresente,
   noteIndicateurDeuxTrois,
+  correctionMeasure,
   validateIndicateurDeuxTrois
 }: Props) {
   return (
@@ -39,7 +41,9 @@ function IndicateurDeuxTroisResult({
             : "--") + "/35"
         }
         secondLineInfo={
-          indicateurEcartNombreEquivalentSalaries
+          correctionMeasure
+            ? "mesures de correction prises en compte"
+            : indicateurEcartNombreEquivalentSalaries
             ? `écart en nombre équivalent salariés ${indicateurEcartNombreEquivalentSalaries}`
             : undefined
         }

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
@@ -9,17 +9,17 @@ import ActionLink from "../../components/ActionLink";
 
 interface Props {
   indicateurEcartAugmentationPromotion: number | undefined;
+  indicateurEcartNombreEquivalentSalaries: number | undefined;
   indicateurSexeSurRepresente: "hommes" | "femmes" | undefined;
   noteIndicateurDeuxTrois: number | undefined;
-  correctionMeasure: boolean;
   validateIndicateurDeuxTrois: (valid: FormState) => void;
 }
 
 function IndicateurDeuxTroisResult({
   indicateurEcartAugmentationPromotion,
+  indicateurEcartNombreEquivalentSalaries,
   indicateurSexeSurRepresente,
   noteIndicateurDeuxTrois,
-  correctionMeasure,
   validateIndicateurDeuxTrois
 }: Props) {
   return (
@@ -36,11 +36,11 @@ function IndicateurDeuxTroisResult({
         secondLineData={
           (noteIndicateurDeuxTrois !== undefined
             ? noteIndicateurDeuxTrois
-            : "--") + "/15"
+            : "--") + "/35"
         }
         secondLineInfo={
-          correctionMeasure
-            ? "mesures de correction prises en compte"
+          indicateurEcartNombreEquivalentSalaries
+            ? `écart en nombre équivalent salariés ${indicateurEcartNombreEquivalentSalaries}`
             : undefined
         }
         indicateurSexeSurRepresente={indicateurSexeSurRepresente}

--- a/packages/app/src/views/Indicateur2et3/index.js
+++ b/packages/app/src/views/Indicateur2et3/index.js
@@ -1,0 +1,2 @@
+import IndicateurDeuxTrois from "./IndicateurDeuxTrois";
+export default IndicateurDeuxTrois;

--- a/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
+++ b/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
@@ -7,6 +7,7 @@ import { AppState } from "../../globals.d";
 import calculIndicateurUn from "../../utils/calculsEgaProIndicateurUn";
 import calculIndicateurDeux from "../../utils/calculsEgaProIndicateurDeux";
 import calculIndicateurTrois from "../../utils/calculsEgaProIndicateurTrois";
+import calculIndicateurDeuxTrois from "../../utils/calculsEgaProIndicateurDeuxTrois";
 import calculIndicateurQuatre from "../../utils/calculsEgaProIndicateurQuatre";
 import calculIndicateurCinq from "../../utils/calculsEgaProIndicateurCinq";
 import { calculNoteIndex } from "../../utils/calculsEgaProIndex";
@@ -19,6 +20,7 @@ import RecapitulatifIndex from "./RecapitulatifIndex";
 import RecapitulatifIndicateurUn from "./RecapitulatifIndicateurUn";
 import RecapitulatifIndicateurDeux from "./RecapitulatifIndicateurDeux";
 import RecapitulatifIndicateurTrois from "./RecapitulatifIndicateurTrois";
+import RecapitulatifIndicateurDeuxTrois from "./RecapitulatifIndicateurDeuxTrois";
 import RecapitulatifIndicateurQuatre from "./RecapitulatifIndicateurQuatre";
 import RecapitulatifIndicateurCinq from "./RecapitulatifIndicateurCinq";
 
@@ -56,6 +58,19 @@ function Recapitulatif({ state }: Props) {
   } = calculIndicateurTrois(state);
 
   const {
+    effectifsIndicateurCalculable: effectifsIndicateurDeuxTroisCalculable,
+    indicateurCalculable: indicateurDeuxTroisCalculable,
+    indicateurEcartAugmentationPromotion,
+    indicateurEcartNombreEquivalentSalaries,
+    indicateurSexeSurRepresente: indicateurDeuxTroisSexeSurRepresente,
+    noteIndicateurDeuxTrois,
+    correctionMeasure: correctionMeasureIndicateurDeuxTrois,
+    tauxAugmentationPromotionHommes,
+    tauxAugmentationPromotionFemmes,
+    plusPetitNombreSalaries
+  } = calculIndicateurDeuxTrois(state);
+
+  const {
     indicateurCalculable: indicateurQuatreCalculable,
     indicateurEcartNombreSalarieesAugmentees,
     noteIndicateurQuatre
@@ -74,6 +89,8 @@ function Recapitulatif({ state }: Props) {
       !effectifsIndicateurDeuxCalculable) &&
     (state.indicateurTrois.formValidated === "Valid" ||
       !effectifsIndicateurTroisCalculable) &&
+    (state.indicateurDeuxTrois.formValidated === "Valid" ||
+      !effectifsIndicateurDeuxTroisCalculable) &&
     state.indicateurQuatre.formValidated === "Valid" &&
     state.indicateurCinq.formValidated === "Valid";
 
@@ -119,6 +136,27 @@ function Recapitulatif({ state }: Props) {
         indicateurSexeSurRepresente={indicateurTroisSexeSurRepresente}
         noteIndicateurTrois={noteIndicateurTrois}
         correctionMeasure={correctionMeasureIndicateurTrois}
+      />
+      <RecapitulatifIndicateurDeuxTrois
+        indicateurDeuxTroisFormValidated={
+          state.indicateurDeuxTrois.formValidated
+        }
+        effectifsIndicateurDeuxTroisCalculable={
+          effectifsIndicateurDeuxTroisCalculable
+        }
+        indicateurDeuxTroisCalculable={indicateurDeuxTroisCalculable}
+        indicateurEcartAugmentationPromotion={
+          indicateurEcartAugmentationPromotion
+        }
+        indicateurEcartNombreEquivalentSalaries={
+          indicateurEcartNombreEquivalentSalaries
+        }
+        indicateurSexeSurRepresente={indicateurDeuxTroisSexeSurRepresente}
+        noteIndicateurDeuxTrois={noteIndicateurDeuxTrois}
+        correctionMeasure={correctionMeasureIndicateurDeuxTrois}
+        tauxAugmentationPromotionHommes={tauxAugmentationPromotionHommes}
+        tauxAugmentationPromotionFemmes={tauxAugmentationPromotionFemmes}
+        plusPetitNombreSalaries={plusPetitNombreSalaries}
       />
       <RecapitulatifIndicateurQuatre
         indicateurQuatreFormValidated={state.indicateurQuatre.formValidated}

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeux.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeux.tsx
@@ -112,6 +112,7 @@ function RecapitulatifIndicateurDeux({
               key={categorieSocioPro}
               name={displayNameCategorieSocioPro(categorieSocioPro)}
               data={ecartTauxAugmentation}
+              asPercent={true}
             />
           )
         )}

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
@@ -1,0 +1,132 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { Fragment } from "react";
+
+import { FormState, CategorieSocioPro } from "../../globals.d";
+
+import {
+  displayNameCategorieSocioPro,
+  displayPercent
+} from "../../utils/helpers";
+
+import InfoBloc from "../../components/InfoBloc";
+import RecapBloc from "./components/RecapBloc";
+import { TextSimulatorLink } from "../../components/SimulatorLink";
+
+import { RowDataFull, RowLabelFull } from "./components/RowData";
+
+interface Props {
+  indicateurTroisFormValidated: FormState;
+  effectifsIndicateurTroisCalculable: boolean;
+  indicateurTroisCalculable: boolean;
+  effectifEtEcartPromoParGroupe: Array<{
+    categorieSocioPro: CategorieSocioPro;
+    ecartTauxPromotion: number | undefined;
+  }>;
+  indicateurEcartPromotion: number | undefined;
+  indicateurSexeSurRepresente: "hommes" | "femmes" | undefined;
+  noteIndicateurTrois: number | undefined;
+  correctionMeasure: boolean;
+}
+
+function RecapitulatifIndicateurTrois({
+  indicateurTroisFormValidated,
+  effectifsIndicateurTroisCalculable,
+  indicateurTroisCalculable,
+  effectifEtEcartPromoParGroupe,
+  indicateurEcartPromotion,
+  indicateurSexeSurRepresente,
+  noteIndicateurTrois,
+  correctionMeasure
+}: Props) {
+  if (!effectifsIndicateurTroisCalculable) {
+    return (
+      <div css={styles.container}>
+        <InfoBloc
+          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
+          text="Malheureusement votre indicateur n’est pas calculable car l’ensemble des groupes valables (c’est-à-dire comptant au moins 10 femmes et 10 hommes), représentent moins de 40% des effectifs."
+        />
+      </div>
+    );
+  }
+
+  if (indicateurTroisFormValidated !== "Valid") {
+    return (
+      <div css={styles.container}>
+        <InfoBloc
+          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
+          text={
+            <Fragment>
+              <span>
+                Nous ne pouvons pas calculer votre indicateur car vous n’avez
+                pas encore validé vos données saissies.
+              </span>{" "}
+              <TextSimulatorLink
+                to="/indicateur3"
+                label="valider les données"
+              />
+            </Fragment>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (!indicateurTroisCalculable) {
+    return (
+      <div css={styles.container}>
+        <InfoBloc
+          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
+          text="Malheureusement votre indicateur n’est pas calculable  car il n’y a pas eu de promotion durant la période de référence"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div css={styles.container}>
+      <RecapBloc
+        title="Indicateur écart de taux de promotions entre les femmes et les hommes"
+        resultBubble={{
+          firstLineLabel: "votre résultat final est",
+          firstLineData:
+            indicateurEcartPromotion !== undefined
+              ? displayPercent(indicateurEcartPromotion)
+              : "--",
+          firstLineInfo: `écart favorable aux ${indicateurSexeSurRepresente}`,
+          secondLineLabel: "votre note obtenue est",
+          secondLineData:
+            (noteIndicateurTrois !== undefined ? noteIndicateurTrois : "--") +
+            "/15",
+          secondLineInfo: correctionMeasure
+            ? "mesures de correction prises en compte"
+            : undefined,
+          indicateurSexeSurRepresente
+        }}
+      >
+        <RowLabelFull label="écart de taux de promotions par csp" />
+
+        {effectifEtEcartPromoParGroupe.map(
+          ({ categorieSocioPro, ecartTauxPromotion }) => (
+            <RowDataFull
+              key={categorieSocioPro}
+              name={displayNameCategorieSocioPro(categorieSocioPro)}
+              data={ecartTauxPromotion}
+            />
+          )
+        )}
+      </RecapBloc>
+    </div>
+  );
+}
+
+const styles = {
+  container: css({
+    display: "flex",
+    flexDirection: "column",
+    marginTop: 22,
+    marginBottom: 22
+  })
+};
+
+export default RecapitulatifIndicateurTrois;

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
@@ -2,59 +2,59 @@
 import { css, jsx } from "@emotion/core";
 import { Fragment } from "react";
 
-import { FormState, CategorieSocioPro } from "../../globals.d";
+import { FormState } from "../../globals.d";
 
-import {
-  displayNameCategorieSocioPro,
-  displayPercent
-} from "../../utils/helpers";
+import { displayPercent } from "../../utils/helpers";
 
 import InfoBloc from "../../components/InfoBloc";
 import RecapBloc from "./components/RecapBloc";
 import { TextSimulatorLink } from "../../components/SimulatorLink";
 
-import { RowDataFull, RowLabelFull } from "./components/RowData";
+import RowData, { RowLabels, RowLabelFull } from "./components/RowData";
 
 interface Props {
-  indicateurTroisFormValidated: FormState;
-  effectifsIndicateurTroisCalculable: boolean;
-  indicateurTroisCalculable: boolean;
-  effectifEtEcartPromoParGroupe: Array<{
-    categorieSocioPro: CategorieSocioPro;
-    ecartTauxPromotion: number | undefined;
-  }>;
-  indicateurEcartPromotion: number | undefined;
+  indicateurDeuxTroisFormValidated: FormState;
+  effectifsIndicateurDeuxTroisCalculable: boolean;
+  indicateurDeuxTroisCalculable: boolean;
+  indicateurEcartAugmentationPromotion: number | undefined;
+  indicateurEcartNombreEquivalentSalaries: number | undefined;
   indicateurSexeSurRepresente: "hommes" | "femmes" | undefined;
-  noteIndicateurTrois: number | undefined;
+  noteIndicateurDeuxTrois: number | undefined;
   correctionMeasure: boolean;
+  tauxAugmentationPromotionFemmes: number | undefined;
+  tauxAugmentationPromotionHommes: number | undefined;
+  plusPetitNombreSalaries: "hommes" | "femmes" | undefined;
 }
 
-function RecapitulatifIndicateurTrois({
-  indicateurTroisFormValidated,
-  effectifsIndicateurTroisCalculable,
-  indicateurTroisCalculable,
-  effectifEtEcartPromoParGroupe,
-  indicateurEcartPromotion,
+function RecapitulatifIndicateurDeuxTrois({
+  indicateurDeuxTroisFormValidated,
+  effectifsIndicateurDeuxTroisCalculable,
+  indicateurDeuxTroisCalculable,
+  indicateurEcartAugmentationPromotion,
+  indicateurEcartNombreEquivalentSalaries,
   indicateurSexeSurRepresente,
-  noteIndicateurTrois,
-  correctionMeasure
+  noteIndicateurDeuxTrois,
+  correctionMeasure,
+  tauxAugmentationPromotionFemmes,
+  tauxAugmentationPromotionHommes,
+  plusPetitNombreSalaries
 }: Props) {
-  if (!effectifsIndicateurTroisCalculable) {
+  if (!effectifsIndicateurDeuxTroisCalculable) {
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
-          text="Malheureusement votre indicateur n’est pas calculable car l’ensemble des groupes valables (c’est-à-dire comptant au moins 10 femmes et 10 hommes), représentent moins de 40% des effectifs."
+          title="Indicateur écart de taux d'augmentations et de promotions entre les femmes et les hommes"
+          text="Malheureusement votre indicateur n’est pas calculable car les effectifs comprennent moins de 5 femmes ou moins de 5 hommes."
         />
       </div>
     );
   }
 
-  if (indicateurTroisFormValidated !== "Valid") {
+  if (indicateurDeuxTroisFormValidated !== "Valid") {
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
+          title="Indicateur écart de taux d'augmentations et de promotions entre les femmes et les hommes"
           text={
             <Fragment>
               <span>
@@ -62,7 +62,7 @@ function RecapitulatifIndicateurTrois({
                 pas encore validé vos données saissies.
               </span>{" "}
               <TextSimulatorLink
-                to="/indicateur3"
+                to="/indicateur2et3"
                 label="valider les données"
               />
             </Fragment>
@@ -72,12 +72,12 @@ function RecapitulatifIndicateurTrois({
     );
   }
 
-  if (!indicateurTroisCalculable) {
+  if (!indicateurDeuxTroisCalculable) {
     return (
       <div css={styles.container}>
         <InfoBloc
-          title="Indicateur écart de taux de promotions entre les femmes et les hommes"
-          text="Malheureusement votre indicateur n’est pas calculable  car il n’y a pas eu de promotion durant la période de référence"
+          title="Indicateur écart de taux d'augmentations et de promotions entre les femmes et les hommes"
+          text="Malheureusement votre indicateur n’est pas calculable  car il n’y a pas eu d'augmentation ou de promotion durant la période de référence"
         />
       </div>
     );
@@ -86,39 +86,88 @@ function RecapitulatifIndicateurTrois({
   return (
     <div css={styles.container}>
       <RecapBloc
-        title="Indicateur écart de taux de promotions entre les femmes et les hommes"
+        title="Indicateur écart de taux de augmentations promotions entre les femmes et les hommes"
         resultBubble={{
           firstLineLabel: "votre résultat final est",
           firstLineData:
-            indicateurEcartPromotion !== undefined
-              ? displayPercent(indicateurEcartPromotion)
+            indicateurEcartAugmentationPromotion !== undefined
+              ? displayPercent(indicateurEcartAugmentationPromotion)
               : "--",
           firstLineInfo: `écart favorable aux ${indicateurSexeSurRepresente}`,
           secondLineLabel: "votre note obtenue est",
           secondLineData:
-            (noteIndicateurTrois !== undefined ? noteIndicateurTrois : "--") +
-            "/15",
+            (noteIndicateurDeuxTrois !== undefined
+              ? noteIndicateurDeuxTrois
+              : "--") + "/35",
           secondLineInfo: correctionMeasure
             ? "mesures de correction prises en compte"
             : undefined,
           indicateurSexeSurRepresente
         }}
       >
-        <RowLabelFull label="écart de taux de promotions par csp" />
+        <RowLabelFull label="taux d'augmentation ou de promotion" />
+        <RowLabels labels={["femmes", "hommes"]} />
+        <RowData
+          name="taux de salariés augmentés ou promus"
+          data={[
+            tauxAugmentationPromotionFemmes,
+            tauxAugmentationPromotionHommes
+          ]}
+          asPercent={true}
+        />
 
-        {effectifEtEcartPromoParGroupe.map(
-          ({ categorieSocioPro, ecartTauxPromotion }) => (
-            <RowDataFull
-              key={categorieSocioPro}
-              name={displayNameCategorieSocioPro(categorieSocioPro)}
-              data={ecartTauxPromotion}
-            />
-          )
-        )}
+        <RowLabelFull label="écart en nombre équivalent de salariés" />
+        <RowData
+          name="nombre équivalent de salariés"
+          data={[indicateurEcartNombreEquivalentSalaries]}
+          message={messageEcartNombreEquivalentSalaries(
+            indicateurSexeSurRepresente,
+            plusPetitNombreSalaries
+          )}
+        />
       </RecapBloc>
     </div>
   );
 }
+
+const messageEcartNombreEquivalentSalaries = (
+  indicateurSexeSurRepresente: "hommes" | "femmes" | undefined,
+  plusPetitNombreSalaries: "hommes" | "femmes" | undefined
+): string => {
+  if (
+    indicateurSexeSurRepresente === "hommes" &&
+    plusPetitNombreSalaries === "femmes"
+  ) {
+    return "si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+  } else if (
+    indicateurSexeSurRepresente === "hommes" &&
+    plusPetitNombreSalaries === "hommes"
+  ) {
+    return "Si ce nombre d'hommes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes.";
+  } else if (
+    indicateurSexeSurRepresente === "hommes" &&
+    plusPetitNombreSalaries === undefined
+  ) {
+    return "Si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+  } else if (
+    indicateurSexeSurRepresente === "femmes" &&
+    plusPetitNombreSalaries === "femmes"
+  ) {
+    return "Si ce nombre de femmes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes.";
+  } else if (
+    indicateurSexeSurRepresente === "femmes" &&
+    plusPetitNombreSalaries === "hommes"
+  ) {
+    return "Si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+  } else if (
+    indicateurSexeSurRepresente === "femmes" &&
+    plusPetitNombreSalaries === undefined
+  ) {
+    return "Si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+  } else {
+    return "nothing";
+  }
+};
 
 const styles = {
   container: css({
@@ -126,7 +175,8 @@ const styles = {
     flexDirection: "column",
     marginTop: 22,
     marginBottom: 22
-  })
+  }),
+  message: css({})
 };
 
-export default RecapitulatifIndicateurTrois;
+export default RecapitulatifIndicateurDeuxTrois;

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurTrois.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurTrois.tsx
@@ -112,6 +112,7 @@ function RecapitulatifIndicateurTrois({
               key={categorieSocioPro}
               name={displayNameCategorieSocioPro(categorieSocioPro)}
               data={ecartTauxPromotion}
+              asPercent={true}
             />
           )
         )}

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
@@ -146,6 +146,7 @@ function RecapitulatifIndicateurUn({
                 effectifEtEcartRemuParTranche[2].ecartRemunerationMoyenne,
                 effectifEtEcartRemuParTranche[3].ecartRemunerationMoyenne
               ]}
+              asPercent={true}
             />
           )
         )}

--- a/packages/app/src/views/Recapitulatif/components/RowData.tsx
+++ b/packages/app/src/views/Recapitulatif/components/RowData.tsx
@@ -10,10 +10,14 @@ import { CellHead, Cell } from "../../../components/Cell";
 
 function RowData({
   name,
-  data
+  data,
+  asPercent,
+  message
 }: {
   name: string;
   data: Array<number | undefined>;
+  asPercent?: boolean;
+  message?: string;
 }) {
   return (
     <div css={styles.container}>
@@ -31,20 +35,27 @@ function RowData({
               datum === undefined && styles.cellEmpty
             ]}
           >
-            {datum !== undefined ? displayFractionPercent(datum, 1) : "nc"}
+            {datum !== undefined
+              ? asPercent
+                ? displayFractionPercent(datum, 1)
+                : datum
+              : "nc"}
           </Cell>
         ))}
       </div>
+      <p css={css({ fontSize: "0.8em" })}>{message}</p>
     </div>
   );
 }
 
 export function RowDataFull({
   name,
-  data
+  data,
+  asPercent
 }: {
   name: string;
   data: number | undefined;
+  asPercent: boolean;
 }) {
   return (
     <div css={styles.container}>
@@ -61,7 +72,11 @@ export function RowDataFull({
             data === undefined && styles.cellEmpty
           ]}
         >
-          {data !== undefined ? displayFractionPercent(data, 1) : "nc"}
+          {data !== undefined
+            ? asPercent
+              ? displayFractionPercent(data, 1)
+              : data
+            : "nc"}
         </Cell>
       </div>
     </div>


### PR DESCRIPTION
Fixes #160

- [x] création de la page en se basant sur les pages d'indicateur 2 ou 3
- [x] ajout de l'entrée pour le nouvel indicateur dans le menu
- [x] l'indicateur ne demande qu'un nombre total d'augmentations ou de promotions
- [x] adaptation du calcul pour ce nouvel indicateur
- [x] adaptation des tests
- [x] ajout de la "mesure de correction"
- [x] ajout du composant pour de choix de la période de déclaration (période de référence, 2 périodes, 3 périodes)
- [ ] ~~si "autre période de référence" (pluri-annuelles) sélectionné, ne pas afficher le radiobutton "il y a eu/pas eu d'augmentations ou promotions"~~
- [x] adapter le récapitulatif