### PR TITLE
feat: comment env in order to have api on localhost

### DIFF
--- a/packages/simulateur/.env
+++ b/packages/simulateur/.env
@@ -3,5 +3,5 @@ PORT=3001
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_NAME=$npm_package_name
 REACT_APP_DECLARATION_URL="http://localhost:4000/"
-REACT_APP_EGAPRO_API_URL="https://egapro-preprod.dev.fabrique.social.gouv.fr/api"
+#REACT_APP_EGAPRO_API_URL="https://egapro-preprod.dev.fabrique.social.gouv.fr/api"
 REACT_APP_SENTRY_DSN=""


### PR DESCRIPTION
Le simulateur, contrairement à la déclaration directe, utilisait par défaut l'API de la préprod.

On commente dans le .env pour avoir la même config entre les fronts. 