### PR TITLE
fix(indicateur2et3): meilleure présentation de l'écart de taux d'augmentation

### DIFF
--- a/packages/app/src/utils/helpers.test.tsx
+++ b/packages/app/src/utils/helpers.test.tsx
@@ -81,12 +81,12 @@ describe("messageEcartNombreEquivalentSalaries", () => {
     });
     test("women favorited", () => {
       expect(messageEcartNombreEquivalentSalaries("femmes", undefined)).toEqual(
-        "Si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
+        "* si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
       );
     });
     test("men favorited", () => {
       expect(messageEcartNombreEquivalentSalaries("hommes", undefined)).toEqual(
-        "Si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
+        "* si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
       );
     });
   });
@@ -99,12 +99,12 @@ describe("messageEcartNombreEquivalentSalaries", () => {
     });
     test("women favorited", () => {
       expect(messageEcartNombreEquivalentSalaries("femmes", "femmes")).toEqual(
-        "Si ce nombre de femmes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes."
+        "* si ce nombre de femmes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes."
       );
     });
     test("men favorited", () => {
       expect(messageEcartNombreEquivalentSalaries("hommes", "femmes")).toEqual(
-        "Si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
+        "* si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
       );
     });
   });
@@ -117,12 +117,12 @@ describe("messageEcartNombreEquivalentSalaries", () => {
     });
     test("women favorited", () => {
       expect(messageEcartNombreEquivalentSalaries("femmes", "hommes")).toEqual(
-        "Si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
+        "* si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes."
       );
     });
     test("men favorited", () => {
       expect(messageEcartNombreEquivalentSalaries("hommes", "hommes")).toEqual(
-        "Si ce nombre d'hommes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes."
+        "* si ce nombre d'hommes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes."
       );
     });
   });

--- a/packages/app/src/utils/helpers.tsx
+++ b/packages/app/src/utils/helpers.tsx
@@ -127,32 +127,32 @@ export const messageEcartNombreEquivalentSalaries = (
     indicateurSexeSurRepresente === "hommes" &&
     plusPetitNombreSalaries === "femmes"
   ) {
-    return "Si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+    return "* si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
   } else if (
     indicateurSexeSurRepresente === "hommes" &&
     plusPetitNombreSalaries === "hommes"
   ) {
-    return "Si ce nombre d'hommes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes.";
+    return "* si ce nombre d'hommes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes.";
   } else if (
     indicateurSexeSurRepresente === "hommes" &&
     plusPetitNombreSalaries === undefined
   ) {
-    return "Si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+    return "* si ce nombre de femmes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
   } else if (
     indicateurSexeSurRepresente === "femmes" &&
     plusPetitNombreSalaries === "femmes"
   ) {
-    return "Si ce nombre de femmes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes.";
+    return "* si ce nombre de femmes n'avait pas reçu d'augmentation parmi les bénéficiaires, les taux d'augmentation seraient égaux entre hommes et femmes.";
   } else if (
     indicateurSexeSurRepresente === "femmes" &&
     plusPetitNombreSalaries === "hommes"
   ) {
-    return "Si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+    return "* si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
   } else if (
     indicateurSexeSurRepresente === "femmes" &&
     plusPetitNombreSalaries === undefined
   ) {
-    return "Si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
+    return "* si ce nombre d'hommes supplémentaires avait bénéficié d'une augmentation, les taux d'augmentation seraient égaux entre hommes et femmes.";
   } else {
     return "";
   }

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
@@ -2,14 +2,14 @@
 import { css, jsx } from "@emotion/core";
 
 import { FormState } from "../../globals.d";
-import { displayPercent, displaySexeSurRepresente } from "../../utils/helpers";
+import { displaySexeSurRepresente } from "../../utils/helpers";
+import { Result } from "./IndicateurDeuxTrois";
 
 import ResultBubble from "../../components/ResultBubble";
 import ActionLink from "../../components/ActionLink";
 
 interface Props {
-  indicateurEcartAugmentationPromotion: number | undefined;
-  indicateurEcartNombreEquivalentSalaries: number | undefined;
+  bestResult: Result;
   indicateurSexeSurRepresente: "hommes" | "femmes" | undefined;
   noteIndicateurDeuxTrois: number | undefined;
   correctionMeasure: boolean;
@@ -17,8 +17,7 @@ interface Props {
 }
 
 function IndicateurDeuxTroisResult({
-  indicateurEcartAugmentationPromotion,
-  indicateurEcartNombreEquivalentSalaries,
+  bestResult,
   indicateurSexeSurRepresente,
   noteIndicateurDeuxTrois,
   correctionMeasure,
@@ -27,12 +26,8 @@ function IndicateurDeuxTroisResult({
   return (
     <div css={styles.container}>
       <ResultBubble
-        firstLineLabel="votre écart de taux d'augmentation est"
-        firstLineData={
-          indicateurEcartAugmentationPromotion !== undefined
-            ? displayPercent(indicateurEcartAugmentationPromotion)
-            : "--"
-        }
+        firstLineLabel={bestResult.label}
+        firstLineData={bestResult.result}
         firstLineInfo={displaySexeSurRepresente(indicateurSexeSurRepresente)}
         secondLineLabel="votre note obtenue est"
         secondLineData={
@@ -43,8 +38,6 @@ function IndicateurDeuxTroisResult({
         secondLineInfo={
           correctionMeasure
             ? "mesures de correction prises en compte"
-            : indicateurEcartNombreEquivalentSalaries
-            ? `écart en nombre équivalent salariés ${indicateurEcartNombreEquivalentSalaries}`
             : undefined
         }
         indicateurSexeSurRepresente={indicateurSexeSurRepresente}

--- a/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
+++ b/packages/app/src/views/Indicateur2et3/IndicateurDeuxTroisResult.tsx
@@ -27,7 +27,7 @@ function IndicateurDeuxTroisResult({
   return (
     <div css={styles.container}>
       <ResultBubble
-        firstLineLabel="votre résultat final est"
+        firstLineLabel="votre écart de taux d'augmentation est"
         firstLineData={
           indicateurEcartAugmentationPromotion !== undefined
             ? displayPercent(indicateurEcartAugmentationPromotion)

--- a/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
+++ b/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
+import { Fragment } from "react";
 import { RouteComponentProps } from "react-router-dom";
 
 import { AppState } from "../../globals.d";
@@ -25,7 +26,6 @@ import RecapitulatifIndicateurTrois from "./RecapitulatifIndicateurTrois";
 import RecapitulatifIndicateurDeuxTrois from "./RecapitulatifIndicateurDeuxTrois";
 import RecapitulatifIndicateurQuatre from "./RecapitulatifIndicateurQuatre";
 import RecapitulatifIndicateurCinq from "./RecapitulatifIndicateurCinq";
-import { Fragment } from "react";
 
 interface Props extends RouteComponentProps {
   state: AppState;

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
@@ -3,17 +3,18 @@ import { css, jsx } from "@emotion/core";
 import { Fragment } from "react";
 
 import { FormState } from "../../globals.d";
-import {
-  displayPercent,
-  displaySexeSurRepresente,
-  messageEcartNombreEquivalentSalaries
-} from "../../utils/helpers";
+import { displaySexeSurRepresente } from "../../utils/helpers";
 
 import InfoBloc from "../../components/InfoBloc";
 import RecapBloc from "./components/RecapBloc";
 import { TextSimulatorLink } from "../../components/SimulatorLink";
 
 import RowData, { RowLabels, RowLabelFull } from "./components/RowData";
+
+import {
+  getResults,
+  AdditionalInfo
+} from "../Indicateur2et3/IndicateurDeuxTrois";
 
 interface Props {
   indicateurDeuxTroisFormValidated: FormState;
@@ -86,16 +87,18 @@ function RecapitulatifIndicateurDeuxTrois({
     );
   }
 
+  const results = getResults(
+    indicateurEcartAugmentationPromotion,
+    indicateurEcartNombreEquivalentSalaries
+  );
+
   return (
     <div css={styles.container}>
       <RecapBloc
         title="Indicateur écart de taux d'augmentations entre les femmes et les hommes"
         resultBubble={{
-          firstLineLabel: "votre écart de taux d'augmentation est",
-          firstLineData:
-            indicateurEcartAugmentationPromotion !== undefined
-              ? displayPercent(indicateurEcartAugmentationPromotion)
-              : "--",
+          firstLineLabel: results.best.label,
+          firstLineData: results.best.result,
           firstLineInfo: displaySexeSurRepresente(indicateurSexeSurRepresente),
           secondLineLabel: "votre note obtenue est",
           secondLineData:
@@ -118,17 +121,12 @@ function RecapitulatifIndicateurDeuxTrois({
           ]}
           asPercent={true}
         />
-
-        <RowLabelFull label="écart en nombre équivalent de salariés" />
-        <RowData
-          name="nombre équivalent de salariés"
-          data={[indicateurEcartNombreEquivalentSalaries]}
-          message={messageEcartNombreEquivalentSalaries(
-            indicateurSexeSurRepresente,
-            plusPetitNombreSalaries
-          )}
-        />
       </RecapBloc>
+      <AdditionalInfo
+        results={results}
+        indicateurSexeSurRepresente={indicateurSexeSurRepresente}
+        plusPetitNombreSalaries={plusPetitNombreSalaries}
+      />
     </div>
   );
 }

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurDeuxTrois.tsx
@@ -91,7 +91,7 @@ function RecapitulatifIndicateurDeuxTrois({
       <RecapBloc
         title="Indicateur écart de taux d'augmentations entre les femmes et les hommes"
         resultBubble={{
-          firstLineLabel: "votre résultat final est",
+          firstLineLabel: "votre écart de taux d'augmentation est",
           firstLineData:
             indicateurEcartAugmentationPromotion !== undefined
               ? displayPercent(indicateurEcartAugmentationPromotion)


### PR DESCRIPTION
Fixes #244

Pour info, à l'heure actuelle la bulle de résultat affiche l'écart de taux d'augmentation, ainsi que le nombre équivalent salariés. En attendant une meilleure présentation, le titre a été changé de "votre résultat final est xx%" à "votre écart de taux d'augmentation est xx%".

<img width="316" alt="Capture d’écran 2019-10-25 à 16 34 24" src="https://user-images.githubusercontent.com/167767/67579732-586f3d00-f745-11e9-8e4c-e82f9737dc8f.png">

<img width="757" alt="Capture d’écran 2019-10-25 à 16 36 09" src="https://user-images.githubusercontent.com/167767/67580461-acc6ec80-f746-11e9-9fc8-f469b8b6e30f.png">
