### PR TITLE
fix: add referer before calling entreprise api

### DIFF
--- a/packages/api/egapro/helpers.py
+++ b/packages/api/egapro/helpers.py
@@ -7,7 +7,7 @@ from difflib import SequenceMatcher
 
 import httpx
 
-from egapro import config, constants, schema, utils
+from egapro import config, constants, schema
 from egapro.loggers import logger
 from egapro.schema.utils import clean_readonly
 
@@ -232,7 +232,8 @@ async def load_from_recherche_entreprises(siren, year=constants.INVALID_YEAR):
         return await load_from_api_entreprises(siren, year)
     logger.debug("Calling Recherche Entreprises for siren %s", siren)
     url = f"https://api.recherche-entreprises.fabrique.social.gouv.fr/api/v1/entreprise/{siren}"
-    data = await get(url)
+    headers = {'Referer': 'egapro'}
+    data = await get(url, headers=headers)
     if not data:
         return {}
     raison_sociale = data.get("simpleLabel")
@@ -278,7 +279,8 @@ async def load_from_api_entreprises(siren, year=constants.INVALID_YEAR):
         "recipient": "egapro",
         "object": "egapro",
     }
-    data = await get(url, params=params)
+    headers = {'Referer': 'egapro'}
+    data = await get(url, params=params, headers=headers)
     if not data:
         return {}
     entreprise = data.get("entreprise", {})

--- a/packages/api/test/api/test_ownership.py
+++ b/packages/api/test/api/test_ownership.py
@@ -36,11 +36,11 @@ async def test_add_owner(client, monkeypatch):
     client.login("staff@email.com")
     resp = await client.put("/ownership/123456782/ba@na.na")
     assert resp.status == 204
-    assert await db.ownership.emails("123456782") == [
-        "foo@bar.baz",
-        "foo@foo.foo",
-        "ba@na.na",
-    ]
+    inserted = await db.ownership.emails("123456782")
+    assert len(inserted) == 3
+    assert "foo@bar.baz" in inserted
+    assert "foo@foo.foo" in inserted
+    assert "ba@na.na" in inserted
 
 
 async def test_delete_owner(client):


### PR DESCRIPTION
- Fixes #1378 
- header `Referer: egapro` added for both api.gouv entreprise api, and Fabrique's "recherche-entreprise" api