### PR TITLE
fix: declaration recap wording when effective count is 0

### DIFF
--- a/packages/app/src/app/(default)/index-egapro/declaration/[siren]/[year]/RecapDeclaration.tsx
+++ b/packages/app/src/app/(default)/index-egapro/declaration/[siren]/[year]/RecapDeclaration.tsx
@@ -117,10 +117,11 @@ export const RecapDeclaration = ({ déclaration, edit }: Props) => {
                   .
                 </p>
                 <p>
-                  {déclaration["periode-reference"].effectifTotal && (
+                  {déclaration["periode-reference"].effectifTotal >= 0 && (
                     <>
-                      <strong>{déclaration["periode-reference"].effectifTotal}</strong> salariés pris en compte pour le
-                      calcul des indicateurs sur la période de référence (en effectif physique)
+                      <strong>{déclaration["periode-reference"].effectifTotal}</strong> salarié
+                      {déclaration["periode-reference"].effectifTotal > 1 ? "s" : ""} pris en compte pour le calcul des
+                      indicateurs sur la période de référence (en effectif physique)
                     </>
                   )}
                 </p>


### PR DESCRIPTION
Closes #2089 

![image](https://github.com/SocialGouv/egapro/assets/90777022/d11de8b4-a60a-44e2-98e8-d99ba2d6d2b4)
