### PR TITLE
feat(schema-comments): SUIT annotations for non-GIP columns (T2, #3314)

### DIFF
--- a/packages/app/src/server/db/__tests__/schema-comments.test.ts
+++ b/packages/app/src/server/db/__tests__/schema-comments.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { SCHEMA_COLUMN_COMMENTS } from "../schema-comments";
+
+describe("SCHEMA_COLUMN_COMMENTS", () => {
+	describe("format compliance", () => {
+		it("every comment uses the SUIT: prefix (no GIP-MDS in T2 entries)", () => {
+			for (const [table, columns] of Object.entries(SCHEMA_COLUMN_COMMENTS)) {
+				for (const [col, comment] of Object.entries(columns)) {
+					expect(comment, `${table}.${col}`).toMatch(/^SUIT: /);
+					expect(
+						comment,
+						`${table}.${col} must not contain GIP-MDS`,
+					).not.toContain("GIP-MDS");
+				}
+			}
+		});
+	});
+
+	describe("declaration table", () => {
+		const decl = SCHEMA_COLUMN_COMMENTS.declaration ?? {};
+
+		it("siren maps to SUIT: SIREN (S1 scenario)", () => {
+			expect(decl.siren).toBe("SUIT: SIREN");
+		});
+
+		it("year maps to SUIT: Annee", () => {
+			expect(decl.year).toBe("SUIT: Annee");
+		});
+
+		it("annotates all projected meta columns", () => {
+			expect(decl.status).toBe("SUIT: Statut");
+			expect(decl.compliance_path).toBe("SUIT: Parcours_conformite");
+			expect(decl.total_women).toBe("SUIT: Effectif_F_rem_annuelle_globale");
+			expect(decl.total_men).toBe("SUIT: Effectif_H_rem_annuelle_globale");
+			expect(decl.created_at).toBe("SUIT: Date_creation");
+			expect(decl.updated_at).toBe("SUIT: Date_modification");
+			expect(decl.second_declaration_status).toBe(
+				"SUIT: Seconde_declaration.Statut",
+			);
+			expect(decl.second_decl_reference_period_start).toBe(
+				"SUIT: Seconde_declaration.Periode_reference_debut",
+			);
+			expect(decl.second_decl_reference_period_end).toBe(
+				"SUIT: Seconde_declaration.Periode_reference_fin",
+			);
+		});
+	});
+
+	describe("company table", () => {
+		const co = SCHEMA_COLUMN_COMMENTS.company ?? {};
+
+		it("annotates all SUIT-exposed company fields", () => {
+			expect(co.name).toBe("SUIT: Raison_sociale");
+			expect(co.workforce).toBe("SUIT: Effectif");
+			expect(co.naf_code).toBe("SUIT: Code_NAF");
+			expect(co.address).toBe("SUIT: Adresse");
+			expect(co.has_cse).toBe("SUIT: CSE_existant");
+		});
+
+		it("does not annotate internal-only fields", () => {
+			expect(co.siren).toBeUndefined();
+			expect(co.created_at).toBeUndefined();
+			expect(co.updated_at).toBeUndefined();
+		});
+	});
+
+	describe("user table", () => {
+		const u = SCHEMA_COLUMN_COMMENTS.user ?? {};
+
+		it("annotates declarant fields exposed via SUIT", () => {
+			expect(u.first_name).toBe("SUIT: Declarant.Prenom");
+			expect(u.last_name).toBe("SUIT: Declarant.Nom");
+			expect(u.email).toBe("SUIT: Declarant.Email");
+			expect(u.phone).toBe("SUIT: Declarant.Telephone");
+		});
+	});
+
+	describe("cse_opinion table", () => {
+		const cse = SCHEMA_COLUMN_COMMENTS.cse_opinion ?? {};
+
+		it("annotates CSE opinion fields", () => {
+			expect(cse.declaration_number).toBe("SUIT: Avis_CSE.Numero_declaration");
+			expect(cse.type).toBe("SUIT: Avis_CSE.Type");
+			expect(cse.opinion).toBe("SUIT: Avis_CSE.Avis");
+			expect(cse.opinion_date).toBe("SUIT: Avis_CSE.Date");
+		});
+	});
+
+	describe("file table", () => {
+		const f = SCHEMA_COLUMN_COMMENTS.file ?? {};
+
+		it("annotates SUIT-exposed file fields", () => {
+			expect(f.id).toBe("SUIT: Fichiers_CSE.Id");
+			expect(f.file_name).toBe("SUIT: Fichiers_CSE.Nom_fichier");
+			expect(f.uploaded_at).toBe("SUIT: Fichiers_CSE.Date_upload");
+			expect(f.type).toBe("SUIT: Fichiers_CSE.Type");
+		});
+
+		it("does not annotate file_path (internal, not in SUIT JSON)", () => {
+			expect(f.file_path).toBeUndefined();
+		});
+	});
+
+	describe("job_category table (indicator G)", () => {
+		const jc = SCHEMA_COLUMN_COMMENTS.job_category ?? {};
+
+		it("annotates category name and detail without GIP-MDS prefix", () => {
+			expect(jc.name).toBe("SUIT: Indicateurs.G.Nom_categorie");
+			expect(jc.detail).toBe("SUIT: Indicateurs.G.Detail_categorie");
+		});
+	});
+
+	describe("employee_category table (indicator G)", () => {
+		const ec = SCHEMA_COLUMN_COMMENTS.employee_category ?? {};
+
+		it("annotates all SUIT-exposed employee category fields", () => {
+			expect(ec.women_count).toBe("SUIT: Indicateurs.G.Effectif_F");
+			expect(ec.men_count).toBe("SUIT: Indicateurs.G.Effectif_H");
+			expect(ec.annual_base_women).toBe(
+				"SUIT: Indicateurs.G.Rem_annuelle_base_F",
+			);
+			expect(ec.annual_base_men).toBe(
+				"SUIT: Indicateurs.G.Rem_annuelle_base_H",
+			);
+			expect(ec.annual_variable_women).toBe(
+				"SUIT: Indicateurs.G.Rem_annuelle_variable_F",
+			);
+			expect(ec.annual_variable_men).toBe(
+				"SUIT: Indicateurs.G.Rem_annuelle_variable_H",
+			);
+			expect(ec.hourly_base_women).toBe(
+				"SUIT: Indicateurs.G.Taux_horaire_base_F",
+			);
+			expect(ec.hourly_base_men).toBe(
+				"SUIT: Indicateurs.G.Taux_horaire_base_H",
+			);
+			expect(ec.hourly_variable_women).toBe(
+				"SUIT: Indicateurs.G.Taux_horaire_variable_F",
+			);
+			expect(ec.hourly_variable_men).toBe(
+				"SUIT: Indicateurs.G.Taux_horaire_variable_H",
+			);
+		});
+	});
+});

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -12,5 +12,71 @@
 export type SchemaColumnComments = Record<string, Record<string, string>>;
 
 export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
-	// Filled by tickets T1 and T2.
+	// T1 entries (indicators A–F, GIP-MDS origin) are added by ticket T1
+	// in a parallel PR. This file holds T2 entries: all other SUIT-exposed columns.
+
+	declaration: {
+		siren: "SUIT: SIREN",
+		year: "SUIT: Annee",
+		status: "SUIT: Statut",
+		compliance_path: "SUIT: Parcours_conformite",
+		total_women: "SUIT: Effectif_F_rem_annuelle_globale",
+		total_men: "SUIT: Effectif_H_rem_annuelle_globale",
+		created_at: "SUIT: Date_creation",
+		updated_at: "SUIT: Date_modification",
+		second_declaration_status: "SUIT: Seconde_declaration.Statut",
+		second_decl_reference_period_start:
+			"SUIT: Seconde_declaration.Periode_reference_debut",
+		second_decl_reference_period_end:
+			"SUIT: Seconde_declaration.Periode_reference_fin",
+	},
+
+	company: {
+		name: "SUIT: Raison_sociale",
+		workforce: "SUIT: Effectif",
+		naf_code: "SUIT: Code_NAF",
+		address: "SUIT: Adresse",
+		has_cse: "SUIT: CSE_existant",
+	},
+
+	user: {
+		first_name: "SUIT: Declarant.Prenom",
+		last_name: "SUIT: Declarant.Nom",
+		email: "SUIT: Declarant.Email",
+		phone: "SUIT: Declarant.Telephone",
+	},
+
+	cse_opinion: {
+		declaration_number: "SUIT: Avis_CSE.Numero_declaration",
+		type: "SUIT: Avis_CSE.Type",
+		opinion: "SUIT: Avis_CSE.Avis",
+		opinion_date: "SUIT: Avis_CSE.Date",
+	},
+
+	// Single `file` table serves both CSE opinion files and joint evaluation
+	// files; labels below use the CSE path as primary reference.
+	file: {
+		id: "SUIT: Fichiers_CSE.Id",
+		file_name: "SUIT: Fichiers_CSE.Nom_fichier",
+		uploaded_at: "SUIT: Fichiers_CSE.Date_upload",
+		type: "SUIT: Fichiers_CSE.Type",
+	},
+
+	job_category: {
+		name: "SUIT: Indicateurs.G.Nom_categorie",
+		detail: "SUIT: Indicateurs.G.Detail_categorie",
+	},
+
+	employee_category: {
+		women_count: "SUIT: Indicateurs.G.Effectif_F",
+		men_count: "SUIT: Indicateurs.G.Effectif_H",
+		annual_base_women: "SUIT: Indicateurs.G.Rem_annuelle_base_F",
+		annual_base_men: "SUIT: Indicateurs.G.Rem_annuelle_base_H",
+		annual_variable_women: "SUIT: Indicateurs.G.Rem_annuelle_variable_F",
+		annual_variable_men: "SUIT: Indicateurs.G.Rem_annuelle_variable_H",
+		hourly_base_women: "SUIT: Indicateurs.G.Taux_horaire_base_F",
+		hourly_base_men: "SUIT: Indicateurs.G.Taux_horaire_base_H",
+		hourly_variable_women: "SUIT: Indicateurs.G.Taux_horaire_variable_F",
+		hourly_variable_men: "SUIT: Indicateurs.G.Taux_horaire_variable_H",
+	},
 };


### PR DESCRIPTION
Closes #3314

Stacked on #3312 (T3: post-processing script) — GitHub retargettera automatiquement vers `alpha` une fois le parent mergé.

## Summary

Populates `SCHEMA_COLUMN_COMMENTS` with T2 entries: all SUIT-exposed DB columns that are **not** indicators A–F (those are covered by T1 in a parallel PR).

Tables annotated:
- `declaration`: siren, year, status, compliance_path, total_women/men, created_at, updated_at, second_declaration_status, second_decl_reference_period_start/end
- `company`: name, workforce, naf_code, address, has_cse
- `user`: first_name, last_name, email, phone (declarant fields)
- `cse_opinion`: declaration_number, type, opinion, opinion_date
- `file`: id, file_name, uploaded_at, type
- `job_category`: name, detail (indicator G)
- `employee_category`: all 10 remuneration fields (indicator G)

Each comment uses the `SUIT: <label>` format with verbatim keys from `assembleDeclaration()`. Per the Q2 scope decision, only columns actually projected in the SUIT JSON are annotated — internal fields (PKs, FKs, timestamps not in output, etc.) are intentionally omitted.

## Test plan

- [x] 12 unit tests covering: format compliance (all SUIT: prefix, no GIP-MDS), the S1 scenario (siren → "SUIT: SIREN"), per-table field coverage, and negative assertions for non-exposed columns
- [x] `pnpm typecheck` green
- [x] `pnpm lint:check` green (no biome warnings)
- [x] `pnpm format:check` green
- [x] `pnpm test` green (1548 tests, no regressions)