### PR TITLE
feat(api): expose file type, joint evaluation file and explicit file names in SUIT export (#3145)

### DIFF
--- a/packages/app/src/app/api/v1/export/declarations/route.ts
+++ b/packages/app/src/app/api/v1/export/declarations/route.ts
@@ -1,12 +1,13 @@
 import { AUDIT_ACTIONS } from "~/modules/audit";
 import {
 	assembleDeclaration,
+	exportDeclarationsQuerySchema,
 	fetchCseFilesByDeclaration,
 	fetchCseOpinionsByDeclaration,
 	fetchIndicatorGByDeclaration,
+	fetchJointEvaluationFilesByDeclaration,
 	fetchSubmittedDeclarations,
-} from "~/modules/export/fetchDeclarations";
-import { exportDeclarationsQuerySchema } from "~/modules/export/schemas";
+} from "~/modules/export";
 import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
 import { verifySuitAuth } from "~/server/services/suitApiAuth";
 
@@ -67,21 +68,27 @@ async function apiExportDeclarationsHandler(
 		const rows = await fetchSubmittedDeclarations(date_begin, dateEnd);
 
 		const declarationIds = rows.map((r) => r.declarationId);
+		const sirenYearKeys = rows.map((r) => ({
+			siren: r.siren,
+			year: r.year,
+		}));
 
-		const [indicatorGMap, cseMap, cseFilesMap] = await Promise.all([
-			fetchIndicatorGByDeclaration(declarationIds),
-			fetchCseOpinionsByDeclaration(declarationIds),
-			fetchCseFilesByDeclaration(
-				rows.map((r) => ({ siren: r.siren, year: r.year })),
-			),
-		]);
+		const [indicatorGMap, cseMap, cseFilesMap, jointEvalFilesMap] =
+			await Promise.all([
+				fetchIndicatorGByDeclaration(declarationIds),
+				fetchCseOpinionsByDeclaration(declarationIds),
+				fetchCseFilesByDeclaration(sirenYearKeys),
+				fetchJointEvaluationFilesByDeclaration(sirenYearKeys),
+			]);
 
 		const data = rows.map((row) => {
+			const key = `${row.siren}-${row.year}`;
 			return assembleDeclaration(
 				row,
 				indicatorGMap.get(row.declarationId) ?? [],
 				cseMap.get(row.declarationId) ?? [],
-				cseFilesMap.get(`${row.siren}-${row.year}`) ?? [],
+				cseFilesMap.get(key) ?? [],
+				jointEvalFilesMap.get(key) ?? [],
 			);
 		});
 

--- a/packages/app/src/app/api/v1/files/route.ts
+++ b/packages/app/src/app/api/v1/files/route.ts
@@ -68,12 +68,9 @@ async function apiFilesHandler(request: Request): Promise<Response> {
 		]);
 
 		const mapKey = `${siren}-${year}`;
-		const sortedCse = [...(cseFilesMap.get(mapKey) ?? [])].sort(
-			(a, b) => a.uploadedAt.getTime() - b.uploadedAt.getTime(),
-		);
-		const cseFiles = sortedCse.map((f, i) => buildCseFilePayload(f, i + 1));
-		const jointFiles = (jointFilesMap.get(mapKey) ?? []).map((f) =>
-			buildJointEvaluationFilePayload(f),
+		const cseFiles = (cseFilesMap.get(mapKey) ?? []).map(buildCseFilePayload);
+		const jointFiles = (jointFilesMap.get(mapKey) ?? []).map(
+			buildJointEvaluationFilePayload,
 		);
 
 		return Response.json({

--- a/packages/app/src/app/api/v1/files/route.ts
+++ b/packages/app/src/app/api/v1/files/route.ts
@@ -1,6 +1,8 @@
 import { AUDIT_ACTIONS } from "~/modules/audit";
 import { parseSiren } from "~/modules/domain";
 import {
+	buildCseFilePayload,
+	buildJointEvaluationFilePayload,
 	exportFilesQuerySchema,
 	fetchCseFilesByDeclaration,
 	fetchJointEvaluationFilesByDeclaration,
@@ -66,20 +68,13 @@ async function apiFilesHandler(request: Request): Promise<Response> {
 		]);
 
 		const mapKey = `${siren}-${year}`;
-		const cseFiles = (cseFilesMap.get(mapKey) ?? []).map((f) => ({
-			id: f.id,
-			type: "cse_opinion" as const,
-			fileName: f.fileName,
-			uploadedAt: f.uploadedAt.toISOString(),
-			downloadUrl: `/api/v1/files/${f.id}`,
-		}));
-		const jointFiles = (jointFilesMap.get(mapKey) ?? []).map((f) => ({
-			id: f.id,
-			type: "joint_evaluation" as const,
-			fileName: f.fileName,
-			uploadedAt: f.uploadedAt.toISOString(),
-			downloadUrl: `/api/v1/files/${f.id}`,
-		}));
+		const sortedCse = [...(cseFilesMap.get(mapKey) ?? [])].sort(
+			(a, b) => a.uploadedAt.getTime() - b.uploadedAt.getTime(),
+		);
+		const cseFiles = sortedCse.map((f, i) => buildCseFilePayload(f, i + 1));
+		const jointFiles = (jointFilesMap.get(mapKey) ?? []).map((f) =>
+			buildJointEvaluationFilePayload(f),
+		);
 
 		return Response.json({
 			siren,

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -4,6 +4,7 @@ const mockFetchSubmitted = vi.fn().mockResolvedValue([]);
 const mockFetchIndicatorG = vi.fn().mockResolvedValue(new Map());
 const mockFetchCse = vi.fn().mockResolvedValue(new Map());
 const mockFetchCseFiles = vi.fn().mockResolvedValue(new Map());
+const mockFetchJointEval = vi.fn().mockResolvedValue(new Map());
 
 vi.mock("~/modules/export/queries", () => ({
 	fetchSubmittedDeclarations: (...args: unknown[]) =>
@@ -13,7 +14,8 @@ vi.mock("~/modules/export/queries", () => ({
 	fetchCseOpinionsByDeclaration: (...args: unknown[]) => mockFetchCse(...args),
 	fetchCseFilesByDeclaration: (...args: unknown[]) =>
 		mockFetchCseFiles(...args),
-	fetchJointEvaluationFilesByDeclaration: vi.fn().mockResolvedValue(new Map()),
+	fetchJointEvaluationFilesByDeclaration: (...args: unknown[]) =>
+		mockFetchJointEval(...args),
 }));
 
 const VALID_AUTH_HEADER = "Bearer test-suit-api-key-that-is-at-least-32-chars";
@@ -77,6 +79,7 @@ describe("GET /api/v1/export/declarations", () => {
 		mockFetchIndicatorG.mockResolvedValue(new Map());
 		mockFetchCse.mockResolvedValue(new Map());
 		mockFetchCseFiles.mockResolvedValue(new Map());
+		mockFetchJointEval.mockResolvedValue(new Map());
 	});
 
 	it("should return 401 when Authorization header is missing", async () => {
@@ -296,8 +299,9 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(decl.indicators.G).toBeNull();
 		expect(decl.indicators.F.annual).toHaveLength(4);
 		expect(decl.secondDeclaration.correction).toBeNull();
-		expect(decl.cseOpinions).toEqual([]);
-		expect(decl.cseFiles).toEqual([]);
+		expect(decl).not.toHaveProperty("cseOpinions");
+		expect(decl).not.toHaveProperty("cseFiles");
+		expect(decl).not.toHaveProperty("jointEvaluationFile");
 	});
 
 	it("should expose CSE opinion declarationNumber alongside type", async () => {
@@ -343,6 +347,23 @@ describe("GET /api/v1/export/declarations", () => {
 							type: "gap",
 							opinion: "unfavorable",
 							opinionDate: "2027-06-01",
+						},
+					],
+				],
+			]),
+		);
+		mockFetchCseFiles.mockResolvedValue(
+			new Map([
+				[
+					"123456789-2027",
+					[
+						{
+							id: "file-abc",
+							siren: "123456789",
+							year: 2027,
+							fileName: "avis.pdf",
+							filePath: "/s3/path",
+							uploadedAt: new Date("2027-03-10T08:30:00Z"),
 						},
 					],
 				],
@@ -432,10 +453,131 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(body.declarations[0].cseFiles).toEqual([
 			{
 				id: "file-abc",
-				fileName: "avis-cse-2027.pdf",
+				type: "cse_opinion",
+				fileName: "avis-cse-123456789-2027-1.pdf",
 				uploadedAt: "2027-03-10T08:30:00.000Z",
 				downloadUrl: "/api/v1/files/file-abc",
 			},
 		]);
+	});
+
+	it("should omit cseOpinions / cseFiles when no CSE file is attached", async () => {
+		mockFetchSubmitted.mockResolvedValue([
+			{
+				declarationId: "decl-1",
+				siren: "123456789",
+				year: 2027,
+				status: "submitted",
+				compliancePath: null,
+				totalWomen: 100,
+				totalMen: 150,
+				secondDeclarationStatus: null,
+				secondDeclReferencePeriodStart: null,
+				secondDeclReferencePeriodEnd: null,
+				createdAt: new Date("2027-03-15T10:00:00Z"),
+				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				companyName: "ACME Corp",
+				workforce: 250,
+				nafCode: "62.02",
+				address: "1 rue test",
+				hasCse: true,
+				declarantFirstName: "Jean",
+				declarantLastName: "Dupont",
+				declarantEmail: "jean@acme.fr",
+				declarantPhone: "0612345678",
+				...nullIndicators,
+			},
+		]);
+		mockFetchCse.mockResolvedValue(
+			new Map([
+				[
+					"decl-1",
+					[
+						{
+							declarationNumber: 1,
+							type: "accuracy",
+							opinion: "favorable",
+							opinionDate: "2027-03-01",
+						},
+					],
+				],
+			]),
+		);
+
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const request = authedRequest(
+			"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+		);
+		const response = await GET(request);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.declarations[0]).not.toHaveProperty("cseOpinions");
+		expect(body.declarations[0]).not.toHaveProperty("cseFiles");
+	});
+
+	it("should include jointEvaluationFile with explicit name when uploaded", async () => {
+		mockFetchSubmitted.mockResolvedValue([
+			{
+				declarationId: "decl-1",
+				siren: "123456789",
+				year: 2027,
+				status: "submitted",
+				compliancePath: null,
+				totalWomen: 100,
+				totalMen: 150,
+				secondDeclarationStatus: null,
+				secondDeclReferencePeriodStart: null,
+				secondDeclReferencePeriodEnd: null,
+				createdAt: new Date("2027-03-15T10:00:00Z"),
+				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				companyName: "ACME Corp",
+				workforce: 250,
+				nafCode: "62.02",
+				address: "1 rue test",
+				hasCse: true,
+				declarantFirstName: "Jean",
+				declarantLastName: "Dupont",
+				declarantEmail: "jean@acme.fr",
+				declarantPhone: "0612345678",
+				...nullIndicators,
+			},
+		]);
+		mockFetchJointEval.mockResolvedValue(
+			new Map([
+				[
+					"123456789-2027",
+					[
+						{
+							id: "je-1",
+							siren: "123456789",
+							year: 2027,
+							fileName: "eval.pdf",
+							filePath: "/s3/je",
+							uploadedAt: new Date("2027-04-01T09:00:00Z"),
+						},
+					],
+				],
+			]),
+		);
+
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const request = authedRequest(
+			"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+		);
+		const response = await GET(request);
+
+		expect(response.status).toBe(200);
+		expect(mockFetchJointEval).toHaveBeenCalledWith([
+			{ siren: "123456789", year: 2027 },
+		]);
+		const body = await response.json();
+		expect(body.declarations[0].jointEvaluationFile).toEqual({
+			id: "je-1",
+			type: "joint_evaluation",
+			fileName: "evaluation-conjointe-123456789-2027.pdf",
+			uploadedAt: "2027-04-01T09:00:00.000Z",
+			downloadUrl: "/api/v1/files/je-1",
+		});
 	});
 });

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -454,7 +454,7 @@ describe("GET /api/v1/export/declarations", () => {
 			{
 				id: "file-abc",
 				type: "cse_opinion",
-				fileName: "avis-cse-123456789-2027-1.pdf",
+				fileName: "avis-cse-2027.pdf",
 				uploadedAt: "2027-03-10T08:30:00.000Z",
 				downloadUrl: "/api/v1/files/file-abc",
 			},
@@ -575,7 +575,7 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(body.declarations[0].jointEvaluationFile).toEqual({
 			id: "je-1",
 			type: "joint_evaluation",
-			fileName: "evaluation-conjointe-123456789-2027.pdf",
+			fileName: "eval.pdf",
 			uploadedAt: "2027-04-01T09:00:00.000Z",
 			downloadUrl: "/api/v1/files/je-1",
 		});

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -224,7 +224,9 @@ describe("assembleDeclaration", () => {
 		expect(result.declarant.email).toBe("jean@acme.fr");
 		expect(result.indicators.G).toBeNull();
 		expect(result.secondDeclaration.correction).toBeNull();
-		expect(result.cseOpinions).toEqual([]);
+		expect(result).not.toHaveProperty("cseOpinions");
+		expect(result).not.toHaveProperty("cseFiles");
+		expect(result).not.toHaveProperty("jointEvaluationFile");
 		expect(result.createdAt).toBe("2027-03-15T10:00:00.000Z");
 	});
 
@@ -280,7 +282,7 @@ describe("assembleDeclaration", () => {
 		expect(result.secondDeclaration.correction?.[0]?.womenCount).toBe(52);
 	});
 
-	it("should map CSE opinions", () => {
+	it("should map CSE opinions when at least one CSE file is present", () => {
 		const opinions: CseRow[] = [
 			{
 				declarationNumber: 1,
@@ -289,19 +291,6 @@ describe("assembleDeclaration", () => {
 				opinionDate: "2027-01-15",
 			},
 		];
-
-		const result = assembleDeclaration(baseRow, [], opinions);
-
-		expect(result.cseOpinions).toHaveLength(1);
-		expect(result.cseOpinions[0]).toEqual({
-			declarationNumber: 1,
-			type: "accuracy",
-			opinion: "favorable",
-			date: "2027-01-15",
-		});
-	});
-
-	it("should map CSE files with download URLs", () => {
 		const files = [
 			{
 				id: "file-xyz",
@@ -313,21 +302,170 @@ describe("assembleDeclaration", () => {
 			},
 		];
 
+		const result = assembleDeclaration(baseRow, [], opinions, files);
+
+		expect(result.cseOpinions).toEqual([
+			{
+				declarationNumber: 1,
+				type: "accuracy",
+				opinion: "favorable",
+				date: "2027-01-15",
+			},
+		]);
+	});
+
+	it("should omit cseOpinions when no CSE file is attached", () => {
+		const opinions: CseRow[] = [
+			{
+				declarationNumber: 1,
+				type: "accuracy",
+				opinion: "favorable",
+				opinionDate: "2027-01-15",
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, [], opinions, []);
+
+		expect(result).not.toHaveProperty("cseOpinions");
+		expect(result).not.toHaveProperty("cseFiles");
+	});
+
+	it("should expose CSE files with explicit names, type and download URLs", () => {
+		const files = [
+			{
+				id: "file-xyz",
+				siren: "123456789",
+				year: 2027,
+				fileName: "original-name.pdf",
+				filePath: "/s3/path",
+				uploadedAt: new Date("2027-02-10T08:30:00Z"),
+			},
+		];
+
 		const result = assembleDeclaration(baseRow, [], [], files);
 
 		expect(result.cseFiles).toEqual([
 			{
 				id: "file-xyz",
-				fileName: "avis-cse.pdf",
+				type: "cse_opinion",
+				fileName: "avis-cse-123456789-2027-1.pdf",
 				uploadedAt: "2027-02-10T08:30:00.000Z",
 				downloadUrl: "/api/v1/files/file-xyz",
 			},
 		]);
 	});
 
-	it("should default cseFiles to empty array when not provided", () => {
-		const result = assembleDeclaration(baseRow, [], []);
-		expect(result.cseFiles).toEqual([]);
+	it("should number multiple CSE files by uploadedAt ascending", () => {
+		const files = [
+			{
+				id: "file-b",
+				siren: "123456789",
+				year: 2027,
+				fileName: "second.pdf",
+				filePath: "/s3/b",
+				uploadedAt: new Date("2027-06-10T08:30:00Z"),
+			},
+			{
+				id: "file-a",
+				siren: "123456789",
+				year: 2027,
+				fileName: "first.pdf",
+				filePath: "/s3/a",
+				uploadedAt: new Date("2027-02-10T08:30:00Z"),
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, [], [], files);
+
+		expect(result.cseFiles?.map((f) => f.fileName)).toEqual([
+			"avis-cse-123456789-2027-1.pdf",
+			"avis-cse-123456789-2027-2.pdf",
+		]);
+		expect(result.cseFiles?.[0]?.id).toBe("file-a");
+	});
+
+	it("should fall back to pdf when the stored fileName has no extension", () => {
+		const files = [
+			{
+				id: "file-noext",
+				siren: "123456789",
+				year: 2027,
+				fileName: "noextension",
+				filePath: "/s3/1",
+				uploadedAt: new Date("2027-02-10T08:30:00Z"),
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, [], [], files);
+
+		expect(result.cseFiles?.[0]?.fileName).toBe(
+			"avis-cse-123456789-2027-1.pdf",
+		);
+	});
+
+	it("should preserve original file extension for CSE files", () => {
+		const files = [
+			{
+				id: "file-1",
+				siren: "123456789",
+				year: 2027,
+				fileName: "scan.PDF",
+				filePath: "/s3/1",
+				uploadedAt: new Date("2027-02-10T08:30:00Z"),
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, [], [], files);
+
+		expect(result.cseFiles?.[0]?.fileName).toBe(
+			"avis-cse-123456789-2027-1.pdf",
+		);
+	});
+
+	it("should expose the joint evaluation file with explicit name", () => {
+		const file = {
+			id: "je-1",
+			siren: "123456789",
+			year: 2027,
+			fileName: "eval.pdf",
+			filePath: "/s3/je",
+			uploadedAt: new Date("2027-04-01T09:00:00Z"),
+		};
+
+		const result = assembleDeclaration(baseRow, [], [], [], [file]);
+
+		expect(result.jointEvaluationFile).toEqual({
+			id: "je-1",
+			type: "joint_evaluation",
+			fileName: "evaluation-conjointe-123456789-2027.pdf",
+			uploadedAt: "2027-04-01T09:00:00.000Z",
+			downloadUrl: "/api/v1/files/je-1",
+		});
+	});
+
+	it("should keep the most recent joint evaluation file when several exist", () => {
+		const files = [
+			{
+				id: "je-old",
+				siren: "123456789",
+				year: 2027,
+				fileName: "old.pdf",
+				filePath: "/s3/old",
+				uploadedAt: new Date("2027-03-01T09:00:00Z"),
+			},
+			{
+				id: "je-new",
+				siren: "123456789",
+				year: 2027,
+				fileName: "new.pdf",
+				filePath: "/s3/new",
+				uploadedAt: new Date("2027-06-01T09:00:00Z"),
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, [], [], [], files);
+
+		expect(result.jointEvaluationFile?.id).toBe("je-new");
 	});
 
 	it("should handle null dates", () => {

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -330,13 +330,13 @@ describe("assembleDeclaration", () => {
 		expect(result).not.toHaveProperty("cseFiles");
 	});
 
-	it("should expose CSE files with explicit names, type and download URLs", () => {
+	it("should expose CSE files with type, stored fileName and download URLs", () => {
 		const files = [
 			{
 				id: "file-xyz",
 				siren: "123456789",
 				year: 2027,
-				fileName: "original-name.pdf",
+				fileName: "avis-cse-original.pdf",
 				filePath: "/s3/path",
 				uploadedAt: new Date("2027-02-10T08:30:00Z"),
 			},
@@ -348,86 +348,19 @@ describe("assembleDeclaration", () => {
 			{
 				id: "file-xyz",
 				type: "cse_opinion",
-				fileName: "avis-cse-123456789-2027-1.pdf",
+				fileName: "avis-cse-original.pdf",
 				uploadedAt: "2027-02-10T08:30:00.000Z",
 				downloadUrl: "/api/v1/files/file-xyz",
 			},
 		]);
 	});
 
-	it("should number multiple CSE files by uploadedAt ascending", () => {
-		const files = [
-			{
-				id: "file-b",
-				siren: "123456789",
-				year: 2027,
-				fileName: "second.pdf",
-				filePath: "/s3/b",
-				uploadedAt: new Date("2027-06-10T08:30:00Z"),
-			},
-			{
-				id: "file-a",
-				siren: "123456789",
-				year: 2027,
-				fileName: "first.pdf",
-				filePath: "/s3/a",
-				uploadedAt: new Date("2027-02-10T08:30:00Z"),
-			},
-		];
-
-		const result = assembleDeclaration(baseRow, [], [], files);
-
-		expect(result.cseFiles?.map((f) => f.fileName)).toEqual([
-			"avis-cse-123456789-2027-1.pdf",
-			"avis-cse-123456789-2027-2.pdf",
-		]);
-		expect(result.cseFiles?.[0]?.id).toBe("file-a");
-	});
-
-	it("should fall back to pdf when the stored fileName has no extension", () => {
-		const files = [
-			{
-				id: "file-noext",
-				siren: "123456789",
-				year: 2027,
-				fileName: "noextension",
-				filePath: "/s3/1",
-				uploadedAt: new Date("2027-02-10T08:30:00Z"),
-			},
-		];
-
-		const result = assembleDeclaration(baseRow, [], [], files);
-
-		expect(result.cseFiles?.[0]?.fileName).toBe(
-			"avis-cse-123456789-2027-1.pdf",
-		);
-	});
-
-	it("should preserve original file extension for CSE files", () => {
-		const files = [
-			{
-				id: "file-1",
-				siren: "123456789",
-				year: 2027,
-				fileName: "scan.PDF",
-				filePath: "/s3/1",
-				uploadedAt: new Date("2027-02-10T08:30:00Z"),
-			},
-		];
-
-		const result = assembleDeclaration(baseRow, [], [], files);
-
-		expect(result.cseFiles?.[0]?.fileName).toBe(
-			"avis-cse-123456789-2027-1.pdf",
-		);
-	});
-
-	it("should expose the joint evaluation file with explicit name", () => {
+	it("should expose the joint evaluation file with stored fileName", () => {
 		const file = {
 			id: "je-1",
 			siren: "123456789",
 			year: 2027,
-			fileName: "eval.pdf",
+			fileName: "eval-originale.pdf",
 			filePath: "/s3/je",
 			uploadedAt: new Date("2027-04-01T09:00:00Z"),
 		};
@@ -437,7 +370,7 @@ describe("assembleDeclaration", () => {
 		expect(result.jointEvaluationFile).toEqual({
 			id: "je-1",
 			type: "joint_evaluation",
-			fileName: "evaluation-conjointe-123456789-2027.pdf",
+			fileName: "eval-originale.pdf",
 			uploadedAt: "2027-04-01T09:00:00.000Z",
 			downloadUrl: "/api/v1/files/je-1",
 		});

--- a/packages/app/src/modules/export/__tests__/filesApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/filesApi.test.ts
@@ -186,14 +186,14 @@ describe("GET /api/v1/files", () => {
 		expect(body.files[0]).toEqual({
 			id: "cse-1",
 			type: "cse_opinion",
-			fileName: "avis-cse.pdf",
+			fileName: "avis-cse-123456789-2027-1.pdf",
 			uploadedAt: "2027-03-10T08:00:00.000Z",
 			downloadUrl: "/api/v1/files/cse-1",
 		});
 		expect(body.files[1]).toEqual({
 			id: "joint-1",
 			type: "joint_evaluation",
-			fileName: "evaluation.pdf",
+			fileName: "evaluation-conjointe-123456789-2027.pdf",
 			uploadedAt: "2027-03-12T09:00:00.000Z",
 			downloadUrl: "/api/v1/files/joint-1",
 		});

--- a/packages/app/src/modules/export/__tests__/filesApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/filesApi.test.ts
@@ -186,14 +186,14 @@ describe("GET /api/v1/files", () => {
 		expect(body.files[0]).toEqual({
 			id: "cse-1",
 			type: "cse_opinion",
-			fileName: "avis-cse-123456789-2027-1.pdf",
+			fileName: "avis-cse.pdf",
 			uploadedAt: "2027-03-10T08:00:00.000Z",
 			downloadUrl: "/api/v1/files/cse-1",
 		});
 		expect(body.files[1]).toEqual({
 			id: "joint-1",
 			type: "joint_evaluation",
-			fileName: "evaluation-conjointe-123456789-2027.pdf",
+			fileName: "evaluation.pdf",
 			uploadedAt: "2027-03-12T09:00:00.000Z",
 			downloadUrl: "/api/v1/files/joint-1",
 		});

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -6,7 +6,7 @@ describe("openApiSpec", () => {
 	it("should be a valid OpenAPI 3.1 structure", () => {
 		expect(openApiSpec.openapi).toBe("3.1.0");
 		expect(openApiSpec.info.title).toBeDefined();
-		expect(openApiSpec.info.version).toBe("1.3.0");
+		expect(openApiSpec.info.version).toBe("1.4.0");
 		expect(openApiSpec.paths).toBeDefined();
 	});
 

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -148,21 +148,13 @@ export function buildIndicatorG(entries: IndicatorGEntry[]): {
 	};
 }
 
-// ── File naming helpers (SUIT-facing explicit names) ─────────────────
+// ── File payload helpers (SUIT-facing) ───────────────────────────────
 
-// Extract the extension from the original upload (fallback to pdf).
-// Uploads today are PDF-only but the source of truth stays the stored name
-// so SUIT consumers do not get a misleading .pdf on a future format.
-function extractExtension(fileName: string): string {
-	const match = fileName.match(/\.([^./\\]+)$/);
-	return match?.[1]?.toLowerCase() ?? "pdf";
-}
-
-export function buildCseFilePayload(file: FileRow, index: number) {
+export function buildCseFilePayload(file: FileRow) {
 	return {
 		id: file.id,
 		type: "cse_opinion" as const,
-		fileName: `avis-cse-${file.siren}-${file.year}-${index}.${extractExtension(file.fileName)}`,
+		fileName: file.fileName,
 		uploadedAt: file.uploadedAt.toISOString(),
 		downloadUrl: `/api/v1/files/${file.id}`,
 	};
@@ -172,7 +164,7 @@ export function buildJointEvaluationFilePayload(file: FileRow) {
 	return {
 		id: file.id,
 		type: "joint_evaluation" as const,
-		fileName: `evaluation-conjointe-${file.siren}-${file.year}.${extractExtension(file.fileName)}`,
+		fileName: file.fileName,
 		uploadedAt: file.uploadedAt.toISOString(),
 		downloadUrl: `/api/v1/files/${file.id}`,
 	};
@@ -196,10 +188,7 @@ export function assembleDeclaration(
 ) {
 	const { initial, correction } = buildIndicatorG(indicatorGEntries);
 
-	const sortedCseFiles = [...cseFiles].sort(
-		(a, b) => a.uploadedAt.getTime() - b.uploadedAt.getTime(),
-	);
-	const hasCseFiles = sortedCseFiles.length > 0;
+	const hasCseFiles = cseFiles.length > 0;
 	const jointEvaluationFile = mostRecent(jointEvaluationFiles);
 
 	return {
@@ -241,7 +230,7 @@ export function assembleDeclaration(
 				opinion: o.opinion,
 				date: o.opinionDate,
 			})),
-			cseFiles: sortedCseFiles.map((f, i) => buildCseFilePayload(f, i + 1)),
+			cseFiles: cseFiles.map(buildCseFilePayload),
 		}),
 		...(jointEvaluationFile && {
 			jointEvaluationFile: buildJointEvaluationFilePayload(jointEvaluationFile),

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -148,6 +148,43 @@ export function buildIndicatorG(entries: IndicatorGEntry[]): {
 	};
 }
 
+// ── File naming helpers (SUIT-facing explicit names) ─────────────────
+
+// Extract the extension from the original upload (fallback to pdf).
+// Uploads today are PDF-only but the source of truth stays the stored name
+// so SUIT consumers do not get a misleading .pdf on a future format.
+function extractExtension(fileName: string): string {
+	const match = fileName.match(/\.([^./\\]+)$/);
+	return match?.[1]?.toLowerCase() ?? "pdf";
+}
+
+export function buildCseFilePayload(file: FileRow, index: number) {
+	return {
+		id: file.id,
+		type: "cse_opinion" as const,
+		fileName: `avis-cse-${file.siren}-${file.year}-${index}.${extractExtension(file.fileName)}`,
+		uploadedAt: file.uploadedAt.toISOString(),
+		downloadUrl: `/api/v1/files/${file.id}`,
+	};
+}
+
+export function buildJointEvaluationFilePayload(file: FileRow) {
+	return {
+		id: file.id,
+		type: "joint_evaluation" as const,
+		fileName: `evaluation-conjointe-${file.siren}-${file.year}.${extractExtension(file.fileName)}`,
+		uploadedAt: file.uploadedAt.toISOString(),
+		downloadUrl: `/api/v1/files/${file.id}`,
+	};
+}
+
+function mostRecent(files: FileRow[]): FileRow | undefined {
+	if (files.length === 0) return undefined;
+	return [...files].sort(
+		(a, b) => b.uploadedAt.getTime() - a.uploadedAt.getTime(),
+	)[0];
+}
+
 // ── Assemble declaration response ────────────────────────────────────
 
 export function assembleDeclaration(
@@ -155,8 +192,15 @@ export function assembleDeclaration(
 	indicatorGEntries: IndicatorGEntry[],
 	opinions: CseRow[],
 	cseFiles: FileRow[] = [],
+	jointEvaluationFiles: FileRow[] = [],
 ) {
 	const { initial, correction } = buildIndicatorG(indicatorGEntries);
+
+	const sortedCseFiles = [...cseFiles].sort(
+		(a, b) => a.uploadedAt.getTime() - b.uploadedAt.getTime(),
+	);
+	const hasCseFiles = sortedCseFiles.length > 0;
+	const jointEvaluationFile = mostRecent(jointEvaluationFiles);
 
 	return {
 		siren: row.siren,
@@ -188,17 +232,19 @@ export function assembleDeclaration(
 			email: row.declarantEmail,
 			phone: row.declarantPhone,
 		},
-		cseOpinions: opinions.map((o) => ({
-			declarationNumber: o.declarationNumber,
-			type: o.type,
-			opinion: o.opinion,
-			date: o.opinionDate,
-		})),
-		cseFiles: cseFiles.map((f) => ({
-			id: f.id,
-			fileName: f.fileName,
-			uploadedAt: f.uploadedAt.toISOString(),
-			downloadUrl: `/api/v1/files/${f.id}`,
-		})),
+		// CSE opinions only surface alongside the files they refer to; without
+		// files, SUIT should not receive orphan opinion metadata.
+		...(hasCseFiles && {
+			cseOpinions: opinions.map((o) => ({
+				declarationNumber: o.declarationNumber,
+				type: o.type,
+				opinion: o.opinion,
+				date: o.opinionDate,
+			})),
+			cseFiles: sortedCseFiles.map((f, i) => buildCseFilePayload(f, i + 1)),
+		}),
+		...(jointEvaluationFile && {
+			jointEvaluationFile: buildJointEvaluationFilePayload(jointEvaluationFile),
+		}),
 	};
 }

--- a/packages/app/src/modules/export/index.ts
+++ b/packages/app/src/modules/export/index.ts
@@ -3,6 +3,8 @@ export { downloadExport } from "./downloadExport";
 export type { FileRow } from "./fetchDeclarations";
 export {
 	assembleDeclaration,
+	buildCseFilePayload,
+	buildJointEvaluationFilePayload,
 	fetchCseFilesByDeclaration,
 	fetchCseOpinionsByDeclaration,
 	fetchFileById,

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -222,7 +222,7 @@ const declarationSchema = {
 			type: "array",
 			items: cseOpinionSchema,
 			description:
-				"CSE opinions (PDF uploads, up to 4/year, companies >= 100 employees)",
+				"CSE opinions (PDF uploads, up to 4/year, companies >= 100 employees). Only present when at least one CSE file has been uploaded — absent otherwise.",
 		},
 		cseFiles: {
 			type: "array",
@@ -230,7 +230,17 @@ const declarationSchema = {
 				type: "object",
 				properties: {
 					id: { type: "string", description: "File unique identifier" },
-					fileName: { type: "string", example: "avis-cse-2026.pdf" },
+					type: {
+						type: "string",
+						enum: ["cse_opinion"],
+						description: "File type: CSE opinion",
+					},
+					fileName: {
+						type: "string",
+						description:
+							"Explicit, SUIT-friendly file name: `avis-cse-{siren}-{year}-{n}.{ext}` (n starts at 1, ordered by upload date).",
+						example: "avis-cse-319159877-2026-1.pdf",
+					},
 					uploadedAt: { type: "string", format: "date-time" },
 					downloadUrl: {
 						type: "string",
@@ -241,7 +251,38 @@ const declarationSchema = {
 				},
 			},
 			description:
-				"CSE opinion files (PDF) attached to the declaration, with a download URL pointing to /api/v1/files/{fileId}",
+				"CSE opinion files attached to the declaration, with a download URL pointing to /api/v1/files/{fileId}. Absent when no file has been uploaded.",
+		},
+		jointEvaluationFile: {
+			oneOf: [
+				{
+					type: "object",
+					properties: {
+						id: { type: "string", description: "File unique identifier" },
+						type: {
+							type: "string",
+							enum: ["joint_evaluation"],
+							description: "File type: joint evaluation",
+						},
+						fileName: {
+							type: "string",
+							description:
+								"Explicit, SUIT-friendly file name: `evaluation-conjointe-{siren}-{year}.{ext}`.",
+							example: "evaluation-conjointe-319159877-2026.pdf",
+						},
+						uploadedAt: { type: "string", format: "date-time" },
+						downloadUrl: {
+							type: "string",
+							description:
+								"Relative URL to download the file via GET /api/v1/files/{fileId}",
+							example: "/api/v1/files/abc-123",
+						},
+					},
+				},
+				{ type: "null" },
+			],
+			description:
+				"Joint evaluation file attached to the declaration (cardinality 1). Absent when no file has been uploaded.",
 		},
 	},
 } as const;
@@ -255,7 +296,12 @@ const fileMetadataSchema = {
 			enum: ["cse_opinion", "joint_evaluation"],
 			description: "File type: CSE opinion or joint evaluation",
 		},
-		fileName: { type: "string", example: "avis-cse-2026.pdf" },
+		fileName: {
+			type: "string",
+			description:
+				"Explicit file name: `avis-cse-{siren}-{year}-{n}.{ext}` for CSE opinions, `evaluation-conjointe-{siren}-{year}.{ext}` for joint evaluations.",
+			example: "avis-cse-319159877-2026-1.pdf",
+		},
 		uploadedAt: { type: "string", format: "date-time" },
 		downloadUrl: {
 			type: "string",
@@ -289,7 +335,7 @@ export const openApiSpec = {
 		title: "EGAPRO — API d'export",
 		description:
 			"API REST sécurisée permettant de consulter les déclarations d'égalité professionnelle et les fichiers associés (avis CSE, évaluations conjointes). L'accès nécessite une signature de requête (RSA-SHA256) et une clé API (Bearer token).",
-		version: "1.3.0",
+		version: "1.4.0",
 		contact: {
 			name: "Équipe EGAPRO — DNUM",
 		},

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -237,9 +237,8 @@ const declarationSchema = {
 					},
 					fileName: {
 						type: "string",
-						description:
-							"Explicit, SUIT-friendly file name: `avis-cse-{siren}-{year}-{n}.{ext}` (n starts at 1, ordered by upload date).",
-						example: "avis-cse-319159877-2026-1.pdf",
+						description: "Original file name as uploaded by the company.",
+						example: "avis-cse-2026.pdf",
 					},
 					uploadedAt: { type: "string", format: "date-time" },
 					downloadUrl: {
@@ -266,9 +265,8 @@ const declarationSchema = {
 						},
 						fileName: {
 							type: "string",
-							description:
-								"Explicit, SUIT-friendly file name: `evaluation-conjointe-{siren}-{year}.{ext}`.",
-							example: "evaluation-conjointe-319159877-2026.pdf",
+							description: "Original file name as uploaded by the company.",
+							example: "evaluation-conjointe-2026.pdf",
 						},
 						uploadedAt: { type: "string", format: "date-time" },
 						downloadUrl: {
@@ -298,9 +296,8 @@ const fileMetadataSchema = {
 		},
 		fileName: {
 			type: "string",
-			description:
-				"Explicit file name: `avis-cse-{siren}-{year}-{n}.{ext}` for CSE opinions, `evaluation-conjointe-{siren}-{year}.{ext}` for joint evaluations.",
-			example: "avis-cse-319159877-2026-1.pdf",
+			description: "Original file name as uploaded by the company.",
+			example: "avis-cse-2026.pdf",
 		},
 		uploadedAt: { type: "string", format: "date-time" },
 		downloadUrl: {


### PR DESCRIPTION
## Summary

Closes #3145

Complément de #3200 (#2905) — enrichit l'API SUIT (`/api/v1/export/declarations` + `/api/v1/files`) avec les informations de fichiers demandées dans le ticket :

- **`jointEvaluationFile`** exposé sur chaque déclaration (cardinalité 1, plus récent conservé si anomalie en base)
- **`type`** (`cse_opinion` | `joint_evaluation`) ajouté sur chaque payload fichier
- **`fileName`** : on renvoie le nom du fichier **tel que stocké en BDD** (nom d'origine uploadé par l'entreprise)
- **Omission** de `cseFiles` **et** `cseOpinions` quand aucun fichier CSE n'est attaché (règle demandée par @gary-van-woerkens)
- `jointEvaluationFile` est indépendant : reste omis / null sans impact sur les champs CSE
- Spec OpenAPI bump 1.3.0 → 1.4.0

## Decisions

- **Joint evaluation = objet unique** (pas un tableau), car contrainte unique en base (`file_joint_eval_unique`). Si >1 fichier (cas théoriquement impossible), on garde le plus récent silencieusement.
- **`type` ajouté aussi sur `/api/v1/files`** pour cohérence SUIT.

## Test plan

- [x] Unit tests `assembleDeclaration` : type, stored fileName, joint eval plus récent, omission cseOpinions/cseFiles
- [x] Integration tests route `/api/v1/export/declarations` : `jointEvaluationFile`, omission cseOpinions/cseFiles
- [x] Integration tests route `/api/v1/files` : type + stored fileName sur CSE + joint eval
- [x] OpenAPI version bump test
- [x] `pnpm typecheck` / `pnpm test` (1326) / `pnpm lint:check` / `pnpm format:check`
- [x] Vérification manuelle en local : appel `/api/v1/export/declarations` avec seed BDD (2 fichiers CSE + 1 joint eval + 2 cseOpinions sur une déclaration ; 0 fichier sur une autre) → `type`, `jointEvaluationFile`, `fileName` BDD et omission `cseFiles`/`cseOpinions` validés