### PR TITLE
fix: user rights have to be updated after a declaration

### DIFF
--- a/packages/simulateur/src/components/AuthContext.tsx
+++ b/packages/simulateur/src/components/AuthContext.tsx
@@ -13,6 +13,8 @@ const initialContext = {
   login: (token: string) => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   logout: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  refreshAuth: () => {},
   loading: false,
 }
 
@@ -59,6 +61,15 @@ export function AuthContextProvider({ children }: { children: React.ReactNode })
     [context],
   )
 
+  const refreshAuth = React.useCallback(async () => {
+    const token = localStorage.getItem("token")
+    if (token) {
+      await login(token)
+    } else {
+      console.debug("Impossible de rafraîchir les données de l'utilisateur car aucun token n'est présent")
+    }
+  }, [login])
+
   const logout = React.useCallback(function logout() {
     localStorage.setItem("token", "")
     localStorage.setItem("tokenInfo", "")
@@ -71,7 +82,7 @@ export function AuthContextProvider({ children }: { children: React.ReactNode })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return <AuthContext.Provider value={{ ...context, logout, login }}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={{ ...context, logout, login, refreshAuth }}>{children}</AuthContext.Provider>
 }
 
 export function useUser(): typeof initialContext {

--- a/packages/simulateur/src/views/Declaration/Declaration.tsx
+++ b/packages/simulateur/src/views/Declaration/Declaration.tsx
@@ -38,6 +38,7 @@ import { logToSentry } from "../../utils/sentry"
 import totalNombreSalaries from "../../utils/totalNombreSalaries"
 import RecapitulatifIndex from "../Recapitulatif/RecapitulatifIndex"
 import DeclarationForm from "./DeclarationForm"
+import { useUser } from "../../components/AuthContext"
 
 function buildHelpers(state: AppState) {
   const trancheEffectifs = state.informations.trancheEffectifs
@@ -219,6 +220,7 @@ const title = "Déclaration"
 const Declaration: FunctionComponent<DeclarationProps> = ({ code, state, dispatch }) => {
   useTitle(title)
   const history = useHistory()
+  const { refreshAuth } = useUser()
 
   const [declaring, setDeclaring] = useState(false)
   const [apiError, setApiError] = useState<string | undefined>(undefined)
@@ -281,6 +283,8 @@ const Declaration: FunctionComponent<DeclarationProps> = ({ code, state, dispatc
       await putDeclaration(data)
       setApiError(undefined)
       setDeclaring(false)
+      // Refresh authentification infos because the user may get another ownership now.
+      refreshAuth()
     } catch (error: any) {
       setDeclaring(false)
       const message = error.jsonBody?.error


### PR DESCRIPTION
Closes #1005

J'ai tenté initialement d'invoquer la nouvelle fonction refreshAuth dans la page MesDeclarations, là où était constaté le problème, mais j'avais alors une boucle infinie de useEffect.
En effet, PrivateRoute affiche un Spinner quand l'auth est en cours, donc le composant MesDeclarations en dessous est unmount. Puis quand l'auth est finie, PrivateRoute mount ce composant, et si ce composant relance l'authentification via un useEffect au mount, cela va avoir un impact sur PrivateRoute, qui va unmount le composant, etc..

J'ai réglé ça en faisant le refresh à la source du changement, c'est à dire dans la dernière page du wizard, la page qui crée réellement la déclaration et qui déclenche un traitement côté API qui va créer automatiquement le ownership entre ce user et ce SIREN. 