### PR TITLE
feat: add BigNote component

### DIFF
--- a/packages/app/src/design-system/base/BigNote.module.scss
+++ b/packages/app/src/design-system/base/BigNote.module.scss
@@ -1,0 +1,34 @@
+.tile:not(.tile-no-border) {
+    box-shadow: 0 0 0 1px var(--border-default-grey);
+    padding: 1rem 2rem;
+}
+
+.tile {
+    text-align: center;
+   
+}
+
+.note {
+    font-weight: 700;
+    line-height: 1;
+    font-size: 3rem;
+}
+
+.text {
+    color: var(--text-title-grey);
+    font-size: 0.875rem !important;
+    line-height: 1.5rem !important;
+    margin-top: .5rem;
+    > * {
+        margin-bottom: 0;
+    }
+    > * + *  {
+        margin-top: 0.25rem;
+    }
+}
+
+.max {
+    font-size: 1.125rem;
+    font-weight: 200;
+    transform: translateY(0.313rem);
+}

--- a/packages/app/src/design-system/base/BigNote.module.scss
+++ b/packages/app/src/design-system/base/BigNote.module.scss
@@ -1,11 +1,15 @@
 .tile:not(.tile-no-border) {
     box-shadow: 0 0 0 1px var(--border-default-grey);
     padding: 1rem 2rem;
+    .text {
+        margin-top: 1rem;
+        padding-top: 1rem;
+        border-top: 1px solid var(--border-default-grey);
+    }
 }
 
 .tile {
     text-align: center;
-   
 }
 
 .note {
@@ -16,7 +20,7 @@
 
 .text {
     color: var(--text-title-grey);
-    font-size: 0.875rem !important;
+    font-size: .875rem !important;
     line-height: 1.5rem !important;
     margin-top: .5rem;
     > * {
@@ -30,5 +34,5 @@
 .max {
     font-size: 1.125rem;
     font-weight: 200;
-    transform: translateY(0.313rem);
+    transform: translateY(.313rem);
 }

--- a/packages/app/src/design-system/base/BigNote.tsx
+++ b/packages/app/src/design-system/base/BigNote.tsx
@@ -1,0 +1,26 @@
+import { fr } from "@codegouvfr/react-dsfr";
+import { cx } from "@codegouvfr/react-dsfr/tools/cx";
+import { type ReactNode } from "react";
+
+import styles from "./BigNote.module.scss";
+
+export type BigNoteProps = {
+  className?: string;
+  classes?: Partial<Record<"description" | "legend" | "max" | "note" | "root" | "text", string>>;
+  legend: NonNullable<ReactNode>;
+  max: number;
+  noBorder?: boolean;
+  note: number;
+  text: NonNullable<ReactNode>;
+};
+
+export const BigNote = ({ note, noBorder, max, text, className, legend, classes = {} }: BigNoteProps) => (
+  <div className={cx(styles.tile, noBorder && styles["tile-no-border"], classes.root, className)}>
+    <div className={cx(fr.cx("fr-m-0", "fr-text--sm"), classes.legend)}>{legend}</div>
+    <div className={styles["tile-note"]}>
+      <span className={cx(styles["note"], classes.note)}>{note}</span>
+      <span className={cx(styles.max, classes.max)}>&nbsp;/&nbsp;{max}</span>
+    </div>
+    <div className={cx(styles.text, classes.text)}>{text}</div>
+  </div>
+);

--- a/packages/app/src/design-system/base/BigNote.tsx
+++ b/packages/app/src/design-system/base/BigNote.tsx
@@ -8,19 +8,25 @@ export type BigNoteProps = {
   className?: string;
   classes?: Partial<Record<"description" | "legend" | "max" | "note" | "root" | "text", string>>;
   legend: NonNullable<ReactNode>;
-  max: number;
+  max?: number;
   noBorder?: boolean;
-  note: number;
-  text: NonNullable<ReactNode>;
+  note?: number;
+  text?: NonNullable<ReactNode>;
 };
 
 export const BigNote = ({ note, noBorder, max, text, className, legend, classes = {} }: BigNoteProps) => (
   <div className={cx(styles.tile, noBorder && styles["tile-no-border"], classes.root, className)}>
     <div className={cx(fr.cx("fr-m-0", "fr-text--sm"), classes.legend)}>{legend}</div>
     <div className={styles["tile-note"]}>
-      <span className={cx(styles["note"], classes.note)}>{note}</span>
-      <span className={cx(styles.max, classes.max)}>&nbsp;/&nbsp;{max}</span>
+      {note !== undefined ? (
+        <>
+          <span className={cx(styles["note"], classes.note)}>{note}</span>
+          {max !== undefined && <span className={cx(styles.max, classes.max)}>&nbsp;/&nbsp;{max}</span>}
+        </>
+      ) : (
+        <span className={cx(styles["note"], classes.note)}>NC</span>
+      )}
     </div>
-    <div className={cx(styles.text, classes.text)}>{text}</div>
+    {text && <div className={cx(styles.text, classes.text)}>{text}</div>}
   </div>
 );

--- a/packages/app/src/design-system/server.ts
+++ b/packages/app/src/design-system/server.ts
@@ -1,5 +1,6 @@
 export * from "./base/AlternativeTable";
 export * from "./base/BackNextButtonsGroup";
+export * from "./base/BigNote";
 export * from "./base/Box";
 export * from "./base/ContentWithChapter";
 export * from "./base/DetailedDownload";


### PR DESCRIPTION
Usage

```
<BigNote
    legend={<>Index de&nbsp;:</>}
    note={88}
    text={
      <>
        <p>
          Total des points obtenus aux indicateurs calculables&nbsp;: <strong>60</strong>
        </p>
        <p>
          Nombre de points maximum pouvant être obtenus aux indicateurs calculables&nbsp;: <strong>75</strong>
        </p>
      </>
    }
    max={100}
  />
```

Add props `noBorder` for remove border like

```
<BigNote
    noBorder
    legend={<>Index de&nbsp;:</>}
    note={88}
    text={
      <>
        <p>
          Total des points obtenus aux indicateurs calculables&nbsp;: <strong>60</strong>
        </p>
        <p>
          Nombre de points maximum pouvant être obtenus aux indicateurs calculables&nbsp;: <strong>75</strong>
        </p>
      </>
    }
    max={100}
  />
```