### PR TITLE
feat(admin): add Déclarations link in admin sidemenu

### DIFF
--- a/packages/app/src/modules/admin/AdminNavigation.tsx
+++ b/packages/app/src/modules/admin/AdminNavigation.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 
 const adminLinks = [
 	{ href: "/admin", label: "Accueil" },
+	{ href: "/admin/declarations", label: "Déclarations" },
 	{ href: "/admin/impersonate", label: "Mimoquer un Siren" },
 	{ href: "/admin/liste-referents", label: "Référents" },
 	{ href: "/admin/parametres", label: "Paramètres" },

--- a/packages/app/src/modules/admin/__tests__/AdminNavigation.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminNavigation.test.tsx
@@ -64,4 +64,28 @@ describe("AdminNavigation", () => {
 			"aria-current",
 		);
 	});
+
+	it("marks /admin/declarations as active — and not Accueil", () => {
+		(usePathname as Mock).mockReturnValue("/admin/declarations");
+		render(<AdminNavigation />);
+		expect(screen.getByRole("link", { name: "Déclarations" })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByRole("link", { name: "Accueil" })).not.toHaveAttribute(
+			"aria-current",
+		);
+	});
+
+	it("marks /admin/declarations/<id> as active on the Déclarations link", () => {
+		(usePathname as Mock).mockReturnValue("/admin/declarations/abc123");
+		render(<AdminNavigation />);
+		expect(screen.getByRole("link", { name: "Déclarations" })).toHaveAttribute(
+			"aria-current",
+			"page",
+		);
+		expect(screen.getByRole("link", { name: "Accueil" })).not.toHaveAttribute(
+			"aria-current",
+		);
+	});
 });

--- a/packages/app/src/modules/admin/__tests__/AdminNavigation.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminNavigation.test.tsx
@@ -20,6 +20,9 @@ describe("AdminNavigation", () => {
 		render(<AdminNavigation />);
 		expect(screen.getByRole("link", { name: "Accueil" })).toBeInTheDocument();
 		expect(
+			screen.getByRole("link", { name: "Déclarations" }),
+		).toBeInTheDocument();
+		expect(
 			screen.getByRole("link", { name: "Mimoquer un Siren" }),
 		).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: "Référents" })).toBeInTheDocument();


### PR DESCRIPTION
fix #3265
closes #3273

## Summary
- Add a new "Déclarations" entry in the admin sidemenu (`AdminNavigation`) pointing to `/admin/declarations`.
- Page already exists; this PR just wires it into the menu.
- Test coverage updated to assert the new link.