### PR TITLE
fix(import-export): proper git checkout for a tag

### DIFF
--- a/packages/import-export/Dockerfile
+++ b/packages/import-export/Dockerfile
@@ -32,7 +32,8 @@ RUN set -ex \
 # Clone egapro, then checkout the proper branch to run the script
 ENTRYPOINT git clone https://github.com/SocialGouv/egapro && \
     cd egapro && \
-    git checkout ${BRANCH_NAME} && \
+    git fetch && \
+    git checkout --track origin/${BRANCH_NAME} && \
     git pull && \
     chmod +x packages/import-export/import-export.sh && \
     packages/import-export/import-export.sh


### PR DESCRIPTION
This should prevent `error: pathspec 'v2-9-2' did not match any file(s) known to git`