### PR TITLE
fix: for 2019 decla and index calculable but 0

### DIFF
--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -168,7 +168,7 @@ const getDeclaration = (data: AppState): any => {
   }
   const index = data.declaration.noteIndex
 
-  if (index || (data.informations.anneeDeclaration && data.informations.anneeDeclaration >= 2020)) {
+  if (index !== undefined || (data.informations.anneeDeclaration && data.informations.anneeDeclaration >= 2020)) {
     declaration.publication = {
       date: toISOString(data.declaration.datePublication),
     }
@@ -179,7 +179,7 @@ const getDeclaration = (data: AppState): any => {
     }
   }
 
-  if (index) {
+  if (index !== undefined) {
     declaration.index = index
     if (index < 75) {
       declaration.mesures_correctives = data.declaration.mesuresCorrection


### PR DESCRIPTION
Erreur de l'API disant que publicationDate est manquante.
publicationDate ne doit pas être envoyée qd l'index est non calculable.
Mais il doit l'être pour un index à 0.