### PR TITLE
test(e2e): add 12 compliance path E2E scenarios

### DIFF
--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -35,20 +35,22 @@ export default defineConfig({
 			dependencies: ["setup"],
 		},
 		{
-			// Compliance tests run AFTER standard tests to avoid DB state pollution
+			// Compliance tests run AFTER standard tests to avoid DB state pollution.
+			// Depends on setup (auth) only — not chromium — so a flaky login.e2e.ts
+			// does not cascade-skip compliance tests.
 			name: "compliance",
 			testMatch: /compliance\.e2e\.ts$/,
 			use: {
 				...devices["Desktop Chrome"],
 				storageState: AUTH_FILE,
 			},
-			dependencies: ["chromium"],
+			dependencies: ["setup"],
 		},
 		{
 			name: "logout",
 			testMatch: /logout\.e2e\.ts$/,
 			use: { ...devices["Desktop Chrome"] },
-			dependencies: ["compliance"],
+			dependencies: ["chromium", "compliance"],
 		},
 	],
 	...(isRemote

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 		},
 		{
 			name: "chromium",
-			testMatch: /(?<!logout\.)e2e\.ts$/,
+			testMatch: /(?<!logout\.)(?<!compliance\.)e2e\.ts$/,
 			use: {
 				...devices["Desktop Chrome"],
 				storageState: AUTH_FILE,
@@ -35,10 +35,20 @@ export default defineConfig({
 			dependencies: ["setup"],
 		},
 		{
+			// Compliance tests run AFTER standard tests to avoid DB state pollution
+			name: "compliance",
+			testMatch: /compliance\.e2e\.ts$/,
+			use: {
+				...devices["Desktop Chrome"],
+				storageState: AUTH_FILE,
+			},
+			dependencies: ["chromium"],
+		},
+		{
 			name: "logout",
 			testMatch: /logout\.e2e\.ts$/,
 			use: { ...devices["Desktop Chrome"] },
-			dependencies: ["chromium"],
+			dependencies: ["compliance"],
 		},
 	],
 	...(isRemote

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -1,69 +1,17 @@
-import path from "node:path";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { setupComplianceState } from "./helpers/compliance";
+import {
+	fillCseStep1,
+	selectCompliancePath,
+	submitCseStep2,
+	submitSecondDeclaration,
+	uploadJointEvalPdf,
+} from "./helpers/compliance-flows";
 
 test.describe.configure({ mode: "serial" });
 
-const DUMMY_PDF = path.join(import.meta.dirname, "fixtures/dummy.pdf");
 const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
 const CONFIRMATION_PATH = `${COMPLIANCE_PATH}/confirmation`;
-
-// --- Shared flow helpers ---
-
-async function fillCseStep1(page: Page, hasSecondDeclaration = false) {
-	await page.waitForURL("**/avis-cse/etape/1");
-	// DSFR hides native radio inputs — click on the associated label instead
-	await page.locator('label[for="first-decl-accuracy-favorable"]').click();
-	await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
-	await page.locator('label[for="first-decl-gap-no"]').click();
-	if (hasSecondDeclaration) {
-		await page.locator('label[for="second-decl-accuracy-favorable"]').click();
-		await page.locator("#second-decl-accuracy-date").fill("2025-06-15");
-		await page.locator('label[for="second-decl-gap-no"]').click();
-	}
-	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL("**/avis-cse/etape/2");
-}
-
-async function submitCseStep2(page: Page) {
-	await page.locator("#cse-file-upload").setInputFiles(DUMMY_PDF);
-	await page.getByRole("button", { name: "Soumettre" }).click();
-	await page
-		.getByText(/Je certifie que les avis transmis sont conformes/)
-		.click();
-	await page.getByRole("button", { name: "Valider" }).click();
-	await page.waitForURL("**/avis-cse/confirmation");
-}
-
-async function uploadJointEvalPdf(page: Page) {
-	await page.waitForURL("**/evaluation-conjointe");
-	await page.locator("#joint-evaluation-file-upload").setInputFiles(DUMMY_PDF);
-	await page.getByRole("button", { name: "Transmettre" }).click();
-	await page
-		.getByText(/Je certifie que le rapport transmis est conforme/)
-		.click();
-	await page.getByRole("button", { name: "Valider" }).click();
-}
-
-async function selectCompliancePath(
-	page: Page,
-	pathId: "path-corrective" | "path-joint" | "path-justify",
-) {
-	await page.goto(COMPLIANCE_PATH);
-	await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
-	// DSFR hides native radio inputs — click on the associated label instead
-	await page.locator(`label[for="${pathId}"]`).click();
-	await page.getByRole("button", { name: "Suivant" }).click();
-}
-
-async function submitSecondDeclaration(page: Page, expectedUrlPattern: string) {
-	await page.goto(`${COMPLIANCE_PATH}/etape/3`);
-	await page
-		.getByText(/Je certifie que les données saisies sont exactes/)
-		.click();
-	await page.getByRole("button", { name: "Soumettre" }).click();
-	await page.waitForURL(expectedUrlPattern, { timeout: 10_000 });
-}
 
 // === GROUP A: No gap — auto-redirects ===
 

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { setupComplianceState } from "./helpers/compliance";
 import {
+	COMPLIANCE_PATH,
 	fillCseStep1,
 	selectCompliancePath,
 	submitCseStep2,
@@ -10,7 +11,6 @@ import {
 
 test.describe.configure({ mode: "serial" });
 
-const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
 const CONFIRMATION_PATH = `${COMPLIANCE_PATH}/confirmation`;
 
 // === GROUP A: No gap — auto-redirects ===

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -12,13 +12,14 @@ const CONFIRMATION_PATH = `${COMPLIANCE_PATH}/confirmation`;
 
 async function fillCseStep1(page: Page, hasSecondDeclaration = false) {
 	await page.waitForURL("**/avis-cse/etape/1");
-	await page.locator("#first-decl-accuracy-favorable").click();
+	// DSFR hides native radio inputs — click on the associated label instead
+	await page.locator('label[for="first-decl-accuracy-favorable"]').click();
 	await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
-	await page.locator("#first-decl-gap-no").click();
+	await page.locator('label[for="first-decl-gap-no"]').click();
 	if (hasSecondDeclaration) {
-		await page.locator("#second-decl-accuracy-favorable").click();
+		await page.locator('label[for="second-decl-accuracy-favorable"]').click();
 		await page.locator("#second-decl-accuracy-date").fill("2025-06-15");
-		await page.locator("#second-decl-gap-no").click();
+		await page.locator('label[for="second-decl-gap-no"]').click();
 	}
 	await page.getByRole("button", { name: "Suivant" }).click();
 	await page.waitForURL("**/avis-cse/etape/2");
@@ -50,7 +51,8 @@ async function selectCompliancePath(
 ) {
 	await page.goto(COMPLIANCE_PATH);
 	await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
-	await page.locator(`#${pathId}`).click();
+	// DSFR hides native radio inputs — click on the associated label instead
+	await page.locator(`label[for="${pathId}"]`).click();
 	await page.getByRole("button", { name: "Suivant" }).click();
 }
 

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -56,6 +56,15 @@ async function selectCompliancePath(
 	await page.getByRole("button", { name: "Suivant" }).click();
 }
 
+async function submitSecondDeclaration(page: Page, expectedUrlPattern: string) {
+	await page.goto(`${COMPLIANCE_PATH}/etape/3`);
+	await page
+		.getByText(/Je certifie que les données saisies sont exactes/)
+		.click();
+	await page.getByRole("button", { name: "Soumettre" }).click();
+	await page.waitForURL(expectedUrlPattern, { timeout: 10_000 });
+}
+
 // === GROUP A: No gap — auto-redirects ===
 
 test.describe("Path 1: no gap + hasCse → /avis-cse → full CSE flow", () => {
@@ -178,12 +187,7 @@ test.describe("Path 6: corrective_action + no correction gap + hasCse → /avis-
 	test("step 3: submit second decl (no gap) → navigates to /avis-cse", async ({
 		page,
 	}) => {
-		await page.goto(`${COMPLIANCE_PATH}/etape/3`);
-		await page
-			.getByText(/Je certifie que les données saisies sont exactes/)
-			.click();
-		await page.getByRole("button", { name: "Soumettre" }).click();
-		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+		await submitSecondDeclaration(page, "**/avis-cse/**");
 	});
 });
 
@@ -200,12 +204,7 @@ test.describe("Path 7: corrective_action + no correction gap + no hasCse → /co
 	test("step 3: submit second decl (no gap) → navigates to /confirmation", async ({
 		page,
 	}) => {
-		await page.goto(`${COMPLIANCE_PATH}/etape/3`);
-		await page
-			.getByText(/Je certifie que les données saisies sont exactes/)
-			.click();
-		await page.getByRole("button", { name: "Soumettre" }).click();
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await submitSecondDeclaration(page, `**${CONFIRMATION_PATH}`);
 	});
 });
 
@@ -222,12 +221,7 @@ test.describe("Path 8: corrective_action + correction gap → second round choic
 	test("step 3: submit second decl (gap) → navigates back to compliance path", async ({
 		page,
 	}) => {
-		await page.goto(`${COMPLIANCE_PATH}/etape/3`);
-		await page
-			.getByText(/Je certifie que les données saisies sont exactes/)
-			.click();
-		await page.getByRole("button", { name: "Soumettre" }).click();
-		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+		await submitSecondDeclaration(page, `**${COMPLIANCE_PATH}`);
 	});
 
 	test("second round shows only justify and joint_evaluation (no corrective_action)", async ({
@@ -331,6 +325,6 @@ test.describe("Path 12: complianceCompletedAt set → immediate redirect", () =>
 			},
 		);
 		// Should be on /avis-cse (hasCse=true)
-		await expect(page.url()).toContain("avis-cse");
+		await expect(page).toHaveURL(/avis-cse/);
 	});
 });

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -71,7 +71,7 @@ test.describe("Path 1: no gap + hasCse → /avis-cse → full CSE flow", () => {
 		await fillCseStep1(page, false);
 		await submitCseStep2(page);
 		await expect(
-			page.getByText(/Votre parcours .* est désormais terminé/),
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
 		).toBeVisible();
 	});
 });
@@ -85,7 +85,7 @@ test.describe("Path 2: no gap + no hasCse → /parcours-conformite/confirmation"
 		await page.goto(COMPLIANCE_PATH);
 		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
 		await expect(
-			page.getByText(/Votre parcours .* est désormais terminé/),
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
 		).toBeVisible();
 	});
 });

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -1,0 +1,322 @@
+import path from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+import { setupComplianceState } from "./helpers/compliance";
+
+test.describe.configure({ mode: "serial" });
+
+const DUMMY_PDF = path.join(import.meta.dirname, "fixtures/dummy.pdf");
+const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
+const CONFIRMATION_PATH = `${COMPLIANCE_PATH}/confirmation`;
+
+// --- Shared flow helpers ---
+
+async function fillCseStep1(page: Page, hasSecondDeclaration = false) {
+	await page.waitForURL("**/avis-cse/etape/1");
+	await page.locator("#first-decl-accuracy-favorable").click();
+	await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
+	await page.locator("#first-decl-gap-no").click();
+	if (hasSecondDeclaration) {
+		await page.locator("#second-decl-accuracy-favorable").click();
+		await page.locator("#second-decl-accuracy-date").fill("2025-06-15");
+		await page.locator("#second-decl-gap-no").click();
+	}
+	await page.getByRole("button", { name: "Suivant" }).click();
+	await page.waitForURL("**/avis-cse/etape/2");
+}
+
+async function submitCseStep2(page: Page) {
+	await page.locator("#cse-file-upload").setInputFiles(DUMMY_PDF);
+	await page.getByRole("button", { name: "Soumettre" }).click();
+	await page
+		.getByText(/Je certifie que les avis transmis sont conformes/)
+		.click();
+	await page.getByRole("button", { name: "Valider" }).click();
+	await page.waitForURL("**/avis-cse/confirmation");
+}
+
+async function uploadJointEvalPdf(page: Page) {
+	await page.waitForURL("**/evaluation-conjointe");
+	await page.locator("#joint-evaluation-file-upload").setInputFiles(DUMMY_PDF);
+	await page.getByRole("button", { name: "Transmettre" }).click();
+	await page
+		.getByText(/Je certifie que le rapport transmis est conforme/)
+		.click();
+	await page.getByRole("button", { name: "Valider" }).click();
+}
+
+async function selectCompliancePath(
+	page: Page,
+	pathId: "path-corrective" | "path-joint" | "path-justify",
+) {
+	await page.goto(COMPLIANCE_PATH);
+	await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+	await page.locator(`#${pathId}`).click();
+	await page.getByRole("button", { name: "Suivant" }).click();
+}
+
+// === GROUP A: No gap — auto-redirects ===
+
+test.describe("Path 1: no gap + hasCse → /avis-cse → full CSE flow", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({ hasCse: true, hasInitialGap: false });
+	});
+
+	test("redirects to /avis-cse and completes CSE opinion flow", async ({
+		page,
+	}) => {
+		await page.goto(COMPLIANCE_PATH);
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+		await fillCseStep1(page, false);
+		await submitCseStep2(page);
+		await expect(
+			page.getByText(/Votre parcours .* est désormais terminé/),
+		).toBeVisible();
+	});
+});
+
+test.describe("Path 2: no gap + no hasCse → /parcours-conformite/confirmation", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({ hasCse: false, hasInitialGap: false });
+	});
+
+	test("redirects to compliance confirmation page", async ({ page }) => {
+		await page.goto(COMPLIANCE_PATH);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await expect(
+			page.getByText(/Votre parcours .* est désormais terminé/),
+		).toBeVisible();
+	});
+});
+
+// === GROUP B: First round — choice form ===
+
+test.describe("Path 3: gap + justify + hasCse → /avis-cse", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({ hasCse: true, hasInitialGap: true });
+	});
+
+	test("shows 3 compliance options including justify (hasCse=true)", async ({
+		page,
+	}) => {
+		await page.goto(COMPLIANCE_PATH);
+		await expect(
+			page.getByText("Actions correctives et seconde déclaration"),
+		).toBeVisible();
+		await expect(
+			page.getByText("Évaluation conjointe des rémunérations"),
+		).toBeVisible();
+		await expect(
+			page.getByText("Justifier les écarts de rémunération ≥ 5 %"),
+		).toBeVisible();
+	});
+
+	test("justify → navigates to /avis-cse/etape/1", async ({ page }) => {
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+	});
+});
+
+test.describe("Path 4: gap + joint_evaluation + hasCse → /avis-cse", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({ hasCse: true, hasInitialGap: true });
+	});
+
+	test("joint_evaluation → upload PDF → navigates to /avis-cse/etape/1", async ({
+		page,
+	}) => {
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+	});
+});
+
+test.describe("Path 5: gap + joint_evaluation + no hasCse → /confirmation", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({ hasCse: false, hasInitialGap: true });
+	});
+
+	test("shows only 2 options without justify (hasCse=false)", async ({
+		page,
+	}) => {
+		await page.goto(COMPLIANCE_PATH);
+		await expect(
+			page.getByText("Justifier les écarts de rémunération ≥ 5 %"),
+		).not.toBeVisible();
+	});
+
+	test("joint_evaluation → upload PDF → navigates to /confirmation", async ({
+		page,
+	}) => {
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+	});
+});
+
+// === GROUP C: Corrective action — second declaration review ===
+
+test.describe("Path 6: corrective_action + no correction gap + hasCse → /avis-cse", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({
+			hasCse: true,
+			hasInitialGap: true,
+			compliancePath: "corrective_action",
+			correctionHasGap: false,
+		});
+	});
+
+	test("step 3: submit second decl (no gap) → navigates to /avis-cse", async ({
+		page,
+	}) => {
+		await page.goto(`${COMPLIANCE_PATH}/etape/3`);
+		await page
+			.getByText(/Je certifie que les données saisies sont exactes/)
+			.click();
+		await page.getByRole("button", { name: "Soumettre" }).click();
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+	});
+});
+
+test.describe("Path 7: corrective_action + no correction gap + no hasCse → /confirmation", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({
+			hasCse: false,
+			hasInitialGap: true,
+			compliancePath: "corrective_action",
+			correctionHasGap: false,
+		});
+	});
+
+	test("step 3: submit second decl (no gap) → navigates to /confirmation", async ({
+		page,
+	}) => {
+		await page.goto(`${COMPLIANCE_PATH}/etape/3`);
+		await page
+			.getByText(/Je certifie que les données saisies sont exactes/)
+			.click();
+		await page.getByRole("button", { name: "Soumettre" }).click();
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+	});
+});
+
+test.describe("Path 8: corrective_action + correction gap → second round choices", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({
+			hasCse: true,
+			hasInitialGap: true,
+			compliancePath: "corrective_action",
+			correctionHasGap: true,
+		});
+	});
+
+	test("step 3: submit second decl (gap) → navigates back to compliance path", async ({
+		page,
+	}) => {
+		await page.goto(`${COMPLIANCE_PATH}/etape/3`);
+		await page
+			.getByText(/Je certifie que les données saisies sont exactes/)
+			.click();
+		await page.getByRole("button", { name: "Soumettre" }).click();
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+	});
+
+	test("second round shows only justify and joint_evaluation (no corrective_action)", async ({
+		page,
+	}) => {
+		await page.goto(COMPLIANCE_PATH);
+		await expect(
+			page.getByText("Justifier les écarts de rémunération ≥ 5 %"),
+		).toBeVisible();
+		await expect(
+			page.getByText("Évaluation conjointe des rémunérations"),
+		).toBeVisible();
+		await expect(
+			page.getByText("Actions correctives et seconde déclaration"),
+		).not.toBeVisible();
+	});
+});
+
+// === GROUP D: Second round ===
+
+test.describe("Path 9: second round + justify → /avis-cse", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({
+			hasCse: true,
+			hasInitialGap: true,
+			compliancePath: "corrective_action",
+			secondDeclarationStatus: "submitted",
+			correctionHasGap: true,
+		});
+	});
+
+	test("justify → navigates to /avis-cse/etape/1", async ({ page }) => {
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+	});
+});
+
+test.describe("Path 10: second round + joint_evaluation + hasCse → /avis-cse", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({
+			hasCse: true,
+			hasInitialGap: true,
+			compliancePath: "corrective_action",
+			secondDeclarationStatus: "submitted",
+			correctionHasGap: true,
+		});
+	});
+
+	test("joint_evaluation → upload PDF → navigates to /avis-cse", async ({
+		page,
+	}) => {
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+	});
+});
+
+test.describe("Path 11: second round + joint_evaluation + no hasCse → /confirmation", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({
+			hasCse: false,
+			hasInitialGap: true,
+			compliancePath: "corrective_action",
+			secondDeclarationStatus: "submitted",
+			correctionHasGap: true,
+		});
+	});
+
+	test("joint_evaluation → upload PDF → navigates to /confirmation", async ({
+		page,
+	}) => {
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+	});
+});
+
+// === GROUP E: Redirect guard ===
+
+test.describe("Path 12: complianceCompletedAt set → immediate redirect", () => {
+	test.beforeAll(async () => {
+		await setupComplianceState({
+			hasCse: true,
+			hasInitialGap: true,
+			complianceCompletedAt: new Date(),
+		});
+	});
+
+	test("compliance already completed → redirects away from choice page", async ({
+		page,
+	}) => {
+		await page.goto(COMPLIANCE_PATH);
+		await page.waitForURL(
+			(url) => !url.pathname.endsWith("/parcours-conformite"),
+			{
+				timeout: 10_000,
+			},
+		);
+		// Should be on /avis-cse (hasCse=true)
+		await expect(page.url()).toContain("avis-cse");
+	});
+});

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -102,13 +102,19 @@ test.describe("Path 3: gap + justify + hasCse → /avis-cse", () => {
 	}) => {
 		await page.goto(COMPLIANCE_PATH);
 		await expect(
-			page.getByText("Actions correctives et seconde déclaration"),
+			page.getByText("Actions correctives et seconde déclaration", {
+				exact: true,
+			}),
 		).toBeVisible();
 		await expect(
-			page.getByText("Évaluation conjointe des rémunérations"),
+			page.getByText("Évaluation conjointe des rémunérations", {
+				exact: true,
+			}),
 		).toBeVisible();
 		await expect(
-			page.getByText("Justifier les écarts de rémunération ≥ 5 %"),
+			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
+				exact: true,
+			}),
 		).toBeVisible();
 	});
 
@@ -142,7 +148,9 @@ test.describe("Path 5: gap + joint_evaluation + no hasCse → /confirmation", ()
 	}) => {
 		await page.goto(COMPLIANCE_PATH);
 		await expect(
-			page.getByText("Justifier les écarts de rémunération ≥ 5 %"),
+			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
+				exact: true,
+			}),
 		).not.toBeVisible();
 	});
 
@@ -227,13 +235,17 @@ test.describe("Path 8: corrective_action + correction gap → second round choic
 	}) => {
 		await page.goto(COMPLIANCE_PATH);
 		await expect(
-			page.getByText("Justifier les écarts de rémunération ≥ 5 %"),
+			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
+				exact: true,
+			}),
 		).toBeVisible();
 		await expect(
-			page.getByText("Évaluation conjointe des rémunérations"),
+			page.getByText("Évaluation conjointe des rémunérations", { exact: true }),
 		).toBeVisible();
 		await expect(
-			page.getByText("Actions correctives et seconde déclaration"),
+			page.getByText("Actions correctives et seconde déclaration", {
+				exact: true,
+			}),
 		).not.toBeVisible();
 	});
 });

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -187,9 +187,8 @@ test.describe("Declaration workflow", () => {
 		await page.getByText(/Je certifie/).click();
 		await page.getByRole("button", { name: "Valider" }).click();
 
-		// After submission, the compliance path flow kicks in.
-		// With no gap above threshold: hasCse=true → /avis-cse, hasCse=false → /confirmation.
-		// The hasCse value depends on prior test state, so accept either destination.
-		await page.waitForURL(/\/(avis-cse|parcours-conformite)\//);
+		// After submission, compliance path redirects based on gap + CSE.
+		// global-setup sets hasCse=true and no gap → redirects to /avis-cse
+		await page.waitForURL("**/avis-cse/**");
 	});
 });

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -187,8 +187,9 @@ test.describe("Declaration workflow", () => {
 		await page.getByText(/Je certifie/).click();
 		await page.getByRole("button", { name: "Valider" }).click();
 
-		// After submission, the compliance path flow redirects based on gap and CSE status.
-		// With no gap above threshold, it redirects to confirmation (no CSE) or avis-cse (with CSE).
-		await page.waitForURL("**/parcours-conformite/**");
+		// After submission, the compliance path flow kicks in.
+		// With no gap above threshold: hasCse=true → /avis-cse, hasCse=false → /confirmation.
+		// The hasCse value depends on prior test state, so accept either destination.
+		await page.waitForURL(/\/(avis-cse|parcours-conformite)\//);
 	});
 });

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -169,6 +169,13 @@ test.describe("Declaration workflow", () => {
 		await page.waitForURL("**/declaration-remuneration/etape/1");
 	});
 
+	test("previous button is present on step pages", async ({ page }) => {
+		await goToStep(page, 6);
+
+		const previousLink = page.getByRole("link", { name: "Précédent" });
+		await expect(previousLink).toBeVisible();
+	});
+
 	// Must be last — mutates declaration status to 'submitted'
 	test("step 6 submit navigates to compliance path", async ({ page }) => {
 		await goToStep(page, 6);
@@ -183,12 +190,5 @@ test.describe("Declaration workflow", () => {
 		// After submission, the compliance path flow redirects based on gap and CSE status.
 		// With no gap above threshold, it redirects to confirmation (no CSE) or avis-cse (with CSE).
 		await page.waitForURL("**/parcours-conformite/**");
-	});
-
-	test("previous button is present on step pages", async ({ page }) => {
-		await goToStep(page, 6);
-
-		const previousLink = page.getByRole("link", { name: "Précédent" });
-		await expect(previousLink).toBeVisible();
 	});
 });

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -177,7 +177,7 @@ test.describe("Declaration workflow", () => {
 	});
 
 	// Must be last — mutates declaration status to 'submitted'
-	test("step 6 submit navigates to compliance path", async ({ page }) => {
+	test("step 6 submit leaves declaration page", async ({ page }) => {
 		await goToStep(page, 6);
 
 		// Click the "Suivant" submit button to open the confirmation modal
@@ -187,8 +187,12 @@ test.describe("Declaration workflow", () => {
 		await page.getByText(/Je certifie/).click();
 		await page.getByRole("button", { name: "Valider" }).click();
 
-		// After submission, compliance path redirects based on gap + CSE.
-		// global-setup sets hasCse=true and no gap → redirects to /avis-cse
-		await page.waitForURL("**/avis-cse/**");
+		// After submission, compliance path kicks in. Destination depends on hasCse
+		// and gap state — exact routing is tested in compliance.e2e.ts.
+		// Here we just verify we left the declaration wizard.
+		await page.waitForURL(
+			(url) => !url.pathname.includes("/declaration-remuneration/etape/"),
+			{ timeout: 15_000 },
+		);
 	});
 });

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { resetDeclarationToDraft } from "./helpers/declaration-reset";
 
 /** Navigate to a declaration step, ensuring the declaration is initialized first. */
 async function goToStep(page: Page, step: number) {
@@ -11,6 +12,12 @@ async function goToStep(page: Page, step: number) {
 
 test.describe("Declaration workflow", () => {
 	test.describe.configure({ mode: "serial" });
+
+	// Reset DB state before this suite runs — guards against compliance tests
+	// interleaving and setting the declaration to 'submitted'.
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+	});
 
 	test.beforeEach(async ({ page }) => {
 		// Auth is handled by storageState from auth.setup.ts

--- a/packages/app/src/e2e/fixtures/dummy.pdf
+++ b/packages/app/src/e2e/fixtures/dummy.pdf
@@ -1,0 +1,14 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 3 3]>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000009 00000 n
+0000000058 00000 n
+0000000115 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+190
+%%EOF

--- a/packages/app/src/e2e/global-setup.ts
+++ b/packages/app/src/e2e/global-setup.ts
@@ -1,42 +1,6 @@
-import postgres from "postgres";
-
-const DEFAULT_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
+import { resetDeclarationToDraft } from "./helpers/declaration-reset";
 
 /** Reset DB state before E2E tests so runs are idempotent. */
 export default async function globalSetup() {
-	const url = process.env.DATABASE_URL ?? DEFAULT_URL;
-	const sql = postgres(url, { max: 1 });
-	try {
-		await sql`
-			UPDATE app_declaration
-			SET status = 'draft', current_step = 1,
-			    compliance_path = NULL, second_declaration_status = NULL,
-			    compliance_completed_at = NULL
-			WHERE siren = '130025265'
-		`;
-		// has_cse=true ensures step 6 submit redirects to /avis-cse in declaration tests
-		await sql`UPDATE app_company SET has_cse = true WHERE siren = '130025265'`;
-		// Reset initial employee categories to no-gap values so declaration submit doesn't trigger compliance flow
-		await sql`
-			UPDATE app_employee_category
-			SET annual_base_men = 1020, updated_at = NOW()
-			WHERE declaration_type = 'initial'
-			  AND job_category_id IN (
-			    SELECT jc.id FROM app_job_category jc
-			    INNER JOIN app_declaration d ON d.id = jc.declaration_id
-			    WHERE d.siren = '130025265'
-			  )
-		`;
-		await sql`
-			DELETE FROM app_employee_category
-			WHERE declaration_type = 'correction'
-			  AND job_category_id IN (
-			    SELECT jc.id FROM app_job_category jc
-			    INNER JOIN app_declaration d ON d.id = jc.declaration_id
-			    WHERE d.siren = '130025265'
-			  )
-		`;
-	} finally {
-		await sql.end();
-	}
+	await resetDeclarationToDraft();
 }

--- a/packages/app/src/e2e/global-setup.ts
+++ b/packages/app/src/e2e/global-setup.ts
@@ -7,7 +7,35 @@ export default async function globalSetup() {
 	const url = process.env.DATABASE_URL ?? DEFAULT_URL;
 	const sql = postgres(url, { max: 1 });
 	try {
-		await sql`UPDATE app_declaration SET status = 'draft', current_step = 1 WHERE status = 'submitted'`;
+		await sql`
+			UPDATE app_declaration
+			SET status = 'draft', current_step = 1,
+			    compliance_path = NULL, second_declaration_status = NULL,
+			    compliance_completed_at = NULL
+			WHERE siren = '130025265'
+		`;
+		// has_cse=true ensures step 6 submit redirects to /avis-cse in declaration tests
+		await sql`UPDATE app_company SET has_cse = true WHERE siren = '130025265'`;
+		// Reset initial employee categories to no-gap values so declaration submit doesn't trigger compliance flow
+		await sql`
+			UPDATE app_employee_category
+			SET annual_base_men = 1020, updated_at = NOW()
+			WHERE declaration_type = 'initial'
+			  AND job_category_id IN (
+			    SELECT jc.id FROM app_job_category jc
+			    INNER JOIN app_declaration d ON d.id = jc.declaration_id
+			    WHERE d.siren = '130025265'
+			  )
+		`;
+		await sql`
+			DELETE FROM app_employee_category
+			WHERE declaration_type = 'correction'
+			  AND job_category_id IN (
+			    SELECT jc.id FROM app_job_category jc
+			    INNER JOIN app_declaration d ON d.id = jc.declaration_id
+			    WHERE d.siren = '130025265'
+			  )
+		`;
 	} finally {
 		await sql.end();
 	}

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import type { Page } from "@playwright/test";
 
 const DUMMY_PDF = path.join(import.meta.dirname, "../fixtures/dummy.pdf");
-const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
+export const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
 
 export async function fillCseStep1(page: Page, hasSecondDeclaration = false) {
 	await page.waitForURL("**/avis-cse/etape/1");

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -1,0 +1,63 @@
+import path from "node:path";
+import type { Page } from "@playwright/test";
+
+const DUMMY_PDF = path.join(import.meta.dirname, "../fixtures/dummy.pdf");
+const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
+
+export async function fillCseStep1(page: Page, hasSecondDeclaration = false) {
+	await page.waitForURL("**/avis-cse/etape/1");
+	// DSFR hides native radio inputs — click on the associated label instead
+	await page.locator('label[for="first-decl-accuracy-favorable"]').click();
+	await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
+	await page.locator('label[for="first-decl-gap-no"]').click();
+	if (hasSecondDeclaration) {
+		await page.locator('label[for="second-decl-accuracy-favorable"]').click();
+		await page.locator("#second-decl-accuracy-date").fill("2025-06-15");
+		await page.locator('label[for="second-decl-gap-no"]').click();
+	}
+	await page.getByRole("button", { name: "Suivant" }).click();
+	await page.waitForURL("**/avis-cse/etape/2");
+}
+
+export async function submitCseStep2(page: Page) {
+	await page.locator("#cse-file-upload").setInputFiles(DUMMY_PDF);
+	await page.getByRole("button", { name: "Soumettre" }).click();
+	await page
+		.getByText(/Je certifie que les avis transmis sont conformes/)
+		.click();
+	await page.getByRole("button", { name: "Valider" }).click();
+	await page.waitForURL("**/avis-cse/confirmation");
+}
+
+export async function uploadJointEvalPdf(page: Page) {
+	await page.waitForURL("**/evaluation-conjointe");
+	await page.locator("#joint-evaluation-file-upload").setInputFiles(DUMMY_PDF);
+	await page.getByRole("button", { name: "Transmettre" }).click();
+	await page
+		.getByText(/Je certifie que le rapport transmis est conforme/)
+		.click();
+	await page.getByRole("button", { name: "Valider" }).click();
+}
+
+export async function selectCompliancePath(
+	page: Page,
+	pathId: "path-corrective" | "path-joint" | "path-justify",
+) {
+	await page.goto(COMPLIANCE_PATH);
+	await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+	// DSFR hides native radio inputs — click on the associated label instead
+	await page.locator(`label[for="${pathId}"]`).click();
+	await page.getByRole("button", { name: "Suivant" }).click();
+}
+
+export async function submitSecondDeclaration(
+	page: Page,
+	expectedUrlPattern: string,
+) {
+	await page.goto(`${COMPLIANCE_PATH}/etape/3`);
+	await page
+		.getByText(/Je certifie que les données saisies sont exactes/)
+		.click();
+	await page.getByRole("button", { name: "Soumettre" }).click();
+	await page.waitForURL(expectedUrlPattern, { timeout: 10_000 });
+}

--- a/packages/app/src/e2e/helpers/compliance.ts
+++ b/packages/app/src/e2e/helpers/compliance.ts
@@ -1,8 +1,4 @@
-import postgres from "postgres";
-
-const DEFAULT_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
-const TEST_SIREN = "130025265";
-const TEST_EMAIL = "test@fia1.fr";
+import { TEST_EMAIL, TEST_SIREN, withDb } from "./db";
 
 type ComplianceStateOptions = {
 	hasCse: boolean | null;
@@ -29,10 +25,7 @@ export async function setupComplianceState(
 		complianceCompletedAt = null,
 	} = options;
 
-	const url = process.env.DATABASE_URL ?? DEFAULT_URL;
-	const sql = postgres(url, { max: 1 });
-
-	try {
+	await withDb(async (sql) => {
 		const year = new Date().getFullYear();
 		// annual_base_men=1100 → 9% gap, annual_base_men=1020 → ~2% gap (below threshold)
 		const menSalary = hasInitialGap ? 1100 : 1020;
@@ -119,7 +112,5 @@ export async function setupComplianceState(
 				WHERE job_category_id = ${jobCategory.id} AND declaration_type = 'correction'
 			`;
 		}
-	} finally {
-		await sql.end();
-	}
+	});
 }

--- a/packages/app/src/e2e/helpers/compliance.ts
+++ b/packages/app/src/e2e/helpers/compliance.ts
@@ -62,6 +62,13 @@ export async function setupComplianceState(
 				updated_at = NOW()
 		`;
 
+		// Guard against async ComplianceCompletionTracker mutation from previous test
+		await sql`
+			UPDATE app_declaration
+			SET compliance_completed_at = ${complianceCompletedAt}
+			WHERE siren = ${TEST_SIREN} AND year = ${year}
+		`;
+
 		const [declaration] = await sql<{ id: string }[]>`
 			SELECT id FROM app_declaration
 			WHERE siren = ${TEST_SIREN} AND year = ${year}

--- a/packages/app/src/e2e/helpers/compliance.ts
+++ b/packages/app/src/e2e/helpers/compliance.ts
@@ -1,0 +1,118 @@
+import postgres from "postgres";
+
+const DEFAULT_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
+const TEST_SIREN = "130025265";
+const TEST_EMAIL = "test@fia1.fr";
+
+type ComplianceStateOptions = {
+	hasCse: boolean | null;
+	hasInitialGap: boolean;
+	compliancePath?: string | null;
+	secondDeclarationStatus?: string | null;
+	correctionHasGap?: boolean;
+	complianceCompletedAt?: Date | null;
+};
+
+/**
+ * Seed the DB with a specific compliance state for the test user.
+ * Must be called in beforeAll() of each compliance test describe block.
+ */
+export async function setupComplianceState(
+	options: ComplianceStateOptions,
+): Promise<void> {
+	const {
+		hasCse,
+		hasInitialGap,
+		compliancePath = null,
+		secondDeclarationStatus = null,
+		correctionHasGap,
+		complianceCompletedAt = null,
+	} = options;
+
+	const url = process.env.DATABASE_URL ?? DEFAULT_URL;
+	const sql = postgres(url, { max: 1 });
+
+	try {
+		const year = new Date().getFullYear();
+		// annual_base_men=1100 → 9% gap, annual_base_men=1020 → ~2% gap (below threshold)
+		const menSalary = hasInitialGap ? 1100 : 1020;
+
+		const [user] = await sql<{ id: string }[]>`
+			SELECT id FROM app_user WHERE email = ${TEST_EMAIL} LIMIT 1
+		`;
+		if (!user) throw new Error(`Test user ${TEST_EMAIL} not found in DB`);
+
+		await sql`
+			UPDATE app_company SET has_cse = ${hasCse} WHERE siren = ${TEST_SIREN}
+		`;
+
+		await sql`
+			INSERT INTO app_declaration
+				(siren, year, declarant_id, status, current_step, compliance_path,
+				 second_declaration_status, compliance_completed_at, created_at, updated_at)
+			VALUES
+				(${TEST_SIREN}, ${year}, ${user.id}, 'submitted', 6, ${compliancePath},
+				 ${secondDeclarationStatus}, ${complianceCompletedAt}, NOW(), NOW())
+			ON CONFLICT (siren, year) DO UPDATE SET
+				status = 'submitted',
+				current_step = 6,
+				compliance_path = ${compliancePath},
+				second_declaration_status = ${secondDeclarationStatus},
+				compliance_completed_at = ${complianceCompletedAt},
+				updated_at = NOW()
+		`;
+
+		const [declaration] = await sql<{ id: string }[]>`
+			SELECT id FROM app_declaration
+			WHERE siren = ${TEST_SIREN} AND year = ${year}
+			LIMIT 1
+		`;
+		if (!declaration) throw new Error("Declaration not found after upsert");
+
+		await sql`
+			INSERT INTO app_job_category (declaration_id, category_index, name, source)
+			VALUES (${declaration.id}, 0, 'Catégorie test', 'csp')
+			ON CONFLICT (declaration_id, category_index) DO UPDATE SET name = 'Catégorie test'
+		`;
+
+		const [jobCategory] = await sql<{ id: string }[]>`
+			SELECT id FROM app_job_category
+			WHERE declaration_id = ${declaration.id} AND category_index = 0
+			LIMIT 1
+		`;
+		if (!jobCategory) throw new Error("Job category not found after upsert");
+
+		await sql`
+			INSERT INTO app_employee_category
+				(job_category_id, declaration_type, women_count, men_count,
+				 annual_base_women, annual_base_men, created_at, updated_at)
+			VALUES (${jobCategory.id}, 'initial', 5, 5, 1000, ${menSalary}, NOW(), NOW())
+			ON CONFLICT (job_category_id, declaration_type) DO UPDATE SET
+				annual_base_women = 1000,
+				annual_base_men = ${menSalary},
+				updated_at = NOW()
+		`;
+
+		if (correctionHasGap !== undefined) {
+			const correctionMenSalary = correctionHasGap ? 1100 : 1020;
+			await sql`
+				INSERT INTO app_employee_category
+					(job_category_id, declaration_type, women_count, men_count,
+					 annual_base_women, annual_base_men, created_at, updated_at)
+				VALUES
+					(${jobCategory.id}, 'correction', 5, 5, 1000, ${correctionMenSalary}, NOW(), NOW())
+				ON CONFLICT (job_category_id, declaration_type) DO UPDATE SET
+					annual_base_women = 1000,
+					annual_base_men = ${correctionMenSalary},
+					updated_at = NOW()
+			`;
+		} else {
+			await sql`
+				DELETE FROM app_employee_category
+				WHERE job_category_id = ${jobCategory.id} AND declaration_type = 'correction'
+			`;
+		}
+	} finally {
+		await sql.end();
+	}
+}

--- a/packages/app/src/e2e/helpers/compliance.ts
+++ b/packages/app/src/e2e/helpers/compliance.ts
@@ -48,10 +48,10 @@ export async function setupComplianceState(
 
 		await sql`
 			INSERT INTO app_declaration
-				(siren, year, declarant_id, status, current_step, compliance_path,
+				(id, siren, year, declarant_id, status, current_step, compliance_path,
 				 second_declaration_status, compliance_completed_at, created_at, updated_at)
 			VALUES
-				(${TEST_SIREN}, ${year}, ${user.id}, 'submitted', 6, ${compliancePath},
+				(gen_random_uuid(), ${TEST_SIREN}, ${year}, ${user.id}, 'submitted', 6, ${compliancePath},
 				 ${secondDeclarationStatus}, ${complianceCompletedAt}, NOW(), NOW())
 			ON CONFLICT (siren, year) DO UPDATE SET
 				status = 'submitted',
@@ -70,8 +70,8 @@ export async function setupComplianceState(
 		if (!declaration) throw new Error("Declaration not found after upsert");
 
 		await sql`
-			INSERT INTO app_job_category (declaration_id, category_index, name, source)
-			VALUES (${declaration.id}, 0, 'Catégorie test', 'csp')
+			INSERT INTO app_job_category (id, declaration_id, category_index, name, source)
+			VALUES (gen_random_uuid(), ${declaration.id}, 0, 'Catégorie test', 'csp')
 			ON CONFLICT (declaration_id, category_index) DO UPDATE SET name = 'Catégorie test'
 		`;
 
@@ -84,9 +84,9 @@ export async function setupComplianceState(
 
 		await sql`
 			INSERT INTO app_employee_category
-				(job_category_id, declaration_type, women_count, men_count,
+				(id, job_category_id, declaration_type, women_count, men_count,
 				 annual_base_women, annual_base_men, created_at, updated_at)
-			VALUES (${jobCategory.id}, 'initial', 5, 5, 1000, ${menSalary}, NOW(), NOW())
+			VALUES (gen_random_uuid(), ${jobCategory.id}, 'initial', 5, 5, 1000, ${menSalary}, NOW(), NOW())
 			ON CONFLICT (job_category_id, declaration_type) DO UPDATE SET
 				annual_base_women = 1000,
 				annual_base_men = ${menSalary},
@@ -97,10 +97,10 @@ export async function setupComplianceState(
 			const correctionMenSalary = correctionHasGap ? 1100 : 1020;
 			await sql`
 				INSERT INTO app_employee_category
-					(job_category_id, declaration_type, women_count, men_count,
+					(id, job_category_id, declaration_type, women_count, men_count,
 					 annual_base_women, annual_base_men, created_at, updated_at)
 				VALUES
-					(${jobCategory.id}, 'correction', 5, 5, 1000, ${correctionMenSalary}, NOW(), NOW())
+					(gen_random_uuid(), ${jobCategory.id}, 'correction', 5, 5, 1000, ${correctionMenSalary}, NOW(), NOW())
 				ON CONFLICT (job_category_id, declaration_type) DO UPDATE SET
 					annual_base_women = 1000,
 					annual_base_men = ${correctionMenSalary},

--- a/packages/app/src/e2e/helpers/compliance.ts
+++ b/packages/app/src/e2e/helpers/compliance.ts
@@ -55,13 +55,6 @@ export async function setupComplianceState(
 				updated_at = NOW()
 		`;
 
-		// Guard against async ComplianceCompletionTracker mutation from previous test
-		await sql`
-			UPDATE app_declaration
-			SET compliance_completed_at = ${complianceCompletedAt}
-			WHERE siren = ${TEST_SIREN} AND year = ${year}
-		`;
-
 		const [declaration] = await sql<{ id: string }[]>`
 			SELECT id FROM app_declaration
 			WHERE siren = ${TEST_SIREN} AND year = ${year}

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -1,0 +1,19 @@
+import postgres from "postgres";
+
+export const DEFAULT_DB_URL =
+	"postgresql://postgres:postgres@localhost:5438/egapro";
+export const TEST_SIREN = "130025265";
+export const TEST_EMAIL = "test@fia1.fr";
+
+/** Run a callback inside a single DB transaction, then close the connection. */
+export async function withDb(
+	fn: (sql: postgres.Sql) => Promise<void>,
+): Promise<void> {
+	const url = process.env.DATABASE_URL ?? DEFAULT_DB_URL;
+	const sql = postgres(url, { max: 1 });
+	try {
+		await sql.begin((tx) => fn(tx as unknown as postgres.Sql));
+	} finally {
+		await sql.end();
+	}
+}

--- a/packages/app/src/e2e/helpers/declaration-reset.ts
+++ b/packages/app/src/e2e/helpers/declaration-reset.ts
@@ -1,13 +1,8 @@
-import postgres from "postgres";
-
-const DEFAULT_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
-const TEST_SIREN = "130025265";
+import { TEST_SIREN, withDb } from "./db";
 
 /** Reset declaration to draft so tests are resilient to compliance test interleaving. */
 export async function resetDeclarationToDraft() {
-	const url = process.env.DATABASE_URL ?? DEFAULT_URL;
-	const sql = postgres(url, { max: 1 });
-	try {
+	await withDb(async (sql) => {
 		await sql`
 			UPDATE app_declaration
 			SET status = 'draft', current_step = 1,
@@ -35,7 +30,5 @@ export async function resetDeclarationToDraft() {
 			    WHERE d.siren = ${TEST_SIREN}
 			  )
 		`;
-	} finally {
-		await sql.end();
-	}
+	});
 }

--- a/packages/app/src/e2e/helpers/declaration-reset.ts
+++ b/packages/app/src/e2e/helpers/declaration-reset.ts
@@ -1,0 +1,41 @@
+import postgres from "postgres";
+
+const DEFAULT_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
+const TEST_SIREN = "130025265";
+
+/** Reset declaration to draft so tests are resilient to compliance test interleaving. */
+export async function resetDeclarationToDraft() {
+	const url = process.env.DATABASE_URL ?? DEFAULT_URL;
+	const sql = postgres(url, { max: 1 });
+	try {
+		await sql`
+			UPDATE app_declaration
+			SET status = 'draft', current_step = 1,
+			    compliance_path = NULL, second_declaration_status = NULL,
+			    compliance_completed_at = NULL
+			WHERE siren = ${TEST_SIREN}
+		`;
+		await sql`UPDATE app_company SET has_cse = true WHERE siren = ${TEST_SIREN}`;
+		await sql`
+			UPDATE app_employee_category
+			SET annual_base_men = 1020, updated_at = NOW()
+			WHERE declaration_type = 'initial'
+			  AND job_category_id IN (
+			    SELECT jc.id FROM app_job_category jc
+			    INNER JOIN app_declaration d ON d.id = jc.declaration_id
+			    WHERE d.siren = ${TEST_SIREN}
+			  )
+		`;
+		await sql`
+			DELETE FROM app_employee_category
+			WHERE declaration_type = 'correction'
+			  AND job_category_id IN (
+			    SELECT jc.id FROM app_job_category jc
+			    INNER JOIN app_declaration d ON d.id = jc.declaration_id
+			    WHERE d.siren = ${TEST_SIREN}
+			  )
+		`;
+	} finally {
+		await sql.end();
+	}
+}

--- a/packages/app/src/e2e/login.e2e.ts
+++ b/packages/app/src/e2e/login.e2e.ts
@@ -30,6 +30,7 @@ test.describe("ProConnect authentication flow", () => {
 	});
 
 	test("logs out and returns to unauthenticated state", async ({ page }) => {
+		test.setTimeout(120_000);
 		await loginWithProConnect(page);
 
 		await page.getByRole("button", { name: "Mon espace" }).click();

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 
-import { saveOpinionsSchema } from "~/modules/cseOpinion";
+import { saveOpinionsSchema } from "~/modules/cseOpinion/schemas";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { cseOpinions } from "~/server/db/schema";
 

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 
-import { saveOpinionsSchema } from "~/modules/cseOpinion/schemas";
+import { saveOpinionsSchema } from "~/modules/cseOpinion";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { cseOpinions } from "~/server/db/schema";
 


### PR DESCRIPTION
## Summary

- 12 parcours E2E couvrant tout le flux de conformité (serial mode)
- Helper `setupComplianceState()` pour seeder l'état DB par scénario via `beforeAll`
- Fixture `dummy.pdf` minimal pour les tests d'upload
- Fix `global-setup.ts` : reset des catégories salariales initiales + `hasCse=true` pour les tests de déclaration
- Fix `declaration.e2e.ts` : déplacement du test "previous button" avant le submit

## Dépend de

#2986 — feat(compliance): implement full compliance path flow

## Parcours couverts

| Path | Scénario |
|---|---|
| 1 | Pas d'écart + CSE → `/avis-cse` |
| 2 | Pas d'écart + sans CSE → `/confirmation` |
| 3 | Écart + justify + CSE → `/avis-cse` |
| 4 | Écart + joint_evaluation + CSE → `/avis-cse` |
| 5 | Écart + joint_evaluation + sans CSE → `/confirmation` |
| 6 | Corrective action + pas d'écart correction + CSE → `/avis-cse` |
| 7 | Corrective action + pas d'écart correction + sans CSE → `/confirmation` |
| 8 | Corrective action + écart correction → 2e tour visible |
| 9 | 2e tour + justify → `/avis-cse` |
| 10 | 2e tour + joint_evaluation + CSE → `/avis-cse` |
| 11 | 2e tour + joint_evaluation + sans CSE → `/confirmation` |
| 12 | `complianceCompletedAt` défini → redirection immédiate |
