### PR TITLE
feat: add compliance path routing and choice screen

### DIFF
--- a/packages/app/drizzle/0009_hot_vector.sql
+++ b/packages/app/drizzle/0009_hot_vector.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_declaration" ADD COLUMN "compliance_completed_at" timestamp with time zone;

--- a/packages/app/drizzle/meta/0009_snapshot.json
+++ b/packages/app/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1265 @@
+{
+	"id": "f3bba16b-2079-4b93-8540-6f1db0830a14",
+	"prevId": "00bacf79-9c67-43ca-a743-c927b966a752",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_account": {
+			"name": "app_account",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider": {
+					"name": "provider",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"provider_account_id": {
+					"name": "provider_account_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"refresh_token": {
+					"name": "refresh_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"access_token": {
+					"name": "access_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"token_type": {
+					"name": "token_type",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"id_token": {
+					"name": "id_token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"session_state": {
+					"name": "session_state",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"account_user_id_idx": {
+					"name": "account_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_account_user_id_app_user_id_fk": {
+					"name": "app_account_user_id_app_user_id_fk",
+					"tableFrom": "app_account",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_account_provider_provider_account_id_pk": {
+					"name": "app_account_provider_provider_account_id_pk",
+					"columns": ["provider", "provider_account_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file_link": {
+			"name": "app_cse_opinion_file_link",
+			"schema": "",
+			"columns": {
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"opinion_id": {
+					"name": "opinion_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk": {
+					"name": "app_cse_opinion_file_link_file_id_app_cse_opinion_file_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk": {
+					"name": "app_cse_opinion_file_link_opinion_id_app_cse_opinion_id_fk",
+					"tableFrom": "app_cse_opinion_file_link",
+					"tableTo": "app_cse_opinion",
+					"columnsFrom": ["opinion_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_cse_opinion_file_link_file_id_opinion_id_pk": {
+					"name": "app_cse_opinion_file_link_file_id_opinion_id_pk",
+					"columns": ["file_id", "opinion_id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_siren_year_idx": {
+					"name": "cse_opinion_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_file_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_siren_year_idx": {
+					"name": "cse_opinion_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_siren_app_company_siren_fk": {
+					"name": "app_cse_opinion_siren_app_company_siren_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_declarant_id_app_user_id_fk": {
+					"name": "app_cse_opinion_declarant_id_app_user_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_siren_year_decl_type_idx": {
+					"name": "cse_opinion_siren_year_decl_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_category": {
+			"name": "app_declaration_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"step": {
+					"name": "step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_name": {
+					"name": "category_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_value": {
+					"name": "women_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_value": {
+					"name": "men_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_median_value": {
+					"name": "women_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_median_value": {
+					"name": "men_median_value",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_cat_siren_year_step_idx": {
+					"name": "declaration_cat_siren_year_step_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "step",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_path": {
+					"name": "compliance_path",
+					"type": "varchar(30)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_status": {
+					"name": "second_declaration_status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_completed_at": {
+					"name": "compliance_completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"declaration_siren_year_idx": {
+					"name": "declaration_siren_year_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"detail": {
+					"name": "detail",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_joint_evaluation_file": {
+			"name": "app_joint_evaluation_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"joint_eval_file_siren_year_idx": {
+					"name": "joint_eval_file_siren_year_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_joint_evaluation_file_siren_app_company_siren_fk": {
+					"name": "app_joint_evaluation_file_siren_app_company_siren_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_joint_evaluation_file_declarant_id_app_user_id_fk": {
+					"name": "app_joint_evaluation_file_declarant_id_app_user_id_fk",
+					"tableFrom": "app_joint_evaluation_file",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_session": {
+			"name": "app_session",
+			"schema": "",
+			"columns": {
+				"session_token": {
+					"name": "session_token",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"t_user_id_idx": {
+					"name": "t_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_session_user_id_app_user_id_fk": {
+					"name": "app_session_user_id_app_user_id_fk",
+					"tableFrom": "app_session",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"image": {
+					"name": "image",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siret": {
+					"name": "siret",
+					"type": "varchar(14)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_verification_token": {
+			"name": "app_verification_token",
+			"schema": "",
+			"columns": {
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"token": {
+					"name": "token",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires": {
+					"name": "expires",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"app_verification_token_identifier_token_pk": {
+					"name": "app_verification_token_identifier_token_pk",
+					"columns": ["identifier", "token"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		}
+	},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
 			"when": 1773328599101,
 			"tag": "0008_powerful_omega_flight",
 			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1773331852632,
+			"tag": "0009_hot_vector",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/app/declaration-remuneration/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/parcours-conformite/confirmation/page.tsx
@@ -1,0 +1,5 @@
+import { ComplianceConfirmation } from "~/modules/declaration-remuneration";
+
+export default function ComplianceConfirmationPage() {
+	return <ComplianceConfirmation />;
+}

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -170,7 +170,7 @@ test.describe("Declaration workflow", () => {
 	});
 
 	// Must be last — mutates declaration status to 'submitted'
-	test("step 6 submit navigates to CSE opinion page", async ({ page }) => {
+	test("step 6 submit navigates to compliance path", async ({ page }) => {
 		await goToStep(page, 6);
 
 		// Click the "Suivant" submit button to open the confirmation modal
@@ -180,8 +180,9 @@ test.describe("Declaration workflow", () => {
 		await page.getByText(/Je certifie/).click();
 		await page.getByRole("button", { name: "Valider" }).click();
 
-		// Verify navigation to the CSE opinion page
-		await page.waitForURL("**/avis-cse/**");
+		// After submission, the compliance path flow redirects based on gap and CSE status.
+		// With no gap above threshold, it redirects to confirmation (no CSE) or avis-cse (with CSE).
+		await page.waitForURL("**/parcours-conformite/**");
 	});
 
 	test("previous button is present on step pages", async ({ page }) => {

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ComplianceCompletionTracker } from "~/modules/declaration-remuneration";
 import { DsfrPictogram } from "~/modules/home";
 import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
@@ -18,6 +19,7 @@ export function ConfirmationPage({ email }: Props) {
 	const year = dataYear + 1;
 	return (
 		<div>
+			<ComplianceCompletionTracker />
 			<h1 className="fr-h4 fr-mb-4w">
 				Démarche des indicateurs de rémunération {year}
 			</h1>

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ComplianceCompletionTracker } from "~/modules/declaration-remuneration";
+import { ComplianceCompletionEffect } from "~/modules/declaration-remuneration";
 import { DsfrPictogram } from "~/modules/home";
 import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
@@ -19,7 +19,7 @@ export function ConfirmationPage({ email }: Props) {
 	const year = dataYear + 1;
 	return (
 		<div>
-			<ComplianceCompletionTracker />
+			<ComplianceCompletionEffect />
 			<h1 className="fr-h4 fr-mb-4w">
 				Démarche des indicateurs de rémunération {year}
 			</h1>

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -1,7 +1,7 @@
 export { DeclarationLayout } from "./DeclarationLayout";
 export { MissingSiret } from "./MissingSiret";
 export { StepPageClient } from "./StepPageClient";
-export { ComplianceCompletionTracker } from "./shared/ComplianceCompletionTracker";
+export { ComplianceCompletionEffect } from "./shared/ComplianceCompletionEffect";
 export { DevFillButton } from "./shared/DevFillButton";
 export {
 	computeGap,

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -1,6 +1,7 @@
 export { DeclarationLayout } from "./DeclarationLayout";
 export { MissingSiret } from "./MissingSiret";
 export { StepPageClient } from "./StepPageClient";
+export { ComplianceCompletionTracker } from "./shared/ComplianceCompletionTracker";
 export { DevFillButton } from "./shared/DevFillButton";
 export {
 	computeGap,
@@ -11,6 +12,7 @@ export {
 	hasGapsAboveThreshold,
 } from "./shared/gapUtils";
 export { mapDbCategories } from "./shared/mapDbCategories";
+export { ComplianceConfirmation } from "./steps/ComplianceConfirmation";
 export { CompliancePathChoice } from "./steps/CompliancePathChoice";
 export { CompliancePathPage } from "./steps/CompliancePathPage";
 export { JointEvaluationPage } from "./steps/jointEvaluation";

--- a/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionEffect.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionEffect.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useComplianceCompletion } from "./useComplianceCompletion";
+
+/** Client component that triggers compliance completion on mount. */
+export function ComplianceCompletionEffect() {
+	useComplianceCompletion();
+	return null;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionTracker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionTracker.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { api } from "~/trpc/react";
+
+export function ComplianceCompletionTracker() {
+	const mutation = api.declaration.completeCompliancePath.useMutation();
+	const called = useRef(false);
+
+	useEffect(() => {
+		if (!called.current) {
+			called.current = true;
+			mutation.mutate();
+		}
+	}, [mutation]);
+
+	return null;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionTracker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/ComplianceCompletionTracker.tsx
@@ -4,15 +4,15 @@ import { useEffect, useRef } from "react";
 import { api } from "~/trpc/react";
 
 export function ComplianceCompletionTracker() {
-	const mutation = api.declaration.completeCompliancePath.useMutation();
+	const { mutate } = api.declaration.completeCompliancePath.useMutation();
 	const called = useRef(false);
 
 	useEffect(() => {
 		if (!called.current) {
 			called.current = true;
-			mutation.mutate();
+			mutate();
 		}
-	}, [mutation]);
+	}, [mutate]);
 
 	return null;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/ComplianceCompletionEffect.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/ComplianceCompletionEffect.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMutate = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			completeCompliancePath: {
+				useMutation: () => ({ mutate: mockMutate }),
+			},
+		},
+	},
+}));
+
+import { ComplianceCompletionEffect } from "../ComplianceCompletionEffect";
+
+describe("ComplianceCompletionEffect", () => {
+	beforeEach(() => {
+		mockMutate.mockClear();
+	});
+
+	it("renders nothing", () => {
+		const { container } = render(<ComplianceCompletionEffect />);
+		expect(container.innerHTML).toBe("");
+	});
+
+	it("triggers compliance completion mutation on mount", () => {
+		render(<ComplianceCompletionEffect />);
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { getPostComplianceDestination } from "../complianceNavigation";
+
+describe("getPostComplianceDestination", () => {
+	it("returns /avis-cse when hasCse is true", () => {
+		expect(getPostComplianceDestination(true)).toBe("/avis-cse");
+	});
+
+	it("returns confirmation path when hasCse is false", () => {
+		expect(getPostComplianceDestination(false)).toBe(
+			"/declaration-remuneration/parcours-conformite/confirmation",
+		);
+	});
+
+	it("returns confirmation path when hasCse is null", () => {
+		expect(getPostComplianceDestination(null)).toBe(
+			"/declaration-remuneration/parcours-conformite/confirmation",
+		);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/useComplianceCompletion.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/useComplianceCompletion.test.ts
@@ -1,0 +1,35 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMutate = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			completeCompliancePath: {
+				useMutation: () => ({ mutate: mockMutate }),
+			},
+		},
+	},
+}));
+
+import { useComplianceCompletion } from "../useComplianceCompletion";
+
+describe("useComplianceCompletion", () => {
+	beforeEach(() => {
+		mockMutate.mockClear();
+	});
+
+	it("calls mutate once on first render", () => {
+		renderHook(() => useComplianceCompletion());
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not call mutate again on re-render", () => {
+		const { rerender } = renderHook(() => useComplianceCompletion());
+		mockMutate.mockClear();
+		rerender();
+		rerender();
+		expect(mockMutate).toHaveBeenCalledTimes(0);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
@@ -1,0 +1,13 @@
+const COMPLIANCE_CONFIRMATION_PATH =
+	"/declaration-remuneration/parcours-conformite/confirmation";
+
+/**
+ * Returns the destination URL after completing a compliance path step,
+ * based on whether the company has a CSE (works council).
+ *
+ * - Has CSE → redirect to CSE opinion page
+ * - No CSE or unknown → redirect to the compliance confirmation page
+ */
+export function getPostComplianceDestination(hasCse: boolean | null): string {
+	return hasCse === true ? "/avis-cse" : COMPLIANCE_CONFIRMATION_PATH;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/useComplianceCompletion.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/useComplianceCompletion.ts
@@ -3,7 +3,8 @@
 import { useEffect, useRef } from "react";
 import { api } from "~/trpc/react";
 
-export function ComplianceCompletionTracker() {
+/** Marks the compliance path as completed on first render (fire-and-forget). */
+export function useComplianceCompletion() {
 	const { mutate } = api.declaration.completeCompliancePath.useMutation();
 	const called = useRef(false);
 
@@ -13,6 +14,4 @@ export function ComplianceCompletionTracker() {
 			mutate();
 		}
 	}, [mutate]);
-
-	return null;
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { DsfrPictogram } from "~/modules/home";
-import { ComplianceCompletionTracker } from "../shared/ComplianceCompletionTracker";
+import { ComplianceCompletionEffect } from "../shared/ComplianceCompletionEffect";
 import common from "../shared/common.module.scss";
 
 export function ComplianceConfirmation() {
@@ -8,7 +8,7 @@ export function ComplianceConfirmation() {
 
 	return (
 		<div className={common.flexColumnGap2}>
-			<ComplianceCompletionTracker />
+			<ComplianceCompletionEffect />
 			<h1 className="fr-h4 fr-mb-0">
 				Parcours de mise en conformité pour l&apos;indicateur par catégorie de
 				salariés

--- a/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { DsfrPictogram } from "~/modules/home";
+import { ComplianceCompletionTracker } from "../shared/ComplianceCompletionTracker";
+import common from "../shared/common.module.scss";
+
+export function ComplianceConfirmation() {
+	const currentYear = new Date().getFullYear();
+
+	return (
+		<div className={common.flexColumnGap2}>
+			<ComplianceCompletionTracker />
+			<h1 className="fr-h4 fr-mb-0">
+				Parcours de mise en conformité pour l&apos;indicateur par catégorie de
+				salariés
+			</h1>
+
+			<div className="fr-mt-2w fr-mb-2w">
+				<DsfrPictogram
+					path="/dsfr/artwork/pictograms/system/success.svg"
+					size={64}
+				/>
+			</div>
+
+			<p className="fr-text--lg fr-text--bold fr-mb-0">
+				Votre parcours de mise en conformité {currentYear} est terminé
+			</p>
+
+			<p className="fr-mb-0">
+				Votre entreprise ne dispose pas de CSE. Aucun avis CSE n&apos;est
+				requis.
+			</p>
+
+			<div className="fr-mt-4w">
+				<Link className="fr-btn" href="/mon-espace">
+					Mon espace
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { api } from "~/trpc/react";
@@ -21,6 +21,180 @@ type Props = {
 	isSecondRound?: boolean;
 	pdfDownloadHref?: string;
 };
+
+function JointEvaluationOption({
+	checked,
+	currentYear,
+	onChange,
+}: {
+	checked: boolean;
+	currentYear: number;
+	onChange: () => void;
+}) {
+	return (
+		<div className="fr-fieldset__element">
+			<CompliancePathOption
+				checked={checked}
+				deadline={`1\u1D49\u02B3 août ${currentYear}`}
+				id="path-joint"
+				learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+				learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
+				name="compliance-path"
+				onChange={onChange}
+				title="Évaluation conjointe des rémunérations"
+				value="joint_evaluation"
+			>
+				<p className="fr-mb-0">
+					Vous choisissez de procéder à une évaluation conjointe des
+					rémunérations afin d&apos;identifier et de corriger les écarts
+					constatés :
+				</p>
+				<ul className="fr-mt-1w fr-mb-0">
+					<li>
+						Élaboration du rapport préalable (à déposer sur le portail Egapro)
+					</li>
+					<li>Analyse conjointe et définition des actions correctrices</li>
+					<li>
+						Mise en place de l&apos;accord collectif ou à défaut un plan
+						d&apos;action
+					</li>
+				</ul>
+			</CompliancePathOption>
+		</div>
+	);
+}
+
+function JustifyOption({
+	checked,
+	currentYear,
+	onChange,
+}: {
+	checked: boolean;
+	currentYear: number;
+	onChange: () => void;
+}) {
+	return (
+		<div className="fr-fieldset__element">
+			<CompliancePathOption
+				checked={checked}
+				deadline={`1\u1D49\u02B3 juin ${currentYear}`}
+				id="path-justify"
+				name="compliance-path"
+				onChange={onChange}
+				title="Justifier les écarts de rémunération ≥ 5 %"
+				value="justify"
+			>
+				<p className="fr-mb-0">
+					Vous avez la possibilité de justifier vos écarts par des critères
+					objectifs et non sexistes :
+				</p>
+				<ul className="fr-mt-1w fr-mb-0">
+					<li>Informer et consulter votre CSE sur cette justification</li>
+					<li>Transmettre l&apos;avis du CSE</li>
+				</ul>
+			</CompliancePathOption>
+		</div>
+	);
+}
+
+function SecondRoundOptions({
+	currentYear,
+	selectedPath,
+	setSelectedPath,
+}: {
+	currentYear: number;
+	selectedPath: CompliancePathValue | undefined;
+	setSelectedPath: (path: CompliancePathValue) => void;
+}) {
+	return (
+		<>
+			<JustifyOption
+				checked={selectedPath === "justify"}
+				currentYear={currentYear}
+				onChange={() => setSelectedPath("justify")}
+			/>
+			<JointEvaluationOption
+				checked={selectedPath === "joint_evaluation"}
+				currentYear={currentYear}
+				onChange={() => setSelectedPath("joint_evaluation")}
+			/>
+		</>
+	);
+}
+
+function FirstRoundOptions({
+	currentYear,
+	hasCse,
+	selectedPath,
+	setSelectedPath,
+}: {
+	currentYear: number;
+	hasCse: boolean | null;
+	selectedPath: CompliancePathValue | undefined;
+	setSelectedPath: (path: CompliancePathValue) => void;
+}) {
+	return (
+		<>
+			<h3 className="fr-h6 fr-mt-3w fr-mb-0">
+				Si la justification n&apos;est pas possible par des critères objectifs
+				et non sexistes
+			</h3>
+
+			<div className="fr-fieldset__element fr-mt-2w">
+				<CompliancePathOption
+					checked={selectedPath === "corrective_action"}
+					deadline={`1\u1D49\u02B3 décembre ${currentYear}`}
+					id="path-corrective"
+					learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+					learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
+					name="compliance-path"
+					onChange={() => setSelectedPath("corrective_action")}
+					title="Actions correctives et seconde déclaration"
+					value="corrective_action"
+				>
+					<p className="fr-mb-0">
+						Vous souhaitez mettre en place des actions correctives, puis
+						recalculer et redéclarer l&apos;indicateur par catégorie de salariés
+						:
+					</p>
+					<ul className="fr-mt-1w fr-mb-0">
+						<li>
+							Mettre en place des actions correctives par accord ou par plan
+							d&apos;action
+						</li>
+						<li>
+							Redéclarer l&apos;indicateur dans un délai de 6 mois après votre
+							première déclaration
+						</li>
+						<li>
+							Informer et consulter votre CSE sur l&apos;exactitude des données
+							et éventuellement, sur la justification des écarts ≥ 5 %
+						</li>
+						<li>Transmettre l&apos;avis ou les avis du CSE</li>
+					</ul>
+					<p className="fr-mt-1w fr-mb-0">
+						Si des écarts non justifiés persistent, vous devez engager une
+						évaluation conjointe des rémunérations.
+					</p>
+				</CompliancePathOption>
+			</div>
+
+			<JointEvaluationOption
+				checked={selectedPath === "joint_evaluation"}
+				currentYear={currentYear}
+				onChange={() => setSelectedPath("joint_evaluation")}
+			/>
+
+			{hasCse === true && (
+				<JustifyOption
+					checked={selectedPath === "justify"}
+					currentYear={currentYear}
+					onChange={() => setSelectedPath("justify")}
+				/>
+			)}
+		</>
+	);
+}
 
 export function CompliancePathChoice({
 	currentYear,
@@ -109,168 +283,18 @@ export function CompliancePathChoice({
 				</legend>
 
 				{isSecondRound ? (
-					<>
-						<div className="fr-fieldset__element">
-							<CompliancePathOption
-								checked={selectedPath === "justify"}
-								deadline={`1\u1D49\u02B3 juin ${currentYear}`}
-								id="path-justify"
-								name="compliance-path"
-								onChange={() => setSelectedPath("justify")}
-								title="Justifier les écarts de rémunération ≥ 5 %"
-								value="justify"
-							>
-								<p className="fr-mb-0">
-									Vous avez la possibilité de justifier vos écarts par des
-									critères objectifs et non sexistes :
-								</p>
-								<ul className="fr-mt-1w fr-mb-0">
-									<li>
-										Informer et consulter votre CSE sur cette justification
-									</li>
-									<li>Transmettre l&apos;avis du CSE</li>
-								</ul>
-							</CompliancePathOption>
-						</div>
-
-						<div className="fr-fieldset__element">
-							<CompliancePathOption
-								checked={selectedPath === "joint_evaluation"}
-								deadline={`1\u1D49\u02B3 août ${currentYear}`}
-								id="path-joint"
-								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-								learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
-								name="compliance-path"
-								onChange={() => setSelectedPath("joint_evaluation")}
-								title="Évaluation conjointe des rémunérations"
-								value="joint_evaluation"
-							>
-								<p className="fr-mb-0">
-									Vous choisissez de procéder à une évaluation conjointe des
-									rémunérations afin d&apos;identifier et de corriger les écarts
-									constatés :
-								</p>
-								<ul className="fr-mt-1w fr-mb-0">
-									<li>
-										Élaboration du rapport préalable (à déposer sur le portail
-										Egapro)
-									</li>
-									<li>
-										Analyse conjointe et définition des actions correctrices
-									</li>
-									<li>
-										Mise en place de l&apos;accord collectif ou à défaut un plan
-										d&apos;action
-									</li>
-								</ul>
-							</CompliancePathOption>
-						</div>
-					</>
+					<SecondRoundOptions
+						currentYear={currentYear}
+						selectedPath={selectedPath}
+						setSelectedPath={setSelectedPath}
+					/>
 				) : (
-					<>
-						<h3 className="fr-h6 fr-mt-3w fr-mb-0">
-							Si la justification n&apos;est pas possible par des critères
-							objectifs et non sexistes
-						</h3>
-
-						<div className="fr-fieldset__element fr-mt-2w">
-							<CompliancePathOption
-								checked={selectedPath === "corrective_action"}
-								deadline={`1\u1D49\u02B3 décembre ${currentYear}`}
-								id="path-corrective"
-								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-								learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
-								name="compliance-path"
-								onChange={() => setSelectedPath("corrective_action")}
-								title="Actions correctives et seconde déclaration"
-								value="corrective_action"
-							>
-								<p className="fr-mb-0">
-									Vous souhaitez mettre en place des actions correctives, puis
-									recalculer et redéclarer l&apos;indicateur par catégorie de
-									salariés :
-								</p>
-								<ul className="fr-mt-1w fr-mb-0">
-									<li>
-										Mettre en place des actions correctives par accord ou par
-										plan d&apos;action
-									</li>
-									<li>
-										Redéclarer l&apos;indicateur dans un délai de 6 mois après
-										votre première déclaration
-									</li>
-									<li>
-										Informer et consulter votre CSE sur l&apos;exactitude des
-										données et éventuellement, sur la justification des écarts ≥
-										5 %
-									</li>
-									<li>Transmettre l&apos;avis ou les avis du CSE</li>
-								</ul>
-								<p className="fr-mt-1w fr-mb-0">
-									Si des écarts non justifiés persistent, vous devez engager une
-									évaluation conjointe des rémunérations.
-								</p>
-							</CompliancePathOption>
-						</div>
-
-						<div className="fr-fieldset__element">
-							<CompliancePathOption
-								checked={selectedPath === "joint_evaluation"}
-								deadline={`1\u1D49\u02B3 août ${currentYear}`}
-								id="path-joint"
-								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-								learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
-								name="compliance-path"
-								onChange={() => setSelectedPath("joint_evaluation")}
-								title="Évaluation conjointe des rémunérations"
-								value="joint_evaluation"
-							>
-								<p className="fr-mb-0">
-									Vous choisissez de procéder à une évaluation conjointe des
-									rémunérations afin d&apos;identifier et de corriger les écarts
-									constatés :
-								</p>
-								<ul className="fr-mt-1w fr-mb-0">
-									<li>
-										Élaboration du rapport préalable (à déposer sur le portail
-										Egapro)
-									</li>
-									<li>
-										Analyse conjointe et définition des actions correctrices
-									</li>
-									<li>
-										Mise en place de l&apos;accord collectif ou à défaut un plan
-										d&apos;action
-									</li>
-								</ul>
-							</CompliancePathOption>
-						</div>
-
-						{hasCse === true && (
-							<div className="fr-fieldset__element">
-								<CompliancePathOption
-									checked={selectedPath === "justify"}
-									deadline={`1\u1D49\u02B3 juin ${currentYear}`}
-									id="path-justify"
-									name="compliance-path"
-									onChange={() => setSelectedPath("justify")}
-									title="Justifier les écarts de rémunération ≥ 5 %"
-									value="justify"
-								>
-									<p className="fr-mb-0">
-										Vous avez la possibilité de justifier vos écarts par des
-										critères objectifs et non sexistes :
-									</p>
-									<ul className="fr-mt-1w fr-mb-0">
-										<li>
-											Informer et consulter votre CSE sur cette justification
-										</li>
-										<li>Transmettre l&apos;avis du CSE</li>
-									</ul>
-								</CompliancePathOption>
-							</div>
-						)}
-					</>
+					<FirstRoundOptions
+						currentYear={currentYear}
+						hasCse={hasCse}
+						selectedPath={selectedPath}
+						setSelectedPath={setSelectedPath}
+					/>
 				)}
 			</fieldset>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -16,22 +16,24 @@ import { DeclarationSuccessBanner } from "./compliancePath/DeclarationSuccessBan
 type Props = {
 	currentYear: number;
 	email: string;
+	hasCse: boolean | null;
 	initialPath?: CompliancePathValue;
-	forcedPath?: CompliancePathValue;
+	isSecondRound?: boolean;
 	pdfDownloadHref?: string;
 };
 
 export function CompliancePathChoice({
 	currentYear,
 	email,
+	hasCse,
 	initialPath,
-	forcedPath,
+	isSecondRound = false,
 	pdfDownloadHref,
 }: Props) {
 	const router = useRouter();
 	const [selectedPath, setSelectedPath] = useState<
 		CompliancePathValue | undefined
-	>(forcedPath ?? initialPath);
+	>(initialPath);
 
 	const mutation = api.declaration.saveCompliancePath.useMutation({
 		onSuccess: (_, { path }) => {
@@ -53,8 +55,6 @@ export function CompliancePathChoice({
 		mutation.mutate({ path: selectedPath });
 	}
 
-	const isDisabled = !!forcedPath;
-
 	return (
 		<form className={common.flexColumnGap2} onSubmit={handleSubmit}>
 			<div className={common.flexBetween}>
@@ -71,14 +71,14 @@ export function CompliancePathChoice({
 			/>
 
 			<h2 className="fr-h4 fr-mb-0">
-				Parcours de mise en conformité pour l'indicateur par catégorie de
+				Parcours de mise en conformité pour l&apos;indicateur par catégorie de
 				salariés
 			</h2>
 
 			<p className="fr-mb-0">
 				Des écarts ≥ 5 % ont été constatés,{" "}
 				<span className="fr-text--medium">
-					vous devez engager l'un des parcours suivants.
+					vous devez engager l&apos;un des parcours suivants.
 				</span>
 			</p>
 
@@ -94,7 +94,7 @@ export function CompliancePathChoice({
 						rel="noopener noreferrer"
 						target="_blank"
 					>
-						Qu'entend-on par critères objectifs et non sexistes ?
+						Qu&apos;entend-on par critères objectifs et non sexistes ?
 						<NewTabNotice />
 					</a>
 				</p>
@@ -108,102 +108,170 @@ export function CompliancePathChoice({
 					Choix du parcours de mise en conformité
 				</legend>
 
-				<div className="fr-fieldset__element">
-					<CompliancePathOption
-						checked={selectedPath === "justify"}
-						deadline={`1\u1D49\u02B3 juin ${currentYear}`}
-						disabled={isDisabled}
-						id="path-justify"
-						name="compliance-path"
-						onChange={() => setSelectedPath("justify")}
-						title="Justifier les écarts de rémunération ≥ 5 %"
-						value="justify"
-					>
-						<p className="fr-mb-0">
-							Vous avez la possibilité de justifier vos écarts par des critères
-							objectifs et non sexistes :
-						</p>
-						<ul className="fr-mt-1w fr-mb-0">
-							<li>Informer et consulter votre CSE sur cette justification</li>
-							<li>Transmettre l'avis du CSE</li>
-						</ul>
-					</CompliancePathOption>
-				</div>
+				{isSecondRound ? (
+					<>
+						<div className="fr-fieldset__element">
+							<CompliancePathOption
+								checked={selectedPath === "justify"}
+								deadline={`1\u1D49\u02B3 juin ${currentYear}`}
+								id="path-justify"
+								name="compliance-path"
+								onChange={() => setSelectedPath("justify")}
+								title="Justifier les écarts de rémunération ≥ 5 %"
+								value="justify"
+							>
+								<p className="fr-mb-0">
+									Vous avez la possibilité de justifier vos écarts par des
+									critères objectifs et non sexistes :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Informer et consulter votre CSE sur cette justification
+									</li>
+									<li>Transmettre l&apos;avis du CSE</li>
+								</ul>
+							</CompliancePathOption>
+						</div>
 
-				<h3 className="fr-h6 fr-mt-3w fr-mb-0">
-					Si la justification n'est pas possible par des critères objectifs et
-					non sexistes
-				</h3>
+						<div className="fr-fieldset__element">
+							<CompliancePathOption
+								checked={selectedPath === "joint_evaluation"}
+								deadline={`1\u1D49\u02B3 août ${currentYear}`}
+								id="path-joint"
+								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
+								name="compliance-path"
+								onChange={() => setSelectedPath("joint_evaluation")}
+								title="Évaluation conjointe des rémunérations"
+								value="joint_evaluation"
+							>
+								<p className="fr-mb-0">
+									Vous choisissez de procéder à une évaluation conjointe des
+									rémunérations afin d&apos;identifier et de corriger les écarts
+									constatés :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Élaboration du rapport préalable (à déposer sur le portail
+										Egapro)
+									</li>
+									<li>
+										Analyse conjointe et définition des actions correctrices
+									</li>
+									<li>
+										Mise en place de l&apos;accord collectif ou à défaut un plan
+										d&apos;action
+									</li>
+								</ul>
+							</CompliancePathOption>
+						</div>
+					</>
+				) : (
+					<>
+						<h3 className="fr-h6 fr-mt-3w fr-mb-0">
+							Si la justification n&apos;est pas possible par des critères
+							objectifs et non sexistes
+						</h3>
 
-				<div className="fr-fieldset__element fr-mt-2w">
-					<CompliancePathOption
-						checked={selectedPath === "corrective_action"}
-						deadline={`1\u1D49\u02B3 décembre ${currentYear}`}
-						disabled={isDisabled}
-						id="path-corrective"
-						learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-						learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
-						name="compliance-path"
-						onChange={() => setSelectedPath("corrective_action")}
-						title="Actions correctives et seconde déclaration"
-						value="corrective_action"
-					>
-						<p className="fr-mb-0">
-							Vous souhaitez mettre en place des actions correctives, puis
-							recalculer et redéclarer l'indicateur par catégorie de salariés :
-						</p>
-						<ul className="fr-mt-1w fr-mb-0">
-							<li>
-								Mettre en place des actions correctives par accord ou par plan
-								d'action
-							</li>
-							<li>
-								Redéclarer l'indicateur dans un délai de 6 mois après votre
-								première déclaration
-							</li>
-							<li>
-								Informer et consulter votre CSE sur l'exactitude des données et
-								éventuellement, sur la justification des écarts ≥ 5 %
-							</li>
-							<li>Transmettre l'avis ou les avis du CSE</li>
-						</ul>
-						<p className="fr-mt-1w fr-mb-0">
-							Si des écarts non justifiés persistent, vous devez engager une
-							évaluation conjointe des rémunérations.
-						</p>
-					</CompliancePathOption>
-				</div>
+						<div className="fr-fieldset__element fr-mt-2w">
+							<CompliancePathOption
+								checked={selectedPath === "corrective_action"}
+								deadline={`1\u1D49\u02B3 décembre ${currentYear}`}
+								id="path-corrective"
+								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
+								name="compliance-path"
+								onChange={() => setSelectedPath("corrective_action")}
+								title="Actions correctives et seconde déclaration"
+								value="corrective_action"
+							>
+								<p className="fr-mb-0">
+									Vous souhaitez mettre en place des actions correctives, puis
+									recalculer et redéclarer l&apos;indicateur par catégorie de
+									salariés :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Mettre en place des actions correctives par accord ou par
+										plan d&apos;action
+									</li>
+									<li>
+										Redéclarer l&apos;indicateur dans un délai de 6 mois après
+										votre première déclaration
+									</li>
+									<li>
+										Informer et consulter votre CSE sur l&apos;exactitude des
+										données et éventuellement, sur la justification des écarts ≥
+										5 %
+									</li>
+									<li>Transmettre l&apos;avis ou les avis du CSE</li>
+								</ul>
+								<p className="fr-mt-1w fr-mb-0">
+									Si des écarts non justifiés persistent, vous devez engager une
+									évaluation conjointe des rémunérations.
+								</p>
+							</CompliancePathOption>
+						</div>
 
-				<div className="fr-fieldset__element">
-					<CompliancePathOption
-						checked={selectedPath === "joint_evaluation"}
-						deadline={`1\u1D49\u02B3 août ${currentYear}`}
-						disabled={isDisabled}
-						id="path-joint"
-						learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-						learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
-						name="compliance-path"
-						onChange={() => setSelectedPath("joint_evaluation")}
-						title="Évaluation conjointe des rémunérations"
-						value="joint_evaluation"
-					>
-						<p className="fr-mb-0">
-							Vous choisissez de procéder à une évaluation conjointe des
-							rémunérations afin d'identifier et de corriger les écarts
-							constatés :
-						</p>
-						<ul className="fr-mt-1w fr-mb-0">
-							<li>
-								Élaboration du rapport préalable (à déposer sur le portail
-								Egapro)
-							</li>
-							<li>Analyse conjointe et définition des actions correctrices</li>
-							<li>
-								Mise en place de l'accord collectif ou à défaut un plan d'action
-							</li>
-						</ul>
-					</CompliancePathOption>
-				</div>
+						<div className="fr-fieldset__element">
+							<CompliancePathOption
+								checked={selectedPath === "joint_evaluation"}
+								deadline={`1\u1D49\u02B3 août ${currentYear}`}
+								id="path-joint"
+								learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
+								name="compliance-path"
+								onChange={() => setSelectedPath("joint_evaluation")}
+								title="Évaluation conjointe des rémunérations"
+								value="joint_evaluation"
+							>
+								<p className="fr-mb-0">
+									Vous choisissez de procéder à une évaluation conjointe des
+									rémunérations afin d&apos;identifier et de corriger les écarts
+									constatés :
+								</p>
+								<ul className="fr-mt-1w fr-mb-0">
+									<li>
+										Élaboration du rapport préalable (à déposer sur le portail
+										Egapro)
+									</li>
+									<li>
+										Analyse conjointe et définition des actions correctrices
+									</li>
+									<li>
+										Mise en place de l&apos;accord collectif ou à défaut un plan
+										d&apos;action
+									</li>
+								</ul>
+							</CompliancePathOption>
+						</div>
+
+						{hasCse === true && (
+							<div className="fr-fieldset__element">
+								<CompliancePathOption
+									checked={selectedPath === "justify"}
+									deadline={`1\u1D49\u02B3 juin ${currentYear}`}
+									id="path-justify"
+									name="compliance-path"
+									onChange={() => setSelectedPath("justify")}
+									title="Justifier les écarts de rémunération ≥ 5 %"
+									value="justify"
+								>
+									<p className="fr-mb-0">
+										Vous avez la possibilité de justifier vos écarts par des
+										critères objectifs et non sexistes :
+									</p>
+									<ul className="fr-mt-1w fr-mb-0">
+										<li>
+											Informer et consulter votre CSE sur cette justification
+										</li>
+										<li>Transmettre l&apos;avis du CSE</li>
+									</ul>
+								</CompliancePathOption>
+							</div>
+						)}
+					</>
+				)}
 			</fieldset>
 
 			<FormActions

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { api } from "~/trpc/react";

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -12,7 +12,7 @@ type ComplianceState =
 	| { type: "first_round" }
 	| { type: "second_round" };
 
-function getComplianceState(
+export function getComplianceState(
 	compliancePath: string | null,
 	secondDeclarationStatus: string | null,
 	initialCategories: Parameters<typeof hasGapsAboveThreshold>[0],

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -3,8 +3,38 @@ import { redirect } from "next/navigation";
 import { auth } from "~/server/auth";
 import { api, HydrateClient } from "~/trpc/server";
 
+import { getPostComplianceDestination } from "../shared/complianceNavigation";
 import { hasGapsAboveThreshold } from "../shared/gapUtils";
 import { CompliancePathChoice } from "./CompliancePathChoice";
+
+type ComplianceState =
+	| { type: "no_gap" }
+	| { type: "first_round" }
+	| { type: "second_round" };
+
+function getComplianceState(
+	compliancePath: string | null,
+	secondDeclarationStatus: string | null,
+	initialCategories: Parameters<typeof hasGapsAboveThreshold>[0],
+	correctionCategories: Parameters<typeof hasGapsAboveThreshold>[0],
+): ComplianceState {
+	if (!hasGapsAboveThreshold(initialCategories)) {
+		return { type: "no_gap" };
+	}
+
+	const hasSubmittedSecondDeclaration =
+		compliancePath === "corrective_action" &&
+		secondDeclarationStatus === "submitted";
+
+	if (
+		hasSubmittedSecondDeclaration &&
+		hasGapsAboveThreshold(correctionCategories)
+	) {
+		return { type: "second_round" };
+	}
+
+	return { type: "first_round" };
+}
 
 export async function CompliancePathPage() {
 	const session = await auth();
@@ -14,19 +44,25 @@ export async function CompliancePathPage() {
 		redirect("/declaration-remuneration/etape/6");
 	}
 
-	const step5Categories = data.employeeCategories.filter(
+	const company = await api.company.get({ siren: data.declaration.siren });
+
+	const initialCategories = data.employeeCategories.filter(
 		(c) => c.declarationType === "initial",
 	);
+	const correctionCategories = data.employeeCategories.filter(
+		(c) => c.declarationType === "correction",
+	);
 
-	if (!hasGapsAboveThreshold(step5Categories)) {
-		redirect("/avis-cse");
+	const state = getComplianceState(
+		data.declaration.compliancePath,
+		data.declaration.secondDeclarationStatus,
+		initialCategories,
+		correctionCategories,
+	);
+
+	if (state.type === "no_gap" || data.declaration.complianceCompletedAt) {
+		redirect(getPostComplianceDestination(company.hasCse));
 	}
-
-	// If previous path was corrective_action and gaps persist, force joint_evaluation
-	const forcedPath =
-		data.declaration.compliancePath === "corrective_action"
-			? ("joint_evaluation" as const)
-			: undefined;
 
 	const email = session?.user?.email ?? "";
 	const currentYear = new Date().getFullYear();
@@ -36,7 +72,7 @@ export async function CompliancePathPage() {
 			<CompliancePathChoice
 				currentYear={currentYear}
 				email={email}
-				forcedPath={forcedPath}
+				hasCse={company.hasCse}
 				initialPath={
 					(data.declaration.compliancePath as
 						| "justify"
@@ -44,6 +80,7 @@ export async function CompliancePathPage() {
 						| "joint_evaluation"
 						| null) ?? undefined
 				}
+				isSecondRound={state.type === "second_round"}
 			/>
 		</HydrateClient>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+	"~/modules/declaration-remuneration/shared/ComplianceCompletionEffect",
+	() => ({
+		ComplianceCompletionEffect: () => null,
+	}),
+);
+
+import { ComplianceConfirmation } from "../ComplianceConfirmation";
+
+describe("ComplianceConfirmation", () => {
+	it("renders the confirmation title", () => {
+		render(<ComplianceConfirmation />);
+
+		expect(
+			screen.getByRole("heading", {
+				name: /Parcours de mise en conformité/,
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("displays the completion message with current year", () => {
+		render(<ComplianceConfirmation />);
+
+		const year = new Date().getFullYear();
+		expect(
+			screen.getByText(
+				new RegExp(`Votre parcours de mise en conformité ${year} est terminé`),
+			),
+		).toBeInTheDocument();
+	});
+
+	it("shows the no CSE message", () => {
+		render(<ComplianceConfirmation />);
+
+		expect(
+			screen.getByText(/Votre entreprise ne dispose pas de CSE/),
+		).toBeInTheDocument();
+	});
+
+	it("has a link to mon espace", () => {
+		render(<ComplianceConfirmation />);
+
+		const link = screen.getByRole("link", { name: "Mon espace" });
+		expect(link).toHaveAttribute("href", "/mon-espace");
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -32,7 +32,13 @@ vi.mock("~/trpc/react", () => ({
 
 describe("CompliancePathChoice", () => {
 	it("renders the page title and success banner", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		expect(
 			screen.getByText(/Déclaration des indicateurs de rémunération/),
 		).toBeInTheDocument();
@@ -42,7 +48,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders all 3 compliance path options", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={true}
+			/>,
+		);
 		expect(
 			screen.getByText("Justifier les écarts de rémunération ≥ 5 %"),
 		).toBeInTheDocument();
@@ -55,15 +67,27 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("disables next button when no path is selected", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const nextButton = screen.getByRole("button", { name: /suivant/i });
 		expect(nextButton).toBeDisabled();
 	});
 
 	it("enables next button after selecting a path", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const radio = screen.getByLabelText(
-			"Justifier les écarts de rémunération ≥ 5 %",
+			"Actions correctives et seconde déclaration",
 		);
 		fireEvent.click(radio);
 		const nextButton = screen.getByRole("button", { name: /suivant/i });
@@ -71,7 +95,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("submits the selected path and navigates to evaluation-conjointe", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const radio = screen.getByLabelText(
 			"Évaluation conjointe des rémunérations",
 		);
@@ -89,7 +119,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("navigates to second declaration when corrective_action is selected", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		const radio = screen.getByLabelText(
 			"Actions correctives et seconde déclaration",
 		);
@@ -111,6 +147,7 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				currentYear={2026}
 				email="test@example.fr"
+				hasCse={null}
 				initialPath="corrective_action"
 			/>,
 		);
@@ -120,22 +157,31 @@ describe("CompliancePathChoice", () => {
 		expect(radio.checked).toBe(true);
 	});
 
-	it("disables radio buttons when forcedPath is set", () => {
+	it("renders isSecondRound options when isSecondRound is set", () => {
 		render(
 			<CompliancePathChoice
 				currentYear={2026}
 				email="test@example.fr"
-				forcedPath="joint_evaluation"
+				hasCse={null}
+				isSecondRound={true}
 			/>,
 		);
-		const radios = screen.getAllByRole("radio");
-		for (const radio of radios) {
-			expect(radio).toBeDisabled();
-		}
+		expect(
+			screen.getByText("Évaluation conjointe des rémunérations"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Actions correctives et seconde déclaration"),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders previous link pointing to step 6", () => {
-		render(<CompliancePathChoice currentYear={2026} email="test@example.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="test@example.fr"
+				hasCse={null}
+			/>,
+		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/6",
@@ -143,7 +189,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders the email in the success banner", () => {
-		render(<CompliancePathChoice currentYear={2026} email="john@company.fr" />);
+		render(
+			<CompliancePathChoice
+				currentYear={2026}
+				email="john@company.fr"
+				hasCse={null}
+			/>,
+		);
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { getComplianceState } from "../CompliancePathPage";
+
+const noGapCategory = {
+	annualBaseWomen: "30000",
+	annualBaseMen: "31000",
+};
+
+const highGapCategory = {
+	annualBaseWomen: "25000",
+	annualBaseMen: "35000",
+};
+
+describe("getComplianceState", () => {
+	it("returns no_gap when no categories have gaps above threshold", () => {
+		const result = getComplianceState(null, null, [noGapCategory], []);
+		expect(result).toEqual({ type: "no_gap" });
+	});
+
+	it("returns no_gap with empty categories", () => {
+		const result = getComplianceState(null, null, [], []);
+		expect(result).toEqual({ type: "no_gap" });
+	});
+
+	it("returns first_round when gaps exist and no compliance path set", () => {
+		const result = getComplianceState(null, null, [highGapCategory], []);
+		expect(result).toEqual({ type: "first_round" });
+	});
+
+	it("returns first_round when path is corrective_action but second declaration not submitted", () => {
+		const result = getComplianceState(
+			"corrective_action",
+			null,
+			[highGapCategory],
+			[],
+		);
+		expect(result).toEqual({ type: "first_round" });
+	});
+
+	it("returns first_round when path is corrective_action, submitted, but correction gaps resolved", () => {
+		const result = getComplianceState(
+			"corrective_action",
+			"submitted",
+			[highGapCategory],
+			[noGapCategory],
+		);
+		expect(result).toEqual({ type: "first_round" });
+	});
+
+	it("returns second_round when corrective_action submitted and correction gaps persist", () => {
+		const result = getComplianceState(
+			"corrective_action",
+			"submitted",
+			[highGapCategory],
+			[highGapCategory],
+		);
+		expect(result).toEqual({ type: "second_round" });
+	});
+
+	it("returns first_round when path is joint_evaluation regardless of second declaration", () => {
+		const result = getComplianceState(
+			"joint_evaluation",
+			"submitted",
+			[highGapCategory],
+			[highGapCategory],
+		);
+		expect(result).toEqual({ type: "first_round" });
+	});
+
+	it("returns first_round when path is justify", () => {
+		const result = getComplianceState("justify", null, [highGapCategory], []);
+		expect(result).toEqual({ type: "first_round" });
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -3,20 +3,31 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { PdfFileUpload, usePdfUploadForm } from "~/modules/shared";
+import { api } from "~/trpc/react";
 
 import { JointEvaluationSubmitModal } from "./JointEvaluationSubmitModal";
 
 type Props = {
 	currentYear: number;
 	declarationDate: string;
+	hasCse: boolean | null;
 };
 
-export function JointEvaluationForm({ currentYear, declarationDate }: Props) {
+export function JointEvaluationForm({
+	currentYear,
+	declarationDate,
+	hasCse,
+}: Props) {
 	const router = useRouter();
-	// TODO: call tRPC mutation to upload file when API is wired
+
+	const uploadMutation = api.jointEvaluation.uploadFile.useMutation({
+		onSuccess: () => router.push(getPostComplianceDestination(hasCse)),
+	});
+
 	const {
 		closeModal,
 		handleConfirm,
@@ -25,7 +36,16 @@ export function JointEvaluationForm({ currentYear, declarationDate }: Props) {
 		modalRef,
 		selectedFile,
 		uploadError,
-	} = usePdfUploadForm({ onConfirm: () => router.push("/avis-cse") });
+	} = usePdfUploadForm({
+		onConfirm: () => {
+			if (selectedFile) {
+				uploadMutation.mutate({
+					fileName: selectedFile.name,
+					filePath: selectedFile.name,
+				});
+			}
+		},
+	});
 
 	return (
 		<>
@@ -138,6 +158,7 @@ export function JointEvaluationForm({ currentYear, declarationDate }: Props) {
 					</Link>
 					<button
 						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+						disabled={uploadMutation.isPending}
 						type="submit"
 					>
 						Transmettre

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
@@ -11,6 +11,7 @@ export async function JointEvaluationPage() {
 		redirect("/declaration-remuneration/parcours-conformite");
 	}
 
+	const company = await api.company.get({ siren: data.declaration.siren });
 	const currentYear = new Date().getFullYear();
 	const declarationDate = data.declaration.updatedAt
 		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
@@ -20,6 +21,7 @@ export async function JointEvaluationPage() {
 		<JointEvaluationForm
 			currentYear={currentYear}
 			declarationDate={declarationDate}
+			hasCse={company.hasCse}
 		/>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -11,10 +11,28 @@ vi.mock("next/navigation", () => ({
 		"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
 }));
 
+vi.mock("~/trpc/react", () => ({
+	api: {
+		jointEvaluation: {
+			uploadFile: {
+				useMutation: () => ({
+					mutate: vi.fn(),
+					isPending: false,
+					error: null,
+				}),
+			},
+		},
+	},
+}));
+
 describe("JointEvaluationForm", () => {
 	it("renders the page title and section heading", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		expect(
@@ -33,7 +51,11 @@ describe("JointEvaluationForm", () => {
 
 	it("renders the deadline callout with the current year", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		expect(screen.getByText(/août 2026/i)).toBeInTheDocument();
@@ -42,7 +64,11 @@ describe("JointEvaluationForm", () => {
 
 	it("shows an error when submitting without a file", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /transmettre/i });
@@ -55,7 +81,11 @@ describe("JointEvaluationForm", () => {
 
 	it("renders the info boxes", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		expect(
@@ -66,7 +96,11 @@ describe("JointEvaluationForm", () => {
 
 	it("links back to the compliance path choice page", () => {
 		render(
-			<JointEvaluationForm currentYear={2026} declarationDate="01/06/2026" />,
+			<JointEvaluationForm
+				currentYear={2026}
+				declarationDate="01/06/2026"
+				hasCse={null}
+			/>,
 		);
 
 		const backLink = screen.getByRole("link", { name: /précédent/i });

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
@@ -11,6 +11,9 @@ vi.mock("~/trpc/server", () => ({
 		declaration: {
 			getOrCreate: vi.fn(),
 		},
+		company: {
+			get: vi.fn(),
+		},
 	},
 }));
 
@@ -39,6 +42,7 @@ describe("JointEvaluationPage", () => {
 		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
 			declaration: { compliancePath: "action_plan", updatedAt: null },
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		await JointEvaluationPage();
 
@@ -54,6 +58,7 @@ describe("JointEvaluationPage", () => {
 				updatedAt: new Date("2025-06-15"),
 			},
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		const page = await JointEvaluationPage();
 		render(page);
@@ -70,6 +75,7 @@ describe("JointEvaluationPage", () => {
 				updatedAt: new Date("2025-06-15"),
 			},
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		const page = await JointEvaluationPage();
 		render(page);
@@ -83,6 +89,7 @@ describe("JointEvaluationPage", () => {
 		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
 			declaration: { compliancePath: "joint_evaluation", updatedAt: null },
 		} as never);
+		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 
 		const page = await JointEvaluationPage();
 		render(page);

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
@@ -37,12 +37,16 @@ import { redirect } from "next/navigation";
 import { api } from "~/trpc/server";
 import { JointEvaluationPage } from "../JointEvaluationPage";
 
+function mockDeclaration(compliancePath: string, updatedAt: Date | null) {
+	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
+		declaration: { compliancePath, updatedAt },
+	} as never);
+	vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
+}
+
 describe("JointEvaluationPage", () => {
 	it("redirects when compliancePath is not joint_evaluation", async () => {
-		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
-			declaration: { compliancePath: "action_plan", updatedAt: null },
-		} as never);
-		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
+		mockDeclaration("action_plan", null);
 
 		await JointEvaluationPage();
 
@@ -52,13 +56,7 @@ describe("JointEvaluationPage", () => {
 	});
 
 	it("renders the form with current year when compliancePath is joint_evaluation", async () => {
-		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
-			declaration: {
-				compliancePath: "joint_evaluation",
-				updatedAt: new Date("2025-06-15"),
-			},
-		} as never);
-		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
+		mockDeclaration("joint_evaluation", new Date("2025-06-15"));
 
 		const page = await JointEvaluationPage();
 		render(page);
@@ -69,13 +67,7 @@ describe("JointEvaluationPage", () => {
 	});
 
 	it("formats declarationDate from updatedAt when available", async () => {
-		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
-			declaration: {
-				compliancePath: "joint_evaluation",
-				updatedAt: new Date("2025-06-15"),
-			},
-		} as never);
-		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
+		mockDeclaration("joint_evaluation", new Date("2025-06-15"));
 
 		const page = await JointEvaluationPage();
 		render(page);
@@ -86,10 +78,7 @@ describe("JointEvaluationPage", () => {
 	});
 
 	it("falls back to today's date when updatedAt is null", async () => {
-		vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
-			declaration: { compliancePath: "joint_evaluation", updatedAt: null },
-		} as never);
-		vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
+		mockDeclaration("joint_evaluation", null);
 
 		const page = await JointEvaluationPage();
 		render(page);

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -307,6 +307,23 @@ describe("declarationRouter", () => {
 		});
 	});
 
+	describe("completeCompliancePath", () => {
+		it("sets complianceCompletedAt timestamp", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.completeCompliancePath();
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({
+					complianceCompletedAt: expect.any(Date),
+					updatedAt: expect.any(Date),
+				}),
+			);
+		});
+	});
+
 	describe("updateStep1", () => {
 		it("updates totals and inserts categories", async () => {
 			const tx = createMockTx([mockDeclaration]);

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -389,4 +389,16 @@ export const declarationRouter = createTRPCRouter({
 
 			return { success: true };
 		}),
+
+	completeCompliancePath: protectedProcedure.mutation(async ({ ctx }) => {
+		const siren = getSiren(ctx.session.user.siret);
+		const year = getCurrentYear();
+
+		await ctx.db
+			.update(declarations)
+			.set({ complianceCompletedAt: new Date(), updatedAt: new Date() })
+			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+
+		return { success: true };
+	}),
 });

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 import { COMPLIANCE_PATHS } from "~/modules/declaration-remuneration/steps/compliancePath/constants";
@@ -393,11 +393,19 @@ export const declarationRouter = createTRPCRouter({
 	completeCompliancePath: protectedProcedure.mutation(async ({ ctx }) => {
 		const siren = getSiren(ctx.session.user.siret);
 		const year = getCurrentYear();
+		const now = new Date();
 
+		// Idempotent: only set complianceCompletedAt on first completion
 		await ctx.db
 			.update(declarations)
-			.set({ complianceCompletedAt: new Date(), updatedAt: new Date() })
-			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+			.set({ complianceCompletedAt: now, updatedAt: now })
+			.where(
+				and(
+					eq(declarations.siren, siren),
+					eq(declarations.year, year),
+					isNull(declarations.complianceCompletedAt),
+				),
+			);
 
 		return { success: true };
 	}),

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -119,6 +119,7 @@ export const declarations = createTable(
 		secondDeclarationStatus: d.varchar({ length: 20 }),
 		secondDeclReferencePeriodStart: d.varchar({ length: 10 }),
 		secondDeclReferencePeriodEnd: d.varchar({ length: 10 }),
+		complianceCompletedAt: d.timestamp({ withTimezone: true }),
 		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 	}),


### PR DESCRIPTION
## Summary
- CompliancePathPage with gap detection and routing logic
- CompliancePathChoice screen (first round / second round options)
- ComplianceConfirmation page for companies without CSE
- ComplianceCompletionTracker prevents re-entry after completion
- JointEvaluation form and page (upload UI)
- `completeCompliancePath` tRPC procedure
- Migration 0009 for `complianceCompletedAt` column

## PR chain
#2999 feat/cse-opinion-flow → #3000 feat/joint-evaluation-upload → **3/4** → #4 feat/compliance-second-declaration

## Test plan
- [x] Unit tests pass
- [x] Typecheck passes