### PR TITLE
feat(schema-wiki): annotate SUIT-exposed non-GIP columns (T2)

### DIFF
--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -16,5 +16,67 @@
 export type SchemaColumnComments = Record<string, Record<string, string>>;
 
 export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
-	// Filled by tickets T1 and T2.
+	// T1 entries (indicators A–F, GIP-MDS origin) are added by ticket T1.
+	// T2 entries below cover all other SUIT-exposed columns.
+	declaration: {
+		// Declaration identity & meta
+		siren: "SUIT: SIREN",
+		year: "SUIT: Annee",
+		status: "SUIT: Statut",
+		compliance_path: "SUIT: Parcours_conformite",
+		created_at: "SUIT: Date_creation",
+		updated_at: "SUIT: Date_modification",
+		// Workforce headcounts (company-declared, not GIP-MDS)
+		total_women: "SUIT: Effectif_F_rem_annuelle_globale",
+		total_men: "SUIT: Effectif_H_rem_annuelle_globale",
+		// Second declaration fields
+		second_declaration_status: "SUIT: Seconde_declaration.Statut",
+		second_decl_reference_period_start:
+			"SUIT: Seconde_declaration.Periode_reference_debut",
+		second_decl_reference_period_end:
+			"SUIT: Seconde_declaration.Periode_reference_fin",
+	},
+	company: {
+		name: "SUIT: Raison_sociale",
+		workforce: "SUIT: Effectif",
+		naf_code: "SUIT: Code_NAF",
+		address: "SUIT: Adresse",
+		has_cse: "SUIT: CSE_existant",
+	},
+	user: {
+		first_name: "SUIT: Declarant.Prenom",
+		last_name: "SUIT: Declarant.Nom",
+		email: "SUIT: Declarant.Email",
+		phone: "SUIT: Declarant.Telephone",
+	},
+	cse_opinion: {
+		declaration_number: "SUIT: Avis_CSE.Numero_declaration",
+		type: "SUIT: Avis_CSE.Type",
+		opinion: "SUIT: Avis_CSE.Avis",
+		opinion_date: "SUIT: Avis_CSE.Date",
+	},
+	file: {
+		id: "SUIT: Fichiers_CSE.Id / Fichier_evaluation_conjointe.Id",
+		file_name:
+			"SUIT: Fichiers_CSE.Nom_fichier / Fichier_evaluation_conjointe.Nom_fichier",
+		uploaded_at:
+			"SUIT: Fichiers_CSE.Date_upload / Fichier_evaluation_conjointe.Date_upload",
+	},
+	// Indicator G — company-calculated CSP pay gaps (no GIP-MDS origin)
+	job_category: {
+		name: "SUIT: Indicateurs.G.Nom_categorie",
+		detail: "SUIT: Indicateurs.G.Detail_categorie",
+	},
+	employee_category: {
+		women_count: "SUIT: Indicateurs.G.Effectif_F",
+		men_count: "SUIT: Indicateurs.G.Effectif_H",
+		annual_base_women: "SUIT: Indicateurs.G.Rem_annuelle_base_F",
+		annual_base_men: "SUIT: Indicateurs.G.Rem_annuelle_base_H",
+		annual_variable_women: "SUIT: Indicateurs.G.Rem_annuelle_variable_F",
+		annual_variable_men: "SUIT: Indicateurs.G.Rem_annuelle_variable_H",
+		hourly_base_women: "SUIT: Indicateurs.G.Taux_horaire_base_F",
+		hourly_base_men: "SUIT: Indicateurs.G.Taux_horaire_base_H",
+		hourly_variable_women: "SUIT: Indicateurs.G.Taux_horaire_variable_F",
+		hourly_variable_men: "SUIT: Indicateurs.G.Taux_horaire_variable_H",
+	},
 };


### PR DESCRIPTION
Closes #3314

## Résumé

Complète `SCHEMA_COLUMN_COMMENTS` avec les annotations des colonnes SUIT non-GIP :
- `declaration`: meta (SIREN, année, statut, dates, effectifs globaux, seconde déclaration)
- `company`: identité entreprise (raison sociale, NAF, adresse, CSE, effectif)
- `user`: champs déclarant exposés via SUIT (prénom, nom, email, téléphone)
- `cse_opinion`: avis CSE (numéro, type, avis, date)
- `file`: fichiers CSE + évaluation conjointe (id, nom, date upload)
- `job_category` + `employee_category`: indicateur G sans préfixe GIP-MDS

Format `SUIT: <label>` — labels copiés verbatim depuis `assembleDeclaration()`.

_Stacked on ticket/3312-post-processing-schema-wiki — GitHub retargettera automatiquement sur `alpha` une fois le parent mergé._

## Plan de test

- [ ] Typecheck vert
- [ ] Tests existants verts
- [ ] Lint vert
- [ ] Vérifier manuellement que chaque label correspond à une clé dans `assembleDeclaration()`
- [ ] Aucune colonne non exposée par SUIT n'est annotée