### PR TITLE
feat(bo): allow searching by email in liste declarants

### DIFF
--- a/packages/app/src/api/core-domain/repo/IOwnershipRequestRepo.ts
+++ b/packages/app/src/api/core-domain/repo/IOwnershipRequestRepo.ts
@@ -17,9 +17,9 @@ export const OWNERSHIP_REQUEST_SORTABLE_COLS = [
 export type OwnershipSearchCriteria = GetOwnershipRequestInputDTO;
 
 export interface IOwnershipRequestRepo extends BulkRepo<OwnershipRequest> {
-  countSearch({ siren, status }: OwnershipSearchCriteria): Promise<number>;
+  countSearch({ query, status }: OwnershipSearchCriteria): Promise<number>;
   search({
-    siren,
+    query,
     status,
     limit,
     offset,

--- a/packages/app/src/api/core-domain/useCases/GetOwnershipRequest.ts
+++ b/packages/app/src/api/core-domain/useCases/GetOwnershipRequest.ts
@@ -9,7 +9,7 @@ export class GetOwnershipRequest implements UseCase<GetOwnershipRequestInputDTO,
   constructor(private readonly ownershipRequestRepo: IOwnershipRequestRepo) {}
 
   public async execute({
-    siren,
+    query,
     status,
     limit: limitQuery = 10,
     offset: offsetQuery = 0,
@@ -20,13 +20,13 @@ export class GetOwnershipRequest implements UseCase<GetOwnershipRequestInputDTO,
     const offset = Math.max(offsetQuery, 0);
 
     const totalCount = await this.ownershipRequestRepo.countSearch({
-      siren,
+      query,
       status,
     });
 
     try {
       const ownershipRequests = await this.ownershipRequestRepo.search({
-        siren,
+        query,
         status,
         limit,
         offset,
@@ -35,7 +35,7 @@ export class GetOwnershipRequest implements UseCase<GetOwnershipRequestInputDTO,
       });
       return {
         params: {
-          siren,
+          query,
           status,
           limit,
           offset,

--- a/packages/app/src/common/core-domain/dtos/OwnershipRequestDTO.ts
+++ b/packages/app/src/common/core-domain/dtos/OwnershipRequestDTO.ts
@@ -39,6 +39,6 @@ export const getOwnershipRequestInputDTOSchema = z.object({
       z.literal("status"),
     ])
     .optional(),
-  siren: z.string().optional(),
+  query: z.string().optional(),
   status: z.nativeEnum(OwnershipRequestStatus.Enum).optional(),
 });

--- a/packages/app/src/pages/admin/liste-declarants.tsx
+++ b/packages/app/src/pages/admin/liste-declarants.tsx
@@ -33,6 +33,7 @@ import {
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { acceptOwnershipRequest } from "@services/apiClient/ownershipRequest";
 import { useListeDeclarants } from "@services/apiClient/useListeDeclarants";
+import type { OwnershipRequestSearchParam } from "@services/apiClient/useOwnershipRequestListStore";
 import { useOwnershipRequestListStore } from "@services/apiClient/useOwnershipRequestListStore";
 import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -211,14 +212,14 @@ const ActionButtons = () => {
   );
 };
 
-type SearchFormType = { siren: string; status: OwnershipRequestStatus.Enum };
+type SearchFormType = OwnershipRequestSearchParam;
 
 const OwnershipRequestPage: NextPageWithLayout = () => {
   const formState = useOwnershipRequestListStore(state => state.formState);
   const submit = useOwnershipRequestListStore(state => state.submit);
   const reset = useOwnershipRequestListStore(state => state.reset);
   const { isLoading } = useListeDeclarants(formState);
-  const { siren, status } = formState;
+  const { query, status } = formState;
   const [animationParent] = useAutoAnimate<HTMLDivElement>();
 
   const {
@@ -228,16 +229,16 @@ const OwnershipRequestPage: NextPageWithLayout = () => {
     setValue,
   } = useForm<SearchFormType>({
     defaultValues: {
-      siren,
       status,
+      query,
     },
   });
 
   // Synchronizing form inputs with store. May look unnecessary at first, but mandatory for correct behaviour of the reset button.
   useEffect(() => {
-    if (siren !== undefined) setValue("siren", siren);
+    if (query !== undefined) setValue("query", query);
     if (status !== undefined) setValue("status", status);
-  }, [siren, status, setValue]);
+  }, [query, status, setValue]);
 
   return (
     <Box as="section">
@@ -251,10 +252,10 @@ const OwnershipRequestPage: NextPageWithLayout = () => {
             <GridCol sm={3}>
               <FormGroup>
                 <FormInput
-                  id="siren-param"
-                  placeholder="Rechercher par Siren"
+                  id="query-param"
+                  placeholder="Rechercher par Siren ou Email"
                   autoComplete="off"
-                  {...register("siren")}
+                  {...register("query")}
                 />
               </FormGroup>
             </GridCol>

--- a/packages/app/src/pages/admin/liste-declarants.tsx
+++ b/packages/app/src/pages/admin/liste-declarants.tsx
@@ -253,7 +253,7 @@ const OwnershipRequestPage: NextPageWithLayout = () => {
               <FormGroup>
                 <FormInput
                   id="query-param"
-                  placeholder="Rechercher par Siren ou Email"
+                  placeholder="Rechercher par Siren ou email"
                   autoComplete="off"
                   {...register("query")}
                 />

--- a/packages/app/src/services/apiClient/useListeDeclarants.ts
+++ b/packages/app/src/services/apiClient/useListeDeclarants.ts
@@ -14,7 +14,7 @@ type SearchParams = Partial<Omit<OwnershipRequestListStoreType["formState"], "ch
 const buildKey = (search?: SearchParams) => {
   if (!search) return null;
 
-  const { orderBy, orderDirection, siren, status, pageNumber, pageSize } = search;
+  const { orderBy, orderDirection, query, status, pageNumber, pageSize } = search;
 
   const limit = pageSize || ITEMS_PER_PAGE;
   const offset = pageNumber ? pageNumber * limit : 0;
@@ -22,7 +22,7 @@ const buildKey = (search?: SearchParams) => {
   const params = new URLSearchParams({
     ...(search.orderBy && { orderBy }),
     ...(search.orderDirection && { orderDirection }),
-    ...(search.siren && { siren }),
+    ...(search.query && { query }),
     ...(search.status && { status }),
     limit: String(limit),
     offset: String(offset),

--- a/packages/app/src/services/apiClient/useOwnershipRequestListStore.tsx
+++ b/packages/app/src/services/apiClient/useOwnershipRequestListStore.tsx
@@ -11,23 +11,26 @@ import { immer } from "zustand/middleware/immer";
 
 export const ITEMS_PER_PAGE = 10;
 
+export interface OwnershipRequestSearchParam {
+  /** siren or email */
+  query: string;
+  status: OwnershipRequestStatus.Enum;
+}
 // Limit and offset are low level. They are replaced by pageSize and pageNumber for convenience.
 export type OwnershipRequestListStoreType = {
   firstPage: () => void;
-  formState: {
+  formState: Partial<OwnershipRequestSearchParam> & {
     checkedItems: string[];
     globalCheck: boolean;
     orderBy?: GetOwnershipRequestInputSchemaDTO["orderBy"];
     orderDirection?: GetOwnershipRequestInputSchemaDTO["orderDirection"];
     pageNumber: number;
     pageSize: number;
-    siren?: string;
-    status?: OwnershipRequestStatus.Enum;
   };
   nextPage: () => void;
   previousPage: () => void;
   reset: () => void;
-  submit: ({ siren, status }: { siren: string; status: OwnershipRequestStatus.Enum }) => void;
+  submit: (param: OwnershipRequestSearchParam) => void;
   toggleAll: (requests: GetOwnershipRequestDTO | undefined) => void;
   toggleItem: ({ id, checked }: { checked: boolean; id: string }) => void;
   togglerOrderColumn: (columnValue: GetOwnershipRequestInputOrderBy) => void;
@@ -39,7 +42,7 @@ export const initialStore: OwnershipRequestListStoreType["formState"] = {
   orderDirection: "desc",
   orderBy: "createdAt",
   status: OwnershipRequestStatus.Enum.TO_PROCESS,
-  siren: "",
+  query: "",
   checkedItems: [],
   globalCheck: false,
 };
@@ -52,10 +55,10 @@ export const useOwnershipRequestListStore = create<OwnershipRequestListStoreType
         set(state => {
           state.formState = initialStore;
         }),
-      submit: ({ siren, status }: { siren: string; status: OwnershipRequestStatus.Enum }) =>
+      submit: ({ query, status }: OwnershipRequestSearchParam) =>
         set(state => {
-          if (siren !== state.formState.siren || status !== state.formState.status) {
-            state.formState.siren = siren;
+          if (query !== state.formState.query || status !== state.formState.status) {
+            state.formState.query = query;
             state.formState.status = status;
             state.formState.pageNumber = 0;
             state.formState.checkedItems = [];


### PR DESCRIPTION
- Closes #1575

## Done
- replace "siren" search field with a "query" search field
- in backend, query can search on chosen column (for now "asker_email", "email", and "siren")
- search is now case wide and case insensitive (i.e. `where column ilike %value%`)