### PR TITLE
feat(api): map SUIT declarations export to GIP labels (#3206)

### DIFF
--- a/packages/app/src/app/api/v1/export/declarations/route.ts
+++ b/packages/app/src/app/api/v1/export/declarations/route.ts
@@ -93,10 +93,10 @@ async function apiExportDeclarationsHandler(
 		});
 
 		return Response.json({
-			date_debut: date_begin,
-			date_fin: dateEnd,
-			nombre: data.length,
-			declarations: data,
+			Date_debut: date_begin,
+			Date_fin: dateEnd,
+			Nombre: data.length,
+			Declarations: data,
 		});
 	} catch (error) {
 		console.error("[api/v1/export/declarations]", error);

--- a/packages/app/src/app/api/v1/export/declarations/route.ts
+++ b/packages/app/src/app/api/v1/export/declarations/route.ts
@@ -93,9 +93,9 @@ async function apiExportDeclarationsHandler(
 		});
 
 		return Response.json({
-			dateBegin: date_begin,
-			dateEnd: dateEnd,
-			count: data.length,
+			date_debut: date_begin,
+			date_fin: dateEnd,
+			nombre: data.length,
 			declarations: data,
 		});
 	} catch (error) {

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -144,10 +144,10 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.nombre).toBe(0);
-		expect(body.declarations).toEqual([]);
-		expect(body.date_debut).toBe("2027-03-15");
-		expect(body.date_fin).toBe("2027-03-16");
+		expect(body.Nombre).toBe(0);
+		expect(body.Declarations).toEqual([]);
+		expect(body.Date_debut).toBe("2027-03-15");
+		expect(body.Date_fin).toBe("2027-03-16");
 		expect(mockFetchSubmitted).toHaveBeenCalledWith("2027-03-15", "2027-03-16");
 	});
 
@@ -160,7 +160,7 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.date_fin).toBe("2027-03-20");
+		expect(body.Date_fin).toBe("2027-03-20");
 		expect(mockFetchSubmitted).toHaveBeenCalledWith("2027-03-15", "2027-03-20");
 	});
 
@@ -238,7 +238,7 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.nombre).toBe(2);
+		expect(body.Nombre).toBe(2);
 
 		expect(mockFetchIndicatorG).toHaveBeenCalledWith(["decl-1", "decl-2"]);
 		expect(mockFetchCse).toHaveBeenCalledWith(["decl-1", "decl-2"]);
@@ -288,9 +288,9 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.nombre).toBe(1);
+		expect(body.Nombre).toBe(1);
 
-		const decl = body.declarations[0];
+		const decl = body.Declarations[0];
 		expect(decl.SIREN).toBe("123456789");
 		expect(decl.Declarant.Email).toBe("jean@acme.fr");
 		expect(decl.Indicateurs.A.Rem_globale_annuelle_moyenne_F).toBe("35000");
@@ -378,7 +378,7 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.declarations[0].Avis_CSE).toEqual([
+		expect(body.Declarations[0].Avis_CSE).toEqual([
 			{
 				Numero_declaration: 1,
 				Type: "accuracy",
@@ -450,7 +450,7 @@ describe("GET /api/v1/export/declarations", () => {
 			{ siren: "123456789", year: 2027 },
 		]);
 		const body = await response.json();
-		expect(body.declarations[0].Fichiers_CSE).toEqual([
+		expect(body.Declarations[0].Fichiers_CSE).toEqual([
 			{
 				Id: "file-abc",
 				Type: "cse_opinion",
@@ -512,8 +512,8 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.declarations[0]).not.toHaveProperty("Avis_CSE");
-		expect(body.declarations[0]).not.toHaveProperty("Fichiers_CSE");
+		expect(body.Declarations[0]).not.toHaveProperty("Avis_CSE");
+		expect(body.Declarations[0]).not.toHaveProperty("Fichiers_CSE");
 	});
 
 	it("should include jointEvaluationFile with explicit name when uploaded", async () => {
@@ -572,7 +572,7 @@ describe("GET /api/v1/export/declarations", () => {
 			{ siren: "123456789", year: 2027 },
 		]);
 		const body = await response.json();
-		expect(body.declarations[0].Fichier_evaluation_conjointe).toEqual({
+		expect(body.Declarations[0].Fichier_evaluation_conjointe).toEqual({
 			Id: "je-1",
 			Type: "joint_evaluation",
 			Nom_fichier: "eval.pdf",

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -144,10 +144,10 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.count).toBe(0);
+		expect(body.nombre).toBe(0);
 		expect(body.declarations).toEqual([]);
-		expect(body.dateBegin).toBe("2027-03-15");
-		expect(body.dateEnd).toBe("2027-03-16");
+		expect(body.date_debut).toBe("2027-03-15");
+		expect(body.date_fin).toBe("2027-03-16");
 		expect(mockFetchSubmitted).toHaveBeenCalledWith("2027-03-15", "2027-03-16");
 	});
 
@@ -160,7 +160,7 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.dateEnd).toBe("2027-03-20");
+		expect(body.date_fin).toBe("2027-03-20");
 		expect(mockFetchSubmitted).toHaveBeenCalledWith("2027-03-15", "2027-03-20");
 	});
 
@@ -238,7 +238,7 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.count).toBe(2);
+		expect(body.nombre).toBe(2);
 
 		expect(mockFetchIndicatorG).toHaveBeenCalledWith(["decl-1", "decl-2"]);
 		expect(mockFetchCse).toHaveBeenCalledWith(["decl-1", "decl-2"]);
@@ -288,20 +288,20 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.count).toBe(1);
+		expect(body.nombre).toBe(1);
 
 		const decl = body.declarations[0];
-		expect(decl.siren).toBe("123456789");
-		expect(decl.declarant.email).toBe("jean@acme.fr");
-		expect(decl.indicators.A.annualWomen).toBe("35000");
-		expect(decl.indicators.A.annualMen).toBe("38000");
-		expect(decl.indicators.A.hourlyWomen).toBeNull();
-		expect(decl.indicators.G).toBeNull();
-		expect(decl.indicators.F.annual).toHaveLength(4);
-		expect(decl.secondDeclaration.correction).toBeNull();
-		expect(decl).not.toHaveProperty("cseOpinions");
-		expect(decl).not.toHaveProperty("cseFiles");
-		expect(decl).not.toHaveProperty("jointEvaluationFile");
+		expect(decl.SIREN).toBe("123456789");
+		expect(decl.Declarant.Email).toBe("jean@acme.fr");
+		expect(decl.Indicateurs.A.Rem_globale_annuelle_moyenne_F).toBe("35000");
+		expect(decl.Indicateurs.A.Rem_globale_annuelle_moyenne_H).toBe("38000");
+		expect(decl.Indicateurs.A.Taux_horaire_global_moyen_F).toBeNull();
+		expect(decl.Indicateurs.G).toBeNull();
+		expect(decl.Indicateurs.F.annuel.Seuil_Q1_Rem_globale).toBeNull();
+		expect(decl.Seconde_declaration.Correction).toBeNull();
+		expect(decl).not.toHaveProperty("Avis_CSE");
+		expect(decl).not.toHaveProperty("Fichiers_CSE");
+		expect(decl).not.toHaveProperty("Fichier_evaluation_conjointe");
 	});
 
 	it("should expose CSE opinion declarationNumber alongside type", async () => {
@@ -378,18 +378,18 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.declarations[0].cseOpinions).toEqual([
+		expect(body.declarations[0].Avis_CSE).toEqual([
 			{
-				declarationNumber: 1,
-				type: "accuracy",
-				opinion: "favorable",
-				date: "2027-03-01",
+				Numero_declaration: 1,
+				Type: "accuracy",
+				Avis: "favorable",
+				Date: "2027-03-01",
 			},
 			{
-				declarationNumber: 2,
-				type: "gap",
-				opinion: "unfavorable",
-				date: "2027-06-01",
+				Numero_declaration: 2,
+				Type: "gap",
+				Avis: "unfavorable",
+				Date: "2027-06-01",
 			},
 		]);
 	});
@@ -450,13 +450,13 @@ describe("GET /api/v1/export/declarations", () => {
 			{ siren: "123456789", year: 2027 },
 		]);
 		const body = await response.json();
-		expect(body.declarations[0].cseFiles).toEqual([
+		expect(body.declarations[0].Fichiers_CSE).toEqual([
 			{
-				id: "file-abc",
-				type: "cse_opinion",
-				fileName: "avis-cse-2027.pdf",
-				uploadedAt: "2027-03-10T08:30:00.000Z",
-				downloadUrl: "/api/v1/files/file-abc",
+				Id: "file-abc",
+				Type: "cse_opinion",
+				Nom_fichier: "avis-cse-2027.pdf",
+				Date_upload: "2027-03-10T08:30:00.000Z",
+				URL_telechargement: "/api/v1/files/file-abc",
 			},
 		]);
 	});
@@ -512,8 +512,8 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body.declarations[0]).not.toHaveProperty("cseOpinions");
-		expect(body.declarations[0]).not.toHaveProperty("cseFiles");
+		expect(body.declarations[0]).not.toHaveProperty("Avis_CSE");
+		expect(body.declarations[0]).not.toHaveProperty("Fichiers_CSE");
 	});
 
 	it("should include jointEvaluationFile with explicit name when uploaded", async () => {
@@ -572,12 +572,12 @@ describe("GET /api/v1/export/declarations", () => {
 			{ siren: "123456789", year: 2027 },
 		]);
 		const body = await response.json();
-		expect(body.declarations[0].jointEvaluationFile).toEqual({
-			id: "je-1",
-			type: "joint_evaluation",
-			fileName: "eval.pdf",
-			uploadedAt: "2027-04-01T09:00:00.000Z",
-			downloadUrl: "/api/v1/files/je-1",
+		expect(body.declarations[0].Fichier_evaluation_conjointe).toEqual({
+			Id: "je-1",
+			Type: "joint_evaluation",
+			Nom_fichier: "eval.pdf",
+			Date_upload: "2027-04-01T09:00:00.000Z",
+			URL_telechargement: "/api/v1/files/je-1",
 		});
 	});
 });

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -82,89 +82,93 @@ const baseRow = {
 };
 
 describe("buildIndicators", () => {
-	it("should map indicator A columns", () => {
+	it("should map indicator A with GIP labels", () => {
 		const result = buildIndicators(baseRow);
 
-		expect(result.A.annualWomen).toBe("35000");
-		expect(result.A.annualMen).toBe("38000");
-		expect(result.A.hourlyWomen).toBe("18.50");
-		expect(result.A.hourlyMen).toBe("19.20");
+		expect(result.A.Rem_globale_annuelle_moyenne_F).toBe("35000");
+		expect(result.A.Rem_globale_annuelle_moyenne_H).toBe("38000");
+		expect(result.A.Taux_horaire_global_moyen_F).toBe("18.50");
+		expect(result.A.Taux_horaire_global_moyen_H).toBe("19.20");
 	});
 
-	it("should map indicator B columns", () => {
+	it("should map indicator B with GIP labels", () => {
 		const result = buildIndicators(baseRow);
 
-		expect(result.B.annualWomen).toBe("2500");
-		expect(result.B.annualMen).toBe("3200");
+		expect(result.B.Rem_variable_annuelle_moyenne_F).toBe("2500");
+		expect(result.B.Rem_variable_annuelle_moyenne_H).toBe("3200");
 	});
 
-	it("should map indicator C and D columns", () => {
+	it("should map indicator C and D with GIP labels", () => {
 		const result = buildIndicators(baseRow);
 
-		expect(result.C.annualWomen).toBe("33500");
-		expect(result.D.hourlyMen).toBe("1.40");
+		expect(result.C.Rem_globale_annuelle_médiane_F).toBe("33500");
+		expect(result.D.Taux_horaire_variable_médian_H).toBe("1.40");
 	});
 
-	it("should map indicator E columns", () => {
+	it("should map indicator E with GIP labels", () => {
 		const result = buildIndicators(baseRow);
 
-		expect(result.E.women).toBe("95");
-		expect(result.E.men).toBe("110");
+		expect(result.E.Effectif_F_rem_annuelle_variable).toBe("95");
+		expect(result.E.Effectif_H_rem_annuelle_variable).toBe("110");
 	});
 
-	it("should map indicator F quartiles with 4 entries per period", () => {
+	it("should expose indicator F as flat objects with thresholds + proportions", () => {
 		const result = buildIndicators(baseRow);
 
-		expect(result.F.annual).toHaveLength(4);
-		expect(result.F.annual[0]).toEqual({
-			threshold: "22000",
-			women: 35,
-			men: 28,
-		});
-		expect(result.F.annual[3]).toEqual({
-			threshold: null,
-			women: 27,
-			men: 35,
-		});
-		expect(result.F.hourly).toHaveLength(4);
-		expect(result.F.hourly[0]).toEqual({
-			threshold: "11.50",
-			women: 40,
-			men: 25,
-		});
+		// Q1 annual: women 35, men 28 → total 63; F = 35/63 = 0.5556, H = 28/63 = 0.4444
+		expect(result.F.annuel.Seuil_Q1_Rem_globale).toBe("22000");
+		expect(result.F.annuel.Quartile1_Rem_globale_annuelle_proportion_F).toBe(
+			0.5556,
+		);
+		expect(result.F.annuel.Quartile1_Rem_globale_annuelle_proportion_H).toBe(
+			0.4444,
+		);
+		// Q4 annual: threshold null, women 27 / men 35 → total 62
+		expect(result.F.annuel.Seuil_Q4_Rem_globale).toBeNull();
+		expect(result.F.annuel.Quartile4_Rem_globale_annuelle_proportion_F).toBe(
+			Math.round((27 / 62) * 10_000) / 10_000,
+		);
+		// Q1 hourly: women 40, men 25 → total 65
+		expect(result.F.horaire.Seuil_Q1_Taux_horaire_global).toBe("11.50");
+		expect(result.F.horaire.Quartile1_Taux_horaire_global_proportion_F).toBe(
+			Math.round((40 / 65) * 10_000) / 10_000,
+		);
 	});
 
-	it("should handle all null indicator columns gracefully", () => {
+	it("should return null proportions when counts are missing or quartile is empty", () => {
 		const nullRow = {
 			...baseRow,
 			indicatorAAnnualWomen: null,
 			indicatorAAnnualMen: null,
-			indicatorAHourlyWomen: null,
-			indicatorAHourlyMen: null,
 			indicatorEWomen: null,
 			indicatorEMen: null,
 			indicatorFAnnualThreshold1: null,
 			indicatorFAnnualWomen1: null,
 			indicatorFAnnualMen1: null,
-			indicatorFHourlyThreshold1: null,
-			indicatorFHourlyWomen1: null,
-			indicatorFHourlyMen1: null,
+			// Q2: both zero → total 0 → proportions must be null, not NaN
+			indicatorFAnnualWomen2: 0,
+			indicatorFAnnualMen2: 0,
 		};
 
 		const result = buildIndicators(nullRow);
 
-		expect(result.A.annualWomen).toBeNull();
-		expect(result.E.women).toBeNull();
-		expect(result.F.annual[0]).toEqual({
-			threshold: null,
-			women: null,
-			men: null,
-		});
+		expect(result.A.Rem_globale_annuelle_moyenne_F).toBeNull();
+		expect(result.E.Effectif_F_rem_annuelle_variable).toBeNull();
+		expect(result.F.annuel.Seuil_Q1_Rem_globale).toBeNull();
+		expect(
+			result.F.annuel.Quartile1_Rem_globale_annuelle_proportion_F,
+		).toBeNull();
+		expect(
+			result.F.annuel.Quartile1_Rem_globale_annuelle_proportion_H,
+		).toBeNull();
+		expect(
+			result.F.annuel.Quartile2_Rem_globale_annuelle_proportion_F,
+		).toBeNull();
 	});
 });
 
 describe("buildIndicatorG", () => {
-	it("should separate initial and correction entries", () => {
+	it("should separate initial and correction entries with French keys", () => {
 		const entries: IndicatorGEntry[] = [
 			{
 				categoryName: "Ouvriers",
@@ -202,9 +206,10 @@ describe("buildIndicatorG", () => {
 
 		expect(result.initial).toHaveLength(1);
 		expect(result.correction).toHaveLength(1);
-		expect(result.initial[0]?.categoryName).toBe("Ouvriers");
-		expect(result.initial[0]?.womenCount).toBe(40);
-		expect(result.correction[0]?.womenCount).toBe(42);
+		expect(result.initial[0]?.Nom_categorie).toBe("Ouvriers");
+		expect(result.initial[0]?.Effectif_F).toBe(40);
+		expect(result.correction[0]?.Effectif_F).toBe(42);
+		expect(result.initial[0]?.Rem_annuelle_base_F).toBe("24000");
 	});
 
 	it("should return empty arrays when no entries", () => {
@@ -216,31 +221,35 @@ describe("buildIndicatorG", () => {
 });
 
 describe("assembleDeclaration", () => {
-	it("should assemble a full declaration with all sections", () => {
+	it("should assemble a full declaration with French top-level keys", () => {
 		const result = assembleDeclaration(baseRow, [], []);
 
-		expect(result.siren).toBe("123456789");
-		expect(result.companyName).toBe("ACME Corp");
-		expect(result.declarant.email).toBe("jean@acme.fr");
-		expect(result.indicators.G).toBeNull();
-		expect(result.secondDeclaration.correction).toBeNull();
-		expect(result).not.toHaveProperty("cseOpinions");
-		expect(result).not.toHaveProperty("cseFiles");
-		expect(result).not.toHaveProperty("jointEvaluationFile");
-		expect(result.createdAt).toBe("2027-03-15T10:00:00.000Z");
+		expect(result.SIREN).toBe("123456789");
+		expect(result.Raison_sociale).toBe("ACME Corp");
+		expect(result.Effectif).toBe(250);
+		expect(result.CSE_existant).toBe(true);
+		expect(result.Annee).toBe(2027);
+		expect(result.Effectif_F_rem_annuelle_globale).toBe(100);
+		expect(result.Effectif_H_rem_annuelle_globale).toBe(150);
+		expect(result.Declarant.Email).toBe("jean@acme.fr");
+		expect(result.Indicateurs.G).toBeNull();
+		expect(result.Seconde_declaration.Correction).toBeNull();
+		expect(result).not.toHaveProperty("Avis_CSE");
+		expect(result).not.toHaveProperty("Fichiers_CSE");
+		expect(result).not.toHaveProperty("Fichier_evaluation_conjointe");
+		expect(result.Date_creation).toBe("2027-03-15T10:00:00.000Z");
 	});
 
-	it("should include indicator A–F values from declaration columns", () => {
+	it("should include indicator A–F values with GIP labels", () => {
 		const result = assembleDeclaration(baseRow, [], []);
 
-		expect(result.indicators.A.annualWomen).toBe("35000");
-		expect(result.indicators.B.hourlyMen).toBe("1.60");
-		expect(result.indicators.E.women).toBe("95");
-		expect(result.indicators.F.annual).toHaveLength(4);
-		expect(result.indicators.F.annual[0]?.threshold).toBe("22000");
+		expect(result.Indicateurs.A.Rem_globale_annuelle_moyenne_F).toBe("35000");
+		expect(result.Indicateurs.B.Taux_horaire_variable_moyen_H).toBe("1.60");
+		expect(result.Indicateurs.E.Effectif_F_rem_annuelle_variable).toBe("95");
+		expect(result.Indicateurs.F.annuel.Seuil_Q1_Rem_globale).toBe("22000");
 	});
 
-	it("should include indicator G initial in indicators and correction in secondDeclaration", () => {
+	it("should include indicator G initial in Indicateurs and correction in Seconde_declaration", () => {
 		const indicatorG: IndicatorGEntry[] = [
 			{
 				categoryName: "Cadres",
@@ -276,10 +285,10 @@ describe("assembleDeclaration", () => {
 
 		const result = assembleDeclaration(baseRow, indicatorG, []);
 
-		expect(result.indicators.G).toHaveLength(1);
-		expect(result.indicators.G?.[0]?.womenCount).toBe(50);
-		expect(result.secondDeclaration.correction).toHaveLength(1);
-		expect(result.secondDeclaration.correction?.[0]?.womenCount).toBe(52);
+		expect(result.Indicateurs.G).toHaveLength(1);
+		expect(result.Indicateurs.G?.[0]?.Effectif_F).toBe(50);
+		expect(result.Seconde_declaration.Correction).toHaveLength(1);
+		expect(result.Seconde_declaration.Correction?.[0]?.Effectif_F).toBe(52);
 	});
 
 	it("should map CSE opinions when at least one CSE file is present", () => {
@@ -304,17 +313,17 @@ describe("assembleDeclaration", () => {
 
 		const result = assembleDeclaration(baseRow, [], opinions, files);
 
-		expect(result.cseOpinions).toEqual([
+		expect(result.Avis_CSE).toEqual([
 			{
-				declarationNumber: 1,
-				type: "accuracy",
-				opinion: "favorable",
-				date: "2027-01-15",
+				Numero_declaration: 1,
+				Type: "accuracy",
+				Avis: "favorable",
+				Date: "2027-01-15",
 			},
 		]);
 	});
 
-	it("should omit cseOpinions when no CSE file is attached", () => {
+	it("should omit Avis_CSE when no CSE file is attached", () => {
 		const opinions: CseRow[] = [
 			{
 				declarationNumber: 1,
@@ -326,8 +335,8 @@ describe("assembleDeclaration", () => {
 
 		const result = assembleDeclaration(baseRow, [], opinions, []);
 
-		expect(result).not.toHaveProperty("cseOpinions");
-		expect(result).not.toHaveProperty("cseFiles");
+		expect(result).not.toHaveProperty("Avis_CSE");
+		expect(result).not.toHaveProperty("Fichiers_CSE");
 	});
 
 	it("should expose CSE files with type, stored fileName and download URLs", () => {
@@ -344,13 +353,13 @@ describe("assembleDeclaration", () => {
 
 		const result = assembleDeclaration(baseRow, [], [], files);
 
-		expect(result.cseFiles).toEqual([
+		expect(result.Fichiers_CSE).toEqual([
 			{
-				id: "file-xyz",
-				type: "cse_opinion",
-				fileName: "avis-cse-original.pdf",
-				uploadedAt: "2027-02-10T08:30:00.000Z",
-				downloadUrl: "/api/v1/files/file-xyz",
+				Id: "file-xyz",
+				Type: "cse_opinion",
+				Nom_fichier: "avis-cse-original.pdf",
+				Date_upload: "2027-02-10T08:30:00.000Z",
+				URL_telechargement: "/api/v1/files/file-xyz",
 			},
 		]);
 	});
@@ -367,12 +376,12 @@ describe("assembleDeclaration", () => {
 
 		const result = assembleDeclaration(baseRow, [], [], [], [file]);
 
-		expect(result.jointEvaluationFile).toEqual({
-			id: "je-1",
-			type: "joint_evaluation",
-			fileName: "eval-originale.pdf",
-			uploadedAt: "2027-04-01T09:00:00.000Z",
-			downloadUrl: "/api/v1/files/je-1",
+		expect(result.Fichier_evaluation_conjointe).toEqual({
+			Id: "je-1",
+			Type: "joint_evaluation",
+			Nom_fichier: "eval-originale.pdf",
+			Date_upload: "2027-04-01T09:00:00.000Z",
+			URL_telechargement: "/api/v1/files/je-1",
 		});
 	});
 
@@ -398,14 +407,14 @@ describe("assembleDeclaration", () => {
 
 		const result = assembleDeclaration(baseRow, [], [], [], files);
 
-		expect(result.jointEvaluationFile?.id).toBe("je-new");
+		expect(result.Fichier_evaluation_conjointe?.Id).toBe("je-new");
 	});
 
 	it("should handle null dates", () => {
 		const rowWithNullDates = { ...baseRow, createdAt: null, updatedAt: null };
 		const result = assembleDeclaration(rowWithNullDates, [], []);
 
-		expect(result.createdAt).toBeNull();
-		expect(result.updatedAt).toBeNull();
+		expect(result.Date_creation).toBeNull();
+		expect(result.Date_modification).toBeNull();
 	});
 });

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -135,6 +135,25 @@ describe("buildIndicators", () => {
 		);
 	});
 
+	it("should return null on both sides when only one gender count is null", () => {
+		// Half-missing data must not surface as 1.0/null — GIP consumers
+		// should see both as null to signal the data-quality issue.
+		const row = {
+			...baseRow,
+			indicatorFAnnualWomen1: 30,
+			indicatorFAnnualMen1: null,
+		};
+
+		const result = buildIndicators(row);
+
+		expect(
+			result.F.annuel.Quartile1_Rem_globale_annuelle_proportion_F,
+		).toBeNull();
+		expect(
+			result.F.annuel.Quartile1_Rem_globale_annuelle_proportion_H,
+		).toBeNull();
+	});
+
 	it("should return null proportions when counts are missing or quartile is empty", () => {
 		const nullRow = {
 			...baseRow,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -14,6 +14,20 @@ export {
 } from "./queries";
 
 import type { DeclarationRow } from "./queries";
+import {
+	INDICATOR_A_LABELS,
+	INDICATOR_B_LABELS,
+	INDICATOR_C_LABELS,
+	INDICATOR_D_LABELS,
+	INDICATOR_E_LABELS,
+	INDICATOR_F_ANNUAL_MEN_LABELS,
+	INDICATOR_F_ANNUAL_THRESHOLD_LABELS,
+	INDICATOR_F_ANNUAL_WOMEN_LABELS,
+	INDICATOR_F_HOURLY_MEN_LABELS,
+	INDICATOR_F_HOURLY_THRESHOLD_LABELS,
+	INDICATOR_F_HOURLY_WOMEN_LABELS,
+	quartileProportion,
+} from "./shared/apiLabels";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -52,104 +66,145 @@ export type FileRow = {
 // ── Build indicators from declaration columns ─────────────────────────
 
 export function buildIndicators(row: DeclarationRow) {
+	const annualF: [number | null, number | null, number | null, number | null] =
+		[
+			row.indicatorFAnnualWomen1,
+			row.indicatorFAnnualWomen2,
+			row.indicatorFAnnualWomen3,
+			row.indicatorFAnnualWomen4,
+		];
+	const annualM: [number | null, number | null, number | null, number | null] =
+		[
+			row.indicatorFAnnualMen1,
+			row.indicatorFAnnualMen2,
+			row.indicatorFAnnualMen3,
+			row.indicatorFAnnualMen4,
+		];
+	const hourlyF: [number | null, number | null, number | null, number | null] =
+		[
+			row.indicatorFHourlyWomen1,
+			row.indicatorFHourlyWomen2,
+			row.indicatorFHourlyWomen3,
+			row.indicatorFHourlyWomen4,
+		];
+	const hourlyM: [number | null, number | null, number | null, number | null] =
+		[
+			row.indicatorFHourlyMen1,
+			row.indicatorFHourlyMen2,
+			row.indicatorFHourlyMen3,
+			row.indicatorFHourlyMen4,
+		];
+
+	const annualThresholds = [
+		row.indicatorFAnnualThreshold1,
+		row.indicatorFAnnualThreshold2,
+		row.indicatorFAnnualThreshold3,
+		row.indicatorFAnnualThreshold4,
+	];
+	const hourlyThresholds = [
+		row.indicatorFHourlyThreshold1,
+		row.indicatorFHourlyThreshold2,
+		row.indicatorFHourlyThreshold3,
+		row.indicatorFHourlyThreshold4,
+	];
+
+	const annualQuartile = Object.fromEntries(
+		Array.from({ length: 4 }, (_, i) => {
+			const women = annualF[i] ?? null;
+			const men = annualM[i] ?? null;
+			const total =
+				women === null && men === null ? null : (women ?? 0) + (men ?? 0);
+			return [
+				[INDICATOR_F_ANNUAL_THRESHOLD_LABELS[i], annualThresholds[i] ?? null],
+				[INDICATOR_F_ANNUAL_WOMEN_LABELS[i], quartileProportion(women, total)],
+				[INDICATOR_F_ANNUAL_MEN_LABELS[i], quartileProportion(men, total)],
+			];
+		}).flat(),
+	);
+
+	const hourlyQuartile = Object.fromEntries(
+		Array.from({ length: 4 }, (_, i) => {
+			const women = hourlyF[i] ?? null;
+			const men = hourlyM[i] ?? null;
+			const total =
+				women === null && men === null ? null : (women ?? 0) + (men ?? 0);
+			return [
+				[INDICATOR_F_HOURLY_THRESHOLD_LABELS[i], hourlyThresholds[i] ?? null],
+				[INDICATOR_F_HOURLY_WOMEN_LABELS[i], quartileProportion(women, total)],
+				[INDICATOR_F_HOURLY_MEN_LABELS[i], quartileProportion(men, total)],
+			];
+		}).flat(),
+	);
+
 	return {
 		A: {
-			annualWomen: row.indicatorAAnnualWomen,
-			annualMen: row.indicatorAAnnualMen,
-			hourlyWomen: row.indicatorAHourlyWomen,
-			hourlyMen: row.indicatorAHourlyMen,
+			[INDICATOR_A_LABELS.annualWomen]: row.indicatorAAnnualWomen,
+			[INDICATOR_A_LABELS.annualMen]: row.indicatorAAnnualMen,
+			[INDICATOR_A_LABELS.hourlyWomen]: row.indicatorAHourlyWomen,
+			[INDICATOR_A_LABELS.hourlyMen]: row.indicatorAHourlyMen,
 		},
 		B: {
-			annualWomen: row.indicatorBAnnualWomen,
-			annualMen: row.indicatorBAnnualMen,
-			hourlyWomen: row.indicatorBHourlyWomen,
-			hourlyMen: row.indicatorBHourlyMen,
+			[INDICATOR_B_LABELS.annualWomen]: row.indicatorBAnnualWomen,
+			[INDICATOR_B_LABELS.annualMen]: row.indicatorBAnnualMen,
+			[INDICATOR_B_LABELS.hourlyWomen]: row.indicatorBHourlyWomen,
+			[INDICATOR_B_LABELS.hourlyMen]: row.indicatorBHourlyMen,
 		},
 		C: {
-			annualWomen: row.indicatorCAnnualWomen,
-			annualMen: row.indicatorCAnnualMen,
-			hourlyWomen: row.indicatorCHourlyWomen,
-			hourlyMen: row.indicatorCHourlyMen,
+			[INDICATOR_C_LABELS.annualWomen]: row.indicatorCAnnualWomen,
+			[INDICATOR_C_LABELS.annualMen]: row.indicatorCAnnualMen,
+			[INDICATOR_C_LABELS.hourlyWomen]: row.indicatorCHourlyWomen,
+			[INDICATOR_C_LABELS.hourlyMen]: row.indicatorCHourlyMen,
 		},
 		D: {
-			annualWomen: row.indicatorDAnnualWomen,
-			annualMen: row.indicatorDAnnualMen,
-			hourlyWomen: row.indicatorDHourlyWomen,
-			hourlyMen: row.indicatorDHourlyMen,
+			[INDICATOR_D_LABELS.annualWomen]: row.indicatorDAnnualWomen,
+			[INDICATOR_D_LABELS.annualMen]: row.indicatorDAnnualMen,
+			[INDICATOR_D_LABELS.hourlyWomen]: row.indicatorDHourlyWomen,
+			[INDICATOR_D_LABELS.hourlyMen]: row.indicatorDHourlyMen,
 		},
 		E: {
-			women: row.indicatorEWomen,
-			men: row.indicatorEMen,
+			[INDICATOR_E_LABELS.women]: row.indicatorEWomen,
+			[INDICATOR_E_LABELS.men]: row.indicatorEMen,
 		},
 		F: {
-			annual: [
-				{
-					threshold: row.indicatorFAnnualThreshold1,
-					women: row.indicatorFAnnualWomen1,
-					men: row.indicatorFAnnualMen1,
-				},
-				{
-					threshold: row.indicatorFAnnualThreshold2,
-					women: row.indicatorFAnnualWomen2,
-					men: row.indicatorFAnnualMen2,
-				},
-				{
-					threshold: row.indicatorFAnnualThreshold3,
-					women: row.indicatorFAnnualWomen3,
-					men: row.indicatorFAnnualMen3,
-				},
-				{
-					threshold: row.indicatorFAnnualThreshold4,
-					women: row.indicatorFAnnualWomen4,
-					men: row.indicatorFAnnualMen4,
-				},
-			],
-			hourly: [
-				{
-					threshold: row.indicatorFHourlyThreshold1,
-					women: row.indicatorFHourlyWomen1,
-					men: row.indicatorFHourlyMen1,
-				},
-				{
-					threshold: row.indicatorFHourlyThreshold2,
-					women: row.indicatorFHourlyWomen2,
-					men: row.indicatorFHourlyMen2,
-				},
-				{
-					threshold: row.indicatorFHourlyThreshold3,
-					women: row.indicatorFHourlyWomen3,
-					men: row.indicatorFHourlyMen3,
-				},
-				{
-					threshold: row.indicatorFHourlyThreshold4,
-					women: row.indicatorFHourlyWomen4,
-					men: row.indicatorFHourlyMen4,
-				},
-			],
+			annuel: annualQuartile,
+			horaire: hourlyQuartile,
 		},
 	};
 }
 
-type IndicatorGCategory = Omit<IndicatorGEntry, "declarationType">;
+// ── Indicator G entries ─────────────────────────────────────────────
 
-export function buildIndicatorG(entries: IndicatorGEntry[]): {
-	initial: IndicatorGCategory[];
-	correction: IndicatorGCategory[];
-} {
-	const toCategory = ({ declarationType: _, ...rest }: IndicatorGEntry) => rest;
+function toIndicatorGCategory(entry: IndicatorGEntry) {
+	return {
+		Nom_categorie: entry.categoryName,
+		Detail_categorie: entry.detail,
+		Effectif_F: entry.womenCount,
+		Effectif_H: entry.menCount,
+		Rem_annuelle_base_F: entry.annualBaseWomen,
+		Rem_annuelle_base_H: entry.annualBaseMen,
+		Rem_annuelle_variable_F: entry.annualVariableWomen,
+		Rem_annuelle_variable_H: entry.annualVariableMen,
+		Taux_horaire_base_F: entry.hourlyBaseWomen,
+		Taux_horaire_base_H: entry.hourlyBaseMen,
+		Taux_horaire_variable_F: entry.hourlyVariableWomen,
+		Taux_horaire_variable_H: entry.hourlyVariableMen,
+	};
+}
 
+export function buildIndicatorG(entries: IndicatorGEntry[]) {
 	return {
 		initial: entries
 			.filter((e) => e.declarationType === "initial")
-			.map(toCategory),
+			.map(toIndicatorGCategory),
 		correction: entries
 			.filter((e) => e.declarationType === "correction")
-			.map(toCategory),
+			.map(toIndicatorGCategory),
 	};
 }
 
-// ── File payload helpers (SUIT-facing) ───────────────────────────────
+// ── File payload helpers ────────────────────────────────────────────
 
+/** English-keyed payload kept for the `/api/v1/files` listing endpoint. */
 export function buildCseFilePayload(file: FileRow) {
 	return {
 		id: file.id,
@@ -167,6 +222,20 @@ export function buildJointEvaluationFilePayload(file: FileRow) {
 		fileName: file.fileName,
 		uploadedAt: file.uploadedAt.toISOString(),
 		downloadUrl: `/api/v1/files/${file.id}`,
+	};
+}
+
+/** French-keyed payload for the SUIT declarations export. */
+function buildFichierPayload(
+	file: FileRow,
+	type: "cse_opinion" | "joint_evaluation",
+) {
+	return {
+		Id: file.id,
+		Type: type,
+		Nom_fichier: file.fileName,
+		Date_upload: file.uploadedAt.toISOString(),
+		URL_telechargement: `/api/v1/files/${file.id}`,
 	};
 }
 
@@ -192,48 +261,51 @@ export function assembleDeclaration(
 	const jointEvaluationFile = mostRecent(jointEvaluationFiles);
 
 	return {
-		siren: row.siren,
-		companyName: row.companyName,
-		workforce: row.workforce,
-		nafCode: row.nafCode,
-		address: row.address,
-		hasCse: row.hasCse,
-		year: row.year,
-		status: row.status,
-		compliancePath: row.compliancePath,
-		createdAt: row.createdAt?.toISOString() ?? null,
-		updatedAt: row.updatedAt?.toISOString() ?? null,
-		totalWomen: row.totalWomen,
-		totalMen: row.totalMen,
-		indicators: {
+		SIREN: row.siren,
+		Raison_sociale: row.companyName,
+		Effectif: row.workforce,
+		Code_NAF: row.nafCode,
+		Adresse: row.address,
+		CSE_existant: row.hasCse,
+		Annee: row.year,
+		Statut: row.status,
+		Parcours_conformite: row.compliancePath,
+		Date_creation: row.createdAt?.toISOString() ?? null,
+		Date_modification: row.updatedAt?.toISOString() ?? null,
+		Effectif_F_rem_annuelle_globale: row.totalWomen,
+		Effectif_H_rem_annuelle_globale: row.totalMen,
+		Indicateurs: {
 			...buildIndicators(row),
 			G: initial.length > 0 ? initial : null,
 		},
-		secondDeclaration: {
-			status: row.secondDeclarationStatus,
-			referencePeriodStart: row.secondDeclReferencePeriodStart,
-			referencePeriodEnd: row.secondDeclReferencePeriodEnd,
-			correction: correction.length > 0 ? correction : null,
+		Seconde_declaration: {
+			Statut: row.secondDeclarationStatus,
+			Periode_reference_debut: row.secondDeclReferencePeriodStart,
+			Periode_reference_fin: row.secondDeclReferencePeriodEnd,
+			Correction: correction.length > 0 ? correction : null,
 		},
-		declarant: {
-			firstName: row.declarantFirstName,
-			lastName: row.declarantLastName,
-			email: row.declarantEmail,
-			phone: row.declarantPhone,
+		Declarant: {
+			Prenom: row.declarantFirstName,
+			Nom: row.declarantLastName,
+			Email: row.declarantEmail,
+			Telephone: row.declarantPhone,
 		},
 		// CSE opinions only surface alongside the files they refer to; without
 		// files, SUIT should not receive orphan opinion metadata.
 		...(hasCseFiles && {
-			cseOpinions: opinions.map((o) => ({
-				declarationNumber: o.declarationNumber,
-				type: o.type,
-				opinion: o.opinion,
-				date: o.opinionDate,
+			Avis_CSE: opinions.map((o) => ({
+				Numero_declaration: o.declarationNumber,
+				Type: o.type,
+				Avis: o.opinion,
+				Date: o.opinionDate,
 			})),
-			cseFiles: cseFiles.map(buildCseFilePayload),
+			Fichiers_CSE: cseFiles.map((f) => buildFichierPayload(f, "cse_opinion")),
 		}),
 		...(jointEvaluationFile && {
-			jointEvaluationFile: buildJointEvaluationFilePayload(jointEvaluationFile),
+			Fichier_evaluation_conjointe: buildFichierPayload(
+				jointEvaluationFile,
+				"joint_evaluation",
+			),
 		}),
 	};
 }

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -112,8 +112,7 @@ export function buildIndicators(row: DeclarationRow) {
 		Array.from({ length: 4 }, (_, i) => {
 			const women = annualF[i] ?? null;
 			const men = annualM[i] ?? null;
-			const total =
-				women === null && men === null ? null : (women ?? 0) + (men ?? 0);
+			const total = women !== null && men !== null ? women + men : null;
 			return [
 				[INDICATOR_F_ANNUAL_THRESHOLD_LABELS[i], annualThresholds[i] ?? null],
 				[INDICATOR_F_ANNUAL_WOMEN_LABELS[i], quartileProportion(women, total)],
@@ -126,8 +125,7 @@ export function buildIndicators(row: DeclarationRow) {
 		Array.from({ length: 4 }, (_, i) => {
 			const women = hourlyF[i] ?? null;
 			const men = hourlyM[i] ?? null;
-			const total =
-				women === null && men === null ? null : (women ?? 0) + (men ?? 0);
+			const total = women !== null && men !== null ? women + men : null;
 			return [
 				[INDICATOR_F_HOURLY_THRESHOLD_LABELS[i], hourlyThresholds[i] ?? null],
 				[INDICATOR_F_HOURLY_WOMEN_LABELS[i], quartileProportion(women, total)],

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -2,152 +2,170 @@
 
 const declarantSchema = {
 	type: "object",
+	description: "Personne physique ayant réalisé la déclaration.",
 	properties: {
-		firstName: { type: ["string", "null"] },
-		lastName: { type: ["string", "null"] },
-		email: { type: ["string", "null"] },
-		phone: { type: ["string", "null"] },
+		Prenom: { type: ["string", "null"] },
+		Nom: { type: ["string", "null"] },
+		Email: { type: ["string", "null"] },
+		Telephone: { type: ["string", "null"] },
 	},
 } as const;
 
 const indicatorGCategorySchema = {
 	type: "object",
+	description:
+		"Catégorie socio-professionnelle déclarée par l'entreprise pour l'indicateur G.",
 	properties: {
-		categoryName: {
+		Nom_categorie: {
 			type: "string",
-			description: "CSP category (e.g. 'Ouvriers', 'Ingénieurs et cadres')",
+			description: "Libellé CSP (ex. 'Ouvriers', 'Ingénieurs et cadres')",
 		},
-		detail: { type: ["string", "null"], description: "Category description" },
-		womenCount: { type: ["integer", "null"] },
-		menCount: { type: ["integer", "null"] },
-		annualBaseWomen: { type: ["string", "null"] },
-		annualBaseMen: { type: ["string", "null"] },
-		annualVariableWomen: { type: ["string", "null"] },
-		annualVariableMen: { type: ["string", "null"] },
-		hourlyBaseWomen: { type: ["string", "null"] },
-		hourlyBaseMen: { type: ["string", "null"] },
-		hourlyVariableWomen: { type: ["string", "null"] },
-		hourlyVariableMen: { type: ["string", "null"] },
+		Detail_categorie: {
+			type: ["string", "null"],
+			description: "Précision éventuelle sur la catégorie",
+		},
+		Effectif_F: { type: ["integer", "null"] },
+		Effectif_H: { type: ["integer", "null"] },
+		Rem_annuelle_base_F: { type: ["string", "null"] },
+		Rem_annuelle_base_H: { type: ["string", "null"] },
+		Rem_annuelle_variable_F: { type: ["string", "null"] },
+		Rem_annuelle_variable_H: { type: ["string", "null"] },
+		Taux_horaire_base_F: { type: ["string", "null"] },
+		Taux_horaire_base_H: { type: ["string", "null"] },
+		Taux_horaire_variable_F: { type: ["string", "null"] },
+		Taux_horaire_variable_H: { type: ["string", "null"] },
 	},
 } as const;
 
 const cseOpinionSchema = {
 	type: "object",
 	properties: {
-		declarationNumber: {
+		Numero_declaration: {
 			type: "integer",
 			enum: [1, 2],
 			description:
-				"Declaration number the CSE opinion refers to: 1 = initial declaration, 2 = second declaration (required when pay gap >= 5%)",
+				"Numéro de déclaration concernée par l'avis : 1 = déclaration initiale, 2 = seconde déclaration (requise si l'écart de rémunération atteint 5%)",
 		},
-		type: {
+		Type: {
 			type: "string",
 			enum: ["accuracy", "gap"],
 			description:
-				"CSE opinion type: 'accuracy' = opinion on data accuracy, 'gap' = opinion on pay gap correction measures",
+				"Type d'avis CSE : 'accuracy' = avis sur l'exactitude des données, 'gap' = avis sur les mesures de correction de l'écart",
 		},
-		opinion: { type: ["string", "null"] },
-		date: { type: ["string", "null"], format: "date" },
+		Avis: { type: ["string", "null"] },
+		Date: { type: ["string", "null"], format: "date" },
 	},
 } as const;
 
-const indicatorFQuartileSchema = {
-	type: "object",
-	description: "Quartile breakdown with salary threshold and headcounts",
-	properties: {
-		threshold: {
-			type: ["string", "null"],
-			description: "Upper salary threshold for this quartile (numeric string)",
-		},
-		women: { type: ["integer", "null"], description: "Women headcount" },
-		men: { type: ["integer", "null"], description: "Men headcount" },
-	},
-} as const;
-
-const indicatorFSchema = {
+const indicatorFAnnualSchema = {
 	type: "object",
 	description:
-		"Pay quartile distribution. Each array has 4 entries (Q1–Q4). Null values indicate the indicator was not provided.",
+		"Répartition par quartile — rémunération globale annuelle. Seuils en euros (chaîne numérique) ; proportions F/H entre 0 et 1.",
 	properties: {
-		annual: {
-			type: "array",
-			items: indicatorFQuartileSchema,
-			description: "Annual salary quartile distribution (Q1 to Q4)",
-		},
-		hourly: {
-			type: "array",
-			items: indicatorFQuartileSchema,
-			description: "Hourly salary quartile distribution (Q1 to Q4)",
-		},
+		Seuil_Q1_Rem_globale: { type: ["string", "null"] },
+		Quartile1_Rem_globale_annuelle_proportion_F: { type: ["number", "null"] },
+		Quartile1_Rem_globale_annuelle_proportion_H: { type: ["number", "null"] },
+		Seuil_Q2_Rem_globale: { type: ["string", "null"] },
+		Quartile2_Rem_globale_annuelle_proportion_F: { type: ["number", "null"] },
+		Quartile2_Rem_globale_annuelle_proportion_H: { type: ["number", "null"] },
+		Seuil_Q3_Rem_globale: { type: ["string", "null"] },
+		Quartile3_Rem_globale_annuelle_proportion_F: { type: ["number", "null"] },
+		Quartile3_Rem_globale_annuelle_proportion_H: { type: ["number", "null"] },
+		Seuil_Q4_Rem_globale: { type: ["string", "null"] },
+		Quartile4_Rem_globale_annuelle_proportion_F: { type: ["number", "null"] },
+		Quartile4_Rem_globale_annuelle_proportion_H: { type: ["number", "null"] },
 	},
 } as const;
 
-const indicatorPayGapSchema = {
+const indicatorFHourlySchema = {
 	type: "object",
-	description: "Pay gap values split by pay period (annual / hourly)",
+	description:
+		"Répartition par quartile — taux horaire global. Seuils en euros (chaîne numérique) ; proportions F/H entre 0 et 1.",
 	properties: {
-		annualWomen: {
-			type: ["string", "null"],
-			description: "Annual pay — women (numeric string)",
-		},
-		annualMen: {
-			type: ["string", "null"],
-			description: "Annual pay — men (numeric string)",
-		},
-		hourlyWomen: {
-			type: ["string", "null"],
-			description: "Hourly pay — women (numeric string)",
-		},
-		hourlyMen: {
-			type: ["string", "null"],
-			description: "Hourly pay — men (numeric string)",
-		},
+		Seuil_Q1_Taux_horaire_global: { type: ["string", "null"] },
+		Quartile1_Taux_horaire_global_proportion_F: { type: ["number", "null"] },
+		Quartile1_Taux_horaire_global_proportion_H: { type: ["number", "null"] },
+		Seuil_Q2_Taux_horaire_global: { type: ["string", "null"] },
+		Quartile2_Taux_horaire_global_proportion_F: { type: ["number", "null"] },
+		Quartile2_Taux_horaire_global_proportion_H: { type: ["number", "null"] },
+		Seuil_Q3_Taux_horaire_global: { type: ["string", "null"] },
+		Quartile3_Taux_horaire_global_proportion_F: { type: ["number", "null"] },
+		Quartile3_Taux_horaire_global_proportion_H: { type: ["number", "null"] },
+		Seuil_Q4_Taux_horaire_global: { type: ["string", "null"] },
+		Quartile4_Taux_horaire_global_proportion_F: { type: ["number", "null"] },
+		Quartile4_Taux_horaire_global_proportion_H: { type: ["number", "null"] },
 	},
 } as const;
 
 const indicatorsSchema = {
 	type: "object",
 	description:
-		"Pre-calculated indicators A–F (from GIP-MDS DSN data) and company-declared indicator G",
+		"Indicateurs A–F (pré-calculés par le GIP-MDS à partir des DSN) et indicateur G déclaré par l'entreprise. Les libellés des champs reprennent ceux du fichier GIP MDS.",
 	properties: {
 		A: {
-			...indicatorPayGapSchema,
-			description: "Mean gross pay gap (annual + hourly)",
+			type: "object",
+			description: "Rémunération globale moyenne (annuel + taux horaire)",
+			properties: {
+				Rem_globale_annuelle_moyenne_F: { type: ["string", "null"] },
+				Rem_globale_annuelle_moyenne_H: { type: ["string", "null"] },
+				Taux_horaire_global_moyen_F: { type: ["string", "null"] },
+				Taux_horaire_global_moyen_H: { type: ["string", "null"] },
+			},
 		},
 		B: {
-			...indicatorPayGapSchema,
-			description: "Mean gross variable pay gap (annual + hourly)",
+			type: "object",
+			description: "Rémunération variable moyenne (annuel + taux horaire)",
+			properties: {
+				Rem_variable_annuelle_moyenne_F: { type: ["string", "null"] },
+				Rem_variable_annuelle_moyenne_H: { type: ["string", "null"] },
+				Taux_horaire_variable_moyen_F: { type: ["string", "null"] },
+				Taux_horaire_variable_moyen_H: { type: ["string", "null"] },
+			},
 		},
 		C: {
-			...indicatorPayGapSchema,
-			description: "Median gross pay gap (annual + hourly)",
+			type: "object",
+			description: "Rémunération globale médiane (annuel + taux horaire)",
+			properties: {
+				Rem_globale_annuelle_médiane_F: { type: ["string", "null"] },
+				Rem_globale_annuelle_médiane_H: { type: ["string", "null"] },
+				Taux_globale_annuelle_médiane_F: { type: ["string", "null"] },
+				Taux_globale_annuelle_médiane_H: { type: ["string", "null"] },
+			},
 		},
 		D: {
-			...indicatorPayGapSchema,
-			description: "Median gross variable pay gap (annual + hourly)",
+			type: "object",
+			description: "Rémunération variable médiane (annuel + taux horaire)",
+			properties: {
+				Rem_variable_annuelle_médiane_F: { type: ["string", "null"] },
+				Rem_variable_annuelle_médiane_H: { type: ["string", "null"] },
+				Taux_horaire_variable_médian_F: { type: ["string", "null"] },
+				Taux_horaire_variable_médian_H: { type: ["string", "null"] },
+			},
 		},
 		E: {
 			type: "object",
-			description: "Variable pay beneficiary count",
+			description: "Effectifs bénéficiaires d'une rémunération variable",
 			properties: {
-				women: {
-					type: ["string", "null"],
-					description: "Women beneficiary count (numeric string)",
-				},
-				men: {
-					type: ["string", "null"],
-					description: "Men beneficiary count (numeric string)",
-				},
+				Effectif_F_rem_annuelle_variable: { type: ["string", "null"] },
+				Effectif_H_rem_annuelle_variable: { type: ["string", "null"] },
 			},
 		},
-		F: indicatorFSchema,
+		F: {
+			type: "object",
+			description:
+				"Répartition par quartile de rémunération. Les proportions F/H reflètent la part de chaque genre dans le quartile (0 à 1).",
+			properties: {
+				annuel: indicatorFAnnualSchema,
+				horaire: indicatorFHourlySchema,
+			},
+		},
 		G: {
 			oneOf: [
 				{ type: "array", items: indicatorGCategorySchema },
 				{ type: "null" },
 			],
 			description:
-				"Company-declared pay gap by CSP (base + variable, annual + hourly). Null if not declared.",
+				"Écart de rémunération par CSP déclaré par l'entreprise. `null` si non déclaré.",
 		},
 	},
 } as const;
@@ -155,124 +173,136 @@ const indicatorsSchema = {
 const declarationSchema = {
 	type: "object",
 	properties: {
-		siren: {
+		SIREN: {
 			type: "string",
-			description: "Company SIREN (9 digits)",
+			description: "SIREN de l'entreprise (9 chiffres)",
 			example: "319159877",
 		},
-		companyName: { type: ["string", "null"], example: "THALES LAS FRANCE SAS" },
-		workforce: {
+		Raison_sociale: {
+			type: ["string", "null"],
+			example: "THALES LAS FRANCE SAS",
+		},
+		Effectif: {
 			type: ["integer", "null"],
-			description: "Total workforce",
+			description: "Effectif total",
 			example: 7403,
 		},
-		nafCode: {
+		Code_NAF: {
 			type: ["string", "null"],
-			description: "NAF/APE code",
+			description: "Code NAF/APE",
 			example: "26.51A",
 		},
-		address: {
+		Adresse: {
 			type: ["string", "null"],
 			example: "2 AVENUE GAY-LUSSAC, 78990 ELANCOURT",
 		},
-		hasCse: {
+		CSE_existant: {
 			type: ["boolean", "null"],
-			description: "Whether the company has a CSE (>= 50 employees)",
+			description: "Présence d'un CSE (>= 50 salariés)",
 		},
-		year: { type: "integer", description: "Declaration year", example: 2026 },
-		status: {
+		Annee: {
+			type: "integer",
+			description: "Année de la déclaration",
+			example: 2026,
+		},
+		Statut: {
 			type: "string",
-			description: "Declaration status",
+			description: "Statut de la déclaration",
 			example: "submitted",
 		},
-		compliancePath: {
+		Parcours_conformite: {
 			type: ["string", "null"],
-			description: "Compliance path chosen by the company",
+			description: "Parcours de conformité choisi par l'entreprise",
 		},
-		createdAt: { type: ["string", "null"], format: "date-time" },
-		updatedAt: { type: ["string", "null"], format: "date-time" },
-		totalWomen: {
+		Date_creation: { type: ["string", "null"], format: "date-time" },
+		Date_modification: { type: ["string", "null"], format: "date-time" },
+		Effectif_F_rem_annuelle_globale: {
 			type: ["integer", "null"],
-			description: "Total women in workforce",
+			description:
+				"Effectif femmes pris en compte pour la rémunération globale annuelle",
 		},
-		totalMen: {
+		Effectif_H_rem_annuelle_globale: {
 			type: ["integer", "null"],
-			description: "Total men in workforce",
+			description:
+				"Effectif hommes pris en compte pour la rémunération globale annuelle",
 		},
-		indicators: indicatorsSchema,
-		secondDeclaration: {
+		Indicateurs: indicatorsSchema,
+		Seconde_declaration: {
 			type: "object",
-			description: "Second declaration (required when pay gap >= 5%)",
+			description:
+				"Seconde déclaration (requise lorsque l'écart de rémunération atteint 5%)",
 			properties: {
-				status: { type: ["string", "null"] },
-				referencePeriodStart: { type: ["string", "null"], format: "date" },
-				referencePeriodEnd: { type: ["string", "null"], format: "date" },
-				correction: {
+				Statut: { type: ["string", "null"] },
+				Periode_reference_debut: { type: ["string", "null"], format: "date" },
+				Periode_reference_fin: { type: ["string", "null"], format: "date" },
+				Correction: {
 					oneOf: [
 						{ type: "array", items: indicatorGCategorySchema },
 						{ type: "null" },
 					],
-					description:
-						"Corrected indicator G categories. Null if no correction.",
+					description: "Indicateur G corrigé. `null` si aucune correction.",
 				},
 			},
 		},
-		declarant: declarantSchema,
-		cseOpinions: {
+		Declarant: declarantSchema,
+		Avis_CSE: {
 			type: "array",
 			items: cseOpinionSchema,
 			description:
-				"CSE opinions (PDF uploads, up to 4/year, companies >= 100 employees). Only present when at least one CSE file has been uploaded — absent otherwise.",
+				"Avis du CSE (PDF, jusqu'à 4/an, entreprises >= 100 salariés). Présent uniquement si au moins un fichier d'avis CSE a été déposé.",
 		},
-		cseFiles: {
+		Fichiers_CSE: {
 			type: "array",
 			items: {
 				type: "object",
 				properties: {
-					id: { type: "string", description: "File unique identifier" },
-					type: {
+					Id: { type: "string", description: "Identifiant unique du fichier" },
+					Type: {
 						type: "string",
 						enum: ["cse_opinion"],
-						description: "File type: CSE opinion",
+						description: "Type : avis CSE",
 					},
-					fileName: {
+					Nom_fichier: {
 						type: "string",
-						description: "Original file name as uploaded by the company.",
+						description: "Nom d'origine du fichier déposé.",
 						example: "avis-cse-2026.pdf",
 					},
-					uploadedAt: { type: "string", format: "date-time" },
-					downloadUrl: {
+					Date_upload: { type: "string", format: "date-time" },
+					URL_telechargement: {
 						type: "string",
 						description:
-							"Relative URL to download the file via GET /api/v1/files/{fileId}",
+							"URL relative pour télécharger le fichier via GET /api/v1/files/{fileId}",
 						example: "/api/v1/files/abc-123",
 					},
 				},
 			},
 			description:
-				"CSE opinion files attached to the declaration, with a download URL pointing to /api/v1/files/{fileId}. Absent when no file has been uploaded.",
+				"Fichiers d'avis CSE attachés à la déclaration. Absent si aucun fichier n'a été déposé.",
 		},
-		jointEvaluationFile: {
+		Fichier_evaluation_conjointe: {
 			oneOf: [
 				{
 					type: "object",
 					properties: {
-						id: { type: "string", description: "File unique identifier" },
-						type: {
+						Id: {
+							type: "string",
+							description: "Identifiant unique du fichier",
+						},
+						Type: {
 							type: "string",
 							enum: ["joint_evaluation"],
-							description: "File type: joint evaluation",
+							description: "Type : évaluation conjointe",
 						},
-						fileName: {
+						Nom_fichier: {
 							type: "string",
-							description: "Original file name as uploaded by the company.",
+							description: "Nom d'origine du fichier déposé.",
 							example: "evaluation-conjointe-2026.pdf",
 						},
-						uploadedAt: { type: "string", format: "date-time" },
-						downloadUrl: {
+						Date_upload: { type: "string", format: "date-time" },
+						URL_telechargement: {
 							type: "string",
 							description:
-								"Relative URL to download the file via GET /api/v1/files/{fileId}",
+								"URL relative pour télécharger le fichier via GET /api/v1/files/{fileId}",
 							example: "/api/v1/files/abc-123",
 						},
 					},
@@ -280,7 +310,7 @@ const declarationSchema = {
 				{ type: "null" },
 			],
 			description:
-				"Joint evaluation file attached to the declaration (cardinality 1). Absent when no file has been uploaded.",
+				"Fichier d'évaluation conjointe attaché à la déclaration (cardinalité 1). Absent si aucun fichier n'a été déposé.",
 		},
 	},
 } as const;
@@ -369,7 +399,7 @@ export const openApiSpec = {
 				operationId: "getDeclarations",
 				summary: "Lister les déclarations par date de soumission",
 				description:
-					"Retourne les déclarations soumises dont la date de mise à jour (`updatedAt`) est comprise dans l'intervalle [`date_begin`, `date_end`[. Inclut les indicateurs A–G, la seconde déclaration et les avis CSE.",
+					"Retourne les déclarations soumises dont la date de mise à jour (`Date_modification`) est comprise dans l'intervalle [`date_begin`, `date_end`[. Inclut les indicateurs A–G, la seconde déclaration et les avis CSE. Les libellés des champs reprennent ceux du fichier GIP MDS.",
 				parameters: [
 					{
 						name: "date_begin",
@@ -398,19 +428,19 @@ export const openApiSpec = {
 								schema: {
 									type: "object",
 									properties: {
-										dateBegin: {
+										date_debut: {
 											type: "string",
 											format: "date",
 											example: "2026-03-01",
 										},
-										dateEnd: {
+										date_fin: {
 											type: "string",
 											format: "date",
 											example: "2026-03-24",
 										},
-										count: {
+										nombre: {
 											type: "integer",
-											description: "Number of declarations returned",
+											description: "Nombre de déclarations retournées",
 											example: 5,
 										},
 										declarations: { type: "array", items: declarationSchema },

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -428,22 +428,22 @@ export const openApiSpec = {
 								schema: {
 									type: "object",
 									properties: {
-										date_debut: {
+										Date_debut: {
 											type: "string",
 											format: "date",
 											example: "2026-03-01",
 										},
-										date_fin: {
+										Date_fin: {
 											type: "string",
 											format: "date",
 											example: "2026-03-24",
 										},
-										nombre: {
+										Nombre: {
 											type: "integer",
 											description: "Nombre de déclarations retournées",
 											example: 5,
 										},
-										declarations: { type: "array", items: declarationSchema },
+										Declarations: { type: "array", items: declarationSchema },
 									},
 								},
 							},

--- a/packages/app/src/modules/export/shared/apiLabels.ts
+++ b/packages/app/src/modules/export/shared/apiLabels.ts
@@ -1,0 +1,102 @@
+/**
+ * French labels used by the SUIT JSON export (`/api/v1/export/declarations`).
+ *
+ * For indicators A–F the keys match the GIP MDS CSV header names (single
+ * source of truth), so consumers can cross-reference the export with the
+ * raw GIP files they already ingest. For other fields the keys follow the
+ * same underscore-separated French style to stay consistent.
+ */
+
+/** Indicator A — mean global remuneration. */
+export const INDICATOR_A_LABELS = {
+	annualWomen: "Rem_globale_annuelle_moyenne_F",
+	annualMen: "Rem_globale_annuelle_moyenne_H",
+	hourlyWomen: "Taux_horaire_global_moyen_F",
+	hourlyMen: "Taux_horaire_global_moyen_H",
+} as const;
+
+/** Indicator B — mean variable remuneration. */
+export const INDICATOR_B_LABELS = {
+	annualWomen: "Rem_variable_annuelle_moyenne_F",
+	annualMen: "Rem_variable_annuelle_moyenne_H",
+	hourlyWomen: "Taux_horaire_variable_moyen_F",
+	hourlyMen: "Taux_horaire_variable_moyen_H",
+} as const;
+
+/** Indicator C — median global remuneration. */
+export const INDICATOR_C_LABELS = {
+	annualWomen: "Rem_globale_annuelle_médiane_F",
+	annualMen: "Rem_globale_annuelle_médiane_H",
+	hourlyWomen: "Taux_globale_annuelle_médiane_F",
+	hourlyMen: "Taux_globale_annuelle_médiane_H",
+} as const;
+
+/** Indicator D — median variable remuneration. */
+export const INDICATOR_D_LABELS = {
+	annualWomen: "Rem_variable_annuelle_médiane_F",
+	annualMen: "Rem_variable_annuelle_médiane_H",
+	hourlyWomen: "Taux_horaire_variable_médian_F",
+	hourlyMen: "Taux_horaire_variable_médian_H",
+} as const;
+
+/** Indicator E — variable pay beneficiary counts. */
+export const INDICATOR_E_LABELS = {
+	women: "Effectif_F_rem_annuelle_variable",
+	men: "Effectif_H_rem_annuelle_variable",
+} as const;
+
+/** Indicator F — quartile labels, per period and per quartile index (1..4). */
+export const INDICATOR_F_ANNUAL_THRESHOLD_LABELS = [
+	"Seuil_Q1_Rem_globale",
+	"Seuil_Q2_Rem_globale",
+	"Seuil_Q3_Rem_globale",
+	"Seuil_Q4_Rem_globale",
+] as const;
+
+export const INDICATOR_F_HOURLY_THRESHOLD_LABELS = [
+	"Seuil_Q1_Taux_horaire_global",
+	"Seuil_Q2_Taux_horaire_global",
+	"Seuil_Q3_Taux_horaire_global",
+	"Seuil_Q4_Taux_horaire_global",
+] as const;
+
+export const INDICATOR_F_ANNUAL_WOMEN_LABELS = [
+	"Quartile1_Rem_globale_annuelle_proportion_F",
+	"Quartile2_Rem_globale_annuelle_proportion_F",
+	"Quartile3_Rem_globale_annuelle_proportion_F",
+	"Quartile4_Rem_globale_annuelle_proportion_F",
+] as const;
+
+export const INDICATOR_F_ANNUAL_MEN_LABELS = [
+	"Quartile1_Rem_globale_annuelle_proportion_H",
+	"Quartile2_Rem_globale_annuelle_proportion_H",
+	"Quartile3_Rem_globale_annuelle_proportion_H",
+	"Quartile4_Rem_globale_annuelle_proportion_H",
+] as const;
+
+export const INDICATOR_F_HOURLY_WOMEN_LABELS = [
+	"Quartile1_Taux_horaire_global_proportion_F",
+	"Quartile2_Taux_horaire_global_proportion_F",
+	"Quartile3_Taux_horaire_global_proportion_F",
+	"Quartile4_Taux_horaire_global_proportion_F",
+] as const;
+
+export const INDICATOR_F_HOURLY_MEN_LABELS = [
+	"Quartile1_Taux_horaire_global_proportion_H",
+	"Quartile2_Taux_horaire_global_proportion_H",
+	"Quartile3_Taux_horaire_global_proportion_H",
+	"Quartile4_Taux_horaire_global_proportion_H",
+] as const;
+
+/**
+ * Compute the women/men proportion inside one indicator F quartile from the
+ * declared headcounts. Returns `null` when data is missing or the quartile
+ * has no one in it. Rounded to 4 decimals for parity with the GIP CSV format.
+ */
+export function quartileProportion(
+	count: number | null,
+	totalCount: number | null,
+): number | null {
+	if (count === null || totalCount === null || totalCount === 0) return null;
+	return Math.round((count / totalCount) * 10_000) / 10_000;
+}


### PR DESCRIPTION
Closes #3206

## Summary

- Rename every key of `/api/v1/export/declarations` to match the GIP MDS vocabulary: indicators A–F use the exact GIP CSV labels (`Rem_globale_annuelle_moyenne_F`, `Taux_horaire_global_moyen_H`, `Seuil_Q1_Rem_globale`, `Quartile1_…_proportion_F`…), and every other field is renamed in French (`SIREN`, `Raison_sociale`, `Declarant.Prenom`, `Avis_CSE`, `Fichiers_CSE`, `Fichier_evaluation_conjointe`…).
- Indicator F now exposes **proportions F/H per quartile** (computed from the stored headcounts) instead of raw counts, matching the GIP file layout.
- `/api/v1/files` and the XLSX export are untouched (out of scope).
- OpenAPI spec + unit/integration tests updated accordingly.

## Test plan

- [x] `pnpm test` — 84 export tests green (including new coverage for F proportions with zero/null guards)
- [x] `pnpm typecheck`
- [x] `pnpm lint:check` / `pnpm format:check` (only pre-existing warning in `DeclarationsSection.tsx`)
- [x] Manual smoke test of the review app against the renamed payload