### PR TITLE
feat(joint-evaluation): wire file upload to S3 storage

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { JointEvaluationForm } from "../JointEvaluationForm";
 
@@ -25,15 +25,26 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
+const defaultProps = {
+	currentYear: 2026,
+	declarationDate: "01/06/2026",
+	hasCse: null as boolean | null,
+};
+
 describe("JointEvaluationForm", () => {
+	beforeEach(() => {
+		HTMLDialogElement.prototype.showModal =
+			HTMLDialogElement.prototype.showModal || vi.fn();
+		HTMLDialogElement.prototype.close =
+			HTMLDialogElement.prototype.close || vi.fn();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
 	it("renders the page title and section heading", () => {
-		render(
-			<JointEvaluationForm
-				currentYear={2026}
-				declarationDate="01/06/2026"
-				hasCse={null}
-			/>,
-		);
+		render(<JointEvaluationForm {...defaultProps} />);
 
 		expect(
 			screen.getByRole("heading", {
@@ -50,26 +61,14 @@ describe("JointEvaluationForm", () => {
 	});
 
 	it("renders the deadline callout with the current year", () => {
-		render(
-			<JointEvaluationForm
-				currentYear={2026}
-				declarationDate="01/06/2026"
-				hasCse={null}
-			/>,
-		);
+		render(<JointEvaluationForm {...defaultProps} />);
 
 		expect(screen.getByText(/août 2026/i)).toBeInTheDocument();
 		expect(screen.getByText(/01\/06\/2026/)).toBeInTheDocument();
 	});
 
 	it("shows an error when submitting without a file", () => {
-		render(
-			<JointEvaluationForm
-				currentYear={2026}
-				declarationDate="01/06/2026"
-				hasCse={null}
-			/>,
-		);
+		render(<JointEvaluationForm {...defaultProps} />);
 
 		const submitButton = screen.getByRole("button", { name: /transmettre/i });
 		fireEvent.click(submitButton);
@@ -80,13 +79,7 @@ describe("JointEvaluationForm", () => {
 	});
 
 	it("renders the info boxes", () => {
-		render(
-			<JointEvaluationForm
-				currentYear={2026}
-				declarationDate="01/06/2026"
-				hasCse={null}
-			/>,
-		);
+		render(<JointEvaluationForm {...defaultProps} />);
 
 		expect(
 			screen.getByText(/ce que vous devez faire dans un délai de 2 mois/i),
@@ -95,18 +88,44 @@ describe("JointEvaluationForm", () => {
 	});
 
 	it("links back to the compliance path choice page", () => {
-		render(
-			<JointEvaluationForm
-				currentYear={2026}
-				declarationDate="01/06/2026"
-				hasCse={null}
-			/>,
-		);
+		render(<JointEvaluationForm {...defaultProps} />);
 
 		const backLink = screen.getByRole("link", { name: /précédent/i });
 		expect(backLink).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/parcours-conformite",
 		);
+	});
+
+	it("opens modal after selecting a file and submitting", () => {
+		const { container } = render(<JointEvaluationForm {...defaultProps} />);
+
+		const input = container.querySelector(
+			'input[type="file"]',
+		) as HTMLInputElement;
+		const file = new File(["pdf-content"], "rapport.pdf", {
+			type: "application/pdf",
+		});
+		fireEvent.change(input, { target: { files: [file] } });
+
+		fireEvent.click(screen.getByRole("button", { name: /transmettre/i }));
+
+		expect(
+			screen.queryByText(/veuillez sélectionner un fichier/i),
+		).not.toBeInTheDocument();
+
+		expect(
+			container.querySelector("dialog#joint-evaluation-submit-modal"),
+		).toBeInTheDocument();
+	});
+
+	it("renders the submit modal with correct labels", () => {
+		const { container } = render(<JointEvaluationForm {...defaultProps} />);
+
+		const dialog = container.querySelector(
+			"dialog#joint-evaluation-submit-modal",
+		);
+		expect(dialog).toBeInTheDocument();
+		expect(screen.getByText(/je certifie/i)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Le router tRPC `uploadFile` reçoit le PDF en base64, le valide côté serveur (magic bytes + taille), et l'upload sur S3
- Le client convertit le `File` en base64 via `FileReader` avant d'appeler la mutation
- Ajout d'une route GET `/api/joint-evaluation-file` pour télécharger le PDF depuis S3
- Nettoyage S3 automatique : suppression de l'ancien fichier lors d'un remplacement, rollback si la transaction DB échoue

