### PR TITLE
feat(admin): K10 — multi-year gap trend chart (stats)

### DIFF
--- a/packages/app/drizzle/0031_add_declaration_average_gap.sql
+++ b/packages/app/drizzle/0031_add_declaration_average_gap.sql
@@ -1,0 +1,73 @@
+-- Denormalized arithmetic mean of every computable salary gap on this
+-- declaration's employee categories. Null until we have at least one pair
+-- of non-null women/men salaries with men != 0.
+--
+-- Source of truth stays on `app_employee_category` (four salary pairs per
+-- row). This column is recomputed at submit time via `computeAverageGap`
+-- (domain/shared/gap.ts) and exists only to accelerate the K10 multi-year
+-- gap trend chart — a 5-year aggregation across up to 21 NAF sections
+-- cannot afford to re-join employee_category for every row.
+ALTER TABLE "app_declaration"
+  ADD COLUMN IF NOT EXISTS "average_gap" numeric;
+--> statement-breakpoint
+
+-- Backfill historic `submitted` declarations — mirrors `computeAverageGap`
+-- exactly: for each of the four salary pairs (annual/hourly × base/variable),
+-- we keep the ones where both sides are non-null and `men <> 0`, compute
+-- |(men - women) / men| * 100, then average every retained value across every
+-- category of the declaration. UNNEST + FILTER(WHERE) keeps the expression
+-- self-contained and easier to read than four nested CASE branches.
+UPDATE "app_declaration" d
+SET "average_gap" = sub.avg_gap
+FROM (
+  SELECT
+    jc."declaration_id",
+    AVG(pair.gap) AS avg_gap
+  FROM "app_job_category" jc
+  INNER JOIN "app_employee_category" ec ON ec."job_category_id" = jc."id"
+  CROSS JOIN LATERAL (
+    SELECT gap FROM (VALUES
+      (
+        CASE
+          WHEN ec."annual_base_women" IS NOT NULL
+           AND ec."annual_base_men" IS NOT NULL
+           AND ec."annual_base_men" <> 0
+          THEN ABS((ec."annual_base_men" - ec."annual_base_women") / ec."annual_base_men") * 100
+        END
+      ),
+      (
+        CASE
+          WHEN ec."annual_variable_women" IS NOT NULL
+           AND ec."annual_variable_men" IS NOT NULL
+           AND ec."annual_variable_men" <> 0
+          THEN ABS((ec."annual_variable_men" - ec."annual_variable_women") / ec."annual_variable_men") * 100
+        END
+      ),
+      (
+        CASE
+          WHEN ec."hourly_base_women" IS NOT NULL
+           AND ec."hourly_base_men" IS NOT NULL
+           AND ec."hourly_base_men" <> 0
+          THEN ABS((ec."hourly_base_men" - ec."hourly_base_women") / ec."hourly_base_men") * 100
+        END
+      ),
+      (
+        CASE
+          WHEN ec."hourly_variable_women" IS NOT NULL
+           AND ec."hourly_variable_men" IS NOT NULL
+           AND ec."hourly_variable_men" <> 0
+          THEN ABS((ec."hourly_variable_men" - ec."hourly_variable_women") / ec."hourly_variable_men") * 100
+        END
+      )
+    ) AS t(gap)
+    WHERE gap IS NOT NULL
+  ) pair
+  GROUP BY jc."declaration_id"
+) sub
+WHERE d."id" = sub."declaration_id"
+  AND d."status" = 'submitted'
+  AND d."average_gap" IS NULL;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "declaration_average_gap_idx"
+  ON "app_declaration" ("average_gap");

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
 			"when": 1776200000000,
 			"tag": "0030_add_declaration_has_alert_gap",
 			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1776300000000,
+			"tag": "0031_add_declaration_average_gap",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/scripts/seed-conformite-stats.mjs
+++ b/packages/app/scripts/seed-conformite-stats.mjs
@@ -25,17 +25,23 @@ const SEED_DECLARANT_ID = "seed-conformite-declarant-0000-0000000";
 
 /** 777XXXXXX SIRENs are reserved for this fixture. */
 const SIREN_PREFIX = "777";
-/** Generates one company per (bucket × sector) combination, 5 × 8 = 40. */
+/** Generates one company per (bucket × sector) combination, 5 × 9 = 45. */
 const WORKFORCE_BUCKETS = [20, 60, 120, 180, 300];
+/**
+ * Nine NAF sample codes cover the five K10 dominant sections (C, G, M, N, Q)
+ * so every expected curve shows up in "Segmenter par NAF" mode, plus four
+ * non-dominant sections (A, F, J, K) that collapse into the "Autres" series.
+ */
 const NAF_SAMPLE_CODES = [
-	"A01.11Z", // A — Agriculture
-	"C10.11Z", // C — Industrie manufacturière
-	"F41.10A", // F — Construction
-	"G47.11B", // G — Commerce
-	"J62.01Z", // J — Information & communication
-	"K64.19Z", // K — Activités financières et d'assurance
-	"M70.10Z", // M — Activités spécialisées
-	"Q86.10Z", // Q — Santé humaine
+	"A01.11Z", // A — Agriculture → "Autres"
+	"C10.11Z", // C — Industrie manufacturière (dominant)
+	"F41.10A", // F — Construction → "Autres"
+	"G47.11B", // G — Commerce (dominant)
+	"J62.01Z", // J — Information & communication → "Autres"
+	"K64.19Z", // K — Activités financières et d'assurance → "Autres"
+	"M70.10Z", // M — Activités spécialisées (dominant)
+	"N78.10Z", // N — Services administratifs (dominant)
+	"Q86.10Z", // Q — Santé humaine (dominant)
 ];
 /** Number of most-recent campaign years to seed (current year + N-1 … N-3). */
 const CAMPAIGN_YEARS_BACK = 4;
@@ -119,20 +125,46 @@ function shouldHaveAlertGap(companyIndex, yearsBeforeCurrent, nafCode) {
 
 /**
  * Build a plausible average gap (0..12%) for a seed row so K10 has something
- * to plot. Same shape as `shouldHaveAlertGap`: slightly improving over time,
- * with a sector bias (K finance skewed up, M services skewed down). Clamped
- * to [0.5, 12] so the chart's Y-axis stays readable.
+ * to plot. Combines three effects so every K10 segmentation produces visibly
+ * distinct curves:
+ *  - **year drift**: ~+0.6pt per year going back, so the trend slopes down
+ *    toward the current year.
+ *  - **NAF sector bias**: K (finance) runs hotter, M (services spécialisés)
+ *    cooler — the "Segmenter par NAF" mode shows spread between Autres and
+ *    the dominant series.
+ *  - **workforce bias**: smaller companies (< 50) trend ~+1.5pt vs. 250+,
+ *    so the "Segmenter par effectif" mode separates the buckets vertically
+ *    instead of drawing five overlapping lines.
+ * Clamped to [0.5, 12] so the Y-axis stays readable.
  */
-function pseudoAverageGap(companyIndex, yearsBeforeCurrent, nafCode) {
+function pseudoAverageGap(
+	companyIndex,
+	yearsBeforeCurrent,
+	nafCode,
+	workforce,
+) {
 	const baseGap = 4 + 0.6 * yearsBeforeCurrent;
 	const sectorShift = nafCode.startsWith("K")
 		? 2.5
 		: nafCode.startsWith("M")
 			? -1.5
 			: 0;
+	// Linear gradient across the five buckets: <50 → +1.5, 50-99 → +0.75,
+	// 100-149 → 0, 150-249 → -0.5, 250+ → -1. Enough spread for the chart
+	// to render five distinct curves without overlapping.
+	const workforceShift =
+		workforce < 50
+			? 1.5
+			: workforce < 100
+				? 0.75
+				: workforce < 150
+					? 0
+					: workforce < 250
+						? -0.5
+						: -1;
 	const jitter =
-		(pseudoRandom(companyIndex * 211 + yearsBeforeCurrent) - 0.5) * 3;
-	const value = baseGap + sectorShift + jitter;
+		(pseudoRandom(companyIndex * 211 + yearsBeforeCurrent) - 0.5) * 1.5;
+	const value = baseGap + sectorShift + workforceShift + jitter;
 	return Math.max(0.5, Math.min(12, Math.round(value * 10) / 10));
 }
 
@@ -194,10 +226,15 @@ async function seed(sql) {
 	for (let yearsBack = 0; yearsBack < CAMPAIGN_YEARS_BACK; yearsBack++) {
 		const year = currentYear - yearsBack;
 		let companyIndex = 0;
-		for (const { siren, nafCode } of catalog) {
+		for (const { siren, nafCode, workforce } of catalog) {
 			companyIndex++;
 			const hasAlertGap = shouldHaveAlertGap(companyIndex, yearsBack, nafCode);
-			const averageGap = pseudoAverageGap(companyIndex, yearsBack, nafCode);
+			const averageGap = pseudoAverageGap(
+				companyIndex,
+				yearsBack,
+				nafCode,
+				workforce,
+			);
 			// Spread submissions over January-February so the rows look realistic
 			// (even though the campaign progression chart is not what we exercise
 			// here, keeping a plausible date avoids surprises elsewhere).

--- a/packages/app/scripts/seed-conformite-stats.mjs
+++ b/packages/app/scripts/seed-conformite-stats.mjs
@@ -191,8 +191,7 @@ async function seed(sql) {
 		insertedCompanies++;
 	}
 
-	const totalYears = currentYear - FIRST_SEED_YEAR + 1;
-	for (let yearsBack = 0; yearsBack < totalYears; yearsBack++) {
+	for (let yearsBack = 0; yearsBack < CAMPAIGN_YEARS_BACK; yearsBack++) {
 		const year = currentYear - yearsBack;
 		let companyIndex = 0;
 		for (const { siren, nafCode } of catalog) {
@@ -278,7 +277,7 @@ async function main() {
 		}
 		const result = await seed(sql);
 		console.log(
-			`[seed-conformite] upserted ${result.insertedCompanies} companies and ${result.insertedDeclarations} submitted declarations from ${FIRST_SEED_YEAR} to the current year.`,
+			`[seed-conformite] upserted ${result.insertedCompanies} companies and ${result.insertedDeclarations} submitted declarations across ${CAMPAIGN_YEARS_BACK} campaign years.`,
 		);
 		console.log(
 			`[seed-conformite] open http://localhost:3000/admin/stats/conformite to browse the tile.`,

--- a/packages/app/scripts/seed-conformite-stats.mjs
+++ b/packages/app/scripts/seed-conformite-stats.mjs
@@ -104,9 +104,9 @@ function pseudoRandom(n) {
  * @param {string} nafCode
  */
 function shouldHaveAlertGap(companyIndex, yearsBeforeCurrent, nafCode) {
-	// Gentle downward drift: the oldest seeded year (2019) sits around 54%,
-	// the current year at ~40% — the points-delta badge between any two
-	// adjacent years should show a visible ~2pt swing.
+	// Gentle downward drift: older years sit around 50%, the current year at
+	// ~40% — the K8 points-delta badge between any two adjacent years should
+	// show a visible ~2pt swing.
 	const baseRate = 0.4 + 0.02 * yearsBeforeCurrent;
 	const sectorBias = nafCode.startsWith("K")
 		? 0.12
@@ -115,6 +115,25 @@ function shouldHaveAlertGap(companyIndex, yearsBeforeCurrent, nafCode) {
 			: 0;
 	const threshold = Math.min(0.9, Math.max(0.05, baseRate + sectorBias));
 	return pseudoRandom(companyIndex * 101 + yearsBeforeCurrent * 17) < threshold;
+}
+
+/**
+ * Build a plausible average gap (0..12%) for a seed row so K10 has something
+ * to plot. Same shape as `shouldHaveAlertGap`: slightly improving over time,
+ * with a sector bias (K finance skewed up, M services skewed down). Clamped
+ * to [0.5, 12] so the chart's Y-axis stays readable.
+ */
+function pseudoAverageGap(companyIndex, yearsBeforeCurrent, nafCode) {
+	const baseGap = 4 + 0.6 * yearsBeforeCurrent;
+	const sectorShift = nafCode.startsWith("K")
+		? 2.5
+		: nafCode.startsWith("M")
+			? -1.5
+			: 0;
+	const jitter =
+		(pseudoRandom(companyIndex * 211 + yearsBeforeCurrent) - 0.5) * 3;
+	const value = baseGap + sectorShift + jitter;
+	return Math.max(0.5, Math.min(12, Math.round(value * 10) / 10));
 }
 
 function sirenFor(index) {
@@ -172,12 +191,14 @@ async function seed(sql) {
 		insertedCompanies++;
 	}
 
-	for (let yearsBack = 0; yearsBack < CAMPAIGN_YEARS_BACK; yearsBack++) {
+	const totalYears = currentYear - FIRST_SEED_YEAR + 1;
+	for (let yearsBack = 0; yearsBack < totalYears; yearsBack++) {
 		const year = currentYear - yearsBack;
 		let companyIndex = 0;
 		for (const { siren, nafCode } of catalog) {
 			companyIndex++;
 			const hasAlertGap = shouldHaveAlertGap(companyIndex, yearsBack, nafCode);
+			const averageGap = pseudoAverageGap(companyIndex, yearsBack, nafCode);
 			// Spread submissions over January-February so the rows look realistic
 			// (even though the campaign progression chart is not what we exercise
 			// here, keeping a plausible date avoids surprises elsewhere).
@@ -187,7 +208,7 @@ async function seed(sql) {
 			await sql`
 				INSERT INTO app_declaration (
 					id, siren, year, declarant_id, current_step, status,
-					submitted_at, has_alert_gap, created_at, updated_at
+					submitted_at, has_alert_gap, average_gap, created_at, updated_at
 				)
 				VALUES (
 					gen_random_uuid(),
@@ -198,6 +219,7 @@ async function seed(sql) {
 					'submitted',
 					${submittedAt},
 					${hasAlertGap},
+					${averageGap},
 					NOW(),
 					NOW()
 				)
@@ -205,6 +227,7 @@ async function seed(sql) {
 					status = 'submitted',
 					submitted_at = EXCLUDED.submitted_at,
 					has_alert_gap = EXCLUDED.has_alert_gap,
+					average_gap = EXCLUDED.average_gap,
 					updated_at = NOW()
 			`;
 			insertedDeclarations++;
@@ -255,7 +278,7 @@ async function main() {
 		}
 		const result = await seed(sql);
 		console.log(
-			`[seed-conformite] upserted ${result.insertedCompanies} companies and ${result.insertedDeclarations} submitted declarations across ${CAMPAIGN_YEARS_BACK} campaign years.`,
+			`[seed-conformite] upserted ${result.insertedCompanies} companies and ${result.insertedDeclarations} submitted declarations from ${FIRST_SEED_YEAR} to the current year.`,
 		);
 		console.log(
 			`[seed-conformite] open http://localhost:3000/admin/stats/conformite to browse the tile.`,

--- a/packages/app/src/e2e/admin-stats-conformite.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-conformite.e2e.ts
@@ -7,7 +7,8 @@ import {
 	seedSubmittedDeclarationsForStats,
 } from "./helpers/db";
 
-// Reserved SIRENs — outside any real range, scoped to the K8 conformity test.
+// Reserved SIRENs — outside any real range, scoped to the K8/K10 conformity
+// test. averageGap values double as K10 fixture data.
 const SIRENS = {
 	currentAlert: "999400001", // year N, alert, small
 	currentSafe: "999400002", // year N, no alert, small
@@ -30,6 +31,7 @@ test.describe("admin conformity stats (K8 — gap alert rate)", () => {
 				workforce: 30,
 				hasAlertGap: true,
 				nafCode: "A01.11Z",
+				averageGap: 6.5,
 			},
 			{
 				siren: SIRENS.currentSafe,
@@ -38,6 +40,7 @@ test.describe("admin conformity stats (K8 — gap alert rate)", () => {
 				workforce: 30,
 				hasAlertGap: false,
 				nafCode: "A01.11Z",
+				averageGap: 2.1,
 			},
 			{
 				siren: SIRENS.currentLargeAlert,
@@ -46,6 +49,7 @@ test.describe("admin conformity stats (K8 — gap alert rate)", () => {
 				workforce: 300,
 				hasAlertGap: true,
 				nafCode: "C10.11Z",
+				averageGap: 7.2,
 			},
 			{
 				siren: SIRENS.currentFinance,
@@ -54,6 +58,7 @@ test.describe("admin conformity stats (K8 — gap alert rate)", () => {
 				workforce: 50,
 				hasAlertGap: true,
 				nafCode: "K64.19Z",
+				averageGap: 8.4,
 			},
 			{
 				siren: SIRENS.previousAlert,
@@ -62,6 +67,7 @@ test.describe("admin conformity stats (K8 — gap alert rate)", () => {
 				workforce: 30,
 				hasAlertGap: true,
 				nafCode: "A01.11Z",
+				averageGap: 6.8,
 			},
 			{
 				siren: SIRENS.previousSafe,
@@ -70,6 +76,7 @@ test.describe("admin conformity stats (K8 — gap alert rate)", () => {
 				workforce: 30,
 				hasAlertGap: false,
 				nafCode: "A01.11Z",
+				averageGap: 2.3,
 			},
 		]);
 	});
@@ -154,6 +161,90 @@ test.describe("admin conformity stats (K8 — gap alert rate)", () => {
 				name: new RegExp(`Taux d'écart ≥ 5 % en ${PREVIOUS_YEAR}`),
 				level: 3,
 			}),
+		).toBeVisible();
+	});
+});
+
+test.describe("admin conformity stats (K10 — multi-year gap trend)", () => {
+	test("admin sees the trend section, chart figure and toggle legend", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+
+		await expect(
+			page.getByRole("heading", {
+				name: "Évolution annuelle des écarts",
+				level: 2,
+			}),
+		).toBeVisible();
+		await expect(
+			page.getByRole("figure", {
+				name: /courbe d'évolution annuelle de l'écart moyen/i,
+			}),
+		).toBeVisible();
+	});
+
+	test("switching to workforce segmentation swaps the legend series", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+
+		await expect(
+			page.getByRole("heading", {
+				name: "Évolution annuelle des écarts",
+				level: 2,
+			}),
+		).toBeVisible();
+
+		await page.getByLabel("Segmenter par").selectOption("workforce");
+
+		// Checkbox group appears when there is more than one series.
+		await expect(
+			page.getByRole("group", { name: /séries affichées/i }),
+		).toBeVisible();
+	});
+
+	test("a checkbox in the toggle legend hides its series from the chart", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+		await page.getByLabel("Segmenter par").selectOption("workforce");
+		await expect(
+			page.getByRole("group", { name: /séries affichées/i }),
+		).toBeVisible();
+
+		const firstCheckbox = page
+			.getByRole("group", { name: /séries affichées/i })
+			.getByRole("checkbox")
+			.first();
+		await expect(firstCheckbox).toBeChecked();
+		await firstCheckbox.uncheck();
+		await expect(firstCheckbox).not.toBeChecked();
+	});
+
+	test("accessible alternative table lists segments and years", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/conformite");
+
+		await expect(
+			page.getByRole("figure", {
+				name: /courbe d'évolution annuelle de l'écart moyen/i,
+			}),
+		).toBeVisible();
+
+		// The trend section uses the same <details> pattern as K2 — open the
+		// second disclosure on the page (the first belongs to the K8 tile if
+		// any ever lands; here K8 has no table, so the first details is K10).
+		await page
+			.locator("summary", {
+				hasText: /consulter les données du graphique sous forme de tableau/i,
+			})
+			.first()
+			.click();
+
+		await expect(
+			page.getByRole("columnheader", { name: String(CURRENT_YEAR) }),
 		).toBeVisible();
 	});
 });

--- a/packages/app/src/e2e/admin-stats-conformite.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-conformite.e2e.ts
@@ -213,16 +213,18 @@ test.describe("admin conformity stats (K10 — multi-year gap trend)", () => {
 	}) => {
 		await page.goto("/admin/stats/conformite");
 		await page.getByLabel("Segmenter par").selectOption("workforce");
-		await expect(
-			page.getByRole("group", { name: /séries affichées/i }),
-		).toBeVisible();
+		const legend = page.getByRole("group", { name: /séries affichées/i });
+		await expect(legend).toBeVisible();
 
-		const firstCheckbox = page
-			.getByRole("group", { name: /séries affichées/i })
-			.getByRole("checkbox")
-			.first();
+		// DSFR checkbox groups hide the underlying <input> (opacity 0, positioned
+		// off-screen) and route clicks through the <label>. Targeting the input
+		// directly with .uncheck() times out because Playwright can't "see" it.
+		// Click the label text — that dispatches the change event the React
+		// controlled checkbox needs, and the input state flips as expected.
+		const firstCheckbox = legend.getByRole("checkbox").first();
+		const firstLabel = legend.locator("label").first();
 		await expect(firstCheckbox).toBeChecked();
-		await firstCheckbox.uncheck();
+		await firstLabel.click();
 		await expect(firstCheckbox).not.toBeChecked();
 	});
 

--- a/packages/app/src/e2e/admin-stats-conformite.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-conformite.e2e.ts
@@ -21,70 +21,74 @@ const SIRENS = {
 const CURRENT_YEAR = getCurrentYear();
 const PREVIOUS_YEAR = CURRENT_YEAR - 1;
 
+// Seed shared by every test in this file — K8 (gap alert rate) and K10
+// (multi-year trend) both consult the same /admin/stats/conformite page,
+// so file-level beforeAll/afterAll avoids re-seeding between describes
+// and prevents the K10 tests from running against an empty DB.
+test.beforeAll(async () => {
+	await seedSubmittedDeclarationsForStats([
+		{
+			siren: SIRENS.currentAlert,
+			year: CURRENT_YEAR,
+			submittedAt: `${CURRENT_YEAR}-01-15T10:00:00Z`,
+			workforce: 30,
+			hasAlertGap: true,
+			nafCode: "A01.11Z",
+			averageGap: 6.5,
+		},
+		{
+			siren: SIRENS.currentSafe,
+			year: CURRENT_YEAR,
+			submittedAt: `${CURRENT_YEAR}-01-16T10:00:00Z`,
+			workforce: 30,
+			hasAlertGap: false,
+			nafCode: "A01.11Z",
+			averageGap: 2.1,
+		},
+		{
+			siren: SIRENS.currentLargeAlert,
+			year: CURRENT_YEAR,
+			submittedAt: `${CURRENT_YEAR}-01-17T10:00:00Z`,
+			workforce: 300,
+			hasAlertGap: true,
+			nafCode: "C10.11Z",
+			averageGap: 7.2,
+		},
+		{
+			siren: SIRENS.currentFinance,
+			year: CURRENT_YEAR,
+			submittedAt: `${CURRENT_YEAR}-01-18T10:00:00Z`,
+			workforce: 50,
+			hasAlertGap: true,
+			nafCode: "K64.19Z",
+			averageGap: 8.4,
+		},
+		{
+			siren: SIRENS.previousAlert,
+			year: PREVIOUS_YEAR,
+			submittedAt: `${PREVIOUS_YEAR}-02-15T10:00:00Z`,
+			workforce: 30,
+			hasAlertGap: true,
+			nafCode: "A01.11Z",
+			averageGap: 6.8,
+		},
+		{
+			siren: SIRENS.previousSafe,
+			year: PREVIOUS_YEAR,
+			submittedAt: `${PREVIOUS_YEAR}-02-16T10:00:00Z`,
+			workforce: 30,
+			hasAlertGap: false,
+			nafCode: "A01.11Z",
+			averageGap: 2.3,
+		},
+	]);
+});
+
+test.afterAll(async () => {
+	await deleteSeededCampaignDeclarations(Object.values(SIRENS));
+});
+
 test.describe("admin conformity stats (K8 — gap alert rate)", () => {
-	test.beforeAll(async () => {
-		await seedSubmittedDeclarationsForStats([
-			{
-				siren: SIRENS.currentAlert,
-				year: CURRENT_YEAR,
-				submittedAt: `${CURRENT_YEAR}-01-15T10:00:00Z`,
-				workforce: 30,
-				hasAlertGap: true,
-				nafCode: "A01.11Z",
-				averageGap: 6.5,
-			},
-			{
-				siren: SIRENS.currentSafe,
-				year: CURRENT_YEAR,
-				submittedAt: `${CURRENT_YEAR}-01-16T10:00:00Z`,
-				workforce: 30,
-				hasAlertGap: false,
-				nafCode: "A01.11Z",
-				averageGap: 2.1,
-			},
-			{
-				siren: SIRENS.currentLargeAlert,
-				year: CURRENT_YEAR,
-				submittedAt: `${CURRENT_YEAR}-01-17T10:00:00Z`,
-				workforce: 300,
-				hasAlertGap: true,
-				nafCode: "C10.11Z",
-				averageGap: 7.2,
-			},
-			{
-				siren: SIRENS.currentFinance,
-				year: CURRENT_YEAR,
-				submittedAt: `${CURRENT_YEAR}-01-18T10:00:00Z`,
-				workforce: 50,
-				hasAlertGap: true,
-				nafCode: "K64.19Z",
-				averageGap: 8.4,
-			},
-			{
-				siren: SIRENS.previousAlert,
-				year: PREVIOUS_YEAR,
-				submittedAt: `${PREVIOUS_YEAR}-02-15T10:00:00Z`,
-				workforce: 30,
-				hasAlertGap: true,
-				nafCode: "A01.11Z",
-				averageGap: 6.8,
-			},
-			{
-				siren: SIRENS.previousSafe,
-				year: PREVIOUS_YEAR,
-				submittedAt: `${PREVIOUS_YEAR}-02-16T10:00:00Z`,
-				workforce: 30,
-				hasAlertGap: false,
-				nafCode: "A01.11Z",
-				averageGap: 2.3,
-			},
-		]);
-	});
-
-	test.afterAll(async () => {
-		await deleteSeededCampaignDeclarations(Object.values(SIRENS));
-	});
-
 	test("admin can open the conformity stats page and sees the KPI tile", async ({
 		page,
 	}) => {

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -444,6 +444,12 @@ type SeededCampaignDeclaration = {
 	 * K8 tests set it to exercise the sector filter, K2 tests leave it null.
 	 */
 	nafCode?: string | null;
+	/**
+	 * Denormalized average gap (%) used by the K10 multi-year trend chart.
+	 * Optional — null means "no exploitable salary pair", which the chart
+	 * filters out.
+	 */
+	averageGap?: number | null;
 };
 
 /**
@@ -470,6 +476,10 @@ export async function seedSubmittedDeclarationsForStats(
 		for (const row of rows) {
 			const nafCode = row.nafCode ?? null;
 			const hasAlertGap = row.hasAlertGap ?? false;
+			const averageGap =
+				row.averageGap === undefined || row.averageGap === null
+					? null
+					: row.averageGap.toString();
 			await sql`
 				INSERT INTO app_company (siren, name, workforce, naf_code, created_at, updated_at)
 				VALUES (${row.siren}, ${`E2E Stats Co. ${row.siren}`}, ${row.workforce}, ${nafCode}, NOW(), NOW())
@@ -480,16 +490,18 @@ export async function seedSubmittedDeclarationsForStats(
 			await sql`
 				INSERT INTO app_declaration (
 					id, siren, year, declarant_id, current_step, status,
-					submitted_at, has_alert_gap, created_at, updated_at
+					submitted_at, has_alert_gap, average_gap, created_at, updated_at
 				)
 				VALUES (
 					gen_random_uuid(), ${row.siren}, ${row.year}, ${declarantId}, 6,
-					'submitted', ${row.submittedAt}, ${hasAlertGap}, NOW(), NOW()
+					'submitted', ${row.submittedAt}, ${hasAlertGap}, ${averageGap},
+					NOW(), NOW()
 				)
 				ON CONFLICT ON CONSTRAINT declaration_siren_year_idx DO UPDATE SET
 					status = 'submitted',
 					submitted_at = EXCLUDED.submitted_at,
-					has_alert_gap = EXCLUDED.has_alert_gap
+					has_alert_gap = EXCLUDED.has_alert_gap,
+					average_gap = EXCLUDED.average_gap
 			`;
 		}
 	} finally {

--- a/packages/app/src/modules/admin/stats/ConformiteStatsPage.tsx
+++ b/packages/app/src/modules/admin/stats/ConformiteStatsPage.tsx
@@ -11,6 +11,9 @@ import {
 import { api } from "~/trpc/react";
 
 import { AdminKpiTile } from "./AdminKpiTile";
+import { GapChartSeriesToggle } from "./GapChartSeriesToggle";
+import { MultiYearGapChart } from "./MultiYearGapChart";
+import { MultiYearGapTable } from "./MultiYearGapTable";
 
 type Props = {
 	/** Reference year — also the default selection of the year filter. */
@@ -18,6 +21,11 @@ type Props = {
 	/** Years available in the year dropdown, newest first. */
 	availableYears: number[];
 };
+
+type SegmentBy = "global" | "workforce" | "naf";
+
+/** Default trend window: last five campaign years. */
+const DEFAULT_TREND_SPAN = 4;
 
 export function ConformiteStatsPage({ currentYear, availableYears }: Props) {
 	const [year, setYear] = useState(currentYear);
@@ -28,14 +36,57 @@ export function ConformiteStatsPage({ currentYear, availableYears }: Props) {
 		NafSectionCode | undefined
 	>(undefined);
 
-	const query = api.adminStats.getGapAlertRate.useQuery(
+	const trendDefaultFrom = Math.max(
+		availableYears[availableYears.length - 1] ?? currentYear,
+		currentYear - DEFAULT_TREND_SPAN,
+	);
+	const [trendYearFrom, setTrendYearFrom] = useState(trendDefaultFrom);
+	const [trendYearTo, setTrendYearTo] = useState(currentYear);
+	const [segmentBy, setSegmentBy] = useState<SegmentBy>("global");
+	const [hiddenSegments, setHiddenSegments] = useState<ReadonlySet<string>>(
+		new Set(),
+	);
+
+	const gapAlertRate = api.adminStats.getGapAlertRate.useQuery(
 		{ year, sizeRange, nafCodePrefix },
+		{ placeholderData: (prev) => prev },
+	);
+
+	const trend = api.adminStats.getMultiYearGapTrend.useQuery(
+		{
+			yearFrom: trendYearFrom,
+			yearTo: trendYearTo,
+			segmentBy,
+			sizeRange,
+			nafCodePrefix,
+		},
 		{ placeholderData: (prev) => prev },
 	);
 
 	const handleYearChange = (event: ChangeEvent<HTMLSelectElement>) => {
 		setYear(Number.parseInt(event.target.value, 10));
 	};
+
+	const handleTrendYearFromChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		const next = Number.parseInt(event.target.value, 10);
+		setTrendYearFrom(next);
+		if (next > trendYearTo) setTrendYearTo(next);
+	};
+
+	const handleTrendYearToChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		const next = Number.parseInt(event.target.value, 10);
+		setTrendYearTo(next);
+		if (next < trendYearFrom) setTrendYearFrom(next);
+	};
+
+	const handleSegmentByChange = (event: ChangeEvent<HTMLSelectElement>) => {
+		setSegmentBy(event.target.value as SegmentBy);
+		// Reset the hidden set on mode change — the series names change, so the
+		// old hidden entries no longer match.
+		setHiddenSegments(new Set());
+	};
+
+	const segments = trend.data?.map(({ segment }) => segment) ?? [];
 
 	return (
 		<>
@@ -83,27 +134,122 @@ export function ConformiteStatsPage({ currentYear, availableYears }: Props) {
 				<h2 className="fr-h3" id="gap-alert-rate-heading">
 					Taux d'écart ≥ 5 %
 				</h2>
-				{query.isLoading && !query.data && (
+				{gapAlertRate.isLoading && !gapAlertRate.data && (
 					<p aria-live="polite">Chargement de l'indicateur…</p>
 				)}
-				{query.isError && (
+				{gapAlertRate.isError && (
 					<div aria-live="polite" className="fr-alert fr-alert--error">
 						<p>Une erreur est survenue lors du chargement du taux d'écart.</p>
 					</div>
 				)}
-				{query.data && (
+				{gapAlertRate.data && (
 					<div className="fr-grid-row fr-grid-row--gutters">
 						<div className="fr-col-12 fr-col-md-6 fr-col-lg-4">
 							<AdminKpiTile
 								deltaLabel={`vs ${year - 1}`}
-								deltaPoints={query.data.delta}
+								deltaPoints={gapAlertRate.data.delta}
 								inverted
-								subtitle={`Sur ${formatCount(query.data.sampleSize)} déclarations`}
+								subtitle={`Sur ${formatCount(gapAlertRate.data.sampleSize)} déclarations`}
 								title={`Taux d'écart ≥ 5 % en ${year}`}
-								value={formatGap(query.data.rate)}
+								value={formatGap(gapAlertRate.data.rate)}
 							/>
 						</div>
 					</div>
+				)}
+			</section>
+
+			<section
+				aria-labelledby="multi-year-gap-trend-heading"
+				className="fr-mt-6w"
+			>
+				<h2 className="fr-h3" id="multi-year-gap-trend-heading">
+					Évolution annuelle des écarts
+				</h2>
+
+				<div className="fr-grid-row fr-grid-row--gutters fr-mt-2w">
+					<div className="fr-col-12 fr-col-md-4">
+						<div className="fr-select-group">
+							<label className="fr-label" htmlFor="trend-year-from-filter">
+								De
+							</label>
+							<select
+								className="fr-select"
+								id="trend-year-from-filter"
+								name="yearFrom"
+								onChange={handleTrendYearFromChange}
+								value={trendYearFrom}
+							>
+								{availableYears.map((y) => (
+									<option key={y} value={y}>
+										{y}
+									</option>
+								))}
+							</select>
+						</div>
+					</div>
+					<div className="fr-col-12 fr-col-md-4">
+						<div className="fr-select-group">
+							<label className="fr-label" htmlFor="trend-year-to-filter">
+								À
+							</label>
+							<select
+								className="fr-select"
+								id="trend-year-to-filter"
+								name="yearTo"
+								onChange={handleTrendYearToChange}
+								value={trendYearTo}
+							>
+								{availableYears.map((y) => (
+									<option key={y} value={y}>
+										{y}
+									</option>
+								))}
+							</select>
+						</div>
+					</div>
+					<div className="fr-col-12 fr-col-md-4">
+						<div className="fr-select-group">
+							<label className="fr-label" htmlFor="trend-segment-filter">
+								Segmenter par
+							</label>
+							<select
+								className="fr-select"
+								id="trend-segment-filter"
+								name="segmentBy"
+								onChange={handleSegmentByChange}
+								value={segmentBy}
+							>
+								<option value="global">Global</option>
+								<option value="workforce">Tranche d'effectif</option>
+								<option value="naf">Secteur NAF</option>
+							</select>
+						</div>
+					</div>
+				</div>
+
+				{trend.isLoading && !trend.data && (
+					<p aria-live="polite">Chargement du graphique…</p>
+				)}
+				{trend.isError && (
+					<div aria-live="polite" className="fr-alert fr-alert--error">
+						<p>Une erreur est survenue lors du chargement de l'évolution.</p>
+					</div>
+				)}
+				{trend.data && (
+					<>
+						<MultiYearGapChart
+							hiddenSegments={hiddenSegments}
+							series={trend.data}
+						/>
+						{segments.length > 1 && (
+							<GapChartSeriesToggle
+								hiddenSegments={hiddenSegments}
+								onChange={setHiddenSegments}
+								segments={segments}
+							/>
+						)}
+						<MultiYearGapTable series={trend.data} />
+					</>
 				)}
 			</section>
 		</>

--- a/packages/app/src/modules/admin/stats/GapChartSeriesToggle.tsx
+++ b/packages/app/src/modules/admin/stats/GapChartSeriesToggle.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+
+type Props = {
+	/**
+	 * Full, ordered list of series on the chart — in the exact order the chart
+	 * renders them, so the checkbox order matches the legend.
+	 */
+	segments: readonly string[];
+	/** Segment names currently hidden. */
+	hiddenSegments: ReadonlySet<string>;
+	/** Called with the next hidden-set when the user toggles a checkbox. */
+	onChange: (next: ReadonlySet<string>) => void;
+	/** Stable id prefix — ensures unique ids when multiple charts coexist. */
+	idPrefix?: string;
+};
+
+export function GapChartSeriesToggle({
+	segments,
+	hiddenSegments,
+	onChange,
+	idPrefix = "gap-chart-series",
+}: Props) {
+	const handleChange =
+		(segment: string) => (event: ChangeEvent<HTMLInputElement>) => {
+			const next = new Set(hiddenSegments);
+			if (event.target.checked) {
+				next.delete(segment);
+			} else {
+				next.add(segment);
+			}
+			onChange(next);
+		};
+
+	return (
+		<fieldset
+			aria-describedby={`${idPrefix}-hint`}
+			className="fr-fieldset"
+			id={`${idPrefix}-fieldset`}
+		>
+			<legend
+				className="fr-fieldset__legend fr-fieldset__legend--regular"
+				id={`${idPrefix}-legend`}
+			>
+				Séries affichées
+				<span className="fr-hint-text" id={`${idPrefix}-hint`}>
+					Décochez une série pour la masquer du graphique.
+				</span>
+			</legend>
+			{segments.map((segment) => {
+				const checkboxId = `${idPrefix}-${segment}`;
+				const checked = !hiddenSegments.has(segment);
+				return (
+					<div
+						className="fr-fieldset__element fr-fieldset__element--inline"
+						key={segment}
+					>
+						<div className="fr-checkbox-group">
+							<input
+								checked={checked}
+								id={checkboxId}
+								name={checkboxId}
+								onChange={handleChange(segment)}
+								type="checkbox"
+							/>
+							<label className="fr-label" htmlFor={checkboxId}>
+								{segment}
+							</label>
+						</div>
+					</div>
+				);
+			})}
+		</fieldset>
+	);
+}

--- a/packages/app/src/modules/admin/stats/MultiYearGapChart.module.scss
+++ b/packages/app/src/modules/admin/stats/MultiYearGapChart.module.scss
@@ -1,0 +1,14 @@
+.chartWrapper {
+	width: 100%;
+	height: 360px;
+}
+
+.tooltipList {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.tooltipItem {
+	font-size: 0.875rem;
+}

--- a/packages/app/src/modules/admin/stats/MultiYearGapChart.tsx
+++ b/packages/app/src/modules/admin/stats/MultiYearGapChart.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import {
+	CartesianGrid,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+import { formatGap } from "~/modules/domain";
+
+import styles from "./MultiYearGapChart.module.scss";
+import type { MultiYearGapTrendSeries } from "./types";
+
+type Props = {
+	series: MultiYearGapTrendSeries[];
+	/**
+	 * Names of the series currently hidden by the toggle checkboxes. The chart
+	 * still plots its X-axis but does not render the corresponding `<Line>`.
+	 */
+	hiddenSegments: ReadonlySet<string>;
+};
+
+type TooltipEntry = {
+	name?: string | number;
+	value?: number;
+	color?: string;
+};
+
+type TrendTooltipProps = {
+	active?: boolean;
+	payload?: TooltipEntry[];
+	label?: string | number;
+	sampleSizes: Record<string, Record<number, number>>;
+};
+
+type MergedPoint = {
+	year: number;
+	[segment: string]: number | null;
+};
+
+/**
+ * DSFR color cycle — one per series, taken from design-system tokens so the
+ * tiles, badges and the chart stay visually consistent. The order is
+ * deterministic so the same segment keeps the same color across re-renders.
+ */
+const SERIES_COLORS = [
+	"var(--background-action-high-blue-france)",
+	"var(--background-action-high-green-bourgeon)",
+	"var(--background-action-high-orange-terre-battue)",
+	"var(--background-action-high-purple-glycine)",
+	"var(--background-action-high-pink-tuile)",
+	"var(--text-mention-grey)",
+];
+
+export function colorForSegment(index: number): string {
+	return SERIES_COLORS[index % SERIES_COLORS.length] ?? SERIES_COLORS[0] ?? "";
+}
+
+/**
+ * Interleave all series into a single row-per-year dataset so Recharts can
+ * plot one line per segment on a shared year axis. Missing points stay null.
+ */
+function mergeSeries(series: MultiYearGapTrendSeries[]): MergedPoint[] {
+	const byYear = new Map<number, MergedPoint>();
+	for (const { segment, points } of series) {
+		for (const { year, avgGap } of points) {
+			const existing = byYear.get(year) ?? { year };
+			existing[segment] = avgGap;
+			byYear.set(year, existing);
+		}
+	}
+	return Array.from(byYear.values()).sort((a, b) => a.year - b.year);
+}
+
+function TrendTooltip({
+	active,
+	payload,
+	label,
+	sampleSizes,
+}: TrendTooltipProps) {
+	if (
+		!active ||
+		!payload ||
+		payload.length === 0 ||
+		typeof label !== "number"
+	) {
+		return null;
+	}
+	return (
+		<div className="fr-p-2w fr-background-alt--grey">
+			<p className="fr-text--sm fr-text--bold fr-mb-1w">Année {label}</p>
+			<ul className={styles.tooltipList}>
+				{payload.map((entry) => {
+					if (entry.value == null) return null;
+					const segment = String(entry.name ?? "");
+					const size = sampleSizes[segment]?.[label] ?? 0;
+					return (
+						<li className={styles.tooltipItem} key={segment}>
+							{segment} : écart moyen {formatGap(entry.value)} (sur{" "}
+							{size.toLocaleString("fr-FR")} déclarations)
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+}
+
+export function MultiYearGapChart({ series, hiddenSegments }: Props) {
+	const data = mergeSeries(series);
+
+	if (data.length === 0) {
+		return (
+			<p aria-live="polite" className="fr-text--sm fr-text-mention--grey">
+				Aucune donnée pour ces filtres.
+			</p>
+		);
+	}
+
+	const sampleSizes: Record<string, Record<number, number>> = {};
+	for (const { segment, points } of series) {
+		sampleSizes[segment] = {};
+		for (const { year, sampleSize } of points) {
+			const current = sampleSizes[segment];
+			if (current) current[year] = sampleSize;
+		}
+	}
+
+	const visibleSeries = series.filter((s) => !hiddenSegments.has(s.segment));
+
+	return (
+		<figure className={styles.chartWrapper}>
+			<figcaption className="fr-sr-only">
+				Courbe d'évolution annuelle de l'écart moyen de rémunération. Les
+				données équivalentes sont disponibles dans le tableau ci-dessous.
+			</figcaption>
+			<ResponsiveContainer>
+				<LineChart data={data}>
+					<CartesianGrid strokeDasharray="3 3" />
+					<XAxis
+						allowDecimals={false}
+						dataKey="year"
+						tickFormatter={(value: number) => String(value)}
+					/>
+					<YAxis tickFormatter={(value: number) => `${value.toFixed(1)} %`} />
+					<Tooltip content={<TrendTooltip sampleSizes={sampleSizes} />} />
+					{visibleSeries.map(({ segment }) => {
+						const originalIndex = series.findIndex(
+							(s) => s.segment === segment,
+						);
+						return (
+							<Line
+								connectNulls
+								dataKey={segment}
+								dot
+								key={segment}
+								name={segment}
+								stroke={colorForSegment(originalIndex)}
+								strokeWidth={2}
+								type="monotone"
+							/>
+						);
+					})}
+				</LineChart>
+			</ResponsiveContainer>
+		</figure>
+	);
+}

--- a/packages/app/src/modules/admin/stats/MultiYearGapTable.tsx
+++ b/packages/app/src/modules/admin/stats/MultiYearGapTable.tsx
@@ -1,0 +1,86 @@
+import { formatCount, formatGap } from "~/modules/domain";
+
+import type { MultiYearGapTrendSeries } from "./types";
+
+type Props = {
+	series: MultiYearGapTrendSeries[];
+};
+
+/**
+ * Accessible alternative to `<MultiYearGapChart>` — renders the same
+ * (segment × year) data as a DSFR table. Required for RGAA: a Recharts SVG
+ * is not readable by assistive tech, so we surface the numbers in a
+ * `<details>` toggle that lives in the DOM at all times.
+ */
+export function MultiYearGapTable({ series }: Props) {
+	if (series.length === 0) return null;
+
+	const years = Array.from(
+		new Set(series.flatMap(({ points }) => points.map(({ year }) => year))),
+	).sort((a, b) => a - b);
+
+	const byYearBySegment = new Map<
+		string,
+		Map<number, { avgGap: number | null; sampleSize: number }>
+	>();
+	for (const { segment, points } of series) {
+		const inner = new Map<
+			number,
+			{ avgGap: number | null; sampleSize: number }
+		>();
+		for (const { year, avgGap, sampleSize } of points) {
+			inner.set(year, { avgGap, sampleSize });
+		}
+		byYearBySegment.set(segment, inner);
+	}
+
+	return (
+		<details className="fr-mt-3w">
+			<summary className="fr-text--sm">
+				Consulter les données du graphique sous forme de tableau
+			</summary>
+			<div className="fr-table fr-table--bordered fr-mt-2w">
+				<div className="fr-table__wrapper">
+					<div className="fr-table__container">
+						<div className="fr-table__content">
+							<table>
+								<caption className="fr-sr-only">
+									Écart moyen de rémunération par segment et par année.
+								</caption>
+								<thead>
+									<tr>
+										<th scope="col">Segment</th>
+										{years.map((year) => (
+											<th key={year} scope="col">
+												{year}
+											</th>
+										))}
+									</tr>
+								</thead>
+								<tbody>
+									{series.map(({ segment }) => (
+										<tr key={segment}>
+											<th scope="row">{segment}</th>
+											{years.map((year) => {
+												const cell = byYearBySegment.get(segment)?.get(year);
+												if (!cell || cell.avgGap === null) {
+													return <td key={year}>—</td>;
+												}
+												return (
+													<td key={year}>
+														{formatGap(cell.avgGap)} (sur{" "}
+														{formatCount(cell.sampleSize)})
+													</td>
+												);
+											})}
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+		</details>
+	);
+}

--- a/packages/app/src/modules/admin/stats/__tests__/GapChartSeriesToggle.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/GapChartSeriesToggle.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { GapChartSeriesToggle } from "../GapChartSeriesToggle";
+
+describe("GapChartSeriesToggle", () => {
+	it("renders one checkbox per segment, all checked by default", () => {
+		render(
+			<GapChartSeriesToggle
+				hiddenSegments={new Set()}
+				onChange={vi.fn()}
+				segments={["Global", "<50", "250+"]}
+			/>,
+		);
+
+		const checkboxes = screen.getAllByRole<HTMLInputElement>("checkbox");
+		expect(checkboxes).toHaveLength(3);
+		for (const cb of checkboxes) expect(cb.checked).toBe(true);
+	});
+
+	it("reflects the hiddenSegments prop as unchecked boxes", () => {
+		render(
+			<GapChartSeriesToggle
+				hiddenSegments={new Set(["<50"])}
+				onChange={vi.fn()}
+				segments={["Global", "<50", "250+"]}
+			/>,
+		);
+
+		expect(
+			screen.getByRole<HTMLInputElement>("checkbox", { name: "<50" }).checked,
+		).toBe(false);
+		expect(
+			screen.getByRole<HTMLInputElement>("checkbox", { name: "Global" })
+				.checked,
+		).toBe(true);
+	});
+
+	it("adds a segment to the hidden set when the user unchecks it", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<GapChartSeriesToggle
+				hiddenSegments={new Set()}
+				onChange={onChange}
+				segments={["Global", "<50"]}
+			/>,
+		);
+
+		await user.click(screen.getByRole("checkbox", { name: "<50" }));
+
+		expect(onChange).toHaveBeenCalledTimes(1);
+		const next = onChange.mock.calls[0]?.[0] as ReadonlySet<string>;
+		expect(next.has("<50")).toBe(true);
+		expect(next.has("Global")).toBe(false);
+	});
+
+	it("removes a segment from the hidden set when the user re-checks it", async () => {
+		const onChange = vi.fn();
+		const user = userEvent.setup();
+		render(
+			<GapChartSeriesToggle
+				hiddenSegments={new Set(["<50"])}
+				onChange={onChange}
+				segments={["Global", "<50"]}
+			/>,
+		);
+
+		await user.click(screen.getByRole("checkbox", { name: "<50" }));
+
+		const next = onChange.mock.calls[0]?.[0] as ReadonlySet<string>;
+		expect(next.has("<50")).toBe(false);
+	});
+
+	it("associates the legend hint via aria-describedby", () => {
+		render(
+			<GapChartSeriesToggle
+				hiddenSegments={new Set()}
+				idPrefix="custom-prefix"
+				onChange={vi.fn()}
+				segments={["Global"]}
+			/>,
+		);
+
+		const fieldset = screen.getByRole("group", { name: /Séries affichées/i });
+		expect(fieldset).toHaveAttribute("aria-describedby", "custom-prefix-hint");
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/MultiYearGapTable.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/MultiYearGapTable.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MultiYearGapTable } from "../MultiYearGapTable";
+
+describe("MultiYearGapTable", () => {
+	it("renders nothing when the series list is empty", () => {
+		const { container } = render(<MultiYearGapTable series={[]} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders one column header per year, sorted ascending", () => {
+		render(
+			<MultiYearGapTable
+				series={[
+					{
+						segment: "Global",
+						points: [
+							{ year: 2026, avgGap: 4.2, sampleSize: 1000 },
+							{ year: 2024, avgGap: 5, sampleSize: 800 },
+							{ year: 2025, avgGap: 4.7, sampleSize: 900 },
+						],
+					},
+				]}
+			/>,
+		);
+
+		const columnHeaders = screen
+			.getAllByRole("columnheader")
+			.filter((h) => h.textContent !== "Segment")
+			.map((h) => h.textContent);
+		expect(columnHeaders).toEqual(["2024", "2025", "2026"]);
+	});
+
+	it("renders one data row per segment with formatted gap + sample size", () => {
+		render(
+			<MultiYearGapTable
+				series={[
+					{
+						segment: "C",
+						points: [{ year: 2026, avgGap: 4.2, sampleSize: 1200 }],
+					},
+					{
+						segment: "G",
+						points: [{ year: 2026, avgGap: 3.8, sampleSize: 500 }],
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByRole("rowheader", { name: "C" })).toBeInTheDocument();
+		expect(screen.getByRole("rowheader", { name: "G" })).toBeInTheDocument();
+		// Formatting combines gap + sample size; match both pieces leniently to
+		// accommodate the narrow no-break space in the French thousand separator.
+		expect(screen.getByText(/4,2 %.*sur.*1.*200/)).toBeInTheDocument();
+		expect(screen.getByText(/3,8 %.*sur.*500/)).toBeInTheDocument();
+	});
+
+	it("renders an em-dash for missing points", () => {
+		render(
+			<MultiYearGapTable
+				series={[
+					{
+						segment: "Global",
+						points: [
+							{ year: 2025, avgGap: 5, sampleSize: 100 },
+							{ year: 2026, avgGap: null, sampleSize: 0 },
+						],
+					},
+				]}
+			/>,
+		);
+
+		const dashes = screen
+			.getAllByRole("cell")
+			.filter((c) => c.textContent === "—");
+		expect(dashes).toHaveLength(1);
+	});
+});

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -6,14 +6,18 @@ export { ConformiteStatsPage } from "./ConformiteStatsPage";
 export type {
 	GetCampaignProgressionInput,
 	GetGapAlertRateInput,
+	GetMultiYearGapTrendInput,
 } from "./schemas";
 export {
 	getCampaignProgressionSchema,
 	getGapAlertRateSchema,
+	getMultiYearGapTrendSchema,
 } from "./schemas";
 export type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
 	GapAlertRateResult,
+	MultiYearGapPoint,
+	MultiYearGapTrendSeries,
 } from "./types";
 export { YearsFilter } from "./YearsFilter";

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -3,6 +3,9 @@ export { CampaignProgressionChart } from "./CampaignProgressionChart";
 export { CampaignProgressionTable } from "./CampaignProgressionTable";
 export { CampaignStatsPage } from "./CampaignStatsPage";
 export { ConformiteStatsPage } from "./ConformiteStatsPage";
+export { GapChartSeriesToggle } from "./GapChartSeriesToggle";
+export { MultiYearGapChart } from "./MultiYearGapChart";
+export { MultiYearGapTable } from "./MultiYearGapTable";
 export type {
 	GetCampaignProgressionInput,
 	GetGapAlertRateInput,

--- a/packages/app/src/modules/admin/stats/schemas.ts
+++ b/packages/app/src/modules/admin/stats/schemas.ts
@@ -46,3 +46,45 @@ export const getGapAlertRateSchema = z.object({
 });
 
 export type GetGapAlertRateInput = z.infer<typeof getGapAlertRateSchema>;
+
+/**
+ * Input for `adminStats.getMultiYearGapTrend` (K10 — Évolution annuelle
+ * des écarts).
+ *
+ * `yearFrom` / `yearTo`: inclusive range on `declarations.year`. `yearTo`
+ * must be ≥ `yearFrom`; the span is capped at 10 years to keep the chart
+ * readable.
+ *
+ * `segmentBy`: which dimension drives the series split:
+ *   - `"global"` → one "National" curve
+ *   - `"workforce"` → one curve per `COMPANY_SIZE_RANGES` bucket
+ *   - `"naf"` → one curve per dominant NAF section (5) + `"Autres"`
+ *
+ * `sizeRange` / `nafCodePrefix`: extra filters. Silently ignored by the
+ * procedure when they would contradict the segmentation (e.g. filtering
+ * by `sizeRange` while `segmentBy === "workforce"`).
+ */
+export const getMultiYearGapTrendSchema = z
+	.object({
+		yearFrom: z.number().int().min(2000).max(2100),
+		yearTo: z.number().int().min(2000).max(2100),
+		segmentBy: z.enum(["global", "workforce", "naf"]),
+		sizeRange: z.enum(COMPANY_SIZE_RANGE_KEYS).optional(),
+		nafCodePrefix: z
+			.string()
+			.length(1)
+			.regex(/^[A-U]$/, "Le code NAF doit être une lettre majuscule entre A et U")
+			.optional(),
+	})
+	.refine((input) => input.yearTo >= input.yearFrom, {
+		message: "yearTo doit être supérieur ou égal à yearFrom",
+		path: ["yearTo"],
+	})
+	.refine((input) => input.yearTo - input.yearFrom <= 9, {
+		message: "La plage d'années ne peut pas dépasser 10 ans",
+		path: ["yearTo"],
+	});
+
+export type GetMultiYearGapTrendInput = z.infer<
+	typeof getMultiYearGapTrendSchema
+>;

--- a/packages/app/src/modules/admin/stats/schemas.ts
+++ b/packages/app/src/modules/admin/stats/schemas.ts
@@ -73,7 +73,10 @@ export const getMultiYearGapTrendSchema = z
 		nafCodePrefix: z
 			.string()
 			.length(1)
-			.regex(/^[A-U]$/, "Le code NAF doit être une lettre majuscule entre A et U")
+			.regex(
+				/^[A-U]$/,
+				"Le code NAF doit être une lettre majuscule entre A et U",
+			)
 			.optional(),
 	})
 	.refine((input) => input.yearTo >= input.yearFrom, {

--- a/packages/app/src/modules/admin/stats/types.ts
+++ b/packages/app/src/modules/admin/stats/types.ts
@@ -34,3 +34,24 @@ export type GapAlertRateResult = {
 	delta: number | null;
 	sampleSize: number;
 };
+
+/**
+ * One (year, avgGap, sampleSize) tuple on a K10 series. `avgGap` is null for
+ * a year when no declaration in the filtered scope exposes an exploitable
+ * salary pair.
+ */
+export type MultiYearGapPoint = {
+	year: number;
+	avgGap: number | null;
+	sampleSize: number;
+};
+
+/**
+ * One series on the K10 multi-year gap trend chart. `segment` is the label
+ * shown in the legend / accessible table — `"Global"`, a workforce bucket
+ * key (`"<50"`, …), a dominant NAF letter (`"C"`, …) or `"Autres"`.
+ */
+export type MultiYearGapTrendSeries = {
+	segment: string;
+	points: MultiYearGapPoint[];
+};

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -54,6 +54,7 @@ export const AUDIT_ACTIONS = {
 	// ── Admin stats reads ─────────────────────────────────
 	ADMIN_STATS_CAMPAIGN_PROGRESSION: "admin_stats.campaign_progression",
 	ADMIN_STATS_GAP_ALERT_RATE: "admin_stats.gap_alert_rate",
+	ADMIN_STATS_MULTI_YEAR_GAP_TREND: "admin_stats.multi_year_gap_trend",
 
 	// ── Sensitive reads ────────────────────────────────────
 	ADMIN_FILE_DOWNLOAD: "admin.file_download",
@@ -123,6 +124,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GAP_ALERT_RATE]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_STATS_MULTI_YEAR_GAP_TREND]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.PROFILE_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA]: "read_sensitive",

--- a/packages/app/src/modules/domain/__tests__/gap.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gap.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	computeAverageGap,
 	computeGap,
 	computeTotal,
 	gapLevel,
@@ -95,5 +96,48 @@ describe("hasGapsAboveThreshold", () => {
 				2,
 			),
 		).toBe(true);
+	});
+});
+
+describe("computeAverageGap", () => {
+	it("returns null for an empty input", () => {
+		expect(computeAverageGap([])).toBeNull();
+	});
+
+	it("returns null when no pair is exploitable", () => {
+		expect(
+			computeAverageGap([
+				{ annualBaseWomen: null, annualBaseMen: null },
+				{ hourlyBaseWomen: undefined, hourlyBaseMen: undefined },
+			]),
+		).toBeNull();
+	});
+
+	it("returns the single gap when only one pair is valid", () => {
+		expect(
+			computeAverageGap([{ annualBaseWomen: "90", annualBaseMen: "100" }]),
+		).toBeCloseTo(10);
+	});
+
+	it("averages gaps across multiple pairs within one category", () => {
+		const result = computeAverageGap([
+			{
+				annualBaseWomen: "90",
+				annualBaseMen: "100", // 10%
+				hourlyBaseWomen: "80",
+				hourlyBaseMen: "100", // 20%
+			},
+		]);
+		expect(result).toBeCloseTo(15);
+	});
+
+	it("averages across multiple categories, skipping unexploitable pairs", () => {
+		const result = computeAverageGap([
+			{ annualBaseWomen: "90", annualBaseMen: "100" }, // 10%
+			{ annualBaseWomen: "80", annualBaseMen: "100" }, // 20%
+			{ annualBaseWomen: null, annualBaseMen: "100" }, // skipped
+			{ annualBaseWomen: "100", annualBaseMen: "0" }, // skipped (men = 0)
+		]);
+		expect(result).toBeCloseTo(15);
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -46,6 +46,7 @@ export {
 } from "./shared/format";
 // Gap business rules (calculations & threshold classification)
 export {
+	computeAverageGap,
 	computeGap,
 	computeTotal,
 	gapLevel,

--- a/packages/app/src/modules/domain/shared/gap.ts
+++ b/packages/app/src/modules/domain/shared/gap.ts
@@ -81,3 +81,41 @@ export function hasGapsAboveThreshold(
 		});
 	});
 }
+
+/**
+ * Arithmetic mean of every computable salary gap across every employee
+ * category (four pairs per row: annual/hourly × base/variable). Pairs where
+ * one side is missing or `men = 0` are skipped — they produce no gap.
+ *
+ * Returns `null` when no pair yields a valid gap (empty categories, all
+ * fields null, etc.). Powers the K10 multi-year gap trend chart.
+ */
+export function computeAverageGap(
+	categories: EmployeeCategoryLike[],
+): number | null {
+	let sum = 0;
+	let count = 0;
+	for (const cat of categories) {
+		const pairs: SalaryPair[] = [
+			{ women: cat.annualBaseWomen ?? null, men: cat.annualBaseMen ?? null },
+			{
+				women: cat.annualVariableWomen ?? null,
+				men: cat.annualVariableMen ?? null,
+			},
+			{ women: cat.hourlyBaseWomen ?? null, men: cat.hourlyBaseMen ?? null },
+			{
+				women: cat.hourlyVariableWomen ?? null,
+				men: cat.hourlyVariableMen ?? null,
+			},
+		];
+		for (const { women, men } of pairs) {
+			if (!women || !men) continue;
+			const gap = computeGap(women, men);
+			if (gap === null) continue;
+			sum += gap;
+			count += 1;
+		}
+	}
+	if (count === 0) return null;
+	return sum / count;
+}

--- a/packages/app/src/modules/shared/__tests__/nafSections.test.ts
+++ b/packages/app/src/modules/shared/__tests__/nafSections.test.ts
@@ -1,33 +1,25 @@
 import { describe, expect, it } from "vitest";
 
 import {
-	classifyNafSegment,
 	DOMINANT_NAF_SECTIONS,
+	NAF_SECTION_CODES,
 	OTHER_NAF_SEGMENT,
 } from "../nafSections";
 
-describe("classifyNafSegment", () => {
-	it("returns the letter prefix for dominant sections", () => {
-		for (const section of DOMINANT_NAF_SECTIONS) {
-			expect(classifyNafSegment(`${section}01.11Z`)).toBe(section);
+describe("DOMINANT_NAF_SECTIONS", () => {
+	it("keeps the five manually curated sections", () => {
+		expect([...DOMINANT_NAF_SECTIONS]).toEqual(["C", "G", "M", "N", "Q"]);
+	});
+
+	it("only references valid NAF section letters", () => {
+		for (const code of DOMINANT_NAF_SECTIONS) {
+			expect(NAF_SECTION_CODES).toContain(code);
 		}
 	});
+});
 
-	it("returns 'Autres' for non-dominant but valid sections", () => {
-		// A, B, D, E, F, H, I, J, K, L, O, P, R, S, T, U are non-dominant.
-		expect(classifyNafSegment("A01.11Z")).toBe(OTHER_NAF_SEGMENT);
-		expect(classifyNafSegment("K64.19Z")).toBe(OTHER_NAF_SEGMENT);
-		expect(classifyNafSegment("U99.00Z")).toBe(OTHER_NAF_SEGMENT);
-	});
-
-	it("normalises the letter case", () => {
-		expect(classifyNafSegment("c10.11z")).toBe("C");
-	});
-
-	it("returns null for null, empty, or invalid prefixes", () => {
-		expect(classifyNafSegment(null)).toBeNull();
-		expect(classifyNafSegment("")).toBeNull();
-		expect(classifyNafSegment("99.00Z")).toBeNull(); // starts with digit
-		expect(classifyNafSegment("Z99.00Z")).toBeNull(); // Z is not a NAF section
+describe("OTHER_NAF_SEGMENT", () => {
+	it("uses the French 'Autres' label for the aggregated bucket", () => {
+		expect(OTHER_NAF_SEGMENT).toBe("Autres");
 	});
 });

--- a/packages/app/src/modules/shared/__tests__/nafSections.test.ts
+++ b/packages/app/src/modules/shared/__tests__/nafSections.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	classifyNafSegment,
+	DOMINANT_NAF_SECTIONS,
+	OTHER_NAF_SEGMENT,
+} from "../nafSections";
+
+describe("classifyNafSegment", () => {
+	it("returns the letter prefix for dominant sections", () => {
+		for (const section of DOMINANT_NAF_SECTIONS) {
+			expect(classifyNafSegment(`${section}01.11Z`)).toBe(section);
+		}
+	});
+
+	it("returns 'Autres' for non-dominant but valid sections", () => {
+		// A, B, D, E, F, H, I, J, K, L, O, P, R, S, T, U are non-dominant.
+		expect(classifyNafSegment("A01.11Z")).toBe(OTHER_NAF_SEGMENT);
+		expect(classifyNafSegment("K64.19Z")).toBe(OTHER_NAF_SEGMENT);
+		expect(classifyNafSegment("U99.00Z")).toBe(OTHER_NAF_SEGMENT);
+	});
+
+	it("normalises the letter case", () => {
+		expect(classifyNafSegment("c10.11z")).toBe("C");
+	});
+
+	it("returns null for null, empty, or invalid prefixes", () => {
+		expect(classifyNafSegment(null)).toBeNull();
+		expect(classifyNafSegment("")).toBeNull();
+		expect(classifyNafSegment("99.00Z")).toBeNull(); // starts with digit
+		expect(classifyNafSegment("Z99.00Z")).toBeNull(); // Z is not a NAF section
+	});
+});

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -2,9 +2,8 @@ export { CompanySizeFilter } from "./CompanySizeFilter";
 export { FileUpload } from "./FileUpload";
 export { getDsfrModal } from "./getDsfrModal";
 export { NafSectorFilter } from "./NafSectorFilter";
-export type { NafSectionCode, NafSegment } from "./nafSections";
+export type { NafSectionCode } from "./nafSections";
 export {
-	classifyNafSegment,
 	DOMINANT_NAF_SECTIONS,
 	NAF_SECTION_CODES,
 	NAF_SECTIONS,

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -2,8 +2,14 @@ export { CompanySizeFilter } from "./CompanySizeFilter";
 export { FileUpload } from "./FileUpload";
 export { getDsfrModal } from "./getDsfrModal";
 export { NafSectorFilter } from "./NafSectorFilter";
-export type { NafSectionCode } from "./nafSections";
-export { NAF_SECTION_CODES, NAF_SECTIONS } from "./nafSections";
+export type { NafSectionCode, NafSegment } from "./nafSections";
+export {
+	classifyNafSegment,
+	DOMINANT_NAF_SECTIONS,
+	NAF_SECTION_CODES,
+	NAF_SECTIONS,
+	OTHER_NAF_SEGMENT,
+} from "./nafSections";
 export { parseSiren } from "./parseSiren";
 export { SubmitModal } from "./SubmitModal";
 export {

--- a/packages/app/src/modules/shared/nafSections.ts
+++ b/packages/app/src/modules/shared/nafSections.ts
@@ -78,22 +78,3 @@ export const DOMINANT_NAF_SECTIONS: readonly NafSectionCode[] = [
 
 /** Label used for the aggregated series bucketing all non-dominant sections. */
 export const OTHER_NAF_SEGMENT = "Autres";
-
-export type NafSegment = NafSectionCode | typeof OTHER_NAF_SEGMENT;
-
-/**
- * Map a full NAF code (e.g. `"62.01Z"`) to its chart segment. Dominant
- * sections keep their letter; everything else collapses into `"Autres"`.
- * Returns `null` when the code is null / empty / unknown.
- */
-export function classifyNafSegment(nafCode: string | null): NafSegment | null {
-	if (!nafCode) return null;
-	const prefix = nafCode.charAt(0).toUpperCase();
-	if (DOMINANT_NAF_SECTIONS.includes(prefix as NafSectionCode)) {
-		return prefix as NafSectionCode;
-	}
-	// Reject obviously invalid prefixes so upstream doesn't silently fold
-	// corrupt data into "Autres".
-	if (!NAF_SECTION_CODES.includes(prefix as NafSectionCode)) return null;
-	return OTHER_NAF_SEGMENT;
-}

--- a/packages/app/src/modules/shared/nafSections.ts
+++ b/packages/app/src/modules/shared/nafSections.ts
@@ -55,3 +55,45 @@ export const NAF_SECTIONS: Record<NafSectionCode, string> = {
 };
 
 export const NAF_SECTION_CODES = Object.keys(NAF_SECTIONS) as NafSectionCode[];
+
+/**
+ * Sections kept as their own series in the K10 multi-year gap trend chart.
+ * The remaining 16 sections are aggregated into a single "Autres" series so
+ * the chart stays readable (max 6 series). Selection: the five sections with
+ * the most declarations on Egapro (companies >= 50 employees).
+ *
+ * C — Industrie manufacturière
+ * G — Commerce, réparation d'automobiles et de motocycles
+ * M — Activités spécialisées, scientifiques et techniques
+ * N — Activités de services administratifs et de soutien
+ * Q — Santé humaine et action sociale
+ */
+export const DOMINANT_NAF_SECTIONS: readonly NafSectionCode[] = [
+	"C",
+	"G",
+	"M",
+	"N",
+	"Q",
+] as const;
+
+/** Label used for the aggregated series bucketing all non-dominant sections. */
+export const OTHER_NAF_SEGMENT = "Autres";
+
+export type NafSegment = NafSectionCode | typeof OTHER_NAF_SEGMENT;
+
+/**
+ * Map a full NAF code (e.g. `"62.01Z"`) to its chart segment. Dominant
+ * sections keep their letter; everything else collapses into `"Autres"`.
+ * Returns `null` when the code is null / empty / unknown.
+ */
+export function classifyNafSegment(nafCode: string | null): NafSegment | null {
+	if (!nafCode) return null;
+	const prefix = nafCode.charAt(0).toUpperCase();
+	if (DOMINANT_NAF_SECTIONS.includes(prefix as NafSectionCode)) {
+		return prefix as NafSectionCode;
+	}
+	// Reject obviously invalid prefixes so upstream doesn't silently fold
+	// corrupt data into "Autres".
+	if (!NAF_SECTION_CODES.includes(prefix as NafSectionCode)) return null;
+	return OTHER_NAF_SEGMENT;
+}

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -293,3 +293,170 @@ describe("adminStatsRouter.getGapAlertRate", () => {
 		).rejects.toThrow();
 	});
 });
+
+// ------------------------------------------------------------------
+// K10 — getMultiYearGapTrend
+// ------------------------------------------------------------------
+
+type TrendRow = {
+	year: number;
+	segment: string;
+	avgGap: string | null;
+	sampleSize: number;
+};
+
+/**
+ * Build a DB mock matching the getMultiYearGapTrend chain:
+ * select → from → optional innerJoin → where → groupBy → orderBy (resolves).
+ */
+function buildTrendDb(rows: TrendRow[]) {
+	const orderBy = vi.fn().mockResolvedValue(rows);
+	const chain = {
+		from: vi.fn().mockReturnThis() as ReturnType<typeof vi.fn>,
+		innerJoin: vi.fn().mockReturnThis() as ReturnType<typeof vi.fn>,
+		where: vi.fn().mockReturnThis() as ReturnType<typeof vi.fn>,
+		groupBy: vi.fn().mockReturnThis() as ReturnType<typeof vi.fn>,
+		orderBy,
+	};
+	return {
+		select: vi.fn().mockReturnValue(chain),
+		__chain: chain,
+	};
+}
+
+describe("adminStatsRouter.getMultiYearGapTrend", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("returns one 'Global' series spanning every requested year", async () => {
+		const db = buildTrendDb([
+			{ year: 2024, segment: "Global", avgGap: "5.12", sampleSize: 800 },
+			{ year: 2025, segment: "Global", avgGap: "4.71", sampleSize: 900 },
+			{ year: 2026, segment: "Global", avgGap: "4.25", sampleSize: 1000 },
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getMultiYearGapTrend({
+			yearFrom: 2024,
+			yearTo: 2026,
+			segmentBy: "global",
+		});
+
+		expect(result).toEqual([
+			{
+				segment: "Global",
+				points: [
+					{ year: 2024, avgGap: 5.1, sampleSize: 800 },
+					{ year: 2025, avgGap: 4.7, sampleSize: 900 },
+					{ year: 2026, avgGap: 4.3, sampleSize: 1000 },
+				],
+			},
+		]);
+	});
+
+	it("splits rows into one series per workforce bucket", async () => {
+		const db = buildTrendDb([
+			{ year: 2025, segment: "<50", avgGap: "6.0", sampleSize: 100 },
+			{ year: 2025, segment: "50-99", avgGap: "5.5", sampleSize: 80 },
+			{ year: 2026, segment: "<50", avgGap: "5.8", sampleSize: 110 },
+			{ year: 2026, segment: "50-99", avgGap: "5.2", sampleSize: 85 },
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getMultiYearGapTrend({
+			yearFrom: 2025,
+			yearTo: 2026,
+			segmentBy: "workforce",
+		});
+
+		expect(result).toHaveLength(2);
+		expect(result.map((s) => s.segment).sort()).toEqual(["50-99", "<50"]);
+		expect(
+			result.find((s) => s.segment === "<50")?.points.map((p) => p.avgGap),
+		).toEqual([6, 5.8]);
+	});
+
+	it("collapses non-dominant NAF sections into 'Autres'", async () => {
+		const db = buildTrendDb([
+			{ year: 2026, segment: "C", avgGap: "4.2", sampleSize: 500 },
+			{ year: 2026, segment: "G", avgGap: "3.9", sampleSize: 600 },
+			{ year: 2026, segment: "Autres", avgGap: "5.1", sampleSize: 1200 },
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getMultiYearGapTrend({
+			yearFrom: 2026,
+			yearTo: 2026,
+			segmentBy: "naf",
+		});
+
+		expect(result.map((s) => s.segment).sort()).toEqual(["Autres", "C", "G"]);
+	});
+
+	it("returns null points when avgGap comes back null for a year", async () => {
+		const db = buildTrendDb([
+			{ year: 2024, segment: "Global", avgGap: null, sampleSize: 0 },
+			{ year: 2025, segment: "Global", avgGap: "4.5", sampleSize: 10 },
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getMultiYearGapTrend({
+			yearFrom: 2024,
+			yearTo: 2025,
+			segmentBy: "global",
+		});
+
+		expect(result[0]?.points[0]?.avgGap).toBeNull();
+		expect(result[0]?.points[1]?.avgGap).toBe(4.5);
+	});
+
+	it("ignores sizeRange filter when segmenting by workforce", async () => {
+		const db = buildTrendDb([]);
+		const caller = await buildCaller(db);
+
+		await caller.getMultiYearGapTrend({
+			yearFrom: 2025,
+			yearTo: 2026,
+			segmentBy: "workforce",
+			sizeRange: "50-99",
+		});
+
+		// The procedure should still issue exactly one query; we just verify
+		// the where predicate was called (filter count is hidden inside `and`).
+		expect(db.__chain.where).toHaveBeenCalledTimes(1);
+		expect(db.__chain.innerJoin).toHaveBeenCalledTimes(1);
+	});
+
+	it("joins on companies only when needed (global + no filter = no join)", async () => {
+		const db = buildTrendDb([]);
+		const caller = await buildCaller(db);
+
+		await caller.getMultiYearGapTrend({
+			yearFrom: 2025,
+			yearTo: 2026,
+			segmentBy: "global",
+		});
+
+		expect(db.__chain.innerJoin).not.toHaveBeenCalled();
+	});
+
+	it("validates the year range (yearTo >= yearFrom, span <= 10 years)", async () => {
+		const db = buildTrendDb([]);
+		const caller = await buildCaller(db);
+
+		await expect(
+			caller.getMultiYearGapTrend({
+				yearFrom: 2026,
+				yearTo: 2020,
+				segmentBy: "global",
+			}),
+		).rejects.toThrow();
+
+		await expect(
+			caller.getMultiYearGapTrend({
+				yearFrom: 2010,
+				yearTo: 2026,
+				segmentBy: "global",
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -306,8 +306,14 @@ type TrendRow = {
 };
 
 /**
- * Build a DB mock matching the getMultiYearGapTrend chain:
- * select → from → optional innerJoin → where → groupBy → orderBy (resolves).
+ * Build a DB mock matching the getMultiYearGapTrend chain. The workforce /
+ * NAF branch runs two queries: an inner `select → from → innerJoin → where
+ * → as()` that materialises the CASE-derived segment column, then an outer
+ * `select → from → groupBy → orderBy (resolves)` that aggregates on the
+ * subquery alias. The global branch only runs the final aggregating chain
+ * (no innerJoin when there are no filters). A single chained mock covers
+ * both shapes — every method returns `this` so the graph can be walked in
+ * any order before `orderBy` resolves with the seeded rows.
  */
 function buildTrendDb(rows: TrendRow[]) {
 	const orderBy = vi.fn().mockResolvedValue(rows);
@@ -317,6 +323,7 @@ function buildTrendDb(rows: TrendRow[]) {
 		where: vi.fn().mockReturnThis() as ReturnType<typeof vi.fn>,
 		groupBy: vi.fn().mockReturnThis() as ReturnType<typeof vi.fn>,
 		orderBy,
+		as: vi.fn().mockReturnThis() as ReturnType<typeof vi.fn>,
 	};
 	return {
 		select: vi.fn().mockReturnValue(chain),

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -339,6 +339,40 @@ describe("declarationRouter", () => {
 			expect(call.hasAlertGap).toBe(true);
 		});
 
+		it("stamps averageGap with the mean of exploitable salary-pair gaps", async () => {
+			const { fetchAllCategories } = await import("../declarationHelpers");
+			vi.mocked(fetchAllCategories).mockResolvedValueOnce({
+				jobCategories: [],
+				employeeCategories: [
+					{
+						annualBaseWomen: "90",
+						annualBaseMen: "100", // 10%
+						hourlyBaseWomen: "80",
+						hourlyBaseMen: "100", // 20%
+					},
+				] as never,
+			});
+
+			const mockDb = createMockDb([{ id: "decl-1", submittedAt: null }]);
+			const caller = await createCaller(mockDb);
+
+			await caller.submit();
+
+			const call = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+			// drizzle `numeric` columns take a string at runtime
+			expect(call.averageGap).toBe("15");
+		});
+
+		it("stamps averageGap=null when no salary pair is exploitable", async () => {
+			const mockDb = createMockDb([{ id: "decl-1", submittedAt: null }]);
+			const caller = await createCaller(mockDb);
+
+			await caller.submit();
+
+			const call = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(call.averageGap).toBeNull();
+		});
+
 		it("throws when siret is missing", async () => {
 			const mockDb = createMockDb();
 			const caller = await createCaller(mockDb, null as never);

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -198,27 +198,55 @@ export const adminStatsRouter = createTRPCRouter({
 				filters.push(isNotNull(companies.nafCode));
 			}
 
+			// Global mode collapses every row into a single series, so we group
+			// by year only. A literal segment expression can't live in `GROUP BY`
+			// — Postgres rejects string constants there ("non-integer constant
+			// in GROUP BY"). The `'Global'` label is attached back in TS.
+			if (input.segmentBy === "global") {
+				const baseQuery = ctx.db.select({
+					year: declarations.year,
+					avgGap: sql<string | null>`avg(${declarations.averageGap})`,
+					sampleSize: sql<number>`count(*)::int`,
+				});
+				const scoped =
+					shouldApplySizeRange || shouldApplyNafFilter
+						? baseQuery
+								.from(declarations)
+								.innerJoin(companies, eq(declarations.siren, companies.siren))
+						: baseQuery.from(declarations);
+				const rows = await scoped
+					.where(and(...filters))
+					.groupBy(declarations.year)
+					.orderBy(declarations.year);
+				if (rows.length === 0) return [];
+				return [
+					{
+						segment: "Global",
+						points: rows.map((row) => ({
+							year: row.year,
+							avgGap:
+								row.avgGap === null
+									? null
+									: Math.round(Number.parseFloat(row.avgGap) * 10) / 10,
+							sampleSize: row.sampleSize,
+						})),
+					},
+				];
+			}
+
+			// Workforce / NAF modes: the segment column is a CASE expression
+			// (a real expression, not a constant), so Postgres is happy to see
+			// it in both SELECT and GROUP BY.
 			const segmentExpr = buildSegmentExpression(input.segmentBy);
-
-			const needsCompaniesJoin =
-				input.segmentBy !== "global" ||
-				shouldApplySizeRange ||
-				shouldApplyNafFilter;
-
-			const baseQuery = ctx.db.select({
-				year: declarations.year,
-				segment: segmentExpr,
-				avgGap: sql<string | null>`avg(${declarations.averageGap})`,
-				sampleSize: sql<number>`count(*)::int`,
-			});
-
-			const scoped = needsCompaniesJoin
-				? baseQuery
-						.from(declarations)
-						.innerJoin(companies, eq(declarations.siren, companies.siren))
-				: baseQuery.from(declarations);
-
-			const rows = await scoped
+			const rows = await ctx.db
+				.select({
+					year: declarations.year,
+					segment: segmentExpr,
+					avgGap: sql<string | null>`avg(${declarations.averageGap})`,
+					sampleSize: sql<number>`count(*)::int`,
+				})
+				.from(declarations)
+				.innerJoin(companies, eq(declarations.siren, companies.siren))
 				.where(and(...filters))
 				.groupBy(declarations.year, segmentExpr)
 				.orderBy(declarations.year, segmentExpr);
@@ -227,12 +255,7 @@ export const adminStatsRouter = createTRPCRouter({
 		}),
 });
 
-function buildSegmentExpression(
-	segmentBy: "global" | "workforce" | "naf",
-): SQL<string> {
-	if (segmentBy === "global") {
-		return sql<string>`'Global'`;
-	}
+function buildSegmentExpression(segmentBy: "workforce" | "naf"): SQL<string> {
 	if (segmentBy === "workforce") {
 		// Mirrors the boundaries of `COMPANY_SIZE_RANGES`. Hard-coding the
 		// buckets as literals keeps the generated SQL self-documenting; if a

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -14,12 +14,16 @@ import type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
 	GapAlertRateResult,
+	MultiYearGapPoint,
+	MultiYearGapTrendSeries,
 } from "~/modules/admin/stats";
 import {
 	getCampaignProgressionSchema,
 	getGapAlertRateSchema,
+	getMultiYearGapTrendSchema,
 } from "~/modules/admin/stats";
 import { COMPANY_SIZE_RANGES } from "~/modules/domain";
+import { DOMINANT_NAF_SECTIONS, OTHER_NAF_SEGMENT } from "~/modules/shared";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import type { DB } from "~/server/db";
 import { companies, declarations } from "~/server/db/schema";
@@ -141,7 +145,136 @@ export const adminStatsRouter = createTRPCRouter({
 				sampleSize: current.total,
 			};
 		}),
+
+	/**
+	 * K10 — "Évolution annuelle des écarts". Returns one curve per segment
+	 * (Global / workforce bucket / NAF section) over the requested range of
+	 * campaign years. Only declarations with an exploitable `average_gap`
+	 * (non-null) contribute — declarations submitted without any salary pair
+	 * filled in are excluded.
+	 */
+	getMultiYearGapTrend: adminProcedure
+		.input(getMultiYearGapTrendSchema)
+		.query(async ({ ctx, input }): Promise<MultiYearGapTrendSeries[]> => {
+			const filters: SQL[] = [
+				eq(declarations.status, "submitted"),
+				isNotNull(declarations.averageGap),
+				between(declarations.year, input.yearFrom, input.yearTo),
+			];
+
+			// Segmentation-aware filter gating: a `sizeRange` filter while the
+			// user asked to *segment* by workforce would collapse every bucket
+			// but one — silently ignore it. Same story for `nafCodePrefix` vs.
+			// "segment by NAF".
+			const shouldApplySizeRange =
+				input.sizeRange !== undefined && input.segmentBy !== "workforce";
+			const shouldApplyNafFilter =
+				input.nafCodePrefix !== undefined && input.segmentBy !== "naf";
+
+			if (shouldApplySizeRange && input.sizeRange) {
+				const { min, max } = COMPANY_SIZE_RANGES[input.sizeRange];
+				filters.push(
+					max === null
+						? gte(companies.workforce, min)
+						: between(companies.workforce, min, max),
+				);
+			}
+
+			if (shouldApplyNafFilter && input.nafCodePrefix) {
+				filters.push(like(companies.nafCode, `${input.nafCodePrefix}%`));
+			}
+
+			if (input.segmentBy === "naf") {
+				// Excludes declarations without a NAF code so they don't end up
+				// in an invisible null segment.
+				filters.push(isNotNull(companies.nafCode));
+			}
+
+			const segmentExpr = buildSegmentExpression(input.segmentBy);
+
+			const needsCompaniesJoin =
+				input.segmentBy !== "global" ||
+				shouldApplySizeRange ||
+				shouldApplyNafFilter;
+
+			const baseQuery = ctx.db.select({
+				year: declarations.year,
+				segment: segmentExpr,
+				avgGap: sql<string | null>`avg(${declarations.averageGap})`,
+				sampleSize: sql<number>`count(*)::int`,
+			});
+
+			const scoped = needsCompaniesJoin
+				? baseQuery
+						.from(declarations)
+						.innerJoin(companies, eq(declarations.siren, companies.siren))
+				: baseQuery.from(declarations);
+
+			const rows = await scoped
+				.where(and(...filters))
+				.groupBy(declarations.year, segmentExpr)
+				.orderBy(declarations.year, segmentExpr);
+
+			return buildTrendSeries(rows);
+		}),
 });
+
+function buildSegmentExpression(
+	segmentBy: "global" | "workforce" | "naf",
+): SQL<string> {
+	if (segmentBy === "global") {
+		return sql<string>`'Global'`;
+	}
+	if (segmentBy === "workforce") {
+		// Mirrors the boundaries of `COMPANY_SIZE_RANGES`. Hard-coding the
+		// buckets as literals keeps the generated SQL self-documenting; if a
+		// new bucket is introduced, the constant in `domain` and this CASE
+		// must be updated together.
+		return sql<string>`case
+			when ${companies.workforce} < 50 then '<50'
+			when ${companies.workforce} < 100 then '50-99'
+			when ${companies.workforce} < 150 then '100-149'
+			when ${companies.workforce} < 250 then '150-249'
+			else '250+'
+		end`;
+	}
+	// NAF: collapse non-dominant sections into a single "Autres" segment.
+	const dominantList = DOMINANT_NAF_SECTIONS.map((code) => `'${code}'`).join(
+		", ",
+	);
+	return sql<string>`case
+		when upper(left(${companies.nafCode}, 1)) in (${sql.raw(dominantList)})
+		then upper(left(${companies.nafCode}, 1))
+		else ${OTHER_NAF_SEGMENT}
+	end`;
+}
+
+type TrendRow = {
+	year: number;
+	segment: string;
+	avgGap: string | null;
+	sampleSize: number;
+};
+
+function buildTrendSeries(rows: TrendRow[]): MultiYearGapTrendSeries[] {
+	const bySegment = new Map<string, MultiYearGapPoint[]>();
+	for (const row of rows) {
+		const list = bySegment.get(row.segment) ?? [];
+		list.push({
+			year: row.year,
+			avgGap:
+				row.avgGap === null
+					? null
+					: Math.round(Number.parseFloat(row.avgGap) * 10) / 10,
+			sampleSize: row.sampleSize,
+		});
+		bySegment.set(row.segment, list);
+	}
+	return Array.from(bySegment.entries()).map(([segment, points]) => ({
+		segment,
+		points,
+	}));
+}
 
 type ComputeYearRateParams = {
 	db: DB;

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -239,11 +239,15 @@ function buildSegmentExpression(
 		end`;
 	}
 	// NAF: collapse non-dominant sections into a single "Autres" segment.
-	const dominantList = DOMINANT_NAF_SECTIONS.map((code) => `'${code}'`).join(
-		", ",
+	// Each dominant letter goes through parameter binding via `sql.join` —
+	// prevents the helper from becoming an injection sink if the constant
+	// is ever sourced from outside the module.
+	const dominantParams = sql.join(
+		DOMINANT_NAF_SECTIONS.map((code) => sql`${code}`),
+		sql`, `,
 	);
 	return sql<string>`case
-		when upper(left(${companies.nafCode}, 1)) in (${sql.raw(dominantList)})
+		when upper(left(${companies.nafCode}, 1)) in (${dominantParams})
 		then upper(left(${companies.nafCode}, 1))
 		else ${OTHER_NAF_SEGMENT}
 	end`;

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -10,24 +10,27 @@ import {
 	sql,
 } from "drizzle-orm";
 
+// Server-only router: every import below bypasses the `~/modules/admin/stats`
+// and `~/modules/shared` barrels and targets internal files instead. Those
+// barrels re-export React-only code (`ConformiteStatsPage`, `useZodForm`,
+// `useDsfrModal`) whose dependency chain ends in `react-hook-form`'s
+// `react-server.esm.mjs` build — which does not expose `useForm`. Indirect
+// imports from server code therefore fail at `next build` and the dev
+// server error overlay. Hitting files directly is ugly but correct until
+// the barrels get split into client/server halves.
+import {
+	getCampaignProgressionSchema,
+	getGapAlertRateSchema,
+	getMultiYearGapTrendSchema,
+} from "~/modules/admin/stats/schemas";
 import type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
 	GapAlertRateResult,
 	MultiYearGapPoint,
 	MultiYearGapTrendSeries,
-} from "~/modules/admin/stats";
-import {
-	getCampaignProgressionSchema,
-	getGapAlertRateSchema,
-	getMultiYearGapTrendSchema,
-} from "~/modules/admin/stats";
+} from "~/modules/admin/stats/types";
 import { COMPANY_SIZE_RANGES } from "~/modules/domain";
-// Server-only router: import the constants directly from the internal file
-// instead of the `~/modules/shared` barrel, which also re-exports the
-// `useZodForm` client hook. The barrel pulls `react-hook-form`, and its
-// server build (`react-server.esm.mjs`) does not export `useForm`, so
-// indirect imports from server code break `next build`.
 import {
 	DOMINANT_NAF_SECTIONS,
 	OTHER_NAF_SEGMENT,

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -23,7 +23,15 @@ import {
 	getMultiYearGapTrendSchema,
 } from "~/modules/admin/stats";
 import { COMPANY_SIZE_RANGES } from "~/modules/domain";
-import { DOMINANT_NAF_SECTIONS, OTHER_NAF_SEGMENT } from "~/modules/shared";
+// Server-only router: import the constants directly from the internal file
+// instead of the `~/modules/shared` barrel, which also re-exports the
+// `useZodForm` client hook. The barrel pulls `react-hook-form`, and its
+// server build (`react-server.esm.mjs`) does not export `useForm`, so
+// indirect imports from server code break `next build`.
+import {
+	DOMINANT_NAF_SECTIONS,
+	OTHER_NAF_SEGMENT,
+} from "~/modules/shared/nafSections";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import type { DB } from "~/server/db";
 import { companies, declarations } from "~/server/db/schema";

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -237,22 +237,35 @@ export const adminStatsRouter = createTRPCRouter({
 				];
 			}
 
-			// Workforce / NAF modes: the segment column is a CASE expression
-			// (a real expression, not a constant), so Postgres is happy to see
-			// it in both SELECT and GROUP BY.
+			// Workforce / NAF modes: the segment column is a CASE expression.
+			// We *must* compute it once in an inner subquery and reference the
+			// alias from the outer aggregation. Inlining the CASE in SELECT +
+			// GROUP BY + ORDER BY directly makes Drizzle re-bind fresh `$N`
+			// parameters at each call site — Postgres then sees three textually
+			// different CASE expressions and rejects the GROUP BY with
+			// "column must appear in the GROUP BY clause".
 			const segmentExpr = buildSegmentExpression(input.segmentBy);
-			const rows = await ctx.db
+			const innerSub = ctx.db
 				.select({
 					year: declarations.year,
-					segment: segmentExpr,
-					avgGap: sql<string | null>`avg(${declarations.averageGap})`,
-					sampleSize: sql<number>`count(*)::int`,
+					segment: segmentExpr.as("segment"),
+					averageGap: declarations.averageGap,
 				})
 				.from(declarations)
 				.innerJoin(companies, eq(declarations.siren, companies.siren))
 				.where(and(...filters))
-				.groupBy(declarations.year, segmentExpr)
-				.orderBy(declarations.year, segmentExpr);
+				.as("gap_trend_src");
+
+			const rows = await ctx.db
+				.select({
+					year: innerSub.year,
+					segment: innerSub.segment,
+					avgGap: sql<string | null>`avg(${innerSub.averageGap})`,
+					sampleSize: sql<number>`count(*)::int`,
+				})
+				.from(innerSub)
+				.groupBy(innerSub.year, innerSub.segment)
+				.orderBy(innerSub.year, innerSub.segment);
 
 			return buildTrendSeries(rows);
 		}),

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -9,7 +9,11 @@ import {
 	updateStep4Schema,
 } from "~/modules/declaration-remuneration/schemas";
 import { mapGipToFormData } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
-import { getCurrentYear, hasGapsAboveThreshold } from "~/modules/domain";
+import {
+	computeAverageGap,
+	getCurrentYear,
+	hasGapsAboveThreshold,
+} from "~/modules/domain";
 import {
 	companyProcedure,
 	companyWriteProcedure,
@@ -465,17 +469,20 @@ export const declarationRouter = createTRPCRouter({
 			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
 			.limit(1);
 
-		// Recompute the denormalized hasAlertGap flag from the employee
-		// categories. Source of truth stays on employee_category; this flag
-		// only exists to accelerate admin-stats KPIs (K8) that aggregate
-		// across a whole campaign year without a four-way join on salary pairs.
+		// Recompute the denormalized hasAlertGap flag + averageGap number from
+		// the employee categories. Source of truth stays on employee_category;
+		// these fields only exist to accelerate admin-stats KPIs (K8 alert
+		// rate, K10 multi-year trend) that aggregate across a whole campaign
+		// year without a four-way join on salary pairs.
 		let hasAlertGap = false;
+		let averageGap: number | null = null;
 		if (existing) {
 			const { employeeCategories: empCats } = await fetchAllCategories(
 				ctx.db,
 				existing.id,
 			);
 			hasAlertGap = hasGapsAboveThreshold(empCats);
+			averageGap = computeAverageGap(empCats);
 		}
 
 		await ctx.db
@@ -485,6 +492,9 @@ export const declarationRouter = createTRPCRouter({
 				currentStep: 6,
 				submittedAt: existing?.submittedAt ?? now,
 				hasAlertGap,
+				// drizzle-orm stores `numeric` as a string at runtime to avoid
+				// silent float truncation — serialize with `.toString()`.
+				averageGap: averageGap === null ? null : averageGap.toString(),
 				updatedAt: now,
 			})
 			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -60,6 +60,8 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"adminStats.getCampaignProgression":
 		AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION,
 	"adminStats.getGapAlertRate": AUDIT_ACTIONS.ADMIN_STATS_GAP_ALERT_RATE,
+	"adminStats.getMultiYearGapTrend":
+		AUDIT_ACTIONS.ADMIN_STATS_MULTI_YEAR_GAP_TREND,
 
 	// ── gip mds ────────────────────────────────────────────
 	"gipMds.importFromUrl": AUDIT_ACTIONS.GIP_MDS_IMPORT,

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -122,6 +122,12 @@ export const declarations = createTable(
 		// up the admin-stats KPIs (K8 in particular) that aggregate across all
 		// declarations of a campaign year without joining employee_category.
 		hasAlertGap: d.boolean().notNull().default(false),
+		// Arithmetic mean of every computable salary gap on the four pairs of
+		// the declaration's employee categories. Recomputed at submit via
+		// `computeAverageGap`; nullable when no pair is exploitable. Feeds the
+		// K10 multi-year trend chart so the aggregation stays a single scan
+		// over declarations without re-joining employee_category.
+		averageGap: d.numeric(),
 		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 	}),
@@ -130,6 +136,7 @@ export const declarations = createTable(
 		index("declaration_declarant_idx").on(t.declarantId),
 		index("declaration_submitted_at_idx").on(t.submittedAt),
 		index("declaration_has_alert_gap_idx").on(t.hasAlertGap),
+		index("declaration_average_gap_idx").on(t.averageGap),
 	],
 );
 


### PR DESCRIPTION
fix #3221

> **Stacked on [#3306](https://github.com/SocialGouv/egapro/pull/3306)** — merge that one first. This PR will auto-retarget to \`alpha\` once #3306 lands.

## Summary
- New section on \`/admin/stats/conformite\` below the K8 tile: a Recharts \`<LineChart>\` plotting the average salary gap over a user-picked year range, with three segmentation modes (Global, by workforce bucket, by dominant NAF section + \"Autres\"). DSFR checkbox group lets the user toggle series on/off; accessible alternative table is always rendered inside a \`<details>\` disclosure.
- New tRPC procedure \`adminStats.getMultiYearGapTrend({ yearFrom, yearTo, segmentBy, sizeRange?, nafCodePrefix? })\` (adminProcedure, audited \`read_sensitive\`). Filters \`sizeRange\` and \`nafCodePrefix\` are silently dropped when they contradict the chosen segmentation. Zod refinements cap the range at 10 years and enforce \`yearTo >= yearFrom\`.
- Adds a denormalized \`average_gap\` column on \`app_declaration\`, recomputed at \`submit\` via the new \`computeAverageGap()\` domain helper alongside \`hasAlertGap\`. Migration \`0031\` backfills historic submitted rows with a \`CROSS JOIN LATERAL\` that mirrors the TypeScript averaging formula. Index on the new column.
- NAF segmentation keeps the five dominant sections as their own series (\`C\`, \`G\`, \`M\`, \`N\`, \`Q\`) and aggregates the remaining 16 into \"Autres\" — implemented as a parameterised \`sql.join\` in the Drizzle \`CASE\` expression (no \`sql.raw\`).
- Reuses \`<CompanySizeFilter>\` and \`<NafSectorFilter>\` from #3306; introduces \`<MultiYearGapChart>\`, \`<MultiYearGapTable>\`, \`<GapChartSeriesToggle>\` + constants \`DOMINANT_NAF_SECTIONS\` / \`OTHER_NAF_SEGMENT\` in the shared module.

## Test plan
- [x] Unit: \`computeAverageGap\` — empty, all-null, single pair, multi-pair, multi-category with skips (5 cases)
- [x] Unit: \`declaration.submit\` — \`averageGap\` written as the mean / null when no pair is exploitable (2 new cases)
- [x] Unit: \`adminStats.getMultiYearGapTrend\` — global / workforce / NAF collapse / null year / filter-segmentation conflict / conditional join / year range validation (7 cases)
- [x] Unit: \`<GapChartSeriesToggle>\` — render, reflect hidden set, add-on-uncheck, remove-on-recheck, \`aria-describedby\` binding (5 cases)
- [x] Unit: \`<MultiYearGapTable>\` — empty, sorted year headers, formatted gap + sample size, em-dash for missing (4 cases)
- [x] Unit: \`DOMINANT_NAF_SECTIONS\` and \`OTHER_NAF_SEGMENT\` constants
- [x] E2E (\`admin-stats-conformite.e2e.ts\` — extended): trend section visible, workforce segmentation spawns the checkbox legend, unchecking hides a series, accessible table lists the year columns (4 new scenarios)
- [x] Seed \`seed-conformite-stats.mjs\` extended with a plausible \`average_gap\` distribution (same deterministic PRNG as \`has_alert_gap\`, clamped to \`[0.5, 12]\`)
- [x] Audit wire-up: \`ADMIN_STATS_MULTI_YEAR_GAP_TREND\` action key + \`read_sensitive\` category + \`PROCEDURE_TO_ACTION\` entry
- [x] Typecheck, lint, format, full vitest suite (1604 tests) — all green