### PR TITLE
fix(declaration): prefill from last declaration with indicator 7 (#3246)

### DIFF
--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -203,48 +203,59 @@ export async function deleteCseOpinions() {
 	}
 }
 
+const PREV_YEAR_DECL_ID_PREFIX = "e2e-prev-year-decl-";
+const PREV_YEAR_DECL_ID_SUFFIX = "-000000000000";
+const PREV_YEAR_JOB_CATEGORY_IDS = [
+	"e2e-jobcat-1111-0000-000000000000",
+	"e2e-jobcat-2222-0000-000000000000",
+	"e2e-jobcat-3333-0000-000000000000",
+] as const;
+
+function previousYearDeclId(yearsBack: number) {
+	return `${PREV_YEAR_DECL_ID_PREFIX}${String(yearsBack).padStart(4, "0")}${PREV_YEAR_DECL_ID_SUFFIX}`;
+}
+
 /**
- * Insert a submitted declaration for the previous year (N-1) with job categories,
- * so the "Reprendre les catégories de l'année précédente" button appears.
+ * Insert a submitted declaration `yearsBack` years before the current year with
+ * job categories (indicator 7). Default `yearsBack = 1` matches the original
+ * N-1 seed so existing callers are unaffected.
  */
-export async function insertPreviousYearDeclaration() {
+export async function insertPreviousYearDeclaration(yearsBack = 1) {
 	const sql = createConnection();
-	const yearResult =
-		await sql`SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int - 1 AS previous_year`;
-	const previousYear = yearResult[0]?.previous_year as number;
-	const declId = "e2e-prev-year-decl-0000-000000000000";
+	const yearResult = await sql`
+		SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int - ${yearsBack} AS target_year
+	`;
+	const targetYear = yearResult[0]?.target_year as number;
+	const declId = previousYearDeclId(yearsBack);
 
 	try {
-		// Get test user id
 		const users = await sql`
 			SELECT user_id FROM app_user_company WHERE siren = ${TEST_SIREN} LIMIT 1
 		`;
 		const userId = users[0]?.user_id;
 		if (!userId) return;
 
-		// Insert submitted declaration for previous year
 		await sql`
 			INSERT INTO app_declaration (id, siren, year, declarant_id, total_women, total_men, current_step, status, created_at, updated_at)
-			VALUES (${declId}, ${TEST_SIREN}, ${previousYear}, ${userId}, 150, 200, 6, 'submitted', NOW(), NOW())
+			VALUES (${declId}, ${TEST_SIREN}, ${targetYear}, ${userId}, 150, 200, 6, 'submitted', NOW(), NOW())
 			ON CONFLICT DO NOTHING
 		`;
 
-		// Insert 3 job categories
 		const categories = [
 			{
-				id: "e2e-jobcat-1111-0000-000000000000",
+				id: PREV_YEAR_JOB_CATEGORY_IDS[0],
 				index: 0,
 				name: "Cadres dirigeants",
 				detail: "Directeurs et cadres supérieurs",
 			},
 			{
-				id: "e2e-jobcat-2222-0000-000000000000",
+				id: PREV_YEAR_JOB_CATEGORY_IDS[1],
 				index: 1,
 				name: "Ingénieurs et cadres",
 				detail: "Ingénieurs, chefs de projet, managers",
 			},
 			{
-				id: "e2e-jobcat-3333-0000-000000000000",
+				id: PREV_YEAR_JOB_CATEGORY_IDS[2],
 				index: 2,
 				name: "Techniciens",
 				detail: "Techniciens qualifiés",
@@ -263,18 +274,13 @@ export async function insertPreviousYearDeclaration() {
 	}
 }
 
-/** Remove the previous year test declaration and its job categories. */
-export async function deletePreviousYearDeclaration() {
+/** Remove the seeded previous-year declaration at `yearsBack` and its job categories. */
+export async function deletePreviousYearDeclaration(yearsBack = 1) {
 	const sql = createConnection();
-	const declId = "e2e-prev-year-decl-0000-000000000000";
+	const declId = previousYearDeclId(yearsBack);
 
 	try {
-		const jobIds = [
-			"e2e-jobcat-1111-0000-000000000000",
-			"e2e-jobcat-2222-0000-000000000000",
-			"e2e-jobcat-3333-0000-000000000000",
-		];
-		await sql`DELETE FROM app_employee_category WHERE job_category_id = ANY(${jobIds})`;
+		await sql`DELETE FROM app_employee_category WHERE job_category_id = ANY(${PREV_YEAR_JOB_CATEGORY_IDS})`;
 		await sql`DELETE FROM app_job_category WHERE declaration_id = ${declId}`;
 		await sql`DELETE FROM app_declaration WHERE id = ${declId}`;
 	} finally {

--- a/packages/app/src/e2e/previous-year-categories.e2e.ts
+++ b/packages/app/src/e2e/previous-year-categories.e2e.ts
@@ -14,51 +14,73 @@ async function goToStep5(page: Page) {
 	await expect(page.getByText("Étape 5 sur 6")).toBeVisible();
 }
 
+async function assertStep5PrefilledWithSeedData(page: Page) {
+	// Source pre-filled from the previous declaration
+	await expect(
+		page.getByRole("combobox", { name: /source utilisée/i }),
+	).toHaveValue("convention-collective");
+
+	// 3 categories pre-filled
+	await expect(page.getByText("Nombre de catégories : 3")).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: /Cadres dirigeants/ }),
+	).toBeVisible();
+	await expect(
+		page.getByRole("button", { name: /Ingénieurs et cadres/ }),
+	).toBeVisible();
+	await expect(page.getByRole("button", { name: /Techniciens/ })).toBeVisible();
+
+	// Detail pre-filled, numeric fields empty
+	await page.getByRole("button", { name: /Cadres dirigeants/ }).click();
+	await expect(page.locator("#cat-0-detail")).toHaveValue(
+		"Directeurs et cadres supérieurs",
+	);
+	await expect(
+		page.getByRole("textbox", { name: "Effectif femmes, catégorie 1" }),
+	).toHaveValue("");
+	await expect(
+		page.getByRole("textbox", {
+			name: "Salaire de base annuel femmes, catégorie 1",
+		}),
+	).toHaveValue("");
+}
+
 test.describe("Previous year categories prefill", () => {
-	test.beforeAll(async () => {
-		await resetDeclarationToDraft();
-		await deleteCurrentYearCategories();
-		await insertPreviousYearDeclaration();
+	test.describe("N-1 declaration contains indicator 7", () => {
+		test.beforeAll(async () => {
+			await resetDeclarationToDraft();
+			await deleteCurrentYearCategories();
+			await insertPreviousYearDeclaration(1);
+		});
+
+		test.afterAll(async () => {
+			await deletePreviousYearDeclaration(1);
+		});
+
+		test("pre-fills category names, details and source with empty numeric fields", async ({
+			page,
+		}) => {
+			await goToStep5(page);
+			await assertStep5PrefilledWithSeedData(page);
+		});
 	});
 
-	test.afterAll(async () => {
-		await deletePreviousYearDeclaration();
-	});
+	test.describe("N-1 skipped, N-2 contains indicator 7", () => {
+		test.beforeAll(async () => {
+			await resetDeclarationToDraft();
+			await deleteCurrentYearCategories();
+			// Make sure no N-1 seed is left over from a previous run.
+			await deletePreviousYearDeclaration(1);
+			await insertPreviousYearDeclaration(2);
+		});
 
-	test("pre-fills N-1 category names, details and source with empty numeric fields", async ({
-		page,
-	}) => {
-		await goToStep5(page);
+		test.afterAll(async () => {
+			await deletePreviousYearDeclaration(2);
+		});
 
-		// Source pre-filled from N-1
-		await expect(
-			page.getByRole("combobox", { name: /source utilisée/i }),
-		).toHaveValue("convention-collective");
-
-		// 3 categories pre-filled
-		await expect(page.getByText("Nombre de catégories : 3")).toBeVisible();
-		await expect(
-			page.getByRole("button", { name: /Cadres dirigeants/ }),
-		).toBeVisible();
-		await expect(
-			page.getByRole("button", { name: /Ingénieurs et cadres/ }),
-		).toBeVisible();
-		await expect(
-			page.getByRole("button", { name: /Techniciens/ }),
-		).toBeVisible();
-
-		// Detail pre-filled, numeric fields empty
-		await page.getByRole("button", { name: /Cadres dirigeants/ }).click();
-		await expect(page.locator("#cat-0-detail")).toHaveValue(
-			"Directeurs et cadres supérieurs",
-		);
-		await expect(
-			page.getByRole("textbox", { name: "Effectif femmes, catégorie 1" }),
-		).toHaveValue("");
-		await expect(
-			page.getByRole("textbox", {
-				name: "Salaire de base annuel femmes, catégorie 1",
-			}),
-		).toHaveValue("");
+		test("falls back to N-2 when N-1 is missing", async ({ page }) => {
+			await goToStep5(page);
+			await assertStep5PrefilledWithSeedData(page);
+		});
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -199,51 +199,74 @@ describe("fetchAllCategories", () => {
 });
 
 describe("fetchPreviousYearJobCategories", () => {
-	it("returns null when no submitted declaration exists for previous year", async () => {
-		const { fetchPreviousYearJobCategories } = await import(
-			"../declarationHelpers"
-		);
+	type PreviousDeclarationRow = { id: string };
+	type JobCategoryRow = {
+		name: string;
+		detail: string | null;
+		source: string;
+		categoryIndex: number;
+	};
 
-		const mockLimit = vi.fn().mockResolvedValue([]);
-		const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-		const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
-
-		const tx = { select: mockSelect } as never;
-
-		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
-
-		expect(result).toBeNull();
-	});
-
-	it("returns null when declaration exists but has no job categories", async () => {
-		const { fetchPreviousYearJobCategories } = await import(
-			"../declarationHelpers"
-		);
-
+	/**
+	 * Builds a mocked Drizzle `tx` where:
+	 *   - the first `select()` chain (declarations query) resolves to
+	 *     `previousDeclarations` after `.orderBy()`
+	 *   - each subsequent `select()` chain (jobCategories query per declaration)
+	 *     resolves to the next entry in `jobsPerDeclaration` after `.where()`
+	 */
+	const makeTx = (
+		previousDeclarations: PreviousDeclarationRow[],
+		jobsPerDeclaration: JobCategoryRow[][],
+	) => {
 		let selectCallCount = 0;
-		const mockLimit = vi.fn().mockResolvedValue([{ id: "decl-prev" }]);
-		const mockWhere = vi.fn().mockImplementation(() => {
-			selectCallCount++;
-			if (selectCallCount === 1) return { limit: mockLimit };
-			return Promise.resolve([]);
-		});
-		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-		const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+		const queuedJobs = [...jobsPerDeclaration];
 
-		const tx = { select: mockSelect } as never;
+		const mockSelect = vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			if (selectCallCount === 1) {
+				const mockOrderBy = vi.fn().mockResolvedValue(previousDeclarations);
+				const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+				const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+				return { from: mockFrom };
+			}
+			const mockWhere = vi.fn().mockResolvedValue(queuedJobs.shift() ?? []);
+			const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+			return { from: mockFrom };
+		});
+
+		return { select: mockSelect } as never;
+	};
+
+	it("returns null when no submitted previous declaration exists", async () => {
+		const { fetchPreviousYearJobCategories } = await import(
+			"../declarationHelpers"
+		);
+
+		const tx = makeTx([], []);
 
 		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
 
 		expect(result).toBeNull();
 	});
 
-	it("returns categories sorted by index with source from previous year", async () => {
+	it("returns null when no previous declaration contains job categories", async () => {
 		const { fetchPreviousYearJobCategories } = await import(
 			"../declarationHelpers"
 		);
 
-		const mockJobs = [
+		const tx = makeTx([{ id: "decl-2025" }, { id: "decl-2024" }], [[], []]);
+
+		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
+
+		expect(result).toBeNull();
+	});
+
+	it("returns categories from the most recent previous declaration", async () => {
+		const { fetchPreviousYearJobCategories } = await import(
+			"../declarationHelpers"
+		);
+
+		const mostRecentJobs: JobCategoryRow[] = [
 			{
 				name: "Employés",
 				detail: "Support",
@@ -258,17 +281,7 @@ describe("fetchPreviousYearJobCategories", () => {
 			},
 		];
 
-		let selectCallCount = 0;
-		const mockLimit = vi.fn().mockResolvedValue([{ id: "decl-prev" }]);
-		const mockWhere = vi.fn().mockImplementation(() => {
-			selectCallCount++;
-			if (selectCallCount === 1) return { limit: mockLimit };
-			return Promise.resolve(mockJobs);
-		});
-		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-		const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
-
-		const tx = { select: mockSelect } as never;
+		const tx = makeTx([{ id: "decl-2025" }], [mostRecentJobs]);
 
 		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
 
@@ -281,12 +294,39 @@ describe("fetchPreviousYearJobCategories", () => {
 		});
 	});
 
+	it("falls back to an earlier year when N-1 has no job categories", async () => {
+		const { fetchPreviousYearJobCategories } = await import(
+			"../declarationHelpers"
+		);
+
+		const olderJobs: JobCategoryRow[] = [
+			{
+				name: "Cadres",
+				detail: "Managers",
+				source: "autre",
+				categoryIndex: 0,
+			},
+		];
+
+		const tx = makeTx(
+			[{ id: "decl-2025" }, { id: "decl-2023" }],
+			[[], olderJobs],
+		);
+
+		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
+
+		expect(result).toEqual({
+			source: "autre",
+			categories: [{ name: "Cadres", detail: "Managers" }],
+		});
+	});
+
 	it("uses empty string for null detail", async () => {
 		const { fetchPreviousYearJobCategories } = await import(
 			"../declarationHelpers"
 		);
 
-		const mockJobs = [
+		const jobs: JobCategoryRow[] = [
 			{
 				name: "Cadres",
 				detail: null,
@@ -295,17 +335,7 @@ describe("fetchPreviousYearJobCategories", () => {
 			},
 		];
 
-		let selectCallCount = 0;
-		const mockLimit = vi.fn().mockResolvedValue([{ id: "decl-prev" }]);
-		const mockWhere = vi.fn().mockImplementation(() => {
-			selectCallCount++;
-			if (selectCallCount === 1) return { limit: mockLimit };
-			return Promise.resolve(mockJobs);
-		});
-		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-		const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
-
-		const tx = { select: mockSelect } as never;
+		const tx = makeTx([{ id: "decl-2025" }], [jobs]);
 
 		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
 

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -199,7 +199,6 @@ describe("fetchAllCategories", () => {
 });
 
 describe("fetchPreviousYearJobCategories", () => {
-	type PreviousDeclarationRow = { id: string };
 	type JobCategoryRow = {
 		name: string;
 		detail: string | null;
@@ -208,65 +207,61 @@ describe("fetchPreviousYearJobCategories", () => {
 	};
 
 	/**
-	 * Builds a mocked Drizzle `tx` where:
-	 *   - the first `select()` chain (declarations query) resolves to
-	 *     `previousDeclarations` after `.orderBy()`
-	 *   - each subsequent `select()` chain (jobCategories query per declaration)
-	 *     resolves to the next entry in `jobsPerDeclaration` after `.where()`
+	 * Build a mocked `tx` with two select chains:
+	 *   1. declarations probe (innerJoin jobCategories, limit 1) → id or nothing
+	 *   2. jobCategories fetch for that id → rows
+	 *
+	 * Each chain resolves at its terminal call (`.limit()` / `.where()`), so
+	 * the mock is driven by the data the query is expected to return, not by
+	 * internal call-order counters.
 	 */
 	const makeTx = (
-		previousDeclarations: PreviousDeclarationRow[],
-		jobsPerDeclaration: JobCategoryRow[][],
+		declarationId: string | null,
+		jobs: JobCategoryRow[] = [],
 	) => {
-		let selectCallCount = 0;
-		const queuedJobs = [...jobsPerDeclaration];
+		const declarationChain = {
+			from: () => ({
+				innerJoin: () => ({
+					where: () => ({
+						orderBy: () => ({
+							limit: () =>
+								Promise.resolve(declarationId ? [{ id: declarationId }] : []),
+						}),
+					}),
+				}),
+			}),
+		};
 
-		const mockSelect = vi.fn().mockImplementation(() => {
-			selectCallCount++;
-			if (selectCallCount === 1) {
-				const mockOrderBy = vi.fn().mockResolvedValue(previousDeclarations);
-				const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-				const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-				return { from: mockFrom };
-			}
-			const mockWhere = vi.fn().mockResolvedValue(queuedJobs.shift() ?? []);
-			const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-			return { from: mockFrom };
-		});
+		const jobCategoriesChain = {
+			from: () => ({
+				where: () => Promise.resolve(jobs),
+			}),
+		};
 
-		return { select: mockSelect } as never;
+		const queue = [declarationChain, jobCategoriesChain];
+		return { select: () => queue.shift() } as never;
 	};
 
-	it("returns null when no submitted previous declaration exists", async () => {
+	it("returns null when no previous declaration contains indicator 7", async () => {
 		const { fetchPreviousYearJobCategories } = await import(
 			"../declarationHelpers"
 		);
 
-		const tx = makeTx([], []);
-
-		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
+		const result = await fetchPreviousYearJobCategories(
+			makeTx(null),
+			"123456789",
+			2026,
+		);
 
 		expect(result).toBeNull();
 	});
 
-	it("returns null when no previous declaration contains job categories", async () => {
+	it("returns categories from the most recent qualifying declaration", async () => {
 		const { fetchPreviousYearJobCategories } = await import(
 			"../declarationHelpers"
 		);
 
-		const tx = makeTx([{ id: "decl-2025" }, { id: "decl-2024" }], [[], []]);
-
-		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
-
-		expect(result).toBeNull();
-	});
-
-	it("returns categories from the most recent previous declaration", async () => {
-		const { fetchPreviousYearJobCategories } = await import(
-			"../declarationHelpers"
-		);
-
-		const mostRecentJobs: JobCategoryRow[] = [
+		const tx = makeTx("decl-2024", [
 			{
 				name: "Employés",
 				detail: "Support",
@@ -279,9 +274,7 @@ describe("fetchPreviousYearJobCategories", () => {
 				source: "convention-collective",
 				categoryIndex: 0,
 			},
-		];
-
-		const tx = makeTx([{ id: "decl-2025" }], [mostRecentJobs]);
+		]);
 
 		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
 
@@ -294,48 +287,19 @@ describe("fetchPreviousYearJobCategories", () => {
 		});
 	});
 
-	it("falls back to an earlier year when N-1 has no job categories", async () => {
-		const { fetchPreviousYearJobCategories } = await import(
-			"../declarationHelpers"
-		);
-
-		const olderJobs: JobCategoryRow[] = [
-			{
-				name: "Cadres",
-				detail: "Managers",
-				source: "autre",
-				categoryIndex: 0,
-			},
-		];
-
-		const tx = makeTx(
-			[{ id: "decl-2025" }, { id: "decl-2023" }],
-			[[], olderJobs],
-		);
-
-		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
-
-		expect(result).toEqual({
-			source: "autre",
-			categories: [{ name: "Cadres", detail: "Managers" }],
-		});
-	});
-
 	it("uses empty string for null detail", async () => {
 		const { fetchPreviousYearJobCategories } = await import(
 			"../declarationHelpers"
 		);
 
-		const jobs: JobCategoryRow[] = [
+		const tx = makeTx("decl-2024", [
 			{
 				name: "Cadres",
 				detail: null,
 				source: "autre",
 				categoryIndex: 0,
 			},
-		];
-
-		const tx = makeTx([{ id: "decl-2025" }], [jobs]);
+		]);
 
 		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
 

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -114,7 +114,8 @@ export const declarationRouter = createTRPCRouter({
 
 		const gipPrefillData = gipRow[0] ? mapGipToFormData(gipRow[0]) : null;
 
-		// Fetch N-1 categories for automatic prefilling when step 5 is empty
+		// Fetch job categories from the most recent previous declaration that
+		// contains indicator 7, for automatic prefilling when step 5 is empty.
 		const hasCurrentCategories = (result.jobCategories ?? []).length > 0;
 		const previousYearCategories = hasCurrentCategories
 			? null

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -97,13 +97,15 @@ export async function fetchPreviousYearJobCategories(
 	siren: string,
 	currentYear: number,
 ) {
-	// Walk previous submitted declarations from most recent down and pick the
-	// first one that actually contains indicator 7 (i.e. has job categories).
-	// A company may skip year N-1 or submit without indicator 7, in which case
-	// we fall back to earlier years.
-	const previousDeclarations = await tx
+	// Find the most recent submitted declaration (strictly before currentYear)
+	// that actually contains indicator 7 — i.e. has at least one row in
+	// app_job_category. The inner join filters empty declarations out; ordering
+	// by year desc + limit 1 keeps this to a single bounded round-trip, so a
+	// company with no indicator 7 on N-1 falls back to N-2 / N-3 automatically.
+	const [previousDeclaration] = await tx
 		.select({ id: declarations.id })
 		.from(declarations)
+		.innerJoin(jobCategories, eq(jobCategories.declarationId, declarations.id))
 		.where(
 			and(
 				eq(declarations.siren, siren),
@@ -111,34 +113,31 @@ export async function fetchPreviousYearJobCategories(
 				eq(declarations.status, "submitted"),
 			),
 		)
-		.orderBy(desc(declarations.year));
+		.orderBy(desc(declarations.year))
+		.limit(1);
 
-	for (const { id } of previousDeclarations) {
-		const jobs = await tx
-			.select({
-				name: jobCategories.name,
-				detail: jobCategories.detail,
-				source: jobCategories.source,
-				categoryIndex: jobCategories.categoryIndex,
-			})
-			.from(jobCategories)
-			.where(eq(jobCategories.declarationId, id));
+	if (!previousDeclaration) return null;
 
-		if (jobs.length === 0) continue;
+	const jobs = await tx
+		.select({
+			name: jobCategories.name,
+			detail: jobCategories.detail,
+			source: jobCategories.source,
+			categoryIndex: jobCategories.categoryIndex,
+		})
+		.from(jobCategories)
+		.where(eq(jobCategories.declarationId, previousDeclaration.id));
 
-		const sorted = [...jobs].sort((a, b) => a.categoryIndex - b.categoryIndex);
-		const source = sorted[0]?.source ?? "";
+	const sorted = [...jobs].sort((a, b) => a.categoryIndex - b.categoryIndex);
+	const source = sorted[0]?.source ?? "";
 
-		return {
-			source,
-			categories: sorted.map((j) => ({
-				name: j.name,
-				detail: j.detail ?? "",
-			})),
-		};
-	}
-
-	return null;
+	return {
+		source,
+		categories: sorted.map((j) => ({
+			name: j.name,
+			detail: j.detail ?? "",
+		})),
+	};
 }
 
 type JobCategoryRow = typeof jobCategories.$inferSelect;

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, lt } from "drizzle-orm";
 
 import {
 	declarations,
@@ -97,44 +97,48 @@ export async function fetchPreviousYearJobCategories(
 	siren: string,
 	currentYear: number,
 ) {
-	const previousYear = currentYear - 1;
-
-	const [previousDeclaration] = await tx
+	// Walk previous submitted declarations from most recent down and pick the
+	// first one that actually contains indicator 7 (i.e. has job categories).
+	// A company may skip year N-1 or submit without indicator 7, in which case
+	// we fall back to earlier years.
+	const previousDeclarations = await tx
 		.select({ id: declarations.id })
 		.from(declarations)
 		.where(
 			and(
 				eq(declarations.siren, siren),
-				eq(declarations.year, previousYear),
+				lt(declarations.year, currentYear),
 				eq(declarations.status, "submitted"),
 			),
 		)
-		.limit(1);
+		.orderBy(desc(declarations.year));
 
-	if (!previousDeclaration) return null;
+	for (const { id } of previousDeclarations) {
+		const jobs = await tx
+			.select({
+				name: jobCategories.name,
+				detail: jobCategories.detail,
+				source: jobCategories.source,
+				categoryIndex: jobCategories.categoryIndex,
+			})
+			.from(jobCategories)
+			.where(eq(jobCategories.declarationId, id));
 
-	const jobs = await tx
-		.select({
-			name: jobCategories.name,
-			detail: jobCategories.detail,
-			source: jobCategories.source,
-			categoryIndex: jobCategories.categoryIndex,
-		})
-		.from(jobCategories)
-		.where(eq(jobCategories.declarationId, previousDeclaration.id));
+		if (jobs.length === 0) continue;
 
-	if (jobs.length === 0) return null;
+		const sorted = [...jobs].sort((a, b) => a.categoryIndex - b.categoryIndex);
+		const source = sorted[0]?.source ?? "";
 
-	const sorted = [...jobs].sort((a, b) => a.categoryIndex - b.categoryIndex);
-	const source = sorted[0]?.source ?? "";
+		return {
+			source,
+			categories: sorted.map((j) => ({
+				name: j.name,
+				detail: j.detail ?? "",
+			})),
+		};
+	}
 
-	return {
-		source,
-		categories: sorted.map((j) => ({
-			name: j.name,
-			detail: j.detail ?? "",
-		})),
-	};
+	return null;
 }
 
 type JobCategoryRow = typeof jobCategories.$inferSelect;


### PR DESCRIPTION
## Summary

Fixes #3246.

Lorsque l'entreprise n'a pas déclaré l'indicateur 7 l'année N-1 (ou n'a pas déclaré du tout), on se rabattait sur rien, alors qu'une déclaration N-2 / N-3 peut contenir des catégories d'emploi réutilisables.

`fetchPreviousYearJobCategories` parcourt désormais toutes les déclarations soumises antérieures à l'année courante, triées par année décroissante, et renvoie les catégories de la première qui contient l'indicateur 7 (rows non vides dans `jobCategories`).

## Changes

- `packages/app/src/server/api/routers/declarationHelpers.ts` — remplace le filtre `year = N-1` par `year < currentYear` + `ORDER BY year DESC` + itération jusqu'à trouver une déclaration avec catégories d'emploi.
- `packages/app/src/server/api/routers/declaration.ts` — commentaire mis à jour (plus de référence trompeuse à "N-1").
- `packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts` — tests mis à jour + nouveau cas : fallback sur N-2 quand N-1 n'a pas de catégories.

## Test plan

- [x] Unit tests — `pnpm test` (1535 passing)
- [x] Lint & format — `pnpm lint:check` + `pnpm format:check`
- [ ] Manual check on review app : une entreprise qui a déclaré l'indicateur 7 il y a 2 ans mais pas l'année dernière doit voir ses catégories préremplies à l'étape 5.