### PR TITLE
fix: lower nginx catch-all ingressroute priority to restore /api routing

### DIFF
--- a/.kontinuous/env/prod/archive/http.yaml
+++ b/.kontinuous/env/prod/archive/http.yaml
@@ -108,7 +108,7 @@ spec:
     match: Host(`egapro.travail.gouv.fr`)
     middlewares:
     - name: security-headers-nginx
-    priority: 10000
+    priority: 50
     services:
     - name: nginx
       port: 80


### PR DESCRIPTION
## Contexte

Signalé par un utilisateur de Annuaire Entreprises : l'endpoint `https://egapro.travail.gouv.fr/api/search?q=...` renvoie un 404 HTML (page Next.js) au lieu du JSON de l'API Python.

## Diagnostic

Dans [.kontinuous/env/prod/archive/http.yaml](.kontinuous/env/prod/archive/http.yaml), deux IngressRoutes Traefik matchent sur l'host `egapro.travail.gouv.fr` :

- `api` (`PathPrefix(/api)` → service Python) : **priority 100**
- `nginx` (catch-all sur l'host → Next.js) : **priority 10000**

Chez Traefik la priority la plus haute gagne, donc le catch-all nginx mange tout `/api/*`, sauf les règles explicitement re-routées à 10000 vers nginx (`/api/auth`, `/api/monitoring`, `/index-egapro/recherche`).

## Correction

On baisse la priority du catch-all nginx à `50` pour que l'ordre de résolution devienne :

| Path | Règle gagnante | Service |
|---|---|---|
| `/api/auth/*` | nginx /api/auth (10000) | nginx |
| `/api/monitoring/*` | nginx /api/monitoring (10000) | nginx |
| `/index-egapro/recherche/*` | nginx (10000) | nginx |
| `/api/search`, `/api/stats`, autres `/api/*` | api (100) | **api Python** ✅ |
| reste | nginx catch-all (50) | nginx (Next.js) |

⚠️ Note : le fichier est actuellement sous `archive/` (archivé dans #3097), donc Helm ne le rend plus. Les IngressRoutes en prod sont des orphelines du cluster. Un `kubectl apply -f` manuel est prévu pour appliquer le correctif — à discuter si on désarchive le fichier dans la foulée pour que Helm reprenne la main.

## Test plan

- [ ] `kubectl apply -f .kontinuous/env/prod/archive/http.yaml` en prod
- [ ] `curl https://egapro.travail.gouv.fr/api/search?q=356000000` renvoie du JSON
- [ ] `curl https://egapro.travail.gouv.fr/api/stats` renvoie du JSON
- [ ] Vérifier que `/api/auth/*` (ProConnect) fonctionne toujours
- [ ] Vérifier que `/` charge toujours le Next.js