### PR TITLE
chore: set pods requests limits

### DIFF
--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -6,6 +6,15 @@ api:
     EGAPRO_SMTP_LOGIN: ""
     EGAPRO_SMTP_PASSWORD: ""
     EGAPRO_SMTP_SSL: ""
+  autoscale:
+    enabled: true
+  resources:
+    requests:
+      cpu: 100m
+      memory: 640M
+    limits:
+      cpu: 200m
+      memory: 1G
 
 app:
   vars:
@@ -15,5 +24,14 @@ app:
     MAILER_SMTP_LOGIN: ""
     MAILER_SMTP_PASSWORD: ""
     MAILER_SMTP_SSL: "False"
+  autoscale:
+    enabled: true
+  resources:
+    requests:
+      cpu: 20m
+      memory: 640M
+    limits:
+      cpu: 125m
+      memory: 1G
 
 maildev: {}

--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -29,7 +29,7 @@ app:
   resources:
     requests:
       cpu: 20m
-      memory: 640M
+      memory: 196M
     limits:
       cpu: 125m
       memory: 1G

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -15,17 +15,25 @@ app:
         name: "egapro-secret"
     - secretRef:
         name: smtp-app
-
+  autoscale:
+    enabled: true
+  resources:
+    requests:
+      cpu: 20m
+      memory: 640M
+    limits:
+      cpu: 125m
+      memory: 1G
 
 api:
   autoscale:
     enabled: true
   resources:
     requests:
-      cpu: 1
+      cpu: 100m
       memory: 640M
     limits:
-      cpu: 2
+      cpu: 200m
       memory: 1G
   vars:
     EGAPRO_SENTRY_DSN: "https://084bf19c0e1141ddadbc1f7b86d2eb57@sentry.fabrique.social.gouv.fr/22"

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -20,7 +20,7 @@ app:
   resources:
     requests:
       cpu: 20m
-      memory: 640M
+      memory: 196M
     limits:
       cpu: 125m
       memory: 1G


### PR DESCRIPTION
The aim is to to fine tune `api` & `app` pods requests and limits on `preprod` and `prod` environments.

![](https://media.giphy.com/media/bKBM7H63PIykM/giphy.gif)