### PR TITLE
feat(compliance): implement full compliance path flow

### DIFF
--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -58,7 +58,7 @@ check_pattern '\.(tsx|jsx)$' \
 check_pattern '\.(ts|tsx)$' \
   'process\.env' \
   'Direct process.env is forbidden. Use: import { env } from "~/env.js".' \
-  '(env\.js|instrumentation(-client)?\.ts|next\.config|trpc/react\.tsx|sentry\.(client|server|edge)\.config\.ts|global-setup\.ts|playwright\.config|drizzle\.config|migrate\.mjs)'
+  '(env\.js|instrumentation(-client)?\.ts|next\.config|trpc/react\.tsx|sentry\.(client|server|edge)\.config\.ts|global-setup\.ts|playwright\.config|drizzle\.config|migrate\.mjs|e2e/helpers/)'
 
 # Deep relative imports — use ~/ path alias
 check_pattern '\.(ts|tsx)$' \

--- a/packages/app/drizzle/0008_powerful_omega_flight.sql
+++ b/packages/app/drizzle/0008_powerful_omega_flight.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "app_joint_evaluation_file" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"siren" varchar(9) NOT NULL,
+	"year" integer NOT NULL,
+	"file_name" varchar(255) NOT NULL,
+	"file_path" varchar(500) NOT NULL,
+	"declarant_id" varchar(255) NOT NULL,
+	"uploaded_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "app_joint_evaluation_file" ADD CONSTRAINT "app_joint_evaluation_file_siren_app_company_siren_fk" FOREIGN KEY ("siren") REFERENCES "public"."app_company"("siren") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_joint_evaluation_file" ADD CONSTRAINT "app_joint_evaluation_file_declarant_id_app_user_id_fk" FOREIGN KEY ("declarant_id") REFERENCES "public"."app_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "joint_eval_file_siren_year_idx" ON "app_joint_evaluation_file" USING btree ("siren","year");

--- a/packages/app/drizzle/0009_hot_vector.sql
+++ b/packages/app/drizzle/0009_hot_vector.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_declaration" ADD COLUMN "compliance_completed_at" timestamp with time zone;

--- a/packages/app/drizzle/meta/0008_snapshot.json
+++ b/packages/app/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1259 @@
+{
+	"id": "00bacf79-9c67-43ca-a743-c927b966a752",
+	"prevId": "b15a568f-2e3e-4e11-b04f-6fd1d1324289",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_account": {
+			"name": "app_account",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_account_id": {
+					"name": "provider_account_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"session_state": {
+					"name": "session_state",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"account_user_id_idx": {
+					"name": "account_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_account_user_id_app_user_id_fk": {
+					"name": "app_account_user_id_app_user_id_fk",
+					"tableFrom": "app_account",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_account_provider_provider_account_id_pk": {
+					"name": "app_account_provider_provider_account_id_pk",
+					"columns": ["provider", "provider_account_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file_link": {
+			"name": "app_cse_opinion_file_link",
+			"schema": "",
+			"columns": {
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"opinion_id": {
+					"name": "opinion_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk": {
+					"name": "app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk": {
+					"name": "app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion",
+					"columnsFrom": ["opinion_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_cse_opinion_file_link_file_id_opinion_id_pk": {
+					"name": "app_cse_opinion_file_link_file_id_opinion_id_pk",
+					"columns": ["file_id", "opinion_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_siren_year_idx": {
+					"name": "cse_opinion_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_file_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_siren_year_idx": {
+					"name": "cse_opinion_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_siren_year_decl_type_idx": {
+					"name": "cse_opinion_siren_year_decl_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_category": {
+			"name": "app_declaration_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"step": {
+					"name": "step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_name": {
+					"name": "category_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_value": {
+					"name": "women_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_value": {
+					"name": "men_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_median_value": {
+					"name": "women_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_median_value": {
+					"name": "men_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_cat_siren_year_step_idx": {
+					"name": "declaration_cat_siren_year_step_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "step",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_path": {
+					"name": "compliance_path",
+					"type": "varchar(30)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_status": {
+					"name": "second_declaration_status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"declaration_siren_year_idx": {
+					"name": "declaration_siren_year_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"detail": {
+					"name": "detail",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_joint_evaluation_file": {
+			"name": "app_joint_evaluation_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"joint_eval_file_siren_year_idx": {
+					"name": "joint_eval_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_joint_evaluation_file_siren_app_company_siren_fk": {
+					"name": "app_joint_evaluation_file_siren_app_company_siren_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_joint_evaluation_file_declarant_id_app_user_id_fk": {
+					"name": "app_joint_evaluation_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_session": {
+			"name": "app_session",
+			"schema": "",
+			"columns": {
+				"session_token": {
+					"name": "session_token",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"t_user_id_idx": {
+					"name": "t_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_session_user_id_app_user_id_fk": {
+					"name": "app_session_user_id_app_user_id_fk",
+					"tableFrom": "app_session",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siret": {
+					"name": "siret",
+					"type": "varchar(14)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_verification_token": {
+			"name": "app_verification_token",
+			"schema": "",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"app_verification_token_identifier_token_pk": {
+					"name": "app_verification_token_identifier_token_pk",
+					"columns": ["identifier", "token"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/app/drizzle/meta/0009_snapshot.json
+++ b/packages/app/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1265 @@
+{
+	"id": "f3bba16b-2079-4b93-8540-6f1db0830a14",
+	"prevId": "00bacf79-9c67-43ca-a743-c927b966a752",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_account": {
+			"name": "app_account",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_account_id": {
+					"name": "provider_account_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"session_state": {
+					"name": "session_state",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"account_user_id_idx": {
+					"name": "account_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_account_user_id_app_user_id_fk": {
+					"name": "app_account_user_id_app_user_id_fk",
+					"tableFrom": "app_account",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_account_provider_provider_account_id_pk": {
+					"name": "app_account_provider_provider_account_id_pk",
+					"columns": ["provider", "provider_account_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file_link": {
+			"name": "app_cse_opinion_file_link",
+			"schema": "",
+			"columns": {
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"opinion_id": {
+					"name": "opinion_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk": {
+					"name": "app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk": {
+					"name": "app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion",
+					"columnsFrom": ["opinion_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_cse_opinion_file_link_file_id_opinion_id_pk": {
+					"name": "app_cse_opinion_file_link_file_id_opinion_id_pk",
+					"columns": ["file_id", "opinion_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_siren_year_idx": {
+					"name": "cse_opinion_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_file_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_siren_year_idx": {
+					"name": "cse_opinion_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_siren_year_decl_type_idx": {
+					"name": "cse_opinion_siren_year_decl_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_category": {
+			"name": "app_declaration_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"step": {
+					"name": "step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_name": {
+					"name": "category_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_value": {
+					"name": "women_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_value": {
+					"name": "men_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_median_value": {
+					"name": "women_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_median_value": {
+					"name": "men_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_cat_siren_year_step_idx": {
+					"name": "declaration_cat_siren_year_step_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "step",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_path": {
+					"name": "compliance_path",
+					"type": "varchar(30)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_status": {
+					"name": "second_declaration_status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_completed_at": {
+					"name": "compliance_completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"declaration_siren_year_idx": {
+					"name": "declaration_siren_year_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"detail": {
+					"name": "detail",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_joint_evaluation_file": {
+			"name": "app_joint_evaluation_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"joint_eval_file_siren_year_idx": {
+					"name": "joint_eval_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_joint_evaluation_file_siren_app_company_siren_fk": {
+					"name": "app_joint_evaluation_file_siren_app_company_siren_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_joint_evaluation_file_declarant_id_app_user_id_fk": {
+					"name": "app_joint_evaluation_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_session": {
+			"name": "app_session",
+			"schema": "",
+			"columns": {
+				"session_token": {
+					"name": "session_token",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"t_user_id_idx": {
+					"name": "t_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_session_user_id_app_user_id_fk": {
+					"name": "app_session_user_id_app_user_id_fk",
+					"tableFrom": "app_session",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siret": {
+					"name": "siret",
+					"type": "varchar(14)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_verification_token": {
+			"name": "app_verification_token",
+			"schema": "",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"app_verification_token_identifier_token_pk": {
+					"name": "app_verification_token_identifier_token_pk",
+					"columns": ["identifier", "token"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -57,6 +57,20 @@
 			"when": 1773158962249,
 			"tag": "0007_gigantic_doctor_faustus",
 			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1773328599101,
+			"tag": "0008_powerful_omega_flight",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1773331852632,
+			"tag": "0009_hot_vector",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -21,21 +21,29 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 	}
 
 	if (step === 1) {
-		const [session, { opinions }] = await Promise.all([
+		const [session, { opinions }, declarationData] = await Promise.all([
 			auth(),
 			api.cseOpinion.get(),
+			api.declaration.getOrCreate(),
 		]);
 		const initialData = mapOpinionsFromDb(opinions);
+		const hasSecondDeclaration =
+			declarationData.declaration.secondDeclarationStatus === "submitted";
 		return (
 			<Step1Opinions
+				compliancePath={declarationData.declaration.compliancePath}
 				email={session?.user?.email ?? undefined}
+				hasSecondDeclaration={hasSecondDeclaration}
 				initialData={initialData}
 			/>
 		);
 	}
 
 	if (step === 2) {
-		return <Step2Upload />;
+		const declarationData = await api.declaration.getOrCreate();
+		const hasSecondDeclaration =
+			declarationData.declaration.secondDeclarationStatus === "submitted";
+		return <Step2Upload hasSecondDeclaration={hasSecondDeclaration} />;
 	}
 
 	notFound();

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/confirmation/page.tsx
@@ -1,0 +1,5 @@
+import { ComplianceConfirmation } from "~/modules/declaration-remuneration";
+
+export default function ComplianceConfirmationPage() {
+	return <ComplianceConfirmation />;
+}

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -170,7 +170,7 @@ test.describe("Declaration workflow", () => {
 	});
 
 	// Must be last — mutates declaration status to 'submitted'
-	test("step 6 submit navigates to CSE opinion page", async ({ page }) => {
+	test("step 6 submit navigates to compliance path", async ({ page }) => {
 		await goToStep(page, 6);
 
 		// Click the "Suivant" submit button to open the confirmation modal
@@ -180,8 +180,9 @@ test.describe("Declaration workflow", () => {
 		await page.getByText(/Je certifie/).click();
 		await page.getByRole("button", { name: "Valider" }).click();
 
-		// Verify navigation to the CSE opinion page
-		await page.waitForURL("**/avis-cse/**");
+		// After submission, the compliance path flow redirects based on gap and CSE status.
+		// With no gap above threshold, it redirects to confirmation (no CSE) or avis-cse (with CSE).
+		await page.waitForURL("**/parcours-conformite/**");
 	});
 
 	test("previous button is present on step pages", async ({ page }) => {

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ComplianceCompletionTracker } from "~/modules/declaration-remuneration";
 import { DsfrPictogram } from "~/modules/home";
 import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
@@ -18,6 +19,7 @@ export function ConfirmationPage({ email }: Props) {
 	const year = dataYear + 1;
 	return (
 		<div>
+			<ComplianceCompletionTracker />
 			<h1 className="fr-h4 fr-mb-4w">
 				Démarche des indicateurs de rémunération {year}
 			</h1>

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -15,9 +15,17 @@ import type { CseOpinionStep1Data, OpinionType } from "./types";
 type Props = {
 	initialData?: CseOpinionStep1Data;
 	email?: string;
+	compliancePath?: string | null;
+	hasSecondDeclaration?: boolean;
 };
 
-export function Step1Opinions({ initialData, email }: Props) {
+export function Step1Opinions({
+	initialData,
+	email,
+	compliancePath,
+	hasSecondDeclaration = true,
+}: Props) {
+	const isJointEvaluation = compliancePath === "joint_evaluation";
 	const router = useRouter();
 
 	const [firstDeclOpinion, setFirstDeclOpinion] = useState<OpinionType | null>(
@@ -63,16 +71,20 @@ export function Step1Opinions({ initialData, email }: Props) {
 		const firstGapIncomplete =
 			firstDeclGap === true && (!firstDeclGapOpinion || !firstDeclGapDate);
 		const secondGapIncomplete =
-			secondDeclGap === true && (!secondDeclGapOpinion || !secondDeclGapDate);
+			hasSecondDeclaration &&
+			secondDeclGap === true &&
+			(!secondDeclGapOpinion || !secondDeclGapDate);
+
+		const secondDeclInvalid =
+			hasSecondDeclaration &&
+			(!secondDeclOpinion || !secondDeclDate || secondDeclGap === null);
 
 		if (
 			!firstDeclOpinion ||
 			!firstDeclDate ||
 			firstDeclGap === null ||
 			firstGapIncomplete ||
-			!secondDeclOpinion ||
-			!secondDeclDate ||
-			secondDeclGap === null ||
+			secondDeclInvalid ||
 			secondGapIncomplete
 		) {
 			setValidationError("Veuillez remplir tous les champs obligatoires.");
@@ -88,35 +100,48 @@ export function Step1Opinions({ initialData, email }: Props) {
 				gapOpinion: firstDeclGapOpinion,
 				gapDate: firstDeclGapDate || null,
 			},
-			secondDeclaration: {
-				accuracyOpinion: secondDeclOpinion,
-				accuracyDate: secondDeclDate,
-				gapConsulted: secondDeclGap,
-				gapOpinion: secondDeclGapOpinion,
-				gapDate: secondDeclGapDate || null,
-			},
+			secondDeclaration:
+				hasSecondDeclaration && secondDeclOpinion && secondDeclGap !== null
+					? {
+							accuracyOpinion: secondDeclOpinion,
+							accuracyDate: secondDeclDate,
+							gapConsulted: secondDeclGap,
+							gapOpinion: secondDeclGapOpinion,
+							gapDate: secondDeclGapDate || null,
+						}
+					: undefined,
 		});
 	}
 
 	return (
 		<form onSubmit={handleSubmit}>
-			<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
-				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
-						Parcours de mise en conformité pour l'indicateur par catégorie de
-						salariés
-					</h1>
+			{isJointEvaluation && (
+				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
+					<div className="fr-col">
+						<h1 className="fr-h4 fr-mb-0">
+							Parcours de mise en conformité pour l'indicateur par catégorie de
+							salariés
+						</h1>
+					</div>
 				</div>
-			</div>
+			)}
 
-			<SubmissionBanner
-				deadline={`1er février ${new Date().getFullYear() + 1}`}
-				email={email ?? "adresse@exemple.fr"}
-			/>
+			{isJointEvaluation && (
+				<SubmissionBanner
+					deadline={`1er février ${new Date().getFullYear() + 1}`}
+					email={email ?? "adresse@exemple.fr"}
+				/>
+			)}
 
-			<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
-				Transmettre l'avis ou les avis du CSE
-			</h2>
+			{isJointEvaluation ? (
+				<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
+					Transmettre l'avis ou les avis du CSE
+				</h2>
+			) : (
+				<h1 className="fr-h4 fr-mb-3w">
+					Transmettre l'avis ou les avis du CSE
+				</h1>
+			)}
 
 			<CseStepIndicator currentStep={1} />
 
@@ -149,28 +174,32 @@ export function Step1Opinions({ initialData, email }: Props) {
 				/>
 			</div>
 
-			<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
+			{hasSecondDeclaration && (
+				<>
+					<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
 
-			<div className={styles.cardStack}>
-				<AccuracyOpinionCard
-					date={secondDeclDate}
-					id="second-decl-accuracy"
-					onDateChange={setSecondDeclDate}
-					onOpinionChange={setSecondDeclOpinion}
-					opinion={secondDeclOpinion}
-					title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
-				/>
+					<div className={styles.cardStack}>
+						<AccuracyOpinionCard
+							date={secondDeclDate}
+							id="second-decl-accuracy"
+							onDateChange={setSecondDeclDate}
+							onOpinionChange={setSecondDeclOpinion}
+							opinion={secondDeclOpinion}
+							title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+						/>
 
-				<GapConsultationCard
-					consulted={secondDeclGap}
-					date={secondDeclGapDate}
-					id="second-decl-gap"
-					onConsultedChange={setSecondDeclGap}
-					onDateChange={setSecondDeclGapDate}
-					onOpinionChange={setSecondDeclGapOpinion}
-					opinion={secondDeclGapOpinion}
-				/>
-			</div>
+						<GapConsultationCard
+							consulted={secondDeclGap}
+							date={secondDeclGapDate}
+							id="second-decl-gap"
+							onConsultedChange={setSecondDeclGap}
+							onDateChange={setSecondDeclGapDate}
+							onOpinionChange={setSecondDeclGapOpinion}
+							opinion={secondDeclGapOpinion}
+						/>
+					</div>
+				</>
+			)}
 
 			<div aria-live="polite">
 				{validationError && (

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -10,7 +10,11 @@ import { OpinionSummaryBox } from "./components/OpinionSummaryBox";
 import { SubmitConfirmationModal } from "./components/SubmitConfirmationModal";
 import formStyles from "./shared/formActions.module.scss";
 
-export function Step2Upload() {
+type Props = {
+	hasSecondDeclaration?: boolean;
+};
+
+export function Step2Upload({ hasSecondDeclaration = true }: Props) {
 	const router = useRouter();
 	const {
 		closeModal,
@@ -58,6 +62,7 @@ export function Step2Upload() {
 						firstDeclTitle="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
 						secondDeclGapTitle="Justification des écarts ≥ 5 % par des critères objectifs et non sexistes de l'indicateur de rémunération par catégorie de salariés"
 						secondDeclTitle="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+						showSecondDeclaration={hasSecondDeclaration}
 					/>
 				</div>
 

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ConfirmationPage } from "../ConfirmationPage";
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			completeCompliancePath: {
+				useMutation: () => ({ mutate: vi.fn() }),
+			},
+		},
+	},
+}));
 
 describe("ConfirmationPage", () => {
 	const year = new Date().getFullYear() + 1;

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -40,8 +40,8 @@ beforeEach(() => {
 });
 
 describe("Step1Opinions", () => {
-	it("renders the page title", () => {
-		render(<Step1Opinions />);
+	it("renders compliance path title when compliancePath is joint_evaluation", () => {
+		render(<Step1Opinions compliancePath="joint_evaluation" />);
 
 		expect(
 			screen.getByText(
@@ -50,27 +50,61 @@ describe("Step1Opinions", () => {
 		).toBeInTheDocument();
 	});
 
+	it("does not render compliance path title for other paths", () => {
+		render(<Step1Opinions compliancePath="justify" />);
+
+		expect(
+			screen.queryByText(
+				/Parcours de mise en conformité pour l'indicateur par catégorie de salariés/,
+			),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders h1 as CSE opinion title when no compliance path banner", () => {
+		render(<Step1Opinions />);
+
+		const heading = screen.getByRole("heading", { level: 1 });
+		expect(heading).toHaveTextContent("Transmettre l'avis ou les avis du CSE");
+	});
+
 	it("renders the stepper at step 1", () => {
 		render(<Step1Opinions />);
 
 		expect(screen.getByText(/Étape 1 sur 2/)).toBeInTheDocument();
 	});
 
-	it("renders both declaration sections", () => {
-		render(<Step1Opinions />);
+	it("renders both declaration sections when hasSecondDeclaration is true", () => {
+		render(<Step1Opinions hasSecondDeclaration={true} />);
 
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
 		expect(screen.getByText("Deuxième déclaration")).toBeInTheDocument();
 	});
 
-	it("renders the submission banner", () => {
-		render(<Step1Opinions />);
+	it("hides second declaration section when hasSecondDeclaration is false", () => {
+		render(<Step1Opinions hasSecondDeclaration={false} />);
+
+		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
+		expect(screen.queryByText("Deuxième déclaration")).not.toBeInTheDocument();
+	});
+
+	it("renders the submission banner for joint_evaluation path", () => {
+		render(<Step1Opinions compliancePath="joint_evaluation" />);
 
 		expect(
 			screen.getByText(
 				/Votre rapport de l'évaluation conjointe a été transmise/,
 			),
 		).toBeInTheDocument();
+	});
+
+	it("does not render the submission banner for other paths", () => {
+		render(<Step1Opinions />);
+
+		expect(
+			screen.queryByText(
+				/Votre rapport de l'évaluation conjointe a été transmise/,
+			),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders previous and next buttons", () => {
@@ -94,10 +128,11 @@ describe("Step1Opinions", () => {
 		expect(mockPush).not.toHaveBeenCalled();
 	});
 
-	it("calls mutation and navigates to step 2 when all fields are filled", async () => {
+	it("calls mutation with both declarations when hasSecondDeclaration is true", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Opinions
+				hasSecondDeclaration={true}
 				initialData={{
 					firstDeclAccuracyOpinion: "favorable",
 					firstDeclAccuracyDate: "2026-01-15",
@@ -134,6 +169,41 @@ describe("Step1Opinions", () => {
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
 	});
 
+	it("calls mutation without secondDeclaration when hasSecondDeclaration is false", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step1Opinions
+				hasSecondDeclaration={false}
+				initialData={{
+					firstDeclAccuracyOpinion: "favorable",
+					firstDeclAccuracyDate: "2026-01-15",
+					firstDeclGapConsulted: false,
+					firstDeclGapOpinion: null,
+					firstDeclGapDate: null,
+					secondDeclAccuracyOpinion: null,
+					secondDeclAccuracyDate: "",
+					secondDeclGapConsulted: null,
+					secondDeclGapOpinion: null,
+					secondDeclGapDate: null,
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+		expect(mockMutate).toHaveBeenCalledWith({
+			firstDeclaration: {
+				accuracyOpinion: "favorable",
+				accuracyDate: "2026-01-15",
+				gapConsulted: false,
+				gapOpinion: null,
+				gapDate: null,
+			},
+			secondDeclaration: undefined,
+		});
+		expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
+	});
+
 	it("renders with initial data pre-filled", () => {
 		render(
 			<Step1Opinions
@@ -161,14 +231,19 @@ describe("Step1Opinions", () => {
 		expect(unfavorableRadios[1]).toBeChecked();
 	});
 
-	it("displays email in submission banner", () => {
-		render(<Step1Opinions email="test@example.fr" />);
+	it("displays email in submission banner for joint_evaluation path", () => {
+		render(
+			<Step1Opinions
+				compliancePath="joint_evaluation"
+				email="test@example.fr"
+			/>,
+		);
 
 		expect(screen.getByText("test@example.fr")).toBeInTheDocument();
 	});
 
-	it("uses default email when none provided", () => {
-		render(<Step1Opinions />);
+	it("uses default email when none provided for joint_evaluation path", () => {
+		render(<Step1Opinions compliancePath="joint_evaluation" />);
 
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});

--- a/packages/app/src/modules/cseOpinion/components/OpinionSummaryBox.tsx
+++ b/packages/app/src/modules/cseOpinion/components/OpinionSummaryBox.tsx
@@ -2,14 +2,16 @@ import styles from "./OpinionSummaryBox.module.scss";
 
 type Props = {
 	firstDeclTitle: string;
-	secondDeclTitle: string;
-	secondDeclGapTitle: string;
+	secondDeclTitle?: string;
+	secondDeclGapTitle?: string;
+	showSecondDeclaration?: boolean;
 };
 
 export function OpinionSummaryBox({
 	firstDeclTitle,
 	secondDeclTitle,
 	secondDeclGapTitle,
+	showSecondDeclaration = true,
 }: Props) {
 	return (
 		<div className={`fr-p-4w ${styles.container}`}>
@@ -18,15 +20,19 @@ export function OpinionSummaryBox({
 			</p>
 
 			<p className="fr-text--sm fr-mb-1w">Première déclaration</p>
-			<ul className="fr-mb-2w">
+			<ul className={showSecondDeclaration ? "fr-mb-2w" : "fr-mb-0"}>
 				<li className="fr-text--sm">{firstDeclTitle}</li>
 			</ul>
 
-			<p className="fr-text--sm fr-mb-1w">Deuxième déclaration</p>
-			<ul className="fr-mb-0">
-				<li className="fr-text--sm">{secondDeclTitle}</li>
-				<li className="fr-text--sm">{secondDeclGapTitle}</li>
-			</ul>
+			{showSecondDeclaration && (
+				<>
+					<p className="fr-text--sm fr-mb-1w">Deuxième déclaration</p>
+					<ul className="fr-mb-0">
+						<li className="fr-text--sm">{secondDeclTitle}</li>
+						<li className="fr-text--sm">{secondDeclGapTitle}</li>
+					</ul>
+				</>
+			)}
 		</div>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/schemas.ts
+++ b/packages/app/src/modules/cseOpinion/schemas.ts
@@ -12,7 +12,7 @@ const declarationOpinionSchema = z.object({
 
 export const saveOpinionsSchema = z.object({
 	firstDeclaration: declarationOpinionSchema,
-	secondDeclaration: declarationOpinionSchema,
+	secondDeclaration: declarationOpinionSchema.optional(),
 });
 
 export type SaveOpinionsInput = z.infer<typeof saveOpinionsSchema>;

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -1,6 +1,7 @@
 export { DeclarationLayout } from "./DeclarationLayout";
 export { MissingSiret } from "./MissingSiret";
 export { StepPageClient } from "./StepPageClient";
+export { ComplianceCompletionTracker } from "./shared/ComplianceCompletionTracker";
 export { DevFillButton } from "./shared/DevFillButton";
 export {
 	computeGap,
@@ -11,6 +12,7 @@ export {
 	hasGapsAboveThreshold,
 } from "./shared/gapUtils";
 export { mapDbCategories } from "./shared/mapDbCategories";
+export { ComplianceConfirmation } from "./steps/ComplianceConfirmation";
 export { CompliancePathChoice } from "./steps/CompliancePathChoice";
 export { CompliancePathPage } from "./steps/CompliancePathPage";
 export { JointEvaluationPage } from "./steps/jointEvaluation";

--- a/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionTracker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionTracker.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { api } from "~/trpc/react";
+
+export function ComplianceCompletionTracker() {
+	const mutation = api.declaration.completeCompliancePath.useMutation();
+	const called = useRef(false);
+
+	useEffect(() => {
+		if (!called.current) {
+			called.current = true;
+			mutation.mutate();
+		}
+	}, [mutation]);
+
+	return null;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
@@ -1,0 +1,13 @@
+const COMPLIANCE_CONFIRMATION_PATH =
+	"/declaration-remuneration/parcours-conformite/confirmation";
+
+/**
+ * Returns the destination URL after completing a compliance path step,
+ * based on whether the company has a CSE (works council).
+ *
+ * - Has CSE → redirect to CSE opinion page
+ * - No CSE or unknown → redirect to the compliance confirmation page
+ */
+export function getPostComplianceDestination(hasCse: boolean | null): string {
+	return hasCse === true ? "/avis-cse" : COMPLIANCE_CONFIRMATION_PATH;
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { DsfrPictogram } from "~/modules/home";
+import { ComplianceCompletionTracker } from "../shared/ComplianceCompletionTracker";
+import common from "../shared/common.module.scss";
+
+export function ComplianceConfirmation() {
+	const currentYear = new Date().getFullYear();
+
+	return (
+		<div className={common.flexColumnGap2}>
+			<ComplianceCompletionTracker />
+			<h1 className="fr-h4 fr-mb-0">
+				Parcours de mise en conformité pour l&apos;indicateur par catégorie de
+				salariés
+			</h1>
+
+			<div className="fr-mt-2w fr-mb-2w">
+				<DsfrPictogram
+					path="/dsfr/artwork/pictograms/system/success.svg"
+					size={64}
+				/>
+			</div>
+
+			<p className="fr-text--lg fr-text--bold fr-mb-0">
+				Votre parcours de mise en conformité {currentYear} est terminé
+			</p>
+
+			<p className="fr-mb-0">
+				Votre entreprise ne dispose pas de CSE. Aucun avis CSE n&apos;est
+				requis.
+			</p>
+
+			<div className="fr-mt-4w">
+				<Link className="fr-btn" href="/mon-espace">
+					Mon espace
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -16,22 +16,24 @@ import { DeclarationSuccessBanner } from "./compliancePath/DeclarationSuccessBan
 type Props = {
 	currentYear: number;
 	email: string;
+	hasCse: boolean | null;
 	initialPath?: CompliancePathValue;
-	forcedPath?: CompliancePathValue;
+	isSecondRound?: boolean;
 	pdfDownloadHref?: string;
 };
 
 export function CompliancePathChoice({
 	currentYear,
 	email,
+	hasCse,
 	initialPath,
-	forcedPath,
+	isSecondRound = false,
 	pdfDownloadHref,
 }: Props) {
 	const router = useRouter();
 	const [selectedPath, setSelectedPath] = useState<
 		CompliancePathValue | undefined
-	>(forcedPath ?? initialPath);
+	>(initialPath);
 
 	const mutation = api.declaration.saveCompliancePath.useMutation({
 		onSuccess: (_, { path }) => {
@@ -53,8 +55,6 @@ export function CompliancePathChoice({
 		mutation.mutate({ path: selectedPath });
 	}
 
-	const isDisabled = !!forcedPath;
-
 	return (
 		<form className={common.flexColumnGap2} onSubmit={handleSubmit}>
 			<div className={common.flexBetween}>
@@ -71,14 +71,14 @@ export function CompliancePathChoice({
 			/>
 
 			<h2 className="fr-h4 fr-mb-0">
-				Parcours de mise en conformité pour l'indicateur par catégorie de
+				Parcours de mise en conformité pour l&apos;indicateur par catégorie de
 				salariés
 			</h2>
 
 			<p className="fr-mb-0">
 				Des écarts ≥ 5 % ont été constatés,{" "}
 				<span className="fr-text--medium">
-					vous devez engager l'un des parcours suivants.
+					vous devez engager l&apos;un des parcours suivants.
 				</span>
 			</p>
 
@@ -94,7 +94,7 @@ export function CompliancePathChoice({
 						rel="noopener noreferrer"
 						target="_blank"
 					>
-						Qu'entend-on par critères objectifs et non sexistes ?
+						Qu&apos;entend-on par critères objectifs et non sexistes ?
 						<NewTabNotice />
 					</a>
 				</p>
@@ -108,102 +108,170 @@ export function CompliancePathChoice({
 					Choix du parcours de mise en conformité
 				</legend>
 
-				<div className="fr-fieldset__element">
-					<CompliancePathOption
-						checked={selectedPath === "justify"}
-						deadline={`1\u1D49\u02B3 juin ${currentYear}`}
-						disabled={isDisabled}
-						id="path-justify"
-						name="compliance-path"
-						onChange={() => setSelectedPath("justify")}
-						title="Justifier les écarts de rémunération ≥ 5 %"
-						value="justify"
-					>
-						<p className="fr-mb-0">
-							Vous avez la possibilité de justifier vos écarts par des critères
-							objectifs et non sexistes :
-						</p>
-						<ul className="fr-mt-1w fr-mb-0">
-							<li>Informer et consulter votre CSE sur cette justification</li>
-							<li>Transmettre l'avis du CSE</li>
-						</ul>
-					</CompliancePathOption>
-				</div>
+				{isSecondRound ? (
+					<>
+						<div className="fr-fieldset__element">
+							<CompliancePathOption
+								checked={selectedPath === "justify"}
+								deadline={`1\u1D49\u02B3 juin ${currentYear}`}
+								id="path-justify"
+								name="compliance-path"
+								onChange={() => setSelectedPath("justify")}
+								title="Justifier les écarts de rémunération ≥ 5 %"
+								value="justify"
+							>
+								<p className="fr-mb-0">
+									Vous avez la possibilité de justifier vos écarts par des
+									critères objectifs et non sexistes :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Informer et consulter votre CSE sur cette justification
+									</li>
+									<li>Transmettre l&apos;avis du CSE</li>
+								</ul>
+							</CompliancePathOption>
+						</div>
 
-				<h3 className="fr-h6 fr-mt-3w fr-mb-0">
-					Si la justification n'est pas possible par des critères objectifs et
-					non sexistes
-				</h3>
+						<div className="fr-fieldset__element">
+							<CompliancePathOption
+								checked={selectedPath === "joint_evaluation"}
+								deadline={`1\u1D49\u02B3 août ${currentYear}`}
+								id="path-joint"
+								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
+								name="compliance-path"
+								onChange={() => setSelectedPath("joint_evaluation")}
+								title="Évaluation conjointe des rémunérations"
+								value="joint_evaluation"
+							>
+								<p className="fr-mb-0">
+									Vous choisissez de procéder à une évaluation conjointe des
+									rémunérations afin d&apos;identifier et de corriger les écarts
+									constatés :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Élaboration du rapport préalable (à déposer sur le portail
+										Egapro)
+									</li>
+									<li>
+										Analyse conjointe et définition des actions correctrices
+									</li>
+									<li>
+										Mise en place de l&apos;accord collectif ou à défaut un plan
+										d&apos;action
+									</li>
+								</ul>
+							</CompliancePathOption>
+						</div>
+					</>
+				) : (
+					<>
+						<h3 className="fr-h6 fr-mt-3w fr-mb-0">
+							Si la justification n&apos;est pas possible par des critères
+							objectifs et non sexistes
+						</h3>
 
-				<div className="fr-fieldset__element fr-mt-2w">
-					<CompliancePathOption
-						checked={selectedPath === "corrective_action"}
-						deadline={`1\u1D49\u02B3 décembre ${currentYear}`}
-						disabled={isDisabled}
-						id="path-corrective"
-						learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-						learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
-						name="compliance-path"
-						onChange={() => setSelectedPath("corrective_action")}
-						title="Actions correctives et seconde déclaration"
-						value="corrective_action"
-					>
-						<p className="fr-mb-0">
-							Vous souhaitez mettre en place des actions correctives, puis
-							recalculer et redéclarer l'indicateur par catégorie de salariés :
-						</p>
-						<ul className="fr-mt-1w fr-mb-0">
-							<li>
-								Mettre en place des actions correctives par accord ou par plan
-								d'action
-							</li>
-							<li>
-								Redéclarer l'indicateur dans un délai de 6 mois après votre
-								première déclaration
-							</li>
-							<li>
-								Informer et consulter votre CSE sur l'exactitude des données et
-								éventuellement, sur la justification des écarts ≥ 5 %
-							</li>
-							<li>Transmettre l'avis ou les avis du CSE</li>
-						</ul>
-						<p className="fr-mt-1w fr-mb-0">
-							Si des écarts non justifiés persistent, vous devez engager une
-							évaluation conjointe des rémunérations.
-						</p>
-					</CompliancePathOption>
-				</div>
+						<div className="fr-fieldset__element fr-mt-2w">
+							<CompliancePathOption
+								checked={selectedPath === "corrective_action"}
+								deadline={`1\u1D49\u02B3 décembre ${currentYear}`}
+								id="path-corrective"
+								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
+								name="compliance-path"
+								onChange={() => setSelectedPath("corrective_action")}
+								title="Actions correctives et seconde déclaration"
+								value="corrective_action"
+							>
+								<p className="fr-mb-0">
+									Vous souhaitez mettre en place des actions correctives, puis
+									recalculer et redéclarer l&apos;indicateur par catégorie de
+									salariés :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Mettre en place des actions correctives par accord ou par
+										plan d&apos;action
+									</li>
+									<li>
+										Redéclarer l&apos;indicateur dans un délai de 6 mois après
+										votre première déclaration
+									</li>
+									<li>
+										Informer et consulter votre CSE sur l&apos;exactitude des
+										données et éventuellement, sur la justification des écarts ≥
+										5 %
+									</li>
+									<li>Transmettre l&apos;avis ou les avis du CSE</li>
+								</ul>
+								<p className="fr-mt-1w fr-mb-0">
+									Si des écarts non justifiés persistent, vous devez engager une
+									évaluation conjointe des rémunérations.
+								</p>
+							</CompliancePathOption>
+						</div>
 
-				<div className="fr-fieldset__element">
-					<CompliancePathOption
-						checked={selectedPath === "joint_evaluation"}
-						deadline={`1\u1D49\u02B3 août ${currentYear}`}
-						disabled={isDisabled}
-						id="path-joint"
-						learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-						learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
-						name="compliance-path"
-						onChange={() => setSelectedPath("joint_evaluation")}
-						title="Évaluation conjointe des rémunérations"
-						value="joint_evaluation"
-					>
-						<p className="fr-mb-0">
-							Vous choisissez de procéder à une évaluation conjointe des
-							rémunérations afin d'identifier et de corriger les écarts
-							constatés :
-						</p>
-						<ul className="fr-mt-1w fr-mb-0">
-							<li>
-								Élaboration du rapport préalable (à déposer sur le portail
-								Egapro)
-							</li>
-							<li>Analyse conjointe et définition des actions correctrices</li>
-							<li>
-								Mise en place de l'accord collectif ou à défaut un plan d'action
-							</li>
-						</ul>
-					</CompliancePathOption>
-				</div>
+						<div className="fr-fieldset__element">
+							<CompliancePathOption
+								checked={selectedPath === "joint_evaluation"}
+								deadline={`1\u1D49\u02B3 août ${currentYear}`}
+								id="path-joint"
+								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
+								name="compliance-path"
+								onChange={() => setSelectedPath("joint_evaluation")}
+								title="Évaluation conjointe des rémunérations"
+								value="joint_evaluation"
+							>
+								<p className="fr-mb-0">
+									Vous choisissez de procéder à une évaluation conjointe des
+									rémunérations afin d&apos;identifier et de corriger les écarts
+									constatés :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Élaboration du rapport préalable (à déposer sur le portail
+										Egapro)
+									</li>
+									<li>
+										Analyse conjointe et définition des actions correctrices
+									</li>
+									<li>
+										Mise en place de l&apos;accord collectif ou à défaut un plan
+										d&apos;action
+									</li>
+								</ul>
+							</CompliancePathOption>
+						</div>
+
+						{hasCse === true && (
+							<div className="fr-fieldset__element">
+								<CompliancePathOption
+									checked={selectedPath === "justify"}
+									deadline={`1\u1D49\u02B3 juin ${currentYear}`}
+									id="path-justify"
+									name="compliance-path"
+									onChange={() => setSelectedPath("justify")}
+									title="Justifier les écarts de rémunération ≥ 5 %"
+									value="justify"
+								>
+									<p className="fr-mb-0">
+										Vous avez la possibilité de justifier vos écarts par des
+										critères objectifs et non sexistes :
+									</p>
+									<ul className="fr-mt-1w fr-mb-0">
+										<li>
+											Informer et consulter votre CSE sur cette justification
+										</li>
+										<li>Transmettre l&apos;avis du CSE</li>
+									</ul>
+								</CompliancePathOption>
+							</div>
+						)}
+					</>
+				)}
 			</fieldset>
 
 			<FormActions

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -3,8 +3,38 @@ import { redirect } from "next/navigation";
 import { auth } from "~/server/auth";
 import { api, HydrateClient } from "~/trpc/server";
 
+import { getPostComplianceDestination } from "../shared/complianceNavigation";
 import { hasGapsAboveThreshold } from "../shared/gapUtils";
 import { CompliancePathChoice } from "./CompliancePathChoice";
+
+type ComplianceState =
+	| { type: "no_gap" }
+	| { type: "first_round" }
+	| { type: "second_round" };
+
+function getComplianceState(
+	compliancePath: string | null,
+	secondDeclarationStatus: string | null,
+	initialCategories: Parameters<typeof hasGapsAboveThreshold>[0],
+	correctionCategories: Parameters<typeof hasGapsAboveThreshold>[0],
+): ComplianceState {
+	if (!hasGapsAboveThreshold(initialCategories)) {
+		return { type: "no_gap" };
+	}
+
+	const hasSubmittedSecondDeclaration =
+		compliancePath === "corrective_action" &&
+		secondDeclarationStatus === "submitted";
+
+	if (
+		hasSubmittedSecondDeclaration &&
+		hasGapsAboveThreshold(correctionCategories)
+	) {
+		return { type: "second_round" };
+	}
+
+	return { type: "first_round" };
+}
 
 export async function CompliancePathPage() {
 	const session = await auth();
@@ -14,19 +44,25 @@ export async function CompliancePathPage() {
 		redirect("/declaration-remuneration/etape/6");
 	}
 
-	const step5Categories = data.employeeCategories.filter(
+	const company = await api.company.get({ siren: data.declaration.siren });
+
+	const initialCategories = data.employeeCategories.filter(
 		(c) => c.declarationType === "initial",
 	);
+	const correctionCategories = data.employeeCategories.filter(
+		(c) => c.declarationType === "correction",
+	);
 
-	if (!hasGapsAboveThreshold(step5Categories)) {
-		redirect("/avis-cse");
+	const state = getComplianceState(
+		data.declaration.compliancePath,
+		data.declaration.secondDeclarationStatus,
+		initialCategories,
+		correctionCategories,
+	);
+
+	if (state.type === "no_gap" || data.declaration.complianceCompletedAt) {
+		redirect(getPostComplianceDestination(company.hasCse));
 	}
-
-	// If previous path was corrective_action and gaps persist, force joint_evaluation
-	const forcedPath =
-		data.declaration.compliancePath === "corrective_action"
-			? ("joint_evaluation" as const)
-			: undefined;
 
 	const email = session?.user?.email ?? "";
 	const currentYear = new Date().getFullYear();
@@ -36,7 +72,7 @@ export async function CompliancePathPage() {
 			<CompliancePathChoice
 				currentYear={currentYear}
 				email={email}
-				forcedPath={forcedPath}
+				hasCse={company.hasCse}
 				initialPath={
 					(data.declaration.compliancePath as
 						| "justify"
@@ -44,6 +80,7 @@ export async function CompliancePathPage() {
 						| "joint_evaluation"
 						| null) ?? undefined
 				}
+				isSecondRound={state.type === "second_round"}
 			/>
 		</HydrateClient>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -32,7 +32,13 @@ vi.mock("~/trpc/react", () => ({
 
 describe("CompliancePathChoice", () => {
 	it("renders the page title and success banner", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		expect(
 			screen.getByText(/Déclaration des indicateurs de rémunération/),
 		).toBeInTheDocument();
@@ -42,7 +48,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders all 3 compliance path options", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={true}
+			/>,
+		);
 		expect(
 			screen.getByText("Justifier les écarts de rémunération ≥ 5 %"),
 		).toBeInTheDocument();
@@ -55,15 +67,27 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("disables next button when no path is selected", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const nextButton = screen.getByRole("button", { name: /suivant/i });
 		expect(nextButton).toBeDisabled();
 	});
 
 	it("enables next button after selecting a path", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const radio = screen.getByLabelText(
-			"Justifier les écarts de rémunération ≥ 5 %",
+			"Actions correctives et seconde déclaration",
 		);
 		fireEvent.click(radio);
 		const nextButton = screen.getByRole("button", { name: /suivant/i });
@@ -71,7 +95,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("submits the selected path and navigates to evaluation-conjointe", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const radio = screen.getByLabelText(
 			"Évaluation conjointe des rémunérations",
 		);
@@ -89,7 +119,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("navigates to second declaration when corrective_action is selected", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const radio = screen.getByLabelText(
 			"Actions correctives et seconde déclaration",
 		);
@@ -111,6 +147,7 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				currentYear={2026}
 				email="test@example.fr"
+				hasCse={null}
 				initialPath="corrective_action"
 			/>,
 		);
@@ -120,22 +157,31 @@ describe("CompliancePathChoice", () => {
 		expect(radio.checked).toBe(true);
 	});
 
-	it("disables radio buttons when forcedPath is set", () => {
+	it("renders isSecondRound options when isSecondRound is set", () => {
 		render(
 			<CompliancePathChoice
 				currentYear={2026}
 				email="test@example.fr"
-				forcedPath="joint_evaluation"
+				hasCse={null}
+				isSecondRound={true}
 			/>,
 		);
-		const radios = screen.getAllByRole("radio");
-		for (const radio of radios) {
-			expect(radio).toBeDisabled();
-		}
+		expect(
+			screen.getByText("Évaluation conjointe des rémunérations"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Actions correctives et seconde déclaration"),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders previous link pointing to step 6", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/6",
@@ -143,7 +189,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders the email in the success banner", () => {
-		render(<CompliancePathChoice currentYear={2026} email="john@company.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="john@company.fr"
+				hasCse={null}
+			/>,
+		);
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -3,20 +3,31 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { PdfFileUpload, usePdfUploadForm } from "~/modules/shared";
+import { api } from "~/trpc/react";
 
 import { JointEvaluationSubmitModal } from "./JointEvaluationSubmitModal";
 
 type Props = {
 	currentYear: number;
 	declarationDate: string;
+	hasCse: boolean | null;
 };
 
-export function JointEvaluationForm({ currentYear, declarationDate }: Props) {
+export function JointEvaluationForm({
+	currentYear,
+	declarationDate,
+	hasCse,
+}: Props) {
 	const router = useRouter();
-	// TODO: call tRPC mutation to upload file when API is wired
+
+	const uploadMutation = api.jointEvaluation.uploadFile.useMutation({
+		onSuccess: () => router.push(getPostComplianceDestination(hasCse)),
+	});
+
 	const {
 		closeModal,
 		handleConfirm,
@@ -25,7 +36,16 @@ export function JointEvaluationForm({ currentYear, declarationDate }: Props) {
 		modalRef,
 		selectedFile,
 		uploadError,
-	} = usePdfUploadForm({ onConfirm: () => router.push("/avis-cse") });
+	} = usePdfUploadForm({
+		onConfirm: () => {
+			if (selectedFile) {
+				uploadMutation.mutate({
+					fileName: selectedFile.name,
+					filePath: selectedFile.name,
+				});
+			}
+		},
+	});
 
 	return (
 		<>
@@ -138,6 +158,7 @@ export function JointEvaluationForm({ currentYear, declarationDate }: Props) {
 					</Link>
 					<button
 						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+						disabled={uploadMutation.isPending}
 						type="submit"
 					>
 						Transmettre

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
@@ -11,6 +11,7 @@ export async function JointEvaluationPage() {
 		redirect("/declaration-remuneration/parcours-conformite");
 	}
 
+	const company = await api.company.get({ siren: data.declaration.siren });
 	const currentYear = new Date().getFullYear();
 	const declarationDate = data.declaration.updatedAt
 		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
@@ -20,6 +21,7 @@ export async function JointEvaluationPage() {
 		<JointEvaluationForm
 			currentYear={currentYear}
 			declarationDate={declarationDate}
+			hasCse={company.hasCse}
 		/>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -11,10 +11,28 @@ vi.mock("next/navigation", () => ({
 		"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
 }));
 
+vi.mock("~/trpc/react", () => ({
+	api: {
+		jointEvaluation: {
+			uploadFile: {
+				useMutation: () => ({
+					mutate: vi.fn(),
+					isPending: false,
+					error: null,
+				}),
+			},
+		},
+	},
+}));
+
 describe("JointEvaluationForm", () => {
 	it("renders the page title and section heading", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		expect(
@@ -33,7 +51,11 @@ describe("JointEvaluationForm", () => {
 
 	it("renders the deadline callout with the current year", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		expect(screen.getByText(/août 2026/i)).toBeInTheDocument();
@@ -42,7 +64,11 @@ describe("JointEvaluationForm", () => {
 
 	it("shows an error when submitting without a file", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /transmettre/i });
@@ -55,7 +81,11 @@ describe("JointEvaluationForm", () => {
 
 	it("renders the info boxes", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		expect(
@@ -66,7 +96,11 @@ describe("JointEvaluationForm", () => {
 
 	it("links back to the compliance path choice page", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		const backLink = screen.getByRole("link", { name: /précédent/i });

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
@@ -11,6 +11,9 @@ vi.mock("~/trpc/server", () => ({
 		declaration: {
 			getOrCreate: vi.fn(),
 		},
+		company: {
+			get: vi.fn(),
+		},
 	},
 }));
 
@@ -39,6 +42,7 @@ describe("JointEvaluationPage", () => {
 		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
 			declaration: { compliancePath: "action_plan", updatedAt: null },
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		await JointEvaluationPage();
 
@@ -54,6 +58,7 @@ describe("JointEvaluationPage", () => {
 				updatedAt: new Date("2025-06-15"),
 			},
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		const page = await JointEvaluationPage();
 		render(page);
@@ -70,6 +75,7 @@ describe("JointEvaluationPage", () => {
 				updatedAt: new Date("2025-06-15"),
 			},
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		const page = await JointEvaluationPage();
 		render(page);
@@ -83,6 +89,7 @@ describe("JointEvaluationPage", () => {
 		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
 			declaration: { compliancePath: "joint_evaluation", updatedAt: null },
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		const page = await JointEvaluationPage();
 		render(page);

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
@@ -16,19 +17,19 @@ import { BASE_PATH } from "./constants";
 import { NextStepsSection } from "./NextStepsSection";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
+const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
+
 type Props = {
+	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
 };
 
 export function SecondDeclarationStep3Review({
+	hasCse,
 	secondDeclarationCategories,
 }: Props) {
 	const router = useRouter();
 	const [certified, setCertified] = useState(false);
-
-	const mutation = api.declaration.submitSecondDeclaration.useMutation({
-		onSuccess: () => router.push("/avis-cse"),
-	});
 
 	const parsed = parseEmployeeCategories(secondDeclarationCategories);
 	const gapsExist = parsed.some(
@@ -38,6 +39,16 @@ export function SecondDeclarationStep3Review({
 			(cat.hourlyBaseGap !== null && cat.hourlyBaseGap >= 5) ||
 			(cat.hourlyVariableGap !== null && cat.hourlyVariableGap >= 5),
 	);
+
+	const mutation = api.declaration.submitSecondDeclaration.useMutation({
+		onSuccess: () => {
+			if (gapsExist) {
+				router.push(COMPLIANCE_PATH);
+			} else {
+				router.push(getPostComplianceDestination(hasCse));
+			}
+		},
+	});
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -18,6 +18,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 	}
 
 	const data = await api.declaration.getOrCreate();
+	const company = await api.company.get({ siren: data.declaration.siren });
 	const currentYear = new Date().getFullYear();
 
 	const initialCategories = mapToEmployeeCategoryRows(
@@ -79,6 +80,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 	return (
 		<HydrateClient>
 			<SecondDeclarationStep3Review
+				hasCse={company.hasCse}
 				secondDeclarationCategories={reviewCategories}
 			/>
 		</HydrateClient>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -59,6 +59,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the title and step indicator", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -73,6 +74,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders category gap card with category name", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -82,6 +84,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders gap columns", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -96,6 +99,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the next steps section", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -105,6 +109,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders certification checkbox", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -116,6 +121,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("disables submit button when not certified", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -127,6 +133,7 @@ describe("SecondDeclarationStep3Review", () => {
 		const user = userEvent.setup();
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -141,6 +148,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders previous link to step 2", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -169,6 +177,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={categoriesWithHighGaps}
 			/>,
 		);
@@ -196,6 +205,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={categoriesWithLowGaps}
 			/>,
 		);

--- a/packages/app/src/modules/declarationPdf/pdfFonts.ts
+++ b/packages/app/src/modules/declarationPdf/pdfFonts.ts
@@ -1,5 +1,5 @@
-import { Font } from "@react-pdf/renderer";
 import { join } from "node:path";
+import { Font } from "@react-pdf/renderer";
 
 export const PDF_FONT_FAMILY = "Marianne";
 

--- a/packages/app/src/server/api/root.ts
+++ b/packages/app/src/server/api/root.ts
@@ -1,6 +1,7 @@
 import { companyRouter } from "~/server/api/routers/company";
 import { cseOpinionRouter } from "~/server/api/routers/cseOpinion";
 import { declarationRouter } from "~/server/api/routers/declaration";
+import { jointEvaluationRouter } from "~/server/api/routers/jointEvaluation";
 import { profileRouter } from "~/server/api/routers/profile";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
@@ -13,6 +14,7 @@ export const appRouter = createTRPCRouter({
 	company: companyRouter,
 	cseOpinion: cseOpinionRouter,
 	declaration: declarationRouter,
+	jointEvaluation: jointEvaluationRouter,
 	profile: profileRouter,
 });
 

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -187,3 +187,219 @@ describe("findUserCompany CSE auto-fetch", () => {
 		);
 	});
 });
+
+describe("companyRouter.list", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns companies with declaration status", async () => {
+		const companyRows = [{ siren: "339787277", name: "Test Company" }];
+		const declRows = [
+			{ siren: "339787277", status: "submitted", currentStep: 6 },
+		];
+
+		// list uses: select().from().innerJoin().where() (no limit) for companies
+		// then select().from().where() for declarations
+		let selectCallCount = 0;
+		const localMockSelect = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			if (selectCallCount === 1) {
+				// companies query
+				return {
+					from: vi.fn().mockReturnValue({
+						innerJoin: vi.fn().mockReturnValue({
+							where: vi.fn().mockResolvedValue(companyRows),
+						}),
+					}),
+				};
+			}
+			// declarations query
+			return {
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue(declRows),
+				}),
+			};
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.list();
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.siren).toBe("339787277");
+		expect(result[0]?.declarationStatus).toBe("done");
+	});
+
+	it("returns empty list when user has no companies", async () => {
+		const localMockSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([]),
+				}),
+			}),
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.list();
+
+		expect(result).toEqual([]);
+	});
+
+	it("skips declaration fetch when no sirens found", async () => {
+		const localMockSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([]),
+				}),
+			}),
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await caller.list();
+
+		// Only 1 select call (companies), no second call for declarations
+		expect(localMockSelect).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("companyRouter.getWithDeclarations", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns company with declaration list", async () => {
+		const companyRow = {
+			siren: "339787277",
+			name: "Test Company",
+			address: "1 rue de Paris",
+			nafCode: "6202A",
+			workforce: 100,
+			hasCse: true,
+		};
+
+		const declRows = [
+			{
+				siren: "339787277",
+				year: 2026,
+				status: "submitted",
+				currentStep: 6,
+				updatedAt: new Date(),
+			},
+		];
+
+		let selectCallCount = 0;
+		const localMockSelect = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			if (selectCallCount === 1) {
+				// findUserCompany query
+				return {
+					from: vi.fn().mockReturnValue({
+						innerJoin: vi.fn().mockReturnValue({
+							where: vi.fn().mockReturnValue({
+								limit: vi.fn().mockResolvedValue([companyRow]),
+							}),
+						}),
+					}),
+				};
+			}
+			// declarations query
+			return {
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						orderBy: vi.fn().mockResolvedValue(declRows),
+					}),
+				}),
+			};
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getWithDeclarations({ siren: "339787277" });
+
+		expect(result.company.siren).toBe("339787277");
+		expect(result.declarations).toBeDefined();
+	});
+});
+
+describe("companyRouter.updateHasCse", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("updates hasCse for the given company", async () => {
+		const companyRow = {
+			siren: "339787277",
+			name: "Test Company",
+			address: "1 rue de Paris",
+			nafCode: "6202A",
+			workforce: 100,
+			hasCse: false,
+		};
+
+		mockLimit.mockResolvedValue([companyRow]);
+		mockWhere.mockReturnValue({ limit: mockLimit });
+		mockInnerJoin.mockReturnValue({ where: mockWhere });
+		mockFrom.mockReturnValue({ innerJoin: mockInnerJoin });
+		mockSelect.mockReturnValue({ from: mockFrom });
+
+		mockUpdateWhere.mockResolvedValue(undefined);
+		mockSet.mockReturnValue({ where: mockUpdateWhere });
+		mockUpdate.mockReturnValue({ set: mockSet });
+
+		const mockDb = { select: mockSelect, update: mockUpdate } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await caller.updateHasCse({ siren: "339787277", hasCse: true });
+
+		expect(mockSet).toHaveBeenCalledWith({ hasCse: true });
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockDelete = vi.fn();
+const mockDeleteWhere = vi.fn();
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockTransaction = vi.fn();
+
+function createMockDb(rows: unknown[] = []) {
+	mockWhere.mockResolvedValue(rows);
+	mockFrom.mockReturnValue({ where: mockWhere });
+	mockSelect.mockReturnValue({ from: mockFrom });
+
+	mockDeleteWhere.mockResolvedValue(undefined);
+	mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+	mockValues.mockResolvedValue(undefined);
+	mockInsert.mockReturnValue({ values: mockValues });
+
+	mockTransaction.mockImplementation(async (fn: Function) =>
+		fn({
+			select: mockSelect,
+			delete: mockDelete,
+			insert: mockInsert,
+		}),
+	);
+
+	return {
+		select: mockSelect,
+		transaction: mockTransaction,
+	} as unknown;
+}
+
+function createCaller(mockDb: unknown, siret = "33978727700015") {
+	return import("../cseOpinion").then(({ cseOpinionRouter }) =>
+		cseOpinionRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1", siret }, expires: "" },
+			headers: new Headers(),
+		} as never),
+	);
+}
+
+describe("cseOpinionRouter", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("get", () => {
+		it("returns opinions for the current siren and year", async () => {
+			const opinions = [
+				{
+					declarationNumber: 1,
+					type: "accuracy",
+					opinion: "favorable",
+					opinionDate: "2026-01-15",
+					gapConsulted: null,
+				},
+			];
+			const mockDb = createMockDb(opinions);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.get();
+
+			expect(mockSelect).toHaveBeenCalled();
+			expect(result).toEqual({ opinions });
+		});
+
+		it("returns empty opinions when none exist", async () => {
+			const mockDb = createMockDb([]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.get();
+
+			expect(result).toEqual({ opinions: [] });
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.get()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("saveOpinions", () => {
+		const validInput = {
+			firstDeclaration: {
+				accuracyOpinion: "favorable" as const,
+				accuracyDate: "2026-01-15",
+				gapConsulted: true,
+				gapOpinion: "unfavorable" as const,
+				gapDate: "2026-01-16",
+			},
+		};
+
+		it("deletes existing opinions and inserts new ones in a transaction", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.saveOpinions(validInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+			expect(mockInsert).toHaveBeenCalled();
+			expect(mockValues).toHaveBeenCalledWith(
+				expect.arrayContaining([
+					expect.objectContaining({
+						siren: "339787277",
+						declarationNumber: 1,
+						type: "accuracy",
+						opinion: "favorable",
+					}),
+					expect.objectContaining({
+						siren: "339787277",
+						declarationNumber: 1,
+						type: "gap",
+						gapConsulted: true,
+						opinion: "unfavorable",
+					}),
+				]),
+			);
+		});
+
+		it("inserts second declaration opinions when provided", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const inputWithSecond = {
+				...validInput,
+				secondDeclaration: {
+					accuracyOpinion: "unfavorable" as const,
+					accuracyDate: "2026-02-01",
+					gapConsulted: false,
+					gapOpinion: null,
+					gapDate: null,
+				},
+			};
+
+			const result = await caller.saveOpinions(inputWithSecond);
+
+			expect(result).toEqual({ success: true });
+			expect(mockValues).toHaveBeenCalledWith(
+				expect.arrayContaining([
+					expect.objectContaining({
+						declarationNumber: 2,
+						type: "accuracy",
+						opinion: "unfavorable",
+					}),
+					expect.objectContaining({
+						declarationNumber: 2,
+						type: "gap",
+						gapConsulted: false,
+					}),
+				]),
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.saveOpinions(validInput)).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -1,0 +1,479 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+vi.mock("../declarationHelpers", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../declarationHelpers")>();
+	return {
+		...original,
+		fetchAllCategories: vi.fn().mockResolvedValue({
+			categories: [],
+			jobCategories: [],
+			employeeCategories: [],
+		}),
+		deleteJobAndEmployeeCategories: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
+const mockLimit = vi.fn();
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockUpdate = vi.fn();
+const mockSet = vi.fn();
+const mockUpdateWhere = vi.fn();
+const mockDelete = vi.fn();
+const mockDeleteWhere = vi.fn();
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockOnConflictDoNothing = vi.fn();
+const mockReturning = vi.fn();
+const mockTransaction = vi.fn();
+
+function createMockTx(selectRows: unknown[] = []) {
+	mockLimit.mockResolvedValue(selectRows);
+	mockWhere.mockReturnValue({ limit: mockLimit });
+	mockFrom.mockReturnValue({ where: mockWhere });
+	mockSelect.mockReturnValue({ from: mockFrom });
+
+	mockUpdateWhere.mockResolvedValue(undefined);
+	mockSet.mockReturnValue({ where: mockUpdateWhere });
+	mockUpdate.mockReturnValue({ set: mockSet });
+
+	mockDeleteWhere.mockResolvedValue(undefined);
+	mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+	mockReturning.mockResolvedValue(selectRows);
+	mockOnConflictDoNothing.mockReturnValue({ returning: mockReturning });
+	mockValues.mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+	mockInsert.mockReturnValue({ values: mockValues });
+
+	return {
+		select: mockSelect,
+		update: mockUpdate,
+		delete: mockDelete,
+		insert: mockInsert,
+	};
+}
+
+function createMockDb(selectRows: unknown[] = []) {
+	const tx = createMockTx(selectRows);
+
+	mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+
+	return {
+		select: mockSelect,
+		update: mockUpdate,
+		delete: mockDelete,
+		insert: mockInsert,
+		transaction: mockTransaction,
+	} as unknown;
+}
+
+function createCaller(mockDb: unknown, siret = "33978727700015") {
+	return import("../declaration").then(({ declarationRouter }) =>
+		declarationRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1", siret }, expires: "" },
+			headers: new Headers(),
+		} as never),
+	);
+}
+
+const mockDeclaration = {
+	id: "decl-1",
+	siren: "339787277",
+	year: 2026,
+	currentStep: 0,
+	status: "draft",
+	declarantId: "user-1",
+	totalWomen: null,
+	totalMen: null,
+};
+
+describe("declarationRouter", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("getOrCreate", () => {
+		function createGetOrCreateTx(
+			existingRows: unknown[],
+			insertReturns: unknown[] | null = null,
+			retryRows: unknown[] | null = null,
+		) {
+			let selectCallCount = 0;
+			const txSelect = vi.fn().mockImplementation(() => ({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockImplementation(() => {
+							selectCallCount++;
+							if (selectCallCount === 1)
+								return Promise.resolve(existingRows);
+							if (retryRows && selectCallCount === 2)
+								return Promise.resolve(retryRows);
+							return Promise.resolve([]);
+						}),
+					}),
+				}),
+			}));
+
+			const txInsert = vi.fn().mockReturnValue({
+				values: vi.fn().mockReturnValue({
+					onConflictDoNothing: vi.fn().mockReturnValue({
+						returning: vi
+							.fn()
+							.mockResolvedValue(insertReturns ?? []),
+					}),
+				}),
+			});
+
+			return { select: txSelect, insert: txInsert, delete: mockDelete };
+		}
+
+		it("returns existing declaration when found", async () => {
+			const tx = createGetOrCreateTx([mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getOrCreate();
+
+			expect(result.declaration).toBeDefined();
+			expect(mockTransaction).toHaveBeenCalled();
+		});
+
+		it("creates new declaration when none exists", async () => {
+			const tx = createGetOrCreateTx([], [mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getOrCreate();
+
+			expect(result.declaration).toBeDefined();
+			expect(result.categories).toEqual([]);
+			expect(result.jobCategories).toEqual([]);
+			expect(result.employeeCategories).toEqual([]);
+		});
+
+		it("retries select after concurrent insert (onConflictDoNothing returns empty)", async () => {
+			const tx = createGetOrCreateTx([], [], [mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getOrCreate();
+
+			expect(result.declaration).toBeDefined();
+		});
+
+		it("throws INTERNAL_SERVER_ERROR when retry also fails", async () => {
+			const tx = createGetOrCreateTx([], [], []);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await expect(caller.getOrCreate()).rejects.toThrow(
+				"Erreur lors de la création",
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.getOrCreate()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("submit", () => {
+		it("sets status to submitted and step to 6", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.submit();
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: "submitted",
+					currentStep: 6,
+				}),
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.submit()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("submitSecondDeclaration", () => {
+		it("sets secondDeclarationStatus to submitted and step to 3", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.submitSecondDeclaration();
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					secondDeclarationStatus: "submitted",
+					secondDeclarationStep: 3,
+				}),
+			);
+		});
+	});
+
+	describe("saveCompliancePath", () => {
+		it("saves a valid compliance path", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.saveCompliancePath({
+				path: "corrective_action",
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					compliancePath: "corrective_action",
+				}),
+			);
+		});
+
+		it("saves joint_evaluation path", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.saveCompliancePath({
+				path: "joint_evaluation",
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					compliancePath: "joint_evaluation",
+				}),
+			);
+		});
+
+		it("rejects invalid compliance path", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.saveCompliancePath({ path: "invalid_path" as never }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("completeCompliancePath", () => {
+		it("sets complianceCompletedAt timestamp", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.completeCompliancePath();
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					complianceCompletedAt: expect.any(Date),
+					updatedAt: expect.any(Date),
+				}),
+			);
+		});
+	});
+
+	describe("updateStep1", () => {
+		it("updates totals and inserts categories", async () => {
+			const tx = createMockTx([mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStep1({
+				categories: [
+					{ name: "Cadres", women: 10, men: 15 },
+					{ name: "Employés", women: 20, men: 25 },
+				],
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.updateStep1({ categories: [] })).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("updateStepCategories", () => {
+		it("saves categories for a given step", async () => {
+			const tx = createMockTx();
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStepCategories({
+				step: 2,
+				categories: [{ name: "Cadres", womenCount: 10, menCount: 15 }],
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+		});
+
+		it("rejects step outside 2-4 range", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.updateStepCategories({ step: 1, categories: [] }),
+			).rejects.toThrow();
+
+			await expect(
+				caller.updateStepCategories({ step: 5, categories: [] }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("updateEmployeeCategories", () => {
+		function createEmployeeTx(declaration: unknown, existingJobs: unknown[] = []) {
+			let selectCallCount = 0;
+			const txSelectWhere = vi.fn().mockImplementation(() => {
+				selectCallCount++;
+				const result = Promise.resolve(
+					selectCallCount === 1 ? [] : existingJobs,
+				);
+				(result as Record<string, unknown>).limit = vi
+					.fn()
+					.mockResolvedValue(declaration ? [declaration] : []);
+				return result;
+			});
+			const txSelectFrom = vi.fn().mockReturnValue({ where: txSelectWhere });
+			const txSelect = vi.fn().mockReturnValue({ from: txSelectFrom });
+
+			mockUpdateWhere.mockResolvedValue(undefined);
+			mockSet.mockReturnValue({ where: mockUpdateWhere });
+			mockUpdate.mockReturnValue({ set: mockSet });
+
+			mockDeleteWhere.mockResolvedValue(undefined);
+			mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+			const mockReturningFn = vi
+				.fn()
+				.mockResolvedValue([{ id: "new-job-1" }]);
+			mockValues.mockReturnValue({
+				returning: mockReturningFn,
+				onConflictDoNothing: vi.fn().mockReturnValue({ returning: mockReturningFn }),
+			});
+			mockInsert.mockReturnValue({ values: mockValues });
+
+			return {
+				select: txSelect,
+				update: mockUpdate,
+				delete: mockDelete,
+				insert: mockInsert,
+			};
+		}
+
+		const employeeInput = {
+			declarationType: "initial" as const,
+			source: "dads",
+			categories: [
+				{
+					name: "Cadres",
+					detail: "Senior",
+					data: { womenCount: 10, menCount: 15 },
+				},
+			],
+		};
+
+		it("creates job and employee categories for initial declaration", async () => {
+			const tx = createEmployeeTx(mockDeclaration);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateEmployeeCategories(employeeInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockInsert).toHaveBeenCalled();
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({ currentStep: 5 }),
+			);
+		});
+
+		it("updates employee categories for correction declaration", async () => {
+			const existingJobs = [
+				{ id: "job-1", categoryIndex: 0, name: "Cadres" },
+			];
+			const tx = createEmployeeTx(mockDeclaration, existingJobs);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const correctionInput = {
+				declarationType: "correction" as const,
+				source: "dads",
+				categories: [
+					{
+						name: "Cadres",
+						detail: "Senior",
+						data: { womenCount: 12, menCount: 18 },
+					},
+				],
+				referencePeriodStart: "2025-01-01",
+				referencePeriodEnd: "2025-12-31",
+			};
+
+			const result =
+				await caller.updateEmployeeCategories(correctionInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					secondDeclarationStep: 2,
+					secondDeclReferencePeriodStart: "2025-01-01",
+					secondDeclReferencePeriodEnd: "2025-12-31",
+				}),
+			);
+		});
+
+		it("throws when declaration not found", async () => {
+			const tx = createEmployeeTx(null);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.updateEmployeeCategories(employeeInput),
+			).rejects.toThrow("Déclaration introuvable");
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -9,7 +9,8 @@ vi.mock("~/server/db", () => ({
 }));
 
 vi.mock("../declarationHelpers", async (importOriginal) => {
-	const original = await importOriginal<typeof import("../declarationHelpers")>();
+	const original =
+		await importOriginal<typeof import("../declarationHelpers")>();
 	return {
 		...original,
 		fetchAllCategories: vi.fn().mockResolvedValue({
@@ -118,8 +119,7 @@ describe("declarationRouter", () => {
 					where: vi.fn().mockReturnValue({
 						limit: vi.fn().mockImplementation(() => {
 							selectCallCount++;
-							if (selectCallCount === 1)
-								return Promise.resolve(existingRows);
+							if (selectCallCount === 1) return Promise.resolve(existingRows);
 							if (retryRows && selectCallCount === 2)
 								return Promise.resolve(retryRows);
 							return Promise.resolve([]);
@@ -131,9 +131,7 @@ describe("declarationRouter", () => {
 			const txInsert = vi.fn().mockReturnValue({
 				values: vi.fn().mockReturnValue({
 					onConflictDoNothing: vi.fn().mockReturnValue({
-						returning: vi
-							.fn()
-							.mockResolvedValue(insertReturns ?? []),
+						returning: vi.fn().mockResolvedValue(insertReturns ?? []),
 					}),
 				}),
 			});
@@ -362,14 +360,17 @@ describe("declarationRouter", () => {
 	});
 
 	describe("updateEmployeeCategories", () => {
-		function createEmployeeTx(declaration: unknown, existingJobs: unknown[] = []) {
+		function createEmployeeTx(
+			declaration: unknown,
+			existingJobs: unknown[] = [],
+		) {
 			let selectCallCount = 0;
 			const txSelectWhere = vi.fn().mockImplementation(() => {
 				selectCallCount++;
 				const result = Promise.resolve(
 					selectCallCount === 1 ? [] : existingJobs,
 				);
-				(result as Record<string, unknown>).limit = vi
+				(result as unknown as Record<string, unknown>).limit = vi
 					.fn()
 					.mockResolvedValue(declaration ? [declaration] : []);
 				return result;
@@ -384,12 +385,12 @@ describe("declarationRouter", () => {
 			mockDeleteWhere.mockResolvedValue(undefined);
 			mockDelete.mockReturnValue({ where: mockDeleteWhere });
 
-			const mockReturningFn = vi
-				.fn()
-				.mockResolvedValue([{ id: "new-job-1" }]);
+			const mockReturningFn = vi.fn().mockResolvedValue([{ id: "new-job-1" }]);
 			mockValues.mockReturnValue({
 				returning: mockReturningFn,
-				onConflictDoNothing: vi.fn().mockReturnValue({ returning: mockReturningFn }),
+				onConflictDoNothing: vi
+					.fn()
+					.mockReturnValue({ returning: mockReturningFn }),
 			});
 			mockInsert.mockReturnValue({ values: mockValues });
 
@@ -430,9 +431,7 @@ describe("declarationRouter", () => {
 		});
 
 		it("updates employee categories for correction declaration", async () => {
-			const existingJobs = [
-				{ id: "job-1", categoryIndex: 0, name: "Cadres" },
-			];
+			const existingJobs = [{ id: "job-1", categoryIndex: 0, name: "Cadres" }];
 			const tx = createEmployeeTx(mockDeclaration, existingJobs);
 			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
 			const mockDb = { transaction: mockTransaction } as unknown;
@@ -452,8 +451,7 @@ describe("declarationRouter", () => {
 				referencePeriodEnd: "2025-12-31",
 			};
 
-			const result =
-				await caller.updateEmployeeCategories(correctionInput);
+			const result = await caller.updateEmployeeCategories(correctionInput);
 
 			expect(result).toEqual({ success: true });
 			expect(mockSet).toHaveBeenCalledWith(

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -176,6 +176,18 @@ describe("declarationRouter", () => {
 			expect(result.declaration).toBeDefined();
 		});
 
+		it("throws NOT_FOUND when existing row is unexpectedly undefined", async () => {
+			// existing.length > 0 but existing[0] is undefined (defensive branch)
+			const tx = createGetOrCreateTx([undefined]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await expect(caller.getOrCreate()).rejects.toThrow(
+				"Declaration introuvable",
+			);
+		});
+
 		it("throws INTERNAL_SERVER_ERROR when retry also fails", async () => {
 			const tx = createGetOrCreateTx([], [], []);
 			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
@@ -318,6 +330,42 @@ describe("declarationRouter", () => {
 			expect(mockTransaction).toHaveBeenCalled();
 		});
 
+		it("skips reset when totals have not changed", async () => {
+			const unchangedDecl = {
+				...mockDeclaration,
+				totalWomen: 30,
+				totalMen: 40,
+			};
+			const tx = createMockTx([unchangedDecl]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStep1({
+				categories: [
+					{ name: "Cadres", women: 10, men: 15 },
+					{ name: "Employés", women: 20, men: 25 },
+				],
+			});
+
+			expect(result).toEqual({ success: true });
+			// set should NOT include score resets
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.not.objectContaining({ remunerationScore: null }),
+			);
+		});
+
+		it("saves with empty categories array", async () => {
+			const tx = createMockTx([mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStep1({ categories: [] });
+
+			expect(result).toEqual({ success: true });
+		});
+
 		it("throws when siret is missing", async () => {
 			const mockDb = createMockDb();
 			const caller = await createCaller(mockDb, null as never);
@@ -329,6 +377,34 @@ describe("declarationRouter", () => {
 	});
 
 	describe("updateStepCategories", () => {
+		it("saves empty categories for a given step", async () => {
+			const tx = createMockTx();
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStepCategories({
+				step: 3,
+				categories: [],
+			});
+
+			expect(result).toEqual({ success: true });
+		});
+
+		it("saves categories with all optional fields undefined", async () => {
+			const tx = createMockTx();
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStepCategories({
+				step: 4,
+				categories: [{ name: "Cadres" }],
+			});
+
+			expect(result).toEqual({ success: true });
+		});
+
 		it("saves categories for a given step", async () => {
 			const tx = createMockTx();
 			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	buildEmployeeCategoryValues,
+	mapToEmployeeCategoryRows,
+} from "../declarationHelpers";
+
+describe("buildEmployeeCategoryValues", () => {
+	it("maps all fields from data to values object", () => {
+		const result = buildEmployeeCategoryValues("job-1", "initial", {
+			womenCount: 10,
+			menCount: 15,
+			annualBaseWomen: "30000",
+			annualBaseMen: "32000",
+			annualVariableWomen: "5000",
+			annualVariableMen: "6000",
+			hourlyBaseWomen: "18.5",
+			hourlyBaseMen: "19.0",
+			hourlyVariableWomen: "3.0",
+			hourlyVariableMen: "3.5",
+		});
+
+		expect(result).toEqual({
+			jobCategoryId: "job-1",
+			declarationType: "initial",
+			womenCount: 10,
+			menCount: 15,
+			annualBaseWomen: "30000",
+			annualBaseMen: "32000",
+			annualVariableWomen: "5000",
+			annualVariableMen: "6000",
+			hourlyBaseWomen: "18.5",
+			hourlyBaseMen: "19.0",
+			hourlyVariableWomen: "3.0",
+			hourlyVariableMen: "3.5",
+		});
+	});
+
+	it("defaults missing fields to null", () => {
+		const result = buildEmployeeCategoryValues("job-1", "correction", {});
+
+		expect(result).toEqual({
+			jobCategoryId: "job-1",
+			declarationType: "correction",
+			womenCount: null,
+			menCount: null,
+			annualBaseWomen: null,
+			annualBaseMen: null,
+			annualVariableWomen: null,
+			annualVariableMen: null,
+			hourlyBaseWomen: null,
+			hourlyBaseMen: null,
+			hourlyVariableWomen: null,
+			hourlyVariableMen: null,
+		});
+	});
+
+	it("handles partial data correctly", () => {
+		const result = buildEmployeeCategoryValues("job-2", "initial", {
+			womenCount: 5,
+			annualBaseWomen: "25000",
+		});
+
+		expect(result.womenCount).toBe(5);
+		expect(result.annualBaseWomen).toBe("25000");
+		expect(result.menCount).toBeNull();
+		expect(result.annualBaseMen).toBeNull();
+	});
+});
+
+describe("mapToEmployeeCategoryRows", () => {
+	const baseJob = {
+		id: "job-1",
+		declarationId: "decl-1",
+		categoryIndex: 0,
+		name: "Cadres",
+		detail: "Senior",
+		source: "dads",
+		createdAt: new Date(),
+	};
+
+	const baseEmpCat = {
+		id: "emp-1",
+		jobCategoryId: "job-1",
+		declarationType: "initial" as const,
+		womenCount: 10,
+		menCount: 15,
+		annualBaseWomen: "30000",
+		annualBaseMen: "32000",
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+		createdAt: new Date(),
+	};
+
+	it("maps jobs and employee categories into rows sorted by categoryIndex", () => {
+		const jobs = [
+			{ ...baseJob, id: "job-2", categoryIndex: 1, name: "Employés" },
+			{ ...baseJob, id: "job-1", categoryIndex: 0, name: "Cadres" },
+		];
+
+		const empCats = [
+			{ ...baseEmpCat, jobCategoryId: "job-1" },
+			{
+				...baseEmpCat,
+				id: "emp-2",
+				jobCategoryId: "job-2",
+				womenCount: 20,
+				menCount: 25,
+			},
+		];
+
+		const result = mapToEmployeeCategoryRows(jobs, empCats, "initial");
+
+		expect(result).toHaveLength(2);
+		expect(result[0]?.name).toBe("Cadres");
+		expect(result[0]?.womenCount).toBe(10);
+		expect(result[1]?.name).toBe("Employés");
+		expect(result[1]?.womenCount).toBe(20);
+	});
+
+	it("returns null fields when no employee category matches", () => {
+		const jobs = [baseJob];
+		const result = mapToEmployeeCategoryRows(jobs, [], "initial");
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.womenCount).toBeNull();
+		expect(result[0]?.menCount).toBeNull();
+	});
+
+	it("filters by declaration type", () => {
+		const jobs = [baseJob];
+		const empCats = [
+			{ ...baseEmpCat, declarationType: "correction" as const, womenCount: 99 },
+		];
+
+		const result = mapToEmployeeCategoryRows(jobs, empCats, "initial");
+
+		expect(result[0]?.womenCount).toBeNull();
+	});
+
+	it("uses empty string for null detail", () => {
+		const jobs = [{ ...baseJob, detail: null }];
+
+		const result = mapToEmployeeCategoryRows(jobs, [], "initial");
+
+		expect(result[0]?.detail).toBe("");
+	});
+});
+
+describe("deleteJobAndEmployeeCategories", () => {
+	it("deletes employee categories then job categories", async () => {
+		const { deleteJobAndEmployeeCategories } = await import(
+			"../declarationHelpers"
+		);
+
+		const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+		const mockDelete = vi.fn().mockReturnValue({ where: mockDeleteWhere });
+		const mockSelectWhere = vi
+			.fn()
+			.mockResolvedValue([{ id: "job-1" }, { id: "job-2" }]);
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect, delete: mockDelete } as never;
+
+		await deleteJobAndEmployeeCategories(tx, "decl-1");
+
+		// 2 employee category deletes + 1 job categories delete = 3 total
+		expect(mockDelete).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not delete job categories when none exist", async () => {
+		const { deleteJobAndEmployeeCategories } = await import(
+			"../declarationHelpers"
+		);
+
+		const mockDelete = vi.fn();
+		const mockSelectWhere = vi.fn().mockResolvedValue([]);
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect, delete: mockDelete } as never;
+
+		await deleteJobAndEmployeeCategories(tx, "decl-1");
+
+		expect(mockDelete).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -94,6 +94,7 @@ describe("mapToEmployeeCategoryRows", () => {
 		hourlyVariableWomen: null,
 		hourlyVariableMen: null,
 		createdAt: new Date(),
+		updatedAt: new Date(),
 	};
 
 	it("maps jobs and employee categories into rows sorted by categoryIndex", () => {

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -152,6 +152,58 @@ describe("mapToEmployeeCategoryRows", () => {
 	});
 });
 
+describe("fetchAllCategories", () => {
+	it("returns categories, jobCategories and employeeCategories", async () => {
+		const { fetchAllCategories } = await import("../declarationHelpers");
+
+		const mockCategories = [{ id: "cat-1", siren: "123456789", year: 2026 }];
+		const mockJobs = [{ id: "job-1" }, { id: "job-2" }];
+		const mockEmpCats = [
+			[{ id: "emp-1", jobCategoryId: "job-1" }],
+			[{ id: "emp-2", jobCategoryId: "job-2" }],
+		];
+
+		let selectCallCount = 0;
+		const mockSelectWhere = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			if (selectCallCount === 1) return Promise.resolve(mockCategories);
+			if (selectCallCount === 2) return Promise.resolve(mockJobs);
+			// Employee category queries
+			return Promise.resolve(mockEmpCats[selectCallCount - 3] ?? []);
+		});
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect } as never;
+
+		const result = await fetchAllCategories(tx, "123456789", 2026, "decl-1");
+
+		expect(result.categories).toEqual(mockCategories);
+		expect(result.jobCategories).toEqual(mockJobs);
+		expect(result.employeeCategories).toHaveLength(2);
+	});
+
+	it("returns empty employeeCategories when no jobs exist", async () => {
+		const { fetchAllCategories } = await import("../declarationHelpers");
+
+		let selectCallCount = 0;
+		const mockSelectWhere = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			return Promise.resolve([]);
+		});
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect } as never;
+
+		const result = await fetchAllCategories(tx, "123456789", 2026, "decl-1");
+
+		expect(result.categories).toEqual([]);
+		expect(result.jobCategories).toEqual([]);
+		expect(result.employeeCategories).toEqual([]);
+	});
+});
+
 describe("deleteJobAndEmployeeCategories", () => {
 	it("deletes employee categories then job categories", async () => {
 		const { deleteJobAndEmployeeCategories } = await import(

--- a/packages/app/src/server/api/routers/__tests__/jointEvaluation.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/jointEvaluation.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockDelete = vi.fn();
+const mockDeleteWhere = vi.fn();
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockLimit = vi.fn();
+const mockTransaction = vi.fn();
+
+function createMockDb(rows: unknown[] = []) {
+	mockLimit.mockResolvedValue(rows);
+	mockWhere.mockReturnValue({ limit: mockLimit });
+	mockFrom.mockReturnValue({ where: mockWhere });
+	mockSelect.mockReturnValue({ from: mockFrom });
+
+	mockDeleteWhere.mockResolvedValue(undefined);
+	mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+	mockValues.mockResolvedValue(undefined);
+	mockInsert.mockReturnValue({ values: mockValues });
+
+	mockTransaction.mockImplementation(async (fn: Function) =>
+		fn({
+			select: mockSelect,
+			delete: mockDelete,
+			insert: mockInsert,
+		}),
+	);
+
+	return {
+		select: mockSelect,
+		transaction: mockTransaction,
+	} as unknown;
+}
+
+function createCaller(mockDb: unknown, siret = "33978727700015") {
+	return import("../jointEvaluation").then(({ jointEvaluationRouter }) =>
+		jointEvaluationRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1", siret }, expires: "" },
+			headers: new Headers(),
+		} as never),
+	);
+}
+
+describe("jointEvaluationRouter", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("uploadFile", () => {
+		const validInput = {
+			fileName: "evaluation.pdf",
+			filePath: "/uploads/evaluation.pdf",
+		};
+
+		it("deletes existing file and inserts new one in a transaction", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.uploadFile(validInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+			expect(mockInsert).toHaveBeenCalled();
+			expect(mockValues).toHaveBeenCalledWith(
+				expect.objectContaining({
+					siren: "339787277",
+					fileName: "evaluation.pdf",
+					filePath: "/uploads/evaluation.pdf",
+					declarantId: "user-1",
+				}),
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.uploadFile(validInput)).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+
+		it("rejects empty fileName", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.uploadFile({ fileName: "", filePath: "/uploads/test.pdf" }),
+			).rejects.toThrow();
+		});
+
+		it("rejects empty filePath", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.uploadFile({ fileName: "test.pdf", filePath: "" }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("getFile", () => {
+		it("returns file when it exists", async () => {
+			const file = {
+				fileName: "evaluation.pdf",
+				filePath: "/uploads/evaluation.pdf",
+				uploadedAt: new Date("2026-01-15"),
+			};
+			const mockDb = createMockDb([file]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getFile();
+
+			expect(result).toEqual(file);
+			expect(mockSelect).toHaveBeenCalled();
+		});
+
+		it("returns null when no file exists", async () => {
+			const mockDb = createMockDb([]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getFile();
+
+			expect(result).toBeNull();
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.getFile()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -76,28 +76,30 @@ export const cseOpinionRouter = createTRPCRouter({
 					declarantId,
 				});
 
-				// Second declaration — accuracy
-				rows.push({
-					siren,
-					year,
-					declarationNumber: 2,
-					type: "accuracy",
-					opinion: input.secondDeclaration.accuracyOpinion,
-					opinionDate: input.secondDeclaration.accuracyDate,
-					declarantId,
-				});
+				if (input.secondDeclaration) {
+					// Second declaration — accuracy
+					rows.push({
+						siren,
+						year,
+						declarationNumber: 2,
+						type: "accuracy",
+						opinion: input.secondDeclaration.accuracyOpinion,
+						opinionDate: input.secondDeclaration.accuracyDate,
+						declarantId,
+					});
 
-				// Second declaration — gap
-				rows.push({
-					siren,
-					year,
-					declarationNumber: 2,
-					type: "gap",
-					gapConsulted: input.secondDeclaration.gapConsulted,
-					opinion: input.secondDeclaration.gapOpinion,
-					opinionDate: input.secondDeclaration.gapDate,
-					declarantId,
-				});
+					// Second declaration — gap
+					rows.push({
+						siren,
+						year,
+						declarationNumber: 2,
+						type: "gap",
+						gapConsulted: input.secondDeclaration.gapConsulted,
+						opinion: input.secondDeclaration.gapOpinion,
+						opinionDate: input.secondDeclaration.gapDate,
+						declarantId,
+					});
+				}
 
 				await tx.insert(cseOpinions).values(rows);
 			});

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -389,4 +389,16 @@ export const declarationRouter = createTRPCRouter({
 
 			return { success: true };
 		}),
+
+	completeCompliancePath: protectedProcedure.mutation(async ({ ctx }) => {
+		const siren = getSiren(ctx.session.user.siret);
+		const year = getCurrentYear();
+
+		await ctx.db
+			.update(declarations)
+			.set({ complianceCompletedAt: new Date(), updatedAt: new Date() })
+			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+
+		return { success: true };
+	}),
 });

--- a/packages/app/src/server/api/routers/jointEvaluation.ts
+++ b/packages/app/src/server/api/routers/jointEvaluation.ts
@@ -1,0 +1,79 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { jointEvaluationFiles } from "~/server/db/schema";
+
+function getSiren(siret: string | null | undefined): string {
+	if (!siret) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "SIRET manquant dans la session",
+		});
+	}
+	return siret.slice(0, 9);
+}
+
+function getCurrentYear() {
+	return new Date().getFullYear();
+}
+
+export const jointEvaluationRouter = createTRPCRouter({
+	uploadFile: protectedProcedure
+		.input(
+			z.object({
+				fileName: z.string().min(1),
+				filePath: z.string().min(1),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const siren = getSiren(ctx.session.user.siret);
+			const year = getCurrentYear();
+			const declarantId = ctx.session.user.id;
+
+			// Upsert: delete existing file for this siren/year, then insert
+			await ctx.db.transaction(async (tx) => {
+				await tx
+					.delete(jointEvaluationFiles)
+					.where(
+						and(
+							eq(jointEvaluationFiles.siren, siren),
+							eq(jointEvaluationFiles.year, year),
+						),
+					);
+
+				await tx.insert(jointEvaluationFiles).values({
+					siren,
+					year,
+					fileName: input.fileName,
+					filePath: input.filePath,
+					declarantId,
+				});
+			});
+
+			return { success: true };
+		}),
+
+	getFile: protectedProcedure.query(async ({ ctx }) => {
+		const siren = getSiren(ctx.session.user.siret);
+		const year = getCurrentYear();
+
+		const rows = await ctx.db
+			.select({
+				fileName: jointEvaluationFiles.fileName,
+				filePath: jointEvaluationFiles.filePath,
+				uploadedAt: jointEvaluationFiles.uploadedAt,
+			})
+			.from(jointEvaluationFiles)
+			.where(
+				and(
+					eq(jointEvaluationFiles.siren, siren),
+					eq(jointEvaluationFiles.year, year),
+				),
+			)
+			.limit(1);
+
+		return rows[0] ?? null;
+	}),
+});

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -119,6 +119,7 @@ export const declarations = createTable(
 		secondDeclarationStatus: d.varchar({ length: 20 }),
 		secondDeclReferencePeriodStart: d.varchar({ length: 10 }),
 		secondDeclReferencePeriodEnd: d.varchar({ length: 10 }),
+		complianceCompletedAt: d.timestamp({ withTimezone: true }),
 		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 	}),
@@ -438,6 +439,48 @@ export const cseOpinionFileLinksRelations = relations(
 		opinion: one(cseOpinions, {
 			fields: [cseOpinionFileLinks.opinionId],
 			references: [cseOpinions.id],
+		}),
+	}),
+);
+
+export const jointEvaluationFiles = createTable(
+	"joint_evaluation_file",
+	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		siren: d
+			.varchar({ length: 9 })
+			.notNull()
+			.references(() => companies.siren),
+		year: d.integer().notNull(),
+		fileName: d.varchar({ length: 255 }).notNull(),
+		filePath: d.varchar({ length: 500 }).notNull(),
+		declarantId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => users.id),
+		uploadedAt: d
+			.timestamp({ withTimezone: true })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+	}),
+	(t) => [index("joint_eval_file_siren_year_idx").on(t.siren, t.year)],
+);
+
+export const jointEvaluationFilesRelations = relations(
+	jointEvaluationFiles,
+	({ one }) => ({
+		company: one(companies, {
+			fields: [jointEvaluationFiles.siren],
+			references: [companies.siren],
+		}),
+		declarant: one(users, {
+			fields: [jointEvaluationFiles.declarantId],
+			references: [users.id],
 		}),
 	}),
 );


### PR DESCRIPTION
## Summary

- Routing conditionnel basé sur l'écart de rémunération et `hasCse` (compagnies ≥ 100 salariés)
- Page de confirmation `/parcours-conformite/confirmation` pour les entreprises sans CSE
- Upload PDF évaluation conjointe (tRPC `jointEvaluation.uploadFile` + table `joint_evaluation_files`)
- `CompliancePathChoice` affiche les options conditionnellement (1er tour vs 2e tour, présence CSE)
- `ComplianceCompletionTracker` empêche de ré-entrer dans le parcours une fois terminé
- Migrations Drizzle pour la nouvelle table

## Flux implémenté

```
Soumission déclaration
  → Pas d'écart → hasCse → /avis-cse | /confirmation
  → Écart → Choix 1er tour (corrective / joint / justify si CSE)
    → corrective_action → 2e déclaration → Écart persistant → Choix 2e tour
    → joint_evaluation → upload PDF → hasCse → /avis-cse | /confirmation
    → justify → /avis-cse
```

## Test plan

- [ ] Vérifier typecheck + unit tests passent
- [ ] Tester manuellement les 6 cas principaux du flux
- [ ] PR suivante contient les E2E couvrant les 12 parcours