### PR TITLE
feat(admin): K8 — taux d'écart >= 5% tile on /admin/stats/conformite

### DIFF
--- a/.kontinuous/env/dev/values.yaml
+++ b/.kontinuous/env/dev/values.yaml
@@ -1,3 +1,8 @@
 app:
   annotations:
     oblik.socialgouv.io/min-limit-cpu: 2
+  vars:
+    # Seed the admin conformity-stats fixture at container startup so every
+    # review app (including alpha) has realistic numbers to browse. Gated
+    # here so preprod / prod never auto-seed — they ship with real data.
+    EGAPRO_AUTO_SEED_CONFORMITE: "true"

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -80,6 +80,9 @@ COPY --from=builder --chown=1000:1000 /app/packages/app/scripts/migrate.mjs ./pa
 # Standalone script invoked by the audit-cleanup CronJob (issue #3268 — direct
 # DB access replaces the former curl → /api/audit/cleanup HTTP trigger).
 COPY --from=builder --chown=1000:1000 /app/packages/app/scripts/audit-cleanup.mjs ./packages/app/scripts/audit-cleanup.mjs
+# Optional conformity-stats fixture seed (dev / alpha review apps only;
+# gated by EGAPRO_AUTO_SEED_CONFORMITE in entrypoint.sh).
+COPY --from=builder --chown=1000:1000 /app/packages/app/scripts/seed-conformite-stats.mjs ./packages/app/scripts/seed-conformite-stats.mjs
 
 USER 1000
 

--- a/packages/app/drizzle/0030_add_declaration_has_alert_gap.sql
+++ b/packages/app/drizzle/0030_add_declaration_has_alert_gap.sql
@@ -1,0 +1,56 @@
+-- Denormalized flag: does this declaration carry at least one salary gap
+-- greater than or equal to the 5% regulatory alert threshold?
+--
+-- Source of truth stays on `app_employee_category` (per-category salary
+-- pairs). This column is recomputed at submit time via `hasGapsAboveThreshold`
+-- (domain/shared/gap.ts). It exists only to accelerate admin-stats KPIs
+-- (K8 "Taux d'écart ≥ 5 %") that aggregate across every declaration of a
+-- campaign year without joining four salary pairs × N categories per row.
+ALTER TABLE "app_declaration"
+  ADD COLUMN IF NOT EXISTS "has_alert_gap" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+
+-- Backfill historic `submitted` declarations by computing the threshold check
+-- directly in SQL. This mirrors `hasGapsAboveThreshold` exactly:
+-- both women and men salary must be non-null; `men` must be non-zero (else
+-- `computeGap` would return null and the pair is skipped); then we flag when
+-- |(men - women) / men| * 100 >= 5 on any of the four salary pairs.
+UPDATE "app_declaration" d
+SET "has_alert_gap" = TRUE
+WHERE d."status" = 'submitted'
+  AND EXISTS (
+    SELECT 1
+    FROM "app_employee_category" ec
+    INNER JOIN "app_job_category" jc ON jc."id" = ec."job_category_id"
+    WHERE jc."declaration_id" = d."id"
+      AND (
+        (
+          ec."annual_base_women" IS NOT NULL
+          AND ec."annual_base_men" IS NOT NULL
+          AND ec."annual_base_men" <> 0
+          AND ABS((ec."annual_base_men" - ec."annual_base_women") / ec."annual_base_men") * 100 >= 5
+        )
+        OR (
+          ec."annual_variable_women" IS NOT NULL
+          AND ec."annual_variable_men" IS NOT NULL
+          AND ec."annual_variable_men" <> 0
+          AND ABS((ec."annual_variable_men" - ec."annual_variable_women") / ec."annual_variable_men") * 100 >= 5
+        )
+        OR (
+          ec."hourly_base_women" IS NOT NULL
+          AND ec."hourly_base_men" IS NOT NULL
+          AND ec."hourly_base_men" <> 0
+          AND ABS((ec."hourly_base_men" - ec."hourly_base_women") / ec."hourly_base_men") * 100 >= 5
+        )
+        OR (
+          ec."hourly_variable_women" IS NOT NULL
+          AND ec."hourly_variable_men" IS NOT NULL
+          AND ec."hourly_variable_men" <> 0
+          AND ABS((ec."hourly_variable_men" - ec."hourly_variable_women") / ec."hourly_variable_men") * 100 >= 5
+        )
+      )
+  );
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "declaration_has_alert_gap_idx"
+  ON "app_declaration" ("has_alert_gap");

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
 			"when": 1776100000000,
 			"tag": "0029_add_declaration_submitted_at",
 			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1776200000000,
+			"tag": "0030_add_declaration_has_alert_gap",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,7 @@
 		"db:migrate": "drizzle-kit migrate",
 		"db:push": "drizzle-kit push",
 		"db:studio": "drizzle-kit studio",
-		"dev": "node scripts/copy-dsfr.mjs && node scripts/copy-swagger-ui.mjs && next dev --turbo",
+		"dev": "node scripts/copy-dsfr.mjs && node scripts/copy-swagger-ui.mjs && (pnpm seed:conformite || true) && next dev --turbo",
 		"preview": "next build && next start",
 		"start": "next start",
 		"test": "vitest run",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,7 +29,8 @@
 		"test:lighthouse": "lhci collect --url=${LIGHTHOUSE_URL:-http://localhost:3000} && lhci upload && lhci assert",
 		"typecheck": "tsc --noEmit",
 		"generate:fetch-companies": "tsx scripts/fetch-large-companies.ts",
-		"generate:mock-gip": "tsx scripts/generate-mock-gip-data.ts"
+		"generate:mock-gip": "tsx scripts/generate-mock-gip-data.ts",
+		"seed:conformite": "node --env-file=.env scripts/seed-conformite-stats.mjs"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.1029.0",

--- a/packages/app/scripts/entrypoint.sh
+++ b/packages/app/scripts/entrypoint.sh
@@ -5,5 +5,18 @@ echo "Running Drizzle migrations..."
 node packages/app/scripts/migrate.mjs
 echo "Migrations completed."
 
+# Opt-in fixture seeding for the admin conformity stats page. Enabled only
+# on dev/alpha review apps via .kontinuous/env/dev/values.yaml — never on
+# preprod or prod. Idempotent upserts, so re-running on every pod restart
+# is safe. Failure is treated as non-fatal: the app still boots.
+if [ "$EGAPRO_AUTO_SEED_CONFORMITE" = "true" ]; then
+  echo "Seeding admin conformity fixture (EGAPRO_AUTO_SEED_CONFORMITE=true)..."
+  if node packages/app/scripts/seed-conformite-stats.mjs; then
+    echo "Conformity fixture seeded."
+  else
+    echo "WARNING: conformity seed failed, continuing startup anyway." >&2
+  fi
+fi
+
 echo "Starting Next.js..."
 exec node packages/app/server.js

--- a/packages/app/scripts/seed-conformite-stats.mjs
+++ b/packages/app/scripts/seed-conformite-stats.mjs
@@ -37,12 +37,8 @@ const NAF_SAMPLE_CODES = [
 	"M70.10Z", // M — Activités spécialisées
 	"Q86.10Z", // Q — Santé humaine
 ];
-/**
- * Kept in sync with `FIRST_DECLARATION_YEAR` from `~/modules/domain` — the
- * year filter on `/admin/stats/conformite` goes from there to the current
- * year, so we seed every slot to avoid empty tiles on older selections.
- */
-const FIRST_SEED_YEAR = 2019;
+/** Number of most-recent campaign years to seed (current year + N-1 … N-3). */
+const CAMPAIGN_YEARS_BACK = 4;
 
 function getDatabaseUrl() {
 	if (process.env.DATABASE_URL) return process.env.DATABASE_URL;

--- a/packages/app/scripts/seed-conformite-stats.mjs
+++ b/packages/app/scripts/seed-conformite-stats.mjs
@@ -1,0 +1,245 @@
+/**
+ * Local dev seed for the K8 admin conformity stats page.
+ *
+ * Populates synthetic companies + submitted declarations across four campaign
+ * years (currentYear-3 … currentYear) so that `/admin/stats/conformite` has
+ * enough data to exercise every filter (year / workforce bucket / NAF sector)
+ * and show a plausible year-over-year delta on the KPI tile.
+ *
+ * Idempotent: each run upserts the same deterministic rows — feel free to run
+ * it repeatedly or after resetting the DB.
+ *
+ * Usage (from packages/app):
+ *   pnpm seed:conformite        # insert / refresh the fixture
+ *   pnpm seed:conformite clean  # remove the fixture
+ *
+ * Env: DATABASE_URL (or POSTGRES_* as with the other scripts in this folder).
+ */
+
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+const SEED_DECLARANT_EMAIL = "seed-conformite@egapro.local";
+const SEED_DECLARANT_ID = "seed-conformite-declarant-0000-0000000";
+
+/** 777XXXXXX SIRENs are reserved for this fixture. */
+const SIREN_PREFIX = "777";
+/** Generates one company per (bucket × sector) combination, 5 × 8 = 40. */
+const WORKFORCE_BUCKETS = [20, 60, 120, 180, 300];
+const NAF_SAMPLE_CODES = [
+	"A01.11Z", // A — Agriculture
+	"C10.11Z", // C — Industrie manufacturière
+	"F41.10A", // F — Construction
+	"G47.11B", // G — Commerce
+	"J62.01Z", // J — Information & communication
+	"K64.19Z", // K — Activités financières et d'assurance
+	"M70.10Z", // M — Activités spécialisées
+	"Q86.10Z", // Q — Santé humaine
+];
+/**
+ * Kept in sync with `FIRST_DECLARATION_YEAR` from `~/modules/domain` — the
+ * year filter on `/admin/stats/conformite` goes from there to the current
+ * year, so we seed every slot to avoid empty tiles on older selections.
+ */
+const FIRST_SEED_YEAR = 2019;
+
+function getDatabaseUrl() {
+	if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+	const user = encodeURIComponent(process.env.POSTGRES_USER ?? "postgres");
+	const password = process.env.POSTGRES_PASSWORD
+		? `:${encodeURIComponent(process.env.POSTGRES_PASSWORD)}`
+		: "";
+	const host = process.env.POSTGRES_HOST ?? "localhost";
+	const port = process.env.POSTGRES_PORT ?? "5438";
+	const db = process.env.POSTGRES_DB ?? "egapro";
+	return `postgresql://${user}${password}@${host}:${port}/${db}`;
+}
+
+/**
+ * Deterministic hash → [0, 1) pseudo-random, so re-runs are stable.
+ * @param {number} n
+ */
+function pseudoRandom(n) {
+	const hash = (n * 2654435761) >>> 0;
+	return hash / 2 ** 32;
+}
+
+/**
+ * Decide whether a (siren, year) pair is flagged as alert. We drift the base
+ * rate down over time so the delta badge is visible (improvement), and we add
+ * a small NAF-sector bias so the sector filter visibly changes the result.
+ *
+ * @param {number} companyIndex
+ * @param {number} yearsBeforeCurrent  0 = current year, 1 = N-1, ...
+ * @param {string} nafCode
+ */
+function shouldHaveAlertGap(companyIndex, yearsBeforeCurrent, nafCode) {
+	// Gentle downward drift: the oldest seeded year (2019) sits around 54%,
+	// the current year at ~40% — the points-delta badge between any two
+	// adjacent years should show a visible ~2pt swing.
+	const baseRate = 0.4 + 0.02 * yearsBeforeCurrent;
+	const sectorBias = nafCode.startsWith("K")
+		? 0.12
+		: nafCode.startsWith("M")
+			? -0.1
+			: 0;
+	const threshold = Math.min(0.9, Math.max(0.05, baseRate + sectorBias));
+	return pseudoRandom(companyIndex * 101 + yearsBeforeCurrent * 17) < threshold;
+}
+
+function sirenFor(index) {
+	return `${SIREN_PREFIX}${String(index).padStart(6, "0")}`;
+}
+
+function buildCompanyCatalog() {
+	/** @type {Array<{ siren: string; workforce: number; nafCode: string }>} */
+	const catalog = [];
+	let index = 1;
+	for (const workforce of WORKFORCE_BUCKETS) {
+		for (const nafCode of NAF_SAMPLE_CODES) {
+			catalog.push({ siren: sirenFor(index), workforce, nafCode });
+			index++;
+		}
+	}
+	return catalog;
+}
+
+/** @param {import("postgres").Sql} sql */
+async function ensureDeclarant(sql) {
+	await sql`
+		INSERT INTO app_user (id, email, is_admin)
+		VALUES (${SEED_DECLARANT_ID}, ${SEED_DECLARANT_EMAIL}, false)
+		ON CONFLICT (id) DO NOTHING
+	`;
+}
+
+/** @param {import("postgres").Sql} sql */
+async function seed(sql) {
+	await ensureDeclarant(sql);
+
+	const catalog = buildCompanyCatalog();
+	const currentYear = new Date().getFullYear();
+
+	let insertedCompanies = 0;
+	let insertedDeclarations = 0;
+
+	for (const { siren, workforce, nafCode } of catalog) {
+		await sql`
+			INSERT INTO app_company (siren, name, workforce, naf_code, created_at, updated_at)
+			VALUES (
+				${siren},
+				${`Seed K8 ${siren}`},
+				${workforce},
+				${nafCode},
+				NOW(),
+				NOW()
+			)
+			ON CONFLICT (siren) DO UPDATE SET
+				workforce = EXCLUDED.workforce,
+				naf_code = EXCLUDED.naf_code,
+				updated_at = NOW()
+		`;
+		insertedCompanies++;
+	}
+
+	for (let yearsBack = 0; yearsBack < CAMPAIGN_YEARS_BACK; yearsBack++) {
+		const year = currentYear - yearsBack;
+		let companyIndex = 0;
+		for (const { siren, nafCode } of catalog) {
+			companyIndex++;
+			const hasAlertGap = shouldHaveAlertGap(companyIndex, yearsBack, nafCode);
+			// Spread submissions over January-February so the rows look realistic
+			// (even though the campaign progression chart is not what we exercise
+			// here, keeping a plausible date avoids surprises elsewhere).
+			const submittedAt = new Date(
+				Date.UTC(year, 0, 15 + (companyIndex % 30), 9, 0, 0),
+			).toISOString();
+			await sql`
+				INSERT INTO app_declaration (
+					id, siren, year, declarant_id, current_step, status,
+					submitted_at, has_alert_gap, created_at, updated_at
+				)
+				VALUES (
+					gen_random_uuid(),
+					${siren},
+					${year},
+					${SEED_DECLARANT_ID},
+					6,
+					'submitted',
+					${submittedAt},
+					${hasAlertGap},
+					NOW(),
+					NOW()
+				)
+				ON CONFLICT ON CONSTRAINT declaration_siren_year_idx DO UPDATE SET
+					status = 'submitted',
+					submitted_at = EXCLUDED.submitted_at,
+					has_alert_gap = EXCLUDED.has_alert_gap,
+					updated_at = NOW()
+			`;
+			insertedDeclarations++;
+		}
+	}
+
+	return { insertedCompanies, insertedDeclarations };
+}
+
+/** @param {import("postgres").Sql} sql */
+async function clean(sql) {
+	const [{ deleted: deletedDeclarations }] = await sql`
+		WITH deleted AS (
+			DELETE FROM app_declaration WHERE siren LIKE ${`${SIREN_PREFIX}%`} RETURNING 1
+		)
+		SELECT COUNT(*)::int AS deleted FROM deleted
+	`;
+	const [{ deleted: deletedCompanies }] = await sql`
+		WITH deleted AS (
+			DELETE FROM app_company WHERE siren LIKE ${`${SIREN_PREFIX}%`} RETURNING 1
+		)
+		SELECT COUNT(*)::int AS deleted FROM deleted
+	`;
+	const [{ deleted: deletedUsers }] = await sql`
+		WITH deleted AS (
+			DELETE FROM app_user WHERE id = ${SEED_DECLARANT_ID} RETURNING 1
+		)
+		SELECT COUNT(*)::int AS deleted FROM deleted
+	`;
+	return { deletedDeclarations, deletedCompanies, deletedUsers };
+}
+
+async function main() {
+	const mode = process.argv[2] ?? "seed";
+	const sql = postgres(getDatabaseUrl(), { max: 1 });
+	try {
+		if (mode === "clean") {
+			const result = await clean(sql);
+			console.log(
+				`[seed-conformite] cleaned: ${result.deletedDeclarations} declarations, ${result.deletedCompanies} companies, ${result.deletedUsers} declarant.`,
+			);
+			return;
+		}
+		if (mode !== "seed") {
+			console.error(`Unknown mode "${mode}". Use "seed" (default) or "clean".`);
+			process.exit(2);
+		}
+		const result = await seed(sql);
+		console.log(
+			`[seed-conformite] upserted ${result.insertedCompanies} companies and ${result.insertedDeclarations} submitted declarations across ${CAMPAIGN_YEARS_BACK} campaign years.`,
+		);
+		console.log(
+			`[seed-conformite] open http://localhost:3000/admin/stats/conformite to browse the tile.`,
+		);
+	} finally {
+		await sql.end();
+	}
+}
+
+if (
+	import.meta.url === `file://${realpathSync(fileURLToPath(import.meta.url))}`
+) {
+	main().catch((error) => {
+		console.error("[seed-conformite] failed:", error);
+		process.exit(1);
+	});
+}

--- a/packages/app/scripts/seed-conformite-stats.mjs
+++ b/packages/app/scripts/seed-conformite-stats.mjs
@@ -40,6 +40,39 @@ const NAF_SAMPLE_CODES = [
 /** Number of most-recent campaign years to seed (current year + N-1 … N-3). */
 const CAMPAIGN_YEARS_BACK = 4;
 
+/**
+ * Hard-fail when the script is about to talk to a production database.
+ *
+ * Defence in depth on top of the `EGAPRO_AUTO_SEED_CONFORMITE` opt-in
+ * flag and the `.kontinuous/env/dev` scoping: even a configuration
+ * mistake that leaks the flag into preprod or prod cannot end up
+ * overwriting real declarations with synthetic ones.
+ *
+ * Signals that prevent execution, in priority order:
+ *  - `NEXT_PUBLIC_EGAPRO_ENV` equals `"prod"` / `"production"` / `"preprod"`
+ *    (set by kontinuous `app.vars`, matches the values in
+ *    `.kontinuous/env/{prod,preprod}/`).
+ *  - `EGAPRO_ENV` same values (some scripts read this non-public form).
+ *
+ * Explicit bypass for CI / emergency: `EGAPRO_ALLOW_SEED_IN_PROD=true`.
+ * Leaves the seed usable from a break-glass terminal if someone ever
+ * needs it — but that is a deliberate, logged decision.
+ */
+function assertNotProduction() {
+	if (process.env.EGAPRO_ALLOW_SEED_IN_PROD === "true") return;
+	const signals = [process.env.NEXT_PUBLIC_EGAPRO_ENV, process.env.EGAPRO_ENV]
+		.filter((v) => typeof v === "string" && v.length > 0)
+		.map((v) => v.toLowerCase());
+	const forbidden = ["prod", "production", "preprod", "preproduction"];
+	const hit = signals.find((v) => forbidden.includes(v));
+	if (hit) {
+		console.error(
+			`[seed-conformite] refusing to run against a ${hit} environment. Set EGAPRO_ALLOW_SEED_IN_PROD=true to override.`,
+		);
+		process.exit(1);
+	}
+}
+
 function getDatabaseUrl() {
 	if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
 	const user = encodeURIComponent(process.env.POSTGRES_USER ?? "postgres");
@@ -205,6 +238,7 @@ async function clean(sql) {
 }
 
 async function main() {
+	assertNotProduction();
 	const mode = process.argv[2] ?? "seed";
 	const sql = postgres(getDatabaseUrl(), { max: 1 });
 	try {

--- a/packages/app/src/app/admin/stats/conformite/page.tsx
+++ b/packages/app/src/app/admin/stats/conformite/page.tsx
@@ -1,0 +1,16 @@
+import { ConformiteStatsPage } from "~/modules/admin/stats";
+import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
+
+export default function Page() {
+	const currentYear = getCurrentYear();
+	const availableYears: number[] = [];
+	for (let year = currentYear; year >= FIRST_DECLARATION_YEAR; year--) {
+		availableYears.push(year);
+	}
+	return (
+		<ConformiteStatsPage
+			availableYears={availableYears}
+			currentYear={currentYear}
+		/>
+	);
+}

--- a/packages/app/src/e2e/admin-stats-conformite.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-conformite.e2e.ts
@@ -1,0 +1,172 @@
+import { expect, test } from "@playwright/test";
+
+import { getCurrentYear } from "~/modules/domain";
+
+import {
+	deleteSeededCampaignDeclarations,
+	seedSubmittedDeclarationsForStats,
+} from "./helpers/db";
+
+// Reserved SIRENs — outside any real range, scoped to the K8 conformity test.
+const SIRENS = {
+	currentAlert: "999400001", // year N, alert, small
+	currentSafe: "999400002", // year N, no alert, small
+	currentLargeAlert: "999400003", // year N, alert, large
+	currentFinance: "999400004", // year N, alert, NAF K
+	previousAlert: "999400005", // year N-1, alert
+	previousSafe: "999400006", // year N-1, no alert
+} as const;
+
+const CURRENT_YEAR = getCurrentYear();
+const PREVIOUS_YEAR = CURRENT_YEAR - 1;
+
+test.describe("admin conformity stats (K8 — gap alert rate)", () => {
+	test.beforeAll(async () => {
+		await seedSubmittedDeclarationsForStats([
+			{
+				siren: SIRENS.currentAlert,
+				year: CURRENT_YEAR,
+				submittedAt: `${CURRENT_YEAR}-01-15T10:00:00Z`,
+				workforce: 30,
+				hasAlertGap: true,
+				nafCode: "A01.11Z",
+			},
+			{
+				siren: SIRENS.currentSafe,
+				year: CURRENT_YEAR,
+				submittedAt: `${CURRENT_YEAR}-01-16T10:00:00Z`,
+				workforce: 30,
+				hasAlertGap: false,
+				nafCode: "A01.11Z",
+			},
+			{
+				siren: SIRENS.currentLargeAlert,
+				year: CURRENT_YEAR,
+				submittedAt: `${CURRENT_YEAR}-01-17T10:00:00Z`,
+				workforce: 300,
+				hasAlertGap: true,
+				nafCode: "C10.11Z",
+			},
+			{
+				siren: SIRENS.currentFinance,
+				year: CURRENT_YEAR,
+				submittedAt: `${CURRENT_YEAR}-01-18T10:00:00Z`,
+				workforce: 50,
+				hasAlertGap: true,
+				nafCode: "K64.19Z",
+			},
+			{
+				siren: SIRENS.previousAlert,
+				year: PREVIOUS_YEAR,
+				submittedAt: `${PREVIOUS_YEAR}-02-15T10:00:00Z`,
+				workforce: 30,
+				hasAlertGap: true,
+				nafCode: "A01.11Z",
+			},
+			{
+				siren: SIRENS.previousSafe,
+				year: PREVIOUS_YEAR,
+				submittedAt: `${PREVIOUS_YEAR}-02-16T10:00:00Z`,
+				workforce: 30,
+				hasAlertGap: false,
+				nafCode: "A01.11Z",
+			},
+		]);
+	});
+
+	test.afterAll(async () => {
+		await deleteSeededCampaignDeclarations(Object.values(SIRENS));
+	});
+
+	test("admin can open the conformity stats page and sees the KPI tile", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+
+		await expect(
+			page.getByRole("heading", { name: "Statistiques conformité", level: 1 }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", {
+				name: "Taux d'écart ≥ 5 %",
+				level: 2,
+			}),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", {
+				name: new RegExp(`Taux d'écart ≥ 5 % en ${CURRENT_YEAR}`),
+				level: 3,
+			}),
+		).toBeVisible();
+	});
+
+	test("filtering by company size updates the tile (fewer declarations)", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+
+		// Wait for the first tile render so we know the query resolved.
+		await expect(
+			page.getByRole("heading", {
+				name: new RegExp(`Taux d'écart ≥ 5 % en ${CURRENT_YEAR}`),
+				level: 3,
+			}),
+		).toBeVisible();
+
+		await page.getByLabel("Tranche d'effectif").selectOption("250+");
+
+		// With the "250+" filter, only currentLargeAlert contributes. The tile
+		// stays mounted and the subtitle reflects the narrower sample.
+		await expect(page.getByText(/Sur 1 déclarations?/)).toBeVisible();
+	});
+
+	test("filtering by NAF sector updates the tile (finance only)", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+		await expect(
+			page.getByRole("heading", {
+				name: new RegExp(`Taux d'écart ≥ 5 % en ${CURRENT_YEAR}`),
+				level: 3,
+			}),
+		).toBeVisible();
+
+		await page.getByLabel("Filtrer par secteur NAF").selectOption("K");
+
+		await expect(page.getByText(/Sur 1 déclarations?/)).toBeVisible();
+	});
+
+	test("switching the year keeps the tile mounted with the new label", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+		await expect(
+			page.getByRole("heading", {
+				name: new RegExp(`Taux d'écart ≥ 5 % en ${CURRENT_YEAR}`),
+				level: 3,
+			}),
+		).toBeVisible();
+
+		await page.getByLabel("Année").selectOption(String(PREVIOUS_YEAR));
+
+		await expect(
+			page.getByRole("heading", {
+				name: new RegExp(`Taux d'écart ≥ 5 % en ${PREVIOUS_YEAR}`),
+				level: 3,
+			}),
+		).toBeVisible();
+	});
+});
+
+test("non-admin users are redirected away from the conformity stats page", async ({
+	browser,
+}) => {
+	const anonCtx = await browser.newContext({ storageState: undefined });
+	try {
+		const page = await anonCtx.newPage();
+		await page.goto("/admin/stats/conformite");
+		await expect(page).toHaveURL(/\/login/);
+	} finally {
+		await anonCtx.close();
+	}
+});

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -434,6 +434,16 @@ type SeededCampaignDeclaration = {
 	submittedAt: string;
 	/** Workforce stored on the synthetic company. */
 	workforce: number;
+	/**
+	 * Denormalized alert-gap flag used by the K8 conformity KPI. Optional so
+	 * the K2 campaign-progression seeds keep working without caring about it.
+	 */
+	hasAlertGap?: boolean;
+	/**
+	 * NAF code (full form, e.g. `"62.01Z"`). Optional for the same reason —
+	 * K8 tests set it to exercise the sector filter, K2 tests leave it null.
+	 */
+	nafCode?: string | null;
 };
 
 /**
@@ -458,23 +468,28 @@ export async function seedSubmittedDeclarationsForStats(
 			);
 		}
 		for (const row of rows) {
+			const nafCode = row.nafCode ?? null;
+			const hasAlertGap = row.hasAlertGap ?? false;
 			await sql`
-				INSERT INTO app_company (siren, name, workforce, created_at, updated_at)
-				VALUES (${row.siren}, ${`E2E Stats Co. ${row.siren}`}, ${row.workforce}, NOW(), NOW())
-				ON CONFLICT (siren) DO UPDATE SET workforce = EXCLUDED.workforce
+				INSERT INTO app_company (siren, name, workforce, naf_code, created_at, updated_at)
+				VALUES (${row.siren}, ${`E2E Stats Co. ${row.siren}`}, ${row.workforce}, ${nafCode}, NOW(), NOW())
+				ON CONFLICT (siren) DO UPDATE SET
+					workforce = EXCLUDED.workforce,
+					naf_code = EXCLUDED.naf_code
 			`;
 			await sql`
 				INSERT INTO app_declaration (
 					id, siren, year, declarant_id, current_step, status,
-					submitted_at, created_at, updated_at
+					submitted_at, has_alert_gap, created_at, updated_at
 				)
 				VALUES (
 					gen_random_uuid(), ${row.siren}, ${row.year}, ${declarantId}, 6,
-					'submitted', ${row.submittedAt}, NOW(), NOW()
+					'submitted', ${row.submittedAt}, ${hasAlertGap}, NOW(), NOW()
 				)
 				ON CONFLICT ON CONSTRAINT declaration_siren_year_idx DO UPDATE SET
 					status = 'submitted',
-					submitted_at = EXCLUDED.submitted_at
+					submitted_at = EXCLUDED.submitted_at,
+					has_alert_gap = EXCLUDED.has_alert_gap
 			`;
 		}
 	} finally {

--- a/packages/app/src/modules/admin/AdminNavigation.tsx
+++ b/packages/app/src/modules/admin/AdminNavigation.tsx
@@ -9,6 +9,7 @@ const adminLinks = [
 	{ href: "/admin/impersonate", label: "Mimoquer un Siren" },
 	{ href: "/admin/liste-referents", label: "Référents" },
 	{ href: "/admin/stats/campagne", label: "Statistiques campagne" },
+	{ href: "/admin/stats/conformite", label: "Statistiques conformité" },
 	{ href: "/admin/parametres", label: "Paramètres" },
 ] as const;
 

--- a/packages/app/src/modules/admin/__tests__/AdminNavigation.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminNavigation.test.tsx
@@ -29,6 +29,9 @@ describe("AdminNavigation", () => {
 		expect(
 			screen.getByRole("link", { name: "Statistiques campagne" }),
 		).toBeInTheDocument();
+		expect(
+			screen.getByRole("link", { name: "Statistiques conformité" }),
+		).toBeInTheDocument();
 	});
 
 	it("marks /admin/stats/campagne as active on that page", () => {
@@ -101,5 +104,16 @@ describe("AdminNavigation", () => {
 		expect(screen.getByRole("link", { name: "Accueil" })).not.toHaveAttribute(
 			"aria-current",
 		);
+	});
+
+	it("marks /admin/stats/conformite as active on that page", () => {
+		(usePathname as Mock).mockReturnValue("/admin/stats/conformite");
+		render(<AdminNavigation />);
+		expect(
+			screen.getByRole("link", { name: "Statistiques conformité" }),
+		).toHaveAttribute("aria-current", "page");
+		expect(
+			screen.getByRole("link", { name: "Statistiques campagne" }),
+		).not.toHaveAttribute("aria-current");
 	});
 });

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.module.scss
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.module.scss
@@ -1,0 +1,18 @@
+.tile {
+	// Lay out the tile body vertically with consistent DSFR spacing.
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.value {
+	font-size: 2.5rem;
+	font-weight: 700;
+	line-height: 1.2;
+	margin: 0;
+}
+
+.subtitle {
+	color: var(--text-mention-grey);
+	margin: 0;
+}

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
@@ -1,0 +1,92 @@
+import { formatPointsDelta } from "~/modules/domain";
+
+import styles from "./AdminKpiTile.module.scss";
+
+type DeltaDirection = "up" | "down" | "flat";
+
+type Props = {
+	title: string;
+	/** Main value, pre-formatted (e.g. "73,4 %"). */
+	value: string;
+	/** Auxiliary line beneath the value (e.g. "4 213 / 5 738 entreprises"). */
+	subtitle?: string;
+	/**
+	 * Points-of-percentage delta vs. previous period. `null` hides the badge
+	 * entirely (no history available).
+	 */
+	deltaPoints?: number | null;
+	/** Label shown after the delta badge (e.g. "vs 2025"). */
+	deltaLabel?: string;
+	/**
+	 * When true, invert the sign→color mapping: a positive delta is rendered
+	 * as an error (red) and a negative one as a success (green). Used by KPIs
+	 * where a rising value signals degradation (e.g. K8 — Taux d'écart ≥ 5 %).
+	 */
+	inverted?: boolean;
+};
+
+function directionOf(deltaPoints: number): DeltaDirection {
+	const rounded = Math.round(deltaPoints * 10) / 10;
+	if (rounded > 0) return "up";
+	if (rounded < 0) return "down";
+	return "flat";
+}
+
+function badgeClassFor(direction: DeltaDirection, inverted: boolean): string {
+	if (direction === "flat") return "fr-badge fr-badge--info fr-badge--no-icon";
+	const positiveClass = "fr-badge fr-badge--success fr-badge--no-icon";
+	const negativeClass = "fr-badge fr-badge--error fr-badge--no-icon";
+	if (direction === "up") return inverted ? negativeClass : positiveClass;
+	return inverted ? positiveClass : negativeClass;
+}
+
+function arrowFor(direction: DeltaDirection): string {
+	if (direction === "up") return "↑";
+	if (direction === "down") return "↓";
+	return "=";
+}
+
+/**
+ * Reusable KPI tile for the admin stats dashboard.
+ *
+ * Renders a DSFR `fr-tile` with a title, a prominent value, an optional
+ * points-delta badge vs. the previous period, and an optional subtitle.
+ * Shared across K1 (declaration rate), K8 (gap alert rate) and later KPIs
+ * — keep business logic out of here, callers pass pre-formatted strings.
+ */
+export function AdminKpiTile({
+	title,
+	value,
+	subtitle,
+	deltaPoints,
+	deltaLabel,
+	inverted = false,
+}: Props) {
+	const direction =
+		deltaPoints === null || deltaPoints === undefined
+			? null
+			: directionOf(deltaPoints);
+
+	return (
+		<div className="fr-tile fr-tile--no-icon fr-tile--no-border">
+			<div className="fr-tile__body">
+				<div className={`fr-tile__content ${styles.tile}`}>
+					<h3 className="fr-tile__title">{title}</h3>
+					<p className={styles.value}>{value}</p>
+					{direction !== null &&
+						deltaPoints !== null &&
+						deltaPoints !== undefined && (
+							<div>
+								<p className={badgeClassFor(direction, inverted)}>
+									<span aria-hidden="true">{arrowFor(direction)} </span>
+									{formatPointsDelta(deltaPoints)}
+									{deltaLabel ? ` ${deltaLabel}` : null}
+								</p>
+							</div>
+						)}
+					{subtitle ? <p className={styles.subtitle}>{subtitle}</p> : null}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/admin/stats/ConformiteStatsPage.tsx
+++ b/packages/app/src/modules/admin/stats/ConformiteStatsPage.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { type ChangeEvent, useState } from "react";
-
-import { formatCount, formatGap } from "~/modules/domain";
 import type { CompanySizeRange } from "~/modules/domain";
+import { formatCount, formatGap } from "~/modules/domain";
 import {
 	CompanySizeFilter,
-	NafSectorFilter,
 	type NafSectionCode,
+	NafSectorFilter,
 } from "~/modules/shared";
 import { api } from "~/trpc/react";
 
@@ -76,10 +75,7 @@ export function ConformiteStatsPage({ currentYear, availableYears }: Props) {
 					/>
 				</div>
 				<div className="fr-col-12 fr-col-md-4">
-					<NafSectorFilter
-						onChange={setNafCodePrefix}
-						value={nafCodePrefix}
-					/>
+					<NafSectorFilter onChange={setNafCodePrefix} value={nafCodePrefix} />
 				</div>
 			</div>
 

--- a/packages/app/src/modules/admin/stats/ConformiteStatsPage.tsx
+++ b/packages/app/src/modules/admin/stats/ConformiteStatsPage.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { type ChangeEvent, useState } from "react";
+
+import { formatCount, formatGap } from "~/modules/domain";
+import type { CompanySizeRange } from "~/modules/domain";
+import {
+	CompanySizeFilter,
+	NafSectorFilter,
+	type NafSectionCode,
+} from "~/modules/shared";
+import { api } from "~/trpc/react";
+
+import { AdminKpiTile } from "./AdminKpiTile";
+
+type Props = {
+	/** Reference year — also the default selection of the year filter. */
+	currentYear: number;
+	/** Years available in the year dropdown, newest first. */
+	availableYears: number[];
+};
+
+export function ConformiteStatsPage({ currentYear, availableYears }: Props) {
+	const [year, setYear] = useState(currentYear);
+	const [sizeRange, setSizeRange] = useState<CompanySizeRange | undefined>(
+		undefined,
+	);
+	const [nafCodePrefix, setNafCodePrefix] = useState<
+		NafSectionCode | undefined
+	>(undefined);
+
+	const query = api.adminStats.getGapAlertRate.useQuery(
+		{ year, sizeRange, nafCodePrefix },
+		{ placeholderData: (prev) => prev },
+	);
+
+	const handleYearChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		setYear(Number.parseInt(event.target.value, 10));
+	};
+
+	return (
+		<>
+			<h1 className="fr-h1">Statistiques conformité</h1>
+			<p>
+				Suivi des indicateurs réglementaires de conformité des déclarations
+				d'égalité professionnelle. Le taux d'écart ≥ 5 % mesure la part
+				d'entreprises en alerte au titre du seuil légal.
+			</p>
+
+			<div className="fr-grid-row fr-grid-row--gutters fr-mt-4w">
+				<div className="fr-col-12 fr-col-md-4">
+					<div className="fr-select-group">
+						<label className="fr-label" htmlFor="conformite-year-filter">
+							Année
+						</label>
+						<select
+							className="fr-select"
+							id="conformite-year-filter"
+							name="year"
+							onChange={handleYearChange}
+							value={year}
+						>
+							{availableYears.map((y) => (
+								<option key={y} value={y}>
+									{y}
+								</option>
+							))}
+						</select>
+					</div>
+				</div>
+				<div className="fr-col-12 fr-col-md-4">
+					<CompanySizeFilter
+						label="Tranche d'effectif"
+						onChange={setSizeRange}
+						value={sizeRange}
+					/>
+				</div>
+				<div className="fr-col-12 fr-col-md-4">
+					<NafSectorFilter
+						onChange={setNafCodePrefix}
+						value={nafCodePrefix}
+					/>
+				</div>
+			</div>
+
+			<section aria-labelledby="gap-alert-rate-heading" className="fr-mt-4w">
+				<h2 className="fr-h3" id="gap-alert-rate-heading">
+					Taux d'écart ≥ 5 %
+				</h2>
+				{query.isLoading && !query.data && (
+					<p aria-live="polite">Chargement de l'indicateur…</p>
+				)}
+				{query.isError && (
+					<div aria-live="polite" className="fr-alert fr-alert--error">
+						<p>Une erreur est survenue lors du chargement du taux d'écart.</p>
+					</div>
+				)}
+				{query.data && (
+					<div className="fr-grid-row fr-grid-row--gutters">
+						<div className="fr-col-12 fr-col-md-6 fr-col-lg-4">
+							<AdminKpiTile
+								deltaLabel={`vs ${year - 1}`}
+								deltaPoints={query.data.delta}
+								inverted
+								subtitle={`Sur ${formatCount(query.data.sampleSize)} déclarations`}
+								title={`Taux d'écart ≥ 5 % en ${year}`}
+								value={formatGap(query.data.rate)}
+							/>
+						</div>
+					</div>
+				)}
+			</section>
+		</>
+	);
+}

--- a/packages/app/src/modules/admin/stats/__tests__/AdminKpiTile.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/AdminKpiTile.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AdminKpiTile } from "../AdminKpiTile";
+
+describe("AdminKpiTile", () => {
+	it("renders the title, value and subtitle", () => {
+		render(
+			<AdminKpiTile
+				subtitle="4 213 / 5 738 entreprises"
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: "Taux de déclaration 2026" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("73,4 %")).toBeInTheDocument();
+		expect(screen.getByText("4 213 / 5 738 entreprises")).toBeInTheDocument();
+	});
+
+	it("does not render a delta badge when deltaPoints is null", () => {
+		const { container } = render(
+			<AdminKpiTile
+				deltaPoints={null}
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		expect(container.querySelector(".fr-badge")).toBeNull();
+	});
+
+	it("renders a success (green) badge for a positive delta by default", () => {
+		const { container } = render(
+			<AdminKpiTile
+				deltaLabel="vs 2025"
+				deltaPoints={2.1}
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.className).toContain("fr-badge--success");
+		expect(badge?.textContent).toMatch(/\+2,1 pts/);
+		expect(badge?.textContent).toMatch(/vs 2025/);
+	});
+
+	it("renders an error (red) badge for a negative delta by default", () => {
+		const { container } = render(
+			<AdminKpiTile
+				deltaPoints={-2.1}
+				title="Taux de déclaration 2026"
+				value="71,3 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge?.className).toContain("fr-badge--error");
+		expect(badge?.textContent).toMatch(/-2,1 pts/);
+	});
+
+	it("renders a neutral (info) badge for a zero delta", () => {
+		const { container } = render(
+			<AdminKpiTile
+				deltaPoints={0}
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge?.className).toContain("fr-badge--info");
+		expect(badge?.textContent).toMatch(/0 pt/);
+	});
+
+	it("flips green/red when inverted is true (positive delta = degradation)", () => {
+		const { container } = render(
+			<AdminKpiTile
+				deltaPoints={2.1}
+				inverted
+				title="Taux d'écart ≥ 5 %"
+				value="42,3 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge?.className).toContain("fr-badge--error");
+	});
+
+	it("flips negative to green when inverted is true (improvement)", () => {
+		const { container } = render(
+			<AdminKpiTile
+				deltaPoints={-2.1}
+				inverted
+				title="Taux d'écart ≥ 5 %"
+				value="40,2 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge?.className).toContain("fr-badge--success");
+	});
+});

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -2,10 +2,17 @@ export { AdminKpiTile } from "./AdminKpiTile";
 export { CampaignProgressionChart } from "./CampaignProgressionChart";
 export { CampaignProgressionTable } from "./CampaignProgressionTable";
 export { CampaignStatsPage } from "./CampaignStatsPage";
-export type { GetCampaignProgressionInput } from "./schemas";
-export { getCampaignProgressionSchema } from "./schemas";
+export type {
+	GetCampaignProgressionInput,
+	GetGapAlertRateInput,
+} from "./schemas";
+export {
+	getCampaignProgressionSchema,
+	getGapAlertRateSchema,
+} from "./schemas";
 export type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
+	GapAlertRateResult,
 } from "./types";
 export { YearsFilter } from "./YearsFilter";

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -2,6 +2,7 @@ export { AdminKpiTile } from "./AdminKpiTile";
 export { CampaignProgressionChart } from "./CampaignProgressionChart";
 export { CampaignProgressionTable } from "./CampaignProgressionTable";
 export { CampaignStatsPage } from "./CampaignStatsPage";
+export { ConformiteStatsPage } from "./ConformiteStatsPage";
 export type {
 	GetCampaignProgressionInput,
 	GetGapAlertRateInput,

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -1,3 +1,4 @@
+export { AdminKpiTile } from "./AdminKpiTile";
 export { CampaignProgressionChart } from "./CampaignProgressionChart";
 export { CampaignProgressionTable } from "./CampaignProgressionTable";
 export { CampaignStatsPage } from "./CampaignStatsPage";

--- a/packages/app/src/modules/admin/stats/schemas.ts
+++ b/packages/app/src/modules/admin/stats/schemas.ts
@@ -23,3 +23,26 @@ export const getCampaignProgressionSchema = z.object({
 export type GetCampaignProgressionInput = z.infer<
 	typeof getCampaignProgressionSchema
 >;
+
+/**
+ * Input for `adminStats.getGapAlertRate` (K8 — Taux d'écart ≥ 5 %).
+ *
+ * `year`: campaign year whose rate is computed. The KPI also fetches the
+ * previous year internally for the delta.
+ *
+ * `sizeRange`: workforce bucket — both numerator and denominator are scoped.
+ *
+ * `nafCodePrefix`: single NAF section letter (A–U). Filters companies whose
+ * `nafCode` starts with that letter.
+ */
+export const getGapAlertRateSchema = z.object({
+	year: z.number().int().min(2000).max(2100),
+	sizeRange: z.enum(COMPANY_SIZE_RANGE_KEYS).optional(),
+	nafCodePrefix: z
+		.string()
+		.length(1)
+		.regex(/^[A-U]$/, "Le code NAF doit être une lettre majuscule entre A et U")
+		.optional(),
+});
+
+export type GetGapAlertRateInput = z.infer<typeof getGapAlertRateSchema>;

--- a/packages/app/src/modules/admin/stats/types.ts
+++ b/packages/app/src/modules/admin/stats/types.ts
@@ -15,3 +15,22 @@ export type CampaignProgressionSeries = {
 	year: number;
 	points: CampaignProgressionPoint[];
 };
+
+/**
+ * K8 — "Taux d'écart ≥ 5 %" tile payload.
+ *
+ * `rate` / `previousRate` are percentages 0..100, one decimal. `null` when
+ * the denominator is zero (no declaration matches the filters).
+ *
+ * `delta` is the percentage-point difference between `rate` and `previousRate`;
+ * `null` when either side is missing (no historical data, empty sample).
+ *
+ * `sampleSize` is the number of declarations retained by the filters for the
+ * current year — always returned, even when `rate` is null.
+ */
+export type GapAlertRateResult = {
+	rate: number | null;
+	previousRate: number | null;
+	delta: number | null;
+	sampleSize: number;
+};

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -53,6 +53,7 @@ export const AUDIT_ACTIONS = {
 
 	// ── Admin stats reads ─────────────────────────────────
 	ADMIN_STATS_CAMPAIGN_PROGRESSION: "admin_stats.campaign_progression",
+	ADMIN_STATS_GAP_ALERT_RATE: "admin_stats.gap_alert_rate",
 
 	// ── Sensitive reads ────────────────────────────────────
 	ADMIN_FILE_DOWNLOAD: "admin.file_download",
@@ -121,6 +122,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_DECLARATION_GET_BY_ID]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_STATS_GAP_ALERT_RATE]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.PROFILE_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA]: "read_sensitive",

--- a/packages/app/src/modules/domain/__tests__/format.test.ts
+++ b/packages/app/src/modules/domain/__tests__/format.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
 	computePercentage,
 	computeProportion,
+	formatCount,
 	formatCurrency,
 	formatGap,
 	formatGapCompact,
 	formatMonthDay,
+	formatPointsDelta,
 	formatShortDate,
 	formatShortDateTime,
 	formatTotal,
@@ -104,5 +106,35 @@ describe("formatMonthDay", () => {
 	it("swaps a MM-DD fragment to the French DD/MM form", () => {
 		expect(formatMonthDay("02-15")).toBe("15/02");
 		expect(formatMonthDay("12-01")).toBe("01/12");
+	});
+});
+
+describe("formatCount", () => {
+	it("formats an integer with French thousand separators", () => {
+		expect(formatCount(4213)).toMatch(/4[\s ]213/);
+	});
+
+	it("leaves values below 1000 unchanged", () => {
+		expect(formatCount(42)).toBe("42");
+	});
+});
+
+describe("formatPointsDelta", () => {
+	it("prefixes a positive value with + and appends pts", () => {
+		expect(formatPointsDelta(2.1)).toBe("+2,1 pts");
+	});
+
+	it("prefixes a negative value with - and appends pts", () => {
+		expect(formatPointsDelta(-2.1)).toBe("-2,1 pts");
+	});
+
+	it("formats zero as '= 0 pt' (singular, no sign)", () => {
+		expect(formatPointsDelta(0)).toBe("= 0 pt");
+		expect(formatPointsDelta(0.04)).toBe("= 0 pt");
+	});
+
+	it("rounds to one decimal", () => {
+		expect(formatPointsDelta(2.16)).toBe("+2,2 pts");
+		expect(formatPointsDelta(-0.18)).toBe("-0,2 pts");
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -33,11 +33,13 @@ export { computeDeclarationStatus } from "./shared/declarationStatus";
 export {
 	computePercentage,
 	computeProportion,
+	formatCount,
 	formatCurrency,
 	formatGap,
 	formatGapCompact,
 	formatLongDate,
 	formatMonthDay,
+	formatPointsDelta,
 	formatShortDate,
 	formatShortDateTime,
 	formatTotal,

--- a/packages/app/src/modules/domain/shared/format.ts
+++ b/packages/app/src/modules/domain/shared/format.ts
@@ -48,6 +48,25 @@ export function formatTotal(value: number | null, unit: string): string {
 	return `${value.toLocaleString("fr-FR", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${unit}`;
 }
 
+/** Format an integer with French thousand separators: `4213` → `"4 213"`. */
+export function formatCount(value: number): string {
+	return value.toLocaleString("fr-FR");
+}
+
+/**
+ * Format a percentage-point delta with sign and unit for KPI badges:
+ * `2.1` → `"+2,1 pts"`, `-2.1` → `"-2,1 pts"`, `0` → `"= 0 pt"`.
+ *
+ * The value is rounded to one decimal before display.
+ */
+export function formatPointsDelta(value: number): string {
+	const rounded = Math.round(value * 10) / 10;
+	if (rounded === 0) return "= 0 pt";
+	const sign = rounded > 0 ? "+" : "-";
+	const abs = Math.abs(rounded).toFixed(1).replace(".", ",");
+	return `${sign}${abs} pts`;
+}
+
 /** Format a date in short French format: `new Date("2026-03-10")` → `"10/03/2026"`. Returns `"—"` for nullish values. */
 export function formatShortDate(date: Date | null | undefined): string {
 	if (!date) return "—";

--- a/packages/app/src/modules/shared/NafSectorFilter.tsx
+++ b/packages/app/src/modules/shared/NafSectorFilter.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+
+import {
+	NAF_SECTION_CODES,
+	NAF_SECTIONS,
+	type NafSectionCode,
+} from "./nafSections";
+
+type Props = {
+	value: NafSectionCode | undefined;
+	onChange: (value: NafSectionCode | undefined) => void;
+	id?: string;
+	label?: string;
+};
+
+const ALL_SECTORS_LABEL = "Tous les secteurs";
+
+export function NafSectorFilter({
+	value,
+	onChange,
+	id = "naf-sector-filter",
+	label = "Filtrer par secteur NAF",
+}: Props) {
+	const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		const next = event.target.value;
+		onChange(next === "" ? undefined : (next as NafSectionCode));
+	};
+
+	return (
+		<div className="fr-select-group">
+			<label className="fr-label" htmlFor={id}>
+				{label}
+			</label>
+			<select
+				className="fr-select"
+				id={id}
+				name="nafCodePrefix"
+				onChange={handleChange}
+				value={value ?? ""}
+			>
+				<option value="">{ALL_SECTORS_LABEL}</option>
+				{NAF_SECTION_CODES.map((code) => (
+					<option key={code} value={code}>
+						{code} — {NAF_SECTIONS[code]}
+					</option>
+				))}
+			</select>
+		</div>
+	);
+}

--- a/packages/app/src/modules/shared/__tests__/NafSectorFilter.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/NafSectorFilter.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { NafSectorFilter } from "../NafSectorFilter";
+
+describe("NafSectorFilter", () => {
+	it("renders the 21 sections plus the 'all sectors' option", () => {
+		render(<NafSectorFilter onChange={vi.fn()} value={undefined} />);
+
+		const select = screen.getByRole<HTMLSelectElement>("combobox", {
+			name: "Filtrer par secteur NAF",
+		});
+		const optionValues = Array.from(select.querySelectorAll("option")).map(
+			(option) => option.value,
+		);
+		expect(optionValues).toEqual([
+			"",
+			"A",
+			"B",
+			"C",
+			"D",
+			"E",
+			"F",
+			"G",
+			"H",
+			"I",
+			"J",
+			"K",
+			"L",
+			"M",
+			"N",
+			"O",
+			"P",
+			"Q",
+			"R",
+			"S",
+			"T",
+			"U",
+		]);
+	});
+
+	it("shows each section label prefixed with its letter", () => {
+		render(<NafSectorFilter onChange={vi.fn()} value={undefined} />);
+
+		expect(
+			screen.getByRole("option", { name: /^J — Information et communication$/ }),
+		).toBeInTheDocument();
+	});
+
+	it("reflects the controlled value", () => {
+		render(<NafSectorFilter onChange={vi.fn()} value="K" />);
+
+		const select = screen.getByRole<HTMLSelectElement>("combobox", {
+			name: "Filtrer par secteur NAF",
+		});
+		expect(select.value).toBe("K");
+	});
+
+	it("calls onChange with the selected section code", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		render(<NafSectorFilter onChange={onChange} value={undefined} />);
+
+		await user.selectOptions(
+			screen.getByRole("combobox", { name: "Filtrer par secteur NAF" }),
+			"F",
+		);
+
+		expect(onChange).toHaveBeenCalledWith("F");
+	});
+
+	it("calls onChange with undefined when 'all sectors' is selected", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		render(<NafSectorFilter onChange={onChange} value="F" />);
+
+		await user.selectOptions(
+			screen.getByRole("combobox", { name: "Filtrer par secteur NAF" }),
+			"Tous les secteurs",
+		);
+
+		expect(onChange).toHaveBeenCalledWith(undefined);
+	});
+});

--- a/packages/app/src/modules/shared/__tests__/NafSectorFilter.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/NafSectorFilter.test.tsx
@@ -44,7 +44,9 @@ describe("NafSectorFilter", () => {
 		render(<NafSectorFilter onChange={vi.fn()} value={undefined} />);
 
 		expect(
-			screen.getByRole("option", { name: /^J — Information et communication$/ }),
+			screen.getByRole("option", {
+				name: /^J — Information et communication$/,
+			}),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -1,6 +1,9 @@
 export { CompanySizeFilter } from "./CompanySizeFilter";
 export { FileUpload } from "./FileUpload";
 export { getDsfrModal } from "./getDsfrModal";
+export { NafSectorFilter } from "./NafSectorFilter";
+export type { NafSectionCode } from "./nafSections";
+export { NAF_SECTION_CODES, NAF_SECTIONS } from "./nafSections";
 export { parseSiren } from "./parseSiren";
 export { SubmitModal } from "./SubmitModal";
 export {

--- a/packages/app/src/modules/shared/nafSections.ts
+++ b/packages/app/src/modules/shared/nafSections.ts
@@ -1,0 +1,57 @@
+/**
+ * NAF sections — French "Nomenclature d'Activités Française" (INSEE 2008).
+ *
+ * 21 top-level sections keyed by their single-letter prefix (A–U), used by
+ * the admin-stats NAF filter. The full company NAF code (e.g. `62.01Z`) is
+ * stored on `companies.nafCode`; matching a section is `LIKE 'J%'`.
+ *
+ * Source: https://www.insee.fr/fr/information/2120875
+ */
+export type NafSectionCode =
+	| "A"
+	| "B"
+	| "C"
+	| "D"
+	| "E"
+	| "F"
+	| "G"
+	| "H"
+	| "I"
+	| "J"
+	| "K"
+	| "L"
+	| "M"
+	| "N"
+	| "O"
+	| "P"
+	| "Q"
+	| "R"
+	| "S"
+	| "T"
+	| "U";
+
+export const NAF_SECTIONS: Record<NafSectionCode, string> = {
+	A: "Agriculture, sylviculture et pêche",
+	B: "Industries extractives",
+	C: "Industrie manufacturière",
+	D: "Production et distribution d'électricité, de gaz, de vapeur et d'air conditionné",
+	E: "Production et distribution d'eau, assainissement, gestion des déchets et dépollution",
+	F: "Construction",
+	G: "Commerce, réparation d'automobiles et de motocycles",
+	H: "Transports et entreposage",
+	I: "Hébergement et restauration",
+	J: "Information et communication",
+	K: "Activités financières et d'assurance",
+	L: "Activités immobilières",
+	M: "Activités spécialisées, scientifiques et techniques",
+	N: "Activités de services administratifs et de soutien",
+	O: "Administration publique",
+	P: "Enseignement",
+	Q: "Santé humaine et action sociale",
+	R: "Arts, spectacles et activités récréatives",
+	S: "Autres activités de services",
+	T: "Activités des ménages en tant qu'employeurs",
+	U: "Activités extra-territoriales",
+};
+
+export const NAF_SECTION_CODES = Object.keys(NAF_SECTIONS) as NafSectionCode[];

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -148,3 +148,148 @@ describe("adminStatsRouter.getCampaignProgression", () => {
 		).rejects.toThrow();
 	});
 });
+
+// ------------------------------------------------------------------
+// K8 — getGapAlertRate
+// ------------------------------------------------------------------
+
+type GapRateRow = { total: number; alerts: number };
+type GapRateDb = ReturnType<typeof buildGapRateDb>;
+
+/**
+ * Build a DB mock for `getGapAlertRate` — the procedure calls computeYearRate
+ * twice (current year + N-1), so we queue two row sets and track which chain
+ * gets returned on each `select()` call.
+ */
+function buildGapRateDb(rowsPerCall: GapRateRow[]) {
+	const calls: Array<{
+		innerJoin: ReturnType<typeof vi.fn>;
+		where: ReturnType<typeof vi.fn>;
+	}> = [];
+
+	const select = vi.fn().mockImplementation(() => {
+		const row = rowsPerCall[calls.length];
+		const where = vi.fn().mockResolvedValue(row ? [row] : []);
+		const innerJoin = vi.fn().mockImplementation(() => ({ where }));
+		const from = vi.fn().mockImplementation(() => ({ innerJoin, where }));
+		calls.push({ innerJoin, where });
+		return { from };
+	});
+
+	return { select, calls };
+}
+
+function buildCaller(db: GapRateDb | ReturnType<typeof buildDb>) {
+	return import("../adminStats").then(({ adminStatsRouter }) =>
+		adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never),
+	);
+}
+
+describe("adminStatsRouter.getGapAlertRate", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("returns nulls for rate / delta and sampleSize=0 when no declaration matches", async () => {
+		const db = buildGapRateDb([
+			{ total: 0, alerts: 0 },
+			{ total: 0, alerts: 0 },
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getGapAlertRate({ year: 2026 });
+
+		expect(result).toEqual({
+			rate: null,
+			previousRate: null,
+			delta: null,
+			sampleSize: 0,
+		});
+	});
+
+	it("returns delta=null when the previous year has no sample", async () => {
+		const db = buildGapRateDb([
+			{ total: 1000, alerts: 420 },
+			{ total: 0, alerts: 0 },
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getGapAlertRate({ year: 2026 });
+
+		expect(result.rate).toBe(42);
+		expect(result.previousRate).toBeNull();
+		expect(result.delta).toBeNull();
+		expect(result.sampleSize).toBe(1000);
+	});
+
+	it("computes a positive delta when the rate rises (degradation)", async () => {
+		const db = buildGapRateDb([
+			{ total: 1000, alerts: 423 }, // 42.3% in 2026
+			{ total: 1000, alerts: 411 }, // 41.1% in 2025
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getGapAlertRate({ year: 2026 });
+
+		expect(result.rate).toBe(42.3);
+		expect(result.previousRate).toBe(41.1);
+		expect(result.delta).toBeCloseTo(1.2, 5);
+		expect(result.sampleSize).toBe(1000);
+	});
+
+	it("computes a negative delta when the rate improves", async () => {
+		const db = buildGapRateDb([
+			{ total: 1000, alerts: 388 }, // 38.8%
+			{ total: 1000, alerts: 411 }, // 41.1%
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getGapAlertRate({ year: 2026 });
+
+		expect(result.delta).toBeCloseTo(-2.3, 5);
+	});
+
+	it("joins on companies only when a sizeRange or nafCodePrefix filter is given", async () => {
+		const db = buildGapRateDb([
+			{ total: 10, alerts: 1 },
+			{ total: 10, alerts: 1 },
+			{ total: 10, alerts: 1 },
+			{ total: 10, alerts: 1 },
+			{ total: 10, alerts: 1 },
+			{ total: 10, alerts: 1 },
+		]);
+		const caller = await buildCaller(db);
+
+		// No filter → no companies join
+		await caller.getGapAlertRate({ year: 2026 });
+		expect(db.calls[0]?.innerJoin).not.toHaveBeenCalled();
+		expect(db.calls[1]?.innerJoin).not.toHaveBeenCalled();
+
+		// sizeRange only → join
+		await caller.getGapAlertRate({ year: 2026, sizeRange: "50-99" });
+		expect(db.calls[2]?.innerJoin).toHaveBeenCalledTimes(1);
+		expect(db.calls[3]?.innerJoin).toHaveBeenCalledTimes(1);
+
+		// nafCodePrefix only → join
+		await caller.getGapAlertRate({ year: 2026, nafCodePrefix: "J" });
+		expect(db.calls[4]?.innerJoin).toHaveBeenCalledTimes(1);
+		expect(db.calls[5]?.innerJoin).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects invalid NAF code prefixes (must be a single letter A–U)", async () => {
+		const db = buildGapRateDb([]);
+		const caller = await buildCaller(db);
+
+		await expect(
+			caller.getGapAlertRate({ year: 2026, nafCodePrefix: "Z" }),
+		).rejects.toThrow();
+		await expect(
+			caller.getGapAlertRate({ year: 2026, nafCodePrefix: "AB" }),
+		).rejects.toThrow();
+		await expect(
+			caller.getGapAlertRate({ year: 2026, nafCodePrefix: "a" }),
+		).rejects.toThrow();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -113,8 +113,21 @@ const mockDeclaration = {
 };
 
 describe("declarationRouter", () => {
-	beforeEach(() => {
+	beforeEach(async () => {
 		vi.resetAllMocks();
+		// `vi.resetAllMocks()` clears implementations set at mock-factory time,
+		// so we have to re-apply the default behaviour of declarationHelpers
+		// here (otherwise `fetchAllCategories` returns undefined and the submit
+		// path — which now destructures its result — throws).
+		const helpers = await import("../declarationHelpers");
+		vi.mocked(helpers.fetchAllCategories).mockResolvedValue({
+			jobCategories: [],
+			employeeCategories: [],
+		});
+		vi.mocked(helpers.deleteJobAndEmployeeCategories).mockResolvedValue(
+			undefined,
+		);
+		vi.mocked(helpers.fetchPreviousYearJobCategories).mockResolvedValue(null);
 	});
 
 	afterEach(() => {
@@ -287,6 +300,43 @@ describe("declarationRouter", () => {
 
 			const call = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
 			expect(call.submittedAt).toBeInstanceOf(Date);
+		});
+
+		it("stamps hasAlertGap=false when no employee category reaches the threshold", async () => {
+			const mockDb = createMockDb([{ id: "decl-1", submittedAt: null }]);
+			const caller = await createCaller(mockDb);
+
+			await caller.submit();
+
+			const call = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(call.hasAlertGap).toBe(false);
+		});
+
+		it("stamps hasAlertGap=true when at least one employee category has a gap >= 5%", async () => {
+			const { fetchAllCategories } = await import("../declarationHelpers");
+			vi.mocked(fetchAllCategories).mockResolvedValueOnce({
+				jobCategories: [],
+				employeeCategories: [
+					{
+						annualBaseWomen: "90",
+						annualBaseMen: "100",
+						annualVariableWomen: null,
+						annualVariableMen: null,
+						hourlyBaseWomen: null,
+						hourlyBaseMen: null,
+						hourlyVariableWomen: null,
+						hourlyVariableMen: null,
+					},
+				] as never,
+			});
+
+			const mockDb = createMockDb([{ id: "decl-1", submittedAt: null }]);
+			const caller = await createCaller(mockDb);
+
+			await caller.submit();
+
+			const call = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(call.hasAlertGap).toBe(true);
 		});
 
 		it("throws when siret is missing", async () => {

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -10,15 +10,15 @@ import {
 	sql,
 } from "drizzle-orm";
 
-import {
-	getCampaignProgressionSchema,
-	getGapAlertRateSchema,
-} from "~/modules/admin/stats/schemas";
 import type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
 	GapAlertRateResult,
-} from "~/modules/admin/stats/types";
+} from "~/modules/admin/stats";
+import {
+	getCampaignProgressionSchema,
+	getGapAlertRateSchema,
+} from "~/modules/admin/stats";
 import { COMPANY_SIZE_RANGES } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import type { DB } from "~/server/db";

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -5,17 +5,23 @@ import {
 	gte,
 	inArray,
 	isNotNull,
+	like,
 	type SQL,
 	sql,
 } from "drizzle-orm";
 
-import { getCampaignProgressionSchema } from "~/modules/admin/stats/schemas";
+import {
+	getCampaignProgressionSchema,
+	getGapAlertRateSchema,
+} from "~/modules/admin/stats/schemas";
 import type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
+	GapAlertRateResult,
 } from "~/modules/admin/stats/types";
 import { COMPANY_SIZE_RANGES } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
+import type { DB } from "~/server/db";
 import { companies, declarations } from "~/server/db/schema";
 
 type AggregatedRow = { day: string; year: number; count: number };
@@ -98,4 +104,100 @@ export const adminStatsRouter = createTRPCRouter({
 
 			return buildSeries(rows as AggregatedRow[]);
 		}),
+
+	/**
+	 * K8 — "Taux d'écart ≥ 5 %". Returns the share of submitted declarations
+	 * whose salary gap crosses the regulatory alert threshold for the given
+	 * year, the same ratio on year-1 for the delta, and the filter sample size.
+	 *
+	 * A rising rate signals degradation — the UI inverts the badge colour
+	 * (red on positive delta) via the `inverted` prop on `<AdminKpiTile>`.
+	 */
+	getGapAlertRate: adminProcedure
+		.input(getGapAlertRateSchema)
+		.query(async ({ ctx, input }): Promise<GapAlertRateResult> => {
+			const rateFor = (year: number) =>
+				computeYearRate({
+					db: ctx.db,
+					year,
+					sizeRange: input.sizeRange,
+					nafCodePrefix: input.nafCodePrefix,
+				});
+
+			const [current, previous] = await Promise.all([
+				rateFor(input.year),
+				rateFor(input.year - 1),
+			]);
+
+			const delta =
+				current.rate === null || previous.rate === null
+					? null
+					: current.rate - previous.rate;
+
+			return {
+				rate: current.rate,
+				previousRate: previous.rate,
+				delta,
+				sampleSize: current.total,
+			};
+		}),
 });
+
+type ComputeYearRateParams = {
+	db: DB;
+	year: number;
+	sizeRange?: keyof typeof COMPANY_SIZE_RANGES;
+	nafCodePrefix?: string;
+};
+
+/**
+ * Run a single aggregation for one campaign year: total submitted count +
+ * alert count. Returns a rate rounded to one decimal (0..100) or `null`
+ * when nothing matches.
+ */
+async function computeYearRate(params: ComputeYearRateParams): Promise<{
+	rate: number | null;
+	total: number;
+}> {
+	const filters: SQL[] = [
+		eq(declarations.status, "submitted"),
+		eq(declarations.year, params.year),
+	];
+
+	if (params.sizeRange) {
+		const { min, max } = COMPANY_SIZE_RANGES[params.sizeRange];
+		filters.push(
+			max === null
+				? gte(companies.workforce, min)
+				: between(companies.workforce, min, max),
+		);
+	}
+
+	if (params.nafCodePrefix) {
+		filters.push(like(companies.nafCode, `${params.nafCodePrefix}%`));
+	}
+
+	const requiresCompaniesJoin = Boolean(
+		params.sizeRange || params.nafCodePrefix,
+	);
+
+	const baseQuery = params.db.select({
+		total: sql<number>`count(*)::int`,
+		alerts: sql<number>`count(*) filter (where ${declarations.hasAlertGap})::int`,
+	});
+
+	const scoped = requiresCompaniesJoin
+		? baseQuery
+				.from(declarations)
+				.innerJoin(companies, eq(declarations.siren, companies.siren))
+		: baseQuery.from(declarations);
+
+	const [row] = await scoped.where(and(...filters));
+	const total = row?.total ?? 0;
+	const alerts = row?.alerts ?? 0;
+
+	if (total === 0) return { rate: null, total: 0 };
+
+	const rate = Math.round((alerts / total) * 1000) / 10;
+	return { rate, total };
+}

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -9,7 +9,7 @@ import {
 	updateStep4Schema,
 } from "~/modules/declaration-remuneration/schemas";
 import { mapGipToFormData } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
-import { getCurrentYear } from "~/modules/domain";
+import { getCurrentYear, hasGapsAboveThreshold } from "~/modules/domain";
 import {
 	companyProcedure,
 	companyWriteProcedure,
@@ -457,10 +457,26 @@ export const declarationRouter = createTRPCRouter({
 		// Preserve the very first submission date — resubmissions after
 		// corrections must not move the campaign progression curve.
 		const [existing] = await ctx.db
-			.select({ submittedAt: declarations.submittedAt })
+			.select({
+				id: declarations.id,
+				submittedAt: declarations.submittedAt,
+			})
 			.from(declarations)
 			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
 			.limit(1);
+
+		// Recompute the denormalized hasAlertGap flag from the employee
+		// categories. Source of truth stays on employee_category; this flag
+		// only exists to accelerate admin-stats KPIs (K8) that aggregate
+		// across a whole campaign year without a four-way join on salary pairs.
+		let hasAlertGap = false;
+		if (existing) {
+			const { employeeCategories: empCats } = await fetchAllCategories(
+				ctx.db,
+				existing.id,
+			);
+			hasAlertGap = hasGapsAboveThreshold(empCats);
+		}
 
 		await ctx.db
 			.update(declarations)
@@ -468,6 +484,7 @@ export const declarationRouter = createTRPCRouter({
 				status: "submitted",
 				currentStep: 6,
 				submittedAt: existing?.submittedAt ?? now,
+				hasAlertGap,
 				updatedAt: now,
 			})
 			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -105,7 +105,7 @@ export async function deleteJobAndEmployeeCategories(
 	}
 }
 
-export async function fetchAllCategories(tx: Tx, declarationId: string) {
+export async function fetchAllCategories(tx: DbOrTx, declarationId: string) {
 	const jobs = await tx
 		.select()
 		.from(jobCategories)

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -59,6 +59,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	// ── admin stats sensitive reads ──────────────────────
 	"adminStats.getCampaignProgression":
 		AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION,
+	"adminStats.getGapAlertRate": AUDIT_ACTIONS.ADMIN_STATS_GAP_ALERT_RATE,
 
 	// ── gip mds ────────────────────────────────────────────
 	"gipMds.importFromUrl": AUDIT_ACTIONS.GIP_MDS_IMPORT,

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -116,6 +116,12 @@ export const declarations = createTable(
 		complianceCompletedAt: d.timestamp({ withTimezone: true }),
 		cseOpinionCompletedAt: d.timestamp({ withTimezone: true }),
 		submittedAt: d.timestamp({ withTimezone: true }),
+		// Denormalized flag recomputed at `submit` time via
+		// `hasGapsAboveThreshold`. The source of truth is still the per-category
+		// salary pairs on `employeeCategories`; this column only exists to speed
+		// up the admin-stats KPIs (K8 in particular) that aggregate across all
+		// declarations of a campaign year without joining employee_category.
+		hasAlertGap: d.boolean().notNull().default(false),
 		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 	}),
@@ -123,6 +129,7 @@ export const declarations = createTable(
 		unique("declaration_siren_year_idx").on(t.siren, t.year),
 		index("declaration_declarant_idx").on(t.declarantId),
 		index("declaration_submitted_at_idx").on(t.submittedAt),
+		index("declaration_has_alert_gap_idx").on(t.hasAlertGap),
 	],
 );
 


### PR DESCRIPTION
fix #3219

## Summary
- New route `/admin/stats/conformite` with an `<AdminKpiTile inverted>` showing the share of submitted declarations whose gap crosses the regulatory 5% threshold for a given campaign year, with a year-on-year points-delta badge (red on rise, green on fall) and the sample size below.
- New tRPC procedure `adminStats.getGapAlertRate({ year, sizeRange?, nafCodePrefix? })` (adminProcedure, audited as `read_sensitive` / 180-day CNIL retention). Two parallel year aggregations feed the delta.
- Backed by a new denormalised `has_alert_gap boolean` column on `app_declaration`, recomputed via `hasGapsAboveThreshold` at every `declaration.submit`. Legacy submitted rows are backfilled in migration `0030` by replaying the same four salary-pair check in SQL. Source of truth stays on `app_employee_category`.
- New shared `<NafSectorFilter>` (DSFR `<select>` over the 21 INSEE 2008 sections A–U) and `NAF_SECTIONS` constant — reusable by K9 / K10 on the same conformity page.
- Ports `<AdminKpiTile>` + `formatPointsDelta` / `formatCount` from #3236 (still open) so K8 is not blocked on K1 merging; the component ships with the `inverted` prop already wired.

## Test plan
- [x] Unit — `AdminKpiTile` (7 cases: renders, no-delta hidden, success/error/info badge, inverted positive/negative)
- [x] Unit — `NafSectorFilter` (5 cases: 21 options, labelled prefix, controlled value, change, reset-to-undefined)
- [x] Unit — `formatCount` / `formatPointsDelta` (6 cases: thousands, sign, zero, rounding)
- [x] Unit — `adminStats.getGapAlertRate` (6 cases: empty sample, no-history delta, rising/falling delta, conditional companies join, NAF regex validation)
- [x] Unit — `declaration.submit` gains 2 cases asserting `hasAlertGap` is written correctly
- [x] Unit — `AdminNavigation` gains a case for the active state on `/admin/stats/conformite`
- [x] E2E (`admin-stats-conformite.e2e.ts`) — admin sees the tile, size filter narrows the sample, NAF filter isolates the finance sector, year dropdown re-labels the tile, non-admin redirected to `/login`
- [x] Audit wire-up — `AUDIT_ACTIONS.ADMIN_STATS_GAP_ALERT_RATE` + `read_sensitive` category + `PROCEDURE_TO_ACTION` entry
- [x] Typecheck, lint, format, full vitest suite (1578 tests) — all green
<img width="1171" height="837" alt="Capture d’écran 2026-04-23 à 12 11 32" src="https://github.com/user-attachments/assets/5e7cd066-2afb-4f23-92e5-062502b21083" />
