### PR TITLE
fix: use declaration.year instead of getCurrentYear() for display

### DIFF
--- a/packages/app/src/app/api/declaration-pdf/route.ts
+++ b/packages/app/src/app/api/declaration-pdf/route.ts
@@ -11,8 +11,9 @@ export async function GET(request: Request) {
 	}
 
 	const siren = extractSiren(session.user.siret);
-	const year = getCurrentYear();
 	const url = new URL(request.url);
+	const yearParam = url.searchParams.get("year");
+	const year = yearParam ? Number.parseInt(yearParam, 10) : getCurrentYear();
 	const declarationType =
 		url.searchParams.get("type") === "correction" ? "correction" : "initial";
 

--- a/packages/app/src/app/api/transmitted-pdf/route.ts
+++ b/packages/app/src/app/api/transmitted-pdf/route.ts
@@ -1,19 +1,22 @@
 import { renderToBuffer } from "@react-pdf/renderer";
 import { buildTransmittedPdfData } from "~/modules/declarationPdf/buildTransmittedPdfData";
 import { TransmittedPdfDocument } from "~/modules/declarationPdf/TransmittedPdfDocument";
-import { extractSiren } from "~/modules/domain";
+import { extractSiren, getCurrentYear } from "~/modules/domain";
 import { auth } from "~/server/auth";
 
-export async function GET() {
+export async function GET(request: Request) {
 	const session = await auth();
 	if (!session?.user?.siret) {
 		return new Response("Non autorisé", { status: 401 });
 	}
 
 	const siren = extractSiren(session.user.siret);
+	const url = new URL(request.url);
+	const yearParam = url.searchParams.get("year");
+	const year = yearParam ? Number.parseInt(yearParam, 10) : getCurrentYear();
 
 	try {
-		const data = await buildTransmittedPdfData(siren, new Date());
+		const data = await buildTransmittedPdfData(siren, year, new Date());
 		const buffer = await renderToBuffer(TransmittedPdfDocument({ data }));
 		const filename = `recapitulatif-elements-transmis-${siren}-${data.year + 1}.pdf`;
 

--- a/packages/app/src/app/avis-cse/confirmation/page.tsx
+++ b/packages/app/src/app/avis-cse/confirmation/page.tsx
@@ -19,6 +19,7 @@ export default async function CseOpinionConfirmationPage() {
 
 	return (
 		<ConfirmationPage
+			dataYear={declarationData.declaration.year - 1}
 			declarationYear={declarationData.declaration.year}
 			email={session?.user?.email ?? undefined}
 			hasSecondDeclaration={hasSubmittedSecondDeclaration(

--- a/packages/app/src/app/avis-cse/confirmation/page.tsx
+++ b/packages/app/src/app/avis-cse/confirmation/page.tsx
@@ -19,6 +19,7 @@ export default async function CseOpinionConfirmationPage() {
 
 	return (
 		<ConfirmationPage
+			declarationYear={declarationData.declaration.year}
 			email={session?.user?.email ?? undefined}
 			hasSecondDeclaration={hasSubmittedSecondDeclaration(
 				declarationData.declaration.secondDeclarationStatus,

--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -32,6 +32,7 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 		return (
 			<Step1Opinions
 				compliancePath={declarationData.declaration.compliancePath}
+				declarationYear={declarationData.declaration.year}
 				email={session?.user?.email ?? undefined}
 				hasSecondDeclaration={hasSecondDeclaration}
 				initialData={initialData}
@@ -48,6 +49,7 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 			declarationData.declaration.secondDeclarationStatus === "submitted";
 		return (
 			<Step2Upload
+				declarationYear={declarationData.declaration.year}
 				existingFiles={files}
 				hasSecondDeclaration={hasSecondDeclaration}
 			/>

--- a/packages/app/src/app/avis-cse/layout.tsx
+++ b/packages/app/src/app/avis-cse/layout.tsx
@@ -21,7 +21,17 @@ export default async function CseOpinionRootLayout({
 	}
 
 	const siren = extractSiren(siret);
-	const company = await api.company.get({ siren });
+	const [company, declarationData] = await Promise.all([
+		api.company.get({ siren }),
+		api.declaration.getOrCreate(),
+	]);
 
-	return <CseOpinionLayout company={company}>{children}</CseOpinionLayout>;
+	return (
+		<CseOpinionLayout
+			company={company}
+			declarationYear={declarationData.declaration.year}
+		>
+			{children}
+		</CseOpinionLayout>
+	);
 }

--- a/packages/app/src/app/declaration-remuneration/layout.tsx
+++ b/packages/app/src/app/declaration-remuneration/layout.tsx
@@ -24,7 +24,17 @@ export default async function DeclarationRootLayout({
 	}
 
 	const siren = extractSiren(siret);
-	const company = await api.company.get({ siren });
+	const [company, declarationData] = await Promise.all([
+		api.company.get({ siren }),
+		api.declaration.getOrCreate(),
+	]);
 
-	return <DeclarationLayout company={company}>{children}</DeclarationLayout>;
+	return (
+		<DeclarationLayout
+			company={company}
+			declarationYear={declarationData.declaration.year}
+		>
+			{children}
+		</DeclarationLayout>
+	);
 }

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import { ComplianceCompletionEffect } from "~/modules/declaration-remuneration";
-import { getCurrentYear } from "~/modules/domain";
 import { DsfrPictogram } from "~/modules/layout";
 import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
@@ -28,17 +27,19 @@ function DownloadCard({ dataYear, href, title, year }: DownloadCardProps) {
 }
 
 type Props = {
+	declarationYear: number;
 	email?: string;
 	hasSecondDeclaration?: boolean;
 };
 
 export function ConfirmationPage({
+	declarationYear,
 	email,
 	hasSecondDeclaration = false,
 }: Props) {
 	const displayEmail = email ?? "adresse@exemple.fr";
-	const dataYear = getCurrentYear();
-	const year = dataYear + 1;
+	const dataYear = declarationYear;
+	const year = declarationYear + 1;
 	return (
 		<div>
 			<ComplianceCompletionEffect />
@@ -75,21 +76,21 @@ export function ConfirmationPage({
 			<div className={`fr-mb-4w ${styles.downloadCards}`}>
 				<DownloadCard
 					dataYear={dataYear}
-					href="/api/declaration-pdf"
+					href={`/api/declaration-pdf?year=${dataYear}`}
 					title="Télécharger le récapitulatif de la déclaration des indicateurs"
 					year={year}
 				/>
 				{hasSecondDeclaration && (
 					<DownloadCard
 						dataYear={dataYear}
-						href="/api/declaration-pdf?type=correction"
+						href={`/api/declaration-pdf?type=correction&year=${dataYear}`}
 						title="Télécharger le récapitulatif de la seconde déclaration de l'indicateur par catégorie de salariés"
 						year={year}
 					/>
 				)}
 				<DownloadCard
 					dataYear={dataYear}
-					href="/api/transmitted-pdf"
+					href={`/api/transmitted-pdf?year=${dataYear}`}
 					title="Télécharger le récapitulatif des éléments transmis"
 					year={year}
 				/>

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -38,7 +38,7 @@ export function ConfirmationPage({
 	hasSecondDeclaration = false,
 }: Props) {
 	const displayEmail = email ?? "adresse@exemple.fr";
-	const dataYear = declarationYear;
+	const dataYear = declarationYear - 1;
 	const year = declarationYear;
 	return (
 		<div>
@@ -76,21 +76,21 @@ export function ConfirmationPage({
 			<div className={`fr-mb-4w ${styles.downloadCards}`}>
 				<DownloadCard
 					dataYear={dataYear}
-					href={`/api/declaration-pdf?year=${dataYear}`}
+					href={`/api/declaration-pdf?year=${declarationYear}`}
 					title="Télécharger le récapitulatif de la déclaration des indicateurs"
 					year={year}
 				/>
 				{hasSecondDeclaration && (
 					<DownloadCard
 						dataYear={dataYear}
-						href={`/api/declaration-pdf?type=correction&year=${dataYear}`}
+						href={`/api/declaration-pdf?type=correction&year=${declarationYear}`}
 						title="Télécharger le récapitulatif de la seconde déclaration de l'indicateur par catégorie de salariés"
 						year={year}
 					/>
 				)}
 				<DownloadCard
 					dataYear={dataYear}
-					href={`/api/transmitted-pdf?year=${dataYear}`}
+					href={`/api/transmitted-pdf?year=${declarationYear}`}
 					title="Télécharger le récapitulatif des éléments transmis"
 					year={year}
 				/>

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -5,119 +5,119 @@ import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
 
 type DownloadCardProps = {
-  dataYear: number;
-  href: string;
-  title: string;
-  year: number;
+	dataYear: number;
+	href: string;
+	title: string;
+	year: number;
 };
 
 function DownloadCard({ dataYear, href, title, year }: DownloadCardProps) {
-  return (
-    <a className={styles.downloadCard} download={title} href={href}>
-      <p className="fr-text--bold fr-text--md fr-mb-1w">{title}</p>
-      <p className="fr-text--sm fr-text--default-grey fr-mb-1w">
-        Année {year} au titre des données {dataYear}
-      </p>
-      <div className={styles.downloadFooter}>
-        <span className="fr-text--xs fr-text--mention-grey">PDF</span>
-        <span aria-hidden="true" className="fr-icon-download-line" />
-      </div>
-    </a>
-  );
+	return (
+		<a className={styles.downloadCard} download={title} href={href}>
+			<p className="fr-text--bold fr-text--md fr-mb-1w">{title}</p>
+			<p className="fr-text--sm fr-text--default-grey fr-mb-1w">
+				Année {year} au titre des données {dataYear}
+			</p>
+			<div className={styles.downloadFooter}>
+				<span className="fr-text--xs fr-text--mention-grey">PDF</span>
+				<span aria-hidden="true" className="fr-icon-download-line" />
+			</div>
+		</a>
+	);
 }
 
 type Props = {
-  declarationYear: number;
-  email?: string;
-  hasSecondDeclaration?: boolean;
+	declarationYear: number;
+	email?: string;
+	hasSecondDeclaration?: boolean;
 };
 
 export function ConfirmationPage({
-  declarationYear,
-  email,
-  hasSecondDeclaration = false,
+	declarationYear,
+	email,
+	hasSecondDeclaration = false,
 }: Props) {
-  const displayEmail = email ?? "adresse@exemple.fr";
-  const dataYear = declarationYear;
-  const year = declarationYear;
-  return (
-    <div>
-      <ComplianceCompletionEffect />
-      <h1 className="fr-h4 fr-mb-4w">
-        Démarche des indicateurs de rémunération {year}
-      </h1>
-      <div className={`fr-mb-4w ${styles.successRow}`}>
-        <DsfrPictogram
-          path="/dsfr/artwork/pictograms/system/success.svg"
-          size={64}
-        />
-        <p className="fr-text--lg fr-text--bold fr-mb-0">
-          Votre parcours {year} est désormais terminé
-        </p>
-      </div>
-      <div className={styles.receiptCard}>
-        <p className="fr-text--sm fr-mb-1w">
-          Un accusé de réception a été envoyé à l&apos;adresse e-mail{" "}
-          <strong>{displayEmail}</strong>.
-        </p>
-        <p className="fr-text--sm fr-text--mention-grey fr-mb-2w">
-          Si ce n&apos;est pas le cas, vérifiez vos courriers indésirables ou
-          SPAM. Sinon, cliquez sur le bouton ci-dessous.
-        </p>
-        <button className="fr-btn fr-btn--tertiary fr-btn--sm" type="button">
-          Renvoyer l&apos;accusé de réception
-        </button>
-      </div>
+	const displayEmail = email ?? "adresse@exemple.fr";
+	const dataYear = declarationYear;
+	const year = declarationYear;
+	return (
+		<div>
+			<ComplianceCompletionEffect />
+			<h1 className="fr-h4 fr-mb-4w">
+				Démarche des indicateurs de rémunération {year}
+			</h1>
+			<div className={`fr-mb-4w ${styles.successRow}`}>
+				<DsfrPictogram
+					path="/dsfr/artwork/pictograms/system/success.svg"
+					size={64}
+				/>
+				<p className="fr-text--lg fr-text--bold fr-mb-0">
+					Votre parcours {year} est désormais terminé
+				</p>
+			</div>
+			<div className={styles.receiptCard}>
+				<p className="fr-text--sm fr-mb-1w">
+					Un accusé de réception a été envoyé à l&apos;adresse e-mail{" "}
+					<strong>{displayEmail}</strong>.
+				</p>
+				<p className="fr-text--sm fr-text--mention-grey fr-mb-2w">
+					Si ce n&apos;est pas le cas, vérifiez vos courriers indésirables ou
+					SPAM. Sinon, cliquez sur le bouton ci-dessous.
+				</p>
+				<button className="fr-btn fr-btn--tertiary fr-btn--sm" type="button">
+					Renvoyer l&apos;accusé de réception
+				</button>
+			</div>
 
-      <h2 className="fr-h5 fr-mb-3w">
-        Documents récapitulatifs de votre déclaration
-      </h2>
+			<h2 className="fr-h5 fr-mb-3w">
+				Documents récapitulatifs de votre déclaration
+			</h2>
 
-      <div className={`fr-mb-4w ${styles.downloadCards}`}>
-        <DownloadCard
-          dataYear={dataYear}
-          href={`/api/declaration-pdf?year=${dataYear}`}
-          title="Télécharger le récapitulatif de la déclaration des indicateurs"
-          year={year}
-        />
-        {hasSecondDeclaration && (
-          <DownloadCard
-            dataYear={dataYear}
-            href={`/api/declaration-pdf?type=correction&year=${dataYear}`}
-            title="Télécharger le récapitulatif de la seconde déclaration de l'indicateur par catégorie de salariés"
-            year={year}
-          />
-        )}
-        <DownloadCard
-          dataYear={dataYear}
-          href={`/api/transmitted-pdf?year=${dataYear}`}
-          title="Télécharger le récapitulatif des éléments transmis"
-          year={year}
-        />
-      </div>
+			<div className={`fr-mb-4w ${styles.downloadCards}`}>
+				<DownloadCard
+					dataYear={dataYear}
+					href={`/api/declaration-pdf?year=${dataYear}`}
+					title="Télécharger le récapitulatif de la déclaration des indicateurs"
+					year={year}
+				/>
+				{hasSecondDeclaration && (
+					<DownloadCard
+						dataYear={dataYear}
+						href={`/api/declaration-pdf?type=correction&year=${dataYear}`}
+						title="Télécharger le récapitulatif de la seconde déclaration de l'indicateur par catégorie de salariés"
+						year={year}
+					/>
+				)}
+				<DownloadCard
+					dataYear={dataYear}
+					href={`/api/transmitted-pdf?year=${dataYear}`}
+					title="Télécharger le récapitulatif des éléments transmis"
+					year={year}
+				/>
+			</div>
 
-      <div className={`fr-p-5w fr-mb-4w ${styles.feedbackBanner}`}>
-        <div>
-          <p className="fr-text--bold fr-mb-1w">
-            Comment s&apos;est passée votre démarche ?
-          </p>
-          <p className="fr-text--sm fr-mb-0">
-            Aidez nous à améliorer Egapro en donnant votre avis, cela ne prend
-            que 2 minutes.
-          </p>
-        </div>
-      </div>
-      <div className={formStyles.actions}>
-        <Link
-          className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
-          href="/avis-cse/etape/2"
-        >
-          Modifier mes dépôts
-        </Link>
-        <Link className="fr-btn" href="/mon-espace">
-          Mon espace
-        </Link>
-      </div>
-    </div>
-  );
+			<div className={`fr-p-5w fr-mb-4w ${styles.feedbackBanner}`}>
+				<div>
+					<p className="fr-text--bold fr-mb-1w">
+						Comment s&apos;est passée votre démarche ?
+					</p>
+					<p className="fr-text--sm fr-mb-0">
+						Aidez nous à améliorer Egapro en donnant votre avis, cela ne prend
+						que 2 minutes.
+					</p>
+				</div>
+			</div>
+			<div className={formStyles.actions}>
+				<Link
+					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+					href="/avis-cse/etape/2"
+				>
+					Modifier mes dépôts
+				</Link>
+				<Link className="fr-btn" href="/mon-espace">
+					Mon espace
+				</Link>
+			</div>
+		</div>
+	);
 }

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -27,24 +27,24 @@ function DownloadCard({ dataYear, href, title, year }: DownloadCardProps) {
 }
 
 type Props = {
+	dataYear: number;
 	declarationYear: number;
 	email?: string;
 	hasSecondDeclaration?: boolean;
 };
 
 export function ConfirmationPage({
+	dataYear,
 	declarationYear,
 	email,
 	hasSecondDeclaration = false,
 }: Props) {
 	const displayEmail = email ?? "adresse@exemple.fr";
-	const dataYear = declarationYear - 1;
-	const year = declarationYear;
 	return (
 		<div>
 			<ComplianceCompletionEffect />
 			<h1 className="fr-h4 fr-mb-4w">
-				Démarche des indicateurs de rémunération {year}
+				Démarche des indicateurs de rémunération {declarationYear}
 			</h1>
 			<div className={`fr-mb-4w ${styles.successRow}`}>
 				<DsfrPictogram
@@ -52,7 +52,7 @@ export function ConfirmationPage({
 					size={64}
 				/>
 				<p className="fr-text--lg fr-text--bold fr-mb-0">
-					Votre parcours {year} est désormais terminé
+					Votre parcours {declarationYear} est désormais terminé
 				</p>
 			</div>
 			<div className={styles.receiptCard}>
@@ -78,21 +78,21 @@ export function ConfirmationPage({
 					dataYear={dataYear}
 					href={`/api/declaration-pdf?year=${declarationYear}`}
 					title="Télécharger le récapitulatif de la déclaration des indicateurs"
-					year={year}
+					year={declarationYear}
 				/>
 				{hasSecondDeclaration && (
 					<DownloadCard
 						dataYear={dataYear}
 						href={`/api/declaration-pdf?type=correction&year=${declarationYear}`}
 						title="Télécharger le récapitulatif de la seconde déclaration de l'indicateur par catégorie de salariés"
-						year={year}
+						year={declarationYear}
 					/>
 				)}
 				<DownloadCard
 					dataYear={dataYear}
 					href={`/api/transmitted-pdf?year=${declarationYear}`}
 					title="Télécharger le récapitulatif des éléments transmis"
-					year={year}
+					year={declarationYear}
 				/>
 			</div>
 

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -5,119 +5,119 @@ import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
 
 type DownloadCardProps = {
-	dataYear: number;
-	href: string;
-	title: string;
-	year: number;
+  dataYear: number;
+  href: string;
+  title: string;
+  year: number;
 };
 
 function DownloadCard({ dataYear, href, title, year }: DownloadCardProps) {
-	return (
-		<a className={styles.downloadCard} download={title} href={href}>
-			<p className="fr-text--bold fr-text--md fr-mb-1w">{title}</p>
-			<p className="fr-text--sm fr-text--default-grey fr-mb-1w">
-				Année {year} au titre des données {dataYear}
-			</p>
-			<div className={styles.downloadFooter}>
-				<span className="fr-text--xs fr-text--mention-grey">PDF</span>
-				<span aria-hidden="true" className="fr-icon-download-line" />
-			</div>
-		</a>
-	);
+  return (
+    <a className={styles.downloadCard} download={title} href={href}>
+      <p className="fr-text--bold fr-text--md fr-mb-1w">{title}</p>
+      <p className="fr-text--sm fr-text--default-grey fr-mb-1w">
+        Année {year} au titre des données {dataYear}
+      </p>
+      <div className={styles.downloadFooter}>
+        <span className="fr-text--xs fr-text--mention-grey">PDF</span>
+        <span aria-hidden="true" className="fr-icon-download-line" />
+      </div>
+    </a>
+  );
 }
 
 type Props = {
-	declarationYear: number;
-	email?: string;
-	hasSecondDeclaration?: boolean;
+  declarationYear: number;
+  email?: string;
+  hasSecondDeclaration?: boolean;
 };
 
 export function ConfirmationPage({
-	declarationYear,
-	email,
-	hasSecondDeclaration = false,
+  declarationYear,
+  email,
+  hasSecondDeclaration = false,
 }: Props) {
-	const displayEmail = email ?? "adresse@exemple.fr";
-	const dataYear = declarationYear;
-	const year = declarationYear + 1;
-	return (
-		<div>
-			<ComplianceCompletionEffect />
-			<h1 className="fr-h4 fr-mb-4w">
-				Démarche des indicateurs de rémunération {year}
-			</h1>
-			<div className={`fr-mb-4w ${styles.successRow}`}>
-				<DsfrPictogram
-					path="/dsfr/artwork/pictograms/system/success.svg"
-					size={64}
-				/>
-				<p className="fr-text--lg fr-text--bold fr-mb-0">
-					Votre parcours {year} est désormais terminé
-				</p>
-			</div>
-			<div className={styles.receiptCard}>
-				<p className="fr-text--sm fr-mb-1w">
-					Un accusé de réception a été envoyé à l&apos;adresse e-mail{" "}
-					<strong>{displayEmail}</strong>.
-				</p>
-				<p className="fr-text--sm fr-text--mention-grey fr-mb-2w">
-					Si ce n&apos;est pas le cas, vérifiez vos courriers indésirables ou
-					SPAM. Sinon, cliquez sur le bouton ci-dessous.
-				</p>
-				<button className="fr-btn fr-btn--tertiary fr-btn--sm" type="button">
-					Renvoyer l&apos;accusé de réception
-				</button>
-			</div>
+  const displayEmail = email ?? "adresse@exemple.fr";
+  const dataYear = declarationYear;
+  const year = declarationYear;
+  return (
+    <div>
+      <ComplianceCompletionEffect />
+      <h1 className="fr-h4 fr-mb-4w">
+        Démarche des indicateurs de rémunération {year}
+      </h1>
+      <div className={`fr-mb-4w ${styles.successRow}`}>
+        <DsfrPictogram
+          path="/dsfr/artwork/pictograms/system/success.svg"
+          size={64}
+        />
+        <p className="fr-text--lg fr-text--bold fr-mb-0">
+          Votre parcours {year} est désormais terminé
+        </p>
+      </div>
+      <div className={styles.receiptCard}>
+        <p className="fr-text--sm fr-mb-1w">
+          Un accusé de réception a été envoyé à l&apos;adresse e-mail{" "}
+          <strong>{displayEmail}</strong>.
+        </p>
+        <p className="fr-text--sm fr-text--mention-grey fr-mb-2w">
+          Si ce n&apos;est pas le cas, vérifiez vos courriers indésirables ou
+          SPAM. Sinon, cliquez sur le bouton ci-dessous.
+        </p>
+        <button className="fr-btn fr-btn--tertiary fr-btn--sm" type="button">
+          Renvoyer l&apos;accusé de réception
+        </button>
+      </div>
 
-			<h2 className="fr-h5 fr-mb-3w">
-				Documents récapitulatifs de votre déclaration
-			</h2>
+      <h2 className="fr-h5 fr-mb-3w">
+        Documents récapitulatifs de votre déclaration
+      </h2>
 
-			<div className={`fr-mb-4w ${styles.downloadCards}`}>
-				<DownloadCard
-					dataYear={dataYear}
-					href={`/api/declaration-pdf?year=${dataYear}`}
-					title="Télécharger le récapitulatif de la déclaration des indicateurs"
-					year={year}
-				/>
-				{hasSecondDeclaration && (
-					<DownloadCard
-						dataYear={dataYear}
-						href={`/api/declaration-pdf?type=correction&year=${dataYear}`}
-						title="Télécharger le récapitulatif de la seconde déclaration de l'indicateur par catégorie de salariés"
-						year={year}
-					/>
-				)}
-				<DownloadCard
-					dataYear={dataYear}
-					href={`/api/transmitted-pdf?year=${dataYear}`}
-					title="Télécharger le récapitulatif des éléments transmis"
-					year={year}
-				/>
-			</div>
+      <div className={`fr-mb-4w ${styles.downloadCards}`}>
+        <DownloadCard
+          dataYear={dataYear}
+          href={`/api/declaration-pdf?year=${dataYear}`}
+          title="Télécharger le récapitulatif de la déclaration des indicateurs"
+          year={year}
+        />
+        {hasSecondDeclaration && (
+          <DownloadCard
+            dataYear={dataYear}
+            href={`/api/declaration-pdf?type=correction&year=${dataYear}`}
+            title="Télécharger le récapitulatif de la seconde déclaration de l'indicateur par catégorie de salariés"
+            year={year}
+          />
+        )}
+        <DownloadCard
+          dataYear={dataYear}
+          href={`/api/transmitted-pdf?year=${dataYear}`}
+          title="Télécharger le récapitulatif des éléments transmis"
+          year={year}
+        />
+      </div>
 
-			<div className={`fr-p-5w fr-mb-4w ${styles.feedbackBanner}`}>
-				<div>
-					<p className="fr-text--bold fr-mb-1w">
-						Comment s&apos;est passée votre démarche ?
-					</p>
-					<p className="fr-text--sm fr-mb-0">
-						Aidez nous à améliorer Egapro en donnant votre avis, cela ne prend
-						que 2 minutes.
-					</p>
-				</div>
-			</div>
-			<div className={formStyles.actions}>
-				<Link
-					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
-					href="/avis-cse/etape/2"
-				>
-					Modifier mes dépôts
-				</Link>
-				<Link className="fr-btn" href="/mon-espace">
-					Mon espace
-				</Link>
-			</div>
-		</div>
-	);
+      <div className={`fr-p-5w fr-mb-4w ${styles.feedbackBanner}`}>
+        <div>
+          <p className="fr-text--bold fr-mb-1w">
+            Comment s&apos;est passée votre démarche ?
+          </p>
+          <p className="fr-text--sm fr-mb-0">
+            Aidez nous à améliorer Egapro en donnant votre avis, cela ne prend
+            que 2 minutes.
+          </p>
+        </div>
+      </div>
+      <div className={formStyles.actions}>
+        <Link
+          className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+          href="/avis-cse/etape/2"
+        >
+          Modifier mes dépôts
+        </Link>
+        <Link className="fr-btn" href="/mon-espace">
+          Mon espace
+        </Link>
+      </div>
+    </div>
+  );
 }

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -1,4 +1,3 @@
-import { getCurrentYear } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -13,12 +12,15 @@ type CompanyData = {
 
 type Props = {
 	company: CompanyData;
+	declarationYear: number;
 	children: React.ReactNode;
 };
 
-export function CseOpinionLayout({ company, children }: Props) {
-	const currentYear = getCurrentYear();
-
+export function CseOpinionLayout({
+	company,
+	declarationYear,
+	children,
+}: Props) {
 	return (
 		<>
 			<div className={`fr-py-3w ${styles.banner}`}>
@@ -31,7 +33,7 @@ export function CseOpinionLayout({ company, children }: Props) {
 								href: "/mon-espace",
 							},
 							{
-								label: `Démarche des indicateurs de rémunération ${currentYear + 1}`,
+								label: `Démarche des indicateurs de rémunération ${declarationYear + 1}`,
 							},
 						]}
 					/>
@@ -48,7 +50,7 @@ export function CseOpinionLayout({ company, children }: Props) {
 						{company.workforce !== null && (
 							<div className="fr-col-auto">
 								<p className="fr-mb-0 fr-text--sm">
-									Effectif annuel moyen en {currentYear - 1} :{" "}
+									Effectif annuel moyen en {declarationYear - 1} :{" "}
 									<strong>{company.workforce}</strong>
 								</p>
 							</div>

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -1,3 +1,4 @@
+import { getCurrentYear } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -50,7 +51,7 @@ export function CseOpinionLayout({
 						{company.workforce !== null && (
 							<div className="fr-col-auto">
 								<p className="fr-mb-0 fr-text--sm">
-									Effectif annuel moyen en {declarationYear - 1} :{" "}
+									Effectif annuel moyen en {getCurrentYear() - 1} :{" "}
 									<strong>{company.workforce}</strong>
 								</p>
 							</div>

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -1,4 +1,4 @@
-import { getCurrentYear } from "~/modules/domain";
+import { getWorkforceYear } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -51,7 +51,7 @@ export function CseOpinionLayout({
 						{company.workforce !== null && (
 							<div className="fr-col-auto">
 								<p className="fr-mb-0 fr-text--sm">
-									Effectif annuel moyen en {getCurrentYear() - 1} :{" "}
+									Effectif annuel moyen en {getWorkforceYear()} :{" "}
 									<strong>{company.workforce}</strong>
 								</p>
 							</div>

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -4,77 +4,77 @@ import { formatSiren } from "~/modules/my-space";
 import styles from "./CseOpinionLayout.module.scss";
 
 type CompanyData = {
-  name: string;
-  siren: string;
-  workforce: number | null;
-  hasCse: boolean | null;
+	name: string;
+	siren: string;
+	workforce: number | null;
+	hasCse: boolean | null;
 };
 
 type Props = {
-  company: CompanyData;
-  declarationYear: number;
-  children: React.ReactNode;
+	company: CompanyData;
+	declarationYear: number;
+	children: React.ReactNode;
 };
 
 export function CseOpinionLayout({
-  company,
-  declarationYear,
-  children,
+	company,
+	declarationYear,
+	children,
 }: Props) {
-  return (
-    <>
-      <div className={`fr-py-3w ${styles.banner}`}>
-        <div className="fr-container">
-          <Breadcrumb
-            items={[
-              { label: "Mon espace", href: "/" },
-              {
-                label: company.name,
-                href: "/mon-espace",
-              },
-              {
-                label: `Démarche des indicateurs de rémunération ${declarationYear}`,
-              },
-            ]}
-          />
+	return (
+		<>
+			<div className={`fr-py-3w ${styles.banner}`}>
+				<div className="fr-container">
+					<Breadcrumb
+						items={[
+							{ label: "Mon espace", href: "/" },
+							{
+								label: company.name,
+								href: "/mon-espace",
+							},
+							{
+								label: `Démarche des indicateurs de rémunération ${declarationYear}`,
+							},
+						]}
+					/>
 
-          <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-            <div className="fr-col-auto">
-              <p
-                className={`fr-text--bold fr-mb-0 fr-flex fr-flex--align-center ${styles.companyInfo}`}
-              >
-                <span aria-hidden="true" className="fr-icon-building-line" />
-                {company.name} - {formatSiren(company.siren)}
-              </p>
-            </div>
-            {company.workforce !== null && (
-              <div className="fr-col-auto">
-                <p className="fr-mb-0 fr-text--sm">
-                  Effectif annuel moyen en {declarationYear - 1} :{" "}
-                  <strong>{company.workforce}</strong>
-                </p>
-              </div>
-            )}
-            <div className="fr-col-auto">
-              <p className="fr-mb-0 fr-text--sm">
-                Existence d'un CSE :{" "}
-                <strong>
-                  {company.hasCse === null
-                    ? "Non renseigné"
-                    : company.hasCse
-                      ? "Oui"
-                      : "Non"}
-                </strong>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <main className="fr-container fr-py-7w" id="content">
-        <div className="fr-grid-row fr-grid-row--center">
-          <div className="fr-col-12 fr-col-lg-8">{children}</div>
-        </div>
-      </main>
-    </>
-  );
+					<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+						<div className="fr-col-auto">
+							<p
+								className={`fr-text--bold fr-mb-0 fr-flex fr-flex--align-center ${styles.companyInfo}`}
+							>
+								<span aria-hidden="true" className="fr-icon-building-line" />
+								{company.name} - {formatSiren(company.siren)}
+							</p>
+						</div>
+						{company.workforce !== null && (
+							<div className="fr-col-auto">
+								<p className="fr-mb-0 fr-text--sm">
+									Effectif annuel moyen en {declarationYear - 1} :{" "}
+									<strong>{company.workforce}</strong>
+								</p>
+							</div>
+						)}
+						<div className="fr-col-auto">
+							<p className="fr-mb-0 fr-text--sm">
+								Existence d'un CSE :{" "}
+								<strong>
+									{company.hasCse === null
+										? "Non renseigné"
+										: company.hasCse
+											? "Oui"
+											: "Non"}
+								</strong>
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+			<main className="fr-container fr-py-7w" id="content">
+				<div className="fr-grid-row fr-grid-row--center">
+					<div className="fr-col-12 fr-col-lg-8">{children}</div>
+				</div>
+			</main>
+		</>
+	);
 }

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -4,77 +4,77 @@ import { formatSiren } from "~/modules/my-space";
 import styles from "./CseOpinionLayout.module.scss";
 
 type CompanyData = {
-	name: string;
-	siren: string;
-	workforce: number | null;
-	hasCse: boolean | null;
+  name: string;
+  siren: string;
+  workforce: number | null;
+  hasCse: boolean | null;
 };
 
 type Props = {
-	company: CompanyData;
-	declarationYear: number;
-	children: React.ReactNode;
+  company: CompanyData;
+  declarationYear: number;
+  children: React.ReactNode;
 };
 
 export function CseOpinionLayout({
-	company,
-	declarationYear,
-	children,
+  company,
+  declarationYear,
+  children,
 }: Props) {
-	return (
-		<>
-			<div className={`fr-py-3w ${styles.banner}`}>
-				<div className="fr-container">
-					<Breadcrumb
-						items={[
-							{ label: "Mon espace", href: "/" },
-							{
-								label: company.name,
-								href: "/mon-espace",
-							},
-							{
-								label: `Démarche des indicateurs de rémunération ${declarationYear + 1}`,
-							},
-						]}
-					/>
+  return (
+    <>
+      <div className={`fr-py-3w ${styles.banner}`}>
+        <div className="fr-container">
+          <Breadcrumb
+            items={[
+              { label: "Mon espace", href: "/" },
+              {
+                label: company.name,
+                href: "/mon-espace",
+              },
+              {
+                label: `Démarche des indicateurs de rémunération ${declarationYear}`,
+              },
+            ]}
+          />
 
-					<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-						<div className="fr-col-auto">
-							<p
-								className={`fr-text--bold fr-mb-0 fr-flex fr-flex--align-center ${styles.companyInfo}`}
-							>
-								<span aria-hidden="true" className="fr-icon-building-line" />
-								{company.name} - {formatSiren(company.siren)}
-							</p>
-						</div>
-						{company.workforce !== null && (
-							<div className="fr-col-auto">
-								<p className="fr-mb-0 fr-text--sm">
-									Effectif annuel moyen en {declarationYear - 1} :{" "}
-									<strong>{company.workforce}</strong>
-								</p>
-							</div>
-						)}
-						<div className="fr-col-auto">
-							<p className="fr-mb-0 fr-text--sm">
-								Existence d'un CSE :{" "}
-								<strong>
-									{company.hasCse === null
-										? "Non renseigné"
-										: company.hasCse
-											? "Oui"
-											: "Non"}
-								</strong>
-							</p>
-						</div>
-					</div>
-				</div>
-			</div>
-			<main className="fr-container fr-py-7w" id="content">
-				<div className="fr-grid-row fr-grid-row--center">
-					<div className="fr-col-12 fr-col-lg-8">{children}</div>
-				</div>
-			</main>
-		</>
-	);
+          <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+            <div className="fr-col-auto">
+              <p
+                className={`fr-text--bold fr-mb-0 fr-flex fr-flex--align-center ${styles.companyInfo}`}
+              >
+                <span aria-hidden="true" className="fr-icon-building-line" />
+                {company.name} - {formatSiren(company.siren)}
+              </p>
+            </div>
+            {company.workforce !== null && (
+              <div className="fr-col-auto">
+                <p className="fr-mb-0 fr-text--sm">
+                  Effectif annuel moyen en {declarationYear - 1} :{" "}
+                  <strong>{company.workforce}</strong>
+                </p>
+              </div>
+            )}
+            <div className="fr-col-auto">
+              <p className="fr-mb-0 fr-text--sm">
+                Existence d'un CSE :{" "}
+                <strong>
+                  {company.hasCse === null
+                    ? "Non renseigné"
+                    : company.hasCse
+                      ? "Oui"
+                      : "Non"}
+                </strong>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <main className="fr-container fr-py-7w" id="content">
+        <div className="fr-grid-row fr-grid-row--center">
+          <div className="fr-col-12 fr-col-lg-8">{children}</div>
+        </div>
+      </main>
+    </>
+  );
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -16,241 +16,241 @@ import formStyles from "./shared/formActions.module.scss";
 import type { OpinionType } from "./types";
 
 type Props = {
-	initialData?: {
-		firstDeclAccuracyOpinion: OpinionType | null;
-		firstDeclAccuracyDate: string | null;
-		firstDeclGapConsulted: boolean | null;
-		firstDeclGapOpinion: OpinionType | null;
-		firstDeclGapDate: string | null;
-		secondDeclAccuracyOpinion: OpinionType | null;
-		secondDeclAccuracyDate: string | null;
-		secondDeclGapConsulted: boolean | null;
-		secondDeclGapOpinion: OpinionType | null;
-		secondDeclGapDate: string | null;
-	};
-	declarationYear: number;
-	email?: string;
-	compliancePath?: string | null;
-	hasSecondDeclaration?: boolean;
+  initialData?: {
+    firstDeclAccuracyOpinion: OpinionType | null;
+    firstDeclAccuracyDate: string | null;
+    firstDeclGapConsulted: boolean | null;
+    firstDeclGapOpinion: OpinionType | null;
+    firstDeclGapDate: string | null;
+    secondDeclAccuracyOpinion: OpinionType | null;
+    secondDeclAccuracyDate: string | null;
+    secondDeclGapConsulted: boolean | null;
+    secondDeclGapOpinion: OpinionType | null;
+    secondDeclGapDate: string | null;
+  };
+  declarationYear: number;
+  email?: string;
+  compliancePath?: string | null;
+  hasSecondDeclaration?: boolean;
 };
 
 export function Step1Opinions({
-	initialData,
-	declarationYear,
-	email,
-	compliancePath,
-	hasSecondDeclaration = true,
+  initialData,
+  declarationYear,
+  email,
+  compliancePath,
+  hasSecondDeclaration = true,
 }: Props) {
-	const isJointEvaluation = compliancePath === "joint_evaluation";
-	const router = useRouter();
+  const isJointEvaluation = compliancePath === "joint_evaluation";
+  const router = useRouter();
 
-	const form = useZodForm(saveOpinionsSchema, {
-		defaultValues: {
-			firstDeclaration: {
-				accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
-				accuracyDate: initialData?.firstDeclAccuracyDate ?? "",
-				gapConsulted: initialData?.firstDeclGapConsulted ?? undefined,
-				gapOpinion: initialData?.firstDeclGapOpinion ?? null,
-				gapDate: initialData?.firstDeclGapDate ?? null,
-			},
-			secondDeclaration: hasSecondDeclaration
-				? {
-						accuracyOpinion:
-							initialData?.secondDeclAccuracyOpinion ?? undefined,
-						accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
-						gapConsulted: initialData?.secondDeclGapConsulted ?? undefined,
-						gapOpinion: initialData?.secondDeclGapOpinion ?? null,
-						gapDate: initialData?.secondDeclGapDate ?? null,
-					}
-				: undefined,
-		},
-	});
+  const form = useZodForm(saveOpinionsSchema, {
+    defaultValues: {
+      firstDeclaration: {
+        accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
+        accuracyDate: initialData?.firstDeclAccuracyDate ?? "",
+        gapConsulted: initialData?.firstDeclGapConsulted ?? undefined,
+        gapOpinion: initialData?.firstDeclGapOpinion ?? null,
+        gapDate: initialData?.firstDeclGapDate ?? null,
+      },
+      secondDeclaration: hasSecondDeclaration
+        ? {
+            accuracyOpinion:
+              initialData?.secondDeclAccuracyOpinion ?? undefined,
+            accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
+            gapConsulted: initialData?.secondDeclGapConsulted ?? undefined,
+            gapOpinion: initialData?.secondDeclGapOpinion ?? null,
+            gapDate: initialData?.secondDeclGapDate ?? null,
+          }
+        : undefined,
+    },
+  });
 
-	const mutation = api.cseOpinion.saveOpinions.useMutation({
-		onSuccess: () => router.push("/avis-cse/etape/2"),
-	});
+  const mutation = api.cseOpinion.saveOpinions.useMutation({
+    onSuccess: () => router.push("/avis-cse/etape/2"),
+  });
 
-	const onSubmit = form.handleSubmit((data) => {
-		// Additional validation for conditional gap fields
-		const firstGapIncomplete =
-			data.firstDeclaration.gapConsulted === true &&
-			(!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
-		const secondGapIncomplete =
-			hasSecondDeclaration &&
-			data.secondDeclaration?.gapConsulted === true &&
-			(!data.secondDeclaration?.gapOpinion || !data.secondDeclaration?.gapDate);
+  const onSubmit = form.handleSubmit((data) => {
+    // Additional validation for conditional gap fields
+    const firstGapIncomplete =
+      data.firstDeclaration.gapConsulted === true &&
+      (!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
+    const secondGapIncomplete =
+      hasSecondDeclaration &&
+      data.secondDeclaration?.gapConsulted === true &&
+      (!data.secondDeclaration?.gapOpinion || !data.secondDeclaration?.gapDate);
 
-		if (firstGapIncomplete) {
-			form.setError("firstDeclaration.gapOpinion", {
-				message: "Veuillez remplir tous les champs de consultation.",
-			});
-			return;
-		}
+    if (firstGapIncomplete) {
+      form.setError("firstDeclaration.gapOpinion", {
+        message: "Veuillez remplir tous les champs de consultation.",
+      });
+      return;
+    }
 
-		if (secondGapIncomplete) {
-			form.setError("secondDeclaration.gapOpinion", {
-				message: "Veuillez remplir tous les champs de consultation.",
-			});
-			return;
-		}
+    if (secondGapIncomplete) {
+      form.setError("secondDeclaration.gapOpinion", {
+        message: "Veuillez remplir tous les champs de consultation.",
+      });
+      return;
+    }
 
-		mutation.mutate(data);
-	});
+    mutation.mutate(data);
+  });
 
-	// Watch fields for controlled sub-components
-	const firstDeclOpinion = form.watch("firstDeclaration.accuracyOpinion");
-	const firstDeclDate = form.watch("firstDeclaration.accuracyDate");
-	const firstDeclGapOpinion = form.watch("firstDeclaration.gapOpinion");
-	const firstDeclGapDate = form.watch("firstDeclaration.gapDate");
-	const secondDeclOpinion = form.watch("secondDeclaration.accuracyOpinion");
-	const secondDeclDate = form.watch("secondDeclaration.accuracyDate");
-	const secondDeclGapOpinion = form.watch("secondDeclaration.gapOpinion");
-	const secondDeclGapDate = form.watch("secondDeclaration.gapDate");
+  // Watch fields for controlled sub-components
+  const firstDeclOpinion = form.watch("firstDeclaration.accuracyOpinion");
+  const firstDeclDate = form.watch("firstDeclaration.accuracyDate");
+  const firstDeclGapOpinion = form.watch("firstDeclaration.gapOpinion");
+  const firstDeclGapDate = form.watch("firstDeclaration.gapDate");
+  const secondDeclOpinion = form.watch("secondDeclaration.accuracyOpinion");
+  const secondDeclDate = form.watch("secondDeclaration.accuracyDate");
+  const secondDeclGapOpinion = form.watch("secondDeclaration.gapOpinion");
+  const secondDeclGapDate = form.watch("secondDeclaration.gapDate");
 
-	return (
-		<form onSubmit={onSubmit}>
-			{isJointEvaluation && (
-				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
-					<div className="fr-col">
-						<h1 className="fr-h4 fr-mb-0">
-							Parcours de mise en conformité pour l'indicateur par catégorie de
-							salariés
-						</h1>
-					</div>
-				</div>
-			)}
+  return (
+    <form onSubmit={onSubmit}>
+      {isJointEvaluation && (
+        <div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
+          <div className="fr-col">
+            <h1 className="fr-h4 fr-mb-0">
+              Parcours de mise en conformité pour l'indicateur par catégorie de
+              salariés
+            </h1>
+          </div>
+        </div>
+      )}
 
-			{isJointEvaluation && (
-				<SubmissionBanner
-					deadline={`1er février ${declarationYear + 1}`}
-					email={email ?? "adresse@exemple.fr"}
-				/>
-			)}
+      {isJointEvaluation && (
+        <SubmissionBanner
+          deadline={`1er février ${declarationYear}`}
+          email={email ?? "adresse@exemple.fr"}
+        />
+      )}
 
-			{isJointEvaluation ? (
-				<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
-					Transmettre l'avis ou les avis du CSE
-				</h2>
-			) : (
-				<h1 className="fr-h4 fr-mb-3w">
-					Transmettre l'avis ou les avis du CSE
-				</h1>
-			)}
+      {isJointEvaluation ? (
+        <h2 className="fr-h4 fr-mt-5w fr-mb-3w">
+          Transmettre l'avis ou les avis du CSE
+        </h2>
+      ) : (
+        <h1 className="fr-h4 fr-mb-3w">
+          Transmettre l'avis ou les avis du CSE
+        </h1>
+      )}
 
-			<CseStepIndicator currentStep={1} />
+      <CseStepIndicator currentStep={1} />
 
-			<p className="fr-text--md fr-mb-2w">
-				Indiquez si le CSE a été consulté et précisez les avis émis avant de
-				soumettre votre déclaration aux services du ministère chargé du Travail.
-			</p>
-			<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
+      <p className="fr-text--md fr-mb-2w">
+        Indiquez si le CSE a été consulté et précisez les avis émis avant de
+        soumettre votre déclaration aux services du ministère chargé du Travail.
+      </p>
+      <p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
 
-			<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
+      <h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
 
-			<div className={styles.cardStack}>
-				<AccuracyOpinionCard
-					date={firstDeclDate ?? ""}
-					id="first-decl-accuracy"
-					onDateChange={(v) =>
-						form.setValue("firstDeclaration.accuracyDate", v)
-					}
-					onOpinionChange={(v) =>
-						form.setValue("firstDeclaration.accuracyOpinion", v)
-					}
-					opinion={firstDeclOpinion ?? null}
-					title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
-				/>
+      <div className={styles.cardStack}>
+        <AccuracyOpinionCard
+          date={firstDeclDate ?? ""}
+          id="first-decl-accuracy"
+          onDateChange={(v) =>
+            form.setValue("firstDeclaration.accuracyDate", v)
+          }
+          onOpinionChange={(v) =>
+            form.setValue("firstDeclaration.accuracyOpinion", v)
+          }
+          opinion={firstDeclOpinion ?? null}
+          title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
+        />
 
-				<Controller
-					control={form.control}
-					name="firstDeclaration.gapConsulted"
-					render={({ field }) => (
-						<GapConsultationCard
-							consulted={field.value ?? null}
-							date={firstDeclGapDate ?? ""}
-							id="first-decl-gap"
-							onConsultedChange={field.onChange}
-							onDateChange={(v) => form.setValue("firstDeclaration.gapDate", v)}
-							onOpinionChange={(v) =>
-								form.setValue("firstDeclaration.gapOpinion", v)
-							}
-							opinion={firstDeclGapOpinion ?? null}
-						/>
-					)}
-				/>
-			</div>
+        <Controller
+          control={form.control}
+          name="firstDeclaration.gapConsulted"
+          render={({ field }) => (
+            <GapConsultationCard
+              consulted={field.value ?? null}
+              date={firstDeclGapDate ?? ""}
+              id="first-decl-gap"
+              onConsultedChange={field.onChange}
+              onDateChange={(v) => form.setValue("firstDeclaration.gapDate", v)}
+              onOpinionChange={(v) =>
+                form.setValue("firstDeclaration.gapOpinion", v)
+              }
+              opinion={firstDeclGapOpinion ?? null}
+            />
+          )}
+        />
+      </div>
 
-			{hasSecondDeclaration && (
-				<>
-					<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
+      {hasSecondDeclaration && (
+        <>
+          <h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
 
-					<div className={styles.cardStack}>
-						<AccuracyOpinionCard
-							date={secondDeclDate ?? ""}
-							id="second-decl-accuracy"
-							onDateChange={(v) =>
-								form.setValue("secondDeclaration.accuracyDate", v)
-							}
-							onOpinionChange={(v) =>
-								form.setValue("secondDeclaration.accuracyOpinion", v)
-							}
-							opinion={secondDeclOpinion ?? null}
-							title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
-						/>
+          <div className={styles.cardStack}>
+            <AccuracyOpinionCard
+              date={secondDeclDate ?? ""}
+              id="second-decl-accuracy"
+              onDateChange={(v) =>
+                form.setValue("secondDeclaration.accuracyDate", v)
+              }
+              onOpinionChange={(v) =>
+                form.setValue("secondDeclaration.accuracyOpinion", v)
+              }
+              opinion={secondDeclOpinion ?? null}
+              title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+            />
 
-						<Controller
-							control={form.control}
-							name="secondDeclaration.gapConsulted"
-							render={({ field }) => (
-								<GapConsultationCard
-									consulted={field.value ?? null}
-									date={secondDeclGapDate ?? ""}
-									id="second-decl-gap"
-									onConsultedChange={field.onChange}
-									onDateChange={(v) =>
-										form.setValue("secondDeclaration.gapDate", v)
-									}
-									onOpinionChange={(v) =>
-										form.setValue("secondDeclaration.gapOpinion", v)
-									}
-									opinion={secondDeclGapOpinion ?? null}
-								/>
-							)}
-						/>
-					</div>
-				</>
-			)}
+            <Controller
+              control={form.control}
+              name="secondDeclaration.gapConsulted"
+              render={({ field }) => (
+                <GapConsultationCard
+                  consulted={field.value ?? null}
+                  date={secondDeclGapDate ?? ""}
+                  id="second-decl-gap"
+                  onConsultedChange={field.onChange}
+                  onDateChange={(v) =>
+                    form.setValue("secondDeclaration.gapDate", v)
+                  }
+                  onOpinionChange={(v) =>
+                    form.setValue("secondDeclaration.gapOpinion", v)
+                  }
+                  opinion={secondDeclGapOpinion ?? null}
+                />
+              )}
+            />
+          </div>
+        </>
+      )}
 
-			<div aria-live="polite">
-				{(form.formState.errors.firstDeclaration ||
-					form.formState.errors.secondDeclaration) && (
-					<div className="fr-alert fr-alert--error fr-mt-3w">
-						<p>Veuillez remplir tous les champs obligatoires.</p>
-					</div>
-				)}
-				{mutation.error && (
-					<div className="fr-alert fr-alert--error fr-mt-3w">
-						<p>{mutation.error.message}</p>
-					</div>
-				)}
-			</div>
+      <div aria-live="polite">
+        {(form.formState.errors.firstDeclaration ||
+          form.formState.errors.secondDeclaration) && (
+          <div className="fr-alert fr-alert--error fr-mt-3w">
+            <p>Veuillez remplir tous les champs obligatoires.</p>
+          </div>
+        )}
+        {mutation.error && (
+          <div className="fr-alert fr-alert--error fr-mt-3w">
+            <p>{mutation.error.message}</p>
+          </div>
+        )}
+      </div>
 
-			<div className={`fr-mt-4w ${formStyles.actions}`}>
-				<button
-					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
-					onClick={() => router.back()}
-					type="button"
-				>
-					Précédent
-				</button>
-				<button
-					className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-					disabled={mutation.isPending}
-					type="submit"
-				>
-					{mutation.isPending ? "Enregistrement…" : "Suivant"}
-				</button>
-			</div>
-		</form>
-	);
+      <div className={`fr-mt-4w ${formStyles.actions}`}>
+        <button
+          className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+          onClick={() => router.back()}
+          type="button"
+        >
+          Précédent
+        </button>
+        <button
+          className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+          disabled={mutation.isPending}
+          type="submit"
+        >
+          {mutation.isPending ? "Enregistrement…" : "Suivant"}
+        </button>
+      </div>
+    </form>
+  );
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -16,241 +16,241 @@ import formStyles from "./shared/formActions.module.scss";
 import type { OpinionType } from "./types";
 
 type Props = {
-  initialData?: {
-    firstDeclAccuracyOpinion: OpinionType | null;
-    firstDeclAccuracyDate: string | null;
-    firstDeclGapConsulted: boolean | null;
-    firstDeclGapOpinion: OpinionType | null;
-    firstDeclGapDate: string | null;
-    secondDeclAccuracyOpinion: OpinionType | null;
-    secondDeclAccuracyDate: string | null;
-    secondDeclGapConsulted: boolean | null;
-    secondDeclGapOpinion: OpinionType | null;
-    secondDeclGapDate: string | null;
-  };
-  declarationYear: number;
-  email?: string;
-  compliancePath?: string | null;
-  hasSecondDeclaration?: boolean;
+	initialData?: {
+		firstDeclAccuracyOpinion: OpinionType | null;
+		firstDeclAccuracyDate: string | null;
+		firstDeclGapConsulted: boolean | null;
+		firstDeclGapOpinion: OpinionType | null;
+		firstDeclGapDate: string | null;
+		secondDeclAccuracyOpinion: OpinionType | null;
+		secondDeclAccuracyDate: string | null;
+		secondDeclGapConsulted: boolean | null;
+		secondDeclGapOpinion: OpinionType | null;
+		secondDeclGapDate: string | null;
+	};
+	declarationYear: number;
+	email?: string;
+	compliancePath?: string | null;
+	hasSecondDeclaration?: boolean;
 };
 
 export function Step1Opinions({
-  initialData,
-  declarationYear,
-  email,
-  compliancePath,
-  hasSecondDeclaration = true,
+	initialData,
+	declarationYear,
+	email,
+	compliancePath,
+	hasSecondDeclaration = true,
 }: Props) {
-  const isJointEvaluation = compliancePath === "joint_evaluation";
-  const router = useRouter();
+	const isJointEvaluation = compliancePath === "joint_evaluation";
+	const router = useRouter();
 
-  const form = useZodForm(saveOpinionsSchema, {
-    defaultValues: {
-      firstDeclaration: {
-        accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
-        accuracyDate: initialData?.firstDeclAccuracyDate ?? "",
-        gapConsulted: initialData?.firstDeclGapConsulted ?? undefined,
-        gapOpinion: initialData?.firstDeclGapOpinion ?? null,
-        gapDate: initialData?.firstDeclGapDate ?? null,
-      },
-      secondDeclaration: hasSecondDeclaration
-        ? {
-            accuracyOpinion:
-              initialData?.secondDeclAccuracyOpinion ?? undefined,
-            accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
-            gapConsulted: initialData?.secondDeclGapConsulted ?? undefined,
-            gapOpinion: initialData?.secondDeclGapOpinion ?? null,
-            gapDate: initialData?.secondDeclGapDate ?? null,
-          }
-        : undefined,
-    },
-  });
+	const form = useZodForm(saveOpinionsSchema, {
+		defaultValues: {
+			firstDeclaration: {
+				accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
+				accuracyDate: initialData?.firstDeclAccuracyDate ?? "",
+				gapConsulted: initialData?.firstDeclGapConsulted ?? undefined,
+				gapOpinion: initialData?.firstDeclGapOpinion ?? null,
+				gapDate: initialData?.firstDeclGapDate ?? null,
+			},
+			secondDeclaration: hasSecondDeclaration
+				? {
+						accuracyOpinion:
+							initialData?.secondDeclAccuracyOpinion ?? undefined,
+						accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
+						gapConsulted: initialData?.secondDeclGapConsulted ?? undefined,
+						gapOpinion: initialData?.secondDeclGapOpinion ?? null,
+						gapDate: initialData?.secondDeclGapDate ?? null,
+					}
+				: undefined,
+		},
+	});
 
-  const mutation = api.cseOpinion.saveOpinions.useMutation({
-    onSuccess: () => router.push("/avis-cse/etape/2"),
-  });
+	const mutation = api.cseOpinion.saveOpinions.useMutation({
+		onSuccess: () => router.push("/avis-cse/etape/2"),
+	});
 
-  const onSubmit = form.handleSubmit((data) => {
-    // Additional validation for conditional gap fields
-    const firstGapIncomplete =
-      data.firstDeclaration.gapConsulted === true &&
-      (!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
-    const secondGapIncomplete =
-      hasSecondDeclaration &&
-      data.secondDeclaration?.gapConsulted === true &&
-      (!data.secondDeclaration?.gapOpinion || !data.secondDeclaration?.gapDate);
+	const onSubmit = form.handleSubmit((data) => {
+		// Additional validation for conditional gap fields
+		const firstGapIncomplete =
+			data.firstDeclaration.gapConsulted === true &&
+			(!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
+		const secondGapIncomplete =
+			hasSecondDeclaration &&
+			data.secondDeclaration?.gapConsulted === true &&
+			(!data.secondDeclaration?.gapOpinion || !data.secondDeclaration?.gapDate);
 
-    if (firstGapIncomplete) {
-      form.setError("firstDeclaration.gapOpinion", {
-        message: "Veuillez remplir tous les champs de consultation.",
-      });
-      return;
-    }
+		if (firstGapIncomplete) {
+			form.setError("firstDeclaration.gapOpinion", {
+				message: "Veuillez remplir tous les champs de consultation.",
+			});
+			return;
+		}
 
-    if (secondGapIncomplete) {
-      form.setError("secondDeclaration.gapOpinion", {
-        message: "Veuillez remplir tous les champs de consultation.",
-      });
-      return;
-    }
+		if (secondGapIncomplete) {
+			form.setError("secondDeclaration.gapOpinion", {
+				message: "Veuillez remplir tous les champs de consultation.",
+			});
+			return;
+		}
 
-    mutation.mutate(data);
-  });
+		mutation.mutate(data);
+	});
 
-  // Watch fields for controlled sub-components
-  const firstDeclOpinion = form.watch("firstDeclaration.accuracyOpinion");
-  const firstDeclDate = form.watch("firstDeclaration.accuracyDate");
-  const firstDeclGapOpinion = form.watch("firstDeclaration.gapOpinion");
-  const firstDeclGapDate = form.watch("firstDeclaration.gapDate");
-  const secondDeclOpinion = form.watch("secondDeclaration.accuracyOpinion");
-  const secondDeclDate = form.watch("secondDeclaration.accuracyDate");
-  const secondDeclGapOpinion = form.watch("secondDeclaration.gapOpinion");
-  const secondDeclGapDate = form.watch("secondDeclaration.gapDate");
+	// Watch fields for controlled sub-components
+	const firstDeclOpinion = form.watch("firstDeclaration.accuracyOpinion");
+	const firstDeclDate = form.watch("firstDeclaration.accuracyDate");
+	const firstDeclGapOpinion = form.watch("firstDeclaration.gapOpinion");
+	const firstDeclGapDate = form.watch("firstDeclaration.gapDate");
+	const secondDeclOpinion = form.watch("secondDeclaration.accuracyOpinion");
+	const secondDeclDate = form.watch("secondDeclaration.accuracyDate");
+	const secondDeclGapOpinion = form.watch("secondDeclaration.gapOpinion");
+	const secondDeclGapDate = form.watch("secondDeclaration.gapDate");
 
-  return (
-    <form onSubmit={onSubmit}>
-      {isJointEvaluation && (
-        <div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
-          <div className="fr-col">
-            <h1 className="fr-h4 fr-mb-0">
-              Parcours de mise en conformité pour l'indicateur par catégorie de
-              salariés
-            </h1>
-          </div>
-        </div>
-      )}
+	return (
+		<form onSubmit={onSubmit}>
+			{isJointEvaluation && (
+				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
+					<div className="fr-col">
+						<h1 className="fr-h4 fr-mb-0">
+							Parcours de mise en conformité pour l'indicateur par catégorie de
+							salariés
+						</h1>
+					</div>
+				</div>
+			)}
 
-      {isJointEvaluation && (
-        <SubmissionBanner
-          deadline={`1er février ${declarationYear}`}
-          email={email ?? "adresse@exemple.fr"}
-        />
-      )}
+			{isJointEvaluation && (
+				<SubmissionBanner
+					deadline={`1er février ${declarationYear}`}
+					email={email ?? "adresse@exemple.fr"}
+				/>
+			)}
 
-      {isJointEvaluation ? (
-        <h2 className="fr-h4 fr-mt-5w fr-mb-3w">
-          Transmettre l'avis ou les avis du CSE
-        </h2>
-      ) : (
-        <h1 className="fr-h4 fr-mb-3w">
-          Transmettre l'avis ou les avis du CSE
-        </h1>
-      )}
+			{isJointEvaluation ? (
+				<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
+					Transmettre l'avis ou les avis du CSE
+				</h2>
+			) : (
+				<h1 className="fr-h4 fr-mb-3w">
+					Transmettre l'avis ou les avis du CSE
+				</h1>
+			)}
 
-      <CseStepIndicator currentStep={1} />
+			<CseStepIndicator currentStep={1} />
 
-      <p className="fr-text--md fr-mb-2w">
-        Indiquez si le CSE a été consulté et précisez les avis émis avant de
-        soumettre votre déclaration aux services du ministère chargé du Travail.
-      </p>
-      <p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
+			<p className="fr-text--md fr-mb-2w">
+				Indiquez si le CSE a été consulté et précisez les avis émis avant de
+				soumettre votre déclaration aux services du ministère chargé du Travail.
+			</p>
+			<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
 
-      <h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
+			<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
 
-      <div className={styles.cardStack}>
-        <AccuracyOpinionCard
-          date={firstDeclDate ?? ""}
-          id="first-decl-accuracy"
-          onDateChange={(v) =>
-            form.setValue("firstDeclaration.accuracyDate", v)
-          }
-          onOpinionChange={(v) =>
-            form.setValue("firstDeclaration.accuracyOpinion", v)
-          }
-          opinion={firstDeclOpinion ?? null}
-          title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
-        />
+			<div className={styles.cardStack}>
+				<AccuracyOpinionCard
+					date={firstDeclDate ?? ""}
+					id="first-decl-accuracy"
+					onDateChange={(v) =>
+						form.setValue("firstDeclaration.accuracyDate", v)
+					}
+					onOpinionChange={(v) =>
+						form.setValue("firstDeclaration.accuracyOpinion", v)
+					}
+					opinion={firstDeclOpinion ?? null}
+					title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
+				/>
 
-        <Controller
-          control={form.control}
-          name="firstDeclaration.gapConsulted"
-          render={({ field }) => (
-            <GapConsultationCard
-              consulted={field.value ?? null}
-              date={firstDeclGapDate ?? ""}
-              id="first-decl-gap"
-              onConsultedChange={field.onChange}
-              onDateChange={(v) => form.setValue("firstDeclaration.gapDate", v)}
-              onOpinionChange={(v) =>
-                form.setValue("firstDeclaration.gapOpinion", v)
-              }
-              opinion={firstDeclGapOpinion ?? null}
-            />
-          )}
-        />
-      </div>
+				<Controller
+					control={form.control}
+					name="firstDeclaration.gapConsulted"
+					render={({ field }) => (
+						<GapConsultationCard
+							consulted={field.value ?? null}
+							date={firstDeclGapDate ?? ""}
+							id="first-decl-gap"
+							onConsultedChange={field.onChange}
+							onDateChange={(v) => form.setValue("firstDeclaration.gapDate", v)}
+							onOpinionChange={(v) =>
+								form.setValue("firstDeclaration.gapOpinion", v)
+							}
+							opinion={firstDeclGapOpinion ?? null}
+						/>
+					)}
+				/>
+			</div>
 
-      {hasSecondDeclaration && (
-        <>
-          <h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
+			{hasSecondDeclaration && (
+				<>
+					<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
 
-          <div className={styles.cardStack}>
-            <AccuracyOpinionCard
-              date={secondDeclDate ?? ""}
-              id="second-decl-accuracy"
-              onDateChange={(v) =>
-                form.setValue("secondDeclaration.accuracyDate", v)
-              }
-              onOpinionChange={(v) =>
-                form.setValue("secondDeclaration.accuracyOpinion", v)
-              }
-              opinion={secondDeclOpinion ?? null}
-              title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
-            />
+					<div className={styles.cardStack}>
+						<AccuracyOpinionCard
+							date={secondDeclDate ?? ""}
+							id="second-decl-accuracy"
+							onDateChange={(v) =>
+								form.setValue("secondDeclaration.accuracyDate", v)
+							}
+							onOpinionChange={(v) =>
+								form.setValue("secondDeclaration.accuracyOpinion", v)
+							}
+							opinion={secondDeclOpinion ?? null}
+							title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+						/>
 
-            <Controller
-              control={form.control}
-              name="secondDeclaration.gapConsulted"
-              render={({ field }) => (
-                <GapConsultationCard
-                  consulted={field.value ?? null}
-                  date={secondDeclGapDate ?? ""}
-                  id="second-decl-gap"
-                  onConsultedChange={field.onChange}
-                  onDateChange={(v) =>
-                    form.setValue("secondDeclaration.gapDate", v)
-                  }
-                  onOpinionChange={(v) =>
-                    form.setValue("secondDeclaration.gapOpinion", v)
-                  }
-                  opinion={secondDeclGapOpinion ?? null}
-                />
-              )}
-            />
-          </div>
-        </>
-      )}
+						<Controller
+							control={form.control}
+							name="secondDeclaration.gapConsulted"
+							render={({ field }) => (
+								<GapConsultationCard
+									consulted={field.value ?? null}
+									date={secondDeclGapDate ?? ""}
+									id="second-decl-gap"
+									onConsultedChange={field.onChange}
+									onDateChange={(v) =>
+										form.setValue("secondDeclaration.gapDate", v)
+									}
+									onOpinionChange={(v) =>
+										form.setValue("secondDeclaration.gapOpinion", v)
+									}
+									opinion={secondDeclGapOpinion ?? null}
+								/>
+							)}
+						/>
+					</div>
+				</>
+			)}
 
-      <div aria-live="polite">
-        {(form.formState.errors.firstDeclaration ||
-          form.formState.errors.secondDeclaration) && (
-          <div className="fr-alert fr-alert--error fr-mt-3w">
-            <p>Veuillez remplir tous les champs obligatoires.</p>
-          </div>
-        )}
-        {mutation.error && (
-          <div className="fr-alert fr-alert--error fr-mt-3w">
-            <p>{mutation.error.message}</p>
-          </div>
-        )}
-      </div>
+			<div aria-live="polite">
+				{(form.formState.errors.firstDeclaration ||
+					form.formState.errors.secondDeclaration) && (
+					<div className="fr-alert fr-alert--error fr-mt-3w">
+						<p>Veuillez remplir tous les champs obligatoires.</p>
+					</div>
+				)}
+				{mutation.error && (
+					<div className="fr-alert fr-alert--error fr-mt-3w">
+						<p>{mutation.error.message}</p>
+					</div>
+				)}
+			</div>
 
-      <div className={`fr-mt-4w ${formStyles.actions}`}>
-        <button
-          className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
-          onClick={() => router.back()}
-          type="button"
-        >
-          Précédent
-        </button>
-        <button
-          className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-          disabled={mutation.isPending}
-          type="submit"
-        >
-          {mutation.isPending ? "Enregistrement…" : "Suivant"}
-        </button>
-      </div>
-    </form>
-  );
+			<div className={`fr-mt-4w ${formStyles.actions}`}>
+				<button
+					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+					onClick={() => router.back()}
+					type="button"
+				>
+					Précédent
+				</button>
+				<button
+					className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+					disabled={mutation.isPending}
+					type="submit"
+				>
+					{mutation.isPending ? "Enregistrement…" : "Suivant"}
+				</button>
+			</div>
+		</form>
+	);
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from "next/navigation";
 import { Controller } from "react-hook-form";
 
-import { getCseYear } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 
@@ -29,6 +28,7 @@ type Props = {
 		secondDeclGapOpinion: OpinionType | null;
 		secondDeclGapDate: string | null;
 	};
+	declarationYear: number;
 	email?: string;
 	compliancePath?: string | null;
 	hasSecondDeclaration?: boolean;
@@ -36,6 +36,7 @@ type Props = {
 
 export function Step1Opinions({
 	initialData,
+	declarationYear,
 	email,
 	compliancePath,
 	hasSecondDeclaration = true,
@@ -121,7 +122,7 @@ export function Step1Opinions({
 
 			{isJointEvaluation && (
 				<SubmissionBanner
-					deadline={`1er février ${getCseYear()}`}
+					deadline={`1er février ${declarationYear + 1}`}
 					email={email ?? "adresse@exemple.fr"}
 				/>
 			)}

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -14,11 +14,13 @@ import formStyles from "./shared/formActions.module.scss";
 import { MAX_CSE_FILES, type UploadedFile } from "./types";
 
 type Props = {
+	declarationYear: number;
 	hasSecondDeclaration?: boolean;
 	existingFiles?: UploadedFile[];
 };
 
 export function Step2Upload({
+	declarationYear,
 	hasSecondDeclaration = true,
 	existingFiles = [],
 }: Props) {
@@ -132,6 +134,7 @@ export function Step2Upload({
 			</form>
 
 			<SubmitConfirmationModal
+				declarationYear={declarationYear}
 				modalRef={modalRef}
 				onClose={closeModal}
 				onSubmit={handleConfirm}

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -19,7 +19,9 @@ describe("ConfirmationPage", () => {
 		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
-			screen.getByText(`Démarche des indicateurs de rémunération ${DECLARATION_YEAR}`),
+			screen.getByText(
+				`Démarche des indicateurs de rémunération ${DECLARATION_YEAR}`,
+			),
 		).toBeInTheDocument();
 	});
 
@@ -27,7 +29,9 @@ describe("ConfirmationPage", () => {
 		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
-			screen.getByText(`Votre parcours ${DECLARATION_YEAR} est désormais terminé`),
+			screen.getByText(
+				`Votre parcours ${DECLARATION_YEAR} est désormais terminé`,
+			),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { getCseYear } from "~/modules/domain";
 import { ConfirmationPage } from "../ConfirmationPage";
 
 vi.mock("~/trpc/react", () => ({
@@ -13,39 +12,45 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
-describe("ConfirmationPage", () => {
-	const year = getCseYear();
+const DECLARATION_YEAR = 2025;
+const CSE_YEAR = DECLARATION_YEAR + 1;
 
+describe("ConfirmationPage", () => {
 	it("renders the page title", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
-			screen.getByText(`Démarche des indicateurs de rémunération ${year}`),
+			screen.getByText(`Démarche des indicateurs de rémunération ${CSE_YEAR}`),
 		).toBeInTheDocument();
 	});
 
 	it("renders the success message", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
-			screen.getByText(`Votre parcours ${year} est désormais terminé`),
+			screen.getByText(`Votre parcours ${CSE_YEAR} est désormais terminé`),
 		).toBeInTheDocument();
 	});
 
 	it("renders the default email in receipt card", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});
 
 	it("renders the provided email in receipt card", () => {
-		render(<ConfirmationPage email="test@example.com" />);
+		render(
+			<ConfirmationPage
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.com"
+			/>,
+		);
 
 		expect(screen.getByText("test@example.com")).toBeInTheDocument();
 	});
 
 	it("renders the resend button", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByRole("button", {
@@ -55,7 +60,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders document download section without second declaration card", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByText("Documents récapitulatifs de votre déclaration"),
@@ -72,7 +77,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders second declaration card when hasSecondDeclaration is true", () => {
-		render(<ConfirmationPage hasSecondDeclaration />);
+		render(
+			<ConfirmationPage
+				declarationYear={DECLARATION_YEAR}
+				hasSecondDeclaration
+			/>,
+		);
 
 		expect(
 			screen.getByText(/récapitulatif de la déclaration des indicateurs/),
@@ -86,36 +96,47 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders download cards as links with correct hrefs", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		const declarationLink = screen
 			.getByText(/récapitulatif de la déclaration des indicateurs/)
 			.closest("a");
-		expect(declarationLink).toHaveAttribute("href", "/api/declaration-pdf");
+		expect(declarationLink).toHaveAttribute(
+			"href",
+			`/api/declaration-pdf?year=${DECLARATION_YEAR}`,
+		);
 		expect(declarationLink).toHaveAttribute("download");
 
 		const transmittedLink = screen
 			.getByText(/récapitulatif des éléments transmis/)
 			.closest("a");
-		expect(transmittedLink).toHaveAttribute("href", "/api/transmitted-pdf");
+		expect(transmittedLink).toHaveAttribute(
+			"href",
+			`/api/transmitted-pdf?year=${DECLARATION_YEAR}`,
+		);
 		expect(transmittedLink).toHaveAttribute("download");
 	});
 
 	it("renders second declaration download card with correction href", () => {
-		render(<ConfirmationPage hasSecondDeclaration />);
+		render(
+			<ConfirmationPage
+				declarationYear={DECLARATION_YEAR}
+				hasSecondDeclaration
+			/>,
+		);
 
 		const secondDeclLink = screen
 			.getByText(/récapitulatif de la seconde déclaration/)
 			.closest("a");
 		expect(secondDeclLink).toHaveAttribute(
 			"href",
-			"/api/declaration-pdf?type=correction",
+			`/api/declaration-pdf?type=correction&year=${DECLARATION_YEAR}`,
 		);
 		expect(secondDeclLink).toHaveAttribute("download");
 	});
 
 	it("renders the feedback banner", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByText("Comment s'est passée votre démarche ?"),
@@ -123,7 +144,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders navigation links", () => {
-		render(<ConfirmationPage />);
+		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		const modifyLink = screen.getByRole("link", {
 			name: /Modifier mes dépôts/,

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -16,7 +16,7 @@ const DECLARATION_YEAR = 2025;
 
 describe("ConfirmationPage", () => {
 	it("renders the page title", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByText(
@@ -26,7 +26,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the success message", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByText(
@@ -36,7 +36,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the default email in receipt card", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});
@@ -44,6 +44,7 @@ describe("ConfirmationPage", () => {
 	it("renders the provided email in receipt card", () => {
 		render(
 			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.com"
 			/>,
@@ -53,7 +54,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the resend button", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByRole("button", {
@@ -63,7 +64,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders document download section without second declaration card", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByText("Documents récapitulatifs de votre déclaration"),
@@ -82,6 +83,7 @@ describe("ConfirmationPage", () => {
 	it("renders second declaration card when hasSecondDeclaration is true", () => {
 		render(
 			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
 				declarationYear={DECLARATION_YEAR}
 				hasSecondDeclaration
 			/>,
@@ -99,7 +101,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders download cards as links with correct hrefs", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		const declarationLink = screen
 			.getByText(/récapitulatif de la déclaration des indicateurs/)
@@ -123,6 +125,7 @@ describe("ConfirmationPage", () => {
 	it("renders second declaration download card with correction href", () => {
 		render(
 			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
 				declarationYear={DECLARATION_YEAR}
 				hasSecondDeclaration
 			/>,
@@ -139,7 +142,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the feedback banner", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		expect(
 			screen.getByText("Comment s'est passée votre démarche ?"),
@@ -147,7 +150,7 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders navigation links", () => {
-		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
+		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
 
 		const modifyLink = screen.getByRole("link", {
 			name: /Modifier mes dépôts/,

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -16,7 +16,12 @@ const DECLARATION_YEAR = 2025;
 
 describe("ConfirmationPage", () => {
 	it("renders the page title", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		expect(
 			screen.getByText(
@@ -26,7 +31,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the success message", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		expect(
 			screen.getByText(
@@ -36,7 +46,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the default email in receipt card", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});
@@ -54,7 +69,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the resend button", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		expect(
 			screen.getByRole("button", {
@@ -64,7 +84,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders document download section without second declaration card", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		expect(
 			screen.getByText("Documents récapitulatifs de votre déclaration"),
@@ -101,7 +126,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders download cards as links with correct hrefs", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		const declarationLink = screen
 			.getByText(/récapitulatif de la déclaration des indicateurs/)
@@ -142,7 +172,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders the feedback banner", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		expect(
 			screen.getByText("Comment s'est passée votre démarche ?"),
@@ -150,7 +185,12 @@ describe("ConfirmationPage", () => {
 	});
 
 	it("renders navigation links", () => {
-		render(<ConfirmationPage dataYear={DECLARATION_YEAR - 1} declarationYear={DECLARATION_YEAR} />);
+		render(
+			<ConfirmationPage
+				dataYear={DECLARATION_YEAR - 1}
+				declarationYear={DECLARATION_YEAR}
+			/>,
+		);
 
 		const modifyLink = screen.getByRole("link", {
 			name: /Modifier mes dépôts/,

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -13,14 +13,13 @@ vi.mock("~/trpc/react", () => ({
 }));
 
 const DECLARATION_YEAR = 2025;
-const CSE_YEAR = DECLARATION_YEAR + 1;
 
 describe("ConfirmationPage", () => {
 	it("renders the page title", () => {
 		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
-			screen.getByText(`Démarche des indicateurs de rémunération ${CSE_YEAR}`),
+			screen.getByText(`Démarche des indicateurs de rémunération ${DECLARATION_YEAR}`),
 		).toBeInTheDocument();
 	});
 
@@ -28,7 +27,7 @@ describe("ConfirmationPage", () => {
 		render(<ConfirmationPage declarationYear={DECLARATION_YEAR} />);
 
 		expect(
-			screen.getByText(`Votre parcours ${CSE_YEAR} est désormais terminé`),
+			screen.getByText(`Votre parcours ${DECLARATION_YEAR} est désormais terminé`),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -41,7 +41,12 @@ beforeEach(() => {
 
 describe("Step1Opinions", () => {
 	it("renders compliance path title when compliancePath is joint_evaluation", () => {
-		render(<Step1Opinions compliancePath="joint_evaluation" />);
+		render(
+			<Step1Opinions
+				compliancePath="joint_evaluation"
+				declarationYear={2025}
+			/>,
+		);
 
 		expect(
 			screen.getByText(
@@ -51,7 +56,7 @@ describe("Step1Opinions", () => {
 	});
 
 	it("does not render compliance path title for other paths", () => {
-		render(<Step1Opinions compliancePath="justify" />);
+		render(<Step1Opinions compliancePath="justify" declarationYear={2025} />);
 
 		expect(
 			screen.queryByText(
@@ -61,34 +66,43 @@ describe("Step1Opinions", () => {
 	});
 
 	it("renders h1 as CSE opinion title when no compliance path banner", () => {
-		render(<Step1Opinions />);
+		render(<Step1Opinions declarationYear={2025} />);
 
 		const heading = screen.getByRole("heading", { level: 1 });
 		expect(heading).toHaveTextContent("Transmettre l'avis ou les avis du CSE");
 	});
 
 	it("renders the stepper at step 1", () => {
-		render(<Step1Opinions />);
+		render(<Step1Opinions declarationYear={2025} />);
 
 		expect(screen.getByText(/Étape 1 sur 2/)).toBeInTheDocument();
 	});
 
 	it("renders both declaration sections when hasSecondDeclaration is true", () => {
-		render(<Step1Opinions hasSecondDeclaration={true} />);
+		render(
+			<Step1Opinions declarationYear={2025} hasSecondDeclaration={true} />,
+		);
 
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
 		expect(screen.getByText("Deuxième déclaration")).toBeInTheDocument();
 	});
 
 	it("hides second declaration section when hasSecondDeclaration is false", () => {
-		render(<Step1Opinions hasSecondDeclaration={false} />);
+		render(
+			<Step1Opinions declarationYear={2025} hasSecondDeclaration={false} />,
+		);
 
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
 		expect(screen.queryByText("Deuxième déclaration")).not.toBeInTheDocument();
 	});
 
 	it("renders the submission banner for joint_evaluation path", () => {
-		render(<Step1Opinions compliancePath="joint_evaluation" />);
+		render(
+			<Step1Opinions
+				compliancePath="joint_evaluation"
+				declarationYear={2025}
+			/>,
+		);
 
 		expect(
 			screen.getByText(
@@ -98,7 +112,7 @@ describe("Step1Opinions", () => {
 	});
 
 	it("does not render the submission banner for other paths", () => {
-		render(<Step1Opinions />);
+		render(<Step1Opinions declarationYear={2025} />);
 
 		expect(
 			screen.queryByText(
@@ -108,7 +122,7 @@ describe("Step1Opinions", () => {
 	});
 
 	it("renders previous and next buttons", () => {
-		render(<Step1Opinions />);
+		render(<Step1Opinions declarationYear={2025} />);
 
 		expect(
 			screen.getByRole("button", { name: /Précédent/ }),
@@ -118,7 +132,7 @@ describe("Step1Opinions", () => {
 
 	it("shows validation error when submitting empty form", async () => {
 		const user = userEvent.setup();
-		render(<Step1Opinions />);
+		render(<Step1Opinions declarationYear={2025} />);
 
 		await user.click(screen.getByRole("button", { name: /Suivant/ }));
 
@@ -132,6 +146,7 @@ describe("Step1Opinions", () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Opinions
+				declarationYear={2025}
 				hasSecondDeclaration={true}
 				initialData={{
 					firstDeclAccuracyOpinion: "favorable",
@@ -173,6 +188,7 @@ describe("Step1Opinions", () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Opinions
+				declarationYear={2025}
 				hasSecondDeclaration={false}
 				initialData={{
 					firstDeclAccuracyOpinion: "favorable",
@@ -207,6 +223,7 @@ describe("Step1Opinions", () => {
 	it("renders with initial data pre-filled", () => {
 		render(
 			<Step1Opinions
+				declarationYear={2025}
 				initialData={{
 					firstDeclAccuracyOpinion: "favorable",
 					firstDeclAccuracyDate: "2026-01-15",
@@ -235,6 +252,7 @@ describe("Step1Opinions", () => {
 		render(
 			<Step1Opinions
 				compliancePath="joint_evaluation"
+				declarationYear={2025}
 				email="test@example.fr"
 			/>,
 		);
@@ -243,7 +261,12 @@ describe("Step1Opinions", () => {
 	});
 
 	it("uses default email when none provided for joint_evaluation path", () => {
-		render(<Step1Opinions compliancePath="joint_evaluation" />);
+		render(
+			<Step1Opinions
+				compliancePath="joint_evaluation"
+				declarationYear={2025}
+			/>,
+		);
 
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});

--- a/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
@@ -39,7 +39,7 @@ function makeFile(name: string, id: string) {
 
 describe("Step2Upload", () => {
 	it("renders the page title", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		expect(
 			screen.getByText("Transmettre l'avis ou les avis du CSE"),
@@ -47,13 +47,13 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the stepper at step 2", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		expect(screen.getByText(/Étape 2 sur 2/)).toBeInTheDocument();
 	});
 
 	it("renders the file upload instructions", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		expect(
 			screen.getByText(/Veuillez importer l'ensemble des avis de votre CSE/),
@@ -62,7 +62,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the dropzone with select button", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		expect(
 			screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
@@ -71,7 +71,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders a hidden file input", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		const fileInput = getFileInput();
 		expect(fileInput).toBeInTheDocument();
@@ -80,7 +80,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the opinion summary box", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		expect(screen.getByText("Avis CSE à transmettre :")).toBeInTheDocument();
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders previous link and add file button", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		const previousLink = screen.getByRole("link", { name: /Précédent/ });
 		expect(previousLink).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe("Step2Upload", () => {
 
 	it("shows error when submitting without file", async () => {
 		const user = userEvent.setup();
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		await user.click(screen.getByRole("button", { name: /Soumettre/ }));
 
@@ -114,7 +114,7 @@ describe("Step2Upload", () => {
 
 	it("sets aria-invalid on file input when error occurs", async () => {
 		const user = userEvent.setup();
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		const fileInput = getFileInput();
 		expect(fileInput).toHaveAttribute("aria-invalid", "false");
@@ -125,7 +125,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("shows error for non-PDF file", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		const file = new File(["content"], "test.txt", { type: "text/plain" });
 		const fileInput = getFileInput();
@@ -140,7 +140,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("shows error for file exceeding 10 MB", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		const largeContent = new ArrayBuffer(11 * 1024 * 1024);
 		const file = new File([largeContent], "large.pdf", {
@@ -156,7 +156,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the confirmation modal dialog", () => {
-		const { container } = render(<Step2Upload />);
+		const { container } = render(<Step2Upload declarationYear={2025} />);
 
 		const dialog = container.querySelector("dialog");
 		expect(dialog).toBeInTheDocument();
@@ -164,7 +164,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("accepts PDF file and shows file card", () => {
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		const file = new File(["content"], "avis-cse.pdf", {
 			type: "application/pdf",
@@ -182,7 +182,7 @@ describe("Step2Upload", () => {
 
 	it("removes file when delete button is clicked", async () => {
 		const user = userEvent.setup();
-		render(<Step2Upload />);
+		render(<Step2Upload declarationYear={2025} />);
 
 		const file = new File(["content"], "avis-cse.pdf", {
 			type: "application/pdf",
@@ -204,6 +204,7 @@ describe("Step2Upload", () => {
 	it("shows existing file cards when files are provided", () => {
 		render(
 			<Step2Upload
+				declarationYear={2025}
 				existingFiles={[
 					makeFile("avis-1.pdf", "file-1"),
 					makeFile("avis-2.pdf", "file-2"),
@@ -217,7 +218,12 @@ describe("Step2Upload", () => {
 	});
 
 	it("shows submit button when files exist but under limit", () => {
-		render(<Step2Upload existingFiles={[makeFile("avis-1.pdf", "file-1")]} />);
+		render(
+			<Step2Upload
+				declarationYear={2025}
+				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
+			/>,
+		);
 
 		expect(
 			screen.getByRole("button", { name: /Soumettre/ }),
@@ -227,6 +233,7 @@ describe("Step2Upload", () => {
 	it("shows file count in hint text", () => {
 		render(
 			<Step2Upload
+				declarationYear={2025}
 				existingFiles={[
 					makeFile("avis-1.pdf", "file-1"),
 					makeFile("avis-2.pdf", "file-2"),
@@ -240,6 +247,7 @@ describe("Step2Upload", () => {
 	it("disables dropzone when max files reached", () => {
 		render(
 			<Step2Upload
+				declarationYear={2025}
 				existingFiles={[
 					makeFile("avis-1.pdf", "f1"),
 					makeFile("avis-2.pdf", "f2"),

--- a/packages/app/src/modules/cseOpinion/__tests__/SubmitConfirmationModal.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/SubmitConfirmationModal.test.tsx
@@ -5,6 +5,7 @@ import { SubmitConfirmationModal } from "../components/SubmitConfirmationModal";
 
 function renderOpenModal(props = {}) {
 	const defaultProps = {
+		declarationYear: 2025,
 		modalRef: { current: null },
 		onClose: vi.fn(),
 		onSubmit: vi.fn(),

--- a/packages/app/src/modules/cseOpinion/components/SubmitConfirmationModal.tsx
+++ b/packages/app/src/modules/cseOpinion/components/SubmitConfirmationModal.tsx
@@ -3,33 +3,33 @@
 import { SubmitModal } from "~/modules/shared";
 
 type Props = {
-	declarationYear: number;
-	modalRef: React.RefObject<HTMLDialogElement | null>;
-	onClose: () => void;
-	onSubmit: () => void;
+  declarationYear: number;
+  modalRef: React.RefObject<HTMLDialogElement | null>;
+  onClose: () => void;
+  onSubmit: () => void;
 };
 
 export function SubmitConfirmationModal({
-	declarationYear,
-	modalRef,
-	onClose,
-	onSubmit,
+  declarationYear,
+  modalRef,
+  onClose,
+  onSubmit,
 }: Props) {
-	return (
-		<SubmitModal
-			certifyInputId="cse-submit-certify"
-			certifyLabel="Je certifie que les avis transmis sont conformes."
-			description={
-				<>
-					Vous allez transmettre aux services du ministère chargé du Travail
-					l&apos;avis ou les avis de votre CSE relatifs à l&apos;ensemble de
-					votre démarche {declarationYear + 1}.
-				</>
-			}
-			modalId="cse-submit-modal"
-			modalRef={modalRef}
-			onClose={onClose}
-			onSubmit={onSubmit}
-		/>
-	);
+  return (
+    <SubmitModal
+      certifyInputId="cse-submit-certify"
+      certifyLabel="Je certifie que les avis transmis sont conformes."
+      description={
+        <>
+          Vous allez transmettre aux services du ministère chargé du Travail
+          l&apos;avis ou les avis de votre CSE relatifs à l&apos;ensemble de
+          votre démarche {declarationYear}.
+        </>
+      }
+      modalId="cse-submit-modal"
+      modalRef={modalRef}
+      onClose={onClose}
+      onSubmit={onSubmit}
+    />
+  );
 }

--- a/packages/app/src/modules/cseOpinion/components/SubmitConfirmationModal.tsx
+++ b/packages/app/src/modules/cseOpinion/components/SubmitConfirmationModal.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { getCseYear } from "~/modules/domain";
 import { SubmitModal } from "~/modules/shared";
 
 type Props = {
+	declarationYear: number;
 	modalRef: React.RefObject<HTMLDialogElement | null>;
 	onClose: () => void;
 	onSubmit: () => void;
 };
 
 export function SubmitConfirmationModal({
+	declarationYear,
 	modalRef,
 	onClose,
 	onSubmit,
@@ -22,7 +23,7 @@ export function SubmitConfirmationModal({
 				<>
 					Vous allez transmettre aux services du ministère chargé du Travail
 					l&apos;avis ou les avis de votre CSE relatifs à l&apos;ensemble de
-					votre démarche {getCseYear()}.
+					votre démarche {declarationYear + 1}.
 				</>
 			}
 			modalId="cse-submit-modal"

--- a/packages/app/src/modules/cseOpinion/components/SubmitConfirmationModal.tsx
+++ b/packages/app/src/modules/cseOpinion/components/SubmitConfirmationModal.tsx
@@ -3,33 +3,33 @@
 import { SubmitModal } from "~/modules/shared";
 
 type Props = {
-  declarationYear: number;
-  modalRef: React.RefObject<HTMLDialogElement | null>;
-  onClose: () => void;
-  onSubmit: () => void;
+	declarationYear: number;
+	modalRef: React.RefObject<HTMLDialogElement | null>;
+	onClose: () => void;
+	onSubmit: () => void;
 };
 
 export function SubmitConfirmationModal({
-  declarationYear,
-  modalRef,
-  onClose,
-  onSubmit,
+	declarationYear,
+	modalRef,
+	onClose,
+	onSubmit,
 }: Props) {
-  return (
-    <SubmitModal
-      certifyInputId="cse-submit-certify"
-      certifyLabel="Je certifie que les avis transmis sont conformes."
-      description={
-        <>
-          Vous allez transmettre aux services du ministère chargé du Travail
-          l&apos;avis ou les avis de votre CSE relatifs à l&apos;ensemble de
-          votre démarche {declarationYear}.
-        </>
-      }
-      modalId="cse-submit-modal"
-      modalRef={modalRef}
-      onClose={onClose}
-      onSubmit={onSubmit}
-    />
-  );
+	return (
+		<SubmitModal
+			certifyInputId="cse-submit-certify"
+			certifyLabel="Je certifie que les avis transmis sont conformes."
+			description={
+				<>
+					Vous allez transmettre aux services du ministère chargé du Travail
+					l&apos;avis ou les avis de votre CSE relatifs à l&apos;ensemble de
+					votre démarche {declarationYear}.
+				</>
+			}
+			modalId="cse-submit-modal"
+			modalRef={modalRef}
+			onClose={onClose}
+			onSubmit={onSubmit}
+		/>
+	);
 }

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -23,7 +23,6 @@ export function DeclarationLayout({
 			<CompanyBanner
 				company={company}
 				currentPageLabel={`Démarche des indicateurs de rémunération ${declarationYear}`}
-				declarationYear={declarationYear}
 			/>
 			<main className="fr-container fr-py-7w" id="content">
 				<div className="fr-grid-row fr-grid-row--center">

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -1,4 +1,3 @@
-import { getCurrentYear } from "~/modules/domain";
 import { CompanyBanner } from "./shared/CompanyBanner";
 
 type CompanyData = {
@@ -10,19 +9,21 @@ type CompanyData = {
 
 type DeclarationLayoutProps = {
 	company: CompanyData;
+	declarationYear: number;
 	children: React.ReactNode;
 };
 
 export function DeclarationLayout({
 	company,
+	declarationYear,
 	children,
 }: DeclarationLayoutProps) {
-	const currentYear = getCurrentYear();
 	return (
 		<>
 			<CompanyBanner
 				company={company}
-				currentPageLabel={`Démarche des indicateurs de rémunération ${currentYear}`}
+				currentPageLabel={`Démarche des indicateurs de rémunération ${declarationYear}`}
+				declarationYear={declarationYear}
 			/>
 			<main className="fr-container fr-py-7w" id="content">
 				<div className="fr-grid-row fr-grid-row--center">

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -19,6 +19,7 @@ type StepPageClientProps = {
 	step: number;
 	declaration: {
 		siren: string;
+		year: number;
 		totalWomen: number | null;
 		totalMen: number | null;
 		status: string | null;
@@ -53,11 +54,16 @@ export function StepPageClient({
 			);
 		case 2:
 			return (
-				<Step2PayGap gipPrefillData={gipPrefillData} initialData={step2Data} />
+				<Step2PayGap
+					declarationYear={declaration.year}
+					gipPrefillData={gipPrefillData}
+					initialData={step2Data}
+				/>
 			);
 		case 3:
 			return (
 				<Step3VariablePay
+					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step3Data}
 					maxMen={declaration.totalMen ?? undefined}
@@ -67,6 +73,7 @@ export function StepPageClient({
 		case 4:
 			return (
 				<Step4QuartileDistribution
+					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step4Data}
 					maxMen={declaration.totalMen ?? undefined}
@@ -76,6 +83,7 @@ export function StepPageClient({
 		case 5:
 			return (
 				<Step5EmployeeCategories
+					declarationYear={declaration.year}
 					initialCategories={step5Categories}
 					initialSource={initialSource}
 					maxMen={declaration.totalMen ?? undefined}
@@ -86,6 +94,7 @@ export function StepPageClient({
 			return (
 				<Step6Review
 					declaration={declaration}
+					declarationYear={declaration.year}
 					isSubmitted={declaration.status === "submitted"}
 					step2Data={step2Data}
 					step3Data={step3Data}

--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
@@ -1,4 +1,3 @@
-import { getCurrentYear } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -12,14 +11,14 @@ type CompanyBannerProps = {
 		hasCse: boolean | null;
 	};
 	currentPageLabel: string;
+	declarationYear: number;
 };
 
 export function CompanyBanner({
 	company,
 	currentPageLabel,
+	declarationYear,
 }: CompanyBannerProps) {
-	const currentYear = getCurrentYear();
-
 	return (
 		<div className={`fr-py-3w ${styles.banner}`}>
 			<div className="fr-container">
@@ -42,7 +41,7 @@ export function CompanyBanner({
 					{company.workforce !== null && (
 						<div className="fr-col-auto">
 							<p className="fr-mb-0 fr-text--sm">
-								Effectif annuel moyen en {currentYear - 1} :{" "}
+								Effectif annuel moyen en {declarationYear - 1} :{" "}
 								<strong>{company.workforce}</strong>
 							</p>
 						</div>

--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
@@ -1,4 +1,4 @@
-import { getCurrentYear } from "~/modules/domain";
+import { getWorkforceYear } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -40,7 +40,7 @@ export function CompanyBanner({
 					{company.workforce !== null && (
 						<div className="fr-col-auto">
 							<p className="fr-mb-0 fr-text--sm">
-								Effectif annuel moyen en {getCurrentYear() - 1} :{" "}
+								Effectif annuel moyen en {getWorkforceYear()} :{" "}
 								<strong>{company.workforce}</strong>
 							</p>
 						</div>

--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
@@ -1,3 +1,4 @@
+import { getCurrentYear } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -11,13 +12,11 @@ type CompanyBannerProps = {
 		hasCse: boolean | null;
 	};
 	currentPageLabel: string;
-	declarationYear: number;
 };
 
 export function CompanyBanner({
 	company,
 	currentPageLabel,
-	declarationYear,
 }: CompanyBannerProps) {
 	return (
 		<div className={`fr-py-3w ${styles.banner}`}>
@@ -41,7 +40,7 @@ export function CompanyBanner({
 					{company.workforce !== null && (
 						<div className="fr-col-auto">
 							<p className="fr-mb-0 fr-text--sm">
-								Effectif annuel moyen en {declarationYear - 1} :{" "}
+								Effectif annuel moyen en {getCurrentYear() - 1} :{" "}
 								<strong>{company.workforce}</strong>
 							</p>
 						</div>

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
@@ -16,7 +16,6 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={defaultCompany}
 				currentPageLabel="Déclaration"
-				declarationYear={2025}
 			/>,
 		);
 
@@ -31,7 +30,6 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={defaultCompany}
 				currentPageLabel="Déclaration"
-				declarationYear={2025}
 			/>,
 		);
 
@@ -43,7 +41,6 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={defaultCompany}
 				currentPageLabel="Déclaration"
-				declarationYear={2025}
 			/>,
 		);
 
@@ -55,7 +52,6 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={defaultCompany}
 				currentPageLabel="Déclaration"
-				declarationYear={2025}
 			/>,
 		);
 
@@ -68,7 +64,6 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={{ ...defaultCompany, workforce: null }}
 				currentPageLabel="Déclaration"
-				declarationYear={2025}
 			/>,
 		);
 
@@ -80,7 +75,6 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={{ ...defaultCompany, hasCse: null }}
 				currentPageLabel="Déclaration"
-				declarationYear={2025}
 			/>,
 		);
 
@@ -92,7 +86,6 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={{ ...defaultCompany, hasCse: false }}
 				currentPageLabel="Déclaration"
-				declarationYear={2025}
 			/>,
 		);
 

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
@@ -13,10 +13,7 @@ const defaultCompany = {
 describe("CompanyBanner", () => {
 	it("renders breadcrumb with 'Mon espace' link and current page label", () => {
 		render(
-			<CompanyBanner
-				company={defaultCompany}
-				currentPageLabel="Déclaration"
-			/>,
+			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
 		);
 
 		const link = screen.getByRole("link", { name: "Mon espace" });
@@ -27,10 +24,7 @@ describe("CompanyBanner", () => {
 
 	it("renders formatted SIREN", () => {
 		render(
-			<CompanyBanner
-				company={defaultCompany}
-				currentPageLabel="Déclaration"
-			/>,
+			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
 		);
 
 		expect(screen.getByText(/123 456 789/)).toBeInTheDocument();
@@ -38,10 +32,7 @@ describe("CompanyBanner", () => {
 
 	it("renders company name", () => {
 		render(
-			<CompanyBanner
-				company={defaultCompany}
-				currentPageLabel="Déclaration"
-			/>,
+			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
 		);
 
 		expect(screen.getByText(/Alpha Solutions/)).toBeInTheDocument();
@@ -49,10 +40,7 @@ describe("CompanyBanner", () => {
 
 	it("renders workforce and CSE values", () => {
 		render(
-			<CompanyBanner
-				company={defaultCompany}
-				currentPageLabel="Déclaration"
-			/>,
+			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
 		);
 
 		expect(screen.getByText("256")).toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
@@ -13,7 +13,11 @@ const defaultCompany = {
 describe("CompanyBanner", () => {
 	it("renders breadcrumb with 'Mon espace' link and current page label", () => {
 		render(
-			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
+			<CompanyBanner
+				company={defaultCompany}
+				currentPageLabel="Déclaration"
+				declarationYear={2025}
+			/>,
 		);
 
 		const link = screen.getByRole("link", { name: "Mon espace" });
@@ -24,7 +28,11 @@ describe("CompanyBanner", () => {
 
 	it("renders formatted SIREN", () => {
 		render(
-			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
+			<CompanyBanner
+				company={defaultCompany}
+				currentPageLabel="Déclaration"
+				declarationYear={2025}
+			/>,
 		);
 
 		expect(screen.getByText(/123 456 789/)).toBeInTheDocument();
@@ -32,7 +40,11 @@ describe("CompanyBanner", () => {
 
 	it("renders company name", () => {
 		render(
-			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
+			<CompanyBanner
+				company={defaultCompany}
+				currentPageLabel="Déclaration"
+				declarationYear={2025}
+			/>,
 		);
 
 		expect(screen.getByText(/Alpha Solutions/)).toBeInTheDocument();
@@ -40,7 +52,11 @@ describe("CompanyBanner", () => {
 
 	it("renders workforce and CSE values", () => {
 		render(
-			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
+			<CompanyBanner
+				company={defaultCompany}
+				currentPageLabel="Déclaration"
+				declarationYear={2025}
+			/>,
 		);
 
 		expect(screen.getByText("256")).toBeInTheDocument();
@@ -52,6 +68,7 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={{ ...defaultCompany, workforce: null }}
 				currentPageLabel="Déclaration"
+				declarationYear={2025}
 			/>,
 		);
 
@@ -63,6 +80,7 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={{ ...defaultCompany, hasCse: null }}
 				currentPageLabel="Déclaration"
+				declarationYear={2025}
 			/>,
 		);
 
@@ -74,6 +92,7 @@ describe("CompanyBanner", () => {
 			<CompanyBanner
 				company={{ ...defaultCompany, hasCse: false }}
 				currentPageLabel="Déclaration"
+				declarationYear={2025}
 			/>,
 		);
 

--- a/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
@@ -1,12 +1,13 @@
 import Link from "next/link";
 import { DownloadDeclarationPdfButton } from "~/modules/declarationPdf";
-import { getCurrentYear } from "~/modules/domain";
 import { DsfrPictogram } from "~/modules/layout";
+import { api } from "~/trpc/server";
 import { ComplianceCompletionEffect } from "../shared/ComplianceCompletionEffect";
 import common from "../shared/common.module.scss";
 
-export function ComplianceConfirmation() {
-	const currentYear = getCurrentYear();
+export async function ComplianceConfirmation() {
+	const data = await api.declaration.getOrCreate();
+	const currentYear = data.declaration.year;
 
 	return (
 		<div className={common.flexColumnGap2}>
@@ -32,7 +33,7 @@ export function ComplianceConfirmation() {
 				requis.
 			</p>
 
-			<DownloadDeclarationPdfButton />
+			<DownloadDeclarationPdfButton year={currentYear} />
 
 			<div className="fr-mt-4w">
 				<Link className="fr-btn" href="/mon-espace">

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
-import { getCurrentYear, hasGapsAboveThreshold } from "~/modules/domain";
+import { hasGapsAboveThreshold } from "~/modules/domain";
 import { auth } from "~/server/auth";
 import { api, HydrateClient } from "~/trpc/server";
 import { getPostComplianceDestination } from "../shared/complianceNavigation";
@@ -63,7 +63,7 @@ export async function CompliancePathPage() {
 	}
 
 	const email = session?.user?.email ?? "";
-	const currentYear = getCurrentYear();
+	const currentYear = data.declaration.year;
 
 	return (
 		<HydrateClient>
@@ -81,8 +81,8 @@ export async function CompliancePathPage() {
 				isSecondRound={state.type === "second_round"}
 				pdfDownloadHref={
 					state.type === "second_round"
-						? "/api/declaration-pdf?type=correction"
-						: "/api/declaration-pdf"
+						? `/api/declaration-pdf?type=correction&year=${currentYear}`
+						: `/api/declaration-pdf?year=${currentYear}`
 				}
 			/>
 		</HydrateClient>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-import { getCurrentYear, normalizeDecimalInput } from "~/modules/domain";
+import { normalizeDecimalInput } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep2Schema } from "../schemas";
@@ -24,11 +24,16 @@ import { TooltipButton } from "../shared/TooltipButton";
 import type { PayGapField, Step2Data } from "../types";
 
 type Step2PayGapProps = {
+	declarationYear: number;
 	initialData: Step2Data;
 	gipPrefillData?: GipPrefillData;
 };
 
-export function Step2PayGap({ initialData, gipPrefillData }: Step2PayGapProps) {
+export function Step2PayGap({
+	declarationYear,
+	initialData,
+	gipPrefillData,
+}: Step2PayGapProps) {
 	const router = useRouter();
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
@@ -47,8 +52,6 @@ export function Step2PayGap({ initialData, gipPrefillData }: Step2PayGapProps) {
 
 	const [saved, setSaved] = useState(hasInitialData);
 	const [validationError, setValidationError] = useState<string | null>(null);
-
-	const currentYear = getCurrentYear();
 
 	const mutation = api.declaration.updateStep2.useMutation({
 		onSuccess: () => router.push("/declaration-remuneration/etape/3"),
@@ -90,7 +93,7 @@ export function Step2PayGap({ initialData, gipPrefillData }: Step2PayGapProps) {
 				saved={saved}
 				title={
 					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {currentYear}
+						Déclaration des indicateurs de rémunération {declarationYear}
 					</h1>
 				}
 			/>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -2,11 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import {
-	computeProportion,
-	getCurrentYear,
-	normalizeDecimalInput,
-} from "~/modules/domain";
+import { computeProportion, normalizeDecimalInput } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep3Schema } from "../schemas";
@@ -32,6 +28,7 @@ import type { PayGapField, Step3Data } from "../types";
 import stepStyles from "./Step3VariablePay.module.scss";
 
 type Step3VariablePayProps = {
+	declarationYear: number;
 	initialData: Step3Data;
 	gipPrefillData?: GipPrefillData;
 	maxWomen?: number;
@@ -39,6 +36,7 @@ type Step3VariablePayProps = {
 };
 
 export function Step3VariablePay({
+	declarationYear,
 	initialData,
 	gipPrefillData,
 	maxWomen,
@@ -67,8 +65,6 @@ export function Step3VariablePay({
 	>(null);
 	const [saved, setSaved] = useState(hasInitialData);
 	const [validationError, setValidationError] = useState<string | null>(null);
-
-	const currentYear = getCurrentYear();
 
 	const mutation = api.declaration.updateStep3.useMutation({
 		onSuccess: () => router.push("/declaration-remuneration/etape/4"),
@@ -137,7 +133,7 @@ export function Step3VariablePay({
 				saved={saved}
 				title={
 					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {currentYear}
+						Déclaration des indicateurs de rémunération {declarationYear}
 					</h1>
 				}
 			/>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { getCurrentYear, normalizeDecimalInput } from "~/modules/domain";
+import { normalizeDecimalInput } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep4Schema } from "../schemas";
@@ -52,6 +52,7 @@ function emptyQuartiles(): QuartileTuple {
 }
 
 type Step4QuartileDistributionProps = {
+	declarationYear: number;
 	initialData: Step4Data;
 	gipPrefillData?: GipPrefillData;
 	maxWomen?: number;
@@ -59,6 +60,7 @@ type Step4QuartileDistributionProps = {
 };
 
 export function Step4QuartileDistribution({
+	declarationYear,
 	initialData,
 	gipPrefillData,
 	maxWomen,
@@ -101,8 +103,6 @@ export function Step4QuartileDistribution({
 	const [formValidationError, setFormValidationError] = useState<string | null>(
 		null,
 	);
-
-	const currentYear = getCurrentYear();
 
 	const mutation = api.declaration.updateStep4.useMutation({
 		onSuccess: () => router.push("/declaration-remuneration/etape/5"),
@@ -188,7 +188,7 @@ export function Step4QuartileDistribution({
 				saved={saved}
 				title={
 					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {currentYear}
+						Déclaration des indicateurs de rémunération {declarationYear}
 					</h1>
 				}
 			/>
@@ -238,7 +238,7 @@ export function Step4QuartileDistribution({
 							<QuartileReadingNote
 								categories={annual}
 								tableType="annual"
-								year={currentYear}
+								year={declarationYear}
 							/>
 						) : undefined
 					}
@@ -267,7 +267,7 @@ export function Step4QuartileDistribution({
 							<QuartileReadingNote
 								categories={hourly}
 								tableType="hourly"
-								year={currentYear}
+								year={declarationYear}
 							/>
 						) : undefined
 					}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -2,13 +2,13 @@
 
 import { useRouter } from "next/navigation";
 
-import { getCurrentYear } from "~/modules/domain";
 import { api } from "~/trpc/react";
 import { StepIndicator } from "../shared/StepIndicator";
 import type { EmployeeCategoryRow } from "../types";
 import { CategoryForm } from "./step5/CategoryForm";
 
 type Props = {
+	declarationYear: number;
 	initialCategories?: EmployeeCategoryRow[];
 	initialSource?: string;
 	maxWomen?: number;
@@ -16,12 +16,12 @@ type Props = {
 };
 
 export function Step5EmployeeCategories({
+	declarationYear,
 	initialCategories,
 	initialSource,
 	maxWomen,
 	maxMen,
 }: Props) {
-	const currentYear = getCurrentYear();
 	const router = useRouter();
 
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
@@ -31,6 +31,7 @@ export function Step5EmployeeCategories({
 	return (
 		<CategoryForm
 			accordionId="accordion-step5"
+			declarationYear={declarationYear}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
@@ -49,7 +50,7 @@ export function Step5EmployeeCategories({
 			submitError={mutation.error?.message}
 			title={
 				<h1 className="fr-h4 fr-mb-0">
-					Déclaration des indicateurs de rémunération {currentYear}
+					Déclaration des indicateurs de rémunération {declarationYear}
 				</h1>
 			}
 			tooltipPrefix="tooltip-step5"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -31,7 +31,6 @@ export function Step5EmployeeCategories({
 	return (
 		<CategoryForm
 			accordionId="accordion-step5"
-			declarationYear={declarationYear}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
@@ -46,6 +45,7 @@ export function Step5EmployeeCategories({
 				})
 			}
 			previousHref="/declaration-remuneration/etape/4"
+			referenceYear={declarationYear - 1}
 			stepper={<StepIndicator currentStep={5} />}
 			submitError={mutation.error?.message}
 			title={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -4,11 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
 import { DownloadDeclarationPdfButton } from "~/modules/declarationPdf";
-import {
-	computeGap,
-	GAP_ALERT_THRESHOLD,
-	getCurrentYear,
-} from "~/modules/domain";
+import { computeGap, GAP_ALERT_THRESHOLD } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import common from "../shared/common.module.scss";
@@ -43,6 +39,7 @@ type Props = {
 		totalMen: number | null;
 		status: string | null;
 	};
+	declarationYear: number;
 	step2Data: Step2Data;
 	step3Data: Step3Data;
 	step4Data: Step4Data;
@@ -52,13 +49,13 @@ type Props = {
 
 export function Step6Review({
 	declaration,
+	declarationYear,
 	step2Data,
 	step3Data,
 	step4Data,
 	step5Categories = [],
 	isSubmitted = false,
 }: Props) {
-	const currentYear = getCurrentYear();
 	const router = useRouter();
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const submitMutation = api.declaration.submit.useMutation({
@@ -159,7 +156,7 @@ export function Step6Review({
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 				<div className="fr-col">
 					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {currentYear}
+						Déclaration des indicateurs de rémunération {declarationYear}
 					</h1>
 				</div>
 				<div className="fr-col-auto">
@@ -329,7 +326,7 @@ export function Step6Review({
 				)}
 			</div>
 
-			{isSubmitted && <DownloadDeclarationPdfButton />}
+			{isSubmitted && <DownloadDeclarationPdfButton year={declarationYear} />}
 
 			{/* Next steps callout when high gap detected */}
 			{highGap && declaration.siren && (
@@ -362,7 +359,7 @@ export function Step6Review({
 					modalRef={modalRef}
 					onClose={closeModal}
 					onSubmit={() => submitMutation.mutate()}
-					year={currentYear}
+					year={declarationYear}
 				/>
 			)}
 		</form>

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { getCurrentYear } from "~/modules/domain";
 
 vi.mock(
 	"~/modules/declaration-remuneration/shared/ComplianceCompletionEffect",
@@ -9,11 +8,26 @@ vi.mock(
 	}),
 );
 
+vi.mock("~/trpc/server", () => ({
+	api: {
+		declaration: {
+			getOrCreate: vi.fn().mockResolvedValue({
+				declaration: { year: 2025 },
+				jobCategories: [],
+				employeeCategories: [],
+				gipPrefillData: null,
+			}),
+		},
+	},
+}));
+
+const DECLARATION_YEAR = 2025;
+
 import { ComplianceConfirmation } from "../ComplianceConfirmation";
 
 describe("ComplianceConfirmation", () => {
-	it("renders the confirmation title", () => {
-		render(<ComplianceConfirmation />);
+	it("renders the confirmation title", async () => {
+		render(await ComplianceConfirmation());
 
 		expect(
 			screen.getByRole("heading", {
@@ -22,38 +36,42 @@ describe("ComplianceConfirmation", () => {
 		).toBeInTheDocument();
 	});
 
-	it("displays the completion message with current year", () => {
-		render(<ComplianceConfirmation />);
+	it("displays the completion message with declaration year", async () => {
+		render(await ComplianceConfirmation());
 
-		const year = getCurrentYear();
 		expect(
 			screen.getByText(
-				new RegExp(`Votre parcours de mise en conformité ${year} est terminé`),
+				new RegExp(
+					`Votre parcours de mise en conformité ${DECLARATION_YEAR} est terminé`,
+				),
 			),
 		).toBeInTheDocument();
 	});
 
-	it("shows the no CSE message", () => {
-		render(<ComplianceConfirmation />);
+	it("shows the no CSE message", async () => {
+		render(await ComplianceConfirmation());
 
 		expect(
 			screen.getByText(/Votre entreprise ne dispose pas de CSE/),
 		).toBeInTheDocument();
 	});
 
-	it("has a link to mon espace", () => {
-		render(<ComplianceConfirmation />);
+	it("has a link to mon espace", async () => {
+		render(await ComplianceConfirmation());
 
 		const link = screen.getByRole("link", { name: "Mon espace" });
 		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
-	it("has a download PDF button", () => {
-		render(<ComplianceConfirmation />);
+	it("has a download PDF button with year", async () => {
+		render(await ComplianceConfirmation());
 
 		const link = screen.getByRole("link", {
 			name: /Télécharger le récapitulatif/,
 		});
-		expect(link).toHaveAttribute("href", "/api/declaration-pdf");
+		expect(link).toHaveAttribute(
+			"href",
+			`/api/declaration-pdf?year=${DECLARATION_YEAR}`,
+		);
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
@@ -35,7 +35,9 @@ const emptyStep2Data = () => ({
 describe("Step2PayGap dev fill", () => {
 	it("fills pay gap rows when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -32,7 +32,9 @@ const emptyStep2Data = () => ({
 
 describe("Step2PayGap", () => {
 	it("renders the table with 4 remuneration rows", () => {
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 		expect(screen.getByText("Annuelle brute moyenne")).toBeInTheDocument();
 		expect(screen.getByText("Horaire brute moyenne")).toBeInTheDocument();
 		expect(screen.getByText("Annuelle brute médiane")).toBeInTheDocument();
@@ -40,7 +42,9 @@ describe("Step2PayGap", () => {
 	});
 
 	it("renders instruction text and mandatory fields notice", () => {
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 		expect(
 			screen.getByText(
 				"Renseignez les informations avant de valider vos indicateurs.",
@@ -52,7 +56,9 @@ describe("Step2PayGap", () => {
 	});
 
 	it("renders table headers", () => {
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 		expect(screen.getByText("Rémunération")).toBeInTheDocument();
 		expect(screen.getByText("Femmes")).toBeInTheDocument();
 		expect(screen.getByText("Hommes")).toBeInTheDocument();
@@ -65,6 +71,7 @@ describe("Step2PayGap", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step2PayGap
+				declarationYear={2025}
 				initialData={{
 					indicatorAAnnualWomen: "100",
 					indicatorAAnnualMen: "200",
@@ -81,13 +88,17 @@ describe("Step2PayGap", () => {
 	});
 
 	it("does not show SavedIndicator when initialData is empty", () => {
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 
 	it("updates values via inline inputs and rejects negative values", async () => {
 		const user = userEvent.setup();
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
 		const menInput = screen.getByLabelText("Annuelle brute moyenne — Hommes");
@@ -108,7 +119,9 @@ describe("Step2PayGap", () => {
 
 	it("computes gap and shows badge after entering values", async () => {
 		const user = userEvent.setup();
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
 		const menInput = screen.getByLabelText("Annuelle brute moyenne — Hommes");
@@ -125,7 +138,9 @@ describe("Step2PayGap", () => {
 
 	it("shows no badge when gap is less than 5%", async () => {
 		const user = userEvent.setup();
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
 		const menInput = screen.getByLabelText("Annuelle brute moyenne — Hommes");
@@ -142,7 +157,9 @@ describe("Step2PayGap", () => {
 	});
 
 	it("renders previous link pointing to step 1", () => {
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/1",
@@ -152,6 +169,7 @@ describe("Step2PayGap", () => {
 	it("uses gipPrefillData when no initialData", () => {
 		render(
 			<Step2PayGap
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
 					step2: {
@@ -201,7 +219,9 @@ describe("Step2PayGap", () => {
 
 	it("shows validation error on submit when fields are incomplete", async () => {
 		const user = userEvent.setup();
-		render(<Step2PayGap initialData={emptyStep2Data()} />);
+		render(
+			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });
 		await user.click(submitButton);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
@@ -37,7 +37,12 @@ const emptyStep3Data = () => ({
 describe("Step3VariablePay dev fill", () => {
 	it("fills rows and beneficiaries when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -34,7 +34,12 @@ const emptyStep3Data = () => ({
 
 describe("Step3VariablePay", () => {
 	it("renders the pay gap table with 4 rows", () => {
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 		expect(screen.getByText("Annuelle brute moyenne")).toBeInTheDocument();
 		expect(screen.getByText("Horaire brute moyenne")).toBeInTheDocument();
 		expect(screen.getByText("Annuelle brute médiane")).toBeInTheDocument();
@@ -44,6 +49,7 @@ describe("Step3VariablePay", () => {
 	it("renders the beneficiaries table with workforce totals", () => {
 		render(
 			<Step3VariablePay
+				declarationYear={2025}
 				initialData={emptyStep3Data()}
 				maxMen={60}
 				maxWomen={50}
@@ -56,7 +62,12 @@ describe("Step3VariablePay", () => {
 	});
 
 	it("renders instruction text and mandatory fields notice", () => {
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 		expect(
 			screen.getByText(
 				"Renseignez les informations avant de valider vos indicateurs.",
@@ -69,7 +80,10 @@ describe("Step3VariablePay", () => {
 
 	it("renders table headers with line break in column header", () => {
 		const { container } = render(
-			<Step3VariablePay initialData={emptyStep3Data()} />,
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
 		);
 		expect(screen.getByText(/Rémunération variable/)).toBeInTheDocument();
 		expect(screen.getByText("Seuil réglementaire : 5%")).toBeInTheDocument();
@@ -81,6 +95,7 @@ describe("Step3VariablePay", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step3VariablePay
+				declarationYear={2025}
 				initialData={{
 					indicatorBAnnualWomen: "100",
 					indicatorBAnnualMen: "200",
@@ -99,13 +114,23 @@ describe("Step3VariablePay", () => {
 	});
 
 	it("does not show SavedIndicator when initialData is empty", () => {
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 
 	it("updates pay gap values via inline inputs and rejects negative values", async () => {
 		const user = userEvent.setup();
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
 		const menInput = screen.getByLabelText("Annuelle brute moyenne — Hommes");
@@ -126,7 +151,12 @@ describe("Step3VariablePay", () => {
 
 	it("computes gap and shows badge after entering values", async () => {
 		const user = userEvent.setup();
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
 		const menInput = screen.getByLabelText("Annuelle brute moyenne — Hommes");
@@ -143,7 +173,12 @@ describe("Step3VariablePay", () => {
 
 	it("updates beneficiary values via inline inputs", async () => {
 		const user = userEvent.setup();
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 
 		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
 		const menInput = screen.getByLabelText("Bénéficiaires hommes");
@@ -161,6 +196,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationYear={2025}
 				initialData={emptyStep3Data()}
 				maxMen={25}
 				maxWomen={15}
@@ -177,7 +213,12 @@ describe("Step3VariablePay", () => {
 	});
 
 	it("renders previous link pointing to step 2", () => {
-		render(<Step3VariablePay initialData={emptyStep3Data()} />);
+		render(
+			<Step3VariablePay
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/2",
@@ -187,6 +228,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData when no initialData", () => {
 		render(
 			<Step3VariablePay
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },
 					step2: {
@@ -240,6 +282,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData with null beneficiary counts", () => {
 		render(
 			<Step3VariablePay
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },
 					step2: {
@@ -292,6 +335,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData with zero beneficiary counts", () => {
 		render(
 			<Step3VariablePay
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },
 					step2: {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
@@ -39,7 +39,12 @@ const emptyStep4Data = () => ({
 describe("Step4QuartileDistribution dev fill", () => {
 	it("fills both tables when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -36,7 +36,12 @@ const emptyStep4Data = () => ({
 
 describe("Step4QuartileDistribution", () => {
 	it("renders two tables with quartile columns", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(
 			screen.getByText("Rémunération annuelle brute moyenne", {
 				selector: "h3",
@@ -56,7 +61,12 @@ describe("Step4QuartileDistribution", () => {
 	});
 
 	it("renders all row labels in both tables", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(screen.getAllByText(/annuelle brute/).length).toBeGreaterThanOrEqual(
 			1,
 		);
@@ -68,14 +78,24 @@ describe("Step4QuartileDistribution", () => {
 	});
 
 	it("renders description text about quartiles", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(
 			screen.getByText(/compare la proportion de femmes et d'hommes/),
 		).toBeInTheDocument();
 	});
 
 	it("renders instruction text and mandatory fields notice", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(
 			screen.getByText(
 				"Renseignez les informations avant de valider vos indicateurs.",
@@ -89,6 +109,7 @@ describe("Step4QuartileDistribution", () => {
 	it("displays pre-filled data with computed percentages", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationYear={2025}
 				initialData={{
 					annual: [
 						{ threshold: "980", women: 19, men: 22 },
@@ -122,6 +143,7 @@ describe("Step4QuartileDistribution", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationYear={2025}
 				initialData={{
 					annual: [
 						{ threshold: "", women: 10, men: 15 },
@@ -142,12 +164,22 @@ describe("Step4QuartileDistribution", () => {
 	});
 
 	it("does not show SavedIndicator when no initial data", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 
 	it("renders inline inputs for remuneration, women count, and men count", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		// 4 quartiles × 2 tables = 8 inputs per row type
 		expect(screen.getAllByLabelText(/Rémunération brute/).length).toBe(8);
 		expect(screen.getAllByLabelText(/Nombre de femmes/).length).toBe(8);
@@ -156,7 +188,12 @@ describe("Step4QuartileDistribution", () => {
 
 	it("updates remuneration values via inline inputs", async () => {
 		const user = userEvent.setup();
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 
 		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
 		const q1Input = remuInputs[0] as HTMLInputElement;
@@ -168,7 +205,12 @@ describe("Step4QuartileDistribution", () => {
 
 	it("rejects negative values in remuneration inputs", async () => {
 		const user = userEvent.setup();
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 
 		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
 		const q1Input = remuInputs[0] as HTMLInputElement;
@@ -182,6 +224,7 @@ describe("Step4QuartileDistribution", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationYear={2025}
 				initialData={emptyStep4Data()}
 				maxMen={25}
 				maxWomen={15}
@@ -198,14 +241,24 @@ describe("Step4QuartileDistribution", () => {
 	});
 
 	it("renders accordion", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(
 			screen.getByText("Définitions et méthode de calcul"),
 		).toBeInTheDocument();
 	});
 
 	it("renders previous link pointing to step 3", () => {
-		render(<Step4QuartileDistribution initialData={emptyStep4Data()} />);
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/3",
@@ -215,6 +268,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData when no initialCategories", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
 					step2: {
@@ -271,6 +325,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData with null Q4 threshold", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
 					step2: {
@@ -324,6 +379,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData with all null quartile data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: null, totalMen: null },
 					step2: {
@@ -376,6 +432,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData with mono-gender quartiles (100% women)", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 200, totalMen: 0 },
 					step2: {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
@@ -29,7 +29,7 @@ beforeEach(() => {
 describe("Step5EmployeeCategories dev fill", () => {
 	it("fills categories when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -48,7 +48,7 @@ function makeCategory(
 
 describe("Step5EmployeeCategories", () => {
 	it("renders with 1 empty category by default", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(
 			screen.getByRole("button", { name: "Catégorie d'emplois n°1" }),
 		).toBeInTheDocument();
@@ -59,12 +59,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders stepper at step 5", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(screen.getByText("Étape 5 sur 6")).toBeInTheDocument();
 	});
 
 	it("renders description text and reference period", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(
 			screen.getByText(/mesurer l'écart de rémunération/),
 		).toBeInTheDocument();
@@ -72,7 +72,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders source dropdown", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(
 			screen.getByLabelText(/Quelle est la source utilisée/),
 		).toBeInTheDocument();
@@ -80,7 +80,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders instruction text", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(
 			screen.getByText(/Saisissez les données manquantes/),
 		).toBeInTheDocument();
@@ -90,7 +90,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table headers for the category", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(screen.getAllByText("Femmes").length).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByText("Hommes").length).toBeGreaterThanOrEqual(1);
 		expect(
@@ -99,7 +99,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table section headers", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(
 			screen.getAllByText("Nombre de salariés [Nombre total]").length,
 		).toBe(1);
@@ -108,14 +108,14 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders name and detail input fields for category", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(document.getElementById("cat-0-name")).toBeInTheDocument();
 		expect(document.getElementById("cat-0-detail")).toBeInTheDocument();
 	});
 
 	it("can add a new category", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		await user.click(
 			screen.getByRole("button", {
@@ -131,7 +131,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("can remove a category after confirmation", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		// Add a second category first
 		await user.click(
@@ -159,7 +159,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("updates input fields and computes gap", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		const annualBaseWomenInput = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -177,7 +177,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("accepts salary values above 9999", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -189,7 +189,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("rejects negative values in number inputs", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -205,7 +205,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("computes annual total from base and variable", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		await user.type(
 			screen.getByLabelText("Salaire de base annuel femmes, catégorie 1"),
@@ -224,6 +224,7 @@ describe("Step5EmployeeCategories", () => {
 	it("shows SavedIndicator when initial data exists", () => {
 		render(
 			<Step5EmployeeCategories
+				declarationYear={2025}
 				initialCategories={[
 					makeCategory({
 						name: "Ingénieurs",
@@ -241,13 +242,14 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("does not show SavedIndicator with empty initial data", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 
 	it("deserializes initial data into form fields", () => {
 		render(
 			<Step5EmployeeCategories
+				declarationYear={2025}
 				initialCategories={[
 					makeCategory({
 						name: "Cadres",
@@ -273,7 +275,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("submits data on form submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		const nameInput = screen.getByLabelText("Nom", {
 			selector: "#cat-0-name",
@@ -297,7 +299,13 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when workforce totals do not match step 1", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories maxMen={20} maxWomen={10} />);
+		render(
+			<Step5EmployeeCategories
+				declarationYear={2025}
+				maxMen={20}
+				maxWomen={10}
+			/>,
+		);
 
 		// Fill required name first
 		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
@@ -319,7 +327,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category name is empty on submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
@@ -331,7 +339,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category names are duplicated", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 
 		// Fill first category name
 		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
@@ -353,7 +361,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders previous link pointing to step 4", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/4",
@@ -361,7 +369,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders accordion for definitions", () => {
-		render(<Step5EmployeeCategories />);
+		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(
 			screen.getByText("Définitions et méthode de calcul"),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -4,8 +4,12 @@ import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/typ
 import { Step6Review } from "../Step6Review";
 
 vi.mock("~/modules/declarationPdf", () => ({
-	DownloadDeclarationPdfButton: () => (
-		<a href="/api/declaration-pdf">Télécharger le récapitulatif (PDF)</a>
+	DownloadDeclarationPdfButton: ({ year }: { year?: number }) => (
+		<a
+			href={year ? `/api/declaration-pdf?year=${year}` : "/api/declaration-pdf"}
+		>
+			Télécharger le récapitulatif (PDF)
+		</a>
 	),
 }));
 
@@ -104,6 +108,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -119,6 +124,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -133,6 +139,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -150,6 +157,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -162,6 +170,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -189,6 +198,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -201,6 +211,7 @@ describe("Step6Review", () => {
 		const { container } = render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -214,6 +225,7 @@ describe("Step6Review", () => {
 		const { container } = render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -227,6 +239,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={{
 					indicatorAAnnualWomen: "95",
 					indicatorAAnnualMen: "100",
@@ -259,6 +272,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -272,6 +286,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={{
 					indicatorBAnnualWomen: "95",
@@ -297,6 +312,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={{
@@ -330,6 +346,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -367,6 +384,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -382,6 +400,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -396,6 +415,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				isSubmitted
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
@@ -412,6 +432,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				isSubmitted
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
@@ -432,6 +453,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				isSubmitted
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
@@ -440,13 +462,14 @@ describe("Step6Review", () => {
 		);
 		expect(
 			screen.getByRole("link", { name: /télécharger le récapitulatif/i }),
-		).toHaveAttribute("href", "/api/declaration-pdf");
+		).toHaveAttribute("href", "/api/declaration-pdf?year=2025");
 	});
 
 	it("does not render PDF download button when not submitted", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -466,6 +489,7 @@ describe("Step6Review", () => {
 					totalMen: null,
 					status: null,
 				}}
+				declarationYear={2025}
 				step2Data={{
 					indicatorAAnnualWomen: "90",
 					indicatorAAnnualMen: "100",
@@ -501,6 +525,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -515,6 +540,7 @@ describe("Step6Review", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
+				declarationYear={2025}
 				step2Data={{
 					indicatorAAnnualWomen: "98",
 					indicatorAAnnualMen: "100",

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 
-import { getCurrentYear } from "~/modules/domain";
 import { api } from "~/trpc/server";
 
 import { JointEvaluationForm } from "./JointEvaluationForm";
@@ -13,7 +12,7 @@ export async function JointEvaluationPage() {
 	}
 
 	const company = await api.company.get({ siren: data.declaration.siren });
-	const currentYear = getCurrentYear();
+	const currentYear = data.declaration.year;
 	const declarationDate = data.declaration.updatedAt
 		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
 		: new Date().toLocaleDateString("fr-FR");

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationPage.test.tsx
@@ -34,13 +34,19 @@ vi.mock("../JointEvaluationForm", () => ({
 }));
 
 import { redirect } from "next/navigation";
-import { getCurrentYear } from "~/modules/domain";
 import { api } from "~/trpc/server";
 import { JointEvaluationPage } from "../JointEvaluationPage";
 
+const DECLARATION_YEAR = 2025;
+
 function mockDeclaration(compliancePath: string, updatedAt: Date | null) {
 	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
-		declaration: { compliancePath, updatedAt },
+		declaration: {
+			compliancePath,
+			updatedAt,
+			siren: "123456789",
+			year: DECLARATION_YEAR,
+		},
 	} as never);
 	vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
 }
@@ -63,7 +69,7 @@ describe("JointEvaluationPage", () => {
 		render(page);
 
 		expect(screen.getByTestId("current-year")).toHaveTextContent(
-			String(getCurrentYear()),
+			String(DECLARATION_YEAR),
 		);
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -11,6 +11,7 @@ import { ReferencePeriodPicker } from "./ReferencePeriodPicker";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 type Props = {
+	declarationYear: number;
 	initialFirstDeclarationCategories: EmployeeCategoryRow[];
 	initialSecondDeclarationCategories?: EmployeeCategoryRow[];
 	initialSource?: string;
@@ -19,6 +20,7 @@ type Props = {
 };
 
 export function SecondDeclarationStep2Form({
+	declarationYear,
 	initialFirstDeclarationCategories,
 	initialSecondDeclarationCategories,
 	initialSource,
@@ -43,6 +45,7 @@ export function SecondDeclarationStep2Form({
 	return (
 		<CategoryForm
 			accordionId="accordion-second-decl"
+			declarationYear={declarationYear}
 			descriptionText="Cette seconde déclaration reprend les catégories de salariés définies lors de la première déclaration. Elle permet de mesurer les écarts de rémunération entre les femmes et les hommes au sein de chaque catégorie, en distinguant le salaire de base des composantes variables ou complémentaires."
 			initialCategories={sourceData}
 			initialSource={initialSource}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -76,7 +76,7 @@ export function SecondDeclarationStep2Form({
 					startDate={startDate}
 				/>
 			}
-			referenceYear={declarationYear}
+			referenceYear={declarationYear - 1}
 			stepper={<SecondDeclarationStepIndicator currentStep={2} />}
 			submitError={periodError || mutation.error?.message}
 			title={

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -45,7 +45,6 @@ export function SecondDeclarationStep2Form({
 	return (
 		<CategoryForm
 			accordionId="accordion-second-decl"
-			declarationYear={declarationYear}
 			descriptionText="Cette seconde déclaration reprend les catégories de salariés définies lors de la première déclaration. Elle permet de mesurer les écarts de rémunération entre les femmes et les hommes au sein de chaque catégorie, en distinguant le salaire de base des composantes variables ou complémentaires."
 			initialCategories={sourceData}
 			initialSource={initialSource}
@@ -77,6 +76,7 @@ export function SecondDeclarationStep2Form({
 					startDate={startDate}
 				/>
 			}
+			referenceYear={declarationYear}
 			stepper={<SecondDeclarationStepIndicator currentStep={2} />}
 			submitError={periodError || mutation.error?.message}
 			title={

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -9,7 +9,7 @@ import { NextStepsBox } from "~/modules/declaration-remuneration/shared/NextStep
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { SubmitDeclarationModal } from "~/modules/declaration-remuneration/shared/SubmitDeclarationModal";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
-import { GAP_ALERT_THRESHOLD, getCurrentYear } from "~/modules/domain";
+import { GAP_ALERT_THRESHOLD } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import stepStyles from "../Step6Review.module.scss";
@@ -20,19 +20,20 @@ import { BASE_PATH } from "./constants";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 type Props = {
+	declarationYear: number;
 	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
 	siren: string;
 };
 
 export function SecondDeclarationStep3Review({
+	declarationYear,
 	hasCse,
 	secondDeclarationCategories,
 	siren,
 }: Props) {
 	const router = useRouter();
 	const modalRef = useRef<HTMLDialogElement>(null);
-	const currentYear = getCurrentYear();
 
 	const parsed = parseEmployeeCategories(secondDeclarationCategories);
 	const gapsExist = parsed.some(
@@ -154,7 +155,7 @@ export function SecondDeclarationStep3Review({
 				modalRef={modalRef}
 				onClose={closeModal}
 				onSubmit={() => mutation.mutate()}
-				year={currentYear}
+				year={declarationYear}
 			/>
 		</form>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 
-import { getCurrentYear } from "~/modules/domain";
 import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
 import { api, HydrateClient } from "~/trpc/server";
 
@@ -20,7 +19,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 
 	const data = await api.declaration.getOrCreate();
 	const company = await api.company.get({ siren: data.declaration.siren });
-	const currentYear = getCurrentYear();
+	const currentYear = data.declaration.year;
 
 	const initialCategories = mapToEmployeeCategoryRows(
 		data.jobCategories,
@@ -58,6 +57,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 		return (
 			<HydrateClient>
 				<SecondDeclarationStep2Form
+					declarationYear={currentYear}
 					initialEndDate={
 						data.declaration.secondDeclReferencePeriodEnd ?? undefined
 					}
@@ -81,6 +81,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 	return (
 		<HydrateClient>
 			<SecondDeclarationStep3Review
+				declarationYear={currentYear}
 				hasCse={company.hasCse}
 				secondDeclarationCategories={reviewCategories}
 				siren={data.declaration.siren}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -58,6 +58,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("renders the title and step indicator", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -72,6 +73,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("displays category name as read-only text", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -88,6 +90,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("displays detail as read-only text", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -100,6 +103,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("displays source as read-only text", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 				initialSource="convention-collective"
 			/>,
@@ -116,6 +120,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("renders reference period date pickers", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -129,6 +134,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("does not render add category button (read-only categories)", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -140,6 +146,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("renders previous link to step 1", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
@@ -169,6 +176,7 @@ describe("SecondDeclarationStep2Form", () => {
 
 		render(
 			<SecondDeclarationStep2Form
+				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 				initialSecondDeclarationCategories={secondDeclData}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -83,6 +83,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the title and step indicator", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 				siren="532847196"
@@ -99,6 +100,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders category gap card with category name", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 				siren="532847196"
@@ -110,6 +112,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders gap columns", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 				siren="532847196"
@@ -126,6 +129,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the next steps section", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 				siren="532847196"
@@ -137,6 +141,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders Soumettre button", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 				siren="532847196"
@@ -150,6 +155,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders modal with certification checkbox", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 				siren="532847196"
@@ -167,6 +173,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders previous link to step 2", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
 				siren="532847196"
@@ -197,6 +204,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={categoriesWithHighGaps}
 				siren="532847196"
@@ -224,6 +232,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={categoriesWithLowGaps}
 				siren="532847196"
@@ -245,6 +254,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={true}
 				secondDeclarationCategories={categoriesWithHighGaps}
 				siren="532847196"
@@ -281,6 +291,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={true}
 				secondDeclarationCategories={categoriesNoGaps}
 				siren="532847196"
@@ -313,6 +324,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={false}
 				secondDeclarationCategories={categoriesNoGaps}
 				siren="532847196"
@@ -339,6 +351,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders empty state when no categories", () => {
 		render(
 			<SecondDeclarationStep3Review
+				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={[]}
 				siren="532847196"

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -59,7 +59,7 @@ function toFormValues(cats: EmployeeCategory[]) {
 }
 
 type Props = {
-	declarationYear: number;
+	referenceYear: number;
 	title: ReactNode;
 	stepper: ReactNode;
 	instructionText: string;
@@ -79,7 +79,7 @@ type Props = {
 };
 
 export function CategoryForm({
-	declarationYear,
+	referenceYear,
 	title,
 	stepper,
 	instructionText,
@@ -97,7 +97,6 @@ export function CategoryForm({
 	referencePeriodPicker,
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 }: Props) {
-	const referenceYear = declarationYear - 1;
 	const baseId = useId();
 	const nextId = useRef(createIdGenerator()).current;
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -18,7 +18,6 @@ import type {
 	EmployeeCategoryRow,
 	EmployeeCategorySubmitData,
 } from "~/modules/declaration-remuneration/types";
-import { getCurrentYear } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import stepStyles from "../Step5EmployeeCategories.module.scss";
 import { CategoryDataTable } from "./CategoryDataTable";
@@ -60,6 +59,7 @@ function toFormValues(cats: EmployeeCategory[]) {
 }
 
 type Props = {
+	declarationYear: number;
 	title: ReactNode;
 	stepper: ReactNode;
 	instructionText: string;
@@ -79,6 +79,7 @@ type Props = {
 };
 
 export function CategoryForm({
+	declarationYear,
 	title,
 	stepper,
 	instructionText,
@@ -96,8 +97,7 @@ export function CategoryForm({
 	referencePeriodPicker,
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 }: Props) {
-	const currentYear = getCurrentYear();
-	const referenceYear = currentYear - 1;
+	const referenceYear = declarationYear - 1;
 	const baseId = useId();
 	const nextId = useRef(createIdGenerator()).current;
 

--- a/packages/app/src/modules/declarationPdf/DownloadDeclarationPdfButton.tsx
+++ b/packages/app/src/modules/declarationPdf/DownloadDeclarationPdfButton.tsx
@@ -1,9 +1,17 @@
-export function DownloadDeclarationPdfButton() {
+type Props = {
+	year?: number;
+};
+
+export function DownloadDeclarationPdfButton({ year }: Props) {
+	const href = year
+		? `/api/declaration-pdf?year=${year}`
+		: "/api/declaration-pdf";
+
 	return (
 		<a
 			className="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-file-pdf-line"
 			download
-			href="/api/declaration-pdf"
+			href={href}
 		>
 			Télécharger le récapitulatif (PDF)
 		</a>

--- a/packages/app/src/modules/declarationPdf/TransmittedPdfDocument.tsx
+++ b/packages/app/src/modules/declarationPdf/TransmittedPdfDocument.tsx
@@ -92,7 +92,9 @@ export function TransmittedPdfDocument({ data }: Props) {
 					<Text style={styles.title}>
 						Récapitulatif des éléments transmis {data.year + 1}
 					</Text>
-					<Text style={styles.subtitle}>Au titre des données {data.year}</Text>
+					<Text style={styles.subtitle}>
+						Au titre des données {data.year - 1}
+					</Text>
 					<Text style={styles.companyInfo}>
 						{data.companyName} — SIREN {data.siren}
 					</Text>

--- a/packages/app/src/modules/declarationPdf/TransmittedPdfDocument.tsx
+++ b/packages/app/src/modules/declarationPdf/TransmittedPdfDocument.tsx
@@ -93,7 +93,7 @@ export function TransmittedPdfDocument({ data }: Props) {
 						Récapitulatif des éléments transmis {data.year + 1}
 					</Text>
 					<Text style={styles.subtitle}>
-						Au titre des données {data.year - 1}
+						Au titre des données {data.dataYear}
 					</Text>
 					<Text style={styles.companyInfo}>
 						{data.companyName} — SIREN {data.siren}

--- a/packages/app/src/modules/declarationPdf/__tests__/DownloadDeclarationPdfButton.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/DownloadDeclarationPdfButton.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DownloadDeclarationPdfButton } from "../DownloadDeclarationPdfButton";
+
+describe("DownloadDeclarationPdfButton", () => {
+	it("renders a download link with year query param when year is provided", () => {
+		render(<DownloadDeclarationPdfButton year={2025} />);
+
+		const link = screen.getByRole("link", {
+			name: /Télécharger le récapitulatif/,
+		});
+		expect(link).toHaveAttribute("href", "/api/declaration-pdf?year=2025");
+		expect(link).toHaveAttribute("download");
+	});
+
+	it("renders a download link without year param when year is omitted", () => {
+		render(<DownloadDeclarationPdfButton />);
+
+		const link = screen.getByRole("link", {
+			name: /Télécharger le récapitulatif/,
+		});
+		expect(link).toHaveAttribute("href", "/api/declaration-pdf");
+	});
+});

--- a/packages/app/src/modules/declarationPdf/__tests__/TransmittedPdfDocument.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/TransmittedPdfDocument.test.tsx
@@ -39,6 +39,7 @@ import { TransmittedPdfDocument } from "../TransmittedPdfDocument";
 const transmittedPdfData: TransmittedPdfData = {
 	companyName: "Acme Corp",
 	siren: "123456789",
+	dataYear: 2024,
 	year: 2025,
 	generatedAt: "10 mars 2026",
 	opinions: [
@@ -128,6 +129,7 @@ describe("TransmittedPdfDocument", () => {
 		const emptyData: TransmittedPdfData = {
 			companyName: "Empty Corp",
 			siren: "987654321",
+			dataYear: 2024,
 			year: 2025,
 			generatedAt: "15 mars 2026",
 			opinions: [],

--- a/packages/app/src/modules/declarationPdf/__tests__/TransmittedPdfDocument.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/TransmittedPdfDocument.test.tsx
@@ -87,7 +87,7 @@ describe("TransmittedPdfDocument", () => {
 		expect(
 			screen.getByText("Récapitulatif des éléments transmis 2026"),
 		).toBeInTheDocument();
-		expect(screen.getByText("Au titre des données 2025")).toBeInTheDocument();
+		expect(screen.getByText("Au titre des données 2024")).toBeInTheDocument();
 		expect(screen.getByText("Acme Corp — SIREN 123456789")).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/declarationPdf/__tests__/buildTransmittedPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildTransmittedPdfData.test.ts
@@ -56,7 +56,7 @@ describe("buildTransmittedPdfData", () => {
 	it("returns assembled PDF data with declaration lookup", async () => {
 		setupMockDb(
 			{ name: "ACME Corp", siren: "123456789" },
-			{ id: "decl-1" },
+			{ id: "decl-1", year: 2025 },
 			[
 				{
 					declarationNumber: 1,
@@ -81,6 +81,8 @@ describe("buildTransmittedPdfData", () => {
 
 		expect(result.companyName).toBe("ACME Corp");
 		expect(result.siren).toBe("123456789");
+		expect(result.year).toBe(2025);
+		expect(result.dataYear).toBe(2024);
 		expect(result.opinions).toHaveLength(1);
 		expect(result.cseFiles).toHaveLength(1);
 		expect(result.jointEvaluationFile).not.toBeNull();
@@ -88,7 +90,7 @@ describe("buildTransmittedPdfData", () => {
 	});
 
 	it("throws when company is not found", async () => {
-		setupMockDb(null, { id: "decl-1" });
+		setupMockDb(null, { id: "decl-1", year: 2025 });
 
 		const { buildTransmittedPdfData } = await import(
 			"../buildTransmittedPdfData"
@@ -114,7 +116,7 @@ describe("buildTransmittedPdfData", () => {
 	it("returns null jointEvaluationFile when none exists", async () => {
 		setupMockDb(
 			{ name: "ACME", siren: "123456789" },
-			{ id: "decl-1" },
+			{ id: "decl-1", year: 2025 },
 			[],
 			[],
 			[],

--- a/packages/app/src/modules/declarationPdf/__tests__/buildTransmittedPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildTransmittedPdfData.test.ts
@@ -75,6 +75,7 @@ describe("buildTransmittedPdfData", () => {
 		);
 		const result = await buildTransmittedPdfData(
 			"123456789",
+			2025,
 			new Date("2026-03-15"),
 		);
 
@@ -94,7 +95,7 @@ describe("buildTransmittedPdfData", () => {
 		);
 
 		await expect(
-			buildTransmittedPdfData("999999999", new Date()),
+			buildTransmittedPdfData("999999999", 2025, new Date()),
 		).rejects.toThrow("Entreprise introuvable");
 	});
 
@@ -106,7 +107,7 @@ describe("buildTransmittedPdfData", () => {
 		);
 
 		await expect(
-			buildTransmittedPdfData("123456789", new Date()),
+			buildTransmittedPdfData("123456789", 2025, new Date()),
 		).rejects.toThrow("Déclaration introuvable");
 	});
 
@@ -124,6 +125,7 @@ describe("buildTransmittedPdfData", () => {
 		);
 		const result = await buildTransmittedPdfData(
 			"123456789",
+			2025,
 			new Date("2026-03-15"),
 		);
 

--- a/packages/app/src/modules/declarationPdf/buildTransmittedPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildTransmittedPdfData.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { and, eq } from "drizzle-orm";
-import { formatLongDate, getCurrentYear } from "~/modules/domain";
+import { formatLongDate } from "~/modules/domain";
 import { db } from "~/server/db";
 import {
 	companies,
@@ -36,10 +36,9 @@ export type TransmittedPdfData = {
 
 export async function buildTransmittedPdfData(
 	siren: string,
+	year: number,
 	now: Date,
 ): Promise<TransmittedPdfData> {
-	const year = getCurrentYear();
-
 	const [companyResults, declarationResults] = await Promise.all([
 		db.select().from(companies).where(eq(companies.siren, siren)).limit(1),
 		db

--- a/packages/app/src/modules/declarationPdf/buildTransmittedPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildTransmittedPdfData.ts
@@ -27,6 +27,7 @@ export type TransmittedPdfFile = {
 export type TransmittedPdfData = {
 	companyName: string;
 	siren: string;
+	dataYear: number;
 	year: number;
 	generatedAt: string;
 	opinions: TransmittedPdfOpinion[];
@@ -89,6 +90,7 @@ export async function buildTransmittedPdfData(
 	return {
 		companyName: company.name,
 		siren,
+		dataYear: declaration.year - 1,
 		year: declaration.year,
 		generatedAt: formatLongDate(now),
 		opinions,

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -4,6 +4,7 @@ import {
 	getCurrentYear,
 	getDeclarationDeadline,
 	getSecondDeclarationDeadline,
+	getWorkforceYear,
 } from "../shared/campaign";
 
 describe("getCurrentYear", () => {
@@ -23,6 +24,21 @@ describe("getCurrentYear", () => {
 	it("returns the year from the system clock", () => {
 		vi.setSystemTime(new Date("2030-01-01"));
 		expect(getCurrentYear()).toBe(2030);
+	});
+});
+
+describe("getWorkforceYear", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("returns current year - 1", () => {
+		vi.setSystemTime(new Date("2025-06-15"));
+		expect(getWorkforceYear()).toBe(2024);
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-	getCseYear,
 	getCurrentYear,
 	getDeclarationDeadline,
 	getSecondDeclarationDeadline,
@@ -24,21 +23,6 @@ describe("getCurrentYear", () => {
 	it("returns the year from the system clock", () => {
 		vi.setSystemTime(new Date("2030-01-01"));
 		expect(getCurrentYear()).toBe(2030);
-	});
-});
-
-describe("getCseYear", () => {
-	beforeEach(() => {
-		vi.useFakeTimers();
-	});
-
-	afterEach(() => {
-		vi.useRealTimers();
-	});
-
-	it("returns current year + 1", () => {
-		vi.setSystemTime(new Date("2025-06-15"));
-		expect(getCseYear()).toBe(2026);
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -5,6 +5,7 @@ export {
 	getCurrentYear,
 	getDeclarationDeadline,
 	getSecondDeclarationDeadline,
+	getWorkforceYear,
 } from "./shared/campaign";
 // Company size
 export { classifyCompanySize, isCseRequired } from "./shared/companySize";

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -2,7 +2,6 @@
 
 // Campaign
 export {
-	getCseYear,
 	getCurrentYear,
 	getDeclarationDeadline,
 	getSecondDeclarationDeadline,

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -3,6 +3,11 @@ export function getCurrentYear(): number {
 	return new Date().getFullYear();
 }
 
+/** Returns the workforce reference year (previous calendar year, as INSEE publishes N-1 data). */
+export function getWorkforceYear(): number {
+	return new Date().getFullYear() - 1;
+}
+
 /** Returns the declaration modification deadline for a given year. */
 export function getDeclarationDeadline(year: number): string {
 	return `1\u1D49\u02B3 juin ${year}`;

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -3,11 +3,6 @@ export function getCurrentYear(): number {
 	return new Date().getFullYear();
 }
 
-/** Returns the CSE opinion year (next calendar year). */
-export function getCseYear(): number {
-	return new Date().getFullYear() + 1;
-}
-
 /** Returns the declaration modification deadline for a given year. */
 export function getDeclarationDeadline(year: number): string {
 	return `1\u1D49\u02B3 juin ${year}`;

--- a/packages/app/src/modules/export/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/export/__tests__/schemas.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getCurrentYear } from "~/modules/domain";
+import { exportFilesQuerySchema } from "../schemas";
+
+describe("exportFilesQuerySchema", () => {
+	it("accepts a valid siren and year", () => {
+		const result = exportFilesQuerySchema.safeParse({
+			siren: "123456789",
+			year: "2025",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a year above getCurrentYear() + 1", () => {
+		const futureYear = String(getCurrentYear() + 2);
+		const result = exportFilesQuerySchema.safeParse({
+			siren: "123456789",
+			year: futureYear,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects a year below FIRST_DECLARATION_YEAR", () => {
+		const result = exportFilesQuerySchema.safeParse({
+			siren: "123456789",
+			year: "2017",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts getCurrentYear() + 1 as max valid year", () => {
+		const maxYear = String(getCurrentYear() + 1);
+		const result = exportFilesQuerySchema.safeParse({
+			siren: "123456789",
+			year: maxYear,
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects an invalid siren", () => {
+		const result = exportFilesQuerySchema.safeParse({
+			siren: "12345",
+			year: "2025",
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/export/schemas.ts
+++ b/packages/app/src/modules/export/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { FIRST_DECLARATION_YEAR, getCseYear } from "~/modules/domain";
+import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
 
 export const exportYearQuerySchema = z.object({
 	year: z
@@ -41,6 +41,6 @@ export const exportFilesQuerySchema = z.object({
 					FIRST_DECLARATION_YEAR,
 					`year must be >= ${FIRST_DECLARATION_YEAR}`,
 				)
-				.max(getCseYear(), `year must be <= ${getCseYear()}`),
+				.max(getCurrentYear() + 1, `year must be <= ${getCurrentYear() + 1}`),
 		),
 });

--- a/packages/app/src/server/api/trpc.ts
+++ b/packages/app/src/server/api/trpc.ts
@@ -8,10 +8,9 @@
  */
 
 import { initTRPC, TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
 import superjson from "superjson";
 import { ZodError } from "zod";
-
-import { and, eq } from "drizzle-orm";
 import { getCurrentYear } from "~/modules/domain";
 import { parseSiren } from "~/modules/shared/parseSiren";
 import { auth } from "~/server/auth";


### PR DESCRIPTION
## Summary

- Replace all UI calls to `getCurrentYear()` with `declaration.year` from the database, so that year labels stay correct across calendar year boundaries (e.g. viewing a 2025 declaration in January 2026)
- Thread `declarationYear` prop through layouts, step components, compliance path, CSE opinion components, and PDF routes
- Layouts now fetch declaration data alongside company data (deduplicated by RSC)
- PDF routes accept `year` as query parameter instead of hardcoding `getCurrentYear()`

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (132 files, 1017 tests)
- [x] `pnpm lint:check` and `pnpm format:check` pass
- [ ] Manual: verify year labels display `declaration.year` (not current calendar year) in declaration steps, compliance path, CSE opinion pages, and PDF downloads