### PR TITLE
fix: display nc on simu recap gap in rate increases

### DIFF
--- a/packages/app/src/app/(default)/index-egapro/simulateur/(funnel)/recapitulatif/RecapSimu.tsx
+++ b/packages/app/src/app/(default)/index-egapro/simulateur/(funnel)/recapitulatif/RecapSimu.tsx
@@ -193,7 +193,6 @@ export const RecapSimu = () => {
           title={NAVIGATION.indicateur2et3.title}
           editLink={simulateurPath("indicateur2et3")}
           content={(() => {
-            if (!resultIndicateurDeuxTrois) return;
             if (funnel.indicateur2and3.calculable === "non") {
               return (
                 <IndicatorNote
@@ -217,6 +216,8 @@ export const RecapSimu = () => {
                 />
               );
             }
+
+            if (!resultIndicateurDeuxTrois) return;
 
             return (
               <>


### PR DESCRIPTION
![image](https://github.com/SocialGouv/egapro/assets/90777022/8872809c-7dff-47a5-9d94-7e7ae70bb06e)


Closes #1968