### PR TITLE
fix(simulateur): Add missing import chakra-ui/toast

### DIFF
--- a/packages/simulateur/package.json
+++ b/packages/simulateur/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^1.1.1",
     "@chakra-ui/react": "^1.7.1",
+    "@chakra-ui/toast": "1.5.4",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11",
     "@fontsource/cabin": "^4.5.0",


### PR DESCRIPTION
Fix pour l'erreur suivante:

ERROR in ../../node_modules/@chakra-ui/toast/dist/index.esm.js 485:14-34
export 'useSyncExternalStore' (imported as 'useSyncExternalStore') was not found in 'react' (possible exports: Children, Component, Fragment, Profiler, PureComponent, StrictMode, Suspense, __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED, cloneElement, createContext, createElement, createFactory, createRef, forwardRef, isValidElement, lazy, memo, useCallback, useContext, useDebugValue, useEffect, useImperativeHandle, useLayoutEffect, useMemo, useReducer, useRef, useState, version)
 @ ./src/utils/hooks.ts 14:0-44 144:14-22 172:10-18 178:14-22 192:10-18
 @ ./src/containers/Simulateur.tsx 19:0-51 157:2-19 452:30-47
 @ ./src/containers/AppLayout.tsx 19:0-38 332:47-57
 @ ./src/App.tsx 21:0-47 118:42-51
 @ ./src/index.tsx 9:0-24 26:38-41