### PR TITLE
fix: écart valeur absolue was hidden wrongly

### DIFF
--- a/packages/app/src/app/(default)/index-egapro/simulateur/(funnel)/indicateur2et3/Form.tsx
+++ b/packages/app/src/app/(default)/index-egapro/simulateur/(funnel)/indicateur2et3/Form.tsx
@@ -233,7 +233,9 @@ export const Indic2and3Form = () => {
                             text={
                               <>
                                 Écart en valeur absolue :{" "}
-                                <strong>{computed?.result ? percentFormat.format(computed.result / 100) : ""}</strong>
+                                <strong>
+                                  {computed?.result !== undefined ? percentFormat.format(computed.result / 100) : ""}
+                                </strong>
                               </>
                             }
                           />


### PR DESCRIPTION
<img width="447" alt="image" src="https://github.com/SocialGouv/egapro/assets/3749428/3d15868a-1f4d-434c-ae29-988813b1bc94">

Régression par rapport au refactor fait hier sur le Form pour l'indicateur 2 ou l'indicateur 3.