### PR TITLE
feat: add joint evaluation file upload

### DIFF
--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -58,7 +58,7 @@ check_pattern '\.(tsx|jsx)$' \
 check_pattern '\.(ts|tsx)$' \
   'process\.env' \
   'Direct process.env is forbidden. Use: import { env } from "~/env.js".' \
-  '(env\.js|instrumentation(-client)?\.ts|next\.config|trpc/react\.tsx|sentry\.(client|server|edge)\.config\.ts|global-setup\.ts|playwright\.config|drizzle\.config|migrate\.mjs)'
+  '(env\.js|instrumentation(-client)?\.ts|next\.config|trpc/react\.tsx|sentry\.(client|server|edge)\.config\.ts|global-setup\.ts|playwright\.config|drizzle\.config|migrate\.mjs|e2e/helpers/)'
 
 # Deep relative imports — use ~/ path alias
 check_pattern '\.(ts|tsx)$' \

--- a/packages/app/drizzle/0008_powerful_omega_flight.sql
+++ b/packages/app/drizzle/0008_powerful_omega_flight.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "app_joint_evaluation_file" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"siren" varchar(9) NOT NULL,
+	"year" integer NOT NULL,
+	"file_name" varchar(255) NOT NULL,
+	"file_path" varchar(500) NOT NULL,
+	"declarant_id" varchar(255) NOT NULL,
+	"uploaded_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "app_joint_evaluation_file" ADD CONSTRAINT "app_joint_evaluation_file_siren_app_company_siren_fk" FOREIGN KEY ("siren") REFERENCES "public"."app_company"("siren") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_joint_evaluation_file" ADD CONSTRAINT "app_joint_evaluation_file_declarant_id_app_user_id_fk" FOREIGN KEY ("declarant_id") REFERENCES "public"."app_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "joint_eval_file_siren_year_idx" ON "app_joint_evaluation_file" USING btree ("siren","year");

--- a/packages/app/drizzle/meta/0008_snapshot.json
+++ b/packages/app/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1259 @@
+{
+	"id": "00bacf79-9c67-43ca-a743-c927b966a752",
+	"prevId": "b15a568f-2e3e-4e11-b04f-6fd1d1324289",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_account": {
+			"name": "app_account",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_account_id": {
+					"name": "provider_account_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"session_state": {
+					"name": "session_state",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"account_user_id_idx": {
+					"name": "account_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_account_user_id_app_user_id_fk": {
+					"name": "app_account_user_id_app_user_id_fk",
+					"tableFrom": "app_account",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_account_provider_provider_account_id_pk": {
+					"name": "app_account_provider_provider_account_id_pk",
+					"columns": ["provider", "provider_account_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file_link": {
+			"name": "app_cse_opinion_file_link",
+			"schema": "",
+			"columns": {
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"opinion_id": {
+					"name": "opinion_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk": {
+					"name": "app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk": {
+					"name": "app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion",
+					"columnsFrom": ["opinion_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_cse_opinion_file_link_file_id_opinion_id_pk": {
+					"name": "app_cse_opinion_file_link_file_id_opinion_id_pk",
+					"columns": ["file_id", "opinion_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_siren_year_idx": {
+					"name": "cse_opinion_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_file_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_siren_year_idx": {
+					"name": "cse_opinion_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_siren_year_decl_type_idx": {
+					"name": "cse_opinion_siren_year_decl_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_category": {
+			"name": "app_declaration_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"step": {
+					"name": "step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_name": {
+					"name": "category_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_value": {
+					"name": "women_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_value": {
+					"name": "men_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_median_value": {
+					"name": "women_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_median_value": {
+					"name": "men_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_cat_siren_year_step_idx": {
+					"name": "declaration_cat_siren_year_step_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "step",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_path": {
+					"name": "compliance_path",
+					"type": "varchar(30)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_status": {
+					"name": "second_declaration_status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"declaration_siren_year_idx": {
+					"name": "declaration_siren_year_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"detail": {
+					"name": "detail",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_joint_evaluation_file": {
+			"name": "app_joint_evaluation_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"joint_eval_file_siren_year_idx": {
+					"name": "joint_eval_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_joint_evaluation_file_siren_app_company_siren_fk": {
+					"name": "app_joint_evaluation_file_siren_app_company_siren_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_joint_evaluation_file_declarant_id_app_user_id_fk": {
+					"name": "app_joint_evaluation_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_session": {
+			"name": "app_session",
+			"schema": "",
+			"columns": {
+				"session_token": {
+					"name": "session_token",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"t_user_id_idx": {
+					"name": "t_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_session_user_id_app_user_id_fk": {
+					"name": "app_session_user_id_app_user_id_fk",
+					"tableFrom": "app_session",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siret": {
+					"name": "siret",
+					"type": "varchar(14)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_verification_token": {
+			"name": "app_verification_token",
+			"schema": "",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"app_verification_token_identifier_token_pk": {
+					"name": "app_verification_token_identifier_token_pk",
+					"columns": ["identifier", "token"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
 			"when": 1773158962249,
 			"tag": "0007_gigantic_doctor_faustus",
 			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1773328599101,
+			"tag": "0008_powerful_omega_flight",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -21,21 +21,29 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 	}
 
 	if (step === 1) {
-		const [session, { opinions }] = await Promise.all([
+		const [session, { opinions }, declarationData] = await Promise.all([
 			auth(),
 			api.cseOpinion.get(),
+			api.declaration.getOrCreate(),
 		]);
 		const initialData = mapOpinionsFromDb(opinions);
+		const hasSecondDeclaration =
+			declarationData.declaration.secondDeclarationStatus === "submitted";
 		return (
 			<Step1Opinions
+				compliancePath={declarationData.declaration.compliancePath}
 				email={session?.user?.email ?? undefined}
+				hasSecondDeclaration={hasSecondDeclaration}
 				initialData={initialData}
 			/>
 		);
 	}
 
 	if (step === 2) {
-		return <Step2Upload />;
+		const declarationData = await api.declaration.getOrCreate();
+		const hasSecondDeclaration =
+			declarationData.declaration.secondDeclarationStatus === "submitted";
+		return <Step2Upload hasSecondDeclaration={hasSecondDeclaration} />;
 	}
 
 	notFound();

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { ComplianceCompletionTracker } from "~/modules/declaration-remuneration";
 import { DsfrPictogram } from "~/modules/home";
 import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
@@ -19,7 +18,6 @@ export function ConfirmationPage({ email }: Props) {
 	const year = dataYear + 1;
 	return (
 		<div>
-			<ComplianceCompletionTracker />
 			<h1 className="fr-h4 fr-mb-4w">
 				Démarche des indicateurs de rémunération {year}
 			</h1>

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ComplianceCompletionTracker } from "~/modules/declaration-remuneration";
 import { DsfrPictogram } from "~/modules/home";
 import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
@@ -18,6 +19,7 @@ export function ConfirmationPage({ email }: Props) {
 	const year = dataYear + 1;
 	return (
 		<div>
+			<ComplianceCompletionTracker />
 			<h1 className="fr-h4 fr-mb-4w">
 				Démarche des indicateurs de rémunération {year}
 			</h1>

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -15,9 +15,17 @@ import type { CseOpinionStep1Data, OpinionType } from "./types";
 type Props = {
 	initialData?: CseOpinionStep1Data;
 	email?: string;
+	compliancePath?: string | null;
+	hasSecondDeclaration?: boolean;
 };
 
-export function Step1Opinions({ initialData, email }: Props) {
+export function Step1Opinions({
+	initialData,
+	email,
+	compliancePath,
+	hasSecondDeclaration = true,
+}: Props) {
+	const isJointEvaluation = compliancePath === "joint_evaluation";
 	const router = useRouter();
 
 	const [firstDeclOpinion, setFirstDeclOpinion] = useState<OpinionType | null>(
@@ -63,16 +71,20 @@ export function Step1Opinions({ initialData, email }: Props) {
 		const firstGapIncomplete =
 			firstDeclGap === true && (!firstDeclGapOpinion || !firstDeclGapDate);
 		const secondGapIncomplete =
-			secondDeclGap === true && (!secondDeclGapOpinion || !secondDeclGapDate);
+			hasSecondDeclaration &&
+			secondDeclGap === true &&
+			(!secondDeclGapOpinion || !secondDeclGapDate);
+
+		const secondDeclInvalid =
+			hasSecondDeclaration &&
+			(!secondDeclOpinion || !secondDeclDate || secondDeclGap === null);
 
 		if (
 			!firstDeclOpinion ||
 			!firstDeclDate ||
 			firstDeclGap === null ||
 			firstGapIncomplete ||
-			!secondDeclOpinion ||
-			!secondDeclDate ||
-			secondDeclGap === null ||
+			secondDeclInvalid ||
 			secondGapIncomplete
 		) {
 			setValidationError("Veuillez remplir tous les champs obligatoires.");
@@ -88,35 +100,48 @@ export function Step1Opinions({ initialData, email }: Props) {
 				gapOpinion: firstDeclGapOpinion,
 				gapDate: firstDeclGapDate || null,
 			},
-			secondDeclaration: {
-				accuracyOpinion: secondDeclOpinion,
-				accuracyDate: secondDeclDate,
-				gapConsulted: secondDeclGap,
-				gapOpinion: secondDeclGapOpinion,
-				gapDate: secondDeclGapDate || null,
-			},
+			secondDeclaration:
+				hasSecondDeclaration && secondDeclOpinion && secondDeclGap !== null
+					? {
+							accuracyOpinion: secondDeclOpinion,
+							accuracyDate: secondDeclDate,
+							gapConsulted: secondDeclGap,
+							gapOpinion: secondDeclGapOpinion,
+							gapDate: secondDeclGapDate || null,
+						}
+					: undefined,
 		});
 	}
 
 	return (
 		<form onSubmit={handleSubmit}>
-			<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
-				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
-						Parcours de mise en conformité pour l'indicateur par catégorie de
-						salariés
-					</h1>
+			{isJointEvaluation && (
+				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
+					<div className="fr-col">
+						<h1 className="fr-h4 fr-mb-0">
+							Parcours de mise en conformité pour l'indicateur par catégorie de
+							salariés
+						</h1>
+					</div>
 				</div>
-			</div>
+			)}
 
-			<SubmissionBanner
-				deadline={`1er février ${new Date().getFullYear() + 1}`}
-				email={email ?? "adresse@exemple.fr"}
-			/>
+			{isJointEvaluation && (
+				<SubmissionBanner
+					deadline={`1er février ${new Date().getFullYear() + 1}`}
+					email={email ?? "adresse@exemple.fr"}
+				/>
+			)}
 
-			<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
-				Transmettre l'avis ou les avis du CSE
-			</h2>
+			{isJointEvaluation ? (
+				<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
+					Transmettre l'avis ou les avis du CSE
+				</h2>
+			) : (
+				<h1 className="fr-h4 fr-mb-3w">
+					Transmettre l'avis ou les avis du CSE
+				</h1>
+			)}
 
 			<CseStepIndicator currentStep={1} />
 
@@ -149,28 +174,32 @@ export function Step1Opinions({ initialData, email }: Props) {
 				/>
 			</div>
 
-			<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
+			{hasSecondDeclaration && (
+				<>
+					<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
 
-			<div className={styles.cardStack}>
-				<AccuracyOpinionCard
-					date={secondDeclDate}
-					id="second-decl-accuracy"
-					onDateChange={setSecondDeclDate}
-					onOpinionChange={setSecondDeclOpinion}
-					opinion={secondDeclOpinion}
-					title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
-				/>
+					<div className={styles.cardStack}>
+						<AccuracyOpinionCard
+							date={secondDeclDate}
+							id="second-decl-accuracy"
+							onDateChange={setSecondDeclDate}
+							onOpinionChange={setSecondDeclOpinion}
+							opinion={secondDeclOpinion}
+							title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+						/>
 
-				<GapConsultationCard
-					consulted={secondDeclGap}
-					date={secondDeclGapDate}
-					id="second-decl-gap"
-					onConsultedChange={setSecondDeclGap}
-					onDateChange={setSecondDeclGapDate}
-					onOpinionChange={setSecondDeclGapOpinion}
-					opinion={secondDeclGapOpinion}
-				/>
-			</div>
+						<GapConsultationCard
+							consulted={secondDeclGap}
+							date={secondDeclGapDate}
+							id="second-decl-gap"
+							onConsultedChange={setSecondDeclGap}
+							onDateChange={setSecondDeclGapDate}
+							onOpinionChange={setSecondDeclGapOpinion}
+							opinion={secondDeclGapOpinion}
+						/>
+					</div>
+				</>
+			)}
 
 			<div aria-live="polite">
 				{validationError && (

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -10,7 +10,11 @@ import { OpinionSummaryBox } from "./components/OpinionSummaryBox";
 import { SubmitConfirmationModal } from "./components/SubmitConfirmationModal";
 import formStyles from "./shared/formActions.module.scss";
 
-export function Step2Upload() {
+type Props = {
+	hasSecondDeclaration?: boolean;
+};
+
+export function Step2Upload({ hasSecondDeclaration = true }: Props) {
 	const router = useRouter();
 	const {
 		closeModal,
@@ -58,6 +62,7 @@ export function Step2Upload() {
 						firstDeclTitle="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
 						secondDeclGapTitle="Justification des écarts ≥ 5 % par des critères objectifs et non sexistes de l'indicateur de rémunération par catégorie de salariés"
 						secondDeclTitle="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+						showSecondDeclaration={hasSecondDeclaration}
 					/>
 				</div>
 

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ConfirmationPage } from "../ConfirmationPage";
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			completeCompliancePath: {
+				useMutation: () => ({ mutate: vi.fn() }),
+			},
+		},
+	},
+}));
 
 describe("ConfirmationPage", () => {
 	const year = new Date().getFullYear() + 1;

--- a/packages/app/src/modules/cseOpinion/__tests__/OpinionSummaryBox.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/OpinionSummaryBox.test.tsx
@@ -25,7 +25,7 @@ describe("OpinionSummaryBox", () => {
 	});
 
 	it("renders second declaration items", () => {
-		render(<OpinionSummaryBox {...defaultProps} />);
+		render(<OpinionSummaryBox {...defaultProps} showSecondDeclaration />);
 
 		expect(screen.getByText("Deuxième déclaration")).toBeInTheDocument();
 		expect(

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -40,8 +40,8 @@ beforeEach(() => {
 });
 
 describe("Step1Opinions", () => {
-	it("renders the page title", () => {
-		render(<Step1Opinions />);
+	it("renders compliance path title when compliancePath is joint_evaluation", () => {
+		render(<Step1Opinions compliancePath="joint_evaluation" />);
 
 		expect(
 			screen.getByText(
@@ -50,27 +50,61 @@ describe("Step1Opinions", () => {
 		).toBeInTheDocument();
 	});
 
+	it("does not render compliance path title for other paths", () => {
+		render(<Step1Opinions compliancePath="justify" />);
+
+		expect(
+			screen.queryByText(
+				/Parcours de mise en conformité pour l'indicateur par catégorie de salariés/,
+			),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders h1 as CSE opinion title when no compliance path banner", () => {
+		render(<Step1Opinions />);
+
+		const heading = screen.getByRole("heading", { level: 1 });
+		expect(heading).toHaveTextContent("Transmettre l'avis ou les avis du CSE");
+	});
+
 	it("renders the stepper at step 1", () => {
 		render(<Step1Opinions />);
 
 		expect(screen.getByText(/Étape 1 sur 2/)).toBeInTheDocument();
 	});
 
-	it("renders both declaration sections", () => {
-		render(<Step1Opinions />);
+	it("renders both declaration sections when hasSecondDeclaration is true", () => {
+		render(<Step1Opinions hasSecondDeclaration={true} />);
 
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
 		expect(screen.getByText("Deuxième déclaration")).toBeInTheDocument();
 	});
 
-	it("renders the submission banner", () => {
-		render(<Step1Opinions />);
+	it("hides second declaration section when hasSecondDeclaration is false", () => {
+		render(<Step1Opinions hasSecondDeclaration={false} />);
+
+		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
+		expect(screen.queryByText("Deuxième déclaration")).not.toBeInTheDocument();
+	});
+
+	it("renders the submission banner for joint_evaluation path", () => {
+		render(<Step1Opinions compliancePath="joint_evaluation" />);
 
 		expect(
 			screen.getByText(
 				/Votre rapport de l'évaluation conjointe a été transmise/,
 			),
 		).toBeInTheDocument();
+	});
+
+	it("does not render the submission banner for other paths", () => {
+		render(<Step1Opinions />);
+
+		expect(
+			screen.queryByText(
+				/Votre rapport de l'évaluation conjointe a été transmise/,
+			),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders previous and next buttons", () => {
@@ -94,10 +128,11 @@ describe("Step1Opinions", () => {
 		expect(mockPush).not.toHaveBeenCalled();
 	});
 
-	it("calls mutation and navigates to step 2 when all fields are filled", async () => {
+	it("calls mutation with both declarations when hasSecondDeclaration is true", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Opinions
+				hasSecondDeclaration={true}
 				initialData={{
 					firstDeclAccuracyOpinion: "favorable",
 					firstDeclAccuracyDate: "2026-01-15",
@@ -134,6 +169,41 @@ describe("Step1Opinions", () => {
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
 	});
 
+	it("calls mutation without secondDeclaration when hasSecondDeclaration is false", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step1Opinions
+				hasSecondDeclaration={false}
+				initialData={{
+					firstDeclAccuracyOpinion: "favorable",
+					firstDeclAccuracyDate: "2026-01-15",
+					firstDeclGapConsulted: false,
+					firstDeclGapOpinion: null,
+					firstDeclGapDate: null,
+					secondDeclAccuracyOpinion: null,
+					secondDeclAccuracyDate: "",
+					secondDeclGapConsulted: null,
+					secondDeclGapOpinion: null,
+					secondDeclGapDate: null,
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+		expect(mockMutate).toHaveBeenCalledWith({
+			firstDeclaration: {
+				accuracyOpinion: "favorable",
+				accuracyDate: "2026-01-15",
+				gapConsulted: false,
+				gapOpinion: null,
+				gapDate: null,
+			},
+			secondDeclaration: undefined,
+		});
+		expect(mockPush).toHaveBeenCalledWith("/avis-cse/etape/2");
+	});
+
 	it("renders with initial data pre-filled", () => {
 		render(
 			<Step1Opinions
@@ -161,14 +231,19 @@ describe("Step1Opinions", () => {
 		expect(unfavorableRadios[1]).toBeChecked();
 	});
 
-	it("displays email in submission banner", () => {
-		render(<Step1Opinions email="test@example.fr" />);
+	it("displays email in submission banner for joint_evaluation path", () => {
+		render(
+			<Step1Opinions
+				compliancePath="joint_evaluation"
+				email="test@example.fr"
+			/>,
+		);
 
 		expect(screen.getByText("test@example.fr")).toBeInTheDocument();
 	});
 
-	it("uses default email when none provided", () => {
-		render(<Step1Opinions />);
+	it("uses default email when none provided for joint_evaluation path", () => {
+		render(<Step1Opinions compliancePath="joint_evaluation" />);
 
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});

--- a/packages/app/src/modules/cseOpinion/components/OpinionSummaryBox.tsx
+++ b/packages/app/src/modules/cseOpinion/components/OpinionSummaryBox.tsx
@@ -2,14 +2,16 @@ import styles from "./OpinionSummaryBox.module.scss";
 
 type Props = {
 	firstDeclTitle: string;
-	secondDeclTitle: string;
-	secondDeclGapTitle: string;
+	secondDeclTitle?: string;
+	secondDeclGapTitle?: string;
+	showSecondDeclaration?: boolean;
 };
 
 export function OpinionSummaryBox({
 	firstDeclTitle,
 	secondDeclTitle,
 	secondDeclGapTitle,
+	showSecondDeclaration = true,
 }: Props) {
 	return (
 		<div className={`fr-p-4w ${styles.container}`}>
@@ -18,15 +20,19 @@ export function OpinionSummaryBox({
 			</p>
 
 			<p className="fr-text--sm fr-mb-1w">Première déclaration</p>
-			<ul className="fr-mb-2w">
+			<ul className={showSecondDeclaration ? "fr-mb-2w" : "fr-mb-0"}>
 				<li className="fr-text--sm">{firstDeclTitle}</li>
 			</ul>
 
-			<p className="fr-text--sm fr-mb-1w">Deuxième déclaration</p>
-			<ul className="fr-mb-0">
-				<li className="fr-text--sm">{secondDeclTitle}</li>
-				<li className="fr-text--sm">{secondDeclGapTitle}</li>
-			</ul>
+			{showSecondDeclaration && (
+				<>
+					<p className="fr-text--sm fr-mb-1w">Deuxième déclaration</p>
+					<ul className="fr-mb-0">
+						<li className="fr-text--sm">{secondDeclTitle}</li>
+						<li className="fr-text--sm">{secondDeclGapTitle}</li>
+					</ul>
+				</>
+			)}
 		</div>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/components/OpinionSummaryBox.tsx
+++ b/packages/app/src/modules/cseOpinion/components/OpinionSummaryBox.tsx
@@ -11,7 +11,7 @@ export function OpinionSummaryBox({
 	firstDeclTitle,
 	secondDeclTitle,
 	secondDeclGapTitle,
-	showSecondDeclaration = true,
+	showSecondDeclaration = false,
 }: Props) {
 	return (
 		<div className={`fr-p-4w ${styles.container}`}>

--- a/packages/app/src/modules/cseOpinion/schemas.ts
+++ b/packages/app/src/modules/cseOpinion/schemas.ts
@@ -12,7 +12,7 @@ const declarationOpinionSchema = z.object({
 
 export const saveOpinionsSchema = z.object({
 	firstDeclaration: declarationOpinionSchema,
-	secondDeclaration: declarationOpinionSchema,
+	secondDeclaration: declarationOpinionSchema.optional(),
 });
 
 export type SaveOpinionsInput = z.infer<typeof saveOpinionsSchema>;

--- a/packages/app/src/modules/declarationPdf/pdfFonts.ts
+++ b/packages/app/src/modules/declarationPdf/pdfFonts.ts
@@ -1,5 +1,5 @@
-import { Font } from "@react-pdf/renderer";
 import { join } from "node:path";
+import { Font } from "@react-pdf/renderer";
 
 export const PDF_FONT_FAMILY = "Marianne";
 

--- a/packages/app/src/server/api/root.ts
+++ b/packages/app/src/server/api/root.ts
@@ -1,6 +1,7 @@
 import { companyRouter } from "~/server/api/routers/company";
 import { cseOpinionRouter } from "~/server/api/routers/cseOpinion";
 import { declarationRouter } from "~/server/api/routers/declaration";
+import { jointEvaluationRouter } from "~/server/api/routers/jointEvaluation";
 import { profileRouter } from "~/server/api/routers/profile";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
@@ -13,6 +14,7 @@ export const appRouter = createTRPCRouter({
 	company: companyRouter,
 	cseOpinion: cseOpinionRouter,
 	declaration: declarationRouter,
+	jointEvaluation: jointEvaluationRouter,
 	profile: profileRouter,
 });
 

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -187,3 +187,219 @@ describe("findUserCompany CSE auto-fetch", () => {
 		);
 	});
 });
+
+describe("companyRouter.list", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns companies with declaration status", async () => {
+		const companyRows = [{ siren: "339787277", name: "Test Company" }];
+		const declRows = [
+			{ siren: "339787277", status: "submitted", currentStep: 6 },
+		];
+
+		// list uses: select().from().innerJoin().where() (no limit) for companies
+		// then select().from().where() for declarations
+		let selectCallCount = 0;
+		const localMockSelect = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			if (selectCallCount === 1) {
+				// companies query
+				return {
+					from: vi.fn().mockReturnValue({
+						innerJoin: vi.fn().mockReturnValue({
+							where: vi.fn().mockResolvedValue(companyRows),
+						}),
+					}),
+				};
+			}
+			// declarations query
+			return {
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue(declRows),
+				}),
+			};
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.list();
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.siren).toBe("339787277");
+		expect(result[0]?.declarationStatus).toBe("done");
+	});
+
+	it("returns empty list when user has no companies", async () => {
+		const localMockSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([]),
+				}),
+			}),
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.list();
+
+		expect(result).toEqual([]);
+	});
+
+	it("skips declaration fetch when no sirens found", async () => {
+		const localMockSelect = vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				innerJoin: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([]),
+				}),
+			}),
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await caller.list();
+
+		// Only 1 select call (companies), no second call for declarations
+		expect(localMockSelect).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("companyRouter.getWithDeclarations", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns company with declaration list", async () => {
+		const companyRow = {
+			siren: "339787277",
+			name: "Test Company",
+			address: "1 rue de Paris",
+			nafCode: "6202A",
+			workforce: 100,
+			hasCse: true,
+		};
+
+		const declRows = [
+			{
+				siren: "339787277",
+				year: 2026,
+				status: "submitted",
+				currentStep: 6,
+				updatedAt: new Date(),
+			},
+		];
+
+		let selectCallCount = 0;
+		const localMockSelect = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			if (selectCallCount === 1) {
+				// findUserCompany query
+				return {
+					from: vi.fn().mockReturnValue({
+						innerJoin: vi.fn().mockReturnValue({
+							where: vi.fn().mockReturnValue({
+								limit: vi.fn().mockResolvedValue([companyRow]),
+							}),
+						}),
+					}),
+				};
+			}
+			// declarations query
+			return {
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						orderBy: vi.fn().mockResolvedValue(declRows),
+					}),
+				}),
+			};
+		});
+
+		const mockDb = { select: localMockSelect } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getWithDeclarations({ siren: "339787277" });
+
+		expect(result.company.siren).toBe("339787277");
+		expect(result.declarations).toBeDefined();
+	});
+});
+
+describe("companyRouter.updateHasCse", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("updates hasCse for the given company", async () => {
+		const companyRow = {
+			siren: "339787277",
+			name: "Test Company",
+			address: "1 rue de Paris",
+			nafCode: "6202A",
+			workforce: 100,
+			hasCse: false,
+		};
+
+		mockLimit.mockResolvedValue([companyRow]);
+		mockWhere.mockReturnValue({ limit: mockLimit });
+		mockInnerJoin.mockReturnValue({ where: mockWhere });
+		mockFrom.mockReturnValue({ innerJoin: mockInnerJoin });
+		mockSelect.mockReturnValue({ from: mockFrom });
+
+		mockUpdateWhere.mockResolvedValue(undefined);
+		mockSet.mockReturnValue({ where: mockUpdateWhere });
+		mockUpdate.mockReturnValue({ set: mockSet });
+
+		const mockDb = { select: mockSelect, update: mockUpdate } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await caller.updateHasCse({ siren: "339787277", hasCse: true });
+
+		expect(mockSet).toHaveBeenCalledWith({ hasCse: true });
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
@@ -28,7 +28,7 @@ function createMockDb(rows: unknown[] = []) {
 	mockValues.mockResolvedValue(undefined);
 	mockInsert.mockReturnValue({ values: mockValues });
 
-	mockTransaction.mockImplementation(async (fn: Function) =>
+	mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
 		fn({
 			select: mockSelect,
 			delete: mockDelete,

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockDelete = vi.fn();
+const mockDeleteWhere = vi.fn();
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockTransaction = vi.fn();
+
+function createMockDb(rows: unknown[] = []) {
+	mockWhere.mockResolvedValue(rows);
+	mockFrom.mockReturnValue({ where: mockWhere });
+	mockSelect.mockReturnValue({ from: mockFrom });
+
+	mockDeleteWhere.mockResolvedValue(undefined);
+	mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+	mockValues.mockResolvedValue(undefined);
+	mockInsert.mockReturnValue({ values: mockValues });
+
+	mockTransaction.mockImplementation(async (fn: Function) =>
+		fn({
+			select: mockSelect,
+			delete: mockDelete,
+			insert: mockInsert,
+		}),
+	);
+
+	return {
+		select: mockSelect,
+		transaction: mockTransaction,
+	} as unknown;
+}
+
+function createCaller(mockDb: unknown, siret = "33978727700015") {
+	return import("../cseOpinion").then(({ cseOpinionRouter }) =>
+		cseOpinionRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1", siret }, expires: "" },
+			headers: new Headers(),
+		} as never),
+	);
+}
+
+describe("cseOpinionRouter", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("get", () => {
+		it("returns opinions for the current siren and year", async () => {
+			const opinions = [
+				{
+					declarationNumber: 1,
+					type: "accuracy",
+					opinion: "favorable",
+					opinionDate: "2026-01-15",
+					gapConsulted: null,
+				},
+			];
+			const mockDb = createMockDb(opinions);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.get();
+
+			expect(mockSelect).toHaveBeenCalled();
+			expect(result).toEqual({ opinions });
+		});
+
+		it("returns empty opinions when none exist", async () => {
+			const mockDb = createMockDb([]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.get();
+
+			expect(result).toEqual({ opinions: [] });
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.get()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("saveOpinions", () => {
+		const validInput = {
+			firstDeclaration: {
+				accuracyOpinion: "favorable" as const,
+				accuracyDate: "2026-01-15",
+				gapConsulted: true,
+				gapOpinion: "unfavorable" as const,
+				gapDate: "2026-01-16",
+			},
+		};
+
+		it("deletes existing opinions and inserts new ones in a transaction", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.saveOpinions(validInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+			expect(mockInsert).toHaveBeenCalled();
+			expect(mockValues).toHaveBeenCalledWith(
+				expect.arrayContaining([
+					expect.objectContaining({
+						siren: "339787277",
+						declarationNumber: 1,
+						type: "accuracy",
+						opinion: "favorable",
+					}),
+					expect.objectContaining({
+						siren: "339787277",
+						declarationNumber: 1,
+						type: "gap",
+						gapConsulted: true,
+						opinion: "unfavorable",
+					}),
+				]),
+			);
+		});
+
+		it("inserts second declaration opinions when provided", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const inputWithSecond = {
+				...validInput,
+				secondDeclaration: {
+					accuracyOpinion: "unfavorable" as const,
+					accuracyDate: "2026-02-01",
+					gapConsulted: false,
+					gapOpinion: null,
+					gapDate: null,
+				},
+			};
+
+			const result = await caller.saveOpinions(inputWithSecond);
+
+			expect(result).toEqual({ success: true });
+			expect(mockValues).toHaveBeenCalledWith(
+				expect.arrayContaining([
+					expect.objectContaining({
+						declarationNumber: 2,
+						type: "accuracy",
+						opinion: "unfavorable",
+					}),
+					expect.objectContaining({
+						declarationNumber: 2,
+						type: "gap",
+						gapConsulted: false,
+					}),
+				]),
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.saveOpinions(validInput)).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -295,23 +295,6 @@ describe("declarationRouter", () => {
 		});
 	});
 
-	describe("completeCompliancePath", () => {
-		it("sets complianceCompletedAt timestamp", async () => {
-			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
-
-			const result = await caller.completeCompliancePath();
-
-			expect(result).toEqual({ success: true });
-			expect(mockSet).toHaveBeenCalledWith(
-				expect.objectContaining({
-					complianceCompletedAt: expect.any(Date),
-					updatedAt: expect.any(Date),
-				}),
-			);
-		});
-	});
-
 	describe("updateStep1", () => {
 		it("updates totals and inserts categories", async () => {
 			const tx = createMockTx([mockDeclaration]);

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -1,0 +1,553 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+vi.mock("../declarationHelpers", async (importOriginal) => {
+	const original =
+		await importOriginal<typeof import("../declarationHelpers")>();
+	return {
+		...original,
+		fetchAllCategories: vi.fn().mockResolvedValue({
+			categories: [],
+			jobCategories: [],
+			employeeCategories: [],
+		}),
+		deleteJobAndEmployeeCategories: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
+const mockLimit = vi.fn();
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockUpdate = vi.fn();
+const mockSet = vi.fn();
+const mockUpdateWhere = vi.fn();
+const mockDelete = vi.fn();
+const mockDeleteWhere = vi.fn();
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockOnConflictDoNothing = vi.fn();
+const mockReturning = vi.fn();
+const mockTransaction = vi.fn();
+
+function createMockTx(selectRows: unknown[] = []) {
+	mockLimit.mockResolvedValue(selectRows);
+	mockWhere.mockReturnValue({ limit: mockLimit });
+	mockFrom.mockReturnValue({ where: mockWhere });
+	mockSelect.mockReturnValue({ from: mockFrom });
+
+	mockUpdateWhere.mockResolvedValue(undefined);
+	mockSet.mockReturnValue({ where: mockUpdateWhere });
+	mockUpdate.mockReturnValue({ set: mockSet });
+
+	mockDeleteWhere.mockResolvedValue(undefined);
+	mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+	mockReturning.mockResolvedValue(selectRows);
+	mockOnConflictDoNothing.mockReturnValue({ returning: mockReturning });
+	mockValues.mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+	mockInsert.mockReturnValue({ values: mockValues });
+
+	return {
+		select: mockSelect,
+		update: mockUpdate,
+		delete: mockDelete,
+		insert: mockInsert,
+	};
+}
+
+function createMockDb(selectRows: unknown[] = []) {
+	const tx = createMockTx(selectRows);
+
+	mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+
+	return {
+		select: mockSelect,
+		update: mockUpdate,
+		delete: mockDelete,
+		insert: mockInsert,
+		transaction: mockTransaction,
+	} as unknown;
+}
+
+function createCaller(mockDb: unknown, siret = "33978727700015") {
+	return import("../declaration").then(({ declarationRouter }) =>
+		declarationRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1", siret }, expires: "" },
+			headers: new Headers(),
+		} as never),
+	);
+}
+
+const mockDeclaration = {
+	id: "decl-1",
+	siren: "339787277",
+	year: 2026,
+	currentStep: 0,
+	status: "draft",
+	declarantId: "user-1",
+	totalWomen: null,
+	totalMen: null,
+};
+
+describe("declarationRouter", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("getOrCreate", () => {
+		function createGetOrCreateTx(
+			existingRows: unknown[],
+			insertReturns: unknown[] | null = null,
+			retryRows: unknown[] | null = null,
+		) {
+			let selectCallCount = 0;
+			const txSelect = vi.fn().mockImplementation(() => ({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockImplementation(() => {
+							selectCallCount++;
+							if (selectCallCount === 1) return Promise.resolve(existingRows);
+							if (retryRows && selectCallCount === 2)
+								return Promise.resolve(retryRows);
+							return Promise.resolve([]);
+						}),
+					}),
+				}),
+			}));
+
+			const txInsert = vi.fn().mockReturnValue({
+				values: vi.fn().mockReturnValue({
+					onConflictDoNothing: vi.fn().mockReturnValue({
+						returning: vi.fn().mockResolvedValue(insertReturns ?? []),
+					}),
+				}),
+			});
+
+			return { select: txSelect, insert: txInsert, delete: mockDelete };
+		}
+
+		it("returns existing declaration when found", async () => {
+			const tx = createGetOrCreateTx([mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getOrCreate();
+
+			expect(result.declaration).toBeDefined();
+			expect(mockTransaction).toHaveBeenCalled();
+		});
+
+		it("creates new declaration when none exists", async () => {
+			const tx = createGetOrCreateTx([], [mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getOrCreate();
+
+			expect(result.declaration).toBeDefined();
+			expect(result.categories).toEqual([]);
+			expect(result.jobCategories).toEqual([]);
+			expect(result.employeeCategories).toEqual([]);
+		});
+
+		it("retries select after concurrent insert (onConflictDoNothing returns empty)", async () => {
+			const tx = createGetOrCreateTx([], [], [mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getOrCreate();
+
+			expect(result.declaration).toBeDefined();
+		});
+
+		it("throws NOT_FOUND when existing row is unexpectedly undefined", async () => {
+			// existing.length > 0 but existing[0] is undefined (defensive branch)
+			const tx = createGetOrCreateTx([undefined]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await expect(caller.getOrCreate()).rejects.toThrow(
+				"Declaration introuvable",
+			);
+		});
+
+		it("throws INTERNAL_SERVER_ERROR when retry also fails", async () => {
+			const tx = createGetOrCreateTx([], [], []);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await expect(caller.getOrCreate()).rejects.toThrow(
+				"Erreur lors de la création",
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.getOrCreate()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("submit", () => {
+		it("sets status to submitted and step to 6", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.submit();
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					status: "submitted",
+					currentStep: 6,
+				}),
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.submit()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("submitSecondDeclaration", () => {
+		it("sets secondDeclarationStatus to submitted and step to 3", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.submitSecondDeclaration();
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					secondDeclarationStatus: "submitted",
+					secondDeclarationStep: 3,
+				}),
+			);
+		});
+	});
+
+	describe("saveCompliancePath", () => {
+		it("saves a valid compliance path", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.saveCompliancePath({
+				path: "corrective_action",
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					compliancePath: "corrective_action",
+				}),
+			);
+		});
+
+		it("saves joint_evaluation path", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.saveCompliancePath({
+				path: "joint_evaluation",
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					compliancePath: "joint_evaluation",
+				}),
+			);
+		});
+
+		it("rejects invalid compliance path", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.saveCompliancePath({ path: "invalid_path" as never }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("completeCompliancePath", () => {
+		it("sets complianceCompletedAt timestamp", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.completeCompliancePath();
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					complianceCompletedAt: expect.any(Date),
+					updatedAt: expect.any(Date),
+				}),
+			);
+		});
+	});
+
+	describe("updateStep1", () => {
+		it("updates totals and inserts categories", async () => {
+			const tx = createMockTx([mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStep1({
+				categories: [
+					{ name: "Cadres", women: 10, men: 15 },
+					{ name: "Employés", women: 20, men: 25 },
+				],
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+		});
+
+		it("skips reset when totals have not changed", async () => {
+			const unchangedDecl = {
+				...mockDeclaration,
+				totalWomen: 30,
+				totalMen: 40,
+			};
+			const tx = createMockTx([unchangedDecl]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStep1({
+				categories: [
+					{ name: "Cadres", women: 10, men: 15 },
+					{ name: "Employés", women: 20, men: 25 },
+				],
+			});
+
+			expect(result).toEqual({ success: true });
+			// set should NOT include score resets
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.not.objectContaining({ remunerationScore: null }),
+			);
+		});
+
+		it("saves with empty categories array", async () => {
+			const tx = createMockTx([mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStep1({ categories: [] });
+
+			expect(result).toEqual({ success: true });
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.updateStep1({ categories: [] })).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+
+	describe("updateStepCategories", () => {
+		it("saves empty categories for a given step", async () => {
+			const tx = createMockTx();
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStepCategories({
+				step: 3,
+				categories: [],
+			});
+
+			expect(result).toEqual({ success: true });
+		});
+
+		it("saves categories with all optional fields undefined", async () => {
+			const tx = createMockTx();
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStepCategories({
+				step: 4,
+				categories: [{ name: "Cadres" }],
+			});
+
+			expect(result).toEqual({ success: true });
+		});
+
+		it("saves categories for a given step", async () => {
+			const tx = createMockTx();
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateStepCategories({
+				step: 2,
+				categories: [{ name: "Cadres", womenCount: 10, menCount: 15 }],
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+		});
+
+		it("rejects step outside 2-4 range", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.updateStepCategories({ step: 1, categories: [] }),
+			).rejects.toThrow();
+
+			await expect(
+				caller.updateStepCategories({ step: 5, categories: [] }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("updateEmployeeCategories", () => {
+		function createEmployeeTx(
+			declaration: unknown,
+			existingJobs: unknown[] = [],
+		) {
+			let selectCallCount = 0;
+			const txSelectWhere = vi.fn().mockImplementation(() => {
+				selectCallCount++;
+				const result = Promise.resolve(
+					selectCallCount === 1 ? [] : existingJobs,
+				);
+				(result as unknown as Record<string, unknown>).limit = vi
+					.fn()
+					.mockResolvedValue(declaration ? [declaration] : []);
+				return result;
+			});
+			const txSelectFrom = vi.fn().mockReturnValue({ where: txSelectWhere });
+			const txSelect = vi.fn().mockReturnValue({ from: txSelectFrom });
+
+			mockUpdateWhere.mockResolvedValue(undefined);
+			mockSet.mockReturnValue({ where: mockUpdateWhere });
+			mockUpdate.mockReturnValue({ set: mockSet });
+
+			mockDeleteWhere.mockResolvedValue(undefined);
+			mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+			const mockReturningFn = vi.fn().mockResolvedValue([{ id: "new-job-1" }]);
+			mockValues.mockReturnValue({
+				returning: mockReturningFn,
+				onConflictDoNothing: vi
+					.fn()
+					.mockReturnValue({ returning: mockReturningFn }),
+			});
+			mockInsert.mockReturnValue({ values: mockValues });
+
+			return {
+				select: txSelect,
+				update: mockUpdate,
+				delete: mockDelete,
+				insert: mockInsert,
+			};
+		}
+
+		const employeeInput = {
+			declarationType: "initial" as const,
+			source: "dads",
+			categories: [
+				{
+					name: "Cadres",
+					detail: "Senior",
+					data: { womenCount: 10, menCount: 15 },
+				},
+			],
+		};
+
+		it("creates job and employee categories for initial declaration", async () => {
+			const tx = createEmployeeTx(mockDeclaration);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.updateEmployeeCategories(employeeInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockInsert).toHaveBeenCalled();
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({ currentStep: 5 }),
+			);
+		});
+
+		it("updates employee categories for correction declaration", async () => {
+			const existingJobs = [{ id: "job-1", categoryIndex: 0, name: "Cadres" }];
+			const tx = createEmployeeTx(mockDeclaration, existingJobs);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			const correctionInput = {
+				declarationType: "correction" as const,
+				source: "dads",
+				categories: [
+					{
+						name: "Cadres",
+						detail: "Senior",
+						data: { womenCount: 12, menCount: 18 },
+					},
+				],
+				referencePeriodStart: "2025-01-01",
+				referencePeriodEnd: "2025-12-31",
+			};
+
+			const result = await caller.updateEmployeeCategories(correctionInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					secondDeclarationStep: 2,
+					secondDeclReferencePeriodStart: "2025-01-01",
+					secondDeclReferencePeriodEnd: "2025-12-31",
+				}),
+			);
+		});
+
+		it("throws when declaration not found", async () => {
+			const tx = createEmployeeTx(null);
+			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.updateEmployeeCategories(employeeInput),
+			).rejects.toThrow("Déclaration introuvable");
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -66,7 +66,9 @@ function createMockTx(selectRows: unknown[] = []) {
 function createMockDb(selectRows: unknown[] = []) {
 	const tx = createMockTx(selectRows);
 
-	mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+	mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+		fn(tx),
+	);
 
 	return {
 		select: mockSelect,
@@ -141,7 +143,9 @@ describe("declarationRouter", () => {
 
 		it("returns existing declaration when found", async () => {
 			const tx = createGetOrCreateTx([mockDeclaration]);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -153,7 +157,9 @@ describe("declarationRouter", () => {
 
 		it("creates new declaration when none exists", async () => {
 			const tx = createGetOrCreateTx([], [mockDeclaration]);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -167,7 +173,9 @@ describe("declarationRouter", () => {
 
 		it("retries select after concurrent insert (onConflictDoNothing returns empty)", async () => {
 			const tx = createGetOrCreateTx([], [], [mockDeclaration]);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -179,7 +187,9 @@ describe("declarationRouter", () => {
 		it("throws NOT_FOUND when existing row is unexpectedly undefined", async () => {
 			// existing.length > 0 but existing[0] is undefined (defensive branch)
 			const tx = createGetOrCreateTx([undefined]);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -190,7 +200,9 @@ describe("declarationRouter", () => {
 
 		it("throws INTERNAL_SERVER_ERROR when retry also fails", async () => {
 			const tx = createGetOrCreateTx([], [], []);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -298,7 +310,9 @@ describe("declarationRouter", () => {
 	describe("updateStep1", () => {
 		it("updates totals and inserts categories", async () => {
 			const tx = createMockTx([mockDeclaration]);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -320,7 +334,9 @@ describe("declarationRouter", () => {
 				totalMen: 40,
 			};
 			const tx = createMockTx([unchangedDecl]);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -340,7 +356,9 @@ describe("declarationRouter", () => {
 
 		it("saves with empty categories array", async () => {
 			const tx = createMockTx([mockDeclaration]);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -362,7 +380,9 @@ describe("declarationRouter", () => {
 	describe("updateStepCategories", () => {
 		it("saves empty categories for a given step", async () => {
 			const tx = createMockTx();
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -376,7 +396,9 @@ describe("declarationRouter", () => {
 
 		it("saves categories with all optional fields undefined", async () => {
 			const tx = createMockTx();
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -390,7 +412,9 @@ describe("declarationRouter", () => {
 
 		it("saves categories for a given step", async () => {
 			const tx = createMockTx();
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -475,7 +499,9 @@ describe("declarationRouter", () => {
 
 		it("creates job and employee categories for initial declaration", async () => {
 			const tx = createEmployeeTx(mockDeclaration);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -492,7 +518,9 @@ describe("declarationRouter", () => {
 		it("updates employee categories for correction declaration", async () => {
 			const existingJobs = [{ id: "job-1", categoryIndex: 0, name: "Cadres" }];
 			const tx = createEmployeeTx(mockDeclaration, existingJobs);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 
@@ -524,7 +552,9 @@ describe("declarationRouter", () => {
 
 		it("throws when declaration not found", async () => {
 			const tx = createEmployeeTx(null);
-			mockTransaction.mockImplementation(async (fn: Function) => fn(tx));
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createCaller(mockDb);
 

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -186,9 +186,7 @@ describe("fetchAllCategories", () => {
 	it("returns empty employeeCategories when no jobs exist", async () => {
 		const { fetchAllCategories } = await import("../declarationHelpers");
 
-		let selectCallCount = 0;
 		const mockSelectWhere = vi.fn().mockImplementation(() => {
-			selectCallCount++;
 			return Promise.resolve([]);
 		});
 		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	buildEmployeeCategoryValues,
+	mapToEmployeeCategoryRows,
+} from "../declarationHelpers";
+
+describe("buildEmployeeCategoryValues", () => {
+	it("maps all fields from data to values object", () => {
+		const result = buildEmployeeCategoryValues("job-1", "initial", {
+			womenCount: 10,
+			menCount: 15,
+			annualBaseWomen: "30000",
+			annualBaseMen: "32000",
+			annualVariableWomen: "5000",
+			annualVariableMen: "6000",
+			hourlyBaseWomen: "18.5",
+			hourlyBaseMen: "19.0",
+			hourlyVariableWomen: "3.0",
+			hourlyVariableMen: "3.5",
+		});
+
+		expect(result).toEqual({
+			jobCategoryId: "job-1",
+			declarationType: "initial",
+			womenCount: 10,
+			menCount: 15,
+			annualBaseWomen: "30000",
+			annualBaseMen: "32000",
+			annualVariableWomen: "5000",
+			annualVariableMen: "6000",
+			hourlyBaseWomen: "18.5",
+			hourlyBaseMen: "19.0",
+			hourlyVariableWomen: "3.0",
+			hourlyVariableMen: "3.5",
+		});
+	});
+
+	it("defaults missing fields to null", () => {
+		const result = buildEmployeeCategoryValues("job-1", "correction", {});
+
+		expect(result).toEqual({
+			jobCategoryId: "job-1",
+			declarationType: "correction",
+			womenCount: null,
+			menCount: null,
+			annualBaseWomen: null,
+			annualBaseMen: null,
+			annualVariableWomen: null,
+			annualVariableMen: null,
+			hourlyBaseWomen: null,
+			hourlyBaseMen: null,
+			hourlyVariableWomen: null,
+			hourlyVariableMen: null,
+		});
+	});
+
+	it("handles partial data correctly", () => {
+		const result = buildEmployeeCategoryValues("job-2", "initial", {
+			womenCount: 5,
+			annualBaseWomen: "25000",
+		});
+
+		expect(result.womenCount).toBe(5);
+		expect(result.annualBaseWomen).toBe("25000");
+		expect(result.menCount).toBeNull();
+		expect(result.annualBaseMen).toBeNull();
+	});
+});
+
+describe("mapToEmployeeCategoryRows", () => {
+	const baseJob = {
+		id: "job-1",
+		declarationId: "decl-1",
+		categoryIndex: 0,
+		name: "Cadres",
+		detail: "Senior",
+		source: "dads",
+		createdAt: new Date(),
+	};
+
+	const baseEmpCat = {
+		id: "emp-1",
+		jobCategoryId: "job-1",
+		declarationType: "initial" as const,
+		womenCount: 10,
+		menCount: 15,
+		annualBaseWomen: "30000",
+		annualBaseMen: "32000",
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	};
+
+	it("maps jobs and employee categories into rows sorted by categoryIndex", () => {
+		const jobs = [
+			{ ...baseJob, id: "job-2", categoryIndex: 1, name: "Employés" },
+			{ ...baseJob, id: "job-1", categoryIndex: 0, name: "Cadres" },
+		];
+
+		const empCats = [
+			{ ...baseEmpCat, jobCategoryId: "job-1" },
+			{
+				...baseEmpCat,
+				id: "emp-2",
+				jobCategoryId: "job-2",
+				womenCount: 20,
+				menCount: 25,
+			},
+		];
+
+		const result = mapToEmployeeCategoryRows(jobs, empCats, "initial");
+
+		expect(result).toHaveLength(2);
+		expect(result[0]?.name).toBe("Cadres");
+		expect(result[0]?.womenCount).toBe(10);
+		expect(result[1]?.name).toBe("Employés");
+		expect(result[1]?.womenCount).toBe(20);
+	});
+
+	it("returns null fields when no employee category matches", () => {
+		const jobs = [baseJob];
+		const result = mapToEmployeeCategoryRows(jobs, [], "initial");
+
+		expect(result).toHaveLength(1);
+		expect(result[0]?.womenCount).toBeNull();
+		expect(result[0]?.menCount).toBeNull();
+	});
+
+	it("filters by declaration type", () => {
+		const jobs = [baseJob];
+		const empCats = [
+			{ ...baseEmpCat, declarationType: "correction" as const, womenCount: 99 },
+		];
+
+		const result = mapToEmployeeCategoryRows(jobs, empCats, "initial");
+
+		expect(result[0]?.womenCount).toBeNull();
+	});
+
+	it("uses empty string for null detail", () => {
+		const jobs = [{ ...baseJob, detail: null }];
+
+		const result = mapToEmployeeCategoryRows(jobs, [], "initial");
+
+		expect(result[0]?.detail).toBe("");
+	});
+});
+
+describe("fetchAllCategories", () => {
+	it("returns categories, jobCategories and employeeCategories", async () => {
+		const { fetchAllCategories } = await import("../declarationHelpers");
+
+		const mockCategories = [{ id: "cat-1", siren: "123456789", year: 2026 }];
+		const mockJobs = [{ id: "job-1" }, { id: "job-2" }];
+		const mockEmpCats = [
+			[{ id: "emp-1", jobCategoryId: "job-1" }],
+			[{ id: "emp-2", jobCategoryId: "job-2" }],
+		];
+
+		let selectCallCount = 0;
+		const mockSelectWhere = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			if (selectCallCount === 1) return Promise.resolve(mockCategories);
+			if (selectCallCount === 2) return Promise.resolve(mockJobs);
+			// Employee category queries
+			return Promise.resolve(mockEmpCats[selectCallCount - 3] ?? []);
+		});
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect } as never;
+
+		const result = await fetchAllCategories(tx, "123456789", 2026, "decl-1");
+
+		expect(result.categories).toEqual(mockCategories);
+		expect(result.jobCategories).toEqual(mockJobs);
+		expect(result.employeeCategories).toHaveLength(2);
+	});
+
+	it("returns empty employeeCategories when no jobs exist", async () => {
+		const { fetchAllCategories } = await import("../declarationHelpers");
+
+		let selectCallCount = 0;
+		const mockSelectWhere = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			return Promise.resolve([]);
+		});
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect } as never;
+
+		const result = await fetchAllCategories(tx, "123456789", 2026, "decl-1");
+
+		expect(result.categories).toEqual([]);
+		expect(result.jobCategories).toEqual([]);
+		expect(result.employeeCategories).toEqual([]);
+	});
+});
+
+describe("deleteJobAndEmployeeCategories", () => {
+	it("deletes employee categories then job categories", async () => {
+		const { deleteJobAndEmployeeCategories } = await import(
+			"../declarationHelpers"
+		);
+
+		const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+		const mockDelete = vi.fn().mockReturnValue({ where: mockDeleteWhere });
+		const mockSelectWhere = vi
+			.fn()
+			.mockResolvedValue([{ id: "job-1" }, { id: "job-2" }]);
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect, delete: mockDelete } as never;
+
+		await deleteJobAndEmployeeCategories(tx, "decl-1");
+
+		// 2 employee category deletes + 1 job categories delete = 3 total
+		expect(mockDelete).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not delete job categories when none exist", async () => {
+		const { deleteJobAndEmployeeCategories } = await import(
+			"../declarationHelpers"
+		);
+
+		const mockDelete = vi.fn();
+		const mockSelectWhere = vi.fn().mockResolvedValue([]);
+		const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+		const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+		const tx = { select: mockSelect, delete: mockDelete } as never;
+
+		await deleteJobAndEmployeeCategories(tx, "decl-1");
+
+		expect(mockDelete).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/jointEvaluation.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/jointEvaluation.test.ts
@@ -30,7 +30,7 @@ function createMockDb(rows: unknown[] = []) {
 	mockValues.mockResolvedValue(undefined);
 	mockInsert.mockReturnValue({ values: mockValues });
 
-	mockTransaction.mockImplementation(async (fn: Function) =>
+	mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
 		fn({
 			select: mockSelect,
 			delete: mockDelete,

--- a/packages/app/src/server/api/routers/__tests__/jointEvaluation.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/jointEvaluation.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockWhere = vi.fn();
+const mockFrom = vi.fn();
+const mockSelect = vi.fn();
+const mockDelete = vi.fn();
+const mockDeleteWhere = vi.fn();
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockLimit = vi.fn();
+const mockTransaction = vi.fn();
+
+function createMockDb(rows: unknown[] = []) {
+	mockLimit.mockResolvedValue(rows);
+	mockWhere.mockReturnValue({ limit: mockLimit });
+	mockFrom.mockReturnValue({ where: mockWhere });
+	mockSelect.mockReturnValue({ from: mockFrom });
+
+	mockDeleteWhere.mockResolvedValue(undefined);
+	mockDelete.mockReturnValue({ where: mockDeleteWhere });
+
+	mockValues.mockResolvedValue(undefined);
+	mockInsert.mockReturnValue({ values: mockValues });
+
+	mockTransaction.mockImplementation(async (fn: Function) =>
+		fn({
+			select: mockSelect,
+			delete: mockDelete,
+			insert: mockInsert,
+		}),
+	);
+
+	return {
+		select: mockSelect,
+		transaction: mockTransaction,
+	} as unknown;
+}
+
+function createCaller(mockDb: unknown, siret = "33978727700015") {
+	return import("../jointEvaluation").then(({ jointEvaluationRouter }) =>
+		jointEvaluationRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1", siret }, expires: "" },
+			headers: new Headers(),
+		} as never),
+	);
+}
+
+describe("jointEvaluationRouter", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("uploadFile", () => {
+		const validInput = {
+			fileName: "evaluation.pdf",
+			filePath: "/uploads/evaluation.pdf",
+		};
+
+		it("deletes existing file and inserts new one in a transaction", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.uploadFile(validInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+			expect(mockInsert).toHaveBeenCalled();
+			expect(mockValues).toHaveBeenCalledWith(
+				expect.objectContaining({
+					siren: "339787277",
+					fileName: "evaluation.pdf",
+					filePath: "/uploads/evaluation.pdf",
+					declarantId: "user-1",
+				}),
+			);
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.uploadFile(validInput)).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+
+		it("rejects empty fileName", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.uploadFile({ fileName: "", filePath: "/uploads/test.pdf" }),
+			).rejects.toThrow();
+		});
+
+		it("rejects empty filePath", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.uploadFile({ fileName: "test.pdf", filePath: "" }),
+			).rejects.toThrow();
+		});
+	});
+
+	describe("getFile", () => {
+		it("returns file when it exists", async () => {
+			const file = {
+				fileName: "evaluation.pdf",
+				filePath: "/uploads/evaluation.pdf",
+				uploadedAt: new Date("2026-01-15"),
+			};
+			const mockDb = createMockDb([file]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getFile();
+
+			expect(result).toEqual(file);
+			expect(mockSelect).toHaveBeenCalled();
+		});
+
+		it("returns null when no file exists", async () => {
+			const mockDb = createMockDb([]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getFile();
+
+			expect(result).toBeNull();
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.getFile()).rejects.toThrow(
+				"SIRET manquant dans la session",
+			);
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 
-import { saveOpinionsSchema } from "~/modules/cseOpinion";
+import { saveOpinionsSchema } from "~/modules/cseOpinion/schemas";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { cseOpinions } from "~/server/db/schema";
 

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -76,28 +76,30 @@ export const cseOpinionRouter = createTRPCRouter({
 					declarantId,
 				});
 
-				// Second declaration — accuracy
-				rows.push({
-					siren,
-					year,
-					declarationNumber: 2,
-					type: "accuracy",
-					opinion: input.secondDeclaration.accuracyOpinion,
-					opinionDate: input.secondDeclaration.accuracyDate,
-					declarantId,
-				});
+				if (input.secondDeclaration) {
+					// Second declaration — accuracy
+					rows.push({
+						siren,
+						year,
+						declarationNumber: 2,
+						type: "accuracy",
+						opinion: input.secondDeclaration.accuracyOpinion,
+						opinionDate: input.secondDeclaration.accuracyDate,
+						declarantId,
+					});
 
-				// Second declaration — gap
-				rows.push({
-					siren,
-					year,
-					declarationNumber: 2,
-					type: "gap",
-					gapConsulted: input.secondDeclaration.gapConsulted,
-					opinion: input.secondDeclaration.gapOpinion,
-					opinionDate: input.secondDeclaration.gapDate,
-					declarantId,
-				});
+					// Second declaration — gap
+					rows.push({
+						siren,
+						year,
+						declarationNumber: 2,
+						type: "gap",
+						gapConsulted: input.secondDeclaration.gapConsulted,
+						opinion: input.secondDeclaration.gapOpinion,
+						opinionDate: input.secondDeclaration.gapDate,
+						declarantId,
+					});
+				}
 
 				await tx.insert(cseOpinions).values(rows);
 			});

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 
-import { saveOpinionsSchema } from "~/modules/cseOpinion/schemas";
+import { saveOpinionsSchema } from "~/modules/cseOpinion";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { cseOpinions } from "~/server/db/schema";
 

--- a/packages/app/src/server/api/routers/jointEvaluation.ts
+++ b/packages/app/src/server/api/routers/jointEvaluation.ts
@@ -32,7 +32,7 @@ export const jointEvaluationRouter = createTRPCRouter({
 			const year = getCurrentYear();
 			const declarantId = ctx.session.user.id;
 
-			// Upsert: delete existing file for this siren/year, then insert
+			// Upsert: one file per company/year — any declarant of the company can replace it
 			await ctx.db.transaction(async (tx) => {
 				await tx
 					.delete(jointEvaluationFiles)

--- a/packages/app/src/server/api/routers/jointEvaluation.ts
+++ b/packages/app/src/server/api/routers/jointEvaluation.ts
@@ -1,0 +1,79 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { jointEvaluationFiles } from "~/server/db/schema";
+
+function getSiren(siret: string | null | undefined): string {
+	if (!siret) {
+		throw new TRPCError({
+			code: "BAD_REQUEST",
+			message: "SIRET manquant dans la session",
+		});
+	}
+	return siret.slice(0, 9);
+}
+
+function getCurrentYear() {
+	return new Date().getFullYear();
+}
+
+export const jointEvaluationRouter = createTRPCRouter({
+	uploadFile: protectedProcedure
+		.input(
+			z.object({
+				fileName: z.string().min(1),
+				filePath: z.string().min(1),
+			}),
+		)
+		.mutation(async ({ ctx, input }) => {
+			const siren = getSiren(ctx.session.user.siret);
+			const year = getCurrentYear();
+			const declarantId = ctx.session.user.id;
+
+			// Upsert: delete existing file for this siren/year, then insert
+			await ctx.db.transaction(async (tx) => {
+				await tx
+					.delete(jointEvaluationFiles)
+					.where(
+						and(
+							eq(jointEvaluationFiles.siren, siren),
+							eq(jointEvaluationFiles.year, year),
+						),
+					);
+
+				await tx.insert(jointEvaluationFiles).values({
+					siren,
+					year,
+					fileName: input.fileName,
+					filePath: input.filePath,
+					declarantId,
+				});
+			});
+
+			return { success: true };
+		}),
+
+	getFile: protectedProcedure.query(async ({ ctx }) => {
+		const siren = getSiren(ctx.session.user.siret);
+		const year = getCurrentYear();
+
+		const rows = await ctx.db
+			.select({
+				fileName: jointEvaluationFiles.fileName,
+				filePath: jointEvaluationFiles.filePath,
+				uploadedAt: jointEvaluationFiles.uploadedAt,
+			})
+			.from(jointEvaluationFiles)
+			.where(
+				and(
+					eq(jointEvaluationFiles.siren, siren),
+					eq(jointEvaluationFiles.year, year),
+				),
+			)
+			.limit(1);
+
+		return rows[0] ?? null;
+	}),
+});

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -441,3 +441,45 @@ export const cseOpinionFileLinksRelations = relations(
 		}),
 	}),
 );
+
+export const jointEvaluationFiles = createTable(
+	"joint_evaluation_file",
+	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		siren: d
+			.varchar({ length: 9 })
+			.notNull()
+			.references(() => companies.siren),
+		year: d.integer().notNull(),
+		fileName: d.varchar({ length: 255 }).notNull(),
+		filePath: d.varchar({ length: 500 }).notNull(),
+		declarantId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => users.id),
+		uploadedAt: d
+			.timestamp({ withTimezone: true })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+	}),
+	(t) => [index("joint_eval_file_siren_year_idx").on(t.siren, t.year)],
+);
+
+export const jointEvaluationFilesRelations = relations(
+	jointEvaluationFiles,
+	({ one }) => ({
+		company: one(companies, {
+			fields: [jointEvaluationFiles.siren],
+			references: [companies.siren],
+		}),
+		declarant: one(users, {
+			fields: [jointEvaluationFiles.declarantId],
+			references: [users.id],
+		}),
+	}),
+);

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -313,11 +313,13 @@ export const companiesRelations = relations(companies, ({ many }) => ({
 	declarations: many(declarations),
 	cseOpinions: many(cseOpinions),
 	cseOpinionFiles: many(cseOpinionFiles),
+	jointEvaluationFiles: many(jointEvaluationFiles),
 }));
 
 export const usersRelations = relations(users, ({ many }) => ({
 	accounts: many(accounts),
 	userCompanies: many(userCompanies),
+	jointEvaluationFiles: many(jointEvaluationFiles),
 }));
 
 // ── CSE Opinion tables ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Joint evaluation DB table (`joint_evaluation_files`) and Drizzle schema
- tRPC router (`uploadFile`, `getFile`) with ownership via session
- Migration 0008
- Unit tests for jointEvaluation router

## PR chain
#2999 feat/cse-opinion-flow → **2/4** → #3 feat/compliance-path-routing → #4 feat/compliance-second-declaration

## Test plan
- [x] Unit tests pass
- [x] Typecheck passes