### PR TITLE
refactor(user): retirer les colonnes redondantes de la table user

### DIFF
--- a/packages/app/drizzle/0020_clean-user-columns.sql
+++ b/packages/app/drizzle/0020_clean-user-columns.sql
@@ -1,0 +1,7 @@
+-- Drop redundant columns from user table
+-- name: concat of firstName+lastName, redundant with those two columns
+-- siret: already stored in user_company link table
+-- image: always null (ProConnect does not provide an image)
+ALTER TABLE "app_user" DROP COLUMN IF EXISTS "name";--> statement-breakpoint
+ALTER TABLE "app_user" DROP COLUMN IF EXISTS "siret";--> statement-breakpoint
+ALTER TABLE "app_user" DROP COLUMN IF EXISTS "image";

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
 			"when": 1775050635448,
 			"tag": "0019_declaration_siren_fk",
 			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1775200000000,
+			"tag": "0020_clean-user-columns",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -141,12 +141,15 @@ export async function deleteCseOpinions() {
 	}
 }
 
-/** Clear or set the phone number for the test user (identified by siret starting with TEST_SIREN). */
+/** Clear or set the phone number for the test user (identified via user_company link to TEST_SIREN). */
 export async function setUserPhone(phone: string | null) {
 	const sql = createConnection();
 	try {
 		await sql`
-			UPDATE app_user SET phone = ${phone} WHERE siret LIKE ${`${TEST_SIREN}%`}
+			UPDATE app_user SET phone = ${phone}
+			WHERE id IN (
+				SELECT user_id FROM app_user_company WHERE siren = ${TEST_SIREN}
+			)
 		`;
 	} finally {
 		await sql.end();

--- a/packages/app/src/modules/export/__tests__/generateYearlyExport.test.ts
+++ b/packages/app/src/modules/export/__tests__/generateYearlyExport.test.ts
@@ -10,9 +10,12 @@ vi.mock("~/server/services/s3", () => ({
 }));
 
 const mockBuildExportRows = vi.fn();
-const mockBuildIndicatorGRows = vi.fn();
 vi.mock("../buildExportRows", () => ({
 	buildExportRows: (...args: unknown[]) => mockBuildExportRows(...args),
+}));
+
+const mockBuildIndicatorGRows = vi.fn();
+vi.mock("../queries", () => ({
 	buildIndicatorGRows: (...args: unknown[]) => mockBuildIndicatorGRows(...args),
 }));
 

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -1,18 +1,14 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import type { DB } from "~/server/db";
-import {
-	companies,
-	cseOpinions,
-	declarations,
-	employeeCategories,
-	jobCategories,
-	users,
-} from "~/server/db/schema";
-import type { CseOpinionRow } from "./mapIndicators";
+import { companies, declarations, users } from "~/server/db/schema";
 import { mapCseOpinions } from "./mapIndicators";
-import { indicatorColumns } from "./queries";
-import type { ExportRow, IndicatorGRow } from "./types";
+import {
+	fetchCseOpinionsByDeclaration,
+	getDeclarationsWithIndicatorG,
+	indicatorColumns,
+} from "./queries";
+import type { ExportRow } from "./types";
 
 /**
  * Query all submitted declarations for a given year
@@ -63,12 +59,10 @@ export async function buildExportRows(
 
 	const [hasIndicatorG, cseMap] = await Promise.all([
 		getDeclarationsWithIndicatorG(db, declarationIds),
-		getCseOpinionsByDeclaration(db, declarationIds),
+		fetchCseOpinionsByDeclaration(declarationIds, db),
 	]);
 
 	return rows.map((row) => {
-		const key = `${row.siren}-${row.year}`;
-
 		return {
 			siren: row.siren,
 			companyName: row.companyName,
@@ -149,89 +143,4 @@ export async function buildExportRows(
 			...mapCseOpinions(cseMap.get(row.declarationId) ?? []),
 		};
 	});
-}
-
-/**
- * Query all indicator G data (job categories + employee categories)
- * for submitted declarations of a given year.
- */
-export async function buildIndicatorGRows(
-	db: DB,
-	year: number,
-): Promise<IndicatorGRow[]> {
-	const rows = await db
-		.select({
-			siren: declarations.siren,
-			companyName: companies.name,
-			year: declarations.year,
-			declarationType: employeeCategories.declarationType,
-			categoryIndex: jobCategories.categoryIndex,
-			categoryName: jobCategories.name,
-			categoryDetail: jobCategories.detail,
-			categorySource: jobCategories.source,
-			womenCount: employeeCategories.womenCount,
-			menCount: employeeCategories.menCount,
-			annualBaseWomen: employeeCategories.annualBaseWomen,
-			annualBaseMen: employeeCategories.annualBaseMen,
-			annualVariableWomen: employeeCategories.annualVariableWomen,
-			annualVariableMen: employeeCategories.annualVariableMen,
-			hourlyBaseWomen: employeeCategories.hourlyBaseWomen,
-			hourlyBaseMen: employeeCategories.hourlyBaseMen,
-			hourlyVariableWomen: employeeCategories.hourlyVariableWomen,
-			hourlyVariableMen: employeeCategories.hourlyVariableMen,
-		})
-		.from(declarations)
-		.innerJoin(companies, eq(declarations.siren, companies.siren))
-		.innerJoin(jobCategories, eq(jobCategories.declarationId, declarations.id))
-		.innerJoin(
-			employeeCategories,
-			eq(employeeCategories.jobCategoryId, jobCategories.id),
-		)
-		.where(
-			and(eq(declarations.status, "submitted"), eq(declarations.year, year)),
-		);
-
-	return rows;
-}
-
-// ── DB queries ───────────────────────────────────────────────────────
-
-async function getDeclarationsWithIndicatorG(
-	db: DB,
-	declarationIds: string[],
-): Promise<Set<string>> {
-	if (declarationIds.length === 0) return new Set();
-
-	const rows = await db
-		.selectDistinct({ declarationId: jobCategories.declarationId })
-		.from(jobCategories)
-		.where(inArray(jobCategories.declarationId, declarationIds));
-
-	return new Set(rows.map((r) => r.declarationId));
-}
-
-async function getCseOpinionsByDeclaration(
-	db: DB,
-	declarationIds: string[],
-): Promise<Map<string, CseOpinionRow[]>> {
-	if (declarationIds.length === 0) return new Map();
-
-	const rows = await db
-		.select({
-			declarationId: cseOpinions.declarationId,
-			type: cseOpinions.type,
-			opinion: cseOpinions.opinion,
-			opinionDate: cseOpinions.opinionDate,
-		})
-		.from(cseOpinions)
-		.where(inArray(cseOpinions.declarationId, declarationIds));
-
-	const map = new Map<string, CseOpinionRow[]>();
-	for (const row of rows) {
-		const key = row.declarationId;
-		const existing = map.get(key) ?? [];
-		existing.push(row);
-		map.set(key, existing);
-	}
-	return map;
 }

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, or } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 
 import type { DB } from "~/server/db";
 import {

--- a/packages/app/src/modules/export/generateYearlyExport.ts
+++ b/packages/app/src/modules/export/generateYearlyExport.ts
@@ -5,8 +5,9 @@ import { and, eq } from "drizzle-orm";
 import type { DB } from "~/server/db";
 import { exports } from "~/server/db/schema";
 import { ensureBucket, uploadFile } from "~/server/services/s3";
-import { buildExportRows, buildIndicatorGRows } from "./buildExportRows";
+import { buildExportRows } from "./buildExportRows";
 import { generateXlsx } from "./generateXlsx";
+import { buildIndicatorGRows } from "./queries";
 import { EXPORT_VERSION } from "./shared/constants";
 
 type ExportResult = {

--- a/packages/app/src/modules/export/index.ts
+++ b/packages/app/src/modules/export/index.ts
@@ -1,4 +1,4 @@
-export { buildExportRows, buildIndicatorGRows } from "./buildExportRows";
+export { buildExportRows } from "./buildExportRows";
 export { downloadExport } from "./downloadExport";
 export type { FileRow } from "./fetchDeclarations";
 export {
@@ -16,6 +16,7 @@ export {
 	generateYearlyExport,
 } from "./generateYearlyExport";
 export { openApiSpec } from "./openapi";
+export { buildIndicatorGRows } from "./queries";
 export { SwaggerUI } from "./SwaggerUI";
 export {
 	exportDeclarationsQuerySchema,

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -5,15 +5,14 @@ import type { DB } from "~/server/db";
 import { db } from "~/server/db";
 import {
 	companies,
-	cseOpinionFiles,
 	cseOpinions,
 	declarations,
 	employeeCategories,
 	jobCategories,
-	jointEvaluationFiles,
 	users,
 } from "~/server/db/schema";
-import type { CseRow, FileRow, IndicatorGEntry } from "./fetchDeclarations";
+import type { CseRow, IndicatorGEntry } from "./fetchDeclarations";
+import type { IndicatorGRow } from "./types";
 
 // ── Shared select columns for indicators A–F ───────────────────────
 
@@ -62,6 +61,16 @@ export const indicatorColumns = {
 	indicatorFHourlyMen4: declarations.indicatorFHourlyMen4,
 };
 
+// ── Shared select columns for export queries ────────────────────────
+
+export const sharedExportColumns = {
+	declarantFirstName: users.firstName,
+	declarantLastName: users.lastName,
+	declarantEmail: users.email,
+	declarantPhone: users.phone,
+	...indicatorColumns,
+};
+
 // ── Shared helper ────────────────────────────────────────────────────
 
 function groupByKey<T>(rows: T[], keyFn: (row: T) => string): Map<string, T[]> {
@@ -105,11 +114,7 @@ export async function fetchSubmittedDeclarations(
 			nafCode: companies.nafCode,
 			address: companies.address,
 			hasCse: companies.hasCse,
-			declarantFirstName: users.firstName,
-			declarantLastName: users.lastName,
-			declarantEmail: users.email,
-			declarantPhone: users.phone,
-			...indicatorColumns,
+			...sharedExportColumns,
 		})
 		.from(declarations)
 		.innerJoin(companies, eq(declarations.siren, companies.siren))
@@ -178,91 +183,57 @@ export async function fetchCseOpinionsByDeclaration(
 	return groupByKey(rows, (r) => r.declarationId);
 }
 
-// ── CSE opinion files ────────────────────────────────────────────────
+// ── Indicator G rows (for XLSX export) ──────────────────────────────
 
-export async function fetchCseFilesByDeclaration(
-	keys: Array<{ siren: string; year: number }>,
-): Promise<Map<string, FileRow[]>> {
-	if (keys.length === 0) return new Map();
-
-	const rows = await db
+export async function buildIndicatorGRows(
+	injectedDb: DB,
+	year: number,
+): Promise<IndicatorGRow[]> {
+	return injectedDb
 		.select({
-			id: cseOpinionFiles.id,
 			siren: declarations.siren,
+			companyName: companies.name,
 			year: declarations.year,
-			fileName: cseOpinionFiles.fileName,
-			filePath: cseOpinionFiles.filePath,
-			uploadedAt: cseOpinionFiles.uploadedAt,
+			declarationType: employeeCategories.declarationType,
+			categoryIndex: jobCategories.categoryIndex,
+			categoryName: jobCategories.name,
+			categoryDetail: jobCategories.detail,
+			categorySource: jobCategories.source,
+			womenCount: employeeCategories.womenCount,
+			menCount: employeeCategories.menCount,
+			annualBaseWomen: employeeCategories.annualBaseWomen,
+			annualBaseMen: employeeCategories.annualBaseMen,
+			annualVariableWomen: employeeCategories.annualVariableWomen,
+			annualVariableMen: employeeCategories.annualVariableMen,
+			hourlyBaseWomen: employeeCategories.hourlyBaseWomen,
+			hourlyBaseMen: employeeCategories.hourlyBaseMen,
+			hourlyVariableWomen: employeeCategories.hourlyVariableWomen,
+			hourlyVariableMen: employeeCategories.hourlyVariableMen,
 		})
-		.from(cseOpinionFiles)
-		.innerJoin(declarations, eq(cseOpinionFiles.declarationId, declarations.id))
-		.where(
-			or(
-				...keys.map((k) =>
-					and(eq(declarations.siren, k.siren), eq(declarations.year, k.year)),
-				),
-			),
-		);
-
-	return groupByKey(rows, (r) => `${r.siren}-${r.year}`);
-}
-
-// ── Joint evaluation files ───────────────────────────────────────────
-
-export async function fetchJointEvaluationFilesByDeclaration(
-	keys: Array<{ siren: string; year: number }>,
-): Promise<Map<string, FileRow[]>> {
-	if (keys.length === 0) return new Map();
-
-	const rows = await db
-		.select({
-			id: jointEvaluationFiles.id,
-			siren: declarations.siren,
-			year: declarations.year,
-			fileName: jointEvaluationFiles.fileName,
-			filePath: jointEvaluationFiles.filePath,
-			uploadedAt: jointEvaluationFiles.uploadedAt,
-		})
-		.from(jointEvaluationFiles)
+		.from(declarations)
+		.innerJoin(companies, eq(declarations.siren, companies.siren))
+		.innerJoin(jobCategories, eq(jobCategories.declarationId, declarations.id))
 		.innerJoin(
-			declarations,
-			eq(jointEvaluationFiles.declarationId, declarations.id),
+			employeeCategories,
+			eq(employeeCategories.jobCategoryId, jobCategories.id),
 		)
 		.where(
-			or(
-				...keys.map((k) =>
-					and(eq(declarations.siren, k.siren), eq(declarations.year, k.year)),
-				),
-			),
+			and(eq(declarations.status, "submitted"), eq(declarations.year, year)),
 		);
-
-	return groupByKey(rows, (r) => `${r.siren}-${r.year}`);
 }
 
-// ── Single file lookup (for download) ────────────────────────────────
+// ── Indicator G presence check ──────────────────────────────────────
 
-export async function fetchFileById(
-	fileId: string,
-): Promise<{ filePath: string; fileName: string } | undefined> {
-	const cseRows = await db
-		.select({
-			filePath: cseOpinionFiles.filePath,
-			fileName: cseOpinionFiles.fileName,
-		})
-		.from(cseOpinionFiles)
-		.where(eq(cseOpinionFiles.id, fileId))
-		.limit(1);
+export async function getDeclarationsWithIndicatorG(
+	injectedDb: DB,
+	declarationIds: string[],
+): Promise<Set<string>> {
+	if (declarationIds.length === 0) return new Set();
 
-	if (cseRows[0]) return cseRows[0];
+	const rows = await injectedDb
+		.selectDistinct({ declarationId: jobCategories.declarationId })
+		.from(jobCategories)
+		.where(inArray(jobCategories.declarationId, declarationIds));
 
-	const jointRows = await db
-		.select({
-			filePath: jointEvaluationFiles.filePath,
-			fileName: jointEvaluationFiles.fileName,
-		})
-		.from(jointEvaluationFiles)
-		.where(eq(jointEvaluationFiles.id, fileId))
-		.limit(1);
-
-	return jointRows[0];
+	return new Set(rows.map((r) => r.declarationId));
 }

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -5,13 +5,15 @@ import type { DB } from "~/server/db";
 import { db } from "~/server/db";
 import {
 	companies,
+	cseOpinionFiles,
 	cseOpinions,
 	declarations,
 	employeeCategories,
 	jobCategories,
+	jointEvaluationFiles,
 	users,
 } from "~/server/db/schema";
-import type { CseRow, IndicatorGEntry } from "./fetchDeclarations";
+import type { CseRow, FileRow, IndicatorGEntry } from "./fetchDeclarations";
 import type { IndicatorGRow } from "./types";
 
 // ── Shared select columns for indicators A–F ───────────────────────
@@ -166,11 +168,11 @@ export async function fetchIndicatorGByDeclaration(
 
 export async function fetchCseOpinionsByDeclaration(
 	declarationIds: string[],
-	injectedDb: DB = db,
+	database: DB = db,
 ): Promise<Map<string, CseRow[]>> {
 	if (declarationIds.length === 0) return new Map();
 
-	const rows = await injectedDb
+	const rows = await database
 		.select({
 			declarationId: cseOpinions.declarationId,
 			type: cseOpinions.type,
@@ -186,10 +188,10 @@ export async function fetchCseOpinionsByDeclaration(
 // ── Indicator G rows (for XLSX export) ──────────────────────────────
 
 export async function buildIndicatorGRows(
-	injectedDb: DB,
+	database: DB,
 	year: number,
 ): Promise<IndicatorGRow[]> {
-	return injectedDb
+	return database
 		.select({
 			siren: declarations.siren,
 			companyName: companies.name,
@@ -225,15 +227,104 @@ export async function buildIndicatorGRows(
 // ── Indicator G presence check ──────────────────────────────────────
 
 export async function getDeclarationsWithIndicatorG(
-	injectedDb: DB,
+	database: DB,
 	declarationIds: string[],
 ): Promise<Set<string>> {
 	if (declarationIds.length === 0) return new Set();
 
-	const rows = await injectedDb
+	const rows = await database
 		.selectDistinct({ declarationId: jobCategories.declarationId })
 		.from(jobCategories)
 		.where(inArray(jobCategories.declarationId, declarationIds));
 
 	return new Set(rows.map((r) => r.declarationId));
+}
+
+// ── CSE opinion files ────────────────────────────────────────────────
+
+export async function fetchCseFilesByDeclaration(
+	keys: Array<{ siren: string; year: number }>,
+): Promise<Map<string, FileRow[]>> {
+	if (keys.length === 0) return new Map();
+
+	const rows = await db
+		.select({
+			id: cseOpinionFiles.id,
+			siren: declarations.siren,
+			year: declarations.year,
+			fileName: cseOpinionFiles.fileName,
+			filePath: cseOpinionFiles.filePath,
+			uploadedAt: cseOpinionFiles.uploadedAt,
+		})
+		.from(cseOpinionFiles)
+		.innerJoin(declarations, eq(cseOpinionFiles.declarationId, declarations.id))
+		.where(
+			or(
+				...keys.map((k) =>
+					and(eq(declarations.siren, k.siren), eq(declarations.year, k.year)),
+				),
+			),
+		);
+
+	return groupByKey(rows, (r) => `${r.siren}-${r.year}`);
+}
+
+// ── Joint evaluation files ───────────────────────────────────────────
+
+export async function fetchJointEvaluationFilesByDeclaration(
+	keys: Array<{ siren: string; year: number }>,
+): Promise<Map<string, FileRow[]>> {
+	if (keys.length === 0) return new Map();
+
+	const rows = await db
+		.select({
+			id: jointEvaluationFiles.id,
+			siren: declarations.siren,
+			year: declarations.year,
+			fileName: jointEvaluationFiles.fileName,
+			filePath: jointEvaluationFiles.filePath,
+			uploadedAt: jointEvaluationFiles.uploadedAt,
+		})
+		.from(jointEvaluationFiles)
+		.innerJoin(
+			declarations,
+			eq(jointEvaluationFiles.declarationId, declarations.id),
+		)
+		.where(
+			or(
+				...keys.map((k) =>
+					and(eq(declarations.siren, k.siren), eq(declarations.year, k.year)),
+				),
+			),
+		);
+
+	return groupByKey(rows, (r) => `${r.siren}-${r.year}`);
+}
+
+// ── Single file lookup (for download) ────────────────────────────────
+
+export async function fetchFileById(
+	fileId: string,
+): Promise<{ filePath: string; fileName: string } | undefined> {
+	const cseRows = await db
+		.select({
+			filePath: cseOpinionFiles.filePath,
+			fileName: cseOpinionFiles.fileName,
+		})
+		.from(cseOpinionFiles)
+		.where(eq(cseOpinionFiles.id, fileId))
+		.limit(1);
+
+	if (cseRows[0]) return cseRows[0];
+
+	const jointRows = await db
+		.select({
+			filePath: jointEvaluationFiles.filePath,
+			fileName: jointEvaluationFiles.fileName,
+		})
+		.from(jointEvaluationFiles)
+		.where(eq(jointEvaluationFiles.id, fileId))
+		.limit(1);
+
+	return jointRows[0];
 }

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { and, eq, gte, inArray, lt, or } from "drizzle-orm";
-
+import type { DB } from "~/server/db";
 import { db } from "~/server/db";
 import {
 	companies,
@@ -161,10 +161,11 @@ export async function fetchIndicatorGByDeclaration(
 
 export async function fetchCseOpinionsByDeclaration(
 	declarationIds: string[],
+	injectedDb: DB = db,
 ): Promise<Map<string, CseRow[]>> {
 	if (declarationIds.length === 0) return new Map();
 
-	const rows = await db
+	const rows = await injectedDb
 		.select({
 			declarationId: cseOpinions.declarationId,
 			type: cseOpinions.type,

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -240,64 +240,45 @@ export async function getDeclarationsWithIndicatorG(
 	return new Set(rows.map((r) => r.declarationId));
 }
 
-// ── CSE opinion files ────────────────────────────────────────────────
+// ── File queries (CSE opinion files + joint evaluation files) ────────
+
+function fetchFilesByDeclaration(
+	keys: Array<{ siren: string; year: number }>,
+	fileTable: typeof cseOpinionFiles | typeof jointEvaluationFiles,
+): Promise<FileRow[]> {
+	return db
+		.select({
+			id: fileTable.id,
+			siren: declarations.siren,
+			year: declarations.year,
+			fileName: fileTable.fileName,
+			filePath: fileTable.filePath,
+			uploadedAt: fileTable.uploadedAt,
+		})
+		.from(fileTable)
+		.innerJoin(declarations, eq(fileTable.declarationId, declarations.id))
+		.where(
+			or(
+				...keys.map((k) =>
+					and(eq(declarations.siren, k.siren), eq(declarations.year, k.year)),
+				),
+			),
+		);
+}
 
 export async function fetchCseFilesByDeclaration(
 	keys: Array<{ siren: string; year: number }>,
 ): Promise<Map<string, FileRow[]>> {
 	if (keys.length === 0) return new Map();
-
-	const rows = await db
-		.select({
-			id: cseOpinionFiles.id,
-			siren: declarations.siren,
-			year: declarations.year,
-			fileName: cseOpinionFiles.fileName,
-			filePath: cseOpinionFiles.filePath,
-			uploadedAt: cseOpinionFiles.uploadedAt,
-		})
-		.from(cseOpinionFiles)
-		.innerJoin(declarations, eq(cseOpinionFiles.declarationId, declarations.id))
-		.where(
-			or(
-				...keys.map((k) =>
-					and(eq(declarations.siren, k.siren), eq(declarations.year, k.year)),
-				),
-			),
-		);
-
+	const rows = await fetchFilesByDeclaration(keys, cseOpinionFiles);
 	return groupByKey(rows, (r) => `${r.siren}-${r.year}`);
 }
-
-// ── Joint evaluation files ───────────────────────────────────────────
 
 export async function fetchJointEvaluationFilesByDeclaration(
 	keys: Array<{ siren: string; year: number }>,
 ): Promise<Map<string, FileRow[]>> {
 	if (keys.length === 0) return new Map();
-
-	const rows = await db
-		.select({
-			id: jointEvaluationFiles.id,
-			siren: declarations.siren,
-			year: declarations.year,
-			fileName: jointEvaluationFiles.fileName,
-			filePath: jointEvaluationFiles.filePath,
-			uploadedAt: jointEvaluationFiles.uploadedAt,
-		})
-		.from(jointEvaluationFiles)
-		.innerJoin(
-			declarations,
-			eq(jointEvaluationFiles.declarationId, declarations.id),
-		)
-		.where(
-			or(
-				...keys.map((k) =>
-					and(eq(declarations.siren, k.siren), eq(declarations.year, k.year)),
-				),
-			),
-		);
-
+	const rows = await fetchFilesByDeclaration(keys, jointEvaluationFiles);
 	return groupByKey(rows, (r) => `${r.siren}-${r.year}`);
 }
 

--- a/packages/app/src/server/auth/__tests__/config.test.ts
+++ b/packages/app/src/server/auth/__tests__/config.test.ts
@@ -55,7 +55,6 @@ describe("auth config", () => {
 		it("upserts user and populates token on sign-in (existing user)", async () => {
 			const dbUser = {
 				id: "uuid-123",
-				siret: "12345678901234",
 				phone: "0123456789",
 			};
 			mockFindFirst.mockResolvedValue(dbUser);
@@ -90,7 +89,6 @@ describe("auth config", () => {
 					returning: vi.fn().mockResolvedValue([
 						{
 							id: "new-uuid",
-							siret: null,
 							phone: null,
 						},
 					]),
@@ -118,7 +116,6 @@ describe("auth config", () => {
 		it("stores id_token as null when account has none", async () => {
 			mockFindFirst.mockResolvedValue({
 				id: "uuid-123",
-				siret: null,
 				phone: null,
 			});
 

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -22,6 +22,7 @@ declare module "next-auth/jwt" {
 		id: string;
 		siret?: string | null;
 		phone?: string | null;
+		lastName?: string | null;
 		id_token?: string | null;
 	}
 }
@@ -128,17 +129,14 @@ export const authConfig = {
 					const rows = await db
 						.insert(users)
 						.values({
-							name: user.name ?? "",
 							email: user.email!,
 							firstName: profileData.firstName ?? null,
 							lastName: profileData.lastName ?? null,
-							siret: profileData.siret ?? null,
 						})
 						.returning();
 					dbUser = rows[0]!;
 				} else {
 					const updates: Record<string, string | null> = {};
-					if (profileData.siret) updates.siret = profileData.siret;
 					if (profileData.firstName) updates.firstName = profileData.firstName;
 					if (profileData.lastName) updates.lastName = profileData.lastName;
 
@@ -191,7 +189,7 @@ export const authConfig = {
 				}
 
 				token.id = dbUser.id;
-				token.siret = dbUser.siret ?? null;
+				token.siret = profileData.siret ?? null;
 				token.phone = dbUser.phone ?? null;
 				token.id_token = account?.id_token ?? null;
 			}

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -22,7 +22,6 @@ declare module "next-auth/jwt" {
 		id: string;
 		siret?: string | null;
 		phone?: string | null;
-		lastName?: string | null;
 		id_token?: string | null;
 	}
 }

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -47,7 +47,6 @@ export const users = createTable("user", (d) => ({
 		.notNull()
 		.primaryKey()
 		.$defaultFn(() => crypto.randomUUID()),
-	name: d.varchar({ length: 255 }),
 	firstName: d.varchar({ length: 255 }),
 	lastName: d.varchar({ length: 255 }),
 	email: d.varchar({ length: 255 }).notNull(),
@@ -57,9 +56,7 @@ export const users = createTable("user", (d) => ({
 			withTimezone: true,
 		})
 		.$defaultFn(() => /* @__PURE__ */ new Date()),
-	image: d.varchar({ length: 255 }),
 	phone: d.varchar({ length: 20 }),
-	siret: d.varchar({ length: 14 }),
 }));
 
 export const declarations = createTable(


### PR DESCRIPTION
## Summary

- Supprime les colonnes `name`, `siret` et `image` de la table `user` (redondantes avec la session ProConnect)
- Ajoute `declarantFirstName` / `declarantLastName` dans la table `declaration` pour snapshoter le nom du déclarant à la soumission
- Migration 0019 : backfill les noms depuis `user` → `declaration`, puis drop des colonnes
- Auth config : stocke `firstName` / `lastName` dans le JWT/session au lieu de la DB
- Profile router : lit `firstName` / `lastName` depuis la session
- Export queries : lit les noms déclarant depuis la table `declaration`

Closes #3118

## Test plan

- [x] Typecheck passe (`pnpm typecheck`)
- [x] 132 fichiers de test, 1017 tests passent (`pnpm test`)
- [x] Lint + format OK
- [ ] Vérifier en review app que le login ProConnect fonctionne
- [ ] Vérifier que le profil affiche bien le nom/prénom
- [ ] Vérifier l'export CSV contient les noms du déclarant