### PR TITLE
fix(my-space): hide page size selector when table has 20 rows or fewer

### DIFF
--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -43,6 +43,7 @@ function getDeadline(declaration: DeclarationItem): string {
 }
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50];
+const PAGE_SIZE_SELECTOR_THRESHOLD = 20;
 
 export function DeclarationsSection({
 	siren,
@@ -142,27 +143,29 @@ export function DeclarationsSection({
 					/>
 				</>
 			)}
-			<div className="fr-table">
-				<div className="fr-table__footer--start">
-					<div className="fr-select-group">
-						<label className="fr-sr-only fr-label" htmlFor="table-page-size">
-							Nombre de lignes par page
-						</label>
-						<select
-							className="fr-select"
-							id="table-page-size"
-							onChange={(e) => handlePageSizeChange(Number(e.target.value))}
-							value={pageSize}
-						>
-							{PAGE_SIZE_OPTIONS.map((size) => (
-								<option key={size} value={size}>
-									{size} lignes par page
-								</option>
-							))}
-						</select>
+			{totalRows > PAGE_SIZE_SELECTOR_THRESHOLD && (
+				<div className="fr-table">
+					<div className="fr-table__footer--start">
+						<div className="fr-select-group">
+							<label className="fr-sr-only fr-label" htmlFor="table-page-size">
+								Nombre de lignes par page
+							</label>
+							<select
+								className="fr-select"
+								id="table-page-size"
+								onChange={(e) => handlePageSizeChange(Number(e.target.value))}
+								value={pageSize}
+							>
+								{PAGE_SIZE_OPTIONS.map((size) => (
+									<option key={size} value={size}>
+										{size} lignes par page
+									</option>
+								))}
+							</select>
+						</div>
 					</div>
 				</div>
-			</div>
+			)}
 			{totalPages > 1 && (
 				<Pagination
 					currentPage={safePage}

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -127,8 +127,29 @@ describe("DeclarationsSection", () => {
 		expect(represButtons).toHaveLength(1);
 	});
 
-	it("renders the page size selector", () => {
+	it("does not render the page size selector when there are 20 rows or fewer", () => {
 		renderSection();
+		expect(
+			screen.queryByRole("combobox", { name: "Nombre de lignes par page" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders the page size selector when there are more than 20 rows", () => {
+		const manyDeclarations: DeclarationItem[] = Array.from(
+			{ length: 21 },
+			(_, i) => ({
+				type: "remuneration" as const,
+				siren: "532847196",
+				year: currentYear - i,
+				status: "done" as const,
+				currentStep: 6,
+				updatedAt: new Date("2025-01-01"),
+				...NO_COMPLIANCE,
+			}),
+		);
+
+		renderSection({ declarations: manyDeclarations });
+
 		expect(
 			screen.getByRole("combobox", { name: "Nombre de lignes par page" }),
 		).toBeInTheDocument();
@@ -241,7 +262,7 @@ describe("DeclarationsSection", () => {
 
 	it("resets to page 1 when page size changes", () => {
 		const manyDeclarations: DeclarationItem[] = Array.from(
-			{ length: 15 },
+			{ length: 25 },
 			(_, i) => ({
 				type: "remuneration" as const,
 				siren: "532847196",
@@ -258,10 +279,10 @@ describe("DeclarationsSection", () => {
 		// Go to page 2
 		fireEvent.click(screen.getByTitle("Page 2"));
 
-		// Change page size to 25
+		// Change page size to 50
 		fireEvent.change(
 			screen.getByRole("combobox", { name: "Nombre de lignes par page" }),
-			{ target: { value: "25" } },
+			{ target: { value: "50" } },
 		);
 
 		// Should be back on page 1 with all rows visible, no pagination


### PR DESCRIPTION
## Summary

- Hide the « Nombre de lignes par page » selector in the my-space declarations table when the total number of rows is ≤ 20 (the option to change page size is irrelevant for small tables).
- Add a `PAGE_SIZE_SELECTOR_THRESHOLD` constant for the threshold.
- Update unit tests to cover both branches (selector hidden ≤ 20, visible > 20).

Closes #3156

## Test plan

- [x] `pnpm test` — 1062/1062 passed
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint:check` / `pnpm format:check` — clean
- [ ] Visual check on review env: small table (≤ 20 rows) hides the selector, large table (> 20 rows) shows it