### PR TITLE
fix: remove pointer events on select when is readonly

### DIFF
--- a/src/theme/components.ts
+++ b/src/theme/components.ts
@@ -72,6 +72,7 @@ const components = {
             _readOnly: {
               background: "primary.200",
               borderColor: "transparent",
+              pointerEvents: "none",
             },
           },
         }),


### PR DESCRIPTION
#868 Fix :  Il faut bloquer la liste de choix des années des indicateurs dans les informations de la simulation quand on est en mode lecture