### PR TITLE
fix(informations): toujours mettre à jour le menu quand on change d'effectifs

### DIFF
--- a/packages/app/src/components/FormAutoSave.tsx
+++ b/packages/app/src/components/FormAutoSave.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { FormSpy } from "react-final-form";
 
-function FormAutoSave({ saveForm }: { saveForm: (values: any) => void }) {
+function FormAutoSave({
+  saveForm,
+  onlyWhenDirty = true // Only auto save when the form is dirty (some value changed from the initialization).
+}: {
+  saveForm: (values: any) => void;
+  onlyWhenDirty?: boolean;
+}) {
   const onChangeForm = ({ values, dirty }: { values: any; dirty: boolean }) => {
-    if (dirty) {
+    if (dirty || (onlyWhenDirty !== undefined && !onlyWhenDirty)) {
       saveForm(values);
     }
   };

--- a/packages/app/src/views/Informations/InformationsForm.tsx
+++ b/packages/app/src/views/Informations/InformationsForm.tsx
@@ -129,7 +129,11 @@ function InformationsForm({
     >
       {({ handleSubmit, hasValidationErrors, submitFailed, values }) => (
         <form onSubmit={handleSubmit} css={styles.container}>
-          <FormAutoSave saveForm={saveForm} />
+          {/* pass `onlyWhenDirty={false}` because we want the form to always
+          auto save, as we update the left menu depending on the "tranche
+          d'effectifs". Otherwise it would not re-update the menu when
+          switching back to the original value */}
+          <FormAutoSave saveForm={saveForm} onlyWhenDirty={false} />
           <FieldNomEntreprise readOnly={readOnly} />
 
           <RadioLabels


### PR DESCRIPTION
Fixes #239

Quand on change de tranche d'effectifs, même si on revient sur la valeur d'origine on met à jour le menu.