### PR TITLE
feat: ajouter un bouton à la fin d'une décla réussie

### DIFF
--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -71,7 +71,7 @@ function AppLayout({ state, dispatch }: Props) {
           <MonProfil />
         </PrivateRoute>
         <Route
-          path="/nouvelleSimulation"
+          path="/nouvelle-simulation"
           exact
           render={(props) => <ResetPage {...props} dispatch={dispatch} state={state} />}
         />

--- a/src/containers/AppLayout.tsx
+++ b/src/containers/AppLayout.tsx
@@ -24,6 +24,7 @@ import Mire from "../views/Mire"
 import { AuthContextProvider, useUser } from "../components/AuthContext"
 import Footer from "../components/Footer"
 import GererUtilisateursPage from "../views/private/GererUtilisateursPage"
+import ResetPage from "../views/ResetPage"
 
 interface Props {
   state: AppState | undefined
@@ -69,6 +70,11 @@ function AppLayout({ state, dispatch }: Props) {
         <PrivateRoute path="/tableauDeBord/mon-profil" exact>
           <MonProfil />
         </PrivateRoute>
+        <Route
+          path="/nouvelleSimulation"
+          exact
+          render={(props) => <ResetPage {...props} dispatch={dispatch} state={state} />}
+        />
         <Route
           render={() => {
             document.title = "Index Egapro"

--- a/src/containers/Simulateur.tsx
+++ b/src/containers/Simulateur.tsx
@@ -102,10 +102,10 @@ function Simulateur({ code, state, dispatch }: Props) {
         const siren =
           simuData?.informationsEntreprise?.formValidated === "Valid" ? simuData?.informationsEntreprise?.siren : null
 
-        // a free siren is a siren that has no owners already bound to it.
-        const freeSiren = await sirenIsFree(siren)
-
         if (siren) {
+          // a free siren is a siren that has no owners already bound to it.
+          const freeSiren = await sirenIsFree(siren)
+
           if (!token) {
             // On ne peut pas voir une simulation avec un SIREN rempli et qu'on n'est pas authentifié.
             // Renvoi sur le formulaire d'email (cf. plus bas).

--- a/src/views/Declaration/Declaration.tsx
+++ b/src/views/Declaration/Declaration.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, Fragment, ReactNode, useState, useEffect, FunctionComponent } from "react"
-import { RouteComponentProps, useHistory, useLocation } from "react-router-dom"
+import { RouteComponentProps, useHistory } from "react-router-dom"
 import { Heading, ListItem, UnorderedList } from "@chakra-ui/react"
 
 import {

--- a/src/views/Declaration/Declaration.tsx
+++ b/src/views/Declaration/Declaration.tsx
@@ -35,7 +35,7 @@ import DeclarationForm from "./DeclarationForm"
 import RecapitulatifIndex from "../Recapitulatif/RecapitulatifIndex"
 import { TextSimulatorLink } from "../../components/SimulatorLink"
 import totalNombreSalaries from "../../utils/totalNombreSalaries"
-import { postIndicatorsDatas, putDeclaration, putIndicatorsDatas } from "../../utils/api"
+import { putDeclaration, putIndicatorsDatas } from "../../utils/api"
 import { formatDataForAPI, logToSentry } from "../../utils/helpers"
 import { useTitle } from "../../utils/hooks"
 import { isFormValid } from "../../utils/formHelpers"
@@ -51,7 +51,6 @@ const title = "Déclaration"
 const Declaration: FunctionComponent<DeclarationProps> = ({ code, state, dispatch }) => {
   useTitle(title)
   const history = useHistory()
-  const location = useLocation()
 
   const [declaring, setDeclaring] = useState(false)
   const [apiError, setApiError] = useState<string | undefined>(undefined)
@@ -62,7 +61,7 @@ const Declaration: FunctionComponent<DeclarationProps> = ({ code, state, dispatc
   )
 
   const resetDeclaration = useCallback(() => {
-    history.push(`/nouvelleSimulation`)
+    history.push(`/nouvelle-simulation`)
   }, [])
 
   const { totalNombreSalariesHomme, totalNombreSalariesFemme } = totalNombreSalaries(state.effectif.nombreSalaries)

--- a/src/views/Declaration/Declaration.tsx
+++ b/src/views/Declaration/Declaration.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, Fragment, ReactNode, useState, useEffect, FunctionComponent } from "react"
-import { RouteComponentProps } from "react-router-dom"
+import { RouteComponentProps, useHistory, useLocation } from "react-router-dom"
 import { Heading, ListItem, UnorderedList } from "@chakra-ui/react"
 
 import {
@@ -35,7 +35,7 @@ import DeclarationForm from "./DeclarationForm"
 import RecapitulatifIndex from "../Recapitulatif/RecapitulatifIndex"
 import { TextSimulatorLink } from "../../components/SimulatorLink"
 import totalNombreSalaries from "../../utils/totalNombreSalaries"
-import { putDeclaration, putIndicatorsDatas } from "../../utils/api"
+import { postIndicatorsDatas, putDeclaration, putIndicatorsDatas } from "../../utils/api"
 import { formatDataForAPI, logToSentry } from "../../utils/helpers"
 import { useTitle } from "../../utils/hooks"
 import { isFormValid } from "../../utils/formHelpers"
@@ -50,6 +50,8 @@ const title = "Déclaration"
 
 const Declaration: FunctionComponent<DeclarationProps> = ({ code, state, dispatch }) => {
   useTitle(title)
+  const history = useHistory()
+  const location = useLocation()
 
   const [declaring, setDeclaring] = useState(false)
   const [apiError, setApiError] = useState<string | undefined>(undefined)
@@ -58,6 +60,10 @@ const Declaration: FunctionComponent<DeclarationProps> = ({ code, state, dispatc
     (data: ActionDeclarationData) => dispatch({ type: "updateDeclaration", data }),
     [dispatch],
   )
+
+  const resetDeclaration = useCallback(() => {
+    history.push(`/nouvelleSimulation`)
+  }, [])
 
   const { totalNombreSalariesHomme, totalNombreSalariesFemme } = totalNombreSalaries(state.effectif.nombreSalaries)
 
@@ -399,6 +405,7 @@ const Declaration: FunctionComponent<DeclarationProps> = ({ code, state, dispatc
               finPeriodeReference={state.informations.finPeriodeReference}
               readOnly={isFormValid(state.declaration) && !declaring}
               updateDeclaration={updateDeclaration}
+              resetDeclaration={resetDeclaration}
               validateDeclaration={validateDeclaration}
               apiError={apiError}
               declaring={declaring}

--- a/src/views/Declaration/DeclarationForm.tsx
+++ b/src/views/Declaration/DeclarationForm.tsx
@@ -20,6 +20,7 @@ import globalStyles from "../../utils/globalStyles"
 import ButtonAction from "../../components/ButtonAction"
 import ErrorMessage from "../../components/ErrorMessage"
 import { resendReceipt } from "../../utils/api"
+import PrimaryButton from "../../components/ds/PrimaryButton"
 
 const validate = (value: string) => {
   const requiredError = required(value)
@@ -68,6 +69,7 @@ interface Props {
   finPeriodeReference: string
   readOnly: boolean
   updateDeclaration: (data: ActionDeclarationData) => void
+  resetDeclaration: () => void
   validateDeclaration: (valid: FormState) => void
   apiError: string | undefined
   declaring: boolean
@@ -80,6 +82,7 @@ function DeclarationForm({
   finPeriodeReference,
   readOnly,
   updateDeclaration,
+  resetDeclaration,
   validateDeclaration,
   apiError,
   declaring,
@@ -213,9 +216,13 @@ function DeclarationForm({
                 readOnly={readOnly}
               />
               <p>
-                {after2020
-                  ? `Avez-vous un site Internet pour publier les résultats obtenus${displayNC} ?`
-                  : "Avez-vous un site Internet pour publier le niveau de résultat obtenu ?"}
+                {after2020 ? (
+                  `Avez-vous un site Internet pour publier les résultats obtenus${displayNC} ?`
+                ) : (
+                  <span style={{ whiteSpace: "nowrap" }}>
+                    Avez-vous un site Internet pour publier le niveau de résultat obtenu ?
+                  </span>
+                )}
               </p>
               <RadiosBoolean
                 fieldName="publicationSurSiteInternet"
@@ -263,6 +270,9 @@ function DeclarationForm({
                 disabled={loading}
                 loading={loading}
               />
+              <PrimaryButton variant="outline" mt={3} onClick={resetDeclaration}>
+                Effectuer une nouvelle simulation et déclaration
+              </PrimaryButton>
             </Fragment>
           ) : (
             <ActionBar>

--- a/src/views/ResetPage.tsx
+++ b/src/views/ResetPage.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+import { RouteComponentProps, useHistory, useLocation } from "react-router-dom"
+import { ActionType, AppState } from "../globals"
+import { postIndicatorsDatas } from "../utils/api"
+
+interface ResetPageProps extends RouteComponentProps {
+  state: AppState | undefined
+  dispatch: (action: ActionType) => void
+}
+
+function ResetPage({ dispatch, state }: ResetPageProps) {
+  const history = useHistory()
+  const location = useLocation()
+
+  React.useEffect(() => {
+    dispatch({ type: "resetState" })
+  }, [])
+
+  React.useEffect(() => {
+    console.log("state", state)
+
+    if (state === undefined) {
+      postIndicatorsDatas({})
+        .then(({ jsonBody: { id } }) => {
+          history.push(`/simulateur/${id}`, {
+            ...(location.state && location.state),
+          })
+        })
+        .catch((error) => {
+          const errorMessage = (error.jsonBody && error.jsonBody.message) || "Erreur lors de la récupération du code"
+          console.error(errorMessage)
+        })
+    }
+  }, [postIndicatorsDatas, state])
+
+  return null
+}
+
+export default ResetPage

--- a/src/views/ResetPage.tsx
+++ b/src/views/ResetPage.tsx
@@ -17,7 +17,7 @@ interface ResetPageProps extends RouteComponentProps {
   dispatch: (action: ActionType) => void
 }
 
-function ResetPage({ dispatch, state }: ResetPageProps) {
+function ResetPage({ dispatch, state }: ResetPageProps): null {
   const history = useHistory()
   const location = useLocation()
 

--- a/src/views/ResetPage.tsx
+++ b/src/views/ResetPage.tsx
@@ -3,6 +3,15 @@ import { RouteComponentProps, useHistory, useLocation } from "react-router-dom"
 import { ActionType, AppState } from "../globals"
 import { postIndicatorsDatas } from "../utils/api"
 
+/**
+ * Virtual page, used to reset the state and redirect on a fresh simulation page.
+ *
+ * It didn't work in adding this logic in Declaration.tsx.
+ * Because then, the state will be undefined (what we want) but then the Simulateur.tsx page will be rendered and
+ * this page is made to show a spinner when state is falsy.
+ *
+ * So, in waiting for a better state management and route management, we decided to add this page.
+ */
 interface ResetPageProps extends RouteComponentProps {
   state: AppState | undefined
   dispatch: (action: ActionType) => void
@@ -17,8 +26,6 @@ function ResetPage({ dispatch, state }: ResetPageProps) {
   }, [])
 
   React.useEffect(() => {
-    console.log("state", state)
-
     if (state === undefined) {
       postIndicatorsDatas({})
         .then(({ jsonBody: { id } }) => {


### PR DESCRIPTION
Pour éviter que les utilisateurs réutilisent un même id de simulation pour faire plusieurs déclarations. 

Rien ne les empêche de le faire encore mais avec ce nouveau bouton, il leur sera plus pratique de ne pas le faire. 