### PR TITLE
feat: adapt to changes on validate-siren endpoint

### DIFF
--- a/packages/declaration/src/assets/js/utils.js
+++ b/packages/declaration/src/assets/js/utils.js
@@ -134,6 +134,8 @@ validateNotAllEmpty = message => {
 checkSirenValidity = async event => {
   const target = event.target
 
+  const year = app.annee || new Date().getFullYear
+
   checkPatternValidity(event)
   if (target.validity.patternMismatch) {
     // We already treated this case in `checkPatternValidity`
@@ -155,7 +157,7 @@ checkSirenValidity = async event => {
   const wrapper = target.parentNode
   wrapper.classList.add("loading")
   wrapper.setAttribute('aria-busy', 'true')
-  const response = await getSirenData(target.value)
+  const response = await getSirenData(target.value, year)
   wrapper.classList.remove("loading")
   wrapper.removeAttribute('aria-busy')
   const raisonSocialeField = getRaisonSocialeField(target)
@@ -176,10 +178,8 @@ checkSirenValidity = async event => {
   target.reportValidity()
 }
 
-getSirenData = async value => {
-  const response = await request('GET', `/validate-siren?siren=${value}`)
-  return response
-}
+getSirenData = async (siren, year) => request('GET', `/validate-siren?siren=${siren}&year=${year}`)
+
 
 getRaisonSocialeField = sirenField => {
   // Return the field associated to the given siren field name

--- a/packages/declaration/src/commencer.html
+++ b/packages/declaration/src/commencer.html
@@ -11,7 +11,7 @@ prevButtonLabel: "Nouvelle déclaration"
 
 <fieldset>
   <div class="row">
-    {% include select.html type="number" name="déclaration.année_indicateurs" label="Année au titre de laquelle les indicateurs sont calculés" required=true empty=true %}
+    {% include select.html type="number" name="déclaration.année_indicateurs" label="Année au titre de laquelle les indicateurs sont calculés" required=true empty=true onchange="updateYearInState()" %}
   </div>
 </fieldset>
 <fieldset>
@@ -23,6 +23,19 @@ prevButtonLabel: "Nouvelle déclaration"
 </fieldset>
 
 <script>
+  // Update year to ensure the Siren's validation to be accurate.
+  function updateYearInState() {
+    app.annee = selectField('déclaration.année_indicateurs').value
+
+    var event = new Event('input', {
+        bubbles: true,
+        cancelable: true,
+    });
+
+    // Trigger the Siren `oninput` event handler to check validity of Siren.
+    selectField('entreprise.siren').dispatchEvent(event);
+  }
+
   document.preFormSubmit = async _ => {
     const anneeIndicateurs = Number(selectField("déclaration.année_indicateurs").value)
     const message = `Vous allez procéder ou accéder à la déclaration de votre index de l’égalité professionnelle pour l’année ${anneeIndicateurs + 1} au titre des données de ${anneeIndicateurs}.`

--- a/packages/simulateur/src/components/FieldSiren.test.tsx
+++ b/packages/simulateur/src/components/FieldSiren.test.tsx
@@ -57,7 +57,7 @@ jest.mock("../utils/api", () => ({
   },
 }))
 
-const validator = sirenValidatorWithOwner(jest.fn())
+const validator = sirenValidatorWithOwner(2020)(jest.fn())
 
 let consoleErrorMock: jest.SpyInstance
 

--- a/packages/simulateur/src/utils/api.ts
+++ b/packages/simulateur/src/utils/api.ts
@@ -95,7 +95,11 @@ export const putDeclaration = (declaration: DeclarationDataField) => {
   return putResource(`/declaration/${entreprise.siren}/${déclaration.année_indicateurs}`, declaration)
 }
 
-export const validateSiren = (siren: string) => getResource(`/validate-siren?siren=${siren}`)
+export const validateSiren = (siren: string, year?: number | undefined) => {
+  return year
+    ? getResource(`/validate-siren?siren=${siren}&year=${year}`)
+    : getResource(`/validate-siren?siren=${siren}`)
+}
 
 /**
  * Return the owners of the given siren. This endpoint returns only if the user is granted.

--- a/packages/simulateur/src/views/InformationsEntreprise/InformationsEntreprise.tsx
+++ b/packages/simulateur/src/views/InformationsEntreprise/InformationsEntreprise.tsx
@@ -39,6 +39,8 @@ const InformationsEntreprise: FunctionComponent<InformationsEntrepriseProps> = (
 
   const alreadyDeclared = declaration?.data?.id === code
 
+  const year = state?.informations?.anneeDeclaration || new Date().getFullYear() // fallback but this case should not happen.
+
   return (
     <PageInformationsEntreprise>
       <LayoutFormAndResult
@@ -49,6 +51,7 @@ const InformationsEntreprise: FunctionComponent<InformationsEntrepriseProps> = (
             updateInformationsEntreprise={updateInformationsEntreprise}
             validateInformationsEntreprise={validateInformationsEntreprise}
             alreadyDeclared={alreadyDeclared}
+            year={year}
           />
         }
         childrenResult={null}

--- a/packages/simulateur/src/views/InformationsEntreprise/InformationsEntrepriseForm.tsx
+++ b/packages/simulateur/src/views/InformationsEntreprise/InformationsEntrepriseForm.tsx
@@ -94,6 +94,7 @@ interface InformationsEntrepriseFormProps {
   updateInformationsEntreprise: (data: ActionInformationsEntrepriseData) => void
   validateInformationsEntreprise: (valid: FormState) => void
   alreadyDeclared: boolean
+  year: number
 }
 
 const InformationsEntrepriseForm: FunctionComponent<InformationsEntrepriseFormProps> = ({
@@ -102,6 +103,7 @@ const InformationsEntrepriseForm: FunctionComponent<InformationsEntrepriseFormPr
   updateInformationsEntreprise,
   validateInformationsEntreprise,
   alreadyDeclared,
+  year,
 }) => {
   const initialValues = {
     nomEntreprise: informationsEntreprise.nomEntreprise,
@@ -223,6 +225,7 @@ const InformationsEntrepriseForm: FunctionComponent<InformationsEntrepriseFormPr
                 label="SIREN"
                 name="siren"
                 readOnly={readOnly}
+                year={year}
                 updateSirenData={(sirenData: EntrepriseType) =>
                   form.batch(() => {
                     form.change("nomEntreprise", sirenData.raison_sociale || "")
@@ -282,6 +285,7 @@ const InformationsEntrepriseForm: FunctionComponent<InformationsEntrepriseFormPr
                             siren={`${entrepriseUES}.siren`}
                             index={index}
                             readOnly={readOnly}
+                            year={year}
                             updateSirenData={(sirenData: EntrepriseType) =>
                               form.change(`${entrepriseUES}.nom`, sirenData.raison_sociale || "")
                             }

--- a/packages/simulateur/src/views/InformationsEntreprise/components/EntrepriseUESInputField.tsx
+++ b/packages/simulateur/src/views/InformationsEntreprise/components/EntrepriseUESInputField.tsx
@@ -16,6 +16,7 @@ type EntrepriseUESInputProps = {
   index: number
   readOnly: boolean
   updateSirenData: (sirenData: EntrepriseType) => void
+  year: number
 }
 
 const EntrepriseUESInput: FunctionComponent<EntrepriseUESInputProps> = ({
@@ -24,6 +25,7 @@ const EntrepriseUESInput: FunctionComponent<EntrepriseUESInputProps> = ({
   index,
   readOnly,
   updateSirenData,
+  year,
 }) => {
   const checkDuplicates = (value: string, allValues: any) => {
     const sirenList = allValues.entreprisesUES.map((entreprise: EntrepriseUES) => entreprise.siren)
@@ -58,7 +60,8 @@ const EntrepriseUESInput: FunctionComponent<EntrepriseUESInputProps> = ({
             name={siren}
             readOnly={readOnly}
             updateSirenData={updateSirenData}
-            validator={composeValidators(checkDuplicates, sirenValidator(updateSirenData))}
+            year={year}
+            validator={composeValidators(checkDuplicates, sirenValidator(year)(updateSirenData))}
           />
         )}
         <FakeInputGroup label="Nom de l'entreprise">{nomField.input.value}</FakeInputGroup>


### PR DESCRIPTION
- closes #961 

---

Côté simulation, j'ai dû adapter le composant `FieldSiren`. Ce composant est à refactor car il est géré par React Hook Form et un système de composition de validator, qui ne sont pas adaptés pour notre cas. 
- les fonctions de validation ne prennent en paramètre que l'input en cours et tous les autres inputs du form. Pas de chance, notre validation porte sur le champ qui fait partie d'un autre form (vu qu'on est dans un wizard, les contraintes inter champs peuvent être sur des champs non présents dans l'écran courant). J'ai dû faire un function builder, qui prend l'année en paramètre et qui rend le validator dans la forme attendu par React Hook Form...
- comme notre state/dispatch n'utilise pas de contexte, j'ai dû passer year de `InformationsEntreprise` à `InformationsEntrepriseForm`  à `FieldSiren`...

---

Côté déclaration, la difficulté est d'avoir l'année alors qu'elle ne se trouve pas encore dans le state, puisqu'on est au début du flot et que c'est la page `commencer.html` qui va justement setter l'année.

J'ai ajouté un event listener sur l'année pour qu'il ajoute en avance l'année dans le state. Il trigger aussi l'input Siren, pour éviter le cas où l'utilisateur modifie le siren avec une année valide, puis modifie l'input année avec une année non valide. Pour éviter, ça il faut gérer maintenant la synchronisation entre les 2 champs.
