### PR TITLE
refactor: extract shared Breadcrumb component from 9 duplicated implementations

### DIFF
--- a/packages/app/src/modules/aide/AidePage.tsx
+++ b/packages/app/src/modules/aide/AidePage.tsx
@@ -1,4 +1,5 @@
-import { AideBreadcrumb } from "./AideBreadcrumb";
+import { Breadcrumb } from "~/modules/layout";
+
 import { AideCallout } from "./AideCallout";
 import { AideIllustration } from "./AideIllustration";
 import { AideResourceCards } from "./AideResourceCards";
@@ -9,10 +10,11 @@ export function AidePage() {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-6w">
-				<AideBreadcrumb
-					collapseId="breadcrumb-aide"
-					current={{ label: "Aide et ressources", href: "/aide" }}
-					items={[{ label: "Accueil", href: "/" }]}
+				<Breadcrumb
+					items={[
+						{ label: "Accueil", href: "/" },
+						{ label: "Aide et ressources" },
+					]}
 				/>
 
 				<h1 className="fr-h1 fr-mt-4w">Aide et ressources</h1>

--- a/packages/app/src/modules/aide/ContactPage.tsx
+++ b/packages/app/src/modules/aide/ContactPage.tsx
@@ -1,4 +1,5 @@
-import { AideBreadcrumb } from "./AideBreadcrumb";
+import { Breadcrumb } from "~/modules/layout";
+
 import { AideIllustration } from "./AideIllustration";
 import styles from "./AideLayout.module.scss";
 import { CopyEmailButton } from "./CopyEmailButton";
@@ -10,12 +11,11 @@ export function ContactPage() {
 	return (
 		<main className={styles.pageBackground} id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-6w">
-				<AideBreadcrumb
-					collapseId="breadcrumb-contact"
-					current={{ label: "Nous contacter", href: "/aide/nous-contacter" }}
+				<Breadcrumb
 					items={[
 						{ label: "Accueil", href: "/" },
 						{ label: "Aide et ressources", href: "/aide" },
+						{ label: "Nous contacter" },
 					]}
 				/>
 

--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
@@ -1,5 +1,4 @@
-import Link from "next/link";
-
+import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
 import styles from "./CompanyBanner.module.scss";
@@ -23,30 +22,12 @@ export function CompanyBanner({
 	return (
 		<div className={`fr-py-3w ${styles.banner}`}>
 			<div className="fr-container">
-				<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-					<button
-						aria-controls="breadcrumb-declaration"
-						aria-expanded="false"
-						className="fr-breadcrumb__button"
-						type="button"
-					>
-						Voir le fil d'Ariane
-					</button>
-					<div className="fr-collapse" id="breadcrumb-declaration">
-						<ol className="fr-breadcrumb__list">
-							<li>
-								<Link className="fr-breadcrumb__link" href="/">
-									Mon espace
-								</Link>
-							</li>
-							<li>
-								<span aria-current="page" className="fr-breadcrumb__link">
-									{currentPageLabel}
-								</span>
-							</li>
-						</ol>
-					</div>
-				</nav>
+				<Breadcrumb
+					items={[
+						{ label: "Mon espace", href: "/" },
+						{ label: currentPageLabel },
+					]}
+				/>
 
 				<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
 					<div className="fr-col-auto">

--- a/packages/app/src/modules/faq/FaqPage.tsx
+++ b/packages/app/src/modules/faq/FaqPage.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { Breadcrumb } from "~/modules/layout";
+
 import { FaqContent } from "./FaqContent";
 import styles from "./FaqPage.module.scss";
 import { FaqSummary } from "./FaqSummary";
@@ -12,30 +14,12 @@ export function FaqPage() {
 		<main id="content" tabIndex={-1}>
 			<div className={styles.headerZone}>
 				<div className="fr-container">
-					<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-						<button
-							aria-controls="breadcrumb-faq"
-							aria-expanded={false}
-							className="fr-breadcrumb__button"
-							type="button"
-						>
-							Voir le fil d'Ariane
-						</button>
-						<div className="fr-collapse" id="breadcrumb-faq">
-							<ol className="fr-breadcrumb__list">
-								<li>
-									<Link className="fr-breadcrumb__link" href="/">
-										Accueil
-									</Link>
-								</li>
-								<li>
-									<span aria-current="page" className="fr-breadcrumb__link">
-										Questions fréquentes (FAQ)
-									</span>
-								</li>
-							</ol>
-						</div>
-					</nav>
+					<Breadcrumb
+						items={[
+							{ label: "Accueil", href: "/" },
+							{ label: "Questions fréquentes (FAQ)" },
+						]}
+					/>
 
 					<Link
 						aria-label="Retour à l'accueil"

--- a/packages/app/src/modules/layout/Breadcrumb.tsx
+++ b/packages/app/src/modules/layout/Breadcrumb.tsx
@@ -1,18 +1,24 @@
+"use client";
+
+import { useId } from "react";
+
 type BreadcrumbItem = {
 	label: string;
-	href: string;
+	href?: string;
 };
 
 type Props = {
-	/** Unique id for the DSFR collapsible breadcrumb container. */
-	collapseId: string;
 	items: BreadcrumbItem[];
-	/** Label + href for the current page (rendered with aria-current="page"). */
-	current: BreadcrumbItem;
 };
 
-/** Shared DSFR breadcrumb used across aide pages. */
-export function AideBreadcrumb({ collapseId, items, current }: Props) {
+/** Shared DSFR breadcrumb component. Last item (without href) is the current page. */
+export function Breadcrumb({ items }: Props) {
+	const collapseId = `breadcrumb-${useId()}`;
+	const parentItems = items.slice(0, -1);
+	const currentItem = items.at(-1);
+
+	if (!currentItem) return null;
+
 	return (
 		<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
 			{/* DSFR JS will manage aria-expanded after hydration */}
@@ -23,11 +29,11 @@ export function AideBreadcrumb({ collapseId, items, current }: Props) {
 				suppressHydrationWarning
 				type="button"
 			>
-				Voir le fil d'Ariane
+				Voir le fil d&#39;Ariane
 			</button>
 			<div className="fr-collapse" id={collapseId}>
 				<ol className="fr-breadcrumb__list">
-					{items.map((item) => (
+					{parentItems.map((item) => (
 						<li key={item.href}>
 							<a className="fr-breadcrumb__link" href={item.href}>
 								{item.label}
@@ -35,13 +41,9 @@ export function AideBreadcrumb({ collapseId, items, current }: Props) {
 						</li>
 					))}
 					<li>
-						<a
-							aria-current="page"
-							className="fr-breadcrumb__link"
-							href={current.href}
-						>
-							{current.label}
-						</a>
+						<span aria-current="page" className="fr-breadcrumb__link">
+							{currentItem.label}
+						</span>
 					</li>
 				</ol>
 			</div>

--- a/packages/app/src/modules/layout/Breadcrumb.tsx
+++ b/packages/app/src/modules/layout/Breadcrumb.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useId } from "react";
 
 type BreadcrumbItem = {
@@ -34,10 +35,10 @@ export function Breadcrumb({ items }: Props) {
 			<div className="fr-collapse" id={collapseId}>
 				<ol className="fr-breadcrumb__list">
 					{parentItems.map((item) => (
-						<li key={item.href}>
-							<a className="fr-breadcrumb__link" href={item.href}>
+						<li key={item.href ?? item.label}>
+							<Link className="fr-breadcrumb__link" href={item.href ?? "/"}>
 								{item.label}
-							</a>
+							</Link>
 						</li>
 					))}
 					<li>

--- a/packages/app/src/modules/layout/__tests__/Breadcrumb.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Breadcrumb } from "../Breadcrumb";
+
+describe("Breadcrumb", () => {
+	it("renders DSFR breadcrumb structure with nav, button, and list", () => {
+		render(
+			<Breadcrumb
+				items={[{ label: "Accueil", href: "/" }, { label: "Page courante" }]}
+			/>,
+		);
+
+		const nav = screen.getByRole("navigation", { name: /vous êtes ici/i });
+		expect(nav).toBeInTheDocument();
+
+		expect(
+			within(nav).getByRole("button", { name: /voir le fil d'ariane/i }),
+		).toBeInTheDocument();
+
+		expect(within(nav).getByRole("list")).toBeInTheDocument();
+	});
+
+	it("renders parent items as links with correct href", () => {
+		render(
+			<Breadcrumb
+				items={[
+					{ label: "Accueil", href: "/" },
+					{ label: "Aide", href: "/aide" },
+					{ label: "Nous contacter" },
+				]}
+			/>,
+		);
+
+		const nav = screen.getByRole("navigation", { name: /vous êtes ici/i });
+
+		const accueilLink = within(nav).getByRole("link", { name: /accueil/i });
+		expect(accueilLink).toHaveAttribute("href", "/");
+
+		const aideLink = within(nav).getByRole("link", { name: /aide/i });
+		expect(aideLink).toHaveAttribute("href", "/aide");
+	});
+
+	it("renders last item with aria-current='page' and no href", () => {
+		render(
+			<Breadcrumb
+				items={[{ label: "Accueil", href: "/" }, { label: "Plan du site" }]}
+			/>,
+		);
+
+		const currentItem = screen.getByText("Plan du site");
+		expect(currentItem).toHaveAttribute("aria-current", "page");
+		expect(currentItem).not.toHaveAttribute("href");
+	});
+
+	it("renders nothing when items array is empty", () => {
+		const { container } = render(<Breadcrumb items={[]} />);
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("links aria-controls to collapse container id", () => {
+		render(
+			<Breadcrumb
+				items={[{ label: "Accueil", href: "/" }, { label: "FAQ" }]}
+			/>,
+		);
+
+		const button = screen.getByRole("button", {
+			name: /voir le fil d'ariane/i,
+		});
+		const controlsId = button.getAttribute("aria-controls") ?? "";
+		expect(controlsId).toBeTruthy();
+		expect(document.getElementById(controlsId)).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/layout/index.ts
+++ b/packages/app/src/modules/layout/index.ts
@@ -1,3 +1,4 @@
+export { Breadcrumb } from "./Breadcrumb";
 export { Footer } from "./Footer";
 export { Header } from "./Header";
 export { NewTabNotice } from "./shared/NewTabNotice";

--- a/packages/app/src/modules/legal/AccessibilityPage/index.tsx
+++ b/packages/app/src/modules/legal/AccessibilityPage/index.tsx
@@ -1,3 +1,5 @@
+import { Breadcrumb } from "~/modules/layout";
+
 import { AccessibilityCompliance } from "./AccessibilityCompliance";
 import { AccessibilityContact } from "./AccessibilityContact";
 import { AccessibilityEstablishment } from "./AccessibilityEstablishment";
@@ -7,34 +9,12 @@ export function AccessibilityPage() {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-6w">
-				<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-					<button
-						aria-controls="breadcrumb-accessibility"
-						aria-expanded="false"
-						className="fr-breadcrumb__button"
-						type="button"
-					>
-						Voir le fil d'Ariane
-					</button>
-					<div className="fr-collapse" id="breadcrumb-accessibility">
-						<ol className="fr-breadcrumb__list">
-							<li>
-								<a className="fr-breadcrumb__link" href="/">
-									Accueil
-								</a>
-							</li>
-							<li>
-								<a
-									aria-current="page"
-									className="fr-breadcrumb__link"
-									href="/declaration-accessibilite"
-								>
-									Déclaration d'accessibilité
-								</a>
-							</li>
-						</ol>
-					</div>
-				</nav>
+				<Breadcrumb
+					items={[
+						{ label: "Accueil", href: "/" },
+						{ label: "Déclaration d'accessibilité" },
+					]}
+				/>
 
 				<h1 className="fr-h1 fr-mt-4w">Déclaration d'accessibilité</h1>
 

--- a/packages/app/src/modules/legal/CookiesPage.tsx
+++ b/packages/app/src/modules/legal/CookiesPage.tsx
@@ -1,36 +1,16 @@
+import { Breadcrumb } from "~/modules/layout";
+
 /** Gestion des cookies page. */
 export function CookiesPage() {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-6w">
-				<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-					<button
-						aria-controls="breadcrumb-cookies"
-						aria-expanded="false"
-						className="fr-breadcrumb__button"
-						type="button"
-					>
-						Voir le fil d'Ariane
-					</button>
-					<div className="fr-collapse" id="breadcrumb-cookies">
-						<ol className="fr-breadcrumb__list">
-							<li>
-								<a className="fr-breadcrumb__link" href="/">
-									Accueil
-								</a>
-							</li>
-							<li>
-								<a
-									aria-current="page"
-									className="fr-breadcrumb__link"
-									href="/gestion-des-cookies"
-								>
-									Gestion des cookies
-								</a>
-							</li>
-						</ol>
-					</div>
-				</nav>
+				<Breadcrumb
+					items={[
+						{ label: "Accueil", href: "/" },
+						{ label: "Gestion des cookies" },
+					]}
+				/>
 
 				<h1 className="fr-h1 fr-mt-4w">Gestion des cookies</h1>
 

--- a/packages/app/src/modules/legal/LegalNoticePage.tsx
+++ b/packages/app/src/modules/legal/LegalNoticePage.tsx
@@ -1,38 +1,16 @@
-import { NewTabNotice } from "~/modules/layout";
+import { Breadcrumb, NewTabNotice } from "~/modules/layout";
 
 /** Mentions légales page. */
 export function LegalNoticePage() {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-6w">
-				<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-					<button
-						aria-controls="breadcrumb-legal-notice"
-						aria-expanded="false"
-						className="fr-breadcrumb__button"
-						type="button"
-					>
-						Voir le fil d'Ariane
-					</button>
-					<div className="fr-collapse" id="breadcrumb-legal-notice">
-						<ol className="fr-breadcrumb__list">
-							<li>
-								<a className="fr-breadcrumb__link" href="/">
-									Accueil
-								</a>
-							</li>
-							<li>
-								<a
-									aria-current="page"
-									className="fr-breadcrumb__link"
-									href="/mentions-legales"
-								>
-									Mentions légales
-								</a>
-							</li>
-						</ol>
-					</div>
-				</nav>
+				<Breadcrumb
+					items={[
+						{ label: "Accueil", href: "/" },
+						{ label: "Mentions légales" },
+					]}
+				/>
 
 				<h1 className="fr-h1 fr-mt-4w">Mentions légales</h1>
 

--- a/packages/app/src/modules/legal/PrivacyPolicyPage/index.tsx
+++ b/packages/app/src/modules/legal/PrivacyPolicyPage/index.tsx
@@ -1,3 +1,5 @@
+import { Breadcrumb } from "~/modules/layout";
+
 import { PrivacyCookies } from "./PrivacyCookies";
 import { PrivacyOverview } from "./PrivacyOverview";
 import { PrivacyRightsAndData } from "./PrivacyRightsAndData";
@@ -7,34 +9,12 @@ export function PrivacyPolicyPage() {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-6w">
-				<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-					<button
-						aria-controls="breadcrumb-privacy"
-						aria-expanded="false"
-						className="fr-breadcrumb__button"
-						type="button"
-					>
-						Voir le fil d'Ariane
-					</button>
-					<div className="fr-collapse" id="breadcrumb-privacy">
-						<ol className="fr-breadcrumb__list">
-							<li>
-								<a className="fr-breadcrumb__link" href="/">
-									Accueil
-								</a>
-							</li>
-							<li>
-								<a
-									aria-current="page"
-									className="fr-breadcrumb__link"
-									href="/donnees-personnelles"
-								>
-									Données personnelles
-								</a>
-							</li>
-						</ol>
-					</div>
-				</nav>
+				<Breadcrumb
+					items={[
+						{ label: "Accueil", href: "/" },
+						{ label: "Données personnelles" },
+					]}
+				/>
 
 				<h1 className="fr-h1 fr-mt-4w">Données personnelles</h1>
 

--- a/packages/app/src/modules/legal/SitemapPage.tsx
+++ b/packages/app/src/modules/legal/SitemapPage.tsx
@@ -1,38 +1,15 @@
 import Link from "next/link";
 
+import { Breadcrumb } from "~/modules/layout";
+
 /** Plan du site page. */
 export function SitemapPage() {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-6w">
-				<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-					<button
-						aria-controls="breadcrumb-sitemap"
-						aria-expanded="false"
-						className="fr-breadcrumb__button"
-						type="button"
-					>
-						Voir le fil d'Ariane
-					</button>
-					<div className="fr-collapse" id="breadcrumb-sitemap">
-						<ol className="fr-breadcrumb__list">
-							<li>
-								<a className="fr-breadcrumb__link" href="/">
-									Accueil
-								</a>
-							</li>
-							<li>
-								<a
-									aria-current="page"
-									className="fr-breadcrumb__link"
-									href="/plan-du-site"
-								>
-									Plan du site
-								</a>
-							</li>
-						</ol>
-					</div>
-				</nav>
+				<Breadcrumb
+					items={[{ label: "Accueil", href: "/" }, { label: "Plan du site" }]}
+				/>
 
 				<h1 className="fr-h1 fr-mt-4w">Plan du site</h1>
 

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { Breadcrumb } from "~/modules/layout";
 
 import styles from "./CompanyInfoBanner.module.scss";
 import { formatSiren } from "./formatSiren";
@@ -9,41 +9,18 @@ type Props = {
 	company: CompanyDetail;
 };
 
-const BREADCRUMB_ID = "breadcrumb-company";
-
 export function CompanyInfoBanner({ company }: Props) {
 	const currentYear = new Date().getFullYear();
 
 	return (
 		<div className={`fr-py-4w ${styles.banner}`}>
 			<div className="fr-container">
-				<nav aria-label="vous êtes ici :" className="fr-breadcrumb">
-					<button
-						aria-controls={BREADCRUMB_ID}
-						aria-expanded="false"
-						className="fr-breadcrumb__button"
-						type="button"
-					>
-						Voir le fil d'Ariane
-					</button>
-					<div className="fr-collapse" id={BREADCRUMB_ID}>
-						<ol className="fr-breadcrumb__list">
-							<li>
-								<Link
-									className="fr-breadcrumb__link"
-									href="/mon-espace/mes-entreprises"
-								>
-									Mon espace
-								</Link>
-							</li>
-							<li>
-								<span aria-current="page" className="fr-breadcrumb__link">
-									{company.name}
-								</span>
-							</li>
-						</ol>
-					</div>
-				</nav>
+				<Breadcrumb
+					items={[
+						{ label: "Mon espace", href: "/mon-espace/mes-entreprises" },
+						{ label: company.name },
+					]}
+				/>
 
 				<div className="fr-mt-3w">
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">

--- a/packages/app/src/test/setup.ts
+++ b/packages/app/src/test/setup.ts
@@ -75,7 +75,7 @@ vi.mock("~/modules/layout", () => ({
 			React.createElement(
 				"button",
 				{ className: "fr-breadcrumb__button", type: "button" },
-				"Voir le fil d\u2019Ariane",
+				"Voir le fil d'Ariane",
 			),
 			React.createElement(
 				"ol",

--- a/packages/app/src/test/setup.ts
+++ b/packages/app/src/test/setup.ts
@@ -48,7 +48,7 @@ vi.mock("next-auth/react", () => ({
 // Global mock for server-only — avoids error in jsdom.
 vi.mock("server-only", () => ({}));
 
-// Global mock for ~/modules/layout — provides NewTabNotice passthrough.
+// Global mock for ~/modules/layout — provides NewTabNotice and Breadcrumb passthroughs.
 vi.mock("~/modules/layout", () => ({
 	NewTabNotice: () =>
 		React.createElement(
@@ -56,6 +56,44 @@ vi.mock("~/modules/layout", () => ({
 			{ className: "fr-sr-only" },
 			"Ouvre une nouvelle fenêtre",
 		),
+	Breadcrumb: ({
+		items,
+	}: {
+		items: Array<{ label: string; href?: string }>;
+	}) => {
+		const parentItems = items.slice(0, -1);
+		const currentItem = items.at(-1);
+		if (!currentItem) return null;
+		return React.createElement(
+			"nav",
+			{ "aria-label": "vous êtes ici :" },
+			React.createElement(
+				"button",
+				{ className: "fr-breadcrumb__button", type: "button" },
+				"Voir le fil d\u2019Ariane",
+			),
+			React.createElement(
+				"ol",
+				null,
+				...parentItems.map((item) =>
+					React.createElement(
+						"li",
+						{ key: item.href },
+						React.createElement("a", { href: item.href }, item.label),
+					),
+				),
+				React.createElement(
+					"li",
+					null,
+					React.createElement(
+						"span",
+						{ "aria-current": "page" },
+						currentItem.label,
+					),
+				),
+			),
+		);
+	},
 }));
 
 // Global mock for ~/trpc/server — provides HydrateClient passthrough.


### PR DESCRIPTION
Replace ~500 lines of copy-pasted DSFR breadcrumb markup across 9 files with a single reusable Breadcrumb component in modules/layout/.

Closes #2884