### PR TITLE
fix: display non-weighted gaps in simu recap

### DIFF
--- a/packages/app/src/app/(default)/index-egapro/simulateur/(funnel)/recapitulatif/RecapSimu.tsx
+++ b/packages/app/src/app/(default)/index-egapro/simulateur/(funnel)/recapitulatif/RecapSimu.tsx
@@ -169,7 +169,7 @@ export const RecapSimu = () => {
                     cols: ageRanges.map(ageRange => {
                       const groupKey = buildRemunerationKey(category.name, ageRange);
                       const canComputeGroup = computerIndicateurUn.canComputeGroup(groupKey);
-                      const groupResult = computerIndicateurUn.computeGroup(groupKey);
+                      const groupResult = computerIndicateurUn.computeGroupBeforeThresholdApplication(groupKey);
                       return canComputeGroup ? precisePercentFormat.format(groupResult.resultRaw / 100) : "NC";
                     }) as [AlternativeTableProps.ColType, ...AlternativeTableProps.ColType[]],
                   }))}
@@ -282,7 +282,7 @@ export const RecapSimu = () => {
                             label: "",
                           },
                           {
-                            label: "Écart pondéré",
+                            label: indicateur === 2 ? "Écarts de taux d'augmentations" : "Écarts de taux de promotions",
                           },
                         ]}
                         body={categories.map(category => ({
@@ -295,7 +295,7 @@ export const RecapSimu = () => {
                                 mergedLabel: "NC",
                               } satisfies Partial<AlternativeTableProps.BodyContent>;
                             }
-                            const groupResult = computerIndicateurDeuxOuTrois.computeGroup(category);
+                            const groupResult = computerIndicateurDeuxOuTrois.computeGroupNonWeightedGap(category);
                             return {
                               cols: [precisePercentFormat.format(groupResult.resultRaw / 100)],
                             } satisfies Partial<AlternativeTableProps.BodyContent>;

--- a/packages/app/src/common/core-domain/computers/AbstractGroupComputer.ts
+++ b/packages/app/src/common/core-domain/computers/AbstractGroupComputer.ts
@@ -18,7 +18,7 @@ export interface DefaultGroup {
   womenCount: number;
 }
 
-type InferGroupKey<T> = Required<T> extends Record<infer K extends string, Any> ? K : never;
+export type InferGroupKey<T> = Required<T> extends Record<infer K extends string, Any> ? K : never;
 type InferGroup<T> = Required<T> extends Record<string, infer G extends DefaultGroup> ? G : never;
 
 export abstract class AbstractGroupComputer<

--- a/packages/app/src/common/core-domain/computers/IndicateurDeuxComputer.ts
+++ b/packages/app/src/common/core-domain/computers/IndicateurDeuxComputer.ts
@@ -1,5 +1,5 @@
 import { type CSP } from "../domain/valueObjects/CSP";
-import { type ComputedResult as BaseComputedResult } from "./AbstractComputer";
+import { type ComputedResult as BaseComputedResult, type ComputedResult } from "./AbstractComputer";
 import { AbstractGroupComputer, type DefaultGroup } from "./AbstractGroupComputer";
 import { type IndicateurUnComputer } from "./IndicateurUnComputer";
 
@@ -74,6 +74,27 @@ export class IndicateurDeuxComputer extends AbstractGroupComputer<Percentages, o
     const groupCount = group.menCount + group.womenCount;
     const { totalGroupCount } = this.getTotalMetadata();
     return (gap * groupCount) / totalGroupCount;
+  }
+
+  protected calculateGap(id: CSP.Enum): number {
+    if (!this.input) {
+      throw new Error("percentages must be set before calling calculateGap");
+    }
+
+    const group = this.input[id] ?? {
+      menCount: 0,
+      men: 0,
+      womenCount: 0,
+      women: 0,
+    };
+
+    const gap = group.men - group.women; // in full percentage (e.g. 100%)
+    return gap;
+  }
+
+  public computeGroupNonWeightedGap(groupKey: CSP.Enum): ComputedResult {
+    const weightedGap = this.calculateGap(groupKey);
+    return this.getNoteAndInfoFromResult(weightedGap);
   }
 
   protected getNoteAndInfoFromResult(weightedGap: number): IndicateurDeuxComputer.ComputedResult {


### PR DESCRIPTION
![image](https://github.com/SocialGouv/egapro/assets/90777022/dcfd9f0b-633d-4b59-89ca-12dc3f68aa71)
![image](https://github.com/SocialGouv/egapro/assets/90777022/54939fb3-8af5-419e-ab0c-d5aaa44d637f)

Closes #1800 