### PR TITLE
fix(ci): déplacement du job import-export dans l'étape 06-release

### DIFF
--- a/.gitlab-ci/stages/05-deploy.yml
+++ b/.gitlab-ci/stages/05-deploy.yml
@@ -265,30 +265,6 @@ Deploy kinto (prod):
       - $PRODUCTION
 
 ###########################################
-###            IMPORT-EXPORT            ###
-###########################################
-
-Import Solen to consolidated export:
-  stage: Deploy
-  image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:0.29.0
-  dependencies: []
-  when: manual
-  #TODO: uncomment the following "only" when it's been tested so it only deploys on preprod
-  # only:
-  #   refs:
-  #     - tags
-  environment:
-    name: ${DEV_ENVIRONMENT_NAME}
-  except:
-    variables:
-      - $PRODUCTION
-  script:
-    - kubectl delete job import-export-job -n ${K8S_NAMESPACE} || true;
-    - envsubst < .k8s/import-export/import-export-job.yml > .k8s/import-export/import-export-job-${PROJECT}.yml
-    - kubectl apply -f .k8s/import-export/import-export-job-${PROJECT}.yml -n ${K8S_NAMESPACE}
-    - kubectl wait --for=condition=complete job/import-export-job --timeout=180000s -n ${K8S_NAMESPACE}
-
-###########################################
 ###          DEPLOY TO PROD K8S         ###
 ###########################################
 

--- a/.gitlab-ci/stages/06-release.yml
+++ b/.gitlab-ci/stages/06-release.yml
@@ -29,4 +29,28 @@ Make a new release and deploy to preprod environment:
     - master
   when: manual
 
+###########################################
+###            IMPORT-EXPORT            ###
+###########################################
+
+Import Solen to consolidated export:
+  stage: Release
+  image: registry.gitlab.factory.social.gouv.fr/socialgouv/docker/kubectl:0.29.0
+  dependencies: []
+  when: manual
+  #TODO: uncomment the following "only" when it's been tested so it only deploys on preprod
+  # only:
+  #   refs:
+  #     - tags
+  environment:
+    name: ${DEV_ENVIRONMENT_NAME}
+  except:
+    variables:
+      - $PRODUCTION
+  script:
+    - kubectl delete job import-export-job -n ${K8S_NAMESPACE} || true;
+    - envsubst < .k8s/import-export/import-export-job.yml > .k8s/import-export/import-export-job-${PROJECT}.yml
+    - kubectl apply -f .k8s/import-export/import-export-job-${PROJECT}.yml -n ${K8S_NAMESPACE}
+    - kubectl wait --for=condition=complete job/import-export-job --timeout=180000s -n ${K8S_NAMESPACE}
+
 ...


### PR DESCRIPTION
À l'heure actuelle avec le job import-export dans l'étape 05-deploy il n'est
pas possible de faire une mise en preprod (06-release) si le job import-export
n'a pas été effectué.