### PR TITLE
feat(schema-comments): annotate A-F indicator columns (GIP-MDS | SUIT)

### DIFF
--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -16,5 +16,79 @@
 export type SchemaColumnComments = Record<string, Record<string, string>>;
 
 export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
-	// Filled by tickets T1 and T2.
+	declaration: {
+		// Indicator A — mean global remuneration (GIP-MDS)
+		indicator_a_annual_women: "GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_F",
+		indicator_a_annual_men: "GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_H",
+		indicator_a_hourly_women: "GIP-MDS | SUIT: Taux_horaire_global_moyen_F",
+		indicator_a_hourly_men: "GIP-MDS | SUIT: Taux_horaire_global_moyen_H",
+		// Indicator B — mean variable remuneration (GIP-MDS)
+		indicator_b_annual_women: "GIP-MDS | SUIT: Rem_variable_annuelle_moyenne_F",
+		indicator_b_annual_men: "GIP-MDS | SUIT: Rem_variable_annuelle_moyenne_H",
+		indicator_b_hourly_women: "GIP-MDS | SUIT: Taux_horaire_variable_moyen_F",
+		indicator_b_hourly_men: "GIP-MDS | SUIT: Taux_horaire_variable_moyen_H",
+		// Indicator C — median global remuneration (GIP-MDS)
+		indicator_c_annual_women: "GIP-MDS | SUIT: Rem_globale_annuelle_médiane_F",
+		indicator_c_annual_men: "GIP-MDS | SUIT: Rem_globale_annuelle_médiane_H",
+		indicator_c_hourly_women: "GIP-MDS | SUIT: Taux_globale_annuelle_médiane_F",
+		indicator_c_hourly_men: "GIP-MDS | SUIT: Taux_globale_annuelle_médiane_H",
+		// Indicator D — median variable remuneration (GIP-MDS)
+		indicator_d_annual_women: "GIP-MDS | SUIT: Rem_variable_annuelle_médiane_F",
+		indicator_d_annual_men: "GIP-MDS | SUIT: Rem_variable_annuelle_médiane_H",
+		indicator_d_hourly_women: "GIP-MDS | SUIT: Taux_horaire_variable_médian_F",
+		indicator_d_hourly_men: "GIP-MDS | SUIT: Taux_horaire_variable_médian_H",
+		// Indicator E — variable pay beneficiary counts (GIP-MDS)
+		indicator_e_women: "GIP-MDS | SUIT: Effectif_F_rem_annuelle_variable",
+		indicator_e_men: "GIP-MDS | SUIT: Effectif_H_rem_annuelle_variable",
+		// Indicator F — annual quartile thresholds (GIP-MDS)
+		indicator_f_annual_threshold1: "GIP-MDS | SUIT: Seuil_Q1_Rem_globale",
+		indicator_f_annual_threshold2: "GIP-MDS | SUIT: Seuil_Q2_Rem_globale",
+		indicator_f_annual_threshold3: "GIP-MDS | SUIT: Seuil_Q3_Rem_globale",
+		indicator_f_annual_threshold4: "GIP-MDS | SUIT: Seuil_Q4_Rem_globale",
+		// Indicator F — annual quartile women counts → proportion F (GIP-MDS)
+		indicator_f_annual_women1:
+			"GIP-MDS | SUIT: Quartile1_Rem_globale_annuelle_proportion_F",
+		indicator_f_annual_women2:
+			"GIP-MDS | SUIT: Quartile2_Rem_globale_annuelle_proportion_F",
+		indicator_f_annual_women3:
+			"GIP-MDS | SUIT: Quartile3_Rem_globale_annuelle_proportion_F",
+		indicator_f_annual_women4:
+			"GIP-MDS | SUIT: Quartile4_Rem_globale_annuelle_proportion_F",
+		// Indicator F — annual quartile men counts → proportion H (GIP-MDS)
+		indicator_f_annual_men1:
+			"GIP-MDS | SUIT: Quartile1_Rem_globale_annuelle_proportion_H",
+		indicator_f_annual_men2:
+			"GIP-MDS | SUIT: Quartile2_Rem_globale_annuelle_proportion_H",
+		indicator_f_annual_men3:
+			"GIP-MDS | SUIT: Quartile3_Rem_globale_annuelle_proportion_H",
+		indicator_f_annual_men4:
+			"GIP-MDS | SUIT: Quartile4_Rem_globale_annuelle_proportion_H",
+		// Indicator F — hourly quartile thresholds (GIP-MDS)
+		indicator_f_hourly_threshold1:
+			"GIP-MDS | SUIT: Seuil_Q1_Taux_horaire_global",
+		indicator_f_hourly_threshold2:
+			"GIP-MDS | SUIT: Seuil_Q2_Taux_horaire_global",
+		indicator_f_hourly_threshold3:
+			"GIP-MDS | SUIT: Seuil_Q3_Taux_horaire_global",
+		indicator_f_hourly_threshold4:
+			"GIP-MDS | SUIT: Seuil_Q4_Taux_horaire_global",
+		// Indicator F — hourly quartile women counts → proportion F (GIP-MDS)
+		indicator_f_hourly_women1:
+			"GIP-MDS | SUIT: Quartile1_Taux_horaire_global_proportion_F",
+		indicator_f_hourly_women2:
+			"GIP-MDS | SUIT: Quartile2_Taux_horaire_global_proportion_F",
+		indicator_f_hourly_women3:
+			"GIP-MDS | SUIT: Quartile3_Taux_horaire_global_proportion_F",
+		indicator_f_hourly_women4:
+			"GIP-MDS | SUIT: Quartile4_Taux_horaire_global_proportion_F",
+		// Indicator F — hourly quartile men counts → proportion H (GIP-MDS)
+		indicator_f_hourly_men1:
+			"GIP-MDS | SUIT: Quartile1_Taux_horaire_global_proportion_H",
+		indicator_f_hourly_men2:
+			"GIP-MDS | SUIT: Quartile2_Taux_horaire_global_proportion_H",
+		indicator_f_hourly_men3:
+			"GIP-MDS | SUIT: Quartile3_Taux_horaire_global_proportion_H",
+		indicator_f_hourly_men4:
+			"GIP-MDS | SUIT: Quartile4_Taux_horaire_global_proportion_H",
+	},
 };


### PR DESCRIPTION
Closes #3313

## Summary

Fills `SCHEMA_COLUMN_COMMENTS` with entries for all indicator A–F columns in the `declaration` table.

Each entry follows the format `GIP-MDS | SUIT: <label>` where `<label>` is copied verbatim from `apiLabels.ts`, cross-referenced against `assembleDeclaration()` to ensure only SUIT-exposed labels are documented.

Coverage:
- Indicator A: 4 columns (annual/hourly × women/men)
- Indicator B: 4 columns (annual/hourly × women/men)
- Indicator C: 4 columns (annual/hourly × women/men)
- Indicator D: 4 columns (annual/hourly × women/men)
- Indicator E: 2 columns (women/men)
- Indicator F: 32 columns (4 quartiles × annual+hourly × threshold+women+men)

Total: 50 annotated columns.

Stacked on ticket/3312-post-processing-schema-wiki — GitHub will retarget to `alpha` once the parent is merged.

## Test plan

- [x] All 1546 existing unit tests pass (`pnpm test`)
- [x] Typecheck green (`pnpm typecheck`)
- [x] Lint + format green (`pnpm lint:check && pnpm format:check`)
- [x] `injectComments` test suite (10 tests) covers the lookup mechanism used by these annotations
- [x] validator, structural-auditor, security-auditor all PASS
- [x] No UI changes — RGAA and design-validator not applicable