### PR TITLE
fix(recapitulatif): affichage de la modalité de calcul de l'indicateur 1 dans le récapitulatif

### DIFF
--- a/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
+++ b/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
@@ -140,6 +140,8 @@ function Recapitulatif({ state }: Props) {
         indicateurEcartRemuneration={indicateurEcartRemuneration}
         indicateurSexeSurRepresente={indicateurUnSexeSurRepresente}
         indicateurUnParCSP={state.indicateurUn.csp}
+        indicateurUnParCoef={state.indicateurUn.coef}
+        indicateurUnParAutre={state.indicateurUn.autre}
         noteIndicateurUn={noteIndicateurUn}
       />
       {(trancheEffectifs !== "50 à 250" && (

--- a/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
+++ b/packages/app/src/views/Recapitulatif/Recapitulatif.tsx
@@ -40,7 +40,7 @@ function Recapitulatif({ state }: Props) {
     effectifEtEcartRemuParTranche,
     indicateurEcartRemuneration,
     indicateurSexeSurRepresente: indicateurUnSexeSurRepresente,
-    noteIndicateurUn
+    noteIndicateurUn,
   } = calculIndicateurUn(state);
 
   const {
@@ -50,7 +50,7 @@ function Recapitulatif({ state }: Props) {
     indicateurEcartAugmentation,
     indicateurSexeSurRepresente: indicateurDeuxSexeSurRepresente,
     noteIndicateurDeux,
-    correctionMeasure: correctionMeasureIndicateurDeux
+    correctionMeasure: correctionMeasureIndicateurDeux,
   } = calculIndicateurDeux(state);
 
   const {
@@ -60,7 +60,7 @@ function Recapitulatif({ state }: Props) {
     indicateurEcartPromotion,
     indicateurSexeSurRepresente: indicateurTroisSexeSurRepresente,
     noteIndicateurTrois,
-    correctionMeasure: correctionMeasureIndicateurTrois
+    correctionMeasure: correctionMeasureIndicateurTrois,
   } = calculIndicateurTrois(state);
 
   const {
@@ -73,19 +73,19 @@ function Recapitulatif({ state }: Props) {
     correctionMeasure: correctionMeasureIndicateurDeuxTrois,
     tauxAugmentationPromotionHommes,
     tauxAugmentationPromotionFemmes,
-    plusPetitNombreSalaries
+    plusPetitNombreSalaries,
   } = calculIndicateurDeuxTrois(state);
 
   const {
     indicateurCalculable: indicateurQuatreCalculable,
     indicateurEcartNombreSalarieesAugmentees,
-    noteIndicateurQuatre
+    noteIndicateurQuatre,
   } = calculIndicateurQuatre(state);
 
   const {
     indicateurSexeSousRepresente: indicateurCinqSexeSousRepresente,
     indicateurNombreSalariesSexeSousRepresente,
-    noteIndicateurCinq
+    noteIndicateurCinq,
   } = calculIndicateurCinq(state);
 
   const allIndicateurValid =
@@ -114,7 +114,7 @@ function Recapitulatif({ state }: Props) {
 
   const {
     totalNombreSalariesHomme,
-    totalNombreSalariesFemme
+    totalNombreSalariesFemme,
   } = totalNombreSalaries(state.effectif.nombreSalaries);
 
   return (
@@ -247,13 +247,13 @@ function Recapitulatif({ state }: Props) {
 const styles = {
   info: css({
     marginLeft: 4,
-    fontSize: 12
+    fontSize: 12,
   }),
   monAvis: css({
     "@media print": {
-      display: "none"
-    }
-  })
+      display: "none",
+    },
+  }),
 };
 
 export default Recapitulatif;

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
@@ -5,14 +5,14 @@ import { Fragment } from "react";
 import { FormState, TranchesAges } from "../../globals";
 import {
   effectifEtEcartRemuGroupCsp,
-  effectifEtEcartRemuGroupCoef
+  effectifEtEcartRemuGroupCoef,
 } from "../../utils/calculsEgaProIndicateurUn";
 
 import {
   displayNameTranchesAges,
   displayNameCategorieSocioPro,
   displayPercent,
-  displaySexeSurRepresente
+  displaySexeSurRepresente,
 } from "../../utils/helpers";
 
 import InfoBloc from "../../components/InfoBloc";
@@ -47,9 +47,7 @@ function RecapitulatifIndicateurUn({
   noteIndicateurUn,
 }: Props) {
   if (!effectifsIndicateurUnCalculable) {
-    const messageCalculParCSP = indicateurUnParCSP ? (
-      undefined
-    ) : (
+    const messageCalculParCSP = indicateurUnParCSP ? undefined : (
       <TextSimulatorLink
         to="/indicateur1"
         label="Vous devez calculer par CSP"
@@ -103,7 +101,7 @@ function RecapitulatifIndicateurUn({
           ? {
               id: el.categorieSocioPro,
               name: displayNameCategorieSocioPro(el.categorieSocioPro),
-              ...el
+              ...el,
             }
           : el;
       if (index % 4 === 0) {
@@ -130,7 +128,7 @@ function RecapitulatifIndicateurUn({
           secondLineLabel: "votre note obtenue est",
           secondLineData:
             (noteIndicateurUn !== undefined ? noteIndicateurUn : "--") + "/40",
-          indicateurSexeSurRepresente
+          indicateurSexeSurRepresente,
         }}
       >
         <RowLabelFull
@@ -147,10 +145,9 @@ function RecapitulatifIndicateurUn({
             displayNameTranchesAges(TranchesAges.MoinsDe30ans),
             displayNameTranchesAges(TranchesAges.De30a39ans),
             displayNameTranchesAges(TranchesAges.De40a49ans),
-            displayNameTranchesAges(TranchesAges.PlusDe50ans)
+            displayNameTranchesAges(TranchesAges.PlusDe50ans),
           ]}
         />
-
         {groupEffectifEtEcartRemuParTranche.map(
           (
             effectifEtEcartRemuParTranche: Array<{
@@ -166,7 +163,7 @@ function RecapitulatifIndicateurUn({
                 effectifEtEcartRemuParTranche[0].ecartRemunerationMoyenne,
                 effectifEtEcartRemuParTranche[1].ecartRemunerationMoyenne,
                 effectifEtEcartRemuParTranche[2].ecartRemunerationMoyenne,
-                effectifEtEcartRemuParTranche[3].ecartRemunerationMoyenne
+                effectifEtEcartRemuParTranche[3].ecartRemunerationMoyenne,
               ]}
               asPercent={true}
             />

--- a/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
+++ b/packages/app/src/views/Recapitulatif/RecapitulatifIndicateurUn.tsx
@@ -30,6 +30,8 @@ interface Props {
   indicateurEcartRemuneration: number | undefined;
   indicateurSexeSurRepresente: "hommes" | "femmes" | undefined;
   indicateurUnParCSP: boolean;
+  indicateurUnParCoef: boolean;
+  indicateurUnParAutre: boolean;
   noteIndicateurUn: number | undefined;
 }
 
@@ -40,7 +42,9 @@ function RecapitulatifIndicateurUn({
   indicateurEcartRemuneration,
   indicateurSexeSurRepresente,
   indicateurUnParCSP,
-  noteIndicateurUn
+  indicateurUnParCoef,
+  indicateurUnParAutre,
+  noteIndicateurUn,
 }: Props) {
   if (!effectifsIndicateurUnCalculable) {
     const messageCalculParCSP = indicateurUnParCSP ? (
@@ -132,7 +136,7 @@ function RecapitulatifIndicateurUn({
         <RowLabelFull
           label={
             <Fragment>
-              écart de rémunération par csp
+              écart de rémunération
               <br />
               (avant seuil de pertinence)
             </Fragment>
@@ -169,6 +173,19 @@ function RecapitulatifIndicateurUn({
           )
         )}
       </RecapBloc>
+      <div css={styles.additionalInfo}>
+        <p>
+          Modalités de calcul de l'indicateur relatif à l'écart de rémunération
+          entre les femmes et les hommes par{" "}
+          <strong>
+            {(indicateurUnParCSP && "catégorie socio-professionnelle") ||
+              (indicateurUnParCoef &&
+                "niveau ou coefficient hiérarchique en application de la classification de branche") ||
+              (indicateurUnParAutre &&
+                "niveau ou coefficient hiérarchique en application d'une autre méthode de cotation des postes")}
+          </strong>
+        </p>
+      </div>
     </div>
   );
 }
@@ -178,8 +195,17 @@ const styles = {
     display: "flex",
     flexDirection: "column",
     marginTop: 22,
-    marginBottom: 22
-  })
+    marginBottom: 22,
+  }),
+  additionalInfo: css({
+    color: "#61676F",
+    fontSize: 14,
+    fontStyle: "italic",
+    maxWidth: 500,
+    "& > p": {
+      marginBottom: 30,
+    },
+  }),
 };
 
 export default RecapitulatifIndicateurUn;


### PR DESCRIPTION
Fixes [trello #98](https://trello.com/c/Z7NITROo/98-etq-entreprise-je-visualise-si-je-d%C3%A9clare-l%C3%A9cart-de-r%C3%A9mun%C3%A9ration-par-coefficient-ou-par-csp)