### PR TITLE
Test on IE11

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,6 +8,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:4000",
   "dependencies": {
     "@emotion/core": "10.0.22",
     "@types/react-text-mask": "5.4.6",
@@ -51,7 +52,8 @@
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      "ie 11"
     ]
   }
 }

--- a/packages/app/src/utils/api.js
+++ b/packages/app/src/utils/api.js
@@ -1,10 +1,9 @@
-const origin = process.env.REACT_APP_API_URL
-  // When deploying using docker, use the API_URL env variable to proxy to the
-  // egapro-api image. See the server.js file for the proxy configuration.
-  ? "/api"
-  // If this REACT_APP_API_URL env variable isn't present, we're in local
-  // development, so no proxy.
-  : "http://localhost:4000/api";
+// When deploying using docker, use the API_URL env variable to proxy to the
+// egapro-api image. See the server.js file for the proxy configuration.
+// When in development, any unrecognized URL will be proxied to the `proxy`
+// entry in the package.json (see
+// https://create-react-app.dev/docs/proxying-api-requests-in-development/)
+const origin = "/api";
 
 const commonHeaders = {
   Accept: "application/json"


### PR DESCRIPTION
Utilisation du mode `proxy` de `create-react-app` : permet de tester sur IE11 dans une virtualbox, même en mode dev (sinon l'url de l'API n'est pas accessible sur http://localhost:4000).