### PR TITLE
feat: connect second declaration to compliance flow

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { api } from "~/trpc/react";

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
@@ -16,19 +17,19 @@ import { BASE_PATH } from "./constants";
 import { NextStepsSection } from "./NextStepsSection";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
+const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
+
 type Props = {
+	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
 };
 
 export function SecondDeclarationStep3Review({
+	hasCse,
 	secondDeclarationCategories,
 }: Props) {
 	const router = useRouter();
 	const [certified, setCertified] = useState(false);
-
-	const mutation = api.declaration.submitSecondDeclaration.useMutation({
-		onSuccess: () => router.push("/avis-cse"),
-	});
 
 	const parsed = parseEmployeeCategories(secondDeclarationCategories);
 	const gapsExist = parsed.some(
@@ -38,6 +39,16 @@ export function SecondDeclarationStep3Review({
 			(cat.hourlyBaseGap !== null && cat.hourlyBaseGap >= 5) ||
 			(cat.hourlyVariableGap !== null && cat.hourlyVariableGap >= 5),
 	);
+
+	const mutation = api.declaration.submitSecondDeclaration.useMutation({
+		onSuccess: () => {
+			if (gapsExist) {
+				router.push(COMPLIANCE_PATH);
+			} else {
+				router.push(getPostComplianceDestination(hasCse));
+			}
+		},
+	});
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -17,8 +17,6 @@ import { BASE_PATH } from "./constants";
 import { NextStepsSection } from "./NextStepsSection";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
-const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
-
 type Props = {
 	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
@@ -43,7 +41,7 @@ export function SecondDeclarationStep3Review({
 	const mutation = api.declaration.submitSecondDeclaration.useMutation({
 		onSuccess: () => {
 			if (gapsExist) {
-				router.push(COMPLIANCE_PATH);
+				router.push(BASE_PATH);
 			} else {
 				router.push(getPostComplianceDestination(hasCse));
 			}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -18,6 +18,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 	}
 
 	const data = await api.declaration.getOrCreate();
+	const company = await api.company.get({ siren: data.declaration.siren });
 	const currentYear = new Date().getFullYear();
 
 	const initialCategories = mapToEmployeeCategoryRows(
@@ -79,6 +80,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 	return (
 		<HydrateClient>
 			<SecondDeclarationStep3Review
+				hasCse={company.hasCse}
 				secondDeclarationCategories={reviewCategories}
 			/>
 		</HydrateClient>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -59,6 +59,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the title and step indicator", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -73,6 +74,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders category gap card with category name", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -82,6 +84,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders gap columns", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -96,6 +99,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the next steps section", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -105,6 +109,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders certification checkbox", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -116,6 +121,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("disables submit button when not certified", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -127,6 +133,7 @@ describe("SecondDeclarationStep3Review", () => {
 		const user = userEvent.setup();
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -141,6 +148,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders previous link to step 2", () => {
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -169,6 +177,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={categoriesWithHighGaps}
 			/>,
 		);
@@ -196,6 +205,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				hasCse={null}
 				secondDeclarationCategories={categoriesWithLowGaps}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -1,15 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { SecondDeclarationStep3Review } from "../SecondDeclarationStep3Review";
+
+const mockMutate = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush }),
+	usePathname: () => "/declaration-remuneration/parcours-conformite/etape/3",
+}));
 
 vi.mock("~/trpc/react", () => ({
 	api: {
 		declaration: {
 			submitSecondDeclaration: {
-				useMutation: () => ({
-					mutate: vi.fn(),
+				useMutation: (opts: { onSuccess?: () => void }) => ({
+					mutate: () => {
+						mockMutate();
+						opts.onSuccess?.();
+					},
 					isPending: false,
 					error: null,
 				}),
@@ -56,6 +67,11 @@ const mockCategories: EmployeeCategoryRow[] = [
 ];
 
 describe("SecondDeclarationStep3Review", () => {
+	beforeEach(() => {
+		mockMutate.mockClear();
+		mockPush.mockClear();
+	});
+
 	it("renders the title and step indicator", () => {
 		render(
 			<SecondDeclarationStep3Review
@@ -212,5 +228,88 @@ describe("SecondDeclarationStep3Review", () => {
 		expect(
 			screen.queryByText("Des écarts ont été de nouveau détectés"),
 		).not.toBeInTheDocument();
+	});
+
+	it("navigates to compliance path when gaps persist after submit", async () => {
+		const user = userEvent.setup();
+		const categoriesWithHighGaps: EmployeeCategoryRow[] = [
+			makeCategory({
+				annualBaseWomen: "1000",
+				annualBaseMen: "2000",
+			}),
+		];
+
+		render(
+			<SecondDeclarationStep3Review
+				hasCse={true}
+				secondDeclarationCategories={categoriesWithHighGaps}
+			/>,
+		);
+
+		await user.click(screen.getByLabelText(/Je certifie/));
+		await user.click(screen.getByRole("button", { name: /soumettre/i }));
+
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+		expect(mockPush).toHaveBeenCalledWith(
+			"/declaration-remuneration/parcours-conformite",
+		);
+	});
+
+	it("navigates to avis-cse when no gaps and hasCse is true", async () => {
+		const user = userEvent.setup();
+		const categoriesNoGaps: EmployeeCategoryRow[] = [
+			makeCategory({
+				annualBaseWomen: "9800",
+				annualBaseMen: "10000",
+			}),
+		];
+
+		render(
+			<SecondDeclarationStep3Review
+				hasCse={true}
+				secondDeclarationCategories={categoriesNoGaps}
+			/>,
+		);
+
+		await user.click(screen.getByLabelText(/Je certifie/));
+		await user.click(screen.getByRole("button", { name: /soumettre/i }));
+
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
+	});
+
+	it("navigates to confirmation when no gaps and no CSE", async () => {
+		const user = userEvent.setup();
+		const categoriesNoGaps: EmployeeCategoryRow[] = [
+			makeCategory({
+				annualBaseWomen: "9800",
+				annualBaseMen: "10000",
+			}),
+		];
+
+		render(
+			<SecondDeclarationStep3Review
+				hasCse={false}
+				secondDeclarationCategories={categoriesNoGaps}
+			/>,
+		);
+
+		await user.click(screen.getByLabelText(/Je certifie/));
+		await user.click(screen.getByRole("button", { name: /soumettre/i }));
+
+		expect(mockMutate).toHaveBeenCalledTimes(1);
+		expect(mockPush).toHaveBeenCalledWith(
+			"/declaration-remuneration/parcours-conformite/confirmation",
+		);
+	});
+
+	it("renders empty state when no categories", () => {
+		render(
+			<SecondDeclarationStep3Review
+				hasCse={null}
+				secondDeclarationCategories={[]}
+			/>,
+		);
+		expect(screen.getByText("Aucune donnée renseignée.")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 
-import { saveOpinionsSchema } from "~/modules/cseOpinion";
+import { saveOpinionsSchema } from "~/modules/cseOpinion/schemas";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { cseOpinions } from "~/server/db/schema";
 

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { and, eq } from "drizzle-orm";
 
-import { saveOpinionsSchema } from "~/modules/cseOpinion/schemas";
+import { saveOpinionsSchema } from "~/modules/cseOpinion";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { cseOpinions } from "~/server/db/schema";
 


### PR DESCRIPTION
## Summary
- SecondDeclarationStep3Review routes based on correction gap
- SecondDeclarationStepPage updated for compliance flow integration
- E2E test updated for new post-submit navigation (parcours-conformite)
- Barrel exports updated

## PR chain
#2999 feat/cse-opinion-flow → #3000 feat/joint-evaluation-upload → #3001 feat/compliance-path-routing → **4/4**

## Test plan
- [x] Unit tests pass
- [x] E2E test updated