### PR TITLE
feat(layout): update help banner to match new design

### DIFF
--- a/packages/app/src/modules/layout/ResourceBanner.tsx
+++ b/packages/app/src/modules/layout/ResourceBanner.tsx
@@ -48,18 +48,18 @@ export function ResourceBanner() {
 						<div className="fr-grid-row fr-grid-row--gutters">
 							<div className="fr-col-12 fr-col-md-4">
 								<ResourceTile
-									detail="Réponses aux questions les plus courantes"
-									href="/faq"
-									pictogramPath="/dsfr/artwork/pictograms/system/information.svg"
-									title="Questions fréquentes (FAQ)"
+									detail="Recherchez et accédez à toutes nos ressources"
+									href="/aide"
+									pictogramPath="/dsfr/artwork/pictograms/document/document-search.svg"
+									title="Centre d'aide"
 								/>
 							</div>
 							<div className="fr-col-12 fr-col-md-4">
 								<ResourceTile
-									detail="Guides, ressources et textes de référence"
-									href="/aide"
-									pictogramPath="/dsfr/artwork/pictograms/document/document.svg"
-									title="Aides et ressources"
+									detail="Réponses aux questions les plus courantes"
+									href="/faq"
+									pictogramPath="/dsfr/artwork/pictograms/system/information.svg"
+									title="Questions fréquentes (FAQ)"
 								/>
 							</div>
 							<div className="fr-col-12 fr-col-md-4">

--- a/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
@@ -13,7 +13,7 @@ describe("ResourceBanner", () => {
 		expect(faqLink).toHaveAttribute("href", "/faq");
 
 		const aideLink = screen.getByRole("link", {
-			name: /aides et ressources/i,
+			name: /centre d'aide/i,
 		});
 		expect(aideLink).toHaveAttribute("href", "/aide");
 
@@ -30,7 +30,7 @@ describe("ResourceBanner", () => {
 			screen.getByText("Réponses aux questions les plus courantes"),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText("Guides, ressources et textes de référence"),
+			screen.getByText("Recherchez et accédez à toutes nos ressources"),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText("Besoin d'aide ? Contactez nos services d'assistance"),


### PR DESCRIPTION
Reorder tiles, rename 'Aides et ressources' to 'Centre d'aide', and use the document-search pictogram per Figma.