### PR TITLE
feat(my-space): rework declarations table and add documents side panel

### DIFF
--- a/packages/app/src/app/api/prefill-pdf/route.ts
+++ b/packages/app/src/app/api/prefill-pdf/route.ts
@@ -19,7 +19,14 @@ export async function GET(request: Request) {
 	const siren = extractSiren(session.user.siret);
 	const url = new URL(request.url);
 	const yearParam = url.searchParams.get("year");
-	const year = yearParam ? Number.parseInt(yearParam, 10) : getCurrentYear();
+	const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : null;
+	if (
+		parsedYear !== null &&
+		(Number.isNaN(parsedYear) || parsedYear < 2000 || parsedYear > 2100)
+	) {
+		return new Response("Paramètre 'year' invalide", { status: 400 });
+	}
+	const year = parsedYear ?? getCurrentYear();
 
 	try {
 		const [row] = await db
@@ -58,6 +65,6 @@ export async function GET(request: Request) {
 		});
 	} catch (error) {
 		console.error("[prefill-pdf]", error);
-		return new Response("Impossible de générer le PDF", { status: 400 });
+		return new Response("Impossible de générer le PDF", { status: 500 });
 	}
 }

--- a/packages/app/src/app/api/prefill-pdf/route.ts
+++ b/packages/app/src/app/api/prefill-pdf/route.ts
@@ -1,0 +1,63 @@
+import { renderToBuffer } from "@react-pdf/renderer";
+import { and, eq } from "drizzle-orm";
+
+import {
+	type PrefillPdfData,
+	PrefillPdfDocument,
+} from "~/modules/declarationPdf/PrefillPdfDocument";
+import { extractSiren, getCurrentYear } from "~/modules/domain";
+import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { companies, gipMdsData } from "~/server/db/schema";
+
+export async function GET(request: Request) {
+	const session = await auth();
+	if (!session?.user?.siret) {
+		return new Response("Non autorisé", { status: 401 });
+	}
+
+	const siren = extractSiren(session.user.siret);
+	const url = new URL(request.url);
+	const yearParam = url.searchParams.get("year");
+	const year = yearParam ? Number.parseInt(yearParam, 10) : getCurrentYear();
+
+	try {
+		const [row] = await db
+			.select()
+			.from(gipMdsData)
+			.where(and(eq(gipMdsData.siren, siren), eq(gipMdsData.year, year)))
+			.limit(1);
+
+		if (!row) {
+			return new Response("Aucune donnée préremplie", { status: 404 });
+		}
+
+		const [company] = await db
+			.select({ name: companies.name })
+			.from(companies)
+			.where(eq(companies.siren, siren))
+			.limit(1);
+
+		const data: PrefillPdfData = {
+			siren,
+			companyName: company?.name ?? `Entreprise ${siren}`,
+			year,
+			periodStart: row.periodStart,
+			periodEnd: row.periodEnd,
+			row: row as unknown as Record<string, string | number | null>,
+		};
+
+		const buffer = await renderToBuffer(PrefillPdfDocument({ data }));
+		const filename = `donnees-preremplies-${siren}-${year}.pdf`;
+
+		return new Response(new Uint8Array(buffer), {
+			headers: {
+				"Content-Type": "application/pdf",
+				"Content-Disposition": `attachment; filename="${filename}"`,
+			},
+		});
+	} catch (error) {
+		console.error("[prefill-pdf]", error);
+		return new Response("Impossible de générer le PDF", { status: 400 });
+	}
+}

--- a/packages/app/src/modules/declarationPdf/PrefillPdfDocument.tsx
+++ b/packages/app/src/modules/declarationPdf/PrefillPdfDocument.tsx
@@ -1,0 +1,148 @@
+import { Document, Page, Text, View } from "@react-pdf/renderer";
+
+import { ensurePdfFontsRegistered } from "./pdfFonts";
+import { styles } from "./pdfStyles";
+
+export type PrefillPdfData = {
+	siren: string;
+	companyName: string;
+	year: number;
+	periodStart: string | null;
+	periodEnd: string | null;
+	row: Record<string, string | number | null>;
+};
+
+type Section = {
+	title: string;
+	fields: Array<[string, string]>; // [label, key]
+};
+
+const SECTIONS: Section[] = [
+	{
+		title: "Effectifs",
+		fields: [
+			["Effectif EMA", "workforceEma"],
+			["Femmes — annuel global", "womenCountAnnualGlobal"],
+			["Hommes — annuel global", "menCountAnnualGlobal"],
+			["Femmes — horaire global", "womenCountHourlyGlobal"],
+			["Hommes — horaire global", "menCountHourlyGlobal"],
+		],
+	},
+	{
+		title: "Indicateur A — Écart de rémunération moyen global",
+		fields: [
+			["Écart annuel moyen", "globalAnnualMeanGap"],
+			["Rémunération annuelle moyenne — femmes", "globalAnnualMeanWomen"],
+			["Rémunération annuelle moyenne — hommes", "globalAnnualMeanMen"],
+			["Écart horaire moyen", "globalHourlyMeanGap"],
+		],
+	},
+	{
+		title: "Indicateur B — Écart de rémunération variable moyen",
+		fields: [
+			["Écart annuel moyen", "variableAnnualMeanGap"],
+			["Rémunération annuelle moyenne — femmes", "variableAnnualMeanWomen"],
+			["Rémunération annuelle moyenne — hommes", "variableAnnualMeanMen"],
+		],
+	},
+	{
+		title: "Indicateur C — Écart de rémunération médian global",
+		fields: [
+			["Écart annuel médian", "globalAnnualMedianGap"],
+			["Rémunération annuelle médiane — femmes", "globalAnnualMedianWomen"],
+			["Rémunération annuelle médiane — hommes", "globalAnnualMedianMen"],
+		],
+	},
+	{
+		title: "Indicateur D — Écart de rémunération variable médian",
+		fields: [
+			["Écart annuel médian", "variableAnnualMedianGap"],
+			["Rémunération annuelle médiane — femmes", "variableAnnualMedianWomen"],
+			["Rémunération annuelle médiane — hommes", "variableAnnualMedianMen"],
+		],
+	},
+	{
+		title: "Indicateur E — Proportion de rémunération variable",
+		fields: [
+			["Proportion — femmes", "variableProportionWomen"],
+			["Proportion — hommes", "variableProportionMen"],
+		],
+	},
+	{
+		title: "Indicateur F — Distribution par quartile (annuel)",
+		fields: [
+			["Seuil Q1", "annualQuartileThreshold1"],
+			["Seuil Q2", "annualQuartileThreshold2"],
+			["Seuil Q3", "annualQuartileThreshold3"],
+			["Seuil Q4", "annualQuartileThreshold4"],
+			["Q1 — femmes", "annualQuartile1ProportionWomen"],
+			["Q1 — hommes", "annualQuartile1ProportionMen"],
+			["Q2 — femmes", "annualQuartile2ProportionWomen"],
+			["Q2 — hommes", "annualQuartile2ProportionMen"],
+			["Q3 — femmes", "annualQuartile3ProportionWomen"],
+			["Q3 — hommes", "annualQuartile3ProportionMen"],
+			["Q4 — femmes", "annualQuartile4ProportionWomen"],
+			["Q4 — hommes", "annualQuartile4ProportionMen"],
+		],
+	},
+	{
+		title: "Indice de confiance",
+		fields: [["Indice de confiance global", "confidenceIndex"]],
+	},
+];
+
+function formatValue(value: string | number | null | undefined): string {
+	if (value === null || value === undefined || value === "") return "—";
+	return String(value);
+}
+
+type Props = {
+	data: PrefillPdfData;
+};
+
+export function PrefillPdfDocument({ data }: Props) {
+	ensurePdfFontsRegistered();
+
+	return (
+		<Document>
+			<Page size="A4" style={styles.page}>
+				<View style={styles.header}>
+					<Text style={styles.title}>
+						Données préremplies {data.year} (issues des données DSN)
+					</Text>
+					<Text style={styles.subtitle}>
+						Au titre des données {data.year - 1}
+					</Text>
+					<Text style={styles.companyInfo}>
+						{data.companyName} — SIREN {data.siren}
+					</Text>
+					{data.periodStart && data.periodEnd && (
+						<Text style={styles.companyInfo}>
+							Période : {data.periodStart} → {data.periodEnd}
+						</Text>
+					)}
+				</View>
+
+				{SECTIONS.map((section) => (
+					<View key={section.title} style={styles.card}>
+						<Text style={styles.cardTitle}>{section.title}</Text>
+						{section.fields.map(([label, key], index) => {
+							const isLast = index === section.fields.length - 1;
+							return (
+								<View
+									key={key}
+									style={isLast ? styles.tableRowLast : styles.tableRow}
+								>
+									<Text style={styles.tableCellLabel}>{label}</Text>
+									<Text style={styles.tableCellValue}>
+										{formatValue(data.row[key])}
+									</Text>
+								</View>
+							);
+						})}
+					</View>
+				))}
+			</Page>
+		</Document>
+	);
+}

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
@@ -195,11 +195,10 @@
 	font-weight: 700;
 	line-height: 1.75rem;
 	color: var(--text-title-blue-france);
-	overflow-wrap: anywhere !important;
-	word-break: break-word !important;
-	white-space: normal !important;
+	overflow-wrap: anywhere;
+	word-break: break-word;
+	white-space: normal;
 	background-image: none;
-	text-wrap: wrap;
 }
 
 .documentCardFooter {

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
@@ -154,6 +154,61 @@
 	gap: 1rem;
 }
 
+// Documents panel — custom card list
+.documentList {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+	min-width: 0;
+}
+
+.documentItem {
+	padding: 0;
+	margin: 0;
+	width: 100%;
+	min-width: 0;
+}
+
+.documentCard {
+	border: 1px solid var(--border-default-grey);
+	background-color: var(--background-default-grey);
+	padding: 1.5rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	width: 100%;
+	min-width: 0;
+	box-sizing: border-box;
+}
+
+.documentCard a.documentCardTitle {
+	display: block;
+	width: 100%;
+	max-width: 100%;
+	min-width: 0;
+	font-family: inherit;
+	font-size: 1.25rem;
+	font-weight: 700;
+	line-height: 1.75rem;
+	color: var(--text-title-blue-france);
+	overflow-wrap: anywhere !important;
+	word-break: break-word !important;
+	white-space: normal !important;
+	background-image: none;
+	text-wrap: wrap;
+}
+
+.documentCardFooter {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
 // Footer
 .footer {
 	display: flex;

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -7,6 +7,11 @@ import { getCurrentYear } from "~/modules/domain";
 
 import { DeclarationLink } from "./DeclarationLink";
 import { getDeclarationStepLabel } from "./DeclarationStepLabel";
+import {
+	DocumentsPanel,
+	getDocumentResourceCount,
+	getDocumentsPanelId,
+} from "./DocumentsPanel";
 import { StatusBadge } from "./StatusBadge";
 import type { DeclarationItem, DeclarationType } from "./types";
 
@@ -22,15 +27,6 @@ type Props = {
 	hasCse: boolean | null;
 	hasNoSanction: boolean;
 };
-
-function formatDate(date: Date | null): string {
-	if (!date) return "Aucune";
-	return new Intl.DateTimeFormat("fr-FR", {
-		day: "2-digit",
-		month: "2-digit",
-		year: "numeric",
-	}).format(date);
-}
 
 const TYPE_DEADLINES: Record<DeclarationType, string> = {
 	remuneration: "01/06",
@@ -204,33 +200,54 @@ function DeclarationsTable({
 									<th scope="col">Déclaration</th>
 									<th scope="col">Année</th>
 									<th scope="col">Étape</th>
-									<th scope="col">Statut</th>
 									<th scope="col">Échéance</th>
-									<th scope="col">Mise à jour</th>
+									<th scope="col">Statut</th>
+									<th scope="col">Ressources</th>
 								</tr>
 							</thead>
 							<tbody>
-								{declarations.map((declaration) => (
-									<tr key={`${declaration.type}-${declaration.year}`}>
-										<td>
-											<DeclarationLink
-												hasCse={hasCse}
-												siren={siren}
-												type={declaration.type}
-												userPhone={userPhone}
-											>
-												{TYPE_LABELS[declaration.type]}
-											</DeclarationLink>
-										</td>
-										<td>{declaration.year}</td>
-										<td>{getDeclarationStepLabel(declaration.currentStep)}</td>
-										<td>
-											<StatusBadge status={declaration.status} />
-										</td>
-										<td>{getDeadline(declaration)}</td>
-										<td>{formatDate(declaration.updatedAt)}</td>
-									</tr>
-								))}
+								{declarations.map((declaration) => {
+									const resourceCount = getDocumentResourceCount(declaration);
+									return (
+										<tr key={`${declaration.type}-${declaration.year}`}>
+											<td>
+												<DeclarationLink
+													hasCse={hasCse}
+													siren={siren}
+													type={declaration.type}
+													userPhone={userPhone}
+												>
+													{TYPE_LABELS[declaration.type]}
+												</DeclarationLink>
+											</td>
+											<td>{declaration.year}</td>
+											<td>
+												{getDeclarationStepLabel(declaration.currentStep)}
+											</td>
+											<td>{getDeadline(declaration)}</td>
+											<td>
+												<StatusBadge status={declaration.status} />
+											</td>
+											<td>
+												{resourceCount > 0 ? (
+													<>
+														<button
+															aria-controls={getDocumentsPanelId(declaration)}
+															className="fr-link"
+															data-fr-opened="false"
+															type="button"
+														>
+															Documents ({resourceCount})
+														</button>
+														<DocumentsPanel declaration={declaration} />
+													</>
+												) : (
+													"Aucune"
+												)}
+											</td>
+										</tr>
+									);
+								})}
 							</tbody>
 						</table>
 					</div>

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useRef } from "react";
-
 import styles from "./DeclarationProcessPanel.module.scss";
 import type { DeclarationItem } from "./types";
 
@@ -65,7 +63,6 @@ type Props = {
 };
 
 export function DocumentsPanel({ declaration }: Props) {
-	const dialogRef = useRef<HTMLDialogElement>(null);
 	const panelId = getDocumentsPanelId(declaration);
 	const titleId = `${panelId}-title`;
 	const resources = getResources(declaration);
@@ -80,7 +77,6 @@ export function DocumentsPanel({ declaration }: Props) {
 			aria-modal="true"
 			className={`fr-modal ${styles.sidePanel}`}
 			id={panelId}
-			ref={dialogRef}
 		>
 			<div className={styles.panelContainer}>
 				<div className={styles.panelHeader}>

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useRef } from "react";
+
+import styles from "./DeclarationProcessPanel.module.scss";
+import type { DeclarationItem } from "./types";
+
+export function getDocumentsPanelId(declaration: DeclarationItem): string {
+	return `documents-panel-${declaration.type}-${declaration.year}`;
+}
+
+type DocumentResource = {
+	title: string;
+	subtitle: string;
+	href: string;
+};
+
+function getResources(declaration: DeclarationItem): DocumentResource[] {
+	const resources: DocumentResource[] = [];
+	if (declaration.type !== "remuneration") return resources;
+
+	const subtitle = `Année ${declaration.year} au titre des données ${declaration.year - 1}`;
+
+	// Available as soon as the GIP MDS prefill has been loaded for this year.
+	if (declaration.hasPrefillData) {
+		resources.push({
+			title: "Télécharger les données préremplies (issues des données DSN)",
+			subtitle,
+			href: `/api/prefill-pdf?year=${declaration.year}`,
+		});
+	}
+
+	// Available once the initial declaration has been submitted.
+	if (declaration.status === "done") {
+		resources.push({
+			title: "Télécharger le récapitulatif de la déclaration des indicateurs",
+			subtitle,
+			href: `/api/declaration-pdf?year=${declaration.year}`,
+		});
+		resources.push({
+			title: "Télécharger le récapitulatif des éléments transmis",
+			subtitle,
+			href: `/api/transmitted-pdf?year=${declaration.year}`,
+		});
+	}
+
+	// Available once the second (corrective) declaration has been submitted.
+	if (declaration.secondDeclarationStatus === "submitted") {
+		resources.push({
+			title: "Télécharger le récapitulatif de la seconde déclaration",
+			subtitle,
+			href: `/api/declaration-pdf?type=correction&year=${declaration.year}`,
+		});
+	}
+
+	return resources;
+}
+
+export function getDocumentResourceCount(declaration: DeclarationItem): number {
+	return getResources(declaration).length;
+}
+
+type Props = {
+	declaration: DeclarationItem;
+};
+
+export function DocumentsPanel({ declaration }: Props) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const panelId = getDocumentsPanelId(declaration);
+	const titleId = `${panelId}-title`;
+	const resources = getResources(declaration);
+	const title =
+		declaration.type === "remuneration"
+			? `Démarche des indicateurs de rémunération ${declaration.year}`
+			: `Démarche de représentation ${declaration.year}`;
+
+	return (
+		<dialog
+			aria-labelledby={titleId}
+			aria-modal="true"
+			className={`fr-modal ${styles.sidePanel}`}
+			id={panelId}
+			ref={dialogRef}
+		>
+			<div className={styles.panelContainer}>
+				<div className={styles.panelHeader}>
+					<button
+						aria-controls={panelId}
+						className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-btn--icon-right fr-icon-close-line"
+						title="Fermer"
+						type="button"
+					>
+						Fermer
+					</button>
+				</div>
+				<div className={styles.panelContent}>
+					<div>
+						<h2 className="fr-h5 fr-mb-3w" id={titleId}>
+							{title}
+						</h2>
+						<ul className={styles.documentList}>
+							{resources.map((resource) => (
+								<li className={styles.documentItem} key={resource.href}>
+									<div className={styles.documentCard}>
+										<a
+											className={styles.documentCardTitle}
+											download
+											href={resource.href}
+										>
+											{resource.title}
+										</a>
+										<p className="fr-text--sm fr-mb-0 fr-text-default--grey">
+											{resource.subtitle}
+										</p>
+										<div className={styles.documentCardFooter}>
+											<p className="fr-text--xs fr-text-mention--grey fr-mb-0">
+												PDF
+											</p>
+											<span
+												aria-hidden="true"
+												className="fr-icon-download-line fr-icon--sm"
+											/>
+										</div>
+									</div>
+								</li>
+							))}
+						</ul>
+					</div>
+				</div>
+			</div>
+		</dialog>
+	);
+}

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -53,6 +53,7 @@ const declarations: DeclarationItem[] = [
 		complianceCompletedAt: null,
 		hasCseOpinion: false,
 		hasJointEvaluationFile: false,
+		hasPrefillData: false,
 	},
 	{
 		type: "representation",
@@ -66,6 +67,7 @@ const declarations: DeclarationItem[] = [
 		complianceCompletedAt: null,
 		hasCseOpinion: false,
 		hasJointEvaluationFile: false,
+		hasPrefillData: false,
 	},
 ];
 

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -13,6 +13,7 @@ const NO_COMPLIANCE = {
 	complianceCompletedAt: null,
 	hasCseOpinion: false,
 	hasJointEvaluationFile: false,
+	hasPrefillData: false,
 };
 
 const declarations: DeclarationItem[] = [
@@ -67,7 +68,7 @@ describe("DeclarationsSection", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders the table column headers including Échéance and Mise à jour", () => {
+	it("renders the table column headers including Échéance and Ressources", () => {
 		renderSection();
 		expect(
 			screen.getAllByRole("columnheader", { name: "Déclaration" }),
@@ -85,7 +86,7 @@ describe("DeclarationsSection", () => {
 			screen.getAllByRole("columnheader", { name: "Échéance" }),
 		).toHaveLength(2);
 		expect(
-			screen.getAllByRole("columnheader", { name: "Mise à jour" }),
+			screen.getAllByRole("columnheader", { name: "Ressources" }),
 		).toHaveLength(2);
 	});
 
@@ -98,14 +99,16 @@ describe("DeclarationsSection", () => {
 		expect(screen.getByText("Effectué")).toBeInTheDocument();
 	});
 
-	it("renders 'Aucune' for declarations with no update date", () => {
+	it("renders 'Aucune' for declarations with no resources", () => {
 		renderSection();
 		expect(screen.getAllByText("Aucune")).toHaveLength(2);
 	});
 
-	it("renders formatted date for declarations with an update date", () => {
+	it("renders a Documents link for completed declarations", () => {
 		renderSection();
-		expect(screen.getByText("15/03/2025")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Documents (2)" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders 'Années précédentes' heading when there are past declarations", () => {

--- a/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
@@ -9,6 +9,7 @@ const NO_COMPLIANCE = {
 	complianceCompletedAt: null,
 	hasCseOpinion: false,
 	hasJointEvaluationFile: false,
+	hasPrefillData: false,
 };
 
 describe("buildDeclarationList", () => {

--- a/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
@@ -23,6 +23,7 @@ function makeDeclaration(
 		complianceCompletedAt: null,
 		hasCseOpinion: false,
 		hasJointEvaluationFile: false,
+		hasPrefillData: false,
 		...overrides,
 	};
 }

--- a/packages/app/src/modules/my-space/buildDeclarationList.ts
+++ b/packages/app/src/modules/my-space/buildDeclarationList.ts
@@ -33,6 +33,7 @@ export function buildDeclarationList(
 	siren: string,
 	dbDeclarations: DbDeclaration[],
 	currentYear: number,
+	yearsWithPrefill: Set<number> = new Set(),
 ): DeclarationItem[] {
 	const rows: DeclarationItem[] = [];
 
@@ -57,9 +58,6 @@ export function buildDeclarationList(
 				hasPrefillData: existing.hasPrefillData,
 			});
 		} else {
-			const prefillOnly = dbDeclarations.find(
-				(d) => d.year === currentYear && d.type === type && d.hasPrefillData,
-			);
 			rows.push({
 				type,
 				siren,
@@ -72,7 +70,8 @@ export function buildDeclarationList(
 				complianceCompletedAt: null,
 				hasCseOpinion: false,
 				hasJointEvaluationFile: false,
-				hasPrefillData: prefillOnly?.hasPrefillData ?? false,
+				hasPrefillData:
+					type === "remuneration" && yearsWithPrefill.has(currentYear),
 			});
 		}
 	}

--- a/packages/app/src/modules/my-space/buildDeclarationList.ts
+++ b/packages/app/src/modules/my-space/buildDeclarationList.ts
@@ -17,6 +17,7 @@ type DbDeclaration = {
 	complianceCompletedAt: Date | null;
 	hasCseOpinion: boolean;
 	hasJointEvaluationFile: boolean;
+	hasPrefillData: boolean;
 };
 
 /**
@@ -53,8 +54,12 @@ export function buildDeclarationList(
 				complianceCompletedAt: existing.complianceCompletedAt,
 				hasCseOpinion: existing.hasCseOpinion,
 				hasJointEvaluationFile: existing.hasJointEvaluationFile,
+				hasPrefillData: existing.hasPrefillData,
 			});
 		} else {
+			const prefillOnly = dbDeclarations.find(
+				(d) => d.year === currentYear && d.type === type && d.hasPrefillData,
+			);
 			rows.push({
 				type,
 				siren,
@@ -67,6 +72,7 @@ export function buildDeclarationList(
 				complianceCompletedAt: null,
 				hasCseOpinion: false,
 				hasJointEvaluationFile: false,
+				hasPrefillData: prefillOnly?.hasPrefillData ?? false,
 			});
 		}
 	}
@@ -89,6 +95,7 @@ export function buildDeclarationList(
 			complianceCompletedAt: d.complianceCompletedAt,
 			hasCseOpinion: d.hasCseOpinion,
 			hasJointEvaluationFile: d.hasJointEvaluationFile,
+			hasPrefillData: d.hasPrefillData,
 		});
 	}
 

--- a/packages/app/src/modules/my-space/types.ts
+++ b/packages/app/src/modules/my-space/types.ts
@@ -32,4 +32,5 @@ export type DeclarationItem = {
 	complianceCompletedAt: Date | null;
 	hasCseOpinion: boolean;
 	hasJointEvaluationFile: boolean;
+	hasPrefillData: boolean;
 };

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -347,6 +347,14 @@ describe("companyRouter.getWithDeclarations", () => {
 					}),
 				};
 			}
+			if (selectCallCount === 5) {
+				// gipMdsData query (simple .from().where(), no join)
+				return {
+					from: vi.fn().mockReturnValue({
+						where: vi.fn().mockResolvedValue([]),
+					}),
+				};
+			}
 			// cseOpinions + jointEvaluationFiles queries (join through declarations)
 			return {
 				from: vi.fn().mockReturnValue({

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -12,6 +12,7 @@ import {
 	cseOpinions,
 	declarations,
 	files,
+	gipMdsData,
 	userCompanies,
 } from "~/server/db/schema";
 import { fetchCseBySiren, fetchSanctionBySiren } from "~/server/services/suit";
@@ -116,7 +117,7 @@ export const companyRouter = createTRPCRouter({
 				input.siren,
 			);
 
-			const [declarationRows, cseOpinionRows, jointEvalRows] =
+			const [declarationRows, cseOpinionRows, jointEvalRows, prefillRows] =
 				await Promise.all([
 					ctx.db
 						.select({
@@ -150,29 +151,58 @@ export const companyRouter = createTRPCRouter({
 								eq(files.type, "joint_evaluation"),
 							),
 						),
+					ctx.db
+						.select({ year: gipMdsData.year })
+						.from(gipMdsData)
+						.where(eq(gipMdsData.siren, input.siren)),
 				]);
 
 			const yearsWithCseOpinion = new Set(cseOpinionRows.map((r) => r.year));
 			const yearsWithJointEval = new Set(jointEvalRows.map((r) => r.year));
+			const yearsWithPrefill = new Set(prefillRows.map((r) => r.year));
 
 			const year = getCurrentYear();
+			const mappedDeclarations = declarationRows.map((d) => ({
+				type: "remuneration" as const,
+				year: d.year,
+				status: computeDeclarationStatus({
+					status: d.status,
+					currentStep: d.currentStep,
+				}),
+				currentStep: d.currentStep ?? 0,
+				updatedAt: d.updatedAt,
+				compliancePath: d.compliancePath,
+				secondDeclarationStatus: d.secondDeclarationStatus,
+				complianceCompletedAt: d.complianceCompletedAt,
+				hasCseOpinion: yearsWithCseOpinion.has(d.year),
+				hasJointEvaluationFile: yearsWithJointEval.has(d.year),
+				hasPrefillData: yearsWithPrefill.has(d.year),
+			}));
+
+			// Inject virtual entries for years that have prefill data but no declaration yet,
+			// so the declaration row can expose the "Documents" resource.
+			const declaredYears = new Set(mappedDeclarations.map((d) => d.year));
+			for (const prefillYear of yearsWithPrefill) {
+				if (!declaredYears.has(prefillYear)) {
+					mappedDeclarations.push({
+						type: "remuneration" as const,
+						year: prefillYear,
+						status: "to_complete",
+						currentStep: 0,
+						updatedAt: null,
+						compliancePath: null,
+						secondDeclarationStatus: null,
+						complianceCompletedAt: null,
+						hasCseOpinion: false,
+						hasJointEvaluationFile: false,
+						hasPrefillData: true,
+					});
+				}
+			}
+
 			const declarationItems = buildDeclarationList(
 				input.siren,
-				declarationRows.map((d) => ({
-					type: "remuneration" as const,
-					year: d.year,
-					status: computeDeclarationStatus({
-						status: d.status,
-						currentStep: d.currentStep,
-					}),
-					currentStep: d.currentStep ?? 0,
-					updatedAt: d.updatedAt,
-					compliancePath: d.compliancePath,
-					secondDeclarationStatus: d.secondDeclarationStatus,
-					complianceCompletedAt: d.complianceCompletedAt,
-					hasCseOpinion: yearsWithCseOpinion.has(d.year),
-					hasJointEvaluationFile: yearsWithJointEval.has(d.year),
-				})),
+				mappedDeclarations,
 				year,
 			);
 

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -179,31 +179,11 @@ export const companyRouter = createTRPCRouter({
 				hasPrefillData: yearsWithPrefill.has(d.year),
 			}));
 
-			// Inject virtual entries for years that have prefill data but no declaration yet,
-			// so the declaration row can expose the "Documents" resource.
-			const declaredYears = new Set(mappedDeclarations.map((d) => d.year));
-			for (const prefillYear of yearsWithPrefill) {
-				if (!declaredYears.has(prefillYear)) {
-					mappedDeclarations.push({
-						type: "remuneration" as const,
-						year: prefillYear,
-						status: "to_complete",
-						currentStep: 0,
-						updatedAt: null,
-						compliancePath: null,
-						secondDeclarationStatus: null,
-						complianceCompletedAt: null,
-						hasCseOpinion: false,
-						hasJointEvaluationFile: false,
-						hasPrefillData: true,
-					});
-				}
-			}
-
 			const declarationItems = buildDeclarationList(
 				input.siren,
 				mappedDeclarations,
 				year,
+				yearsWithPrefill,
 			);
 
 			return { company, declarations: declarationItems };

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,4 +20,4 @@ sonar.exclusions=**/__tests__/**,**/*.test.*,**/*.spec.*,**/migrations/**,**/e2e
 sonar.coverage.exclusions=**/instrumentation.ts,**/instrumentation-client.ts,**/sentry.*.config.ts,**/env.js,**/trpc/**,**/server/db/**,**/server/auth/**,**/server/services/**,**/app/api/**,**/testError/**,**/pdfStyles.ts,**/pdfFonts.ts,**/modules/export/queries.ts
 
 # Duplication exclusions (data-only files with repetitive structure)
-sonar.cpd.exclusions=**/faqData.ts,**/devFillData.ts
+sonar.cpd.exclusions=**/faqData.ts,**/devFillData.ts,**/PrefillPdfDocument.tsx


### PR DESCRIPTION
## Summary
- Replace "Mise à jour" column with "Ressources", reorder Échéance before État
- New side panel listing downloadable documents per declaration, opened from the Ressources column
- Documents shown progressively based on declaration state:
  - **Données préremplies DSN** (PDF) — when a `gip_mds_data` row exists
  - **Récapitulatif de la déclaration des indicateurs** — when status is `done`
  - **Récapitulatif des éléments transmis** — when status is `done`
  - **Récapitulatif de la seconde déclaration** — when `secondDeclarationStatus === "submitted"`
- New `/api/prefill-pdf` route generating a PDF from `gip_mds_data` (sections: workforce + indicators A–F + confidence index)

## Test plan
- [ ] Open Mon Espace, verify the table headers: Démarches · Année · Étape · Échéance · État · Ressources
- [ ] For a declaration with prefill data only → "Documents (1)" opens the panel showing the prefill PDF
- [ ] For a `done` declaration → "Documents (2 ou 3)" depending on second declaration state
- [ ] Click each document link to verify the PDF downloads