### PR TITLE
feat: add second declaration screens (corrective action path)

### DIFF
--- a/packages/app/drizzle/0007_gigantic_doctor_faustus.sql
+++ b/packages/app/drizzle/0007_gigantic_doctor_faustus.sql
@@ -1,0 +1,40 @@
+CREATE TYPE "public"."declaration_type" AS ENUM('initial', 'correction');--> statement-breakpoint
+CREATE TABLE "app_employee_category" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"job_category_id" varchar(255) NOT NULL,
+	"declaration_type" "declaration_type" NOT NULL,
+	"women_count" integer,
+	"men_count" integer,
+	"annual_base_women" numeric,
+	"annual_base_men" numeric,
+	"annual_variable_women" numeric,
+	"annual_variable_men" numeric,
+	"hourly_base_women" numeric,
+	"hourly_base_men" numeric,
+	"hourly_variable_women" numeric,
+	"hourly_variable_men" numeric,
+	"created_at" timestamp with time zone,
+	"updated_at" timestamp with time zone,
+	CONSTRAINT "employee_category_job_type_idx" UNIQUE("job_category_id","declaration_type")
+);
+--> statement-breakpoint
+CREATE TABLE "app_job_category" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"declaration_id" varchar(255) NOT NULL,
+	"category_index" integer NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"detail" varchar(500),
+	"source" varchar(50) NOT NULL,
+	CONSTRAINT "job_category_declaration_index_idx" UNIQUE("declaration_id","category_index")
+);
+--> statement-breakpoint
+ALTER TABLE "app_declaration" DROP CONSTRAINT "app_declaration_siren_year_pk";--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD COLUMN "id" varchar(255) PRIMARY KEY NOT NULL;--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD COLUMN "compliance_path" varchar(30);--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD COLUMN "second_declaration_step" integer;--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD COLUMN "second_declaration_status" varchar(20);--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD COLUMN "second_decl_reference_period_start" varchar(10);--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD COLUMN "second_decl_reference_period_end" varchar(10);--> statement-breakpoint
+ALTER TABLE "app_employee_category" ADD CONSTRAINT "app_employee_category_job_category_id_app_job_category_id_fk" FOREIGN KEY ("job_category_id") REFERENCES "public"."app_job_category"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_job_category" ADD CONSTRAINT "app_job_category_declaration_id_app_declaration_id_fk" FOREIGN KEY ("declaration_id") REFERENCES "public"."app_declaration"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD CONSTRAINT "declaration_siren_year_idx" UNIQUE("siren","year");

--- a/packages/app/drizzle/0007_salty_bucky.sql
+++ b/packages/app/drizzle/0007_salty_bucky.sql
@@ -1,1 +1,0 @@
-ALTER TABLE "app_declaration" ADD COLUMN "compliance_path" varchar(30);

--- a/packages/app/drizzle/meta/0007_snapshot.json
+++ b/packages/app/drizzle/meta/0007_snapshot.json
@@ -1,5 +1,5 @@
 {
-	"id": "5f228e94-b184-43df-a930-84638e2f28a4",
+	"id": "b15a568f-2e3e-4e11-b04f-6fd1d1324289",
 	"prevId": "f3e2b98f-a20d-4aea-bb64-55902054d546",
 	"version": "7",
 	"dialect": "postgresql",
@@ -563,6 +563,12 @@
 			"name": "app_declaration",
 			"schema": "",
 			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
 				"siren": {
 					"name": "siren",
 					"type": "varchar(9)",
@@ -617,12 +623,6 @@
 					"primaryKey": false,
 					"notNull": false
 				},
-				"compliance_path": {
-					"name": "compliance_path",
-					"type": "varchar(30)",
-					"primaryKey": false,
-					"notNull": false
-				},
 				"current_step": {
 					"name": "current_step",
 					"type": "integer",
@@ -636,6 +636,36 @@
 					"primaryKey": false,
 					"notNull": false,
 					"default": "'draft'"
+				},
+				"compliance_path": {
+					"name": "compliance_path",
+					"type": "varchar(30)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_status": {
+					"name": "second_declaration_status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
 				},
 				"created_at": {
 					"name": "created_at",
@@ -678,13 +708,199 @@
 					"onUpdate": "no action"
 				}
 			},
-			"compositePrimaryKeys": {
-				"app_declaration_siren_year_pk": {
-					"name": "app_declaration_siren_year_pk",
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"declaration_siren_year_idx": {
+					"name": "declaration_siren_year_idx",
+					"nullsNotDistinct": false,
 					"columns": ["siren", "year"]
 				}
 			},
-			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"detail": {
+					"name": "detail",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
 			"policies": {},
 			"checkConstraints": {},
 			"isRLSEnabled": false
@@ -921,7 +1137,13 @@
 			"isRLSEnabled": false
 		}
 	},
-	"enums": {},
+	"enums": {
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		}
+	},
 	"schemas": {},
 	"sequences": {},
 	"roles": {},

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -54,8 +54,8 @@
 		{
 			"idx": 7,
 			"version": "7",
-			"when": 1773063693536,
-			"tag": "0007_salty_bucky",
+			"when": 1773158962249,
+			"tag": "0007_gigantic_doctor_faustus",
 			"breakpoints": true
 		}
 	]

--- a/packages/app/src/app/declaration-remuneration/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/etape/[step]/page.tsx
@@ -3,6 +3,7 @@ import {
 	StepPageClient,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
+import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
 import { api, HydrateClient } from "~/trpc/server";
 
 type StepPageProps = {
@@ -36,6 +37,14 @@ export default async function StepPage({ params }: StepPageProps) {
 				womenMedianValue: c.womenMedianValue ?? undefined,
 				menMedianValue: c.menMedianValue ?? undefined,
 			}));
+
+	const step5Categories = mapToEmployeeCategoryRows(
+		data.jobCategories,
+		data.employeeCategories,
+		"initial",
+	);
+
+	const initialSource = data.jobCategories[0]?.source;
 
 	const step1Categories = data.categories
 		.filter((c) => c.step === 1)
@@ -72,12 +81,13 @@ export default async function StepPage({ params }: StepPageProps) {
 		<HydrateClient>
 			<StepPageClient
 				declaration={data.declaration}
+				initialSource={initialSource}
 				step={step}
 				step1Categories={step1Categories}
 				step2Rows={step2Rows}
 				step3Data={step3Data}
 				step4Categories={stepCategories(4)}
-				step5Categories={stepCategories(5)}
+				step5Categories={step5Categories}
 			/>
 		</HydrateClient>
 	);

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
@@ -1,16 +1,44 @@
 import { notFound } from "next/navigation";
-
+import type { StepCategoryData } from "~/modules/declaration-remuneration";
 import {
+	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,
 	SecondDeclarationStep3Review,
 } from "~/modules/declaration-remuneration";
-import { SECOND_DECLARATION_TOTAL_STEPS } from "~/modules/declaration-remuneration/steps/secondDeclaration/constants";
 import { api, HydrateClient } from "~/trpc/server";
 
 type Props = {
 	params: Promise<{ step: string }>;
 };
+
+type DbCategory = {
+	step: number;
+	categoryName: string;
+	womenCount: number | null;
+	menCount: number | null;
+	womenValue: string | null;
+	menValue: string | null;
+	womenMedianValue: string | null;
+	menMedianValue: string | null;
+};
+
+function mapCategories(
+	categories: DbCategory[],
+	step: number,
+): StepCategoryData[] {
+	return categories
+		.filter((c) => c.step === step)
+		.map((c) => ({
+			name: c.categoryName,
+			womenCount: c.womenCount ?? undefined,
+			menCount: c.menCount ?? undefined,
+			womenValue: c.womenValue ?? undefined,
+			menValue: c.menValue ?? undefined,
+			womenMedianValue: c.womenMedianValue ?? undefined,
+			menMedianValue: c.menMedianValue ?? undefined,
+		}));
+}
 
 export default async function SecondDeclarationStepPage({ params }: Props) {
 	const { step: stepParam } = await params;
@@ -23,31 +51,8 @@ export default async function SecondDeclarationStepPage({ params }: Props) {
 	const data = await api.declaration.getOrCreate();
 	const currentYear = new Date().getFullYear();
 
-	// Extract step 5 categories (first declaration data) for pre-filling
-	const step5Categories = data.categories
-		.filter((c) => c.step === 5)
-		.map((c) => ({
-			name: c.categoryName,
-			womenCount: c.womenCount ?? undefined,
-			menCount: c.menCount ?? undefined,
-			womenValue: c.womenValue ?? undefined,
-			menValue: c.menValue ?? undefined,
-			womenMedianValue: c.womenMedianValue ?? undefined,
-			menMedianValue: c.menMedianValue ?? undefined,
-		}));
-
-	// Extract step 7 categories (second declaration data, if already started)
-	const step7Categories = data.categories
-		.filter((c) => c.step === 7)
-		.map((c) => ({
-			name: c.categoryName,
-			womenCount: c.womenCount ?? undefined,
-			menCount: c.menCount ?? undefined,
-			womenValue: c.womenValue ?? undefined,
-			menValue: c.menValue ?? undefined,
-			womenMedianValue: c.womenMedianValue ?? undefined,
-			menMedianValue: c.menMedianValue ?? undefined,
-		}));
+	const step5Categories = mapCategories(data.categories, 5);
+	const step7Categories = mapCategories(data.categories, 7);
 
 	const declarationDate = data.declaration.updatedAt
 		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
@@ -1,0 +1,89 @@
+import { notFound } from "next/navigation";
+
+import {
+	SecondDeclarationStep1Info,
+	SecondDeclarationStep2Form,
+	SecondDeclarationStep3Review,
+} from "~/modules/declaration-remuneration";
+import { SECOND_DECLARATION_TOTAL_STEPS } from "~/modules/declaration-remuneration/steps/secondDeclaration/constants";
+import { api, HydrateClient } from "~/trpc/server";
+
+type Props = {
+	params: Promise<{ step: string }>;
+};
+
+export default async function SecondDeclarationStepPage({ params }: Props) {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+
+	if (Number.isNaN(step) || step < 1 || step > SECOND_DECLARATION_TOTAL_STEPS) {
+		notFound();
+	}
+
+	const data = await api.declaration.getOrCreate();
+	const currentYear = new Date().getFullYear();
+
+	// Extract step 5 categories (first declaration data) for pre-filling
+	const step5Categories = data.categories
+		.filter((c) => c.step === 5)
+		.map((c) => ({
+			name: c.categoryName,
+			womenCount: c.womenCount ?? undefined,
+			menCount: c.menCount ?? undefined,
+			womenValue: c.womenValue ?? undefined,
+			menValue: c.menValue ?? undefined,
+			womenMedianValue: c.womenMedianValue ?? undefined,
+			menMedianValue: c.menMedianValue ?? undefined,
+		}));
+
+	// Extract step 7 categories (second declaration data, if already started)
+	const step7Categories = data.categories
+		.filter((c) => c.step === 7)
+		.map((c) => ({
+			name: c.categoryName,
+			womenCount: c.womenCount ?? undefined,
+			menCount: c.menCount ?? undefined,
+			womenValue: c.womenValue ?? undefined,
+			menValue: c.menValue ?? undefined,
+			womenMedianValue: c.womenMedianValue ?? undefined,
+			menMedianValue: c.menMedianValue ?? undefined,
+		}));
+
+	const declarationDate = data.declaration.updatedAt
+		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
+		: new Date().toLocaleDateString("fr-FR");
+
+	if (step === 1) {
+		return (
+			<SecondDeclarationStep1Info
+				currentYear={currentYear}
+				declarationDate={declarationDate}
+			/>
+		);
+	}
+
+	if (step === 2) {
+		return (
+			<HydrateClient>
+				<SecondDeclarationStep2Form
+					initialFirstDeclarationCategories={step5Categories}
+					initialSecondDeclarationCategories={
+						step7Categories.length > 0 ? step7Categories : undefined
+					}
+				/>
+			</HydrateClient>
+		);
+	}
+
+	// step === 3
+	const reviewCategories =
+		step7Categories.length > 0 ? step7Categories : step5Categories;
+
+	return (
+		<HydrateClient>
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={reviewCategories}
+			/>
+		</HydrateClient>
+	);
+}

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
-import type { StepCategoryData } from "~/modules/declaration-remuneration";
+
 import {
+	mapDbCategories,
 	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,
@@ -11,34 +12,6 @@ import { api, HydrateClient } from "~/trpc/server";
 type Props = {
 	params: Promise<{ step: string }>;
 };
-
-type DbCategory = {
-	step: number;
-	categoryName: string;
-	womenCount: number | null;
-	menCount: number | null;
-	womenValue: string | null;
-	menValue: string | null;
-	womenMedianValue: string | null;
-	menMedianValue: string | null;
-};
-
-function mapCategories(
-	categories: DbCategory[],
-	step: number,
-): StepCategoryData[] {
-	return categories
-		.filter((c) => c.step === step)
-		.map((c) => ({
-			name: c.categoryName,
-			womenCount: c.womenCount ?? undefined,
-			menCount: c.menCount ?? undefined,
-			womenValue: c.womenValue ?? undefined,
-			menValue: c.menValue ?? undefined,
-			womenMedianValue: c.womenMedianValue ?? undefined,
-			menMedianValue: c.menMedianValue ?? undefined,
-		}));
-}
 
 export default async function SecondDeclarationStepPage({ params }: Props) {
 	const { step: stepParam } = await params;
@@ -51,8 +24,8 @@ export default async function SecondDeclarationStepPage({ params }: Props) {
 	const data = await api.declaration.getOrCreate();
 	const currentYear = new Date().getFullYear();
 
-	const step5Categories = mapCategories(data.categories, 5);
-	const step7Categories = mapCategories(data.categories, 7);
+	const step5Categories = mapDbCategories(data.categories, 5);
+	const step7Categories = mapDbCategories(data.categories, 7);
 
 	const declarationDate = data.declaration.updatedAt
 		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
@@ -1,12 +1,12 @@
 import { notFound } from "next/navigation";
 
 import {
-	mapDbCategories,
 	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,
 	SecondDeclarationStep3Review,
 } from "~/modules/declaration-remuneration";
+import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
 import { api, HydrateClient } from "~/trpc/server";
 
 type Props = {
@@ -24,8 +24,24 @@ export default async function SecondDeclarationStepPage({ params }: Props) {
 	const data = await api.declaration.getOrCreate();
 	const currentYear = new Date().getFullYear();
 
-	const step5Categories = mapDbCategories(data.categories, 5);
-	const step7Categories = mapDbCategories(data.categories, 7);
+	const initialCategories = mapToEmployeeCategoryRows(
+		data.jobCategories,
+		data.employeeCategories,
+		"initial",
+	);
+
+	const hasCorrectionData = data.employeeCategories.some(
+		(e) => e.declarationType === "correction",
+	);
+	const correctionCategories = hasCorrectionData
+		? mapToEmployeeCategoryRows(
+				data.jobCategories,
+				data.employeeCategories,
+				"correction",
+			)
+		: [];
+
+	const initialSource = data.jobCategories[0]?.source;
 
 	const declarationDate = data.declaration.updatedAt
 		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
@@ -44,9 +60,16 @@ export default async function SecondDeclarationStepPage({ params }: Props) {
 		return (
 			<HydrateClient>
 				<SecondDeclarationStep2Form
-					initialFirstDeclarationCategories={step5Categories}
+					initialEndDate={
+						data.declaration.secondDeclReferencePeriodEnd ?? undefined
+					}
+					initialFirstDeclarationCategories={initialCategories}
 					initialSecondDeclarationCategories={
-						step7Categories.length > 0 ? step7Categories : undefined
+						correctionCategories.length > 0 ? correctionCategories : undefined
+					}
+					initialSource={initialSource}
+					initialStartDate={
+						data.declaration.secondDeclReferencePeriodStart ?? undefined
 					}
 				/>
 			</HydrateClient>
@@ -55,7 +78,7 @@ export default async function SecondDeclarationStepPage({ params }: Props) {
 
 	// step === 3
 	const reviewCategories =
-		step7Categories.length > 0 ? step7Categories : step5Categories;
+		correctionCategories.length > 0 ? correctionCategories : initialCategories;
 
 	return (
 		<HydrateClient>

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx
@@ -1,90 +1,12 @@
-import { notFound } from "next/navigation";
-
-import {
-	SECOND_DECLARATION_TOTAL_STEPS,
-	SecondDeclarationStep1Info,
-	SecondDeclarationStep2Form,
-	SecondDeclarationStep3Review,
-} from "~/modules/declaration-remuneration";
-import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
-import { api, HydrateClient } from "~/trpc/server";
+import { SecondDeclarationStepPage } from "~/modules/declaration-remuneration";
 
 type Props = {
 	params: Promise<{ step: string }>;
 };
 
-export default async function SecondDeclarationStepPage({ params }: Props) {
+export default async function Page({ params }: Props) {
 	const { step: stepParam } = await params;
 	const step = Number.parseInt(stepParam, 10);
 
-	if (Number.isNaN(step) || step < 1 || step > SECOND_DECLARATION_TOTAL_STEPS) {
-		notFound();
-	}
-
-	const data = await api.declaration.getOrCreate();
-	const currentYear = new Date().getFullYear();
-
-	const initialCategories = mapToEmployeeCategoryRows(
-		data.jobCategories,
-		data.employeeCategories,
-		"initial",
-	);
-
-	const hasCorrectionData = data.employeeCategories.some(
-		(e) => e.declarationType === "correction",
-	);
-	const correctionCategories = hasCorrectionData
-		? mapToEmployeeCategoryRows(
-				data.jobCategories,
-				data.employeeCategories,
-				"correction",
-			)
-		: [];
-
-	const initialSource = data.jobCategories[0]?.source;
-
-	const declarationDate = data.declaration.updatedAt
-		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
-		: new Date().toLocaleDateString("fr-FR");
-
-	if (step === 1) {
-		return (
-			<SecondDeclarationStep1Info
-				currentYear={currentYear}
-				declarationDate={declarationDate}
-			/>
-		);
-	}
-
-	if (step === 2) {
-		return (
-			<HydrateClient>
-				<SecondDeclarationStep2Form
-					initialEndDate={
-						data.declaration.secondDeclReferencePeriodEnd ?? undefined
-					}
-					initialFirstDeclarationCategories={initialCategories}
-					initialSecondDeclarationCategories={
-						correctionCategories.length > 0 ? correctionCategories : undefined
-					}
-					initialSource={initialSource}
-					initialStartDate={
-						data.declaration.secondDeclReferencePeriodStart ?? undefined
-					}
-				/>
-			</HydrateClient>
-		);
-	}
-
-	// step === 3
-	const reviewCategories =
-		correctionCategories.length > 0 ? correctionCategories : initialCategories;
-
-	return (
-		<HydrateClient>
-			<SecondDeclarationStep3Review
-				secondDeclarationCategories={reviewCategories}
-			/>
-		</HydrateClient>
-	);
+	return <SecondDeclarationStepPage step={step} />;
 }

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/page.tsx
@@ -1,51 +1,5 @@
-import { redirect } from "next/navigation";
+import { CompliancePathPage } from "~/modules/declaration-remuneration";
 
-import {
-	CompliancePathChoice,
-	hasGapsAboveThreshold,
-} from "~/modules/declaration-remuneration";
-import { auth } from "~/server/auth";
-import { api, HydrateClient } from "~/trpc/server";
-
-export default async function CompliancePathPage() {
-	const session = await auth();
-	const data = await api.declaration.getOrCreate();
-
-	if (data.declaration.status !== "submitted") {
-		redirect("/declaration-remuneration/etape/6");
-	}
-
-	const step5Categories = data.employeeCategories.filter(
-		(c) => c.declarationType === "initial",
-	);
-
-	if (!hasGapsAboveThreshold(step5Categories)) {
-		redirect("/avis-cse");
-	}
-
-	// If previous path was corrective_action and gaps persist, force joint_evaluation
-	const forcedPath =
-		data.declaration.compliancePath === "corrective_action"
-			? ("joint_evaluation" as const)
-			: undefined;
-
-	const email = session?.user?.email ?? "";
-	const currentYear = new Date().getFullYear();
-
-	return (
-		<HydrateClient>
-			<CompliancePathChoice
-				currentYear={currentYear}
-				email={email}
-				forcedPath={forcedPath}
-				initialPath={
-					(data.declaration.compliancePath as
-						| "justify"
-						| "corrective_action"
-						| "joint_evaluation"
-						| null) ?? undefined
-				}
-			/>
-		</HydrateClient>
-	);
+export default function Page() {
+	return <CompliancePathPage />;
 }

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/page.tsx
@@ -15,13 +15,9 @@ export default async function CompliancePathPage() {
 		redirect("/declaration-remuneration/etape/6");
 	}
 
-	const step5Categories = data.categories
-		.filter((c) => c.step === 5)
-		.map((c) => ({
-			name: c.categoryName,
-			womenValue: c.womenValue ?? undefined,
-			menValue: c.menValue ?? undefined,
-		}));
+	const step5Categories = data.employeeCategories.filter(
+		(c) => c.declarationType === "initial",
+	);
 
 	if (!hasGapsAboveThreshold(step5Categories)) {
 		redirect("/avis-cse");

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -8,6 +8,7 @@ import { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 import { Step6Review } from "./steps/Step6Review";
 import type {
 	CategoryData,
+	EmployeeCategoryRow,
 	PayGapRow,
 	StepCategoryData,
 	VariablePayData,
@@ -24,7 +25,8 @@ type StepPageClientProps = {
 	step2Rows: PayGapRow[];
 	step3Data: VariablePayData;
 	step4Categories: StepCategoryData[];
-	step5Categories: StepCategoryData[];
+	step5Categories: EmployeeCategoryRow[];
+	initialSource?: string;
 };
 
 export function StepPageClient({
@@ -35,6 +37,7 @@ export function StepPageClient({
 	step3Data,
 	step4Categories,
 	step5Categories,
+	initialSource,
 }: StepPageClientProps) {
 	switch (step) {
 		case 1:
@@ -69,6 +72,7 @@ export function StepPageClient({
 			return (
 				<Step5EmployeeCategories
 					initialCategories={step5Categories}
+					initialSource={initialSource}
 					maxMen={declaration.totalMen ?? undefined}
 					maxWomen={declaration.totalWomen ?? undefined}
 				/>

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -11,6 +11,7 @@ export {
 } from "./shared/gapUtils";
 export { mapDbCategories } from "./shared/mapDbCategories";
 export { CompliancePathChoice } from "./steps/CompliancePathChoice";
+export { CompliancePathPage } from "./steps/CompliancePathPage";
 export { Step1Workforce } from "./steps/Step1Workforce";
 export { Step2PayGap } from "./steps/Step2PayGap";
 export { Step3VariablePay } from "./steps/Step3VariablePay";
@@ -22,6 +23,7 @@ export {
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,
 	SecondDeclarationStep3Review,
+	SecondDeclarationStepPage,
 } from "./steps/secondDeclaration";
 export { parseEmployeeCategories } from "./steps/step6/parseStep5Categories";
 export type {

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -17,6 +17,7 @@ export { Step4QuartileDistribution } from "./steps/Step4QuartileDistribution";
 export { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 export { Step6Review } from "./steps/Step6Review";
 export {
+	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,
 	SecondDeclarationStep3Review,

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -23,9 +23,10 @@ export {
 	SecondDeclarationStep2Form,
 	SecondDeclarationStep3Review,
 } from "./steps/secondDeclaration";
-export { parseStep5Categories } from "./steps/step6/parseStep5Categories";
+export { parseEmployeeCategories } from "./steps/step6/parseStep5Categories";
 export type {
 	CategoryData,
+	EmployeeCategoryRow,
 	PayGapRow,
 	StepCategoryData,
 	VariablePayData,

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -16,7 +16,11 @@ export { Step3VariablePay } from "./steps/Step3VariablePay";
 export { Step4QuartileDistribution } from "./steps/Step4QuartileDistribution";
 export { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 export { Step6Review } from "./steps/Step6Review";
-
+export {
+	SecondDeclarationStep1Info,
+	SecondDeclarationStep2Form,
+	SecondDeclarationStep3Review,
+} from "./steps/secondDeclaration";
 export { parseStep5Categories } from "./steps/step6/parseStep5Categories";
 export type {
 	CategoryData,

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -9,6 +9,7 @@ export {
 	gapLevel,
 	hasGapsAboveThreshold,
 } from "./shared/gapUtils";
+export { mapDbCategories } from "./shared/mapDbCategories";
 export { CompliancePathChoice } from "./steps/CompliancePathChoice";
 export { Step1Workforce } from "./steps/Step1Workforce";
 export { Step2PayGap } from "./steps/Step2PayGap";

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/gapUtils.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/gapUtils.test.ts
@@ -286,17 +286,13 @@ describe("formatTotal", () => {
 describe("hasGapsAboveThreshold", () => {
 	it("returns true when a category has a gap >= 5%", () => {
 		expect(
-			hasGapsAboveThreshold([
-				{ name: "cat:0:annual:base", womenValue: "90", menValue: "100" },
-			]),
+			hasGapsAboveThreshold([{ annualBaseWomen: "90", annualBaseMen: "100" }]),
 		).toBe(true);
 	});
 
 	it("returns false when all gaps are below 5%", () => {
 		expect(
-			hasGapsAboveThreshold([
-				{ name: "cat:0:annual:base", womenValue: "97", menValue: "100" },
-			]),
+			hasGapsAboveThreshold([{ annualBaseWomen: "97", annualBaseMen: "100" }]),
 		).toBe(false);
 	});
 
@@ -304,22 +300,20 @@ describe("hasGapsAboveThreshold", () => {
 		expect(hasGapsAboveThreshold([])).toBe(false);
 	});
 
-	it("skips name rows (containing :name:)", () => {
-		expect(
-			hasGapsAboveThreshold([
-				{ name: "cat:0:name:Ingénieurs", womenValue: "10", menValue: "100" },
-			]),
-		).toBe(false);
+	it("skips categories without values", () => {
+		expect(hasGapsAboveThreshold([{}])).toBe(false);
 	});
 
-	it("skips categories without values", () => {
-		expect(hasGapsAboveThreshold([{ name: "cat:0:annual:base" }])).toBe(false);
+	it("detects gaps in hourly fields", () => {
+		expect(
+			hasGapsAboveThreshold([{ hourlyBaseWomen: "10", hourlyBaseMen: "20" }]),
+		).toBe(true);
 	});
 
 	it("uses custom threshold when provided", () => {
 		expect(
 			hasGapsAboveThreshold(
-				[{ name: "cat:0:annual:base", womenValue: "97", menValue: "100" }],
+				[{ annualBaseWomen: "97", annualBaseMen: "100" }],
 				2,
 			),
 		).toBe(true);

--- a/packages/app/src/modules/declaration-remuneration/shared/gapUtils.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/gapUtils.ts
@@ -73,7 +73,7 @@ export function computeProportion(count: string, total?: number): string {
 	return `${((n / total) * 100).toFixed(1).replace(".", ",")} %`;
 }
 
-export function formatCurrency(value?: string): string {
+export function formatCurrency(value?: string | null): string {
 	if (!value) return "-";
 	const n = Number.parseFloat(value);
 	if (Number.isNaN(n)) return "-";
@@ -97,16 +97,44 @@ export function formatTotal(value: number | null, unit: string): string {
 	return `${value.toLocaleString("fr-FR", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${unit}`;
 }
 
-/** Checks if any step 5 category has an absolute gap >= threshold (default 5%) */
+type SalaryPair = {
+	women: string | null;
+	men: string | null;
+};
+
+type EmployeeCategoryLike = {
+	annualBaseWomen?: string | null;
+	annualBaseMen?: string | null;
+	annualVariableWomen?: string | null;
+	annualVariableMen?: string | null;
+	hourlyBaseWomen?: string | null;
+	hourlyBaseMen?: string | null;
+	hourlyVariableWomen?: string | null;
+	hourlyVariableMen?: string | null;
+};
+
+// Returns true if any employee category has a salary gap >= threshold (default 5%).
 export function hasGapsAboveThreshold(
-	step5Categories: { name: string; womenValue?: string; menValue?: string }[],
+	categories: EmployeeCategoryLike[],
 	threshold = 5,
 ): boolean {
-	for (const cat of step5Categories) {
-		if (!cat.womenValue || !cat.menValue) continue;
-		if (cat.name.includes(":name:")) continue;
-		const gap = computeGap(cat.womenValue, cat.menValue);
-		if (gap !== null && gap >= threshold) return true;
-	}
-	return false;
+	return categories.some((cat) => {
+		const pairs: SalaryPair[] = [
+			{ women: cat.annualBaseWomen ?? null, men: cat.annualBaseMen ?? null },
+			{
+				women: cat.annualVariableWomen ?? null,
+				men: cat.annualVariableMen ?? null,
+			},
+			{ women: cat.hourlyBaseWomen ?? null, men: cat.hourlyBaseMen ?? null },
+			{
+				women: cat.hourlyVariableWomen ?? null,
+				men: cat.hourlyVariableMen ?? null,
+			},
+		];
+		return pairs.some(({ women, men }) => {
+			if (!women || !men) return false;
+			const gap = computeGap(women, men);
+			return gap !== null && gap >= threshold;
+		});
+	});
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/mapDbCategories.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/mapDbCategories.ts
@@ -1,0 +1,29 @@
+import type { StepCategoryData } from "../types";
+
+type DbCategory = {
+	step: number;
+	categoryName: string;
+	womenCount: number | null;
+	menCount: number | null;
+	womenValue: string | null;
+	menValue: string | null;
+	womenMedianValue: string | null;
+	menMedianValue: string | null;
+};
+
+export function mapDbCategories(
+	categories: DbCategory[],
+	step: number,
+): StepCategoryData[] {
+	return categories
+		.filter((c) => c.step === step)
+		.map((c) => ({
+			name: c.categoryName,
+			womenCount: c.womenCount ?? undefined,
+			menCount: c.menCount ?? undefined,
+			womenValue: c.womenValue ?? undefined,
+			menValue: c.menValue ?? undefined,
+			womenMedianValue: c.womenMedianValue ?? undefined,
+			menMedianValue: c.menMedianValue ?? undefined,
+		}));
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -34,7 +34,13 @@ export function CompliancePathChoice({
 	>(forcedPath ?? initialPath);
 
 	const mutation = api.declaration.saveCompliancePath.useMutation({
-		onSuccess: () => router.push("/avis-cse"),
+		onSuccess: (_, { path }) => {
+			if (path === "corrective_action") {
+				router.push("/declaration-remuneration/parcours-conformite/etape/1");
+			} else {
+				router.push("/avis-cse");
+			}
+		},
 	});
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -1,0 +1,50 @@
+import { redirect } from "next/navigation";
+
+import { auth } from "~/server/auth";
+import { api, HydrateClient } from "~/trpc/server";
+
+import { hasGapsAboveThreshold } from "../shared/gapUtils";
+import { CompliancePathChoice } from "./CompliancePathChoice";
+
+export async function CompliancePathPage() {
+	const session = await auth();
+	const data = await api.declaration.getOrCreate();
+
+	if (data.declaration.status !== "submitted") {
+		redirect("/declaration-remuneration/etape/6");
+	}
+
+	const step5Categories = data.employeeCategories.filter(
+		(c) => c.declarationType === "initial",
+	);
+
+	if (!hasGapsAboveThreshold(step5Categories)) {
+		redirect("/avis-cse");
+	}
+
+	// If previous path was corrective_action and gaps persist, force joint_evaluation
+	const forcedPath =
+		data.declaration.compliancePath === "corrective_action"
+			? ("joint_evaluation" as const)
+			: undefined;
+
+	const email = session?.user?.email ?? "";
+	const currentYear = new Date().getFullYear();
+
+	return (
+		<HydrateClient>
+			<CompliancePathChoice
+				currentYear={currentYear}
+				email={email}
+				forcedPath={forcedPath}
+				initialPath={
+					(data.declaration.compliancePath as
+						| "justify"
+						| "corrective_action"
+						| "joint_evaluation"
+						| null) ?? undefined
+				}
+			/>
+		</HydrateClient>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -1,32 +1,13 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useRef, useState } from "react";
 
 import { api } from "~/trpc/react";
-import { DefinitionAccordion } from "../shared/DefinitionAccordion";
-import { FormActions } from "../shared/FormActions";
-import { normalizeDecimalInput } from "../shared/gapUtils";
-import { SavedIndicator } from "../shared/SavedIndicator";
 import { StepIndicator } from "../shared/StepIndicator";
-import { TooltipButton } from "../shared/TooltipButton";
 import type { StepCategoryData } from "../types";
-import stepStyles from "./Step5EmployeeCategories.module.scss";
-import { CategoryDataTable } from "./step5/CategoryDataTable";
-import {
-	createEmptyCategory,
-	deserializeCategories,
-	type EmployeeCategory,
-	serializeCategories,
-} from "./step5/categorySerializer";
-import { DeleteCategoryDialog } from "./step5/DeleteCategoryDialog";
+import { CategoryForm } from "./step5/CategoryForm";
 
-let nextCategoryId = 0;
-function nextId() {
-	return nextCategoryId++;
-}
-
-type Step5EmployeeCategoriesProps = {
+type Props = {
 	initialCategories?: StepCategoryData[];
 	maxWomen?: number;
 	maxMen?: number;
@@ -36,324 +17,34 @@ export function Step5EmployeeCategories({
 	initialCategories,
 	maxWomen,
 	maxMen,
-}: Step5EmployeeCategoriesProps) {
-	const router = useRouter();
+}: Props) {
 	const currentYear = new Date().getFullYear();
-	const referenceYear = currentYear - 1;
-
-	const initial =
-		initialCategories?.length && initialCategories.length > 0
-			? deserializeCategories(initialCategories, nextId)
-			: {
-					categories: [createEmptyCategory(nextId())],
-					source: "",
-				};
-
-	const [categories, setCategories] = useState<EmployeeCategory[]>(
-		initial.categories,
-	);
-	const [source, setSource] = useState(initial.source);
-
-	const hasInitialData = initialCategories?.some(
-		(c) =>
-			c.name.startsWith("cat:") &&
-			!c.name.match(/^cat:\d+:(name|detail):/) &&
-			(c.womenCount !== undefined || c.womenValue !== undefined),
-	);
-	const [saved, setSaved] = useState(!!hasInitialData);
-
-	const [workforceError, setWorkforceError] = useState("");
-	const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
-	const deleteDialogRef = useRef<HTMLDialogElement>(null);
-
-	const closeDeleteDialog = useCallback(() => {
-		deleteDialogRef.current?.close();
-		setDeleteIndex(null);
-	}, []);
+	const router = useRouter();
 
 	const mutation = api.declaration.updateStepCategories.useMutation({
 		onSuccess: () => router.push("/declaration-remuneration/etape/6"),
 	});
 
-	function updateCategory(
-		index: number,
-		field: keyof EmployeeCategory,
-		value: string,
-	) {
-		setCategories((prev) =>
-			prev.map((cat, i) => (i === index ? { ...cat, [field]: value } : cat)),
-		);
-		setSaved(false);
-	}
-
-	function handlePositiveNumberChange(
-		index: number,
-		field: keyof EmployeeCategory,
-		isInteger: boolean,
-	) {
-		return (e: React.ChangeEvent<HTMLInputElement>) => {
-			let val = e.target.value;
-			if (val === "") {
-				updateCategory(index, field, val);
-				return;
-			}
-			if (!isInteger) {
-				const normalized = normalizeDecimalInput(val);
-				if (normalized === null) return;
-				val = normalized;
-			}
-			const n = isInteger ? Number.parseInt(val, 10) : Number.parseFloat(val);
-			if (Number.isNaN(n) || n < 0) return;
-			updateCategory(index, field, val);
-		};
-	}
-
-	function addCategory() {
-		setCategories((prev) => [...prev, createEmptyCategory(nextId())]);
-		setSaved(false);
-	}
-
-	function askRemoveCategory(index: number) {
-		setDeleteIndex(index);
-		deleteDialogRef.current?.showModal();
-	}
-
-	function confirmRemoveCategory() {
-		if (deleteIndex !== null) {
-			setCategories((prev) => prev.filter((_, i) => i !== deleteIndex));
-			setSaved(false);
-		}
-		closeDeleteDialog();
-	}
-
-	function handleSubmit(e: React.FormEvent) {
-		e.preventDefault();
-		setWorkforceError("");
-
-		const emptyNames = categories.some((cat) => !cat.name.trim());
-		if (emptyNames) {
-			setWorkforceError(
-				"Le nom de chaque catégorie d'emplois est obligatoire.",
-			);
-			return;
-		}
-
-		const names = categories.map((cat) => cat.name.trim().toLowerCase());
-		const hasDuplicates = names.length !== new Set(names).size;
-		if (hasDuplicates) {
-			setWorkforceError(
-				"Les noms des catégories d'emplois doivent être uniques.",
-			);
-			return;
-		}
-
-		if (maxWomen !== undefined || maxMen !== undefined) {
-			const totalWomen = categories.reduce(
-				(sum, cat) =>
-					sum + (cat.womenCount ? Number.parseInt(cat.womenCount, 10) : 0),
-				0,
-			);
-			const totalMen = categories.reduce(
-				(sum, cat) =>
-					sum + (cat.menCount ? Number.parseInt(cat.menCount, 10) : 0),
-				0,
-			);
-
-			const errors: string[] = [];
-			if (maxWomen !== undefined && totalWomen !== maxWomen) {
-				errors.push(
-					`Le total des effectifs femmes (${totalWomen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxWomen}).`,
-				);
-			}
-			if (maxMen !== undefined && totalMen !== maxMen) {
-				errors.push(
-					`Le total des effectifs hommes (${totalMen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxMen}).`,
-				);
-			}
-			if (errors.length > 0) {
-				setWorkforceError(errors.join(" "));
-				return;
-			}
-		}
-
-		mutation.mutate({
-			step: 5,
-			categories: serializeCategories(categories, source),
-		});
-	}
-
 	return (
-		<form className={stepStyles.form} onSubmit={handleSubmit}>
-			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
-				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {currentYear}
-					</h1>
-				</div>
-				{saved && (
-					<div className="fr-col-auto">
-						<SavedIndicator />
-					</div>
-				)}
-			</div>
-
-			<StepIndicator currentStep={5} />
-
-			<div className={stepStyles.categoryBlock}>
-				<p className="fr-mb-0">
-					Cet indicateur permet de mesurer l&apos;écart de rémunération entre
-					les femmes et les hommes au sein de chaque catégorie de salariés, en
-					distinguant le salaire de base des composantes variables ou
-					complémentaires.
-				</p>
-
-				<div className={stepStyles.categoryHeader}>
-					<p className="fr-mb-0">
-						Période de référence pour le calcul des indicateurs : 01/01/
-						{referenceYear} - 31/12/{referenceYear}.
-					</p>
-					<TooltipButton
-						id="tooltip-step5-period"
-						label="Information sur la période de référence"
-					/>
-				</div>
-
-				<div className="fr-select-group">
-					<label className="fr-label" htmlFor="source-select">
-						Quelle est la source utilisée pour déterminer les catégories
-						d&apos;emplois ?
-					</label>
-					<select
-						className="fr-select"
-						id="source-select"
-						onChange={(e) => {
-							setSource(e.target.value);
-							setSaved(false);
-						}}
-						value={source}
-					>
-						<option disabled value="">
-							Sélectionner une option
-						</option>
-						<option value="convention-collective">Convention collective</option>
-						<option value="accord-entreprise">Accord d&apos;entreprise</option>
-						<option value="classification-interne">
-							Classification interne
-						</option>
-						<option value="autre">Autre</option>
-					</select>
-				</div>
-			</div>
-
-			<div className={stepStyles.descriptionBlock}>
-				<div className={stepStyles.descriptionRow}>
-					<p className={`fr-mb-0 ${stepStyles.descriptionTitle}`}>
-						Saisissez les données manquantes avant de valider votre indicateur.
-					</p>
-					<TooltipButton
-						id="tooltip-step5-instruction"
-						label="Information sur la saisie"
-					/>
-				</div>
-				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
-			</div>
-
-			{categories.map((cat, index) => (
-				<div className={stepStyles.categoryBlock} key={cat.id}>
-					<div className={stepStyles.categoryFooter}>
-						<p className="fr-text--bold fr-mb-0">
-							Catégorie d&apos;emplois n°{index + 1}
-						</p>
-						{categories.length > 1 && (
-							<button
-								className="fr-btn fr-btn--tertiary fr-icon-delete-line fr-btn--icon-left fr-btn--sm"
-								onClick={() => askRemoveCategory(index)}
-								type="button"
-							>
-								Supprimer
-							</button>
-						)}
-					</div>
-
-					<div className="fr-input-group fr-mb-0">
-						<label className="fr-label" htmlFor={`cat-${index}-name`}>
-							Nom
-						</label>
-						<input
-							className="fr-input"
-							id={`cat-${index}-name`}
-							onChange={(e) => updateCategory(index, "name", e.target.value)}
-							type="text"
-							value={cat.name}
-						/>
-					</div>
-
-					<div className="fr-input-group fr-mb-0">
-						<label className="fr-label" htmlFor={`cat-${index}-detail`}>
-							Détail des emplois
-						</label>
-						<input
-							className="fr-input"
-							id={`cat-${index}-detail`}
-							onChange={(e) => updateCategory(index, "detail", e.target.value)}
-							type="text"
-							value={cat.detail}
-						/>
-					</div>
-
-					<CategoryDataTable
-						category={cat}
-						categoryIndex={index}
-						onPositiveNumberChange={handlePositiveNumberChange}
-					/>
-				</div>
-			))}
-
-			<div className={stepStyles.categoryFooter}>
-				<p className="fr-text--bold fr-mb-0">
-					Nombre de catégories : {categories.length}
-				</p>
-				<button
-					className="fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left"
-					onClick={addCategory}
-					type="button"
-				>
-					Ajouter une catégorie d&apos;emplois
-				</button>
-			</div>
-
-			<DefinitionAccordion
-				id="accordion-step5"
-				title="Définitions et méthode de calcul"
-			/>
-
-			{workforceError && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
-					<p>{workforceError}</p>
-				</div>
-			)}
-
-			{mutation.error && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
-					<p>{mutation.error.message}</p>
-				</div>
-			)}
-
-			<FormActions
-				isSubmitting={mutation.isPending}
-				previousHref="/declaration-remuneration/etape/4"
-			/>
-
-			<DeleteCategoryDialog
-				categoryName={
-					deleteIndex !== null
-						? categories[deleteIndex]?.name || `n°${deleteIndex + 1}`
-						: null
-				}
-				dialogRef={deleteDialogRef}
-				onCancel={closeDeleteDialog}
-				onConfirm={confirmRemoveCategory}
-			/>
-		</form>
+		<CategoryForm
+			accordionId="accordion-step5"
+			initialCategories={initialCategories ?? []}
+			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
+			isSubmitting={mutation.isPending}
+			maxMen={maxMen}
+			maxWomen={maxWomen}
+			onSubmit={(serialized) =>
+				mutation.mutate({ step: 5, categories: serialized })
+			}
+			previousHref="/declaration-remuneration/etape/4"
+			stepper={<StepIndicator currentStep={5} />}
+			submitError={mutation.error?.message}
+			title={
+				<h1 className="fr-h4 fr-mb-0">
+					Déclaration des indicateurs de rémunération {currentYear}
+				</h1>
+			}
+			tooltipPrefix="tooltip-step5"
+		/>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -4,24 +4,26 @@ import { useRouter } from "next/navigation";
 
 import { api } from "~/trpc/react";
 import { StepIndicator } from "../shared/StepIndicator";
-import type { StepCategoryData } from "../types";
+import type { EmployeeCategoryRow } from "../types";
 import { CategoryForm } from "./step5/CategoryForm";
 
 type Props = {
-	initialCategories?: StepCategoryData[];
+	initialCategories?: EmployeeCategoryRow[];
+	initialSource?: string;
 	maxWomen?: number;
 	maxMen?: number;
 };
 
 export function Step5EmployeeCategories({
 	initialCategories,
+	initialSource,
 	maxWomen,
 	maxMen,
 }: Props) {
 	const currentYear = new Date().getFullYear();
 	const router = useRouter();
 
-	const mutation = api.declaration.updateStepCategories.useMutation({
+	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => router.push("/declaration-remuneration/etape/6"),
 	});
 
@@ -29,12 +31,17 @@ export function Step5EmployeeCategories({
 		<CategoryForm
 			accordionId="accordion-step5"
 			initialCategories={initialCategories ?? []}
+			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
 			isSubmitting={mutation.isPending}
 			maxMen={maxMen}
 			maxWomen={maxWomen}
-			onSubmit={(serialized) =>
-				mutation.mutate({ step: 5, categories: serialized })
+			onSubmit={(data) =>
+				mutation.mutate({
+					declarationType: "initial",
+					source: data.source,
+					categories: data.categories,
+				})
 			}
 			previousHref="/declaration-remuneration/etape/4"
 			stepper={<StepIndicator currentStep={5} />}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -11,12 +11,17 @@ import { FormActions } from "../shared/FormActions";
 import { computeGap } from "../shared/gapUtils";
 import { SavedIndicator } from "../shared/SavedIndicator";
 import { StepIndicator } from "../shared/StepIndicator";
-import type { PayGapRow, StepCategoryData, VariablePayData } from "../types";
+import type {
+	EmployeeCategoryRow,
+	PayGapRow,
+	StepCategoryData,
+	VariablePayData,
+} from "../types";
 import stepStyles from "./Step6Review.module.scss";
 import { CardTitle } from "./step6/CardTitle";
 import { GapColumn } from "./step6/GapColumn";
 import { GapSideBySide } from "./step6/GapSideBySide";
-import { parseStep5Categories } from "./step6/parseStep5Categories";
+import { parseEmployeeCategories } from "./step6/parseStep5Categories";
 import { QuartileColumn } from "./step6/QuartileColumn";
 import { SubmitModal } from "./step6/SubmitModal";
 
@@ -38,7 +43,7 @@ type Props = {
 	step2Rows?: PayGapRow[];
 	step3Data?: VariablePayData;
 	step4Categories?: StepCategoryData[];
-	step5Categories?: StepCategoryData[];
+	step5Categories?: EmployeeCategoryRow[];
 	isSubmitted?: boolean;
 };
 
@@ -88,7 +93,7 @@ export function Step6Review({
 	);
 
 	// Parse step 5 categories
-	const step5Parsed = parseStep5Categories(step5Categories);
+	const step5Parsed = parseEmployeeCategories(step5Categories);
 
 	// Check if any gap is high (>= 5%)
 	const allGaps = [

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -15,10 +15,12 @@ vi.mock("~/trpc/react", () => ({
 	api: {
 		declaration: {
 			saveCompliancePath: {
-				useMutation: (opts: { onSuccess?: () => void }) => ({
-					mutate: (args: unknown) => {
+				useMutation: (opts: {
+					onSuccess?: (data: unknown, variables: { path: string }) => void;
+				}) => ({
+					mutate: (args: { path: string }) => {
 						mockMutate(args);
-						opts.onSuccess?.();
+						opts.onSuccess?.(undefined, args);
 					},
 					isPending: false,
 					error: null,
@@ -82,6 +84,24 @@ describe("CompliancePathChoice", () => {
 
 		expect(mockMutate).toHaveBeenCalledWith({ path: "joint_evaluation" });
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
+	});
+
+	it("navigates to second declaration when corrective_action is selected", () => {
+		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		const radio = screen.getByLabelText(
+			"Actions correctives et seconde déclaration",
+		);
+		fireEvent.click(radio);
+
+		const form = screen
+			.getByRole("button", { name: /suivant/i })
+			.closest("form") as HTMLFormElement;
+		fireEvent.submit(form);
+
+		expect(mockMutate).toHaveBeenCalledWith({ path: "corrective_action" });
+		expect(mockPush).toHaveBeenCalledWith(
+			"/declaration-remuneration/parcours-conformite/etape/1",
+		);
 	});
 
 	it("pre-selects the initial path when provided", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { Step5EmployeeCategories } from "../Step5EmployeeCategories";
 
 const mockMutate = vi.fn();
@@ -8,7 +9,7 @@ const mockMutate = vi.fn();
 vi.mock("~/trpc/react", () => ({
 	api: {
 		declaration: {
-			updateStepCategories: {
+			updateEmployeeCategories: {
 				useMutation: () => ({
 					mutate: mockMutate,
 					isPending: false,
@@ -24,6 +25,26 @@ beforeEach(() => {
 	HTMLDialogElement.prototype.showModal = vi.fn();
 	HTMLDialogElement.prototype.close = vi.fn();
 });
+
+function makeCategory(
+	overrides: Partial<EmployeeCategoryRow> = {},
+): EmployeeCategoryRow {
+	return {
+		name: "",
+		detail: "",
+		womenCount: null,
+		menCount: null,
+		annualBaseWomen: null,
+		annualBaseMen: null,
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+		...overrides,
+	};
+}
 
 describe("Step5EmployeeCategories", () => {
 	it("renders with 1 empty category by default", () => {
@@ -192,23 +213,16 @@ describe("Step5EmployeeCategories", () => {
 		render(
 			<Step5EmployeeCategories
 				initialCategories={[
-					{ name: "meta:source:autre" },
-					{ name: "cat:0:name:Ingénieurs" },
-					{ name: "cat:0:detail:Dev" },
-					{
-						name: "cat:0:effectif",
+					makeCategory({
+						name: "Ingénieurs",
+						detail: "Dev",
 						womenCount: 10,
 						menCount: 15,
-					},
-					{
-						name: "cat:0:annual:base",
-						womenValue: "3000",
-						menValue: "3200",
-					},
-					{ name: "cat:0:annual:variable" },
-					{ name: "cat:0:hourly:base" },
-					{ name: "cat:0:hourly:variable" },
+						annualBaseWomen: "3000",
+						annualBaseMen: "3200",
+					}),
 				]}
+				initialSource="autre"
 			/>,
 		);
 		expect(screen.getByText("Enregistré")).toBeInTheDocument();
@@ -223,19 +237,14 @@ describe("Step5EmployeeCategories", () => {
 		render(
 			<Step5EmployeeCategories
 				initialCategories={[
-					{ name: "meta:source:convention-collective" },
-					{ name: "cat:0:name:Cadres" },
-					{ name: "cat:0:detail:Managers" },
-					{
-						name: "cat:0:effectif",
+					makeCategory({
+						name: "Cadres",
+						detail: "Managers",
 						womenCount: 5,
 						menCount: 8,
-					},
-					{ name: "cat:0:annual:base" },
-					{ name: "cat:0:annual:variable" },
-					{ name: "cat:0:hourly:base" },
-					{ name: "cat:0:hourly:variable" },
+					}),
 				]}
+				initialSource="convention-collective"
 			/>,
 		);
 
@@ -250,7 +259,7 @@ describe("Step5EmployeeCategories", () => {
 		expect(detailInput).toHaveValue("Managers");
 	});
 
-	it("submits serialized data on form submit", async () => {
+	it("submits data on form submit", async () => {
 		const user = userEvent.setup();
 		render(<Step5EmployeeCategories />);
 
@@ -263,11 +272,11 @@ describe("Step5EmployeeCategories", () => {
 
 		expect(mockMutate).toHaveBeenCalledWith(
 			expect.objectContaining({
-				step: 5,
+				declarationType: "initial",
+				source: expect.any(String),
 				categories: expect.arrayContaining([
-					expect.objectContaining({ name: "meta:source:" }),
 					expect.objectContaining({
-						name: "cat:0:name:Techniciens",
+						name: "Techniciens",
 					}),
 				]),
 			}),

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -28,9 +28,11 @@ beforeEach(() => {
 describe("Step5EmployeeCategories", () => {
 	it("renders with 1 empty category by default", () => {
 		render(<Step5EmployeeCategories />);
-		expect(screen.getByText("Catégorie d'emplois n°1")).toBeInTheDocument();
 		expect(
-			screen.queryByText("Catégorie d'emplois n°2"),
+			screen.getByRole("button", { name: "Catégorie d'emplois n°1" }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: "Catégorie d'emplois n°2" }),
 		).not.toBeInTheDocument();
 		expect(screen.getByText("Nombre de catégories : 1")).toBeInTheDocument();
 	});
@@ -100,7 +102,9 @@ describe("Step5EmployeeCategories", () => {
 			}),
 		);
 
-		expect(screen.getByText("Catégorie d'emplois n°2")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Catégorie d'emplois n°2" }),
+		).toBeInTheDocument();
 		expect(screen.getByText("Nombre de catégories : 2")).toBeInTheDocument();
 	});
 
@@ -127,7 +131,7 @@ describe("Step5EmployeeCategories", () => {
 		await user.click(dialogScope.getByText("Supprimer"));
 
 		expect(
-			screen.queryByText("Catégorie d'emplois n°2"),
+			screen.queryByRole("button", { name: "Catégorie d'emplois n°2" }),
 		).not.toBeInTheDocument();
 		expect(screen.getByText("Nombre de catégories : 1")).toBeInTheDocument();
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { Step6Review } from "../Step6Review";
 
 vi.mock("~/modules/declarationPdf", () => ({
@@ -23,6 +24,26 @@ vi.mock("~/trpc/react", () => ({
 		},
 	},
 }));
+
+function makeCategory(
+	overrides: Partial<EmployeeCategoryRow> = {},
+): EmployeeCategoryRow {
+	return {
+		name: "",
+		detail: "",
+		womenCount: null,
+		menCount: null,
+		annualBaseWomen: null,
+		annualBaseMen: null,
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+		...overrides,
+	};
+}
 
 describe("Step6Review", () => {
 	it("renders title and stepper at step 6", () => {
@@ -119,17 +140,14 @@ describe("Step6Review", () => {
 				]}
 			/>,
 		);
-		// Side-by-side headers
 		expect(screen.getAllByText("Annuelle brute").length).toBeGreaterThanOrEqual(
 			1,
 		);
 		expect(screen.getAllByText("Horaire brute").length).toBeGreaterThanOrEqual(
 			1,
 		);
-		// Row labels
 		expect(screen.getAllByText("Moyenne").length).toBeGreaterThanOrEqual(2);
 		expect(screen.getAllByText("Médiane").length).toBeGreaterThanOrEqual(2);
-		// Gap values and badges
 		expect(screen.getAllByText("5,0 %").length).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByText("3,0 %").length).toBeGreaterThanOrEqual(1);
 		expect(screen.queryByText("faible")).not.toBeInTheDocument();
@@ -210,45 +228,32 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				step5Categories={[
-					{ name: "meta:source:autre" },
-					{ name: "cat:0:name:Ingénieurs" },
-					{ name: "cat:0:detail:Dev" },
-					{ name: "cat:0:effectif", womenCount: 10, menCount: 15 },
-					{
-						name: "cat:0:annual:base",
-						womenValue: "3000",
-						menValue: "3200",
-					},
-					{
-						name: "cat:0:annual:variable",
-						womenValue: "500",
-						menValue: "600",
-					},
-					{
-						name: "cat:0:hourly:base",
-						womenValue: "18",
-						menValue: "19",
-					},
-					{
-						name: "cat:0:hourly:variable",
-						womenValue: "3",
-						menValue: "4",
-					},
+					makeCategory({
+						name: "Ingénieurs",
+						detail: "Dev",
+						womenCount: 10,
+						menCount: 15,
+						annualBaseWomen: "3000",
+						annualBaseMen: "3200",
+						annualVariableWomen: "500",
+						annualVariableMen: "600",
+						hourlyBaseWomen: "18",
+						hourlyBaseMen: "19",
+						hourlyVariableWomen: "3",
+						hourlyVariableMen: "4",
+					}),
 				]}
 			/>,
 		);
 		expect(screen.getByText("Ingénieurs")).toBeInTheDocument();
-		// Side-by-side headers
 		expect(screen.getAllByText("Annuelle brute").length).toBeGreaterThanOrEqual(
 			1,
 		);
 		expect(screen.getAllByText("Horaire brute").length).toBeGreaterThanOrEqual(
 			1,
 		);
-		// Row labels (2 per column = 4 total)
 		expect(screen.getAllByText("Salaire de base").length).toBe(2);
 		expect(screen.getAllByText("Composantes variables").length).toBe(2);
-		// Badges present
 		expect(screen.getAllByText("élevé").length).toBeGreaterThanOrEqual(1);
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/NextStepsSection.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/NextStepsSection.tsx
@@ -1,0 +1,101 @@
+import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
+
+type Props = {
+	hasGapsAboveThreshold: boolean;
+};
+
+export function NextStepsSection({ hasGapsAboveThreshold }: Props) {
+	return (
+		<div className="fr-callout">
+			<h3 className="fr-callout__title">Prochaines étapes</h3>
+			<div className="fr-callout__text">
+				<p>
+					Au cours du temps imparti pour réaliser votre déclaration, vous devez{" "}
+					<strong>obligatoirement</strong> informer et consulter le CSE sur
+					l&apos;exactitude des données déclarées.
+				</p>
+				<p>
+					Le ou les avis du CSE devront être transmis sur le portail lors de la
+					dernière étape.
+				</p>
+
+				{hasGapsAboveThreshold && <GapsDetectedWarning />}
+
+				<HelpLinks />
+			</div>
+		</div>
+	);
+}
+
+function GapsDetectedWarning() {
+	return (
+		<>
+			<p className="fr-text--bold">Des écarts ont été de nouveau détectés</p>
+			<p>
+				Suite à l&apos;analyse de vos données de l&apos;indicateur par catégorie
+				de salariés, <strong>des écarts ≥ 5 % ont été identifiés</strong>. Vous
+				devez <strong>engager un parcours de mise en conformité</strong> suivant
+				:
+			</p>
+			<ul>
+				<li>
+					<strong>
+						Justifier les écarts par des critères objectifs et non sexistes.
+					</strong>{" "}
+					Si vous choisissez ce parcours, vous devez informer et consulter le
+					CSE (avis à transmettre lors de la dernière étape).
+				</li>
+			</ul>
+			<p>
+				Si la justification n&apos;est pas possible par des critères objectifs
+				et non sexistes, vous pouvez :
+			</p>
+			<ul>
+				<li>Réaliser une évaluation conjointe des rémunérations</li>
+			</ul>
+		</>
+	);
+}
+
+function HelpLinks() {
+	return (
+		<>
+			<p className="fr-text--bold fr-mt-3w">Pour vous aider</p>
+			<ul className="fr-raw-list">
+				<li>
+					<a
+						className="fr-link"
+						href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						Qu&apos;entend-on par critères objectifs et non sexistes ?
+						<NewTabNotice />
+					</a>
+				</li>
+				<li>
+					<a
+						className="fr-link"
+						href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						En savoir plus sur actions correctives et seconde déclaration
+						<NewTabNotice />
+					</a>
+				</li>
+				<li>
+					<a
+						className="fr-link"
+						href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+						rel="noopener noreferrer"
+						target="_blank"
+					>
+						En savoir plus sur évaluation conjointe des rémunérations
+						<NewTabNotice />
+					</a>
+				</li>
+			</ul>
+		</>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
@@ -1,0 +1,66 @@
+import { TooltipButton } from "~/modules/declaration-remuneration/shared/TooltipButton";
+
+type Props = {
+	startDate: string;
+	endDate: string;
+	onStartDateChange: (value: string) => void;
+	onEndDateChange: (value: string) => void;
+};
+
+export function ReferencePeriodPicker({
+	startDate,
+	endDate,
+	onStartDateChange,
+	onEndDateChange,
+}: Props) {
+	return (
+		<div>
+			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-2w">
+				<div className="fr-col-auto">
+					<p className="fr-mb-0 fr-text--medium">
+						Quelle est la période de référence pour le calcul de
+						l&apos;indicateur ?
+					</p>
+				</div>
+				<div className="fr-col-auto">
+					<TooltipButton
+						id="tooltip-second-decl-period"
+						label="Informations sur la période prise en compte pour la seconde déclaration"
+					/>
+				</div>
+			</div>
+			<div className="fr-grid-row fr-grid-row--gutters">
+				<div className="fr-col-12 fr-col-md-4">
+					<div className="fr-input-group">
+						<label className="fr-label" htmlFor="period-start-date">
+							Date de début
+							<span className="fr-hint-text">Format attendu : JJ/MM/AAAA</span>
+						</label>
+						<input
+							className="fr-input"
+							id="period-start-date"
+							onChange={(e) => onStartDateChange(e.target.value)}
+							type="date"
+							value={startDate}
+						/>
+					</div>
+				</div>
+				<div className="fr-col-12 fr-col-md-4">
+					<div className="fr-input-group">
+						<label className="fr-label" htmlFor="period-end-date">
+							Date de fin
+							<span className="fr-hint-text">Format attendu : JJ/MM/AAAA</span>
+						</label>
+						<input
+							className="fr-input"
+							id="period-end-date"
+							onChange={(e) => onEndDateChange(e.target.value)}
+							type="date"
+							value={endDate}
+						/>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -1,0 +1,97 @@
+import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
+import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
+import { BASE_PATH } from "./constants";
+import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
+
+type Props = {
+	currentYear: number;
+	declarationDate: string;
+};
+
+export function SecondDeclarationStep1Info({
+	currentYear,
+	declarationDate,
+}: Props) {
+	const deadline = `1\u1D49\u02B3 décembre ${currentYear}`;
+
+	return (
+		<div className={common.flexColumnGap2}>
+			<div className={common.flexBetween}>
+				<h1 className="fr-h4 fr-mb-0">
+					Parcours de mise en conformité pour l&apos;indicateur par catégorie de
+					salariés
+				</h1>
+				<SavedIndicator />
+			</div>
+
+			<SecondDeclarationStepIndicator currentStep={1} />
+
+			<p className="fr-mb-0">
+				Vous devez mettre en œuvre des <strong>actions correctives</strong> et
+				effectuer une{" "}
+				<strong>
+					seconde déclaration de l&apos;indicateur par catégorie de salariés
+				</strong>
+				.
+			</p>
+
+			<DeadlineBlock deadline={deadline} declarationDate={declarationDate} />
+
+			<ObligationsCallout />
+
+			<FormActions
+				nextHref={`${BASE_PATH}/etape/2`}
+				nextLabel="Suivant"
+				previousHref={BASE_PATH}
+			/>
+		</div>
+	);
+}
+
+// -- Sub-components --
+
+function DeadlineBlock({
+	deadline,
+	declarationDate,
+}: {
+	deadline: string;
+	declarationDate: string;
+}) {
+	return (
+		<div className="fr-pl-3w">
+			<p className="fr-mb-0 fr-text--sm fr-text--mention-grey">Date limite</p>
+			<p className="fr-h5 fr-mb-0">{deadline}</p>
+			<p className="fr-mb-0 fr-text--sm fr-text--mention-grey">
+				Déclaration effectuée le {declarationDate}
+			</p>
+		</div>
+	);
+}
+
+function ObligationsCallout() {
+	return (
+		<div className="fr-callout">
+			<h3 className="fr-callout__title">
+				Ce que vous devez faire dans un délais de 6 mois
+			</h3>
+			<div className="fr-callout__text">
+				<ul className="fr-mb-0">
+					<li>
+						Mettre en place des actions correctives par accord ou plan
+						d&apos;action
+					</li>
+					<li>
+						Redéclarer l&apos;indicateur dans un délai de 6 mois après votre
+						première déclaration
+					</li>
+					<li>
+						Informer et consulter votre CSE sur l&apos;exactitude des données et
+						éventuellement sur la justification en cas d&apos;écarts ≥ 5 %
+					</li>
+					<li>Transmettre l&apos;avis ou les avis du CSE</li>
+				</ul>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -73,7 +73,7 @@ function ObligationsCallout() {
 	return (
 		<div className="fr-callout">
 			<h3 className="fr-callout__title">
-				Ce que vous devez faire dans un délais de 6 mois
+				Ce que vous devez faire dans un délai de 6 mois
 			</h3>
 			<div className="fr-callout__text">
 				<ul className="fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 
 import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
 import { CategoryForm } from "../step5/CategoryForm";
 import { BASE_PATH } from "./constants";
+import { ReferencePeriodPicker } from "./ReferencePeriodPicker";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 type Props = {
@@ -17,6 +19,8 @@ export function SecondDeclarationStep2Form({
 	initialSecondDeclarationCategories,
 }: Props) {
 	const router = useRouter();
+	const [startDate, setStartDate] = useState("");
+	const [endDate, setEndDate] = useState("");
 
 	// Use second declaration data if already started, otherwise pre-fill from first
 	const sourceData =
@@ -31,6 +35,7 @@ export function SecondDeclarationStep2Form({
 	return (
 		<CategoryForm
 			accordionId="accordion-second-decl"
+			descriptionText="Cette seconde déclaration reprend les catégories de salariés définies lors de la première déclaration. Elle permet de mesurer les écarts de rémunération entre les femmes et les hommes au sein de chaque catégorie, en distinguant le salaire de base des composantes variables ou complémentaires."
 			initialCategories={sourceData}
 			instructionText="Modifiez les données de votre première déclaration avant de valider votre indicateur."
 			isSubmitting={isSubmitting}
@@ -40,6 +45,14 @@ export function SecondDeclarationStep2Form({
 			}}
 			previousHref={`${BASE_PATH}/etape/1`}
 			readOnlyNameDetail
+			referencePeriodPicker={
+				<ReferencePeriodPicker
+					endDate={endDate}
+					onEndDateChange={setEndDate}
+					onStartDateChange={setStartDate}
+					startDate={startDate}
+				/>
+			}
 			stepper={<SecondDeclarationStepIndicator currentStep={2} />}
 			title={
 				<h1 className="fr-h4 fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import { CategoryForm } from "../step5/CategoryForm";
+import { BASE_PATH } from "./constants";
+import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
+
+type Props = {
+	initialFirstDeclarationCategories: StepCategoryData[];
+	initialSecondDeclarationCategories?: StepCategoryData[];
+};
+
+export function SecondDeclarationStep2Form({
+	initialFirstDeclarationCategories,
+	initialSecondDeclarationCategories,
+}: Props) {
+	const router = useRouter();
+
+	// Use second declaration data if already started, otherwise pre-fill from first
+	const sourceData =
+		initialSecondDeclarationCategories &&
+		initialSecondDeclarationCategories.length > 0
+			? initialSecondDeclarationCategories
+			: initialFirstDeclarationCategories;
+
+	// TODO: Replace with actual tRPC mutation when backend is ready
+	const isSubmitting = false;
+
+	return (
+		<CategoryForm
+			accordionId="accordion-second-decl"
+			initialCategories={sourceData}
+			instructionText="Modifiez les données de votre première déclaration avant de valider votre indicateur."
+			isSubmitting={isSubmitting}
+			onSubmit={() => {
+				// TODO: Call tRPC mutation when backend is ready
+				router.push(`${BASE_PATH}/etape/3`);
+			}}
+			previousHref={`${BASE_PATH}/etape/1`}
+			readOnlyNameDetail
+			stepper={<SecondDeclarationStepIndicator currentStep={2} />}
+			title={
+				<h1 className="fr-h4 fr-mb-0">
+					Parcours de mise en conformité pour l&apos;indicateur par catégorie de
+					salariés
+				</h1>
+			}
+			tooltipPrefix="tooltip-second-decl"
+		/>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -3,46 +3,59 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
+import { api } from "~/trpc/react";
 import { CategoryForm } from "../step5/CategoryForm";
 import { BASE_PATH } from "./constants";
 import { ReferencePeriodPicker } from "./ReferencePeriodPicker";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 type Props = {
-	initialFirstDeclarationCategories: StepCategoryData[];
-	initialSecondDeclarationCategories?: StepCategoryData[];
+	initialFirstDeclarationCategories: EmployeeCategoryRow[];
+	initialSecondDeclarationCategories?: EmployeeCategoryRow[];
+	initialSource?: string;
+	initialStartDate?: string;
+	initialEndDate?: string;
 };
 
 export function SecondDeclarationStep2Form({
 	initialFirstDeclarationCategories,
 	initialSecondDeclarationCategories,
+	initialSource,
+	initialStartDate = "",
+	initialEndDate = "",
 }: Props) {
 	const router = useRouter();
-	const [startDate, setStartDate] = useState("");
-	const [endDate, setEndDate] = useState("");
+	const [startDate, setStartDate] = useState(initialStartDate);
+	const [endDate, setEndDate] = useState(initialEndDate);
 
-	// Use second declaration data if already started, otherwise pre-fill from first
 	const sourceData =
 		initialSecondDeclarationCategories &&
 		initialSecondDeclarationCategories.length > 0
 			? initialSecondDeclarationCategories
 			: initialFirstDeclarationCategories;
 
-	// TODO: Replace with actual tRPC mutation when backend is ready
-	const isSubmitting = false;
+	const mutation = api.declaration.updateEmployeeCategories.useMutation({
+		onSuccess: () => router.push(`${BASE_PATH}/etape/3`),
+	});
 
 	return (
 		<CategoryForm
 			accordionId="accordion-second-decl"
 			descriptionText="Cette seconde déclaration reprend les catégories de salariés définies lors de la première déclaration. Elle permet de mesurer les écarts de rémunération entre les femmes et les hommes au sein de chaque catégorie, en distinguant le salaire de base des composantes variables ou complémentaires."
 			initialCategories={sourceData}
+			initialSource={initialSource}
 			instructionText="Modifiez les données de votre première déclaration avant de valider votre indicateur."
-			isSubmitting={isSubmitting}
-			onSubmit={() => {
-				// TODO: Call tRPC mutation when backend is ready
-				router.push(`${BASE_PATH}/etape/3`);
-			}}
+			isSubmitting={mutation.isPending}
+			onSubmit={(data) =>
+				mutation.mutate({
+					declarationType: "correction",
+					source: data.source,
+					categories: data.categories,
+					referencePeriodStart: startDate || undefined,
+					referencePeriodEnd: endDate || undefined,
+				})
+			}
 			previousHref={`${BASE_PATH}/etape/1`}
 			readOnlyNameDetail
 			referencePeriodPicker={
@@ -54,6 +67,7 @@ export function SecondDeclarationStep2Form({
 				/>
 			}
 			stepper={<SecondDeclarationStepIndicator currentStep={2} />}
+			submitError={mutation.error?.message}
 			title={
 				<h1 className="fr-h4 fr-mb-0">
 					Parcours de mise en conformité pour l&apos;indicateur par catégorie de

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -36,7 +36,7 @@ export function SecondDeclarationStep3Review({
 		e.preventDefault();
 		if (!certified) return;
 		// TODO: Call tRPC mutation when backend is ready
-		router.push(BASE_PATH);
+		router.push("/avis-cse");
 	}
 
 	return (

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
+import { hasGapsAboveThreshold } from "~/modules/declaration-remuneration/shared/gapUtils";
+import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
+import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import stepStyles from "../Step6Review.module.scss";
+import { CardTitle } from "../step6/CardTitle";
+import { GapColumn } from "../step6/GapColumn";
+import { parseStep5Categories } from "../step6/parseStep5Categories";
+import { BASE_PATH } from "./constants";
+import { NextStepsSection } from "./NextStepsSection";
+import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
+
+type Props = {
+	secondDeclarationCategories: StepCategoryData[];
+};
+
+export function SecondDeclarationStep3Review({
+	secondDeclarationCategories,
+}: Props) {
+	const router = useRouter();
+	const [certified, setCertified] = useState(false);
+
+	// TODO: Replace with actual tRPC mutation when backend is ready
+	const isSubmitting = false;
+
+	const parsed = parseStep5Categories(secondDeclarationCategories);
+	const gapsExist = hasGapsAboveThreshold(secondDeclarationCategories);
+
+	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+		e.preventDefault();
+		if (!certified) return;
+		// TODO: Call tRPC mutation when backend is ready
+		router.push(BASE_PATH);
+	}
+
+	return (
+		<form className={common.flexColumnGap2} onSubmit={handleSubmit}>
+			<div className={common.flexBetween}>
+				<h1 className="fr-h4 fr-mb-0">
+					Parcours de mise en conformité pour l&apos;indicateur par catégorie de
+					salariés
+				</h1>
+				<SavedIndicator />
+			</div>
+
+			<SecondDeclarationStepIndicator currentStep={3} />
+
+			<p className={`fr-mb-0 ${common.mentionGrey}`}>
+				Vérifiez que toutes les informations ont été complétées avant de
+				soumettre votre seconde déclaration des écarts de rémunération par
+				catégorie de salariés aux services du ministère chargé du travail.
+			</p>
+
+			<h2 className="fr-h5 fr-mb-0">Indicateurs par catégorie de salariés</h2>
+
+			<div className={stepStyles.card}>
+				<CardTitle tooltipId="tooltip-second-decl-categories">
+					Écart de rémunération par catégories de salariés (salaire de base et
+					primes)
+				</CardTitle>
+				{parsed.length > 0 ? (
+					parsed.map((cat) => (
+						<div key={cat.index}>
+							<p className="fr-text--bold fr-mb-0">
+								[Catégorie d&apos;emplois n°{cat.index + 1}]
+							</p>
+							<div className={stepStyles.sideBySide}>
+								<GapColumn
+									columns={[
+										{ label: "Salaire de base", gap: cat.annualBaseGap },
+										{
+											label: "Composantes variables ou complémentaires",
+											gap: cat.annualVariableGap,
+										},
+									]}
+									title="Annuelle brute"
+								/>
+								<div className={stepStyles.verticalSeparator} />
+								<GapColumn
+									columns={[
+										{ label: "Salaire de base", gap: cat.hourlyBaseGap },
+										{
+											label: "Composantes variables ou complémentaires",
+											gap: cat.hourlyVariableGap,
+										},
+									]}
+									title="Horaire brute"
+								/>
+							</div>
+						</div>
+					))
+				) : (
+					<p className={`fr-mb-0 ${common.mentionGrey}`}>
+						Aucune donnée renseignée.
+					</p>
+				)}
+			</div>
+
+			<NextStepsSection hasGapsAboveThreshold={gapsExist} />
+
+			<div className="fr-checkbox-group">
+				<input
+					checked={certified}
+					id="certification-checkbox"
+					onChange={(e) => setCertified(e.target.checked)}
+					type="checkbox"
+				/>
+				<label className="fr-label" htmlFor="certification-checkbox">
+					Je certifie que les données saisies sont exactes et conformes aux
+					informations disponibles dans les systèmes de paie et de gestion des
+					ressources humaines de l&apos;entreprise.
+				</label>
+			</div>
+
+			<FormActions
+				isSubmitting={isSubmitting}
+				nextDisabled={!certified}
+				nextLabel="Soumettre"
+				previousHref={`${BASE_PATH}/etape/2`}
+			/>
+		</form>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -5,19 +5,19 @@ import { useState } from "react";
 
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
-import { hasGapsAboveThreshold } from "~/modules/declaration-remuneration/shared/gapUtils";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
-import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
+import { api } from "~/trpc/react";
 import stepStyles from "../Step6Review.module.scss";
 import { CardTitle } from "../step6/CardTitle";
 import { GapColumn } from "../step6/GapColumn";
-import { parseStep5Categories } from "../step6/parseStep5Categories";
+import { parseEmployeeCategories } from "../step6/parseStep5Categories";
 import { BASE_PATH } from "./constants";
 import { NextStepsSection } from "./NextStepsSection";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 type Props = {
-	secondDeclarationCategories: StepCategoryData[];
+	secondDeclarationCategories: EmployeeCategoryRow[];
 };
 
 export function SecondDeclarationStep3Review({
@@ -26,17 +26,23 @@ export function SecondDeclarationStep3Review({
 	const router = useRouter();
 	const [certified, setCertified] = useState(false);
 
-	// TODO: Replace with actual tRPC mutation when backend is ready
-	const isSubmitting = false;
+	const mutation = api.declaration.submitSecondDeclaration.useMutation({
+		onSuccess: () => router.push("/avis-cse"),
+	});
 
-	const parsed = parseStep5Categories(secondDeclarationCategories);
-	const gapsExist = hasGapsAboveThreshold(secondDeclarationCategories);
+	const parsed = parseEmployeeCategories(secondDeclarationCategories);
+	const gapsExist = parsed.some(
+		(cat) =>
+			(cat.annualBaseGap !== null && cat.annualBaseGap >= 5) ||
+			(cat.annualVariableGap !== null && cat.annualVariableGap >= 5) ||
+			(cat.hourlyBaseGap !== null && cat.hourlyBaseGap >= 5) ||
+			(cat.hourlyVariableGap !== null && cat.hourlyVariableGap >= 5),
+	);
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();
 		if (!certified) return;
-		// TODO: Call tRPC mutation when backend is ready
-		router.push("/avis-cse");
+		mutation.mutate();
 	}
 
 	return (
@@ -119,7 +125,7 @@ export function SecondDeclarationStep3Review({
 			</div>
 
 			<FormActions
-				isSubmitting={isSubmitting}
+				isSubmitting={mutation.isPending}
 				nextDisabled={!certified}
 				nextLabel="Soumettre"
 				previousHref={`${BASE_PATH}/etape/2`}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepIndicator.tsx
@@ -1,0 +1,37 @@
+import {
+	SECOND_DECLARATION_STEP_TITLES,
+	SECOND_DECLARATION_TOTAL_STEPS,
+} from "./constants";
+
+type Props = {
+	currentStep: 1 | 2 | 3;
+};
+
+export function SecondDeclarationStepIndicator({ currentStep }: Props) {
+	const title = SECOND_DECLARATION_STEP_TITLES[currentStep] ?? "";
+	const nextTitle =
+		currentStep < SECOND_DECLARATION_TOTAL_STEPS
+			? SECOND_DECLARATION_STEP_TITLES[currentStep + 1]
+			: undefined;
+
+	return (
+		<div className="fr-stepper fr-mb-3w">
+			<h2 className="fr-stepper__title">
+				{title}
+				<span className="fr-stepper__state">
+					Étape {currentStep} sur {SECOND_DECLARATION_TOTAL_STEPS}
+				</span>
+			</h2>
+			<div
+				className="fr-stepper__steps"
+				data-fr-current-step={currentStep}
+				data-fr-steps={SECOND_DECLARATION_TOTAL_STEPS}
+			/>
+			{nextTitle && (
+				<p className="fr-stepper__details">
+					<span className="fr-text--bold">Étape suivante :</span> {nextTitle}
+				</p>
+			)}
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -1,0 +1,86 @@
+import { notFound } from "next/navigation";
+
+import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
+import { api, HydrateClient } from "~/trpc/server";
+
+import { SECOND_DECLARATION_TOTAL_STEPS } from "./constants";
+import { SecondDeclarationStep1Info } from "./SecondDeclarationStep1Info";
+import { SecondDeclarationStep2Form } from "./SecondDeclarationStep2Form";
+import { SecondDeclarationStep3Review } from "./SecondDeclarationStep3Review";
+
+type Props = {
+	step: number;
+};
+
+export async function SecondDeclarationStepPage({ step }: Props) {
+	if (Number.isNaN(step) || step < 1 || step > SECOND_DECLARATION_TOTAL_STEPS) {
+		notFound();
+	}
+
+	const data = await api.declaration.getOrCreate();
+	const currentYear = new Date().getFullYear();
+
+	const initialCategories = mapToEmployeeCategoryRows(
+		data.jobCategories,
+		data.employeeCategories,
+		"initial",
+	);
+
+	const hasCorrectionData = data.employeeCategories.some(
+		(e) => e.declarationType === "correction",
+	);
+	const correctionCategories = hasCorrectionData
+		? mapToEmployeeCategoryRows(
+				data.jobCategories,
+				data.employeeCategories,
+				"correction",
+			)
+		: [];
+
+	const initialSource = data.jobCategories[0]?.source;
+
+	const declarationDate = data.declaration.updatedAt
+		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
+		: new Date().toLocaleDateString("fr-FR");
+
+	if (step === 1) {
+		return (
+			<SecondDeclarationStep1Info
+				currentYear={currentYear}
+				declarationDate={declarationDate}
+			/>
+		);
+	}
+
+	if (step === 2) {
+		return (
+			<HydrateClient>
+				<SecondDeclarationStep2Form
+					initialEndDate={
+						data.declaration.secondDeclReferencePeriodEnd ?? undefined
+					}
+					initialFirstDeclarationCategories={initialCategories}
+					initialSecondDeclarationCategories={
+						correctionCategories.length > 0 ? correctionCategories : undefined
+					}
+					initialSource={initialSource}
+					initialStartDate={
+						data.declaration.secondDeclReferencePeriodStart ?? undefined
+					}
+				/>
+			</HydrateClient>
+		);
+	}
+
+	// step === 3
+	const reviewCategories =
+		correctionCategories.length > 0 ? correctionCategories : initialCategories;
+
+	return (
+		<HydrateClient>
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={reviewCategories}
+			/>
+		</HydrateClient>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
@@ -60,7 +60,7 @@ describe("SecondDeclarationStep1Info", () => {
 			/>,
 		);
 		expect(
-			screen.getByText("Ce que vous devez faire dans un délais de 6 mois"),
+			screen.getByText("Ce que vous devez faire dans un délai de 6 mois"),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(/Mettre en place des actions correctives/),

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SecondDeclarationStep1Info } from "../SecondDeclarationStep1Info";
+
+describe("SecondDeclarationStep1Info", () => {
+	it("renders the main title", () => {
+		render(
+			<SecondDeclarationStep1Info
+				currentYear={2027}
+				declarationDate="01/06/2027"
+			/>,
+		);
+		expect(
+			screen.getByText(
+				/Parcours de mise en conformité pour l.indicateur par catégorie de salariés/,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders stepper at step 1 of 3", () => {
+		render(
+			<SecondDeclarationStep1Info
+				currentYear={2027}
+				declarationDate="01/06/2027"
+			/>,
+		);
+		expect(screen.getByText("Étape 1 sur 3")).toBeInTheDocument();
+		expect(
+			screen.getByText("Actions correctives et seconde déclaration"),
+		).toBeInTheDocument();
+	});
+
+	it("displays the deadline", () => {
+		render(
+			<SecondDeclarationStep1Info
+				currentYear={2027}
+				declarationDate="01/06/2027"
+			/>,
+		);
+		expect(screen.getByText(/1\u1D49\u02B3 décembre 2027/)).toBeInTheDocument();
+	});
+
+	it("displays the declaration date", () => {
+		render(
+			<SecondDeclarationStep1Info
+				currentYear={2027}
+				declarationDate="01/06/2027"
+			/>,
+		);
+		expect(
+			screen.getByText(/Déclaration effectuée le 01\/06\/2027/),
+		).toBeInTheDocument();
+	});
+
+	it("renders the obligations callout", () => {
+		render(
+			<SecondDeclarationStep1Info
+				currentYear={2027}
+				declarationDate="01/06/2027"
+			/>,
+		);
+		expect(
+			screen.getByText("Ce que vous devez faire dans un délais de 6 mois"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/Mettre en place des actions correctives/),
+		).toBeInTheDocument();
+	});
+
+	it("renders previous link to parcours-conformite and next to step 2", () => {
+		render(
+			<SecondDeclarationStep1Info
+				currentYear={2027}
+				declarationDate="01/06/2027"
+			/>,
+		);
+		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/parcours-conformite",
+		);
+		expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/parcours-conformite/etape/2",
+		);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -36,7 +36,12 @@ describe("SecondDeclarationStep2Form", () => {
 			/>,
 		);
 		expect(screen.getByText("Nom :")).toBeInTheDocument();
-		expect(screen.getAllByText("Ouvriers")).toHaveLength(2); // accordion button + read-only text
+		expect(
+			screen.getByRole("button", {
+				name: "Catégorie d'emplois n°1 : Ouvriers",
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByText("Ouvriers")).toBeInTheDocument(); // read-only name text
 		expect(screen.queryByLabelText("Nom")).not.toBeInTheDocument();
 	});
 
@@ -52,16 +57,33 @@ describe("SecondDeclarationStep2Form", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("renders source selector with pre-filled value", () => {
+	it("displays source as read-only text", () => {
 		render(
 			<SecondDeclarationStep2Form
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		const select = screen.getByLabelText(
-			/Quelle est la source/,
-		) as HTMLSelectElement;
-		expect(select.value).toBe("convention-collective");
+		expect(
+			screen.getByText(/Source utilisée pour déterminer/),
+		).toBeInTheDocument();
+		expect(screen.getByText("Convention collective")).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText(/Quelle est la source/),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders reference period date pickers", () => {
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getByLabelText(/Date de début/)).toBeInTheDocument();
+		expect(screen.getByLabelText(/Date de fin/)).toBeInTheDocument();
+		// Should NOT show the static period text from step 5
+		expect(
+			screen.queryByText(/Période de référence pour le calcul des indicateurs/),
+		).not.toBeInTheDocument();
 	});
 
 	it("does not render add category button (read-only categories)", () => {
@@ -105,6 +127,11 @@ describe("SecondDeclarationStep2Form", () => {
 				initialSecondDeclarationCategories={secondDeclData}
 			/>,
 		);
-		expect(screen.getAllByText("Techniciens")).toHaveLength(2); // accordion button + read-only text
+		expect(
+			screen.getByRole("button", {
+				name: "Catégorie d'emplois n°1 : Techniciens",
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByText("Techniciens")).toBeInTheDocument(); // read-only name text
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import { SecondDeclarationStep2Form } from "../SecondDeclarationStep2Form";
+
+const mockCategories: StepCategoryData[] = [
+	{ name: "meta:source:convention-collective" },
+	{ name: "cat:0:name:Ouvriers" },
+	{ name: "cat:0:detail:Opérateurs de production" },
+	{ name: "cat:0:effectif", womenCount: 50, menCount: 60 },
+	{ name: "cat:0:annual:base", womenValue: "19114", menValue: "24383" },
+	{ name: "cat:0:annual:variable", womenValue: "2132", menValue: "1802" },
+	{ name: "cat:0:hourly:base", womenValue: "18.88", menValue: "16.73" },
+	{ name: "cat:0:hourly:variable", womenValue: "1.04", menValue: "1.02" },
+];
+
+describe("SecondDeclarationStep2Form", () => {
+	it("renders the title and step indicator", () => {
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(
+			screen.getByText(
+				/Parcours de mise en conformité pour l.indicateur par catégorie de salariés/,
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText("Étape 2 sur 3")).toBeInTheDocument();
+	});
+
+	it("displays category name as read-only text", () => {
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getByText("Nom :")).toBeInTheDocument();
+		expect(screen.getAllByText("Ouvriers")).toHaveLength(2); // accordion button + read-only text
+		expect(screen.queryByLabelText("Nom")).not.toBeInTheDocument();
+	});
+
+	it("displays detail as read-only text", () => {
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getByText("Opérateurs de production")).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText("Détail des emplois"),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders source selector with pre-filled value", () => {
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+			/>,
+		);
+		const select = screen.getByLabelText(
+			/Quelle est la source/,
+		) as HTMLSelectElement;
+		expect(select.value).toBe("convention-collective");
+	});
+
+	it("does not render add category button (read-only categories)", () => {
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(
+			screen.queryByRole("button", { name: /Ajouter une catégorie/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders previous link to step 1", () => {
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/parcours-conformite/etape/1",
+		);
+	});
+
+	it("uses second declaration data when available", () => {
+		const secondDeclData: StepCategoryData[] = [
+			{ name: "meta:source:accord-entreprise" },
+			{ name: "cat:0:name:Techniciens" },
+			{ name: "cat:0:detail:Senior" },
+			{ name: "cat:0:effectif", womenCount: 30, menCount: 40 },
+			{ name: "cat:0:annual:base", womenValue: "25000", menValue: "26000" },
+			{ name: "cat:0:annual:variable", womenValue: "3000", menValue: "3200" },
+			{ name: "cat:0:hourly:base", womenValue: "20", menValue: "21" },
+			{ name: "cat:0:hourly:variable", womenValue: "2", menValue: "2.5" },
+		];
+
+		render(
+			<SecondDeclarationStep2Form
+				initialFirstDeclarationCategories={mockCategories}
+				initialSecondDeclarationCategories={secondDeclData}
+			/>,
+		);
+		expect(screen.getAllByText("Techniciens")).toHaveLength(2); // accordion button + read-only text
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -1,17 +1,57 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import { describe, expect, it, vi } from "vitest";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { SecondDeclarationStep2Form } from "../SecondDeclarationStep2Form";
 
-const mockCategories: StepCategoryData[] = [
-	{ name: "meta:source:convention-collective" },
-	{ name: "cat:0:name:Ouvriers" },
-	{ name: "cat:0:detail:Opérateurs de production" },
-	{ name: "cat:0:effectif", womenCount: 50, menCount: 60 },
-	{ name: "cat:0:annual:base", womenValue: "19114", menValue: "24383" },
-	{ name: "cat:0:annual:variable", womenValue: "2132", menValue: "1802" },
-	{ name: "cat:0:hourly:base", womenValue: "18.88", menValue: "16.73" },
-	{ name: "cat:0:hourly:variable", womenValue: "1.04", menValue: "1.02" },
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			updateEmployeeCategories: {
+				useMutation: () => ({
+					mutate: vi.fn(),
+					isPending: false,
+					error: null,
+				}),
+			},
+		},
+	},
+}));
+
+function makeCategory(
+	overrides: Partial<EmployeeCategoryRow> = {},
+): EmployeeCategoryRow {
+	return {
+		name: "",
+		detail: "",
+		womenCount: null,
+		menCount: null,
+		annualBaseWomen: null,
+		annualBaseMen: null,
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+		...overrides,
+	};
+}
+
+const mockCategories: EmployeeCategoryRow[] = [
+	makeCategory({
+		name: "Ouvriers",
+		detail: "Opérateurs de production",
+		womenCount: 50,
+		menCount: 60,
+		annualBaseWomen: "19114",
+		annualBaseMen: "24383",
+		annualVariableWomen: "2132",
+		annualVariableMen: "1802",
+		hourlyBaseWomen: "18.88",
+		hourlyBaseMen: "16.73",
+		hourlyVariableWomen: "1.04",
+		hourlyVariableMen: "1.02",
+	}),
 ];
 
 describe("SecondDeclarationStep2Form", () => {
@@ -41,7 +81,7 @@ describe("SecondDeclarationStep2Form", () => {
 				name: "Catégorie d'emplois n°1 : Ouvriers",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Ouvriers")).toBeInTheDocument(); // read-only name text
+		expect(screen.getByText("Ouvriers")).toBeInTheDocument();
 		expect(screen.queryByLabelText("Nom")).not.toBeInTheDocument();
 	});
 
@@ -61,6 +101,7 @@ describe("SecondDeclarationStep2Form", () => {
 		render(
 			<SecondDeclarationStep2Form
 				initialFirstDeclarationCategories={mockCategories}
+				initialSource="convention-collective"
 			/>,
 		);
 		expect(
@@ -80,7 +121,6 @@ describe("SecondDeclarationStep2Form", () => {
 		);
 		expect(screen.getByLabelText(/Date de début/)).toBeInTheDocument();
 		expect(screen.getByLabelText(/Date de fin/)).toBeInTheDocument();
-		// Should NOT show the static period text from step 5
 		expect(
 			screen.queryByText(/Période de référence pour le calcul des indicateurs/),
 		).not.toBeInTheDocument();
@@ -110,15 +150,21 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("uses second declaration data when available", () => {
-		const secondDeclData: StepCategoryData[] = [
-			{ name: "meta:source:accord-entreprise" },
-			{ name: "cat:0:name:Techniciens" },
-			{ name: "cat:0:detail:Senior" },
-			{ name: "cat:0:effectif", womenCount: 30, menCount: 40 },
-			{ name: "cat:0:annual:base", womenValue: "25000", menValue: "26000" },
-			{ name: "cat:0:annual:variable", womenValue: "3000", menValue: "3200" },
-			{ name: "cat:0:hourly:base", womenValue: "20", menValue: "21" },
-			{ name: "cat:0:hourly:variable", womenValue: "2", menValue: "2.5" },
+		const secondDeclData: EmployeeCategoryRow[] = [
+			makeCategory({
+				name: "Techniciens",
+				detail: "Senior",
+				womenCount: 30,
+				menCount: 40,
+				annualBaseWomen: "25000",
+				annualBaseMen: "26000",
+				annualVariableWomen: "3000",
+				annualVariableMen: "3200",
+				hourlyBaseWomen: "20",
+				hourlyBaseMen: "21",
+				hourlyVariableWomen: "2",
+				hourlyVariableMen: "2.5",
+			}),
 		];
 
 		render(
@@ -132,6 +178,6 @@ describe("SecondDeclarationStep2Form", () => {
 				name: "Catégorie d'emplois n°1 : Techniciens",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Techniciens")).toBeInTheDocument(); // read-only name text
+		expect(screen.getByText("Techniciens")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -1,18 +1,58 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
-import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import { describe, expect, it, vi } from "vitest";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { SecondDeclarationStep3Review } from "../SecondDeclarationStep3Review";
 
-const mockCategories: StepCategoryData[] = [
-	{ name: "meta:source:autre" },
-	{ name: "cat:0:name:Ingénieurs" },
-	{ name: "cat:0:detail:Dev" },
-	{ name: "cat:0:effectif", womenCount: 10, menCount: 15 },
-	{ name: "cat:0:annual:base", womenValue: "3000", menValue: "3200" },
-	{ name: "cat:0:annual:variable", womenValue: "500", menValue: "600" },
-	{ name: "cat:0:hourly:base", womenValue: "18", menValue: "19" },
-	{ name: "cat:0:hourly:variable", womenValue: "3", menValue: "4" },
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			submitSecondDeclaration: {
+				useMutation: () => ({
+					mutate: vi.fn(),
+					isPending: false,
+					error: null,
+				}),
+			},
+		},
+	},
+}));
+
+function makeCategory(
+	overrides: Partial<EmployeeCategoryRow> = {},
+): EmployeeCategoryRow {
+	return {
+		name: "",
+		detail: "",
+		womenCount: null,
+		menCount: null,
+		annualBaseWomen: null,
+		annualBaseMen: null,
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+		...overrides,
+	};
+}
+
+const mockCategories: EmployeeCategoryRow[] = [
+	makeCategory({
+		name: "Ingénieurs",
+		detail: "Dev",
+		womenCount: 10,
+		menCount: 15,
+		annualBaseWomen: "3000",
+		annualBaseMen: "3200",
+		annualVariableWomen: "500",
+		annualVariableMen: "600",
+		hourlyBaseWomen: "18",
+		hourlyBaseMen: "19",
+		hourlyVariableWomen: "3",
+		hourlyVariableMen: "4",
+	}),
 ];
 
 describe("SecondDeclarationStep3Review", () => {
@@ -111,15 +151,20 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("shows gap warning when gaps >= 5% exist", () => {
-		const categoriesWithHighGaps: StepCategoryData[] = [
-			{ name: "meta:source:autre" },
-			{ name: "cat:0:name:Ouvriers" },
-			{ name: "cat:0:detail:" },
-			{ name: "cat:0:effectif", womenCount: 10, menCount: 15 },
-			{ name: "cat:0:annual:base", womenValue: "1000", menValue: "2000" },
-			{ name: "cat:0:annual:variable", womenValue: "100", menValue: "200" },
-			{ name: "cat:0:hourly:base", womenValue: "10", menValue: "20" },
-			{ name: "cat:0:hourly:variable", womenValue: "1", menValue: "2" },
+		const categoriesWithHighGaps: EmployeeCategoryRow[] = [
+			makeCategory({
+				name: "Ouvriers",
+				womenCount: 10,
+				menCount: 15,
+				annualBaseWomen: "1000",
+				annualBaseMen: "2000",
+				annualVariableWomen: "100",
+				annualVariableMen: "200",
+				hourlyBaseWomen: "10",
+				hourlyBaseMen: "20",
+				hourlyVariableWomen: "1",
+				hourlyVariableMen: "2",
+			}),
 		];
 
 		render(
@@ -133,15 +178,20 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("does not show gap warning when all gaps < 5%", () => {
-		const categoriesWithLowGaps: StepCategoryData[] = [
-			{ name: "meta:source:autre" },
-			{ name: "cat:0:name:Ouvriers" },
-			{ name: "cat:0:detail:" },
-			{ name: "cat:0:effectif", womenCount: 10, menCount: 15 },
-			{ name: "cat:0:annual:base", womenValue: "9800", menValue: "10000" },
-			{ name: "cat:0:annual:variable", womenValue: "980", menValue: "1000" },
-			{ name: "cat:0:hourly:base", womenValue: "98", menValue: "100" },
-			{ name: "cat:0:hourly:variable", womenValue: "9.8", menValue: "10" },
+		const categoriesWithLowGaps: EmployeeCategoryRow[] = [
+			makeCategory({
+				name: "Ouvriers",
+				womenCount: 10,
+				menCount: 15,
+				annualBaseWomen: "9800",
+				annualBaseMen: "10000",
+				annualVariableWomen: "980",
+				annualVariableMen: "1000",
+				hourlyBaseWomen: "98",
+				hourlyBaseMen: "100",
+				hourlyVariableWomen: "9.8",
+				hourlyVariableMen: "10",
+			}),
 		];
 
 		render(

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import { SecondDeclarationStep3Review } from "../SecondDeclarationStep3Review";
+
+const mockCategories: StepCategoryData[] = [
+	{ name: "meta:source:autre" },
+	{ name: "cat:0:name:Ingénieurs" },
+	{ name: "cat:0:detail:Dev" },
+	{ name: "cat:0:effectif", womenCount: 10, menCount: 15 },
+	{ name: "cat:0:annual:base", womenValue: "3000", menValue: "3200" },
+	{ name: "cat:0:annual:variable", womenValue: "500", menValue: "600" },
+	{ name: "cat:0:hourly:base", womenValue: "18", menValue: "19" },
+	{ name: "cat:0:hourly:variable", womenValue: "3", menValue: "4" },
+];
+
+describe("SecondDeclarationStep3Review", () => {
+	it("renders the title and step indicator", () => {
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(
+			screen.getByText(
+				/Parcours de mise en conformité pour l.indicateur par catégorie de salariés/,
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText("Étape 3 sur 3")).toBeInTheDocument();
+	});
+
+	it("renders category gap card with category name", () => {
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getByText(/Catégorie d.emplois n°1/)).toBeInTheDocument();
+	});
+
+	it("renders gap columns", () => {
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getAllByText("Annuelle brute").length).toBeGreaterThanOrEqual(
+			1,
+		);
+		expect(screen.getAllByText("Horaire brute").length).toBeGreaterThanOrEqual(
+			1,
+		);
+	});
+
+	it("renders the next steps section", () => {
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getByText("Prochaines étapes")).toBeInTheDocument();
+	});
+
+	it("renders certification checkbox", () => {
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(
+			screen.getByLabelText(/Je certifie que les données saisies/),
+		).toBeInTheDocument();
+	});
+
+	it("disables submit button when not certified", () => {
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		const submitButton = screen.getByRole("button", { name: /soumettre/i });
+		expect(submitButton).toBeDisabled();
+	});
+
+	it("enables submit button when certified", async () => {
+		const user = userEvent.setup();
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		const checkbox = screen.getByLabelText(
+			/Je certifie que les données saisies/,
+		);
+		await user.click(checkbox);
+		const submitButton = screen.getByRole("button", { name: /soumettre/i });
+		expect(submitButton).not.toBeDisabled();
+	});
+
+	it("renders previous link to step 2", () => {
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={mockCategories}
+			/>,
+		);
+		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/parcours-conformite/etape/2",
+		);
+	});
+
+	it("shows gap warning when gaps >= 5% exist", () => {
+		const categoriesWithHighGaps: StepCategoryData[] = [
+			{ name: "meta:source:autre" },
+			{ name: "cat:0:name:Ouvriers" },
+			{ name: "cat:0:detail:" },
+			{ name: "cat:0:effectif", womenCount: 10, menCount: 15 },
+			{ name: "cat:0:annual:base", womenValue: "1000", menValue: "2000" },
+			{ name: "cat:0:annual:variable", womenValue: "100", menValue: "200" },
+			{ name: "cat:0:hourly:base", womenValue: "10", menValue: "20" },
+			{ name: "cat:0:hourly:variable", womenValue: "1", menValue: "2" },
+		];
+
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={categoriesWithHighGaps}
+			/>,
+		);
+		expect(
+			screen.getByText("Des écarts ont été de nouveau détectés"),
+		).toBeInTheDocument();
+	});
+
+	it("does not show gap warning when all gaps < 5%", () => {
+		const categoriesWithLowGaps: StepCategoryData[] = [
+			{ name: "meta:source:autre" },
+			{ name: "cat:0:name:Ouvriers" },
+			{ name: "cat:0:detail:" },
+			{ name: "cat:0:effectif", womenCount: 10, menCount: 15 },
+			{ name: "cat:0:annual:base", womenValue: "9800", menValue: "10000" },
+			{ name: "cat:0:annual:variable", womenValue: "980", menValue: "1000" },
+			{ name: "cat:0:hourly:base", womenValue: "98", menValue: "100" },
+			{ name: "cat:0:hourly:variable", womenValue: "9.8", menValue: "10" },
+		];
+
+		render(
+			<SecondDeclarationStep3Review
+				secondDeclarationCategories={categoriesWithLowGaps}
+			/>,
+		);
+		expect(
+			screen.queryByText("Des écarts ont été de nouveau détectés"),
+		).not.toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/constants.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/constants.ts
@@ -1,0 +1,14 @@
+// Internal step number used in declarationCategories for the second declaration.
+export const SECOND_DECLARATION_CATEGORY_STEP = 7;
+
+export const SECOND_DECLARATION_TOTAL_STEPS = 3;
+
+export const SECOND_DECLARATION_STEP_TITLES = [
+	"",
+	"Actions correctives et seconde déclaration",
+	"Seconde déclaration des écarts de rémunération par catégorie de salariés",
+	"Récapitulatif de votre déclaration",
+] as const;
+
+export const BASE_PATH =
+	"/declaration-remuneration/parcours-conformite" as const;

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/index.ts
@@ -8,3 +8,4 @@ export { SecondDeclarationStep1Info } from "./SecondDeclarationStep1Info";
 export { SecondDeclarationStep2Form } from "./SecondDeclarationStep2Form";
 export { SecondDeclarationStep3Review } from "./SecondDeclarationStep3Review";
 export { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
+export { SecondDeclarationStepPage } from "./SecondDeclarationStepPage";

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/index.ts
@@ -1,0 +1,10 @@
+export {
+	BASE_PATH,
+	SECOND_DECLARATION_CATEGORY_STEP,
+	SECOND_DECLARATION_STEP_TITLES,
+	SECOND_DECLARATION_TOTAL_STEPS,
+} from "./constants";
+export { SecondDeclarationStep1Info } from "./SecondDeclarationStep1Info";
+export { SecondDeclarationStep2Form } from "./SecondDeclarationStep2Form";
+export { SecondDeclarationStep3Review } from "./SecondDeclarationStep3Review";
+export { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -48,7 +48,6 @@ export function CategoryDataTable({
 			: null;
 
 	const id = (suffix: string) => `cat-${catIndex}-${suffix}`;
-
 	return (
 		<div className="fr-table fr-table--no-caption fr-mb-0">
 			<div className="fr-table__wrapper">

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -5,10 +5,10 @@ import {
 	computeGap,
 	computeTotal,
 	displayDecimal,
-	formatGapCompact,
 	formatTotal,
 } from "~/modules/declaration-remuneration/shared/gapUtils";
 import stepStyles from "../Step5EmployeeCategories.module.scss";
+import { GapBadge } from "../step6/GapBadge";
 import type { EmployeeCategory } from "./categorySerializer";
 
 type Props = {
@@ -111,10 +111,7 @@ export function CategoryDataTable({
 											<span className="fr-text--sm">nb</span>
 										</div>
 									</td>
-									<td>
-										{formatGapCompact(computeGap(cat.womenCount, cat.menCount))}{" "}
-										%
-									</td>
+									<td />
 								</tr>
 
 								{/* Section: Rémunération annuelle brute */}
@@ -154,10 +151,9 @@ export function CategoryDataTable({
 										</div>
 									</td>
 									<td>
-										{formatGapCompact(
-											computeGap(cat.annualBaseWomen, cat.annualBaseMen),
-										)}{" "}
-										%
+										<GapBadge
+											gap={computeGap(cat.annualBaseWomen, cat.annualBaseMen)}
+										/>
 									</td>
 								</tr>
 								<tr>
@@ -195,26 +191,24 @@ export function CategoryDataTable({
 										</div>
 									</td>
 									<td>
-										{formatGapCompact(
-											computeGap(
+										<GapBadge
+											gap={computeGap(
 												cat.annualVariableWomen,
 												cat.annualVariableMen,
-											),
-										)}{" "}
-										%
+											)}
+										/>
 									</td>
 								</tr>
 								{/* Total annuel */}
 								<tr>
-									<td className={stepStyles.sectionHeader} colSpan={4}>
+									<td className={stepStyles.sectionHeader}>
 										<strong>Total</strong>
 									</td>
-								</tr>
-								<tr>
-									<td>{/* empty label */}</td>
 									<td>{formatTotal(annualTotalWomen, "€")}</td>
 									<td>{formatTotal(annualTotalMen, "€")}</td>
-									<td>{formatGapCompact(annualTotalGap)} %</td>
+									<td>
+										<GapBadge gap={annualTotalGap} />
+									</td>
 								</tr>
 
 								{/* Section: Rémunération horaire brute */}
@@ -254,10 +248,9 @@ export function CategoryDataTable({
 										</div>
 									</td>
 									<td>
-										{formatGapCompact(
-											computeGap(cat.hourlyBaseWomen, cat.hourlyBaseMen),
-										)}{" "}
-										%
+										<GapBadge
+											gap={computeGap(cat.hourlyBaseWomen, cat.hourlyBaseMen)}
+										/>
 									</td>
 								</tr>
 								<tr>
@@ -295,26 +288,24 @@ export function CategoryDataTable({
 										</div>
 									</td>
 									<td>
-										{formatGapCompact(
-											computeGap(
+										<GapBadge
+											gap={computeGap(
 												cat.hourlyVariableWomen,
 												cat.hourlyVariableMen,
-											),
-										)}{" "}
-										%
+											)}
+										/>
 									</td>
 								</tr>
 								{/* Total horaire */}
 								<tr>
-									<td className={stepStyles.sectionHeader} colSpan={4}>
+									<td className={stepStyles.sectionHeader}>
 										<strong>Total</strong>
 									</td>
-								</tr>
-								<tr>
-									<td>{/* empty label */}</td>
 									<td>{formatTotal(hourlyTotalWomen, "€")}</td>
 									<td>{formatTotal(hourlyTotalMen, "€")}</td>
-									<td>{formatGapCompact(hourlyTotalGap)} %</td>
+									<td>
+										<GapBadge gap={hourlyTotalGap} />
+									</td>
 								</tr>
 							</tbody>
 						</table>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -1,20 +1,23 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 
 import { DefinitionAccordion } from "~/modules/declaration-remuneration/shared/DefinitionAccordion";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { TooltipButton } from "~/modules/declaration-remuneration/shared/TooltipButton";
-import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import type {
+	EmployeeCategoryRow,
+	EmployeeCategorySubmitData,
+} from "~/modules/declaration-remuneration/types";
 import stepStyles from "../Step5EmployeeCategories.module.scss";
 import { CategoryDataTable } from "./CategoryDataTable";
 import {
 	createEmptyCategory,
-	deserializeCategories,
 	type EmployeeCategory,
-	serializeCategories,
+	fromDatabaseRows,
+	toSubmitData,
 } from "./categorySerializer";
 import { DeleteCategoryDialog } from "./DeleteCategoryDialog";
 
@@ -25,9 +28,9 @@ const SOURCE_LABELS: Record<string, string> = {
 	autre: "Autre",
 };
 
-let nextCategoryId = 0;
-function nextId() {
-	return nextCategoryId++;
+function createIdGenerator() {
+	let id = 0;
+	return () => id++;
 }
 
 type Props = {
@@ -37,10 +40,11 @@ type Props = {
 	tooltipPrefix: string;
 	accordionId: string;
 	previousHref: string;
-	initialCategories: StepCategoryData[];
+	initialCategories: EmployeeCategoryRow[];
+	initialSource?: string;
 	maxWomen?: number;
 	maxMen?: number;
-	onSubmit: (serialized: StepCategoryData[]) => void;
+	onSubmit: (data: EmployeeCategorySubmitData) => void;
 	isSubmitting: boolean;
 	submitError?: string | null;
 	readOnlyNameDetail?: boolean;
@@ -56,6 +60,7 @@ export function CategoryForm({
 	accordionId,
 	previousHref,
 	initialCategories,
+	initialSource = "",
 	maxWomen,
 	maxMen,
 	onSubmit,
@@ -67,23 +72,17 @@ export function CategoryForm({
 }: Props) {
 	const currentYear = new Date().getFullYear();
 	const referenceYear = currentYear - 1;
-
-	const initial =
-		initialCategories.length > 0
-			? deserializeCategories(initialCategories, nextId)
-			: { categories: [createEmptyCategory(nextId())], source: "" };
+	const baseId = useId();
+	const nextId = useRef(createIdGenerator()).current;
 
 	const [categories, setCategories] = useState<EmployeeCategory[]>(
-		initial.categories,
+		initialCategories.length > 0
+			? fromDatabaseRows(initialCategories, nextId)
+			: [createEmptyCategory(nextId())],
 	);
-	const [source, setSource] = useState(initial.source);
+	const [source, setSource] = useState(initialSource);
 
-	const hasInitialData = initialCategories.some(
-		(c) =>
-			c.name.startsWith("cat:") &&
-			!c.name.match(/^cat:\d+:(name|detail):/) &&
-			(c.womenCount !== undefined || c.womenValue !== undefined),
-	);
+	const hasInitialData = initialCategories.length > 0;
 	const [saved, setSaved] = useState(hasInitialData);
 
 	const [workforceError, setWorkforceError] = useState("");
@@ -191,9 +190,8 @@ export function CategoryForm({
 			}
 		}
 
-		onSubmit(serializeCategories(categories, source));
+		onSubmit(toSubmitData(categories, source));
 	}
-
 	return (
 		<form className={stepStyles.form} onSubmit={handleSubmit}>
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
@@ -278,7 +276,7 @@ export function CategoryForm({
 
 			<div className="fr-accordions-group" data-fr-group="false">
 				{categories.map((cat, index) => {
-					const collapseId = `cat-accordion-${cat.id}`;
+					const collapseId = `${baseId}-accordion-${index}`;
 					const categoryNumber = `Catégorie d'emplois n°${index + 1}`;
 					const categoryLabel = cat.name.trim()
 						? `${categoryNumber} : ${cat.name.trim()}`

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -1,0 +1,404 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useCallback, useRef, useState } from "react";
+
+import { DefinitionAccordion } from "~/modules/declaration-remuneration/shared/DefinitionAccordion";
+import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
+import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
+import { TooltipButton } from "~/modules/declaration-remuneration/shared/TooltipButton";
+import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import stepStyles from "../Step5EmployeeCategories.module.scss";
+import { CategoryDataTable } from "./CategoryDataTable";
+import {
+	createEmptyCategory,
+	deserializeCategories,
+	type EmployeeCategory,
+	serializeCategories,
+} from "./categorySerializer";
+import { DeleteCategoryDialog } from "./DeleteCategoryDialog";
+
+let nextCategoryId = 0;
+function nextId() {
+	return nextCategoryId++;
+}
+
+type Props = {
+	title: ReactNode;
+	stepper: ReactNode;
+	instructionText: string;
+	tooltipPrefix: string;
+	accordionId: string;
+	previousHref: string;
+	initialCategories: StepCategoryData[];
+	maxWomen?: number;
+	maxMen?: number;
+	onSubmit: (serialized: StepCategoryData[]) => void;
+	isSubmitting: boolean;
+	submitError?: string | null;
+	readOnlyNameDetail?: boolean;
+};
+
+export function CategoryForm({
+	title,
+	stepper,
+	instructionText,
+	tooltipPrefix,
+	accordionId,
+	previousHref,
+	initialCategories,
+	maxWomen,
+	maxMen,
+	onSubmit,
+	isSubmitting,
+	submitError,
+	readOnlyNameDetail = false,
+}: Props) {
+	const currentYear = new Date().getFullYear();
+	const referenceYear = currentYear - 1;
+
+	const initial =
+		initialCategories.length > 0
+			? deserializeCategories(initialCategories, nextId)
+			: { categories: [createEmptyCategory(nextId())], source: "" };
+
+	const [categories, setCategories] = useState<EmployeeCategory[]>(
+		initial.categories,
+	);
+	const [source, setSource] = useState(initial.source);
+
+	const hasInitialData = initialCategories.some(
+		(c) =>
+			c.name.startsWith("cat:") &&
+			!c.name.match(/^cat:\d+:(name|detail):/) &&
+			(c.womenCount !== undefined || c.womenValue !== undefined),
+	);
+	const [saved, setSaved] = useState(hasInitialData);
+
+	const [workforceError, setWorkforceError] = useState("");
+	const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
+	const deleteDialogRef = useRef<HTMLDialogElement>(null);
+
+	const closeDeleteDialog = useCallback(() => {
+		deleteDialogRef.current?.close();
+		setDeleteIndex(null);
+	}, []);
+
+	function updateCategory(
+		index: number,
+		field: keyof EmployeeCategory,
+		value: string,
+	) {
+		setCategories((prev) =>
+			prev.map((cat, i) => (i === index ? { ...cat, [field]: value } : cat)),
+		);
+		setSaved(false);
+	}
+
+	function handlePositiveNumberChange(
+		index: number,
+		field: keyof EmployeeCategory,
+		isInteger: boolean,
+	) {
+		return (e: React.ChangeEvent<HTMLInputElement>) => {
+			const val = e.target.value;
+			if (val === "") {
+				updateCategory(index, field, val);
+				return;
+			}
+			const n = isInteger ? Number.parseInt(val, 10) : Number.parseFloat(val);
+			if (Number.isNaN(n) || n < 0) return;
+			updateCategory(index, field, val);
+		};
+	}
+
+	function addCategory() {
+		setCategories((prev) => [...prev, createEmptyCategory(nextId())]);
+		setSaved(false);
+	}
+
+	function askRemoveCategory(index: number) {
+		setDeleteIndex(index);
+		deleteDialogRef.current?.showModal();
+	}
+
+	function confirmRemoveCategory() {
+		if (deleteIndex !== null) {
+			setCategories((prev) => prev.filter((_, i) => i !== deleteIndex));
+			setSaved(false);
+		}
+		closeDeleteDialog();
+	}
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		setWorkforceError("");
+
+		const emptyNames = categories.some((cat) => !cat.name.trim());
+		if (emptyNames) {
+			setWorkforceError(
+				"Le nom de chaque catégorie d'emplois est obligatoire.",
+			);
+			return;
+		}
+
+		const names = categories.map((cat) => cat.name.trim().toLowerCase());
+		const hasDuplicates = names.length !== new Set(names).size;
+		if (hasDuplicates) {
+			setWorkforceError(
+				"Les noms des catégories d'emplois doivent être uniques.",
+			);
+			return;
+		}
+
+		if (maxWomen !== undefined || maxMen !== undefined) {
+			const totalWomen = categories.reduce(
+				(sum, cat) =>
+					sum + (cat.womenCount ? Number.parseInt(cat.womenCount, 10) : 0),
+				0,
+			);
+			const totalMen = categories.reduce(
+				(sum, cat) =>
+					sum + (cat.menCount ? Number.parseInt(cat.menCount, 10) : 0),
+				0,
+			);
+
+			const errors: string[] = [];
+			if (maxWomen !== undefined && totalWomen !== maxWomen) {
+				errors.push(
+					`Le total des effectifs femmes (${totalWomen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxWomen}).`,
+				);
+			}
+			if (maxMen !== undefined && totalMen !== maxMen) {
+				errors.push(
+					`Le total des effectifs hommes (${totalMen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxMen}).`,
+				);
+			}
+			if (errors.length > 0) {
+				setWorkforceError(errors.join(" "));
+				return;
+			}
+		}
+
+		onSubmit(serializeCategories(categories, source));
+	}
+
+	return (
+		<form className={stepStyles.form} onSubmit={handleSubmit}>
+			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+				<div className="fr-col">{title}</div>
+				{saved && (
+					<div className="fr-col-auto">
+						<SavedIndicator />
+					</div>
+				)}
+			</div>
+
+			{stepper}
+
+			<div className={stepStyles.categoryBlock}>
+				<p className="fr-mb-0">
+					Cet indicateur permet de mesurer l&apos;écart de rémunération entre
+					les femmes et les hommes au sein de chaque catégorie de salariés, en
+					distinguant le salaire de base des composantes variables ou
+					complémentaires.
+				</p>
+
+				<div className={stepStyles.categoryHeader}>
+					<p className="fr-mb-0">
+						Période de référence pour le calcul des indicateurs : 01/01/
+						{referenceYear} - 31/12/{referenceYear}.
+					</p>
+					<TooltipButton
+						id={`${tooltipPrefix}-period`}
+						label="Information sur la période de référence"
+					/>
+				</div>
+
+				<div className="fr-select-group">
+					<label className="fr-label" htmlFor="source-select">
+						Quelle est la source utilisée pour déterminer les catégories
+						d&apos;emplois ?
+					</label>
+					<select
+						className="fr-select"
+						id="source-select"
+						onChange={(e) => {
+							setSource(e.target.value);
+							setSaved(false);
+						}}
+						value={source}
+					>
+						<option disabled value="">
+							Sélectionner une option
+						</option>
+						<option value="convention-collective">Convention collective</option>
+						<option value="accord-entreprise">Accord d&apos;entreprise</option>
+						<option value="classification-interne">
+							Classification interne
+						</option>
+						<option value="autre">Autre</option>
+					</select>
+				</div>
+			</div>
+
+			<div className={stepStyles.descriptionBlock}>
+				<div className={stepStyles.descriptionRow}>
+					<p className={`fr-mb-0 ${stepStyles.descriptionTitle}`}>
+						{instructionText}
+					</p>
+					<TooltipButton
+						id={`${tooltipPrefix}-instruction`}
+						label="Information sur la saisie"
+					/>
+				</div>
+				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
+			</div>
+
+			<div className="fr-accordions-group" data-fr-group="false">
+				{categories.map((cat, index) => {
+					const collapseId = `cat-accordion-${cat.id}`;
+					const categoryLabel =
+						cat.name.trim() || `Catégorie d'emplois n°${index + 1}`;
+
+					return (
+						<section className="fr-accordion" key={cat.id}>
+							<h3 className="fr-accordion__title">
+								<button
+									aria-controls={collapseId}
+									aria-expanded="true"
+									className="fr-accordion__btn"
+									type="button"
+								>
+									{categoryLabel}
+								</button>
+							</h3>
+							<div
+								className="fr-collapse fr-collapse--expanded"
+								id={collapseId}
+							>
+								<div className={stepStyles.categoryBlock}>
+									{!readOnlyNameDetail && categories.length > 1 && (
+										<div className={stepStyles.categoryFooter}>
+											<button
+												className="fr-btn fr-btn--tertiary fr-icon-delete-line fr-btn--icon-left fr-btn--sm"
+												onClick={() => askRemoveCategory(index)}
+												type="button"
+											>
+												Supprimer
+											</button>
+										</div>
+									)}
+
+									{readOnlyNameDetail ? (
+										<>
+											<p className="fr-mb-0">
+												<span className="fr-text--bold">Nom : </span>
+												{cat.name}
+											</p>
+											<p className="fr-mb-0">
+												<span className="fr-text--bold">
+													Détail des emplois :{" "}
+												</span>
+												{cat.detail}
+											</p>
+										</>
+									) : (
+										<>
+											<div className="fr-input-group fr-mb-0">
+												<label
+													className="fr-label"
+													htmlFor={`cat-${index}-name`}
+												>
+													Nom
+												</label>
+												<input
+													className="fr-input"
+													id={`cat-${index}-name`}
+													onChange={(e) =>
+														updateCategory(index, "name", e.target.value)
+													}
+													type="text"
+													value={cat.name}
+												/>
+											</div>
+
+											<div className="fr-input-group fr-mb-0">
+												<label
+													className="fr-label"
+													htmlFor={`cat-${index}-detail`}
+												>
+													Détail des emplois
+												</label>
+												<input
+													className="fr-input"
+													id={`cat-${index}-detail`}
+													onChange={(e) =>
+														updateCategory(index, "detail", e.target.value)
+													}
+													type="text"
+													value={cat.detail}
+												/>
+											</div>
+										</>
+									)}
+
+									<CategoryDataTable
+										category={cat}
+										categoryIndex={index}
+										onPositiveNumberChange={handlePositiveNumberChange}
+									/>
+								</div>
+							</div>
+						</section>
+					);
+				})}
+			</div>
+
+			<div className={stepStyles.categoryFooter}>
+				<p className="fr-text--bold fr-mb-0">
+					Nombre de catégories : {categories.length}
+				</p>
+				{!readOnlyNameDetail && (
+					<button
+						className="fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left"
+						onClick={addCategory}
+						type="button"
+					>
+						Ajouter une catégorie d&apos;emplois
+					</button>
+				)}
+			</div>
+
+			<DefinitionAccordion
+				id={accordionId}
+				title="Définitions et méthode de calcul"
+			/>
+
+			{workforceError && (
+				<div aria-live="polite" className="fr-alert fr-alert--error">
+					<p>{workforceError}</p>
+				</div>
+			)}
+
+			{submitError && (
+				<div aria-live="polite" className="fr-alert fr-alert--error">
+					<p>{submitError}</p>
+				</div>
+			)}
+
+			<FormActions isSubmitting={isSubmitting} previousHref={previousHref} />
+
+			<DeleteCategoryDialog
+				categoryName={
+					deleteIndex !== null
+						? categories[deleteIndex]?.name || `n°${deleteIndex + 1}`
+						: null
+				}
+				dialogRef={deleteDialogRef}
+				onCancel={closeDeleteDialog}
+				onConfirm={confirmRemoveCategory}
+			/>
+		</form>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -18,6 +18,13 @@ import {
 } from "./categorySerializer";
 import { DeleteCategoryDialog } from "./DeleteCategoryDialog";
 
+const SOURCE_LABELS: Record<string, string> = {
+	"convention-collective": "Convention collective",
+	"accord-entreprise": "Accord d'entreprise",
+	"classification-interne": "Classification interne",
+	autre: "Autre",
+};
+
 let nextCategoryId = 0;
 function nextId() {
 	return nextCategoryId++;
@@ -37,6 +44,8 @@ type Props = {
 	isSubmitting: boolean;
 	submitError?: string | null;
 	readOnlyNameDetail?: boolean;
+	referencePeriodPicker?: ReactNode;
+	descriptionText?: string;
 };
 
 export function CategoryForm({
@@ -53,6 +62,8 @@ export function CategoryForm({
 	isSubmitting,
 	submitError,
 	readOnlyNameDetail = false,
+	referencePeriodPicker,
+	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 }: Props) {
 	const currentYear = new Date().getFullYear();
 	const referenceYear = currentYear - 1;
@@ -197,49 +208,59 @@ export function CategoryForm({
 			{stepper}
 
 			<div className={stepStyles.categoryBlock}>
-				<p className="fr-mb-0">
-					Cet indicateur permet de mesurer l&apos;écart de rémunération entre
-					les femmes et les hommes au sein de chaque catégorie de salariés, en
-					distinguant le salaire de base des composantes variables ou
-					complémentaires.
-				</p>
+				<p className="fr-mb-0">{descriptionText}</p>
 
-				<div className={stepStyles.categoryHeader}>
+				{readOnlyNameDetail ? (
 					<p className="fr-mb-0">
-						Période de référence pour le calcul des indicateurs : 01/01/
-						{referenceYear} - 31/12/{referenceYear}.
+						Source utilisée pour déterminer les catégories d&apos;emplois :{" "}
+						<span className="fr-text--bold">
+							{SOURCE_LABELS[source] ?? source}
+						</span>
 					</p>
-					<TooltipButton
-						id={`${tooltipPrefix}-period`}
-						label="Information sur la période de référence"
-					/>
-				</div>
+				) : (
+					<div className="fr-select-group">
+						<label className="fr-label" htmlFor="source-select">
+							Quelle est la source utilisée pour déterminer les catégories
+							d&apos;emplois ?
+						</label>
+						<select
+							className="fr-select"
+							id="source-select"
+							onChange={(e) => {
+								setSource(e.target.value);
+								setSaved(false);
+							}}
+							value={source}
+						>
+							<option disabled value="">
+								Sélectionner une option
+							</option>
+							<option value="convention-collective">
+								Convention collective
+							</option>
+							<option value="accord-entreprise">
+								Accord d&apos;entreprise
+							</option>
+							<option value="classification-interne">
+								Classification interne
+							</option>
+							<option value="autre">Autre</option>
+						</select>
+					</div>
+				)}
 
-				<div className="fr-select-group">
-					<label className="fr-label" htmlFor="source-select">
-						Quelle est la source utilisée pour déterminer les catégories
-						d&apos;emplois ?
-					</label>
-					<select
-						className="fr-select"
-						id="source-select"
-						onChange={(e) => {
-							setSource(e.target.value);
-							setSaved(false);
-						}}
-						value={source}
-					>
-						<option disabled value="">
-							Sélectionner une option
-						</option>
-						<option value="convention-collective">Convention collective</option>
-						<option value="accord-entreprise">Accord d&apos;entreprise</option>
-						<option value="classification-interne">
-							Classification interne
-						</option>
-						<option value="autre">Autre</option>
-					</select>
-				</div>
+				{referencePeriodPicker ?? (
+					<div className={stepStyles.categoryHeader}>
+						<p className="fr-mb-0">
+							Période de référence pour le calcul des indicateurs : 01/01/
+							{referenceYear} - 31/12/{referenceYear}.
+						</p>
+						<TooltipButton
+							id={`${tooltipPrefix}-period`}
+							label="Information sur la période de référence"
+						/>
+					</div>
+				)}
 			</div>
 
 			<div className={stepStyles.descriptionBlock}>
@@ -258,8 +279,10 @@ export function CategoryForm({
 			<div className="fr-accordions-group" data-fr-group="false">
 				{categories.map((cat, index) => {
 					const collapseId = `cat-accordion-${cat.id}`;
-					const categoryLabel =
-						cat.name.trim() || `Catégorie d'emplois n°${index + 1}`;
+					const categoryNumber = `Catégorie d'emplois n°${index + 1}`;
+					const categoryLabel = cat.name.trim()
+						? `${categoryNumber} : ${cat.name.trim()}`
+						: categoryNumber;
 
 					return (
 						<section className="fr-accordion" key={cat.id}>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/categorySerializer.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/categorySerializer.ts
@@ -1,4 +1,7 @@
-import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import type {
+	EmployeeCategoryRow,
+	EmployeeCategorySubmitData,
+} from "~/modules/declaration-remuneration/types";
 
 export type EmployeeCategory = {
 	id: number;
@@ -14,14 +17,6 @@ export type EmployeeCategory = {
 	hourlyBaseMen: string;
 	hourlyVariableWomen: string;
 	hourlyVariableMen: string;
-};
-
-type SerializedRow = {
-	name: string;
-	womenCount?: number;
-	menCount?: number;
-	womenValue?: string;
-	menValue?: string;
 };
 
 const EMPTY_FIELDS = {
@@ -43,135 +38,58 @@ export function createEmptyCategory(id: number): EmployeeCategory {
 	return { id, ...EMPTY_FIELDS };
 }
 
-export function serializeCategories(
-	categories: EmployeeCategory[],
-	source: string,
-): SerializedRow[] {
-	const result: SerializedRow[] = [{ name: `meta:source:${source}` }];
-
-	for (let i = 0; i < categories.length; i++) {
-		const cat = categories[i] as EmployeeCategory;
-		const p = `cat:${i}`;
-
-		result.push({ name: `${p}:name:${cat.name}` });
-		result.push({ name: `${p}:detail:${cat.detail}` });
-		result.push({
-			name: `${p}:effectif`,
-			womenCount: cat.womenCount
-				? Number.parseInt(cat.womenCount, 10)
-				: undefined,
-			menCount: cat.menCount ? Number.parseInt(cat.menCount, 10) : undefined,
-		});
-		result.push({
-			name: `${p}:annual:base`,
-			womenValue: cat.annualBaseWomen || undefined,
-			menValue: cat.annualBaseMen || undefined,
-		});
-		result.push({
-			name: `${p}:annual:variable`,
-			womenValue: cat.annualVariableWomen || undefined,
-			menValue: cat.annualVariableMen || undefined,
-		});
-		result.push({
-			name: `${p}:hourly:base`,
-			womenValue: cat.hourlyBaseWomen || undefined,
-			menValue: cat.hourlyBaseMen || undefined,
-		});
-		result.push({
-			name: `${p}:hourly:variable`,
-			womenValue: cat.hourlyVariableWomen || undefined,
-			menValue: cat.hourlyVariableMen || undefined,
-		});
-	}
-
-	return result;
+export function fromDatabaseRows(
+	rows: EmployeeCategoryRow[],
+	nextId: () => number,
+): EmployeeCategory[] {
+	return rows.map((row) => ({
+		id: nextId(),
+		name: row.name,
+		detail: row.detail,
+		womenCount: row.womenCount?.toString() ?? "",
+		menCount: row.menCount?.toString() ?? "",
+		annualBaseWomen: row.annualBaseWomen ?? "",
+		annualBaseMen: row.annualBaseMen ?? "",
+		annualVariableWomen: row.annualVariableWomen ?? "",
+		annualVariableMen: row.annualVariableMen ?? "",
+		hourlyBaseWomen: row.hourlyBaseWomen ?? "",
+		hourlyBaseMen: row.hourlyBaseMen ?? "",
+		hourlyVariableWomen: row.hourlyVariableWomen ?? "",
+		hourlyVariableMen: row.hourlyVariableMen ?? "",
+	}));
 }
 
-export function deserializeCategories(
-	data: StepCategoryData[],
-	nextId: () => number,
-): {
-	categories: EmployeeCategory[];
-	source: string;
-} {
-	const sourceRow = data.find((d) => d.name.startsWith("meta:source:"));
-	const source = sourceRow ? sourceRow.name.replace("meta:source:", "") : "";
+function toInt(val: string): number | undefined {
+	if (!val) return undefined;
+	const n = Number.parseInt(val, 10);
+	return Number.isNaN(n) ? undefined : n;
+}
 
-	const catMap = new Map<number, EmployeeCategory>();
+function toStr(val: string): string | undefined {
+	return val || undefined;
+}
 
-	const getOrCreate = (index: number): EmployeeCategory => {
-		if (!catMap.has(index)) {
-			catMap.set(index, createEmptyCategory(nextId()));
-		}
-		return catMap.get(index) as EmployeeCategory;
+export function toSubmitData(
+	categories: EmployeeCategory[],
+	source: string,
+): EmployeeCategorySubmitData {
+	return {
+		source,
+		categories: categories.map((cat) => ({
+			name: cat.name,
+			detail: cat.detail,
+			data: {
+				womenCount: toInt(cat.womenCount),
+				menCount: toInt(cat.menCount),
+				annualBaseWomen: toStr(cat.annualBaseWomen),
+				annualBaseMen: toStr(cat.annualBaseMen),
+				annualVariableWomen: toStr(cat.annualVariableWomen),
+				annualVariableMen: toStr(cat.annualVariableMen),
+				hourlyBaseWomen: toStr(cat.hourlyBaseWomen),
+				hourlyBaseMen: toStr(cat.hourlyBaseMen),
+				hourlyVariableWomen: toStr(cat.hourlyVariableWomen),
+				hourlyVariableMen: toStr(cat.hourlyVariableMen),
+			},
+		})),
 	};
-
-	for (const row of data) {
-		const nameMatch = row.name.match(/^cat:(\d+):name:(.*)$/);
-		if (nameMatch) {
-			const index = Number.parseInt(nameMatch[1] as string, 10);
-			const cat = getOrCreate(index);
-			catMap.set(index, { ...cat, name: nameMatch[2] as string });
-			continue;
-		}
-
-		const detailMatch = row.name.match(/^cat:(\d+):detail:(.*)$/);
-		if (detailMatch) {
-			const index = Number.parseInt(detailMatch[1] as string, 10);
-			const cat = getOrCreate(index);
-			catMap.set(index, { ...cat, detail: detailMatch[2] as string });
-			continue;
-		}
-
-		const match = row.name.match(/^cat:(\d+):(.+)$/);
-		if (!match) continue;
-
-		const index = Number.parseInt(match[1] as string, 10);
-		const field = match[2] as string;
-		const cat = getOrCreate(index);
-
-		switch (field) {
-			case "effectif":
-				catMap.set(index, {
-					...cat,
-					womenCount: row.womenCount?.toString() ?? "",
-					menCount: row.menCount?.toString() ?? "",
-				});
-				break;
-			case "annual:base":
-				catMap.set(index, {
-					...cat,
-					annualBaseWomen: row.womenValue ?? "",
-					annualBaseMen: row.menValue ?? "",
-				});
-				break;
-			case "annual:variable":
-				catMap.set(index, {
-					...cat,
-					annualVariableWomen: row.womenValue ?? "",
-					annualVariableMen: row.menValue ?? "",
-				});
-				break;
-			case "hourly:base":
-				catMap.set(index, {
-					...cat,
-					hourlyBaseWomen: row.womenValue ?? "",
-					hourlyBaseMen: row.menValue ?? "",
-				});
-				break;
-			case "hourly:variable":
-				catMap.set(index, {
-					...cat,
-					hourlyVariableWomen: row.womenValue ?? "",
-					hourlyVariableMen: row.menValue ?? "",
-				});
-				break;
-		}
-	}
-
-	const categories = Array.from(catMap.entries())
-		.sort(([a], [b]) => a - b)
-		.map(([, cat]) => cat);
-
-	return { categories, source };
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/parseStep5Categories.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/parseStep5Categories.ts
@@ -1,5 +1,5 @@
 import { computeGap } from "~/modules/declaration-remuneration/shared/gapUtils";
-import type { StepCategoryData } from "~/modules/declaration-remuneration/types";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 
 export type ParsedCategory = {
 	index: number;
@@ -10,59 +10,26 @@ export type ParsedCategory = {
 	hourlyVariableGap: number | null;
 };
 
-/** Parses step 5 category data into structured gap information per category */
-export function parseStep5Categories(
-	step5Categories: StepCategoryData[],
+function gapOrNull(women: string | null, men: string | null): number | null {
+	if (!women || !men) return null;
+	return computeGap(women, men);
+}
+
+export function parseEmployeeCategories(
+	categories: EmployeeCategoryRow[],
 ): ParsedCategory[] {
-	const catIndices = new Set<number>();
-	for (const c of step5Categories) {
-		const match = c.name.match(/^cat:(\d+):/);
-		if (match) catIndices.add(Number.parseInt(match[1] as string, 10));
-	}
-
-	const result: ParsedCategory[] = [];
-	for (const idx of [...catIndices].sort((a, b) => a - b)) {
-		const nameRow = step5Categories.find((c) =>
-			c.name.startsWith(`cat:${idx}:name:`),
-		);
-		const catName =
-			nameRow?.name.replace(`cat:${idx}:name:`, "") ||
-			`Catégorie d'emplois n°${idx + 1}`;
-
-		const annualBase = step5Categories.find(
-			(c) => c.name === `cat:${idx}:annual:base`,
-		);
-		const annualVariable = step5Categories.find(
-			(c) => c.name === `cat:${idx}:annual:variable`,
-		);
-		const hourlyBase = step5Categories.find(
-			(c) => c.name === `cat:${idx}:hourly:base`,
-		);
-		const hourlyVariable = step5Categories.find(
-			(c) => c.name === `cat:${idx}:hourly:variable`,
-		);
-
-		result.push({
-			index: idx,
-			name: catName,
-			annualBaseGap:
-				annualBase?.womenValue && annualBase?.menValue
-					? computeGap(annualBase.womenValue, annualBase.menValue)
-					: null,
-			annualVariableGap:
-				annualVariable?.womenValue && annualVariable?.menValue
-					? computeGap(annualVariable.womenValue, annualVariable.menValue)
-					: null,
-			hourlyBaseGap:
-				hourlyBase?.womenValue && hourlyBase?.menValue
-					? computeGap(hourlyBase.womenValue, hourlyBase.menValue)
-					: null,
-			hourlyVariableGap:
-				hourlyVariable?.womenValue && hourlyVariable?.menValue
-					? computeGap(hourlyVariable.womenValue, hourlyVariable.menValue)
-					: null,
-		});
-	}
-
-	return result;
+	return categories.map((cat, index) => ({
+		index,
+		name: cat.name,
+		annualBaseGap: gapOrNull(cat.annualBaseWomen, cat.annualBaseMen),
+		annualVariableGap: gapOrNull(
+			cat.annualVariableWomen,
+			cat.annualVariableMen,
+		),
+		hourlyBaseGap: gapOrNull(cat.hourlyBaseWomen, cat.hourlyBaseMen),
+		hourlyVariableGap: gapOrNull(
+			cat.hourlyVariableWomen,
+			cat.hourlyVariableMen,
+		),
+	}));
 }

--- a/packages/app/src/modules/declaration-remuneration/types.ts
+++ b/packages/app/src/modules/declaration-remuneration/types.ts
@@ -28,6 +28,41 @@ export type VariablePayData = {
 	beneficiaryMen: string;
 };
 
+export type EmployeeCategoryRow = {
+	name: string;
+	detail: string;
+	womenCount: number | null;
+	menCount: number | null;
+	annualBaseWomen: string | null;
+	annualBaseMen: string | null;
+	annualVariableWomen: string | null;
+	annualVariableMen: string | null;
+	hourlyBaseWomen: string | null;
+	hourlyBaseMen: string | null;
+	hourlyVariableWomen: string | null;
+	hourlyVariableMen: string | null;
+};
+
+export type EmployeeCategorySubmitData = {
+	source: string;
+	categories: Array<{
+		name: string;
+		detail: string;
+		data: {
+			womenCount?: number;
+			menCount?: number;
+			annualBaseWomen?: string;
+			annualBaseMen?: string;
+			annualVariableWomen?: string;
+			annualVariableMen?: string;
+			hourlyBaseWomen?: string;
+			hourlyBaseMen?: string;
+			hourlyVariableWomen?: string;
+			hourlyVariableMen?: string;
+		};
+	}>;
+};
+
 export const DEFAULT_CATEGORIES = [
 	"Ouvriers",
 	"Employés",

--- a/packages/app/src/modules/declarationPdf/__tests__/DeclarationPdfDocument.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/DeclarationPdfDocument.test.tsx
@@ -162,12 +162,17 @@ const declarationPdfData: DeclarationPdfData = {
 	step5Categories: [
 		{
 			name: "Ingénieurs",
+			detail: "",
 			womenCount: 5,
 			menCount: 8,
-			womenValue: "55000",
-			menValue: "58000",
-			womenMedianValue: undefined,
-			menMedianValue: undefined,
+			annualBaseWomen: "55000",
+			annualBaseMen: "58000",
+			annualVariableWomen: null,
+			annualVariableMen: null,
+			hourlyBaseWomen: null,
+			hourlyBaseMen: null,
+			hourlyVariableWomen: null,
+			hourlyVariableMen: null,
 		},
 	],
 };

--- a/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
@@ -29,6 +29,16 @@ vi.mock("~/server/db/schema", () => ({
 		$inferSelect: {},
 	},
 	companies: { siren: "siren" },
+	jobCategories: { declarationId: "declarationId" },
+	employeeCategories: { jobCategoryId: "jobCategoryId" },
+}));
+
+vi.mock("~/server/api/routers/declarationHelpers", () => ({
+	mapToEmployeeCategoryRows: (
+		_jobs: unknown[],
+		_empCats: unknown[],
+		_type: string,
+	) => [],
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -64,8 +74,10 @@ describe("buildPdfData", () => {
 
 	it("returns transformed data for a submitted declaration", async () => {
 		resetMocks();
+		// Query 1: declarations
 		queryResults.push([
 			{
+				id: "decl-uuid",
 				siren: "123456789",
 				year: 2026,
 				status: "submitted",
@@ -73,7 +85,9 @@ describe("buildPdfData", () => {
 				totalMen: 60,
 			},
 		]);
+		// Query 2: companies
 		queryResults.push([{ siren: "123456789", name: "Acme Corp" }]);
+		// Query 3: declarationCategories (steps 1-4 only, step 5 from new tables)
 		queryResults.push([
 			{
 				step: 1,
@@ -125,17 +139,9 @@ describe("buildPdfData", () => {
 				womenMedianValue: null,
 				menMedianValue: null,
 			},
-			{
-				step: 5,
-				categoryName: "cat:0:name:Ingénieurs",
-				womenCount: 5,
-				menCount: 8,
-				womenValue: "55000",
-				menValue: "58000",
-				womenMedianValue: null,
-				menMedianValue: null,
-			},
 		]);
+		// Query 4: jobCategories (empty — mapToEmployeeCategoryRows is mocked)
+		queryResults.push([]);
 
 		const { buildPdfData } = await import("../buildPdfData");
 		const result = await buildPdfData(
@@ -185,14 +191,16 @@ describe("buildPdfData", () => {
 			},
 		]);
 
-		expect(result.step5Categories).toHaveLength(1);
-		expect(result.step5Categories[0]?.name).toBe("cat:0:name:Ingénieurs");
+		// step5Categories comes from mapToEmployeeCategoryRows mock (returns [])
+		expect(result.step5Categories).toEqual([]);
 	});
 
 	it("falls back to default company name when company not found", async () => {
 		resetMocks();
+		// Query 1: declarations
 		queryResults.push([
 			{
+				id: "decl-uuid-2",
 				siren: "999999999",
 				year: 2026,
 				status: "submitted",
@@ -200,7 +208,11 @@ describe("buildPdfData", () => {
 				totalMen: null,
 			},
 		]);
+		// Query 2: companies (not found)
 		queryResults.push([]);
+		// Query 3: declarationCategories (empty)
+		queryResults.push([]);
+		// Query 4: jobCategories (empty)
 		queryResults.push([]);
 
 		const { buildPdfData } = await import("../buildPdfData");

--- a/packages/app/src/modules/declarationPdf/buildPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildPdfData.ts
@@ -2,11 +2,14 @@ import "server-only";
 
 import { and, eq } from "drizzle-orm";
 import type { StepCategoryData } from "~/modules/declaration-remuneration";
+import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
 import { db } from "~/server/db";
 import {
 	companies,
 	declarationCategories,
 	declarations,
+	employeeCategories,
+	jobCategories,
 } from "~/server/db/schema";
 
 import type { DeclarationPdfData } from "./types";
@@ -65,6 +68,25 @@ export async function buildPdfData(
 			),
 		);
 
+	const jobs = await db
+		.select()
+		.from(jobCategories)
+		.where(eq(jobCategories.declarationId, declaration.id));
+
+	const jobIds = jobs.map((j) => j.id);
+	let empCats: (typeof employeeCategories.$inferSelect)[] = [];
+	if (jobIds.length > 0) {
+		const results = await Promise.all(
+			jobIds.map((id) =>
+				db
+					.select()
+					.from(employeeCategories)
+					.where(eq(employeeCategories.jobCategoryId, id)),
+			),
+		);
+		empCats = results.flat();
+	}
+
 	const step1Categories = categories
 		.filter((c) => c.step === 1)
 		.map((c) => ({
@@ -97,7 +119,7 @@ export async function buildPdfData(
 	};
 
 	const step4Categories = mapStepCategories(categories, 4);
-	const step5Categories = mapStepCategories(categories, 5);
+	const step5Categories = mapToEmployeeCategoryRows(jobs, empCats, "initial");
 
 	return {
 		companyName: company?.name ?? `Entreprise ${siren}`,

--- a/packages/app/src/modules/declarationPdf/sections/CategorySection.tsx
+++ b/packages/app/src/modules/declarationPdf/sections/CategorySection.tsx
@@ -2,7 +2,7 @@ import { Text, View } from "@react-pdf/renderer";
 
 import {
 	formatCurrency,
-	parseStep5Categories,
+	parseEmployeeCategories,
 } from "~/modules/declaration-remuneration";
 
 import { styles } from "../pdfStyles";
@@ -10,10 +10,7 @@ import type { DeclarationPdfData } from "../types";
 import { GapCell } from "./GapCell";
 
 export function CategorySection({ data }: { data: DeclarationPdfData }) {
-	const parsed = parseStep5Categories(data.step5Categories);
-
-	const findCatValue = (idx: number, suffix: string) =>
-		data.step5Categories.find((c) => c.name === `cat:${idx}:${suffix}`);
+	const parsed = parseEmployeeCategories(data.step5Categories);
 
 	return (
 		<View style={styles.card}>
@@ -22,18 +19,14 @@ export function CategorySection({ data }: { data: DeclarationPdfData }) {
 			</Text>
 			{parsed.length > 0 ? (
 				parsed.map((cat) => {
-					const annualBase = findCatValue(cat.index, "annual:base");
-					const annualVar = findCatValue(cat.index, "annual:variable");
-					const hourlyBase = findCatValue(cat.index, "hourly:base");
-					const hourlyVar = findCatValue(cat.index, "hourly:variable");
-					const effectif = findCatValue(cat.index, "effectif");
+					const row = data.step5Categories[cat.index];
 
 					return (
 						<View key={cat.index} style={styles.categoryBlock}>
 							<Text style={styles.sectionLabel}>
 								{cat.name}
-								{effectif
-									? ` (${effectif.womenCount ?? 0} F / ${effectif.menCount ?? 0} H)`
+								{row
+									? ` (${row.womenCount ?? 0} F / ${row.menCount ?? 0} H)`
 									: ""}
 							</Text>
 							<View style={styles.tableHeader}>
@@ -55,20 +48,20 @@ export function CategorySection({ data }: { data: DeclarationPdfData }) {
 									Salaire de base (annuel)
 								</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(annualBase?.womenValue)}
+									{formatCurrency(row?.annualBaseWomen)}
 								</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(annualBase?.menValue)}
+									{formatCurrency(row?.annualBaseMen)}
 								</Text>
 								<GapCell gap={cat.annualBaseGap} />
 							</View>
 							<View style={styles.tableRow}>
 								<Text style={styles.tableCellLabel}>Variables (annuel)</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(annualVar?.womenValue)}
+									{formatCurrency(row?.annualVariableWomen)}
 								</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(annualVar?.menValue)}
+									{formatCurrency(row?.annualVariableMen)}
 								</Text>
 								<GapCell gap={cat.annualVariableGap} />
 							</View>
@@ -77,20 +70,20 @@ export function CategorySection({ data }: { data: DeclarationPdfData }) {
 									Salaire de base (horaire)
 								</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(hourlyBase?.womenValue)}
+									{formatCurrency(row?.hourlyBaseWomen)}
 								</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(hourlyBase?.menValue)}
+									{formatCurrency(row?.hourlyBaseMen)}
 								</Text>
 								<GapCell gap={cat.hourlyBaseGap} />
 							</View>
 							<View style={styles.tableRow}>
 								<Text style={styles.tableCellLabel}>Variables (horaire)</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(hourlyVar?.womenValue)}
+									{formatCurrency(row?.hourlyVariableWomen)}
 								</Text>
 								<Text style={styles.tableCellValue}>
-									{formatCurrency(hourlyVar?.menValue)}
+									{formatCurrency(row?.hourlyVariableMen)}
 								</Text>
 								<GapCell gap={cat.hourlyVariableGap} />
 							</View>

--- a/packages/app/src/modules/declarationPdf/types.ts
+++ b/packages/app/src/modules/declarationPdf/types.ts
@@ -1,5 +1,6 @@
 import type {
 	CategoryData,
+	EmployeeCategoryRow,
 	PayGapRow,
 	StepCategoryData,
 	VariablePayData,
@@ -16,5 +17,5 @@ export type DeclarationPdfData = {
 	step2Rows: PayGapRow[];
 	step3Data: VariablePayData;
 	step4Categories: StepCategoryData[];
-	step5Categories: StepCategoryData[];
+	step5Categories: EmployeeCategoryRow[];
 };

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -4,7 +4,22 @@ import { z } from "zod";
 
 import { COMPLIANCE_PATHS } from "~/modules/declaration-remuneration/steps/compliancePath/constants";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
-import { declarationCategories, declarations } from "~/server/db/schema";
+import {
+	declarationCategories,
+	declarations,
+	employeeCategories,
+	jobCategories,
+} from "~/server/db/schema";
+import {
+	buildEmployeeCategoryValues,
+	deleteJobAndEmployeeCategories,
+	fetchAllCategories,
+} from "./declarationHelpers";
+import {
+	updateEmployeeCategoriesSchema,
+	updateStep1Schema,
+	updateStepCategoriesSchema,
+} from "./schemas";
 
 function getSiren(siret: string | null | undefined): string {
 	if (!siret) {
@@ -33,22 +48,16 @@ export const declarationRouter = createTRPCRouter({
 				.limit(1);
 
 			if (existing.length > 0) {
-				const categories = await tx
-					.select()
-					.from(declarationCategories)
-					.where(
-						and(
-							eq(declarationCategories.siren, siren),
-							eq(declarationCategories.year, year),
-						),
-					);
 				const declaration = existing[0];
 				if (!declaration)
 					throw new TRPCError({
 						code: "NOT_FOUND",
 						message: "Declaration introuvable",
 					});
-				return { declaration, categories };
+				return {
+					declaration,
+					...(await fetchAllCategories(tx, siren, year, declaration.id)),
+				};
 			}
 
 			const newDeclaration = await tx
@@ -78,16 +87,10 @@ export const declarationRouter = createTRPCRouter({
 						code: "INTERNAL_SERVER_ERROR",
 						message: "Erreur lors de la création",
 					});
-				const categories = await tx
-					.select()
-					.from(declarationCategories)
-					.where(
-						and(
-							eq(declarationCategories.siren, siren),
-							eq(declarationCategories.year, year),
-						),
-					);
-				return { declaration, categories };
+				return {
+					declaration,
+					...(await fetchAllCategories(tx, siren, year, declaration.id)),
+				};
 			}
 
 			const declaration = newDeclaration[0];
@@ -96,22 +99,17 @@ export const declarationRouter = createTRPCRouter({
 					code: "INTERNAL_SERVER_ERROR",
 					message: "Erreur lors de la création",
 				});
-			return { declaration, categories: [] };
+			return {
+				declaration,
+				categories: [],
+				jobCategories: [],
+				employeeCategories: [],
+			};
 		});
 	}),
 
 	updateStep1: protectedProcedure
-		.input(
-			z.object({
-				categories: z.array(
-					z.object({
-						name: z.string(),
-						women: z.number().int().min(0),
-						men: z.number().int().min(0),
-					}),
-				),
-			}),
-		)
+		.input(updateStep1Schema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = getSiren(ctx.session.user.siret);
 			const year = getCurrentYear();
@@ -120,7 +118,6 @@ export const declarationRouter = createTRPCRouter({
 			const totalMen = input.categories.reduce((sum, c) => sum + c.men, 0);
 
 			await ctx.db.transaction(async (tx) => {
-				// Check if step 1 data changed → reset subsequent steps
 				const existing = await tx
 					.select()
 					.from(declarations)
@@ -134,7 +131,6 @@ export const declarationRouter = createTRPCRouter({
 					existing[0]?.totalMen !== totalMen;
 
 				if (hasChanged) {
-					// Delete categories for steps 2-5
 					await tx
 						.delete(declarationCategories)
 						.where(
@@ -143,9 +139,13 @@ export const declarationRouter = createTRPCRouter({
 								eq(declarationCategories.year, year),
 							),
 						);
+
+					const declarationId = existing[0]?.id;
+					if (declarationId) {
+						await deleteJobAndEmployeeCategories(tx, declarationId);
+					}
 				}
 
-				// Update declaration
 				await tx
 					.update(declarations)
 					.set({
@@ -195,22 +195,7 @@ export const declarationRouter = createTRPCRouter({
 		}),
 
 	updateStepCategories: protectedProcedure
-		.input(
-			z.object({
-				step: z.number().int().min(2).max(5),
-				categories: z.array(
-					z.object({
-						name: z.string(),
-						womenCount: z.number().int().min(0).optional(),
-						menCount: z.number().int().min(0).optional(),
-						womenValue: z.string().optional(),
-						menValue: z.string().optional(),
-						womenMedianValue: z.string().optional(),
-						menMedianValue: z.string().optional(),
-					}),
-				),
-			}),
-		)
+		.input(updateStepCategoriesSchema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = getSiren(ctx.session.user.siret);
 			const year = getCurrentYear();
@@ -258,6 +243,115 @@ export const declarationRouter = createTRPCRouter({
 
 			return { success: true };
 		}),
+
+	updateEmployeeCategories: protectedProcedure
+		.input(updateEmployeeCategoriesSchema)
+		.mutation(async ({ ctx, input }) => {
+			const siren = getSiren(ctx.session.user.siret);
+			const year = getCurrentYear();
+
+			await ctx.db.transaction(async (tx) => {
+				const [declaration] = await tx
+					.select()
+					.from(declarations)
+					.where(
+						and(eq(declarations.siren, siren), eq(declarations.year, year)),
+					)
+					.limit(1);
+
+				if (!declaration)
+					throw new TRPCError({
+						code: "NOT_FOUND",
+						message: "Déclaration introuvable",
+					});
+
+				// Check existing job categories
+				const existingJobs = await tx
+					.select()
+					.from(jobCategories)
+					.where(eq(jobCategories.declarationId, declaration.id));
+
+				if (input.declarationType === "initial") {
+					// For initial: recreate job categories + employee data
+					await deleteJobAndEmployeeCategories(tx, declaration.id);
+
+					for (let i = 0; i < input.categories.length; i++) {
+						const cat = input.categories[i];
+						if (!cat) continue;
+						const [job] = await tx
+							.insert(jobCategories)
+							.values({
+								declarationId: declaration.id,
+								categoryIndex: i,
+								name: cat.name,
+								detail: cat.detail || null,
+								source: input.source,
+							})
+							.returning();
+						if (!job) continue;
+
+						await tx
+							.insert(employeeCategories)
+							.values(buildEmployeeCategoryValues(job.id, "initial", cat.data));
+					}
+
+					await tx
+						.update(declarations)
+						.set({ currentStep: 5, updatedAt: new Date() })
+						.where(eq(declarations.id, declaration.id));
+				} else {
+					// For correction: reuse existing job categories, upsert employee data
+					for (const job of existingJobs) {
+						const cat = input.categories[job.categoryIndex];
+						if (!cat) continue;
+
+						await tx
+							.delete(employeeCategories)
+							.where(
+								and(
+									eq(employeeCategories.jobCategoryId, job.id),
+									eq(employeeCategories.declarationType, "correction"),
+								),
+							);
+
+						await tx
+							.insert(employeeCategories)
+							.values(
+								buildEmployeeCategoryValues(job.id, "correction", cat.data),
+							);
+					}
+
+					await tx
+						.update(declarations)
+						.set({
+							secondDeclarationStep: 2,
+							secondDeclReferencePeriodStart:
+								input.referencePeriodStart ?? null,
+							secondDeclReferencePeriodEnd: input.referencePeriodEnd ?? null,
+							updatedAt: new Date(),
+						})
+						.where(eq(declarations.id, declaration.id));
+				}
+			});
+
+			return { success: true };
+		}),
+
+	submitSecondDeclaration: protectedProcedure.mutation(async ({ ctx }) => {
+		const siren = getSiren(ctx.session.user.siret);
+		const year = getCurrentYear();
+
+		await ctx.db
+			.update(declarations)
+			.set({
+				secondDeclarationStatus: "submitted",
+				secondDeclarationStep: 3,
+				updatedAt: new Date(),
+			})
+			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+
+		return { success: true };
+	}),
 
 	submit: protectedProcedure.mutation(async ({ ctx }) => {
 		const siren = getSiren(ctx.session.user.siret);

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -1,0 +1,140 @@
+import { and, eq } from "drizzle-orm";
+
+import {
+	declarationCategories,
+	employeeCategories,
+	jobCategories,
+} from "~/server/db/schema";
+
+export type Tx = Parameters<
+	Parameters<import("~/server/db").DB["transaction"]>[0]
+>[0];
+
+type EmployeeCategoryData = {
+	womenCount?: number;
+	menCount?: number;
+	annualBaseWomen?: string;
+	annualBaseMen?: string;
+	annualVariableWomen?: string;
+	annualVariableMen?: string;
+	hourlyBaseWomen?: string;
+	hourlyBaseMen?: string;
+	hourlyVariableWomen?: string;
+	hourlyVariableMen?: string;
+};
+
+export function buildEmployeeCategoryValues(
+	jobCategoryId: string,
+	declarationType: "initial" | "correction",
+	data: EmployeeCategoryData,
+) {
+	return {
+		jobCategoryId,
+		declarationType: declarationType as typeof declarationType,
+		womenCount: data.womenCount ?? null,
+		menCount: data.menCount ?? null,
+		annualBaseWomen: data.annualBaseWomen ?? null,
+		annualBaseMen: data.annualBaseMen ?? null,
+		annualVariableWomen: data.annualVariableWomen ?? null,
+		annualVariableMen: data.annualVariableMen ?? null,
+		hourlyBaseWomen: data.hourlyBaseWomen ?? null,
+		hourlyBaseMen: data.hourlyBaseMen ?? null,
+		hourlyVariableWomen: data.hourlyVariableWomen ?? null,
+		hourlyVariableMen: data.hourlyVariableMen ?? null,
+	};
+}
+
+export async function deleteJobAndEmployeeCategories(
+	tx: Tx,
+	declarationId: string,
+) {
+	const jobs = await tx
+		.select({ id: jobCategories.id })
+		.from(jobCategories)
+		.where(eq(jobCategories.declarationId, declarationId));
+	for (const job of jobs) {
+		await tx
+			.delete(employeeCategories)
+			.where(eq(employeeCategories.jobCategoryId, job.id));
+	}
+	if (jobs.length > 0) {
+		await tx
+			.delete(jobCategories)
+			.where(eq(jobCategories.declarationId, declarationId));
+	}
+}
+
+export async function fetchAllCategories(
+	tx: Tx,
+	siren: string,
+	year: number,
+	declarationId: string,
+) {
+	const [categories, jobs] = await Promise.all([
+		tx
+			.select()
+			.from(declarationCategories)
+			.where(
+				and(
+					eq(declarationCategories.siren, siren),
+					eq(declarationCategories.year, year),
+				),
+			),
+		tx
+			.select()
+			.from(jobCategories)
+			.where(eq(jobCategories.declarationId, declarationId)),
+	]);
+
+	const jobIds = jobs.map((j) => j.id);
+	let empCategories: (typeof employeeCategories.$inferSelect)[] = [];
+	if (jobIds.length > 0) {
+		const results = await Promise.all(
+			jobIds.map((id) =>
+				tx
+					.select()
+					.from(employeeCategories)
+					.where(eq(employeeCategories.jobCategoryId, id)),
+			),
+		);
+		empCategories = results.flat();
+	}
+
+	return {
+		categories,
+		jobCategories: jobs,
+		employeeCategories: empCategories,
+	};
+}
+
+type JobCategoryRow = typeof jobCategories.$inferSelect;
+type EmployeeCategoryDbRow = typeof employeeCategories.$inferSelect;
+
+export function mapToEmployeeCategoryRows(
+	jobs: JobCategoryRow[],
+	empCats: EmployeeCategoryDbRow[],
+	declarationType: "initial" | "correction",
+) {
+	return jobs
+		.sort((a, b) => a.categoryIndex - b.categoryIndex)
+		.map((job) => {
+			const emp = empCats.find(
+				(e) =>
+					e.jobCategoryId === job.id && e.declarationType === declarationType,
+			);
+			return {
+				name: job.name,
+				detail: job.detail ?? "",
+				womenCount: emp?.womenCount ?? null,
+				menCount: emp?.menCount ?? null,
+				annualBaseWomen: emp?.annualBaseWomen ?? null,
+				annualBaseMen: emp?.annualBaseMen ?? null,
+				annualVariableWomen: emp?.annualVariableWomen ?? null,
+				annualVariableMen: emp?.annualVariableMen ?? null,
+				hourlyBaseWomen: emp?.hourlyBaseWomen ?? null,
+				hourlyBaseMen: emp?.hourlyBaseMen ?? null,
+				hourlyVariableWomen: emp?.hourlyVariableWomen ?? null,
+				hourlyVariableMen: emp?.hourlyVariableMen ?? null,
+			};
+		});
+}

--- a/packages/app/src/server/api/routers/schemas.ts
+++ b/packages/app/src/server/api/routers/schemas.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const updateStep1Schema = z.object({
+	categories: z.array(
+		z.object({
+			name: z.string(),
+			women: z.number().int().min(0),
+			men: z.number().int().min(0),
+		}),
+	),
+});
+
+export const updateStepCategoriesSchema = z.object({
+	step: z.number().int().min(2).max(4),
+	categories: z.array(
+		z.object({
+			name: z.string(),
+			womenCount: z.number().int().min(0).optional(),
+			menCount: z.number().int().min(0).optional(),
+			womenValue: z.string().optional(),
+			menValue: z.string().optional(),
+			womenMedianValue: z.string().optional(),
+			menMedianValue: z.string().optional(),
+		}),
+	),
+});
+
+const employeeCategoryDataSchema = z.object({
+	womenCount: z.number().int().min(0).optional(),
+	menCount: z.number().int().min(0).optional(),
+	annualBaseWomen: z.string().optional(),
+	annualBaseMen: z.string().optional(),
+	annualVariableWomen: z.string().optional(),
+	annualVariableMen: z.string().optional(),
+	hourlyBaseWomen: z.string().optional(),
+	hourlyBaseMen: z.string().optional(),
+	hourlyVariableWomen: z.string().optional(),
+	hourlyVariableMen: z.string().optional(),
+});
+
+export const updateEmployeeCategoriesSchema = z.object({
+	declarationType: z.enum(["initial", "correction"]),
+	source: z.string().min(1),
+	categories: z.array(
+		z.object({
+			name: z.string().min(1),
+			detail: z.string(),
+			data: employeeCategoryDataSchema,
+		}),
+	),
+	referencePeriodStart: z.string().optional(),
+	referencePeriodEnd: z.string().optional(),
+});

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -1,5 +1,11 @@
 import { relations } from "drizzle-orm";
-import { index, pgTableCreator, primaryKey, unique } from "drizzle-orm/pg-core";
+import {
+	index,
+	pgEnum,
+	pgTableCreator,
+	primaryKey,
+	unique,
+} from "drizzle-orm/pg-core";
 import type { AdapterAccount } from "next-auth/adapters";
 
 /**
@@ -89,6 +95,11 @@ export const verificationTokens = createTable(
 export const declarations = createTable(
 	"declaration",
 	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
 		siren: d.varchar({ length: 9 }).notNull(),
 		year: d.integer().notNull(),
 		declarantId: d
@@ -104,11 +115,15 @@ export const declarations = createTable(
 		compliancePath: d.varchar({ length: 30 }),
 		currentStep: d.integer().default(0),
 		status: d.varchar({ length: 20 }).default("draft"),
+		secondDeclarationStep: d.integer(),
+		secondDeclarationStatus: d.varchar({ length: 20 }),
+		secondDeclReferencePeriodStart: d.varchar({ length: 10 }),
+		secondDeclReferencePeriodEnd: d.varchar({ length: 10 }),
 		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 	}),
 	(t) => [
-		primaryKey({ columns: [t.siren, t.year] }),
+		unique("declaration_siren_year_idx").on(t.siren, t.year),
 		index("declaration_declarant_idx").on(t.declarantId),
 	],
 );
@@ -120,7 +135,12 @@ export const declarationsRelations = relations(
 			fields: [declarations.declarantId],
 			references: [users.id],
 		}),
+		company: one(companies, {
+			fields: [declarations.siren],
+			references: [companies.siren],
+		}),
 		categories: many(declarationCategories),
+		jobCategories: many(jobCategories),
 	}),
 );
 
@@ -157,6 +177,95 @@ export const declarationCategoriesRelations = relations(
 		}),
 	}),
 );
+
+// ── Employee category tables (indicator G) ─────────────────────────
+
+export const declarationTypeEnum = pgEnum("declaration_type", [
+	"initial",
+	"correction",
+]);
+
+export const jobCategories = createTable(
+	"job_category",
+	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		declarationId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => declarations.id),
+		categoryIndex: d.integer().notNull(),
+		name: d.varchar({ length: 255 }).notNull(),
+		detail: d.varchar({ length: 500 }),
+		source: d.varchar({ length: 50 }).notNull(),
+	}),
+	(t) => [
+		unique("job_category_declaration_index_idx").on(
+			t.declarationId,
+			t.categoryIndex,
+		),
+	],
+);
+
+export const jobCategoriesRelations = relations(
+	jobCategories,
+	({ one, many }) => ({
+		declaration: one(declarations, {
+			fields: [jobCategories.declarationId],
+			references: [declarations.id],
+		}),
+		employeeCategories: many(employeeCategories),
+	}),
+);
+
+export const employeeCategories = createTable(
+	"employee_category",
+	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		jobCategoryId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => jobCategories.id),
+		declarationType: declarationTypeEnum().notNull(),
+		womenCount: d.integer(),
+		menCount: d.integer(),
+		annualBaseWomen: d.numeric(),
+		annualBaseMen: d.numeric(),
+		annualVariableWomen: d.numeric(),
+		annualVariableMen: d.numeric(),
+		hourlyBaseWomen: d.numeric(),
+		hourlyBaseMen: d.numeric(),
+		hourlyVariableWomen: d.numeric(),
+		hourlyVariableMen: d.numeric(),
+		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+	}),
+	(t) => [
+		unique("employee_category_job_type_idx").on(
+			t.jobCategoryId,
+			t.declarationType,
+		),
+	],
+);
+
+export const employeeCategoriesRelations = relations(
+	employeeCategories,
+	({ one }) => ({
+		jobCategory: one(jobCategories, {
+			fields: [employeeCategories.jobCategoryId],
+			references: [jobCategories.id],
+		}),
+	}),
+);
+
+// ── Company tables ─────────────────────────────────────────────────
 
 export const companies = createTable("company", (d) => ({
 	siren: d.varchar({ length: 9 }).notNull().primaryKey(),


### PR DESCRIPTION
## Summary

- **3 écrans pour le parcours de mise en conformité** (indicateur par catégorie de salariés) :
  - Étape 1 : page informative sur les actions correctives
  - Étape 2 : formulaire catégories pré-rempli depuis la 1ère déclaration (nom/détail en lecture seule)
  - Étape 3 : récapitulatif avec badges d'écart + checkbox de certification
- **Extraction de `CategoryForm`** : composant partagé entre `Step5EmployeeCategories` et `SecondDeclarationStep2Form` (suppression de ~300 lignes de duplication)
- **`CategoryDataTable`** : ajout de `GapBadge` dans la colonne écart, suppression du calcul d'écart sur la ligne effectifs, fusion des lignes Total
- **Front-end only** : pas de mutation tRPC ni de migration DB (à venir dans une PR suivante)