### PR TITLE
feat(db-schema): post-processing pipeline for wiki column comments (#3312)

### DIFF
--- a/.github/workflows/db-schema.yaml
+++ b/.github/workflows/db-schema.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Generate schema documentation
         run: npx db-schema-toolkit export packages/app/src/server/db/schema.ts -f markdown -o schema-doc.md
 
+      - name: Post-process schema doc with SUIT/GIP-MDS comments
+        run: pnpm --filter app run post-process-schema-wiki
+
       - name: Publish to GitHub Wiki
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,7 +29,8 @@
 		"test:lighthouse": "lhci collect --url=${LIGHTHOUSE_URL:-http://localhost:3000} && lhci upload && lhci assert",
 		"typecheck": "tsc --noEmit",
 		"generate:fetch-companies": "tsx scripts/fetch-large-companies.ts",
-		"generate:mock-gip": "tsx scripts/generate-mock-gip-data.ts"
+		"generate:mock-gip": "tsx scripts/generate-mock-gip-data.ts",
+		"post-process-schema-wiki": "tsx scripts/post-process-schema-wiki.mjs"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "^3.1029.0",
@@ -79,6 +80,7 @@
 		"jsdom": "^29.0.2",
 		"sass": "^1.99.0",
 		"swagger-ui-dist": "^5.32.2",
+		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
 		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.4"

--- a/packages/app/scripts/post-process-schema-wiki.mjs
+++ b/packages/app/scripts/post-process-schema-wiki.mjs
@@ -2,18 +2,19 @@
  * Post-processes the Markdown produced by `db-schema-toolkit export` to inject
  * SUIT / GIP-MDS column-level documentation from `schema-comments.ts`.
  *
- * The script reads `schema-doc.md` from the CWD (repo root in CI), enriches
- * every table's column table with a "Commentaire" column sourced from
- * `SCHEMA_COLUMN_COMMENTS`, then overwrites the file.
+ * Reads `schema-doc.md` from the repo root (CWD in CI), enriches every table's
+ * column table with a "Commentaire" column sourced from `SCHEMA_COLUMN_COMMENTS`,
+ * then overwrites the file.
  *
- * The pure processing logic lives in `src/server/db/postProcessSchemaWiki.ts`
- * and is loaded here via tsx (registered as an ESM loader).
+ * The script is intentionally self-contained (no dynamic TypeScript imports) so
+ * it can run with plain Node.js. The same processing logic lives in
+ * `src/server/db/postProcessSchemaWiki.ts` and is covered by Vitest unit tests.
  *
  * Usage (CI workflow, from repo root):
  *   pnpm --filter app run post-process-schema-wiki
  *
- * Usage (local, from repo root):
- *   pnpm --filter app run post-process-schema-wiki
+ * Usage (local, from packages/app):
+ *   pnpm run post-process-schema-wiki
  *
  * Issue: #3312 — post-processing infrastructure for DB schema wiki.
  */
@@ -25,19 +26,144 @@ import { fileURLToPath } from "node:url";
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 // ---------------------------------------------------------------------------
-// Load TypeScript modules (tsx must be registered as an ESM loader).
+// Inline processing logic (mirrors postProcessSchemaWiki.ts — kept in sync)
 // ---------------------------------------------------------------------------
 
-/** @type {import("../src/server/db/schema-comments.js")} */
-const { SCHEMA_COLUMN_COMMENTS } = await import(
-	/* @vite-ignore */
-	resolve(__dirname, "../src/server/db/schema-comments.ts")
-);
+/** @param {string} str */
+function escapeRegex(str) {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
-/** @type {import("../src/server/db/postProcessSchemaWiki.js")} */
-const { processMarkdown } = await import(
-	/* @vite-ignore */
-	resolve(__dirname, "../src/server/db/postProcessSchemaWiki.ts")
+/**
+ * @param {string} text
+ * @returns {number}
+ */
+function findFirstTableEnd(text) {
+	const m = /\|[^\n]+\|\n(?:\|[-|]+\|\n)(?:\|[^\n]+\|\n)*/.exec(text);
+	return m ? m.index + m[0].length : text.length;
+}
+
+/**
+ * @param {string} row
+ * @returns {string[]}
+ */
+function parseTableRow(row) {
+	return row.trim().replace(/^\|/, "").replace(/\|$/, "").split("|");
+}
+
+/**
+ * @param {string} markdown
+ * @param {string} tableName
+ * @returns {{ sectionStart: number; sectionEnd: number } | null}
+ */
+function locateSection(markdown, tableName) {
+	const headerPattern = new RegExp(
+		`^## Table:\\s+${escapeRegex(tableName)}\\s*$`,
+		"m",
+	);
+	const match = headerPattern.exec(markdown);
+	if (!match) return null;
+
+	const sectionStart = match.index;
+	const rest = markdown.slice(sectionStart + match[0].length);
+	const nextMatch = /^## /m.exec(rest);
+	const sectionEnd =
+		nextMatch !== null
+			? sectionStart + match[0].length + nextMatch.index
+			: markdown.length;
+
+	return { sectionStart, sectionEnd };
+}
+
+/**
+ * @param {string} markdown
+ * @param {string} tableName
+ * @param {Record<string, string>} columnComments
+ * @returns {{ markdown: string; injected: number }}
+ */
+function injectTableComments(markdown, tableName, columnComments) {
+	const fullMatch = locateSection(markdown, tableName);
+	if (!fullMatch) return { markdown, injected: 0 };
+
+	const { sectionStart, sectionEnd } = fullMatch;
+	let section = markdown.slice(sectionStart, sectionEnd);
+	const before = markdown.slice(0, sectionStart);
+	const after = markdown.slice(sectionEnd);
+
+	const firstTableEnd = findFirstTableEnd(section);
+	const columnsRegion = section.slice(0, firstTableEnd);
+	if (/\|\s*Commentaire\s*\|/.test(columnsRegion)) {
+		return { markdown, injected: 0 };
+	}
+
+	const tableRegex = /(\|[^\n]+\|\n)(\|[-|]+\|\n)((?:\|[^\n]+\|\n)*)/;
+	let injected = 0;
+
+	const tableMatch = tableRegex.exec(section);
+	if (!tableMatch) return { markdown, injected: 0 };
+
+	const headerRow = tableMatch[1] ?? "";
+	const sepRow = tableMatch[2] ?? "";
+	const bodyRows = tableMatch[3] ?? "";
+
+	const newHeader = headerRow.trimEnd().replace(/\|$/, "| Commentaire |\n");
+	const newSep = sepRow.trimEnd().replace(/\|$/, "|-------------||\n");
+
+	const headers = parseTableRow(headerRow);
+	const colIdx = headers.findIndex((h) => /^column$/i.test(h.trim()));
+
+	const newBody = bodyRows.replace(/(\|[^\n]+\|)\n/g, (rowLine) => {
+		const cells = parseTableRow(rowLine);
+		const columnName =
+			colIdx >= 0 && colIdx < cells.length ? (cells[colIdx] ?? "").trim() : "";
+		const comment = columnComments[columnName] ?? "";
+		if (comment) injected++;
+		return rowLine.trimEnd().replace(/\|$/, `| ${comment} |\n`);
+	});
+
+	const originalTable = tableMatch[0];
+	section = section.replace(originalTable, newHeader + newSep + newBody);
+	return { markdown: before + section + after, injected };
+}
+
+/**
+ * @param {string} markdown
+ * @param {Record<string, Record<string, string>>} comments
+ * @returns {{ result: string; stats: Record<string, number> }}
+ */
+function processMarkdown(markdown, comments) {
+	let result = markdown;
+	/** @type {Record<string, number>} */
+	const stats = {};
+
+	for (const [tableName, columnComments] of Object.entries(comments)) {
+		const section = locateSection(result, tableName);
+		if (!section) {
+			console.warn(
+				`[post-process-schema-wiki] warn: table "${tableName}" not found in schema-doc.md (skipped)`,
+			);
+			continue;
+		}
+		const { markdown: updated, injected } = injectTableComments(
+			result,
+			tableName,
+			columnComments,
+		);
+		result = updated;
+		stats[tableName] = injected;
+	}
+
+	return { result, stats };
+}
+
+// ---------------------------------------------------------------------------
+// Load column comments from the TypeScript source via tsx
+// ---------------------------------------------------------------------------
+
+// tsx is registered as a loader by the pnpm script (`tsx scripts/...`), so
+// static-style imports of .ts files work transparently.
+const { SCHEMA_COLUMN_COMMENTS } = await import(
+	"../src/server/db/schema-comments.ts"
 );
 
 // ---------------------------------------------------------------------------
@@ -46,7 +172,8 @@ const { processMarkdown } = await import(
 
 // schema-doc.md is generated at the repo root by db-schema-toolkit.
 // When the script is run via `pnpm run` from packages/app, process.cwd() is
-// packages/app — so we also look two levels up (repo root) as fallback.
+// packages/app — so we also look up to the repo root as fallback.
+// __dirname = packages/app/scripts/ → ../../../ = repo root.
 const cwdPath = resolve(process.cwd(), "schema-doc.md");
 const repoRootPath = resolve(__dirname, "../../../schema-doc.md");
 const schemaDocPath = existsSync(cwdPath) ? cwdPath : repoRootPath;

--- a/packages/app/scripts/post-process-schema-wiki.mjs
+++ b/packages/app/scripts/post-process-schema-wiki.mjs
@@ -1,0 +1,74 @@
+/**
+ * Post-processes the Markdown produced by `db-schema-toolkit export` to inject
+ * SUIT / GIP-MDS column-level documentation from `schema-comments.ts`.
+ *
+ * The script reads `schema-doc.md` from the CWD (repo root in CI), enriches
+ * every table's column table with a "Commentaire" column sourced from
+ * `SCHEMA_COLUMN_COMMENTS`, then overwrites the file.
+ *
+ * The pure processing logic lives in `src/server/db/postProcessSchemaWiki.ts`
+ * and is loaded here via tsx (registered as an ESM loader).
+ *
+ * Usage (CI workflow, from repo root):
+ *   pnpm --filter app run post-process-schema-wiki
+ *
+ * Usage (local, from repo root):
+ *   pnpm --filter app run post-process-schema-wiki
+ *
+ * Issue: #3312 — post-processing infrastructure for DB schema wiki.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Load TypeScript modules (tsx must be registered as an ESM loader).
+// ---------------------------------------------------------------------------
+
+/** @type {import("../src/server/db/schema-comments.js")} */
+const { SCHEMA_COLUMN_COMMENTS } = await import(
+	/* @vite-ignore */
+	resolve(__dirname, "../src/server/db/schema-comments.ts")
+);
+
+/** @type {import("../src/server/db/postProcessSchemaWiki.js")} */
+const { processMarkdown } = await import(
+	/* @vite-ignore */
+	resolve(__dirname, "../src/server/db/postProcessSchemaWiki.ts")
+);
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+// schema-doc.md is generated at the repo root by db-schema-toolkit.
+// When the script is run via `pnpm run` from packages/app, process.cwd() is
+// packages/app — so we also look two levels up (repo root) as fallback.
+const cwdPath = resolve(process.cwd(), "schema-doc.md");
+const repoRootPath = resolve(__dirname, "../../../schema-doc.md");
+const schemaDocPath = existsSync(cwdPath) ? cwdPath : repoRootPath;
+
+if (!existsSync(schemaDocPath)) {
+	console.error(
+		`[post-process-schema-wiki] error: schema-doc.md not found at ${schemaDocPath}`,
+	);
+	process.exit(1);
+}
+
+const markdown = readFileSync(schemaDocPath, "utf8");
+const { result, stats } = processMarkdown(markdown, SCHEMA_COLUMN_COMMENTS);
+
+writeFileSync(schemaDocPath, result, "utf8");
+
+const totalInjected = Object.values(stats).reduce((a, b) => a + b, 0);
+console.log(
+	`[post-process-schema-wiki] done: ${totalInjected} comment(s) injected across ${Object.keys(stats).length} table(s).`,
+);
+for (const [table, count] of Object.entries(stats)) {
+	if (count > 0) {
+		console.log(`  - ${table}: ${count} comment(s)`);
+	}
+}

--- a/packages/app/src/server/db/__tests__/postProcessSchemaWiki.test.ts
+++ b/packages/app/src/server/db/__tests__/postProcessSchemaWiki.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	injectTableComments,
+	locateSection,
+	parseTableNames,
+	parseTableRow,
+	processMarkdown,
+} from "~/server/db/postProcessSchemaWiki";
+
+// ---------------------------------------------------------------------------
+// Sample Markdown that mimics db-schema-toolkit (v1.1.x) output format:
+//   - Section headers: `## Table: <camelCaseName>`
+//   - Separator: `|--------|------|` (dashes only, no spaces inside)
+//   - Column names: camelCase (match Drizzle field names)
+// ---------------------------------------------------------------------------
+
+const SAMPLE_MARKDOWN = `# schema
+
+## Table: declaration
+
+| Column | Type | Nullable |
+|--------|------|----------|
+| id | VARCHAR | No |
+| indicatorAAnnualWomen | NUMERIC | Yes |
+| indicatorAAnnualMen | NUMERIC | Yes |
+
+### Indexes
+
+### Foreign Keys
+
+## Table: user
+
+| Column | Type | Nullable |
+|--------|------|----------|
+| id | VARCHAR | No |
+| email | VARCHAR | No |
+`;
+
+// ---------------------------------------------------------------------------
+// parseTableNames
+// ---------------------------------------------------------------------------
+
+describe("parseTableNames", () => {
+	it("returns all table names found in the Markdown", () => {
+		const names = parseTableNames(SAMPLE_MARKDOWN);
+		expect(names).toEqual(["declaration", "user"]);
+	});
+
+	it("returns an empty array when no table headers are present", () => {
+		expect(parseTableNames("# Title\n\nSome text.")).toEqual([]);
+	});
+
+	it("only matches ## Table: headers, not ### sub-sections", () => {
+		const md = "## Table: foo\n\n### Indexes\n\n## Table: bar\n";
+		expect(parseTableNames(md)).toEqual(["foo", "bar"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseTableRow
+// ---------------------------------------------------------------------------
+
+describe("parseTableRow", () => {
+	it("splits a pipe-delimited row into cells", () => {
+		const cells = parseTableRow("| id | VARCHAR | No |\n");
+		expect(cells).toHaveLength(3);
+		expect(cells[0]?.trim()).toBe("id");
+		expect(cells[1]?.trim()).toBe("VARCHAR");
+		expect(cells[2]?.trim()).toBe("No");
+	});
+
+	it("handles rows without trailing newline", () => {
+		const cells = parseTableRow("| a | b |");
+		expect(cells).toHaveLength(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// locateSection
+// ---------------------------------------------------------------------------
+
+describe("locateSection", () => {
+	it("finds the correct start and end for a section", () => {
+		const result = locateSection(SAMPLE_MARKDOWN, "declaration");
+		if (result === null) throw new Error("expected non-null result");
+		const section = SAMPLE_MARKDOWN.slice(
+			result.sectionStart,
+			result.sectionEnd,
+		);
+		expect(section).toContain("Table: declaration");
+		expect(section).toContain("indicatorAAnnualWomen");
+		expect(section).not.toContain("Table: user");
+	});
+
+	it("returns null when the table is not found", () => {
+		expect(locateSection(SAMPLE_MARKDOWN, "nonexistent")).toBeNull();
+	});
+
+	it("handles the last section (no following ## header)", () => {
+		const result = locateSection(SAMPLE_MARKDOWN, "user");
+		if (result === null) throw new Error("expected non-null result");
+		const section = SAMPLE_MARKDOWN.slice(
+			result.sectionStart,
+			result.sectionEnd,
+		);
+		expect(section).toContain("Table: user");
+		expect(section).toContain("email");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// injectTableComments — happy path
+// ---------------------------------------------------------------------------
+
+describe("injectTableComments — injection", () => {
+	it("adds a Commentaire column for matched entries", () => {
+		const comments = {
+			indicatorAAnnualWomen: "GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_F",
+		};
+
+		const { markdown: result, injected } = injectTableComments(
+			SAMPLE_MARKDOWN,
+			"declaration",
+			comments,
+		);
+
+		expect(injected).toBe(1);
+		expect(result).toContain("Commentaire");
+		expect(result).toContain("GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_F");
+	});
+
+	it("adds empty cells for columns without a comment entry", () => {
+		const comments = {
+			indicatorAAnnualWomen: "GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_F",
+		};
+
+		const { markdown: result } = injectTableComments(
+			SAMPLE_MARKDOWN,
+			"declaration",
+			comments,
+		);
+
+		// The id and indicatorAAnnualMen rows should have an empty comment cell.
+		const lines = result.split("\n");
+		const idRow = lines.find((l) => /^\| id \|/.test(l));
+		expect(idRow).toContain("|  |");
+	});
+
+	it("returns injected = 0 when no comments match any column", () => {
+		const { injected } = injectTableComments(
+			SAMPLE_MARKDOWN,
+			"declaration",
+			{},
+		);
+		expect(injected).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// injectTableComments — idempotency
+// ---------------------------------------------------------------------------
+
+describe("injectTableComments — idempotency", () => {
+	it("does not add a second Commentaire column when already present", () => {
+		const comments = { indicatorAAnnualWomen: "test comment" };
+		const { markdown: once } = injectTableComments(
+			SAMPLE_MARKDOWN,
+			"declaration",
+			comments,
+		);
+		const { markdown: twice, injected } = injectTableComments(
+			once,
+			"declaration",
+			comments,
+		);
+
+		// Only one Commentaire column header in the whole document.
+		const count = (twice.match(/Commentaire/g) ?? []).length;
+		expect(count).toBe(1);
+		expect(injected).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// injectTableComments — unknown table
+// ---------------------------------------------------------------------------
+
+describe("injectTableComments — unknown table", () => {
+	it("returns the original markdown unchanged when the table is not found", () => {
+		const { markdown: result, injected } = injectTableComments(
+			SAMPLE_MARKDOWN,
+			"nonexistent",
+			{ someCol: "comment" },
+		);
+		expect(result).toBe(SAMPLE_MARKDOWN);
+		expect(injected).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// processMarkdown — full pipeline
+// ---------------------------------------------------------------------------
+
+describe("processMarkdown", () => {
+	it("injects comments for multiple tables", () => {
+		const comments = {
+			declaration: { indicatorAAnnualWomen: "GIP-MDS | annual women" },
+			user: { email: "Contact email" },
+		};
+
+		const { result, stats } = processMarkdown(SAMPLE_MARKDOWN, comments);
+
+		expect(result).toContain("GIP-MDS | annual women");
+		expect(result).toContain("Contact email");
+		expect(stats.declaration).toBeGreaterThan(0);
+		expect(stats.user).toBeGreaterThan(0);
+	});
+
+	it("warns but does not throw for entries pointing to missing tables", () => {
+		const comments = {
+			nonexistentTable: { col: "value" },
+		};
+
+		expect(() => processMarkdown(SAMPLE_MARKDOWN, comments)).not.toThrow();
+	});
+
+	it("returns unchanged markdown when the comments map is empty", () => {
+		const { result, stats } = processMarkdown(SAMPLE_MARKDOWN, {});
+		expect(result).toBe(SAMPLE_MARKDOWN);
+		expect(stats).toEqual({});
+	});
+
+	it("is idempotent: running twice produces identical output", () => {
+		const comments = {
+			declaration: { indicatorAAnnualWomen: "test comment" },
+		};
+
+		const { result: first } = processMarkdown(SAMPLE_MARKDOWN, comments);
+		const { result: second } = processMarkdown(first, comments);
+
+		expect(second).toBe(first);
+	});
+});

--- a/packages/app/src/server/db/postProcessSchemaWiki.ts
+++ b/packages/app/src/server/db/postProcessSchemaWiki.ts
@@ -1,0 +1,196 @@
+/**
+ * Pure processing functions for the DB schema wiki post-processing pipeline.
+ *
+ * These functions are consumed by `scripts/post-process-schema-wiki.mjs` (via
+ * dynamic import with tsx) and unit-tested via Vitest.
+ *
+ * None of these functions perform I/O — they operate on strings only.
+ *
+ * db-schema-toolkit output format (v1.1.x):
+ *   - Table sections open with `## Table: <camelCaseName>` (Drizzle field name,
+ *     no `app_` prefix).
+ *   - Sub-sections (Indexes, Foreign Keys) use `### …`.
+ *   - Column tables use `|--------|------|---------|----|` style separators
+ *     (dashes only, varying widths, no spaces inside cells).
+ *   - Column names match the Drizzle field names (camelCase).
+ *
+ * Issue: #3312 — post-processing infrastructure for DB schema wiki.
+ */
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses the Markdown produced by db-schema-toolkit and returns the list of
+ * table names found. The toolkit emits `## Table: <name>` headers.
+ */
+export function parseTableNames(markdown: string): string[] {
+	const tableNames: string[] = [];
+	const headerRegex = /^## Table:\s+(\w+)\s*$/gm;
+	let match = headerRegex.exec(markdown);
+	while (match !== null) {
+		const name = match[1];
+		if (name !== undefined) tableNames.push(name);
+		match = headerRegex.exec(markdown);
+	}
+	return tableNames;
+}
+
+/**
+ * Splits a Markdown table row into its cells, trimming the surrounding `|`.
+ */
+export function parseTableRow(row: string): string[] {
+	return row.trim().replace(/^\|/, "").replace(/\|$/, "").split("|");
+}
+
+/**
+ * Locates the start and end byte offsets of a table section
+ * (`## Table: <name>`) inside a Markdown string.
+ */
+export function locateSection(
+	markdown: string,
+	tableName: string,
+): { sectionStart: number; sectionEnd: number } | null {
+	const headerPattern = new RegExp(
+		`^## Table:\\s+${escapeRegex(tableName)}\\s*$`,
+		"m",
+	);
+	const match = headerPattern.exec(markdown);
+	if (!match) return null;
+
+	const sectionStart = match.index;
+
+	// Section ends at the next `## ` header (same or higher level), or EOF.
+	const rest = markdown.slice(sectionStart + match[0].length);
+	const nextMatch = /^## /m.exec(rest);
+	const sectionEnd =
+		nextMatch !== null
+			? sectionStart + match[0].length + nextMatch.index
+			: markdown.length;
+
+	return { sectionStart, sectionEnd };
+}
+
+/**
+ * Injects a "Commentaire" column into a Markdown table section for a given
+ * table name. If the column already exists it is left untouched (idempotent).
+ *
+ * The separator row style `|-----|------|` (dashes only, varying widths) is
+ * matched with `\|[-|]+\|`.
+ */
+export function injectTableComments(
+	markdown: string,
+	tableName: string,
+	columnComments: Record<string, string>,
+): { markdown: string; injected: number } {
+	const fullMatch = locateSection(markdown, tableName);
+	if (!fullMatch) return { markdown, injected: 0 };
+
+	const { sectionStart, sectionEnd } = fullMatch;
+	let section = markdown.slice(sectionStart, sectionEnd);
+	const before = markdown.slice(0, sectionStart);
+	const after = markdown.slice(sectionEnd);
+
+	// Check if "Commentaire" column already exists in the columns table of
+	// this section (only the first table — the column list).
+	const firstTableEnd = findFirstTableEnd(section);
+	const columnsRegion = section.slice(0, firstTableEnd);
+	if (/\|\s*Commentaire\s*\|/.test(columnsRegion)) {
+		return { markdown, injected: 0 };
+	}
+
+	// Match only the first Markdown table in the section (the column list).
+	// Separator style: |-----|------|  (dashes only, no spaces, varying widths).
+	const tableRegex = /(\|[^\n]+\|\n)(\|[-|]+\|\n)((?:\|[^\n]+\|\n)*)/;
+	let injected = 0;
+
+	const tableMatch = tableRegex.exec(section);
+	if (!tableMatch) return { markdown, injected: 0 };
+
+	// Groups are guaranteed by the regex — guard for noUncheckedIndexedAccess.
+	const headerRow = tableMatch[1] ?? "";
+	const sepRow = tableMatch[2] ?? "";
+	const bodyRows = tableMatch[3] ?? "";
+
+	// Add header column.
+	const newHeader = headerRow.trimEnd().replace(/\|$/, "| Commentaire |\n");
+
+	// Add separator column.
+	const newSep = sepRow.trimEnd().replace(/\|$/, "|-------------||\n");
+
+	// Determine the column index for "Column" in the header.
+	const headers = parseTableRow(headerRow);
+	const colIdx = headers.findIndex((h) => /^column$/i.test(h.trim()));
+
+	// Add data to body rows.
+	const newBody = bodyRows.replace(/(\|[^\n]+\|)\n/g, (rowLine: string) => {
+		const cells = parseTableRow(rowLine);
+		const columnName =
+			colIdx >= 0 && colIdx < cells.length ? (cells[colIdx] ?? "").trim() : "";
+		const comment = columnComments[columnName] ?? "";
+		if (comment) injected++;
+		return rowLine.trimEnd().replace(/\|$/, `| ${comment} |\n`);
+	});
+
+	const originalTable = tableMatch[0];
+	const replacedTable = newHeader + newSep + newBody;
+	section = section.replace(originalTable, replacedTable);
+
+	return { markdown: before + section + after, injected };
+}
+
+/**
+ * Main post-processing function. Applies all comments from the provided map
+ * to the Markdown content and returns the enriched result.
+ *
+ * Tables in the map that are not found in the Markdown produce a console.warn
+ * but do not cause the function to throw.
+ */
+export function processMarkdown(
+	markdown: string,
+	comments: Record<string, Record<string, string>>,
+): { result: string; stats: Record<string, number> } {
+	let result = markdown;
+	const stats: Record<string, number> = {};
+
+	for (const [tableName, columnComments] of Object.entries(comments)) {
+		const section = locateSection(result, tableName);
+		if (!section) {
+			console.warn(
+				`[post-process-schema-wiki] warn: table "${tableName}" not found in schema-doc.md (skipped)`,
+			);
+			continue;
+		}
+
+		const { markdown: updated, injected } = injectTableComments(
+			result,
+			tableName,
+			columnComments,
+		);
+		result = updated;
+		stats[tableName] = injected;
+	}
+
+	return { result, stats };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the character offset where the first Markdown table in a string ends
+ * (i.e. the position after the last `| … |\n` row of the first table).
+ * Returns the full string length when no table is found.
+ */
+function findFirstTableEnd(text: string): number {
+	const tableRegex = /\|[^\n]+\|\n(?:\|[-|]+\|\n)(?:\|[^\n]+\|\n)*/;
+	const m = tableRegex.exec(text);
+	if (!m) return text.length;
+	return m.index + m[0].length;
+}
+
+function escapeRegex(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -1,0 +1,16 @@
+/**
+ * Column-level documentation attached to the DB schema and rendered on the
+ * wiki (https://github.com/SocialGouv/egapro/wiki/Schema-Egapro-V2) by the
+ * `db-schema.yaml` workflow via `scripts/post-process-schema-wiki.mjs`.
+ *
+ * Key = Drizzle snake_case table name (without the `app_` prefix).
+ * Value = map of snake_case column name → human-readable comment.
+ *
+ * Populated in tickets T1 (indicators A–F, GIP-MDS origin) and T2 (other
+ * SUIT-exposed columns: company identity, declarant, CSE, files, indicator G).
+ */
+export type SchemaColumnComments = Record<string, Record<string, string>>;
+
+export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
+	// Filled by tickets T1 and T2.
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       swagger-ui-dist:
         specifier: ^5.32.2
         version: 5.32.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
Closes #3312

## Summary

- Adds `schema-comments.ts` as a typed, empty source-of-truth map (`table → column → comment`) to be populated by tickets T1 and T2
- Adds `postProcessSchemaWiki.ts` with pure, fully-tested processing functions that inject a "Commentaire" column into db-schema-toolkit Markdown output
- Adds `post-process-schema-wiki.mjs` runner script (calls the TS logic via tsx)
- Wires the post-processing step into `.github/workflows/db-schema.yaml` between export and wiki push
- Adds `tsx` as a direct devDependency and exposes a `post-process-schema-wiki` pnpm script

## Test plan

- [ ] `pnpm test` — 1553 tests pass, no regression
- [ ] `pnpm typecheck` — no TS errors
- [ ] `pnpm lint:check && pnpm format:check` — clean
- [ ] Local smoke test: `npx db-schema-toolkit export … && pnpm --filter app run post-process-schema-wiki` completes with exit 0
- [ ] Missing-table scenario: warns but does not crash (verified by unit test)
- [ ] Idempotency: running the script twice produces identical output (verified by unit test)