### PR TITLE
fix: problem with jekyll 4 in docker dev

### DIFF
--- a/packages/declaration/Dockerfile.dev
+++ b/packages/declaration/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll:4
+FROM jekyll/jekyll:4.2.0
 
 ARG EGAPRO_API_URL
 


### PR DESCRIPTION
Problème lors du `yarn dev:declaration`

<img width="1630" alt="image" src="https://github.com/SocialGouv/egapro/assets/3749428/6c7c4528-fb6c-4ae2-ad7d-48d150a258c1">

Le problème vient de la version utilisée dans docker.dev (juste 4, sans précision) et du fait que l'équipe Jekyll a fait un breaking change sans changer la version majeure de l'image Docker. Fonctionne en précisant la version exacte 4.2.0.