### PR TITLE
feat(mimoquage): read-only fields + navigation through saved steps

### DIFF
--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -120,7 +120,7 @@ test.describe("Declaration process panel", () => {
 			).toBeVisible();
 
 			const ctaLink = panel.getByRole("link", {
-				name: "Commencer la déclaration",
+				name: "Continuer la déclaration",
 			});
 			await expect(ctaLink).toHaveAttribute("href", /evaluation-conjointe/);
 		});
@@ -149,7 +149,7 @@ test.describe("Declaration process panel", () => {
 			).toBeVisible();
 
 			const ctaLink = panel.getByRole("link", {
-				name: "Commencer la déclaration",
+				name: "Continuer la déclaration",
 			});
 			await expect(ctaLink).toHaveAttribute("href", /avis-cse/);
 		});

--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
@@ -12,6 +12,15 @@ type FormActionsProps = {
 	isSubmitting?: boolean;
 	nextDisabled?: boolean;
 	className?: string;
+	/**
+	 * URL used by the "Suivant" button while admin impersonation is active.
+	 * - Provided (data already saved) → button is rendered as a Link so the admin
+	 *   can navigate without triggering the submit/save mutation.
+	 * - Omitted (data never saved) → button stays disabled, since navigating
+	 *   forward without any saved data would skip a step (issue #3230).
+	 * Ignored when `nextHref` is set (the button is already a Link).
+	 */
+	mimoquageNextHref?: string;
 };
 
 export function FormActions({
@@ -21,6 +30,7 @@ export function FormActions({
 	isSubmitting = false,
 	nextDisabled = false,
 	className,
+	mimoquageNextHref,
 }: FormActionsProps) {
 	const { isReadOnly, buttonProps, tooltip } = useReadOnlyGuard();
 
@@ -43,6 +53,17 @@ export function FormActions({
 				>
 					{nextLabel}
 				</Link>
+			) : isReadOnly && mimoquageNextHref ? (
+				<span>
+					<Link
+						aria-describedby={buttonProps["aria-describedby"]}
+						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+						href={mimoquageNextHref}
+					>
+						{nextLabel}
+					</Link>
+					{tooltip}
+				</span>
 			) : (
 				<span>
 					<button

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
@@ -38,6 +38,7 @@ type PayGapTableProps = {
 	rows: PayGapRow[];
 	onRowChange: (index: number, field: PayGapField, value: string) => void;
 	className?: string;
+	disabled?: boolean;
 };
 
 export function PayGapTable({
@@ -46,6 +47,7 @@ export function PayGapTable({
 	rows,
 	onRowChange,
 	className,
+	disabled = false,
 }: PayGapTableProps) {
 	return (
 		<div
@@ -84,6 +86,7 @@ export function PayGapTable({
 													<input
 														aria-label={`${row.label} — Femmes`}
 														className="fr-input"
+														disabled={disabled}
 														inputMode="decimal"
 														onChange={(e) =>
 															onRowChange(i, "womenValue", e.target.value)
@@ -99,6 +102,7 @@ export function PayGapTable({
 													<input
 														aria-label={`${row.label} — Hommes`}
 														className="fr-input"
+														disabled={disabled}
 														inputMode="decimal"
 														onChange={(e) =>
 															onRowChange(i, "menValue", e.target.value)

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
@@ -52,7 +52,7 @@ describe("FormActions", () => {
 			mockedUseSession.mockReset();
 		});
 
-		it("disables the submit button and renders a tooltip when impersonating", () => {
+		function mockImpersonating() {
 			mockedUseSession.mockReturnValue({
 				data: {
 					user: {
@@ -63,6 +63,10 @@ describe("FormActions", () => {
 				},
 				status: "authenticated",
 			} as unknown as ReturnType<typeof useSession>);
+		}
+
+		it("disables the submit button and renders a tooltip when impersonating without a saved record", () => {
+			mockImpersonating();
 
 			render(<FormActions />);
 
@@ -71,6 +75,32 @@ describe("FormActions", () => {
 			const tooltip = screen.getByRole("tooltip");
 			expect(tooltip).toHaveTextContent("mimoquage");
 			expect(button).toHaveAttribute("aria-describedby", tooltip.id);
+		});
+
+		it("renders a Link instead of the submit button when impersonating with mimoquageNextHref", () => {
+			mockImpersonating();
+
+			render(
+				<FormActions mimoquageNextHref="/declaration-remuneration/etape/2" />,
+			);
+
+			expect(
+				screen.queryByRole("button", { name: /suivant/i }),
+			).not.toBeInTheDocument();
+			const link = screen.getByRole("link", { name: /suivant/i });
+			expect(link).toHaveAttribute("href", "/declaration-remuneration/etape/2");
+			const tooltip = screen.getByRole("tooltip");
+			expect(link).toHaveAttribute("aria-describedby", tooltip.id);
+		});
+
+		it("ignores mimoquageNextHref when not impersonating", () => {
+			render(
+				<FormActions mimoquageNextHref="/declaration-remuneration/etape/2" />,
+			);
+
+			const button = screen.getByRole("button", { name: /suivant/i });
+			expect(button).toHaveAttribute("type", "submit");
+			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 		});
 
 		it("does not render the tooltip when not impersonating", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Controller } from "react-hook-form";
+import { useIsImpersonating } from "~/modules/auth";
 import { saveCompliancePathSchema } from "~/modules/declaration-remuneration/schemas";
 import type { CampaignDeadlines } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
@@ -27,10 +28,12 @@ type Props = {
 function JointEvaluationOption({
 	checked,
 	deadline,
+	disabled,
 	onChange,
 }: {
 	checked: boolean;
 	deadline: Date;
+	disabled?: boolean;
 	onChange: () => void;
 }) {
 	return (
@@ -38,6 +41,7 @@ function JointEvaluationOption({
 			<CompliancePathOption
 				checked={checked}
 				deadline={deadline}
+				disabled={disabled}
 				id="path-joint"
 				learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
 				learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
@@ -69,10 +73,12 @@ function JointEvaluationOption({
 function JustifyOption({
 	checked,
 	deadline,
+	disabled,
 	onChange,
 }: {
 	checked: boolean;
 	deadline: Date;
+	disabled?: boolean;
 	onChange: () => void;
 }) {
 	return (
@@ -80,6 +86,7 @@ function JustifyOption({
 			<CompliancePathOption
 				checked={checked}
 				deadline={deadline}
+				disabled={disabled}
 				id="path-justify"
 				name="compliance-path"
 				onChange={onChange}
@@ -100,11 +107,13 @@ function JustifyOption({
 }
 
 function SecondRoundOptions({
+	disabled,
 	justificationDeadline,
 	jointEvaluationDeadline,
 	selectedPath,
 	setSelectedPath,
 }: {
+	disabled?: boolean;
 	justificationDeadline: Date;
 	jointEvaluationDeadline: Date;
 	selectedPath: CompliancePathValue | undefined;
@@ -115,11 +124,13 @@ function SecondRoundOptions({
 			<JustifyOption
 				checked={selectedPath === "justify"}
 				deadline={justificationDeadline}
+				disabled={disabled}
 				onChange={() => setSelectedPath("justify")}
 			/>
 			<JointEvaluationOption
 				checked={selectedPath === "joint_evaluation"}
 				deadline={jointEvaluationDeadline}
+				disabled={disabled}
 				onChange={() => setSelectedPath("joint_evaluation")}
 			/>
 		</>
@@ -128,12 +139,14 @@ function SecondRoundOptions({
 
 function FirstRoundOptions({
 	correctiveActionDeadline,
+	disabled,
 	jointEvaluationDeadline,
 	justificationDeadline,
 	selectedPath,
 	setSelectedPath,
 }: {
 	correctiveActionDeadline: Date;
+	disabled?: boolean;
 	jointEvaluationDeadline: Date;
 	justificationDeadline: Date;
 	selectedPath: CompliancePathValue | undefined;
@@ -144,6 +157,7 @@ function FirstRoundOptions({
 			<JustifyOption
 				checked={selectedPath === "justify"}
 				deadline={justificationDeadline}
+				disabled={disabled}
 				onChange={() => setSelectedPath("justify")}
 			/>
 
@@ -156,6 +170,7 @@ function FirstRoundOptions({
 				<CompliancePathOption
 					checked={selectedPath === "corrective_action"}
 					deadline={correctiveActionDeadline}
+					disabled={disabled}
 					id="path-corrective"
 					learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
 					learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
@@ -194,10 +209,21 @@ function FirstRoundOptions({
 			<JointEvaluationOption
 				checked={selectedPath === "joint_evaluation"}
 				deadline={jointEvaluationDeadline}
+				disabled={disabled}
 				onChange={() => setSelectedPath("joint_evaluation")}
 			/>
 		</>
 	);
+}
+
+function getCompliancePathHref(path: CompliancePathValue): string {
+	if (path === "corrective_action") {
+		return "/declaration-remuneration/parcours-conformite/etape/1";
+	}
+	if (path === "joint_evaluation") {
+		return "/declaration-remuneration/parcours-conformite/evaluation-conjointe";
+	}
+	return "/avis-cse";
 }
 
 export function CompliancePathChoice({
@@ -209,6 +235,7 @@ export function CompliancePathChoice({
 	pdfDownloadHref,
 }: Props) {
 	const router = useRouter();
+	const isImpersonating = useIsImpersonating();
 
 	const form = useZodForm(saveCompliancePathSchema, {
 		defaultValues: { path: initialPath },
@@ -300,6 +327,7 @@ export function CompliancePathChoice({
 
 						{isSecondRound ? (
 							<SecondRoundOptions
+								disabled={isImpersonating}
 								jointEvaluationDeadline={
 									campaignDeadlines.decl2JointEvaluationDeadline
 								}
@@ -314,6 +342,7 @@ export function CompliancePathChoice({
 								correctiveActionDeadline={
 									campaignDeadlines.decl2ModificationDeadline
 								}
+								disabled={isImpersonating}
 								jointEvaluationDeadline={
 									campaignDeadlines.decl1JointEvaluationDeadline
 								}
@@ -330,6 +359,9 @@ export function CompliancePathChoice({
 
 			<FormActions
 				isSubmitting={mutation.isPending}
+				mimoquageNextHref={
+					initialPath ? getCompliancePathHref(initialPath) : undefined
+				}
 				nextDisabled={!selectedPath}
 				nextLabel="Suivant"
 				previousHref="/declaration-remuneration/etape/6"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { useIsImpersonating } from "~/modules/auth";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep1Schema } from "../schemas";
@@ -30,6 +31,7 @@ export function Step1Workforce({
 	gipPrefillData,
 }: Step1WorkforceProps) {
 	const router = useRouter();
+	const isImpersonating = useIsImpersonating();
 	const isPrefilled = !!gipPrefillData;
 
 	const hasInitialData = initialData.totalWomen > 0 || initialData.totalMen > 0;
@@ -165,6 +167,7 @@ export function Step1Workforce({
 													<input
 														aria-label="Nombre de femmes"
 														className="fr-input"
+														disabled={isImpersonating}
 														inputMode="numeric"
 														onChange={handleWomenChange}
 														pattern="[0-9]*"
@@ -176,6 +179,7 @@ export function Step1Workforce({
 													<input
 														aria-label="Nombre d'hommes"
 														className="fr-input"
+														disabled={isImpersonating}
 														inputMode="numeric"
 														onChange={handleMenChange}
 														pattern="[0-9]*"
@@ -216,6 +220,9 @@ export function Step1Workforce({
 			<FormActions
 				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
+				mimoquageNextHref={
+					hasInitialData ? "/declaration-remuneration/etape/2" : undefined
+				}
 				previousHref="/"
 			/>
 		</form>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
@@ -35,6 +36,7 @@ export function Step2PayGap({
 	gipPrefillData,
 }: Step2PayGapProps) {
 	const router = useRouter();
+	const isImpersonating = useIsImpersonating();
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
 	const defaultValues = hasSavedData
@@ -131,6 +133,7 @@ export function Step2PayGap({
 					<PayGapTable
 						caption="Écart de rémunération"
 						columnHeader="Rémunération"
+						disabled={isImpersonating}
 						onRowChange={handleRowChange}
 						rows={rows}
 					/>
@@ -159,6 +162,9 @@ export function Step2PayGap({
 			<FormActions
 				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
+				mimoquageNextHref={
+					hasSavedData ? "/declaration-remuneration/etape/3" : undefined
+				}
 				previousHref="/declaration-remuneration/etape/1"
 			/>
 		</form>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { useIsImpersonating } from "~/modules/auth";
 import { computeProportion, normalizeDecimalInput } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
@@ -43,6 +44,7 @@ export function Step3VariablePay({
 	maxMen,
 }: Step3VariablePayProps) {
 	const router = useRouter();
+	const isImpersonating = useIsImpersonating();
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
 	const defaultValues = hasSavedData
@@ -179,6 +181,7 @@ export function Step3VariablePay({
 								ou complémentaire
 							</>
 						}
+						disabled={isImpersonating}
 						onRowChange={handleRowChange}
 						rows={rows}
 					/>
@@ -232,6 +235,7 @@ export function Step3VariablePay({
 													<input
 														aria-label="Bénéficiaires femmes"
 														className="fr-input"
+														disabled={isImpersonating}
 														inputMode="numeric"
 														onChange={(e) =>
 															handleBenefChange(
@@ -262,6 +266,7 @@ export function Step3VariablePay({
 													<input
 														aria-label="Bénéficiaires hommes"
 														className="fr-input"
+														disabled={isImpersonating}
 														inputMode="numeric"
 														onChange={(e) =>
 															handleBenefChange(
@@ -330,6 +335,9 @@ export function Step3VariablePay({
 			<FormActions
 				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
+				mimoquageNextHref={
+					hasSavedData ? "/declaration-remuneration/etape/4" : undefined
+				}
 				previousHref="/declaration-remuneration/etape/2"
 			/>
 		</form>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
@@ -67,6 +68,7 @@ export function Step4QuartileDistribution({
 	maxMen,
 }: Step4QuartileDistributionProps) {
 	const router = useRouter();
+	const isImpersonating = useIsImpersonating();
 
 	const hasSavedData =
 		initialData.annual.some(
@@ -227,6 +229,7 @@ export function Step4QuartileDistribution({
 			{/* Tables */}
 			<div className={stepStyles.dataContainer}>
 				<QuartileTable
+					disabled={isImpersonating}
 					onQuartileChange={(index, field, value) =>
 						handleQuartileChange("annual", index, field, value)
 					}
@@ -254,6 +257,7 @@ export function Step4QuartileDistribution({
 				/>
 
 				<QuartileTable
+					disabled={isImpersonating}
 					onQuartileChange={(index, field, value) =>
 						handleQuartileChange("hourly", index, field, value)
 					}
@@ -301,6 +305,9 @@ export function Step4QuartileDistribution({
 			<FormActions
 				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
+				mimoquageNextHref={
+					hasSavedData ? "/declaration-remuneration/etape/5" : undefined
+				}
 				previousHref="/declaration-remuneration/etape/3"
 			/>
 		</form>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 
+import { useIsImpersonating } from "~/modules/auth";
 import { api } from "~/trpc/react";
 import { StepIndicator } from "../shared/StepIndicator";
 import type { EmployeeCategoryRow } from "../types";
@@ -25,6 +26,8 @@ export function Step5EmployeeCategories({
 	siren,
 }: Props) {
 	const router = useRouter();
+	const isImpersonating = useIsImpersonating();
+	const hasInitialData = (initialCategories?.length ?? 0) > 0;
 
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => router.push("/declaration-remuneration/etape/6"),
@@ -33,12 +36,16 @@ export function Step5EmployeeCategories({
 	return (
 		<CategoryForm
 			accordionId="accordion-step5"
+			disabled={isImpersonating}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
 			isSubmitting={mutation.isPending}
 			maxMen={maxMen}
 			maxWomen={maxWomen}
+			mimoquageNextHref={
+				hasInitialData ? "/declaration-remuneration/etape/6" : undefined
+			}
 			onSubmit={(data) =>
 				mutation.mutate({
 					declarationType: "initial",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
@@ -5,6 +5,7 @@ type Props = {
 	endDate: string;
 	onStartDateChange: (value: string) => void;
 	onEndDateChange: (value: string) => void;
+	disabled?: boolean;
 };
 
 export function ReferencePeriodPicker({
@@ -12,6 +13,7 @@ export function ReferencePeriodPicker({
 	endDate,
 	onStartDateChange,
 	onEndDateChange,
+	disabled = false,
 }: Props) {
 	return (
 		<div>
@@ -38,6 +40,7 @@ export function ReferencePeriodPicker({
 						</label>
 						<input
 							className="fr-input"
+							disabled={disabled}
 							id="period-start-date"
 							onChange={(e) => onStartDateChange(e.target.value)}
 							type="date"
@@ -53,6 +56,7 @@ export function ReferencePeriodPicker({
 						</label>
 						<input
 							className="fr-input"
+							disabled={disabled}
 							id="period-end-date"
 							onChange={(e) => onEndDateChange(e.target.value)}
 							type="date"

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-
+import { useIsImpersonating } from "~/modules/auth";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { api } from "~/trpc/react";
 import { CategoryForm } from "../step5/CategoryForm";
@@ -28,6 +28,7 @@ export function SecondDeclarationStep2Form({
 	initialEndDate = "",
 }: Props) {
 	const router = useRouter();
+	const isImpersonating = useIsImpersonating();
 	const [startDate, setStartDate] = useState(initialStartDate);
 	const [endDate, setEndDate] = useState(initialEndDate);
 	const [periodError, setPeriodError] = useState("");
@@ -37,6 +38,8 @@ export function SecondDeclarationStep2Form({
 		initialSecondDeclarationCategories.length > 0
 			? initialSecondDeclarationCategories
 			: initialFirstDeclarationCategories;
+	const hasSavedSecondDeclaration =
+		(initialSecondDeclarationCategories?.length ?? 0) > 0;
 
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => router.push(`${BASE_PATH}/etape/3`),
@@ -46,10 +49,14 @@ export function SecondDeclarationStep2Form({
 		<CategoryForm
 			accordionId="accordion-second-decl"
 			descriptionText="Cette seconde déclaration reprend les catégories de salariés définies lors de la première déclaration. Elle permet de mesurer les écarts de rémunération entre les femmes et les hommes au sein de chaque catégorie, en distinguant le salaire de base des composantes variables ou complémentaires."
+			disabled={isImpersonating}
 			initialCategories={sourceData}
 			initialSource={initialSource}
 			instructionText="Modifiez les données de votre première déclaration avant de valider votre indicateur."
 			isSubmitting={mutation.isPending}
+			mimoquageNextHref={
+				hasSavedSecondDeclaration ? `${BASE_PATH}/etape/3` : undefined
+			}
 			onSubmit={(data) => {
 				if (!startDate || !endDate) {
 					setPeriodError(
@@ -70,6 +77,7 @@ export function SecondDeclarationStep2Form({
 			readOnlyNameDetail
 			referencePeriodPicker={
 				<ReferencePeriodPicker
+					disabled={isImpersonating}
 					endDate={endDate}
 					onEndDateChange={setEndDate}
 					onStartDateChange={setStartDate}

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -17,6 +17,7 @@ type Props = {
 		field: "threshold" | "women" | "men",
 		value: string,
 	) => void;
+	disabled?: boolean;
 };
 
 /** Format ordinal text like "1er quartile" → 1<sup>er</sup> quartile */
@@ -40,6 +41,7 @@ export function QuartileTable({
 	readingNote,
 	sourceNote,
 	onQuartileChange,
+	disabled = false,
 }: Props) {
 	const totalWomen = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
 	const totalMen = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
@@ -89,6 +91,7 @@ export function QuartileTable({
 														<input
 															aria-label={`Rémunération brute ${QUARTILE_NAMES[i]}`}
 															className="fr-input"
+															disabled={disabled}
 															inputMode="decimal"
 															onChange={(e) =>
 																onQuartileChange(i, "threshold", e.target.value)
@@ -114,6 +117,7 @@ export function QuartileTable({
 													<input
 														aria-label={`Nombre de femmes ${QUARTILE_NAMES[i]}`}
 														className="fr-input"
+														disabled={disabled}
 														inputMode="numeric"
 														onChange={(e) =>
 															onQuartileChange(i, "women", e.target.value)
@@ -163,6 +167,7 @@ export function QuartileTable({
 													<input
 														aria-label={`Nombre d'hommes ${QUARTILE_NAMES[i]}`}
 														className="fr-input"
+														disabled={disabled}
 														inputMode="numeric"
 														onChange={(e) =>
 															onQuartileChange(i, "men", e.target.value)

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -19,12 +19,14 @@ type Props = {
 		field: keyof EmployeeCategory,
 		isInteger: boolean,
 	) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+	disabled?: boolean;
 };
 
 export function CategoryDataTable({
 	category: cat,
 	categoryIndex: catIndex,
 	onPositiveNumberChange: pos,
+	disabled = false,
 }: Props) {
 	const annualTotalWomen = computeTotal(
 		cat.annualBaseWomen,
@@ -93,6 +95,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Effectif femmes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("women-count")}
 												inputMode="numeric"
 												onChange={pos(catIndex, "womenCount", true)}
@@ -108,6 +111,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Effectif hommes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("men-count")}
 												inputMode="numeric"
 												onChange={pos(catIndex, "menCount", true)}
@@ -134,6 +138,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Salaire de base annuel femmes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("annual-base-women")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "annualBaseWomen", false)}
@@ -148,6 +153,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Salaire de base annuel hommes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("annual-base-men")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "annualBaseMen", false)}
@@ -174,6 +180,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Composantes variables annuelles femmes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("annual-variable-women")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "annualVariableWomen", false)}
@@ -188,6 +195,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Composantes variables annuelles hommes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("annual-variable-men")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "annualVariableMen", false)}
@@ -231,6 +239,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Salaire de base horaire femmes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("hourly-base-women")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "hourlyBaseWomen", false)}
@@ -245,6 +254,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Salaire de base horaire hommes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("hourly-base-men")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "hourlyBaseMen", false)}
@@ -271,6 +281,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Composantes variables horaires femmes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("hourly-variable-women")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "hourlyVariableWomen", false)}
@@ -285,6 +296,7 @@ export function CategoryDataTable({
 											<input
 												aria-label={`Composantes variables horaires hommes, catégorie ${catIndex + 1}`}
 												className={`fr-input ${stepStyles.compactInput}`}
+												disabled={disabled}
 												id={id("hourly-variable-men")}
 												inputMode="decimal"
 												onChange={pos(catIndex, "hourlyVariableMen", false)}

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -78,6 +78,8 @@ type Props = {
 	referencePeriodPicker?: ReactNode;
 	descriptionText?: string;
 	siren?: string;
+	disabled?: boolean;
+	mimoquageNextHref?: string;
 };
 
 export function CategoryForm({
@@ -99,6 +101,8 @@ export function CategoryForm({
 	referencePeriodPicker,
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 	siren,
+	disabled = false,
+	mimoquageNextHref,
 }: Props) {
 	const baseId = useId();
 	const nextId = useRef(createIdGenerator()).current;
@@ -273,6 +277,7 @@ export function CategoryForm({
 						</label>
 						<select
 							className="fr-select"
+							disabled={disabled}
 							id="source-select"
 							{...form.register("source")}
 							onChange={(e) => {
@@ -326,6 +331,7 @@ export function CategoryForm({
 
 			{!readOnlyNameDetail && (
 				<CategoryImportExport
+					disabled={disabled}
 					getCategories={() =>
 						form.getValues("categories").map((cat, i) => ({
 							id: i,
@@ -369,6 +375,7 @@ export function CategoryForm({
 										<div className={stepStyles.categoryFooter}>
 											<button
 												className="fr-btn fr-btn--tertiary fr-icon-delete-line fr-btn--icon-left fr-btn--sm"
+												disabled={disabled}
 												onClick={() => askRemoveCategory(index)}
 												type="button"
 											>
@@ -401,6 +408,7 @@ export function CategoryForm({
 												</label>
 												<input
 													className="fr-input"
+													disabled={disabled}
 													id={`cat-${index}-name`}
 													{...form.register(`categories.${index}.name`)}
 													onChange={(e) => {
@@ -423,6 +431,7 @@ export function CategoryForm({
 												</label>
 												<input
 													className="fr-input"
+													disabled={disabled}
 													id={`cat-${index}-detail`}
 													{...form.register(`categories.${index}.detail`)}
 													onChange={(e) => {
@@ -443,6 +452,7 @@ export function CategoryForm({
 											cat ? { id: index, ...cat } : createEmptyCategory(index)
 										}
 										categoryIndex={index}
+										disabled={disabled}
 										onPositiveNumberChange={handlePositiveNumberChange}
 									/>
 								</div>
@@ -459,6 +469,7 @@ export function CategoryForm({
 				{!readOnlyNameDetail && (
 					<button
 						className="fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left"
+						disabled={disabled}
 						onClick={addCategory}
 						type="button"
 					>
@@ -477,7 +488,11 @@ export function CategoryForm({
 				validationError={workforceError}
 			/>
 
-			<FormActions isSubmitting={isSubmitting} previousHref={previousHref} />
+			<FormActions
+				isSubmitting={isSubmitting}
+				mimoquageNextHref={mimoquageNextHref}
+				previousHref={previousHref}
+			/>
 
 			<DeleteCategoryDialog
 				categoryName={

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryImportExport.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryImportExport.tsx
@@ -15,6 +15,7 @@ type Props = {
 	onImport: (categories: EmployeeCategory[]) => void;
 	siren?: string;
 	year?: number;
+	disabled?: boolean;
 };
 
 export function CategoryImportExport({
@@ -22,6 +23,7 @@ export function CategoryImportExport({
 	onImport,
 	siren,
 	year,
+	disabled = false,
 }: Props) {
 	const baseId = useId();
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -98,6 +100,7 @@ export function CategoryImportExport({
 						aria-controls={importModalId}
 						className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-upload-line fr-btn--icon-left"
 						data-fr-opened="false"
+						disabled={disabled}
 						type="button"
 					>
 						Importer un fichier

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -86,9 +86,7 @@ export function DeclarationProcessPanel({
 						<HelpSection />
 						<div className={styles.footer}>
 							<a className="fr-btn" href={ctaHref}>
-								{variant === "closed"
-									? "Voir la déclaration"
-									: "Commencer la déclaration"}
+								{getCtaLabel(variant)}
 							</a>
 						</div>
 					</div>
@@ -96,6 +94,12 @@ export function DeclarationProcessPanel({
 			</div>
 		</dialog>
 	);
+}
+
+function getCtaLabel(variant: PanelVariant): string {
+	if (variant === "closed") return "Voir la déclaration";
+	if (variant === "start") return "Commencer la déclaration";
+	return "Continuer la déclaration";
 }
 
 function PanelHeader({

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -111,6 +111,13 @@ describe("DeclarationProcessPanel", () => {
 				panel.queryByText(/Vous devez au préalable disposer/),
 			).not.toBeInTheDocument();
 		});
+
+		it('renders "Continuer la déclaration" CTA', () => {
+			const { dialog } = renderPanel("compliance");
+			const ctaLinks = dialog.querySelectorAll("a.fr-btn");
+			const cta = ctaLinks[ctaLinks.length - 1];
+			expect(cta).toHaveTextContent("Continuer la déclaration");
+		});
 	});
 
 	describe("variant: evaluation", () => {


### PR DESCRIPTION
## Summary

Reworks the admin impersonation (mimoquage) UX across the declaration flow:

- **Fields are read-only** during mimoquage — every input/select/radio in the declaration steps is `disabled`.
- **"Suivant" buttons stay clickable** when the underlying step has already been saved by the company: the button renders as a `<Link>` to the next step, so the admin can walk through without triggering any save mutation.
- **"Suivant" stays disabled** when no record has ever been saved for the step (admin can't skip past an empty step).
- **Compliance path screen**: radio options are disabled in mimoquage; the existing `nextDisabled={!selectedPath}` keeps "Suivant" gated on a selection.
- **Panel CTA**: now reads "Continuer la déclaration" for any in-progress variant, instead of always "Commencer la déclaration".

### Implementation

- New `mimoquageNextHref?` prop on `FormActions`. When set + impersonating → render Link with the read-only tooltip; otherwise fallback to the disabled-submit behavior.
- `disabled` cascaded through `PayGapTable`, `QuartileTable`, `CategoryDataTable`, `CategoryForm`, `CategoryImportExport`, `ReferencePeriodPicker`. Step1/Step3 inline inputs disabled directly.
- Steps 1–5 + `SecondDeclarationStep2Form` pass `mimoquageNextHref` based on their existing `hasSavedData` / `hasInitialData` heuristics.
- `Step6Review`, `SecondDeclarationStep3Review`, `JointEvaluationForm` intentionally untouched: they're terminal submits with no "next step without saving" semantic.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run` (1518 tests pass, including updated `FormActions` and `DeclarationProcessPanel` specs)
- [x] `pnpm check:write` (biome clean)
- [ ] Manually impersonate a company with a partly-filled declaration → walk steps 1→6 with "Suivant", verify no mutation fires
- [ ] Impersonate a brand-new declaration → "Suivant" stays disabled with tooltip
- [ ] On compliance path screen during mimoquage → radios disabled, "Suivant" navigates to the persisted path's screen
- [ ] Open the declaration process panel for an in-progress declaration → CTA reads "Continuer la déclaration"