### PR TITLE
fix(header): masquer le menu de navigation en mode connecté

### DIFF
--- a/packages/app/src/modules/layout/Header/MobileMenu.tsx
+++ b/packages/app/src/modules/layout/Header/MobileMenu.tsx
@@ -49,7 +49,7 @@ export async function MobileMenu() {
 						</li>
 					</ul>
 				</div>
-				<Navigation />
+				{!session?.user && <Navigation />}
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/layout/Header/__tests__/MobileMenu.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/MobileMenu.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { usePathname } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+	auth: mocks.auth,
+}));
+
+import { MobileMenu } from "../MobileMenu";
+
+beforeEach(() => {
+	vi.mocked(usePathname).mockReturnValue("/");
+});
+
+describe("MobileMenu", () => {
+	it("renders the main navigation when no user is signed in", async () => {
+		mocks.auth.mockResolvedValue(null);
+
+		render(await MobileMenu());
+
+		expect(
+			screen.getByRole("navigation", { name: "Menu principal" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: "Se connecter" }),
+		).toBeInTheDocument();
+	});
+
+	it("hides the main navigation when a user is signed in", async () => {
+		mocks.auth.mockResolvedValue({
+			user: {
+				email: "jean.dupont@example.fr",
+				name: "Jean Dupont",
+				phone: null,
+			},
+		});
+
+		render(await MobileMenu());
+
+		expect(
+			screen.queryByRole("navigation", { name: "Menu principal" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Mon espace" }),
+		).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Résumé

- Masque le menu de navigation principal (liens "Accueil" et "Observatoire") du header lorsque l'utilisateur est connecté.
- Le menu reste affiché pour les utilisateurs non connectés.

Closes #3157

## Test plan

- [ ] Vérifier qu'en mode déconnecté, les liens "Accueil" et "Observatoire" sont visibles dans le header (desktop + mobile)
- [ ] Vérifier qu'en mode connecté (ProConnect), les liens "Accueil" et "Observatoire" ne sont plus visibles
- [ ] Vérifier que le menu mobile (modal) reste fonctionnel pour les deux états (Aide + Se connecter / Compte utilisateur)