### PR TITLE
fix(api): handle floats and float string in jsonb after repeqsearch

### DIFF
--- a/packages/api/egapro/sql/search_representation_equilibree.sql
+++ b/packages/api/egapro/sql/search_representation_equilibree.sql
@@ -1,9 +1,9 @@
 SELECT
     array_agg(representation_equilibree.data ORDER BY representation_equilibree.declared_at DESC) as data,
-    jsonb_object_agg(representation_equilibree.year::text, (representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_femmes_cadres')::int) as pourcentage_femmes_cadres,
-    jsonb_object_agg(representation_equilibree.year::text, (representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_hommes_cadres')::int) as pourcentage_hommes_cadres,
-    jsonb_object_agg(representation_equilibree.year::text, (representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_femmes_membres')::int) as pourcentage_femmes_membres,
-    jsonb_object_agg(representation_equilibree.year::text, (representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_hommes_membres')::int) as pourcentage_hommes_membres
+    jsonb_object_agg(representation_equilibree.year::text, replace((representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_femmes_cadres')::text, ',', '.')::real) as pourcentage_femmes_cadres,
+    jsonb_object_agg(representation_equilibree.year::text, replace((representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_hommes_cadres')::text, ',', '.')::real) as pourcentage_hommes_cadres,
+    jsonb_object_agg(representation_equilibree.year::text, replace((representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_femmes_membres')::text, ',', '.')::real) as pourcentage_femmes_membres,
+    jsonb_object_agg(representation_equilibree.year::text, replace((representation_equilibree.data->'indicateurs'->'représentation_équilibrée'->>'pourcentage_hommes_membres')::text, ',', '.')::real) as pourcentage_hommes_membres
 FROM representation_equilibree
 JOIN search_representation_equilibree ON representation_equilibree.siren=search_representation_equilibree.siren AND representation_equilibree.year=search_representation_equilibree.year
     {where}

--- a/packages/api/test/test_ft.py
+++ b/packages/api/test/test_ft.py
@@ -779,3 +779,27 @@ async def test_search_representation_equilibree_amp_and_parens_are_excaped(repre
     )
     results = await db.search_representation_equilibree.run(query="zanzi & (bar)")
     assert len(results)
+
+async def test_search_representation_equilibree_percent_with_weird_float():
+    await db.representation_equilibree.put(
+        "987654321",
+        2019,
+        {
+            "entreprise": {
+                "raison_sociale": "Le Regalia",
+                "département": "75",
+                "région": "11",
+            },
+            "déclaration": {"date": datetime.now()},
+            "indicateurs": {
+                "représentation_équilibrée": {
+                    "pourcentage_femmes_cadres": "49.1",
+                    "pourcentage_hommes_cadres": "50,9",
+                    "pourcentage_femmes_membres": 49.1,
+                    "pourcentage_hommes_membres": 50.9
+                }
+            }
+        },
+    )
+    results = await db.search_representation_equilibree.run(query="regalia")
+    assert len(results)


### PR DESCRIPTION
- Ref: #1325 
- handle whatever weird float is found is jsonb data field

e.g. : (all are ok now)
```json
{
  "pourcentage_femmes_cadres": "49.1",
  "pourcentage_hommes_cadres": "50,9",
  "pourcentage_femmes_membres": 49.1
}
```