### PR TITLE
fix(declaration): datePublication et lienPublication déplacés dans informationsComplementaires

### DIFF
--- a/packages/app/src/AppReducer.test.tsx
+++ b/packages/app/src/AppReducer.test.tsx
@@ -729,7 +729,7 @@ describe("updateInformationsComplementaires", () => {
     type: "updateInformationsComplementaires" as "updateInformationsComplementaires",
     data: {
       dateConsultationCSE: "01/02/2017",
-      anneeDeclaration: "2018",
+      anneeDeclaration: 2018,
       datePublication: "01/02/2020",
       lienPublication: "https://example.com"
     }

--- a/packages/app/src/AppReducer.tsx
+++ b/packages/app/src/AppReducer.tsx
@@ -137,7 +137,7 @@ const defaultState: AppState = {
   informationsComplementaires: {
     formValidated: "None",
     dateConsultationCSE: "",
-    anneeDeclaration: "",
+    anneeDeclaration: undefined,
     datePublication: "",
     lienPublication: ""
   },

--- a/packages/app/src/__fixtures__/stateComplete.tsx
+++ b/packages/app/src/__fixtures__/stateComplete.tsx
@@ -434,7 +434,7 @@ const actionUpdateInformationsComplementaires = {
   type: "updateInformationsComplementaires" as "updateInformationsComplementaires",
   data: {
     dateConsultationCSE: "01/02/2019",
-    anneeDeclaration: "2020",
+    anneeDeclaration: 2020,
     datePublication: "01/02/2020",
     lienPublication: "https://example.com"
   }

--- a/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
+++ b/packages/app/src/__snapshots__/AppReducer.test.tsx.snap
@@ -338,7 +338,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -711,7 +711,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "Valid",
@@ -1050,7 +1050,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -1418,7 +1418,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -1759,7 +1759,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -2125,7 +2125,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -2464,7 +2464,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -2830,7 +2830,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -3169,7 +3169,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -3535,7 +3535,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -3874,7 +3874,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -4240,7 +4240,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -4579,7 +4579,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -4945,7 +4945,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -5284,7 +5284,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -5650,7 +5650,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -5989,7 +5989,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -6355,7 +6355,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -6728,7 +6728,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -7094,7 +7094,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -7467,7 +7467,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -7833,7 +7833,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -8206,7 +8206,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -8605,7 +8605,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -8978,7 +8978,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -9310,7 +9310,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -9649,7 +9649,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -10015,7 +10015,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -10354,7 +10354,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -10720,7 +10720,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -11059,7 +11059,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -11425,7 +11425,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2018",
+    "anneeDeclaration": 2018,
     "dateConsultationCSE": "01/02/2017",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -11764,7 +11764,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2018",
+    "anneeDeclaration": 2018,
     "dateConsultationCSE": "01/02/2017",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -12130,7 +12130,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -12469,7 +12469,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -12835,7 +12835,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -13170,7 +13170,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -13541,7 +13541,7 @@ Object {
     "trancheEffectifs": "251 à 999",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -13880,7 +13880,7 @@ Object {
     "trancheEffectifs": "251 à 999",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -14246,7 +14246,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -14585,7 +14585,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -14951,7 +14951,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "Valid",
@@ -15324,7 +15324,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "Valid",
@@ -15697,7 +15697,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "Valid",
@@ -16070,7 +16070,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -16409,7 +16409,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -16775,7 +16775,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -17114,7 +17114,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -17480,7 +17480,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -17819,7 +17819,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -18185,7 +18185,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -18524,7 +18524,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -18890,7 +18890,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -19229,7 +19229,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -19595,7 +19595,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -19934,7 +19934,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -20300,7 +20300,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -20639,7 +20639,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -21005,7 +21005,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "Valid",
@@ -21378,7 +21378,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -21717,7 +21717,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -22083,7 +22083,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "Valid",
@@ -22456,7 +22456,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -22795,7 +22795,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -23161,7 +23161,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "Valid",
@@ -23500,7 +23500,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "Valid",
@@ -23866,7 +23866,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -24205,7 +24205,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -24571,7 +24571,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -24910,7 +24910,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",
@@ -25276,7 +25276,7 @@ Object {
     "trancheEffectifs": "1000 et plus",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "2020",
+    "anneeDeclaration": 2020,
     "dateConsultationCSE": "01/02/2019",
     "datePublication": "01/02/2020",
     "formValidated": "None",
@@ -25615,7 +25615,7 @@ Object {
     "trancheEffectifs": "50 à 250",
   },
   "informationsComplementaires": Object {
-    "anneeDeclaration": "",
+    "anneeDeclaration": undefined,
     "dateConsultationCSE": "",
     "datePublication": "",
     "formValidated": "None",

--- a/packages/app/src/globals.d.ts
+++ b/packages/app/src/globals.d.ts
@@ -72,7 +72,7 @@ export type AppState = {
   informationsComplementaires: {
     formValidated: FormState;
     dateConsultationCSE: string;
-    anneeDeclaration: string;
+    anneeDeclaration: number | undefined;
     datePublication: string;
     lienPublication: string;
   };
@@ -314,7 +314,7 @@ export type ActionInformationsDeclarantData = {
 
 export type ActionInformationsComplementairesData = {
   dateConsultationCSE: string;
-  anneeDeclaration: string;
+  anneeDeclaration: number | undefined;
   datePublication: string;
   lienPublication: string;
 };

--- a/packages/app/src/views/InformationsComplementaires/InformationsComplementairesForm.tsx
+++ b/packages/app/src/views/InformationsComplementaires/InformationsComplementairesForm.tsx
@@ -8,7 +8,13 @@ import {
   ActionInformationsComplementairesData
 } from "../../globals";
 
-import { mustBeDate, required } from "../../utils/formHelpers";
+import {
+  mustBeDate,
+  mustBeNumber,
+  required,
+  parseIntFormValue,
+  parseIntStateValue
+} from "../../utils/formHelpers";
 
 import ActionBar from "../../components/ActionBar";
 import ActionLink from "../../components/ActionLink";
@@ -44,6 +50,16 @@ const validate = (value: string) => {
   }
 };
 
+const validateInt = (value: string) => {
+  const requiredError = required(value);
+  const mustBeNumberError = mustBeNumber(value);
+  if (!requiredError && !mustBeNumberError) {
+    return undefined;
+  } else {
+    return { required: requiredError, mustBeNumber: mustBeNumberError };
+  }
+};
+
 const validateForm = ({
   dateConsultationCSE,
   anneeDeclaration,
@@ -56,7 +72,7 @@ const validateForm = ({
   lienPublication: string;
 }) => ({
   dateConsultationCSE: validateDate(dateConsultationCSE),
-  anneeDeclaration: validate(anneeDeclaration),
+  anneeDeclaration: validateInt(anneeDeclaration),
   datePublication: validateDate(datePublication),
   lienPublication: validate(lienPublication)
 });
@@ -76,9 +92,11 @@ function InformationsComplementairesForm({
   updateInformationsComplementaires,
   validateInformationsComplementaires
 }: Props) {
-  const initialValues: ActionInformationsComplementairesData = {
+  const initialValues = {
     dateConsultationCSE: informationsComplementaires.dateConsultationCSE,
-    anneeDeclaration: informationsComplementaires.anneeDeclaration,
+    anneeDeclaration: parseIntStateValue(
+      informationsComplementaires.anneeDeclaration
+    ),
     datePublication: informationsComplementaires.datePublication,
     lienPublication: informationsComplementaires.lienPublication
   };
@@ -93,7 +111,7 @@ function InformationsComplementairesForm({
 
     updateInformationsComplementaires({
       dateConsultationCSE,
-      anneeDeclaration,
+      anneeDeclaration: parseIntFormValue(anneeDeclaration),
       datePublication,
       lienPublication
     });

--- a/packages/kinto/import-solen.py
+++ b/packages/kinto/import-solen.py
@@ -259,8 +259,8 @@ class RowProcessor(object):
 
     def importNiveauResultat(self):
         # Niveau de résultat de l'entreprise ou de l'UES
-        self.importDateField("date_publ_niv > Valeur date", "declaration/datePublication")
-        self.importField("site_internet_publ", "declaration/lienPublication")
+        self.importDateField("date_publ_niv > Valeur date", "informationsComplementaires/datePublication")
+        self.importField("site_internet_publ", "informationsComplementaires/lienPublication")
 
     def setValeursTranche(self, niveau, path, index, fieldName, custom=False):
         niveaux = [niveau + " > -30", niveau + " > 30-39", niveau + " > 40-49", niveau + " > 50+"]

--- a/packages/kinto/json-schema.json
+++ b/packages/kinto/json-schema.json
@@ -347,7 +347,9 @@
               "$ref": "#/definitions/formValidated"
             },
             "anneeDeclaration": { "type": "integer" },
-            "dateConsultationCSE": { "type": "string" }
+            "dateConsultationCSE": { "type": "string" },
+            "datePublication": { "type": "string" },
+            "lienPublication": { "type": "string" }
           }
         },
         "declaration": {


### PR DESCRIPTION
Fixes #422

Il y a aussi la donnée `anneeDeclaration` qui est passée en `integer` au lieu de `string`