### PR TITLE
Nouvelle page informations entreprise et période de référence

### DIFF
--- a/packages/app/src/AppReducer.test.tsx
+++ b/packages/app/src/AppReducer.test.tsx
@@ -52,7 +52,8 @@ describe("updateInformations", () => {
     data: {
       nomEntreprise: "acme",
       trancheEffectifs: "250 à 999" as TrancheEffectifs,
-      debutPeriodeReference: "2019-10-15"
+      debutPeriodeReference: "2019-10-15",
+      finPeriodeReference: "2020-10-14"
     }
   };
 

--- a/packages/app/src/AppReducer.test.tsx
+++ b/packages/app/src/AppReducer.test.tsx
@@ -2,7 +2,8 @@ import {
   CategorieSocioPro,
   TranchesAges,
   FormState,
-  PeriodeDeclaration
+  PeriodeDeclaration,
+  TrancheEffectifs
 } from "./globals.d";
 
 import AppReducer from "./AppReducer";
@@ -44,6 +45,29 @@ describe("resetState", () => {
 //////////////////
 // UPDATE ////////
 //////////////////
+
+describe("updateInformations", () => {
+  const action = {
+    type: "updateInformations" as "updateInformations",
+    data: {
+      nomEntreprise: "acme",
+      trancheEffectifs: "250 à 999" as TrancheEffectifs,
+      debutPeriodeReference: "2019-10-15"
+    }
+  };
+
+  test("nothing undefined state", () => {
+    expect(AppReducer(stateUndefined, action)).toMatchSnapshot();
+  });
+
+  test("change default state", () => {
+    expect(AppReducer(stateDefault, action)).toMatchSnapshot();
+  });
+
+  test("change complete state", () => {
+    expect(AppReducer(stateComplete, action)).toMatchSnapshot();
+  });
+});
 
 describe("updateEffectif", () => {
   const action = {
@@ -631,6 +655,25 @@ describe("updateIndicateurCinq", () => {
 //////////////////
 // VALIDATE //////
 //////////////////
+
+describe("validateInformations", () => {
+  const action = {
+    type: "validateInformations" as "validateInformations",
+    valid: "Valid" as FormState
+  };
+
+  test("nothing undefined state", () => {
+    expect(AppReducer(stateUndefined, action)).toMatchSnapshot();
+  });
+
+  test("change default state", () => {
+    expect(AppReducer(stateDefault, action)).toMatchSnapshot();
+  });
+
+  test("change complete state", () => {
+    expect(AppReducer(stateComplete, action)).toMatchSnapshot();
+  });
+});
 
 describe("validateEffectif", () => {
   describe("Valid", () => {

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -63,6 +63,12 @@ const dataIndicateurTrois = mapEnum(
 );
 
 const defaultState: AppState = {
+  informations: {
+    formValidated: "None",
+    nomEntreprise: "",
+    trancheEffectifs: "50 à 249",
+    debutPeriodeReference: ""
+  },
   effectif: {
     formValidated: "None",
     nombreSalaries: dataEffectif
@@ -121,6 +127,31 @@ function AppReducer(
     return state;
   }
   switch (action.type) {
+    case "updateInformations": {
+      const {
+        nomEntreprise,
+        trancheEffectifs,
+        debutPeriodeReference
+      } = action.data;
+      return {
+        ...state,
+        informations: {
+          ...state.informations,
+          nomEntreprise,
+          trancheEffectifs,
+          debutPeriodeReference
+        }
+      };
+    }
+    case "validateInformations": {
+      return {
+        ...state,
+        informations: {
+          ...state.informations,
+          formValidated: action.valid
+        }
+      };
+    }
     case "updateEffectif": {
       const { nombreSalaries } = action.data;
       return {

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -67,7 +67,8 @@ const defaultState: AppState = {
     formValidated: "None",
     nomEntreprise: "",
     trancheEffectifs: "50 à 249",
-    debutPeriodeReference: ""
+    debutPeriodeReference: "",
+    finPeriodeReference: ""
   },
   effectif: {
     formValidated: "None",
@@ -131,7 +132,8 @@ function AppReducer(
       const {
         nomEntreprise,
         trancheEffectifs,
-        debutPeriodeReference
+        debutPeriodeReference,
+        finPeriodeReference
       } = action.data;
       return {
         ...state,
@@ -139,7 +141,8 @@ function AppReducer(
           ...state.informations,
           nomEntreprise,
           trancheEffectifs,
-          debutPeriodeReference
+          debutPeriodeReference,
+          finPeriodeReference
         }
       };
     }

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -147,6 +147,24 @@ function AppReducer(
       };
     }
     case "validateInformations": {
+      if (action.valid === "None") {
+        return {
+          ...state,
+          informations: { ...state.informations, formValidated: action.valid },
+          indicateurDeux:
+            state.indicateurDeux.formValidated === "Valid"
+              ? { ...state.indicateurDeux, formValidated: "Invalid" }
+              : state.indicateurDeux,
+          indicateurTrois:
+            state.indicateurTrois.formValidated === "Valid"
+              ? { ...state.indicateurTrois, formValidated: "Invalid" }
+              : state.indicateurTrois,
+          indicateurDeuxTrois:
+            state.indicateurDeuxTrois.formValidated === "Valid"
+              ? { ...state.indicateurDeuxTrois, formValidated: "Invalid" }
+              : state.indicateurDeuxTrois
+        };
+      }
       return {
         ...state,
         informations: {

--- a/packages/app/src/__fixtures__/stateComplete.tsx
+++ b/packages/app/src/__fixtures__/stateComplete.tsx
@@ -1,13 +1,23 @@
 import {
   CategorieSocioPro,
   PeriodeDeclaration,
-  TranchesAges
+  TranchesAges,
+  TrancheEffectifs
 } from "../globals.d";
 import AppReducer from "../AppReducer";
 
 const actionInitiateState = {
   type: "initiateState" as "initiateState",
   data: {}
+};
+
+const actionUpdateInformations = {
+  type: "updateInformations" as "updateInformations",
+  data: {
+    nomEntreprise: "BigCorp",
+    trancheEffectifs: "1000 et plus" as TrancheEffectifs,
+    debutPeriodeReference: "2019-01-01"
+  }
 };
 
 const actionUpdateEffectif = {
@@ -402,7 +412,10 @@ const stateDefault = AppReducer(
                 AppReducer(
                   AppReducer(
                     AppReducer(
-                      AppReducer(undefined, actionInitiateState),
+                      AppReducer(
+                        AppReducer(undefined, actionInitiateState),
+                        actionUpdateInformations
+                      ),
                       actionUpdateEffectif
                     ),
                     actionUpdateIndicateurUnCsp

--- a/packages/app/src/__fixtures__/stateComplete.tsx
+++ b/packages/app/src/__fixtures__/stateComplete.tsx
@@ -16,7 +16,8 @@ const actionUpdateInformations = {
   data: {
     nomEntreprise: "BigCorp",
     trancheEffectifs: "1000 et plus" as TrancheEffectifs,
-    debutPeriodeReference: "2019-01-01"
+    debutPeriodeReference: "2019-01-01",
+    finPeriodeReference: "2019-12-31"
   }
 };
 

--- a/packages/app/src/__fixtures__/stateCompleteAndValidate.tsx
+++ b/packages/app/src/__fixtures__/stateCompleteAndValidate.tsx
@@ -3,6 +3,11 @@ import AppReducer from "../AppReducer";
 
 import stateComplete from "./stateComplete";
 
+const actionValidateInformations = {
+  type: "validateInformations" as "validateInformations",
+  valid: "Valid" as FormState
+};
+
 const actionValidateEffectif = {
   type: "validateEffectif" as "validateEffectif",
   valid: "Valid" as FormState
@@ -57,7 +62,10 @@ const stateDefault = AppReducer(
           AppReducer(
             AppReducer(
               AppReducer(
-                AppReducer(stateComplete, actionValidateEffectif),
+                AppReducer(
+                  AppReducer(stateComplete, actionValidateInformations),
+                  actionValidateEffectif
+                ),
                 actionValidateIndicateurUnCoefGroup
               ),
               actionValidateIndicateurUnCoefEffectif

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -328,6 +328,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -657,6 +658,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "Valid",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -952,6 +954,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -1283,6 +1286,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -1578,6 +1582,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -1909,6 +1914,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -2204,6 +2210,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -2535,6 +2542,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -2830,6 +2838,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -3161,6 +3170,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -3456,6 +3466,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -3787,6 +3798,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -4082,6 +4094,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -4413,6 +4426,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -4708,6 +4722,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -5039,6 +5054,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -5368,6 +5384,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -5699,6 +5716,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -6028,6 +6046,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -6359,6 +6378,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -6688,6 +6708,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -7052,6 +7073,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -7381,6 +7403,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -7678,6 +7701,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -7973,6 +7997,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -8304,6 +8329,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -8599,6 +8625,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -8930,6 +8957,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -9225,6 +9253,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -9556,6 +9585,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-10-15",
+    "finPeriodeReference": "2020-10-14",
     "formValidated": "None",
     "nomEntreprise": "acme",
     "trancheEffectifs": "250 à 999",
@@ -9851,6 +9881,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-10-15",
+    "finPeriodeReference": "2020-10-14",
     "formValidated": "None",
     "nomEntreprise": "acme",
     "trancheEffectifs": "250 à 999",
@@ -10182,6 +10213,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "Valid",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -10511,6 +10543,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "Valid",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -10840,6 +10873,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "Valid",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -11169,6 +11203,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -11464,6 +11499,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -11795,6 +11831,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -12090,6 +12127,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -12421,6 +12459,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -12716,6 +12755,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -13047,6 +13087,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -13342,6 +13383,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -13673,6 +13715,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -13968,6 +14011,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -14299,6 +14343,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -14594,6 +14639,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -14925,6 +14971,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -15220,6 +15267,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -15551,6 +15599,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "Valid",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -15880,6 +15929,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -16175,6 +16225,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -16506,6 +16557,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "Valid",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -16835,6 +16887,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "None",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -17130,6 +17183,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "None",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",
@@ -17461,6 +17515,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "2019-01-01",
+    "finPeriodeReference": "2019-12-31",
     "formValidated": "Valid",
     "nomEntreprise": "BigCorp",
     "trancheEffectifs": "1000 et plus",
@@ -17756,6 +17811,7 @@ Object {
   },
   "informations": Object {
     "debutPeriodeReference": "",
+    "finPeriodeReference": "",
     "formValidated": "Valid",
     "nomEntreprise": "",
     "trancheEffectifs": "50 à 249",

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -326,6 +326,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -649,6 +655,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "Valid",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -937,6 +949,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -1263,6 +1281,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -1551,6 +1575,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -1877,6 +1907,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -2165,6 +2201,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -2491,6 +2533,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -2779,6 +2827,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -3105,6 +3159,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -3393,6 +3453,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -3719,6 +3785,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -4007,6 +4079,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -4333,6 +4411,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -4621,6 +4705,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -4947,6 +5037,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -5269,6 +5365,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -5595,6 +5697,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -5917,6 +6025,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -6243,6 +6357,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -6565,6 +6685,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -6924,6 +7050,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -7247,6 +7379,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
+  },
 }
 `;
 
@@ -7538,6 +7676,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -7826,6 +7970,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -8152,6 +8302,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -8440,6 +8596,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -8766,6 +8928,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -9055,10 +9223,642 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
+  },
 }
 `;
 
 exports[`updateIndicateurUnType nothing undefined state 1`] = `undefined`;
+
+exports[`updateInformations change complete state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 23,
+            "nombreSalariesHommes": 32,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 12,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 34,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 21,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 63,
+            "nombreSalariesHommes": 25,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 52,
+            "nombreSalariesHommes": 62,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 18,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 27,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 14,
+            "nombreSalariesHommes": 15,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 4,
+            "nombreSalariesHommes": 5,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 6,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 10,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 13,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": 4,
+    "nombreSalariesHommes": 6,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": false,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": 2.2,
+        "tauxAugmentationHommes": 3.5,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": 1.3,
+        "tauxAugmentationHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": 8.02,
+        "tauxAugmentationHommes": 6.92,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": 12.15,
+        "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeDeclaration": "unePeriodeReference",
+    "presenceAugmentationPromotion": false,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": 7,
+    "nombreSalarieesPeriodeAugmentation": 7,
+    "presenceCongeMat": false,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": false,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": 1.1,
+        "tauxPromotionHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": 0.3,
+        "tauxPromotionHommes": 2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": 2,
+        "tauxPromotionHommes": 3,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": 4,
+        "tauxPromotionHommes": 5.55,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [
+      Object {
+        "name": "Business Developers",
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 4,
+            "remunerationAnnuelleBrutFemmes": 25000,
+            "remunerationAnnuelleBrutHommes": 24000,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 2,
+            "nombreSalariesHommes": 6,
+            "remunerationAnnuelleBrutFemmes": 32000,
+            "remunerationAnnuelleBrutHommes": 32000,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 41000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 1,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 49000,
+            "remunerationAnnuelleBrutHommes": 51500,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 25500,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27500,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 31000,
+            "remunerationAnnuelleBrutHommes": 33000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 39000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 26000,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27000,
+            "remunerationAnnuelleBrutHommes": 29000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 34000,
+            "remunerationAnnuelleBrutHommes": 36000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 42000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 36000,
+            "remunerationAnnuelleBrutHommes": 38000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 37000,
+            "remunerationAnnuelleBrutHommes": 39000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 44000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 52000,
+            "remunerationAnnuelleBrutHommes": 56000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "2019-10-15",
+    "formValidated": "None",
+    "nomEntreprise": "acme",
+    "trancheEffectifs": "250 à 999",
+  },
+}
+`;
+
+exports[`updateInformations change default state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": undefined,
+    "nombreSalariesHommes": undefined,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": true,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeDeclaration": "unePeriodeReference",
+    "presenceAugmentationPromotion": true,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": undefined,
+    "nombreSalarieesPeriodeAugmentation": undefined,
+    "presenceCongeMat": true,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": true,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "2019-10-15",
+    "formValidated": "None",
+    "nomEntreprise": "acme",
+    "trancheEffectifs": "250 à 999",
+  },
+}
+`;
+
+exports[`updateInformations nothing undefined state 1`] = `undefined`;
 
 exports[`validateEffectif None with csp false invalid complete validate state 1`] = `
 Object {
@@ -9379,6 +10179,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "Valid",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
   },
 }
 `;
@@ -9703,6 +10509,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "Valid",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -10025,6 +10837,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "Valid",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
   },
 }
 `;
@@ -10349,6 +11167,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -10637,6 +11461,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -10963,6 +11793,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -11251,6 +12087,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -11577,6 +12419,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -11865,6 +12713,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -12191,6 +13045,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -12479,6 +13339,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -12805,6 +13671,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -13093,6 +13965,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -13419,6 +14297,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -13707,6 +14591,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -14033,6 +14923,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -14321,6 +15217,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -14647,6 +15549,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "Valid",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -14970,6 +15878,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -15258,6 +16172,12 @@ Object {
         ],
       },
     ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
   },
 }
 `;
@@ -15584,6 +16504,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "Valid",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -15907,6 +16833,12 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "None",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
 }
 `;
 
@@ -16196,7 +17128,639 @@ Object {
       },
     ],
   },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "None",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
+  },
 }
 `;
 
 exports[`validateIndicateurUnCoefGroup Valid nothing undefined state 1`] = `undefined`;
+
+exports[`validateInformations change complete state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 23,
+            "nombreSalariesHommes": 32,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 12,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 34,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 21,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 63,
+            "nombreSalariesHommes": 25,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 52,
+            "nombreSalariesHommes": 62,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 18,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 27,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 14,
+            "nombreSalariesHommes": 15,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 4,
+            "nombreSalariesHommes": 5,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 6,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 7,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 7,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 10,
+            "nombreSalariesHommes": 8,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 13,
+            "nombreSalariesHommes": 13,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 16,
+            "nombreSalariesHommes": 19,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": 4,
+    "nombreSalariesHommes": 6,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": false,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": 2.2,
+        "tauxAugmentationHommes": 3.5,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": 1.3,
+        "tauxAugmentationHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": 8.02,
+        "tauxAugmentationHommes": 6.92,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": 12.15,
+        "tauxAugmentationHommes": 13.56,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "nombreAugmentationPromotionFemmes": 1,
+    "nombreAugmentationPromotionHommes": 2,
+    "periodeDeclaration": "unePeriodeReference",
+    "presenceAugmentationPromotion": false,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": 7,
+    "nombreSalarieesPeriodeAugmentation": 7,
+    "presenceCongeMat": false,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": false,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": 1.1,
+        "tauxPromotionHommes": 2.2,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": 0.3,
+        "tauxPromotionHommes": 2,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": 2,
+        "tauxPromotionHommes": 3,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": 4,
+        "tauxPromotionHommes": 5.55,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [
+      Object {
+        "name": "Business Developers",
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 4,
+            "remunerationAnnuelleBrutFemmes": 25000,
+            "remunerationAnnuelleBrutHommes": 24000,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": 2,
+            "nombreSalariesHommes": 6,
+            "remunerationAnnuelleBrutFemmes": 32000,
+            "remunerationAnnuelleBrutHommes": 32000,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": 5,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 41000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": 1,
+            "nombreSalariesHommes": 3,
+            "remunerationAnnuelleBrutFemmes": 49000,
+            "remunerationAnnuelleBrutHommes": 51500,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 25500,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27500,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 23000,
+            "remunerationAnnuelleBrutHommes": 25000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 24000,
+            "remunerationAnnuelleBrutHommes": 26000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 31000,
+            "remunerationAnnuelleBrutHommes": 33000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 39000,
+            "remunerationAnnuelleBrutHommes": 43000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 26000,
+            "remunerationAnnuelleBrutHommes": 28000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 27000,
+            "remunerationAnnuelleBrutHommes": 29000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 34000,
+            "remunerationAnnuelleBrutHommes": 36000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 42000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": 36000,
+            "remunerationAnnuelleBrutHommes": 38000,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 37000,
+            "remunerationAnnuelleBrutHommes": 39000,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 44000,
+            "remunerationAnnuelleBrutHommes": 46000,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": 52000,
+            "remunerationAnnuelleBrutHommes": 56000,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "2019-01-01",
+    "formValidated": "Valid",
+    "nomEntreprise": "BigCorp",
+    "trancheEffectifs": "1000 et plus",
+  },
+}
+`;
+
+exports[`validateInformations change default state 1`] = `
+Object {
+  "effectif": Object {
+    "formValidated": "None",
+    "nombreSalaries": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "nombreSalariesFemmes": undefined,
+            "nombreSalariesHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "indicateurCinq": Object {
+    "formValidated": "None",
+    "nombreSalariesFemmes": undefined,
+    "nombreSalariesHommes": undefined,
+  },
+  "indicateurDeux": Object {
+    "formValidated": "None",
+    "presenceAugmentation": true,
+    "tauxAugmentation": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxAugmentationFemmes": undefined,
+        "tauxAugmentationHommes": undefined,
+      },
+    ],
+  },
+  "indicateurDeuxTrois": Object {
+    "formValidated": "None",
+    "nombreAugmentationPromotionFemmes": undefined,
+    "nombreAugmentationPromotionHommes": undefined,
+    "periodeDeclaration": "unePeriodeReference",
+    "presenceAugmentationPromotion": true,
+  },
+  "indicateurQuatre": Object {
+    "formValidated": "None",
+    "nombreSalarieesAugmentees": undefined,
+    "nombreSalarieesPeriodeAugmentation": undefined,
+    "presenceCongeMat": true,
+  },
+  "indicateurTrois": Object {
+    "formValidated": "None",
+    "presencePromotion": true,
+    "tauxPromotion": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tauxPromotionFemmes": undefined,
+        "tauxPromotionHommes": undefined,
+      },
+    ],
+  },
+  "indicateurUn": Object {
+    "coefficient": Array [],
+    "coefficientEffectifFormValidated": "None",
+    "coefficientGroupFormValidated": "None",
+    "csp": true,
+    "formValidated": "None",
+    "remunerationAnnuelle": Array [
+      Object {
+        "categorieSocioPro": 0,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 1,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 2,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+      Object {
+        "categorieSocioPro": 3,
+        "tranchesAges": Array [
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 0,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 1,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 2,
+          },
+          Object {
+            "remunerationAnnuelleBrutFemmes": undefined,
+            "remunerationAnnuelleBrutHommes": undefined,
+            "trancheAge": 3,
+          },
+        ],
+      },
+    ],
+  },
+  "informations": Object {
+    "debutPeriodeReference": "",
+    "formValidated": "Valid",
+    "nomEntreprise": "",
+    "trancheEffectifs": "50 à 249",
+  },
+}
+`;
+
+exports[`validateInformations nothing undefined state 1`] = `undefined`;

--- a/packages/app/src/components/Input.tsx
+++ b/packages/app/src/components/Input.tsx
@@ -14,9 +14,15 @@ interface Props {
   field: FieldRenderProps<string, HTMLInputElement>;
   placeholder?: string;
   style?: any;
+  readOnly?: boolean;
 }
 
-function Input({ field: { input, meta }, placeholder, style }: Props) {
+function Input({
+  field: { input, meta },
+  placeholder,
+  style,
+  readOnly = false
+}: Props) {
   const error = hasFieldError(meta);
 
   return (
@@ -25,6 +31,7 @@ function Input({ field: { input, meta }, placeholder, style }: Props) {
       autoComplete="off"
       placeholder={placeholder}
       id={input.name}
+      readOnly={readOnly}
       {...input}
     />
   );

--- a/packages/app/src/components/Menu.tsx
+++ b/packages/app/src/components/Menu.tsx
@@ -60,6 +60,7 @@ function CustomNavLink({
 }
 
 interface Props {
+  informationsFormValidated: FormState;
   effectifFormValidated: FormState;
   indicateurUnFormValidated: FormState;
   indicateurDeuxFormValidated: FormState;
@@ -70,6 +71,7 @@ interface Props {
 }
 
 function Menu({
+  informationsFormValidated,
   effectifFormValidated,
   indicateurUnFormValidated,
   indicateurDeuxFormValidated,
@@ -103,6 +105,12 @@ function Menu({
                 to={`/simulateur/${code}`}
                 title="vos informations"
                 activeOnlyWhenExact={true}
+              />
+              <CustomNavLink
+                to={`/simulateur/${code}/informations`}
+                title="informations entreprise"
+                label="et période de référence"
+                valid={informationsFormValidated}
               />
               <CustomNavLink
                 to={`/simulateur/${code}/effectifs`}

--- a/packages/app/src/components/RadioLabels.tsx
+++ b/packages/app/src/components/RadioLabels.tsx
@@ -41,7 +41,7 @@ interface Props {
 function RadioLabels({ readOnly, fieldName, label, value, choices }: Props) {
   return (
     <div css={styles.container}>
-      <p>{label}</p>
+      <p css={styles.inputLabel}>{label}</p>
       <div css={[styles.radioField]}>
         {choices.map(({ label: choiceLabel, value: choiceValue }) => (
           <RadioField
@@ -63,11 +63,16 @@ const styles = {
     display: "flex",
     flexDirection: "column",
     fontSize: 14,
-    marginBottom: 20
+    marginBottom: 40
   }),
   radioField: css({
     display: "flex",
     marginTop: 5
+  }),
+  inputLabel: css({
+    fontSize: 14,
+    fontWeight: "bold",
+    lineHeight: "17px"
   }),
   label: css({
     backgroundColor: "#fff",

--- a/packages/app/src/components/RadioLabels.tsx
+++ b/packages/app/src/components/RadioLabels.tsx
@@ -1,0 +1,103 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { ReactNode } from "react";
+import { useField } from "react-final-form";
+
+function RadioField({
+  fieldName,
+  label,
+  value,
+  choiceValue,
+  disabled
+}: {
+  fieldName: string;
+  label: ReactNode;
+  value: string;
+  choiceValue: string;
+  disabled: boolean;
+}) {
+  const { input } = useField(fieldName, { type: "radio", value: choiceValue });
+  return (
+    <label css={[styles.label, value === choiceValue && styles.labelChecked]}>
+      <input css={styles.radio} {...input} disabled={disabled} />
+      <span css={styles.labelText}>{label}</span>
+    </label>
+  );
+}
+
+export type RadioLabelChoice = {
+  label: string;
+  value: string;
+};
+
+interface Props {
+  readOnly: boolean;
+  fieldName: string;
+  label: string;
+  value: string;
+  choices: RadioLabelChoice[];
+}
+
+function RadioLabels({ readOnly, fieldName, label, value, choices }: Props) {
+  return (
+    <div css={styles.container}>
+      <p>{label}</p>
+      <div css={[styles.radioField]}>
+        {choices.map(({ label: choiceLabel, value: choiceValue }) => (
+          <RadioField
+            key={choiceLabel}
+            fieldName={fieldName}
+            label={choiceLabel}
+            value={value}
+            choiceValue={choiceValue}
+            disabled={readOnly}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const styles = {
+  container: css({
+    display: "flex",
+    flexDirection: "column",
+    fontSize: 14,
+    marginBottom: 20
+  }),
+  radioField: css({
+    display: "flex",
+    marginTop: 5
+  }),
+  label: css({
+    backgroundColor: "#fff",
+    flex: 1,
+    fontSize: 14,
+    cursor: "pointer",
+    display: "inline-block",
+    padding: "10px 20px",
+    border: "solid #191a49 1px",
+    borderRight: 0,
+    textAlign: "center",
+    "&:first-of-type": {
+      borderRight: 0,
+      borderRadius: "4px 0 0 4px"
+    },
+    "&:last-of-type": {
+      borderRadius: "0 4px 4px 0",
+      borderRight: "solid #191a49 1px"
+    }
+  }),
+  labelChecked: css({
+    backgroundColor: "#696CD1",
+    color: "#fff"
+  }),
+  labelText: css({
+    lineHeight: "16px"
+  }),
+  radio: css({
+    display: "none"
+  })
+};
+
+export default RadioLabels;

--- a/packages/app/src/containers/MainScrollView.tsx
+++ b/packages/app/src/containers/MainScrollView.tsx
@@ -21,6 +21,9 @@ function MainScrollView({ children, state, location }: Props) {
 
   const menu = (
     <Menu
+      informationsFormValidated={
+        state ? state.informations.formValidated : "None"
+      }
       effectifFormValidated={state ? state.effectif.formValidated : "None"}
       indicateurUnFormValidated={
         state ? state.indicateurUn.formValidated : "None"

--- a/packages/app/src/containers/Simulateur.tsx
+++ b/packages/app/src/containers/Simulateur.tsx
@@ -20,6 +20,7 @@ import IndicateurTrois from "../views/Indicateur3";
 import IndicateurDeuxTrois from "../views/Indicateur2et3";
 import IndicateurQuatre from "../views/Indicateur4";
 import IndicateurCinq from "../views/Indicateur5";
+import Informations from "../views/Informations";
 import Recapitulatif from "../views/Recapitulatif";
 
 interface Props {
@@ -84,6 +85,12 @@ function Simulateur({ code, state, dispatch }: Props) {
         path="/simulateur/:code/"
         exact
         render={props => <HomeSimulateur {...props} code={code} />}
+      />
+      <Route
+        path="/simulateur/:code/informations"
+        render={props => (
+          <Informations {...props} state={state} dispatch={dispatch} />
+        )}
       />
       <Route
         path="/simulateur/:code/effectifs"

--- a/packages/app/src/globals.d.ts
+++ b/packages/app/src/globals.d.ts
@@ -1,4 +1,10 @@
 export type AppState = {
+  informations: {
+    formValidated: FormState;
+    nomEntreprise: string;
+    trancheEffectifs: "50 à 249" | "250 à 999" | "1000 et plus";
+    debutPeriodeReference: string;
+  };
   effectif: {
     formValidated: FormState;
     nombreSalaries: Array<GroupeEffectif>;
@@ -46,6 +52,8 @@ export type PeriodeDeclaration =
   | "deuxPeriodesReference"
   | "troisPeriodesReference";
 
+export type TrancheEffectifs = "50 à 249" | "250 à 999" | "1000 et plus";
+
 export type FormState = "None" | "Valid" | "Invalid";
 
 export type ActionType =
@@ -55,6 +63,14 @@ export type ActionType =
   | {
       type: "initiateState";
       data: any;
+    }
+  | {
+      type: "updateInformations";
+      data: ActionInformationsData;
+    }
+  | {
+      type: "validateInformations";
+      valid: FormState;
     }
   | {
       type: "updateEffectif";
@@ -135,6 +151,12 @@ export type ActionType =
       type: "validateIndicateurCinq";
       valid: FormState;
     };
+
+export type ActionInformationsData = {
+  nomEntreprise: string;
+  trancheEffectifs: "50 à 249" | "250 à 999" | "1000 et plus";
+  debutPeriodeReference: string;
+};
 
 export type ActionEffectifData = {
   nombreSalaries: Array<GroupeEffectif>;

--- a/packages/app/src/globals.d.ts
+++ b/packages/app/src/globals.d.ts
@@ -2,8 +2,9 @@ export type AppState = {
   informations: {
     formValidated: FormState;
     nomEntreprise: string;
-    trancheEffectifs: "50 à 249" | "250 à 999" | "1000 et plus";
+    trancheEffectifs: TrancheEffectifs;
     debutPeriodeReference: string;
+    finPeriodeReference: string;
   };
   effectif: {
     formValidated: FormState;
@@ -154,8 +155,9 @@ export type ActionType =
 
 export type ActionInformationsData = {
   nomEntreprise: string;
-  trancheEffectifs: "50 à 249" | "250 à 999" | "1000 et plus";
+  trancheEffectifs: TrancheEffectifs;
   debutPeriodeReference: string;
+  finPeriodeReference: string;
 };
 
 export type ActionEffectifData = {

--- a/packages/app/src/utils/formHelpers.tsx
+++ b/packages/app/src/utils/formHelpers.tsx
@@ -1,5 +1,5 @@
 import { fractionToPercentage, percentageToFraction } from "./helpers";
-import { PeriodeDeclaration } from "../globals.d";
+import { PeriodeDeclaration, TrancheEffectifs } from "../globals.d";
 
 // INT PARSE
 
@@ -49,6 +49,21 @@ export const parsePeriodeDeclarationFormValue = (
       return "troisPeriodesReference" as PeriodeDeclaration;
     default:
       return "unePeriodeReference" as PeriodeDeclaration;
+  }
+};
+
+// TrancheEffectif PARSE
+
+export const parseTrancheEffectifsFormValue = (
+  value: string
+): TrancheEffectifs => {
+  switch (value) {
+    case "250 à 999":
+      return "250 à 999" as TrancheEffectifs;
+    case "1000 et plus":
+      return "1000 et plus" as TrancheEffectifs;
+    default:
+      return "50 à 249" as TrancheEffectifs;
   }
 };
 

--- a/packages/app/src/utils/formHelpers.tsx
+++ b/packages/app/src/utils/formHelpers.tsx
@@ -72,13 +72,16 @@ export const parseTrancheEffectifsFormValue = (
 export const required = (value: string): boolean => (value ? false : true);
 
 export const mustBeNumber = (value: string): boolean =>
-  Number.isNaN(Number(value)) ? true : false;
+  Number.isNaN(Number(value));
 
 export const minNumber = (value: string, min: number): boolean =>
-  Number(value) < min ? true : false;
+  Number(value) < min;
 
 export const maxNumber = (value: string, max: number): boolean =>
-  Number(value) > max ? true : false;
+  Number(value) > max;
+
+export const mustBeDate = (value: string): boolean =>
+  Number.isNaN(Date.parse(value));
 
 const regexpEmail = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 export const validateEmail = (email: string) => !regexpEmail.test(email);

--- a/packages/app/src/utils/helpers.test.tsx
+++ b/packages/app/src/utils/helpers.test.tsx
@@ -1,0 +1,15 @@
+import { calendarYear, Year } from "./helpers";
+
+describe("calendarYear", () => {
+  test("adds a year", () => {
+    expect(calendarYear("2018-12-31", Year.Add)).toEqual("2019-12-30");
+    expect(calendarYear("2019-01-01", Year.Add)).toEqual("2019-12-31");
+    expect(calendarYear("2019-01-02", Year.Add)).toEqual("2020-01-01");
+  });
+
+  test("subtracts a year", () => {
+    expect(calendarYear("2018-12-30", Year.Subtract)).toEqual("2017-12-31");
+    expect(calendarYear("2018-12-31", Year.Subtract)).toEqual("2018-01-01");
+    expect(calendarYear("2019-01-01", Year.Subtract)).toEqual("2018-01-02");
+  });
+});

--- a/packages/app/src/utils/helpers.test.tsx
+++ b/packages/app/src/utils/helpers.test.tsx
@@ -2,14 +2,26 @@ import { calendarYear, Year } from "./helpers";
 
 describe("calendarYear", () => {
   test("adds a year", () => {
-    expect(calendarYear("2018-12-31", Year.Add)).toEqual("2019-12-30");
-    expect(calendarYear("2019-01-01", Year.Add)).toEqual("2019-12-31");
-    expect(calendarYear("2019-01-02", Year.Add)).toEqual("2020-01-01");
+    expect(calendarYear("2018-12-31", Year.Add, 1)).toEqual("2019-12-30");
+    expect(calendarYear("2019-01-01", Year.Add, 1)).toEqual("2019-12-31");
+    expect(calendarYear("2019-01-02", Year.Add, 1)).toEqual("2020-01-01");
   });
 
   test("subtracts a year", () => {
-    expect(calendarYear("2018-12-30", Year.Subtract)).toEqual("2017-12-31");
-    expect(calendarYear("2018-12-31", Year.Subtract)).toEqual("2018-01-01");
-    expect(calendarYear("2019-01-01", Year.Subtract)).toEqual("2018-01-02");
+    expect(calendarYear("2018-12-30", Year.Subtract, 1)).toEqual("2017-12-31");
+    expect(calendarYear("2018-12-31", Year.Subtract, 1)).toEqual("2018-01-01");
+    expect(calendarYear("2019-01-01", Year.Subtract, 1)).toEqual("2018-01-02");
+  });
+
+  test("adds more than one year", () => {
+    expect(calendarYear("2018-12-31", Year.Add, 2)).toEqual("2020-12-30");
+    expect(calendarYear("2019-01-01", Year.Add, 2)).toEqual("2020-12-31");
+    expect(calendarYear("2019-01-02", Year.Add, 2)).toEqual("2021-01-01");
+  });
+
+  test("subtracts more than one year", () => {
+    expect(calendarYear("2018-12-30", Year.Subtract, 2)).toEqual("2016-12-31");
+    expect(calendarYear("2018-12-31", Year.Subtract, 2)).toEqual("2017-01-01");
+    expect(calendarYear("2019-01-01", Year.Subtract, 2)).toEqual("2017-01-02");
   });
 });

--- a/packages/app/src/utils/helpers.tsx
+++ b/packages/app/src/utils/helpers.tsx
@@ -67,10 +67,14 @@ export enum Year {
 
 // Return a date that is exactly one year later or before:
 // Eg: one year in the future: 2019-01-01 -> 2019-12-31
-export function calendarYear(dateStr: string, operation: Year): string {
+export function calendarYear(
+  dateStr: string,
+  operation: Year,
+  numYears: number
+): string {
   // Adding a year: we subtract a day to the final result.
   // Subtracting a year: we add a day to the final result.
-  const year = operation === Year.Add ? 1 : -1;
+  const year = operation === Year.Add ? numYears : -numYears;
   const day = operation === Year.Add ? -1 : 1;
   const date = new Date(dateStr);
   date.setFullYear(date.getFullYear() + year);

--- a/packages/app/src/utils/helpers.tsx
+++ b/packages/app/src/utils/helpers.tsx
@@ -57,3 +57,25 @@ export const roundDecimal = (num: number, decimal: number): number => {
 export const fractionToPercentage = (num: number) => roundDecimal(num * 100, 5);
 
 export const percentageToFraction = (num: number) => roundDecimal(num / 100, 5);
+
+/* Dates */
+
+export enum Year {
+  Add,
+  Subtract
+}
+
+// Return a date that is exactly one year later or before:
+// Eg: one year in the future: 2019-01-01 -> 2019-12-31
+export function calendarYear(dateStr: string, operation: Year): string {
+  // Adding a year: we subtract a day to the final result.
+  // Subtracting a year: we add a day to the final result.
+  const year = operation === Year.Add ? 1 : -1;
+  const day = operation === Year.Add ? -1 : 1;
+  const date = new Date(dateStr);
+  date.setFullYear(date.getFullYear() + year);
+  date.setDate(date.getDate() + day);
+  // Only keep YYYY-MM-DD.
+  const asString = date.toISOString().slice(0, 10);
+  return asString;
+}

--- a/packages/app/src/views/Effectif/Effectif.tsx
+++ b/packages/app/src/views/Effectif/Effectif.tsx
@@ -71,7 +71,8 @@ function Effectif({ state, dispatch }: Props) {
       {state.effectif.formValidated === "Valid" &&
         (state.indicateurUn.formValidated === "Invalid" ||
           state.indicateurDeux.formValidated === "Invalid" ||
-          state.indicateurTrois.formValidated === "Invalid") && (
+          state.indicateurTrois.formValidated === "Invalid" ||
+          state.indicateurDeuxTrois.formValidated === "Invalid") && (
           <InfoBloc
             title="Vos effectifs ont été modifiés"
             icon="cross"
@@ -102,9 +103,18 @@ function Effectif({ state, dispatch }: Props) {
                     </Fragment>
                   )}
                   {state.indicateurTrois.formValidated === "Invalid" && (
+                    <Fragment>
+                      <TextSimulatorLink
+                        to="/indicateur3"
+                        label="aller à l'indicateur écart de taux de promotions"
+                      />
+                      &emsp;
+                    </Fragment>
+                  )}
+                  {state.indicateurDeuxTrois.formValidated === "Invalid" && (
                     <TextSimulatorLink
-                      to="/indicateur3"
-                      label="aller à l'indicateur écart de taux de promotions"
+                      to="/indicateur2et3"
+                      label="aller à l'indicateur écart de taux d'augmentations et de propotions"
                     />
                   )}
                 </span>

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -133,6 +133,7 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
       <LayoutFormAndResult
         childrenForm={
           <IndicateurDeuxTroisForm
+            finPeriodeReference={state.informations.finPeriodeReference}
             presenceAugmentationPromotion={
               state.indicateurDeuxTrois.presenceAugmentationPromotion
             }

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTrois.tsx
@@ -52,6 +52,23 @@ function IndicateurDeuxTrois({ state, dispatch }: Props) {
     correctionMeasure
   } = calculIndicateurDeuxTrois(state);
 
+  // le formulaire d'informations n'est pas validé
+  if (state.informations.formValidated !== "Valid") {
+    return (
+      <PageIndicateurDeuxTrois>
+        <InfoBloc
+          title="vous devez renseignez vos informations d'entreprise avant d’avoir accès à cet indicateur"
+          text={
+            <TextSimulatorLink
+              to="/informations"
+              label="renseigner les informations"
+            />
+          }
+        />
+      </PageIndicateurDeuxTrois>
+    );
+  }
+
   // le formulaire d'effectif n'est pas validé
   if (state.effectif.formValidated !== "Valid") {
     return (

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisForm.tsx
@@ -23,8 +23,10 @@ import {
   parseBooleanStateValue,
   parsePeriodeDeclarationFormValue
 } from "../../utils/formHelpers";
+import { calendarYear, Year } from "../../utils/helpers";
 
 interface Props {
+  finPeriodeReference: string;
   presenceAugmentationPromotion: boolean;
   nombreAugmentationPromotionFemmes: number | undefined;
   nombreAugmentationPromotionHommes: number | undefined;
@@ -35,6 +37,7 @@ interface Props {
 }
 
 function IndicateurDeuxTroisForm({
+  finPeriodeReference,
   presenceAugmentationPromotion,
   nombreAugmentationPromotionFemmes,
   nombreAugmentationPromotionHommes,
@@ -82,6 +85,10 @@ function IndicateurDeuxTroisForm({
     validateIndicateurDeuxTrois("Valid");
   };
 
+  const oneYear = calendarYear(finPeriodeReference, Year.Subtract, 1);
+  const twoYears = calendarYear(finPeriodeReference, Year.Subtract, 2);
+  const threeYears = calendarYear(finPeriodeReference, Year.Subtract, 3);
+
   return (
     <Form
       onSubmit={onSubmit}
@@ -101,15 +108,15 @@ function IndicateurDeuxTroisForm({
             readOnly={readOnly}
             choices={[
               {
-                label: "la dernière période de référence",
+                label: `la période de référence choisie pour l'index du ${oneYear} au ${finPeriodeReference}`,
                 value: "unePeriodeReference"
               },
               {
-                label: "les deux dernières périodes de référence",
+                label: `les deux dernières périodes de référence du ${twoYears} au ${finPeriodeReference}`,
                 value: "deuxPeriodesReference"
               },
               {
-                label: "les trois dernières périodes de référence",
+                label: `les trois dernières périodes de référence du ${threeYears} au ${finPeriodeReference}`,
                 value: "troisPeriodesReference"
               }
             ]}

--- a/packages/app/src/views/Informations/Informations.tsx
+++ b/packages/app/src/views/Informations/Informations.tsx
@@ -1,0 +1,73 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { useCallback, ReactNode } from "react";
+import { RouteComponentProps } from "react-router-dom";
+
+import {
+  AppState,
+  FormState,
+  ActionType,
+  ActionInformationsData
+} from "../../globals";
+
+import Page from "../../components/Page";
+import LayoutFormAndResult from "../../components/LayoutFormAndResult";
+
+import InformationsForm from "./InformationsForm";
+import InformationsResult from "./InformationsResult";
+
+interface Props extends RouteComponentProps {
+  state: AppState;
+  dispatch: (action: ActionType) => void;
+}
+
+function Informations({ state, dispatch }: Props) {
+  const updateInformations = useCallback(
+    (data: ActionInformationsData) =>
+      dispatch({ type: "updateInformations", data }),
+    [dispatch]
+  );
+
+  const validateInformations = useCallback(
+    (valid: FormState) => dispatch({ type: "validateInformations", valid }),
+    [dispatch]
+  );
+
+  return (
+    <PageInformations>
+      <LayoutFormAndResult
+        childrenForm={
+          <InformationsForm
+            informations={state.informations}
+            readOnly={state.informations.formValidated === "Valid"}
+            updateInformations={updateInformations}
+            validateInformations={validateInformations}
+          />
+        }
+        childrenResult={
+          state.informations.formValidated === "Valid" && (
+            <InformationsResult
+              nomEntreprise={state.informations.nomEntreprise}
+              trancheEffectifs={state.informations.trancheEffectifs}
+              debutPeriodeReference={state.informations.debutPeriodeReference}
+              validateInformations={validateInformations}
+            />
+          )
+        }
+      />
+    </PageInformations>
+  );
+}
+
+function PageInformations({ children }: { children: ReactNode }) {
+  return (
+    <Page
+      title="Information société et période de référence"
+      tagline="Renseignez le nom et la tranche d'effectifs de votre enteprise, ainsi que la période de référence."
+    >
+      {children}
+    </Page>
+  );
+}
+
+export default Informations;

--- a/packages/app/src/views/Informations/Informations.tsx
+++ b/packages/app/src/views/Informations/Informations.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/core";
-import { useCallback, ReactNode } from "react";
+import { useCallback, Fragment, ReactNode } from "react";
 import { RouteComponentProps } from "react-router-dom";
 
 import {
@@ -10,8 +10,10 @@ import {
   ActionInformationsData
 } from "../../globals";
 
+import InfoBloc from "../../components/InfoBloc";
 import Page from "../../components/Page";
 import LayoutFormAndResult from "../../components/LayoutFormAndResult";
+import { TextSimulatorLink } from "../../components/SimulatorLink";
 
 import InformationsForm from "./InformationsForm";
 import InformationsResult from "./InformationsResult";
@@ -56,6 +58,51 @@ function Informations({ state, dispatch }: Props) {
           )
         }
       />
+
+      {state.informations.formValidated === "Valid" &&
+        (state.indicateurDeux.formValidated === "Invalid" ||
+          state.indicateurTrois.formValidated === "Invalid" ||
+          state.indicateurDeuxTrois.formValidated === "Invalid") && (
+          <InfoBloc
+            title="Vos informations ont été modifiés"
+            icon="cross"
+            text={
+              <Fragment>
+                <span>
+                  afin de s'assurer de la cohérence de votre index, merci de
+                  vérifier les données de vos indicateurs.
+                </span>
+                &emsp;
+                <span>
+                  {state.indicateurDeux.formValidated === "Invalid" && (
+                    <Fragment>
+                      <TextSimulatorLink
+                        to="/indicateur2"
+                        label="aller à l'indicateur écart de taux d'augmentations"
+                      />
+                      &emsp;
+                    </Fragment>
+                  )}
+                  {state.indicateurTrois.formValidated === "Invalid" && (
+                    <Fragment>
+                      <TextSimulatorLink
+                        to="/indicateur3"
+                        label="aller à l'indicateur écart de taux de promotions"
+                      />
+                      &emsp;
+                    </Fragment>
+                  )}
+                  {state.indicateurDeuxTrois.formValidated === "Invalid" && (
+                    <TextSimulatorLink
+                      to="/indicateur2et3"
+                      label="aller à l'indicateur écart de taux d'augmentations et de propotions"
+                    />
+                  )}
+                </span>
+              </Fragment>
+            }
+          />
+        )}
     </PageInformations>
   );
 }

--- a/packages/app/src/views/Informations/Informations.tsx
+++ b/packages/app/src/views/Informations/Informations.tsx
@@ -50,6 +50,7 @@ function Informations({ state, dispatch }: Props) {
               nomEntreprise={state.informations.nomEntreprise}
               trancheEffectifs={state.informations.trancheEffectifs}
               debutPeriodeReference={state.informations.debutPeriodeReference}
+              finPeriodeReference={state.informations.finPeriodeReference}
               validateInformations={validateInformations}
             />
           )

--- a/packages/app/src/views/Informations/InformationsForm.tsx
+++ b/packages/app/src/views/Informations/InformationsForm.tsx
@@ -1,0 +1,123 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { Form, Field } from "react-final-form";
+
+import { AppState, FormState, ActionInformationsData } from "../../globals";
+
+import { parseTrancheEffectifsFormValue } from "../../utils/formHelpers";
+
+import RadioButtons from "../../components/RadioButtons";
+import ActionBar from "../../components/ActionBar";
+import FormAutoSave from "../../components/FormAutoSave";
+import FormSubmit from "../../components/FormSubmit";
+import { ButtonSimulatorLink } from "../../components/SimulatorLink";
+
+///////////////////
+
+interface Props {
+  informations: AppState["informations"];
+  readOnly: boolean;
+  updateInformations: (data: ActionInformationsData) => void;
+  validateInformations: (valid: FormState) => void;
+}
+
+function InformationsForm({
+  informations,
+  readOnly,
+  updateInformations,
+  validateInformations
+}: Props) {
+  const initialValues: ActionInformationsData = {
+    nomEntreprise: informations.nomEntreprise,
+    trancheEffectifs: informations.trancheEffectifs,
+    debutPeriodeReference: informations.debutPeriodeReference
+  };
+
+  const saveForm = (formData: any) => {
+    const { nomEntreprise, trancheEffectifs, debutPeriodeReference } = formData;
+
+    updateInformations({
+      nomEntreprise: nomEntreprise,
+      trancheEffectifs: parseTrancheEffectifsFormValue(trancheEffectifs),
+      debutPeriodeReference: debutPeriodeReference
+    });
+  };
+
+  const onSubmit = (formData: any) => {
+    saveForm(formData);
+    validateInformations("Valid");
+  };
+
+  return (
+    <Form
+      onSubmit={onSubmit}
+      initialValues={initialValues}
+      // mandatory to not change user inputs
+      // because we want to keep wrong string inside the input
+      // we don't want to block string value
+      initialValuesEqual={() => true}
+    >
+      {({ handleSubmit, hasValidationErrors, submitFailed, values }) => (
+        <form onSubmit={handleSubmit} css={styles.container}>
+          <FormAutoSave saveForm={saveForm} />
+          <label>Quel est le nom de l'entreprise ?</label>
+          <Field name="nomEntreprise" component="input" readOnly={readOnly} />
+
+          <RadioButtons
+            fieldName="trancheEffectifs"
+            label="Quelle est la tranche d'effectifs de l'entreprise ?"
+            choices={[
+              {
+                label: "Entre 50 et 249",
+                value: "50 à 249"
+              },
+              {
+                label: "Entre 250 et 999",
+                value: "250 à 999"
+              },
+              {
+                label: "1000 et plus",
+                value: "1000 et plus"
+              }
+            ]}
+            value={values.trancheEffectifs}
+            readOnly={readOnly}
+          />
+
+          <label>
+            Sur quelle période souhaitez-vous faire votre votre déclaration ?
+          </label>
+          <Field
+            name="debutPeriodeReference"
+            component="input"
+            type="date"
+            readOnly={readOnly}
+          />
+
+          {readOnly ? (
+            <ActionBar>
+              <ButtonSimulatorLink to="/effectifs" label="suivant" />
+            </ActionBar>
+          ) : (
+            <ActionBar>
+              <FormSubmit
+                hasValidationErrors={hasValidationErrors}
+                submitFailed={submitFailed}
+                errorMessage="L’indicateur ne peut pas être validé si tous les champs ne sont pas remplis."
+              />
+            </ActionBar>
+          )}
+        </form>
+      )}
+    </Form>
+  );
+}
+
+const styles = {
+  container: css({
+    display: "flex",
+    flexDirection: "column"
+  })
+};
+
+export default InformationsForm;

--- a/packages/app/src/views/Informations/InformationsForm.tsx
+++ b/packages/app/src/views/Informations/InformationsForm.tsx
@@ -70,7 +70,7 @@ const calculator = createDecorator(
     updates: {
       finPeriodeReference: (dateDebut, { finPeriodeReference }: any) =>
         valueValidateForCalculator(dateDebut)
-          ? calendarYear(dateDebut, Year.Add)
+          ? calendarYear(dateDebut, Year.Add, 1)
           : finPeriodeReference
     }
   },
@@ -79,7 +79,7 @@ const calculator = createDecorator(
     updates: {
       debutPeriodeReference: (dateFin, { debutPeriodeReference }: any) =>
         valueValidateForCalculator(dateFin)
-          ? calendarYear(dateFin, Year.Subtract)
+          ? calendarYear(dateFin, Year.Subtract, 1)
           : debutPeriodeReference
     }
   }

--- a/packages/app/src/views/Informations/InformationsForm.tsx
+++ b/packages/app/src/views/Informations/InformationsForm.tsx
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
-import { Fragment } from "react";
 import { FieldMetaState, Form, useField } from "react-final-form";
 
 import { AppState, FormState, ActionInformationsData } from "../../globals";
@@ -47,13 +46,16 @@ const validateDate = (value: string) => {
 
 const validateForm = ({
   nomEntreprise,
-  debutPeriodeReference
+  debutPeriodeReference,
+  finPeriodeReference
 }: {
   nomEntreprise: string;
   debutPeriodeReference: string;
+  finPeriodeReference: string;
 }) => ({
   nomEntreprise: validate(nomEntreprise),
-  debutPeriodeReference: validateDate(debutPeriodeReference)
+  debutPeriodeReference: validateDate(debutPeriodeReference),
+  finPeriodeReference: validateDate(finPeriodeReference)
 });
 
 interface Props {
@@ -72,16 +74,23 @@ function InformationsForm({
   const initialValues: ActionInformationsData = {
     nomEntreprise: informations.nomEntreprise,
     trancheEffectifs: informations.trancheEffectifs,
-    debutPeriodeReference: informations.debutPeriodeReference
+    debutPeriodeReference: informations.debutPeriodeReference,
+    finPeriodeReference: informations.finPeriodeReference
   };
 
   const saveForm = (formData: any) => {
-    const { nomEntreprise, trancheEffectifs, debutPeriodeReference } = formData;
+    const {
+      nomEntreprise,
+      trancheEffectifs,
+      debutPeriodeReference,
+      finPeriodeReference
+    } = formData;
 
     updateInformations({
       nomEntreprise: nomEntreprise,
       trancheEffectifs: parseTrancheEffectifsFormValue(trancheEffectifs),
-      debutPeriodeReference: debutPeriodeReference
+      debutPeriodeReference: debutPeriodeReference,
+      finPeriodeReference: finPeriodeReference
     });
   };
 
@@ -126,7 +135,7 @@ function InformationsForm({
             readOnly={readOnly}
           />
 
-          <FieldDebutPeriodeReference readOnly={readOnly} />
+          <FieldPeriodeReference readOnly={readOnly} />
 
           {readOnly ? (
             <ActionBar>
@@ -152,7 +161,7 @@ function FieldNomEntreprise({ readOnly }: { readOnly: boolean }) {
   const error = hasFieldError(field.meta);
 
   return (
-    <Fragment>
+    <div css={styles.formField}>
       <label
         css={[styles.label, error && styles.labelError]}
         htmlFor={field.input.name}
@@ -165,25 +174,55 @@ function FieldNomEntreprise({ readOnly }: { readOnly: boolean }) {
       <p css={styles.error}>
         {error && "le nom de l'entreprise n’est pas valide"}
       </p>
-    </Fragment>
+    </div>
+  );
+}
+
+function FieldPeriodeReference({ readOnly }: { readOnly: boolean }) {
+  return (
+    <div>
+      <label css={styles.label}>
+        Sur quelle période souhaitez-vous faire votre votre déclaration ?
+      </label>
+      <div css={styles.dates}>
+        <FieldDate
+          name="debutPeriodeReference"
+          label="Date de début"
+          readOnly={readOnly}
+        />
+        <FieldDate
+          name="finPeriodeReference"
+          label="Date de fin"
+          readOnly={readOnly}
+        />
+      </div>
+    </div>
   );
 }
 
 const hasMustBeDateError = (meta: FieldMetaState<string>) =>
   meta.error && meta.touched && meta.error.mustBeDate;
 
-function FieldDebutPeriodeReference({ readOnly }: { readOnly: boolean }) {
-  const field = useField("debutPeriodeReference", { validate, type: "date" });
+function FieldDate({
+  name,
+  label,
+  readOnly
+}: {
+  name: string;
+  label: string;
+  readOnly: boolean;
+}) {
+  const field = useField(name, { validate, type: "date" });
   const error = hasFieldError(field.meta);
   const mustBeDateError = hasMustBeDateError(field.meta);
 
   return (
-    <Fragment>
+    <div css={styles.dateField}>
       <label
         css={[styles.label, error && styles.labelError]}
         htmlFor={field.input.name}
       >
-        Sur quelle période souhaitez-vous faire votre votre déclaration ?
+        {label}
       </label>
       <div css={styles.fieldRow}>
         <Input field={field} readOnly={readOnly} />
@@ -194,7 +233,7 @@ function FieldDebutPeriodeReference({ readOnly }: { readOnly: boolean }) {
             ? "ce champ doit contenir une date au format jj/mm/aaaa"
             : "ce champ n’est pas valide, renseignez une date au format jj/mm/aaaa")}
       </p>
-    </Fragment>
+    </div>
   );
 }
 
@@ -203,8 +242,12 @@ const styles = {
     display: "flex",
     flexDirection: "column"
   }),
+  formField: css({
+    marginBottom: 20
+  }),
   label: css({
     fontSize: 14,
+    fontWeight: "bold",
     lineHeight: "17px"
   }),
   labelError: css({
@@ -214,7 +257,8 @@ const styles = {
     height: 38,
     marginTop: 5,
     marginBottom: 5,
-    display: "flex"
+    display: "flex",
+    input: { borderRadius: 4 }
   }),
   error: css({
     height: 18,
@@ -222,6 +266,13 @@ const styles = {
     fontSize: 12,
     textDecoration: "underline",
     lineHeight: "15px"
+  }),
+  dates: css({
+    display: "flex",
+    justifyContent: "space-between"
+  }),
+  dateField: css({
+    marginTop: 5
   })
 };
 

--- a/packages/app/src/views/Informations/InformationsForm.tsx
+++ b/packages/app/src/views/Informations/InformationsForm.tsx
@@ -15,7 +15,7 @@ import ActionBar from "../../components/ActionBar";
 import FormAutoSave from "../../components/FormAutoSave";
 import FormSubmit from "../../components/FormSubmit";
 import Input, { hasFieldError } from "../../components/Input";
-import RadioButtons from "../../components/RadioButtons";
+import RadioLabels from "../../components/RadioLabels";
 import { ButtonSimulatorLink } from "../../components/SimulatorLink";
 import globalStyles from "../../utils/globalStyles";
 
@@ -105,7 +105,7 @@ function InformationsForm({
           <FormAutoSave saveForm={saveForm} />
           <FieldNomEntreprise readOnly={readOnly} />
 
-          <RadioButtons
+          <RadioLabels
             fieldName="trancheEffectifs"
             label="Quelle est la tranche d'effectifs de l'entreprise ?"
             choices={[

--- a/packages/app/src/views/Informations/InformationsForm.tsx
+++ b/packages/app/src/views/Informations/InformationsForm.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 import { FieldMetaState, Form, useField } from "react-final-form";
+import createDecorator from "final-form-calculate";
 
 import { AppState, FormState, ActionInformationsData } from "../../globals";
 
@@ -9,6 +10,7 @@ import {
   parseTrancheEffectifsFormValue,
   required
 } from "../../utils/formHelpers";
+import { calendarYear, Year } from "../../utils/helpers";
 
 import ActionBar from "../../components/ActionBar";
 import FormAutoSave from "../../components/FormAutoSave";
@@ -58,6 +60,31 @@ const validateForm = ({
   finPeriodeReference: validateDate(finPeriodeReference)
 });
 
+const valueValidateForCalculator = (value: string) => {
+  return validateDate(value) === undefined;
+};
+
+const calculator = createDecorator(
+  {
+    field: "debutPeriodeReference",
+    updates: {
+      finPeriodeReference: (dateDebut, { finPeriodeReference }: any) =>
+        valueValidateForCalculator(dateDebut)
+          ? calendarYear(dateDebut, Year.Add)
+          : finPeriodeReference
+    }
+  },
+  {
+    field: "finPeriodeReference",
+    updates: {
+      debutPeriodeReference: (dateFin, { debutPeriodeReference }: any) =>
+        valueValidateForCalculator(dateFin)
+          ? calendarYear(dateFin, Year.Subtract)
+          : debutPeriodeReference
+    }
+  }
+);
+
 interface Props {
   informations: AppState["informations"];
   readOnly: boolean;
@@ -103,6 +130,7 @@ function InformationsForm({
     <Form
       onSubmit={onSubmit}
       initialValues={initialValues}
+      decorators={[calculator]}
       validate={validateForm}
       // mandatory to not change user inputs
       // because we want to keep wrong string inside the input

--- a/packages/app/src/views/Informations/InformationsResult.tsx
+++ b/packages/app/src/views/Informations/InformationsResult.tsx
@@ -1,0 +1,54 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+
+import { FormState } from "../../globals";
+
+import ResultBubble from "../../components/ResultBubble";
+import ActionLink from "../../components/ActionLink";
+
+interface Props {
+  nomEntreprise: string;
+  trancheEffectifs: "50 à 249" | "250 à 999" | "1000 et plus";
+  debutPeriodeReference: string;
+  validateInformations: (valid: FormState) => void;
+}
+
+function InformationsResult({
+  nomEntreprise,
+  trancheEffectifs,
+  debutPeriodeReference,
+  validateInformations
+}: Props) {
+  return (
+    <div css={styles.container}>
+      <ResultBubble
+        firstLineLabel="le nom de votre entreprise"
+        firstLineData={nomEntreprise}
+        firstLineInfo={`votre tranche d'effectifs: ${trancheEffectifs}`}
+        secondLineLabel="votre période de référence est"
+        secondLineData={debutPeriodeReference}
+        indicateurSexeSurRepresente="hommes"
+      />
+
+      <p css={styles.edit}>
+        <ActionLink onClick={() => validateInformations("None")}>
+          modifier les données saisies
+        </ActionLink>
+      </p>
+    </div>
+  );
+}
+
+const styles = {
+  container: css({
+    maxWidth: 250,
+    marginTop: 64
+  }),
+  edit: css({
+    marginTop: 14,
+    marginBottom: 14,
+    textAlign: "center"
+  })
+};
+
+export default InformationsResult;

--- a/packages/app/src/views/Informations/InformationsResult.tsx
+++ b/packages/app/src/views/Informations/InformationsResult.tsx
@@ -1,15 +1,16 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 
-import { FormState } from "../../globals";
+import { FormState, TrancheEffectifs } from "../../globals";
 
 import ResultBubble from "../../components/ResultBubble";
 import ActionLink from "../../components/ActionLink";
 
 interface Props {
   nomEntreprise: string;
-  trancheEffectifs: "50 à 249" | "250 à 999" | "1000 et plus";
+  trancheEffectifs: TrancheEffectifs;
   debutPeriodeReference: string;
+  finPeriodeReference: string;
   validateInformations: (valid: FormState) => void;
 }
 
@@ -17,6 +18,7 @@ function InformationsResult({
   nomEntreprise,
   trancheEffectifs,
   debutPeriodeReference,
+  finPeriodeReference,
   validateInformations
 }: Props) {
   return (
@@ -25,8 +27,8 @@ function InformationsResult({
         firstLineLabel="le nom de votre entreprise"
         firstLineData={nomEntreprise}
         firstLineInfo={`votre tranche d'effectifs: ${trancheEffectifs}`}
-        secondLineLabel="votre période de référence débute le"
-        secondLineData={debutPeriodeReference}
+        secondLineLabel="votre période de référence est"
+        secondLineData={`${debutPeriodeReference} au ${finPeriodeReference}`}
         indicateurSexeSurRepresente="hommes"
       />
 

--- a/packages/app/src/views/Informations/InformationsResult.tsx
+++ b/packages/app/src/views/Informations/InformationsResult.tsx
@@ -25,7 +25,7 @@ function InformationsResult({
         firstLineLabel="le nom de votre entreprise"
         firstLineData={nomEntreprise}
         firstLineInfo={`votre tranche d'effectifs: ${trancheEffectifs}`}
-        secondLineLabel="votre période de référence est"
+        secondLineLabel="votre période de référence débute le"
         secondLineData={debutPeriodeReference}
         indicateurSexeSurRepresente="hommes"
       />

--- a/packages/app/src/views/Informations/index.js
+++ b/packages/app/src/views/Informations/index.js
@@ -1,0 +1,2 @@
+import Informations from "./Informations";
+export default Informations;

--- a/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
+++ b/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
@@ -11,12 +11,14 @@ import calculIndicateurDeuxTrois from "../../utils/calculsEgaProIndicateurDeuxTr
 import calculIndicateurQuatre from "../../utils/calculsEgaProIndicateurQuatre";
 import calculIndicateurCinq from "../../utils/calculsEgaProIndicateurCinq";
 import { calculNoteIndex } from "../../utils/calculsEgaProIndex";
+import totalNombreSalaries from "../../utils/totalNombreSalaries";
 
 import Page from "../../components/Page";
 import ActionBar from "../../components/ActionBar";
 import ButtonAction from "../../components/ButtonAction";
 
 import RecapitulatifIndex from "./RecapitulatifIndex";
+import RecapitulatifInformations from "./RecapitulatifInformations";
 import RecapitulatifIndicateurUn from "./RecapitulatifIndicateurUn";
 import RecapitulatifIndicateurDeux from "./RecapitulatifIndicateurDeux";
 import RecapitulatifIndicateurTrois from "./RecapitulatifIndicateurTrois";
@@ -102,8 +104,19 @@ function Recapitulatif({ state }: Props) {
     noteIndicateurCinq
   );
 
+  const {
+    totalNombreSalariesHomme,
+    totalNombreSalariesFemme
+  } = totalNombreSalaries(state.effectif.nombreSalaries);
+
   return (
     <Page title="Récapitulatif des résultats de vos indicateurs">
+      <RecapitulatifInformations
+        informationsFormValidated={state.informations.formValidated}
+        trancheEffectifs={state.informations.trancheEffectifs}
+        debutPeriodeReference={state.informations.debutPeriodeReference}
+        nombreSalaries={totalNombreSalariesHomme + totalNombreSalariesFemme}
+      />
       <RecapitulatifIndex
         allIndicateurValid={allIndicateurValid}
         noteIndex={noteIndex}

--- a/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
+++ b/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
@@ -115,6 +115,7 @@ function Recapitulatif({ state }: Props) {
         informationsFormValidated={state.informations.formValidated}
         trancheEffectifs={state.informations.trancheEffectifs}
         debutPeriodeReference={state.informations.debutPeriodeReference}
+        finPeriodeReference={state.informations.finPeriodeReference}
         nombreSalaries={totalNombreSalariesHomme + totalNombreSalariesFemme}
       />
       <RecapitulatifIndex

--- a/packages/app/src/views/Recapitulatif/RecapitulatifInformations.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifInformations.tsx
@@ -1,0 +1,89 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { Fragment } from "react";
+
+import { FormState, TrancheEffectifs } from "../../globals";
+
+import InfoBloc from "../../components/InfoBloc";
+import { TextSimulatorLink } from "../../components/SimulatorLink";
+import { useColumnsWidth, useLayoutType } from "../../components/GridContext";
+
+interface Props {
+  informationsFormValidated: FormState;
+  trancheEffectifs: TrancheEffectifs;
+  debutPeriodeReference: string;
+  nombreSalaries: number | undefined;
+}
+
+function RecapitulatifInformations({
+  informationsFormValidated,
+  trancheEffectifs,
+  debutPeriodeReference,
+  nombreSalaries
+}: Props) {
+  const layoutType = useLayoutType();
+  const width = useColumnsWidth(layoutType === "desktop" ? 6 : 7);
+
+  if (informationsFormValidated !== "Valid") {
+    return (
+      <div css={styles.container}>
+        <InfoBloc
+          title="Informations"
+          text={
+            <Fragment>
+              <span>
+                Nous ne pouvons pas afficher les informations de votre
+                entreprise car vous n’avez pas encore validé vos données
+                saissies.
+              </span>{" "}
+              <TextSimulatorLink
+                to="/informations"
+                label="valider les données"
+              />
+            </Fragment>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div css={[styles.container, css({ width })]}>
+      <dl css={styles.dataDisplay}>
+        <dt>Effectifs</dt>
+        <dd>{nombreSalaries}</dd>
+
+        <dt>Tranche de déclaration</dt>
+        <dd>{trancheEffectifs}</dd>
+
+        <dt>Date de début de période de référence</dt>
+        <dd>{debutPeriodeReference}</dd>
+      </dl>
+    </div>
+  );
+}
+
+const styles = {
+  container: css({
+    display: "flex",
+    flexDirection: "column",
+    marginTop: 22,
+    marginBottom: 22
+  }),
+  dataDisplay: css({
+    dt: {
+      fontWeight: "bold"
+    },
+    dd: {
+      backgroundColor: "#fff",
+      lineHeight: "2.5em",
+      paddingLeft: "1em",
+      marginBottom: 20,
+      marginLeft: 0,
+      marginTop: 5,
+      borderRadius: 4
+    }
+  })
+};
+
+export default RecapitulatifInformations;

--- a/packages/app/src/views/Recapitulatif/RecapitulatifInformations.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifInformations.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
-import { Fragment } from "react";
+import { Fragment, ReactNode } from "react";
 
 import { FormState, TrancheEffectifs } from "../../globals";
 
@@ -12,6 +12,7 @@ interface Props {
   informationsFormValidated: FormState;
   trancheEffectifs: TrancheEffectifs;
   debutPeriodeReference: string;
+  finPeriodeReference: string;
   nombreSalaries: number | undefined;
 }
 
@@ -19,6 +20,7 @@ function RecapitulatifInformations({
   informationsFormValidated,
   trancheEffectifs,
   debutPeriodeReference,
+  finPeriodeReference,
   nombreSalaries
 }: Props) {
   const layoutType = useLayoutType();
@@ -49,17 +51,37 @@ function RecapitulatifInformations({
 
   return (
     <div css={[styles.container, css({ width })]}>
-      <dl css={styles.dataDisplay}>
-        <dt>Effectifs</dt>
-        <dd>{nombreSalaries}</dd>
+      <DataDisplay header="Effectifs" data={nombreSalaries} />
 
-        <dt>Tranche de déclaration</dt>
-        <dd>{trancheEffectifs}</dd>
+      <DataDisplay header="Tranche de déclaration" data={trancheEffectifs} />
 
-        <dt>Date de début de période de référence</dt>
-        <dd>{debutPeriodeReference}</dd>
-      </dl>
+      <DataDisplay header="Periode de référence">
+        <div css={styles.dates}>
+          <div css={styles.dateField}>
+            <DataDisplay header="Date de début" data={debutPeriodeReference} />
+          </div>
+
+          <div css={styles.dateField}>
+            <DataDisplay header="Date de fin" data={finPeriodeReference} />
+          </div>
+        </div>
+      </DataDisplay>
     </div>
+  );
+}
+
+interface DataDisplayProps {
+  header: string;
+  children?: ReactNode;
+  data?: any;
+}
+
+function DataDisplay({ header, data, children }: DataDisplayProps) {
+  return (
+    <Fragment>
+      <p css={styles.header}>{header}</p>
+      {data ? <div css={styles.data}>{data}</div> : children}
+    </Fragment>
   );
 }
 
@@ -70,20 +92,24 @@ const styles = {
     marginTop: 22,
     marginBottom: 22
   }),
-  dataDisplay: css({
-    dt: {
-      fontWeight: "bold"
-    },
-    dd: {
-      backgroundColor: "#fff",
-      lineHeight: "2.5em",
-      paddingLeft: "1em",
-      marginBottom: 20,
-      marginLeft: 0,
-      marginTop: 5,
-      borderRadius: 4
-    }
-  })
+  header: css({
+    fontWeight: "bold",
+    marginTop: 5
+  }),
+  dates: css({
+    display: "flex",
+    justifyContent: "space-between"
+  }),
+  data: css({
+    backgroundColor: "#fff",
+    lineHeight: "2.5em",
+    paddingLeft: "1em",
+    marginBottom: 20,
+    marginLeft: 0,
+    marginTop: 5,
+    borderRadius: 4
+  }),
+  dateField: css({ width: "40%" })
 };
 
 export default RecapitulatifInformations;


### PR DESCRIPTION
Fixes #161 

- [x] ajout du formulaire pour entrer les informations de l'entreprise et période de référence
- [x] validation du formulaire : pas de nom d'entreprise vide ni de date de période de référence vide
- [x] ajout des infos de cette page dans la page récapitulatif
- [x] supprimer la partie "récapitulatif dans la page" (le cercle vert)
- [x] ajout de la date de fin de période de référence
- [x] permettre la saisie de la date de début ou de fin de la période de référence et automatiquement calculer l'autre
- [ ] lors d'une modification de la tranche d'effectifs, invalider les indicateurs liés
- [x] lors d'une modification de la période de référence, invalider l'indicateur "2 et 3"  
- [x] utiliser les dates réelles de la période de référence sur l'indicateur "deux et trois" (pour la période de déclaration)
- [x] ajout du style sur le formulaire