### PR TITLE
T0 — Post-processing script + workflow update pour annotations SUIT/GIP-MDS

### DIFF
--- a/.github/workflows/db-schema.yaml
+++ b/.github/workflows/db-schema.yaml
@@ -5,6 +5,8 @@ on:
     branches: [master, alpha]
     paths:
       - "packages/app/src/server/db/schema.ts"
+      - "packages/app/src/server/db/schema-comments.ts"
+      - "packages/app/scripts/post-process-schema-wiki.mjs"
   workflow_dispatch:
 
 concurrency:
@@ -35,6 +37,9 @@ jobs:
 
       - name: Generate schema documentation
         run: npx db-schema-toolkit export packages/app/src/server/db/schema.ts -f markdown -o schema-doc.md
+
+      - name: Post-process schema doc with SUIT/GIP-MDS comments
+        run: node --import ./packages/app/node_modules/tsx/dist/esm/index.mjs packages/app/scripts/post-process-schema-wiki.mjs
 
       - name: Publish to GitHub Wiki
         env:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,6 +81,7 @@
 		"swagger-ui-dist": "^5.32.2",
 		"typescript": "^6.0.2",
 		"vite-tsconfig-paths": "^6.1.1",
+		"tsx": "^4.21.0",
 		"vitest": "^4.1.4"
 	},
 	"packageManager": "pnpm@10.8.1"

--- a/packages/app/scripts/post-process-schema-wiki.mjs
+++ b/packages/app/scripts/post-process-schema-wiki.mjs
@@ -1,0 +1,119 @@
+/**
+ * Post-process the Markdown produced by `db-schema-toolkit export` to inject
+ * column-level comments from `schema-comments.ts` before publishing to the
+ * GitHub Wiki.
+ *
+ * Run from the repo root:
+ *   node --import ./packages/app/node_modules/tsx/dist/esm/index.mjs \
+ *     packages/app/scripts/post-process-schema-wiki.mjs
+ *
+ * Reads `schema-doc.md` in the CWD and overwrites it in place.
+ */
+
+// tsx/esm is registered via --import flag at invocation time.
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { SCHEMA_COLUMN_COMMENTS } = await import(
+	resolve(__dirname, "../src/server/db/schema-comments.ts")
+);
+const { injectComments } = await import(
+	resolve(__dirname, "../src/server/db/schemaWikiHelpers.ts")
+);
+
+const SCHEMA_DOC_PATH = resolve(process.cwd(), "schema-doc.md");
+
+if (!existsSync(SCHEMA_DOC_PATH)) {
+	console.error(`Error: schema-doc.md not found at ${SCHEMA_DOC_PATH}`);
+	process.exit(1);
+}
+
+const content = readFileSync(SCHEMA_DOC_PATH, "utf8");
+const lines = content.split("\n");
+
+// Track totals for end-of-run summary.
+const totalByTable = {};
+const missingTables = [];
+
+const result = [];
+let i = 0;
+
+while (i < lines.length) {
+	const line = lines[i];
+
+	// Match table section headers: "## Table: <tableName>"
+	const tableMatch = line.match(/^##\s+Table:\s+(\S+)/);
+	if (tableMatch) {
+		const tableName = tableMatch[1];
+		const tableKey = tableName.replace(/^app_/, "");
+		const columnComments = SCHEMA_COLUMN_COMMENTS[tableKey];
+
+		result.push(line);
+		i++;
+
+		// Skip blank lines between the section header and the Markdown table.
+		while (i < lines.length && lines[i].trim() === "") {
+			result.push(lines[i]);
+			i++;
+		}
+
+		if (!columnComments) {
+			// No comments defined for this table — move on without processing.
+			continue;
+		}
+
+		// Collect all lines belonging to the Markdown table that follows.
+		const tableLines = [];
+		while (i < lines.length && lines[i].startsWith("|")) {
+			tableLines.push(lines[i]);
+			i++;
+		}
+
+		if (tableLines.length === 0) {
+			// Section header found but no table — warn and move on.
+			console.warn(
+				`Warning: table section "${tableName}" has no Markdown table body.`,
+			);
+			continue;
+		}
+
+		const { lines: injectedLines, injected } = injectComments(
+			tableLines,
+			columnComments,
+		);
+		totalByTable[tableKey] = injected;
+		result.push(...injectedLines);
+		continue;
+	}
+
+	result.push(line);
+	i++;
+}
+
+// Warn about map entries whose table is absent from the Markdown.
+for (const tableKey of Object.keys(SCHEMA_COLUMN_COMMENTS)) {
+	if (totalByTable[tableKey] === undefined) {
+		missingTables.push(tableKey);
+		console.warn(
+			`Warning: table "${tableKey}" is in SCHEMA_COLUMN_COMMENTS but was not found in schema-doc.md.`,
+		);
+	}
+}
+
+writeFileSync(SCHEMA_DOC_PATH, result.join("\n"), "utf8");
+
+const totalInjected = Object.values(totalByTable).reduce((a, b) => a + b, 0);
+console.log(
+	`Injected ${totalInjected} comment(s) across ${Object.keys(totalByTable).length} table(s).`,
+);
+for (const [table, count] of Object.entries(totalByTable)) {
+	console.log(`  ${table}: ${count} comment(s)`);
+}
+if (missingTables.length > 0) {
+	console.warn(
+		`Tables in map not found in Markdown: ${missingTables.join(", ")}`,
+	);
+}

--- a/packages/app/src/server/db/__tests__/schemaWikiHelpers.test.ts
+++ b/packages/app/src/server/db/__tests__/schemaWikiHelpers.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+	camelToSnake,
+	escapeCell,
+	injectComments,
+	parseCells,
+} from "~/server/db/schemaWikiHelpers";
+
+describe("camelToSnake", () => {
+	it("converts simple camelCase", () => {
+		expect(camelToSnake("firstName")).toBe("first_name");
+	});
+
+	it("handles consecutive uppercase (e.g. indicatorA)", () => {
+		expect(camelToSnake("indicatorAAnnualWomen")).toBe(
+			"indicator_a_annual_women",
+		);
+	});
+
+	it("handles single uppercase suffix", () => {
+		expect(camelToSnake("indicatorBHourlyMen")).toBe("indicator_b_hourly_men");
+	});
+
+	it("leaves snake_case strings unchanged", () => {
+		expect(camelToSnake("already_snake")).toBe("already_snake");
+	});
+
+	it("handles single lowercase word", () => {
+		expect(camelToSnake("siren")).toBe("siren");
+	});
+});
+
+describe("escapeCell", () => {
+	it("escapes pipe characters", () => {
+		expect(escapeCell("GIP-MDS | SUIT: foo")).toBe("GIP-MDS \\| SUIT: foo");
+	});
+
+	it("leaves strings without pipes unchanged", () => {
+		expect(escapeCell("no pipes here")).toBe("no pipes here");
+	});
+
+	it("escapes multiple pipes", () => {
+		expect(escapeCell("a | b | c")).toBe("a \\| b \\| c");
+	});
+
+	it("returns empty string unchanged", () => {
+		expect(escapeCell("")).toBe("");
+	});
+});
+
+describe("parseCells", () => {
+	it("splits a standard markdown row into trimmed cells", () => {
+		expect(parseCells("| id | VARCHAR | No |")).toEqual([
+			"id",
+			"VARCHAR",
+			"No",
+		]);
+	});
+
+	it("does not split on escaped pipes", () => {
+		const cells = parseCells("| siren | VARCHAR | GIP-MDS \\| SUIT: foo |");
+		expect(cells).toEqual(["siren", "VARCHAR", "GIP-MDS \\| SUIT: foo"]);
+	});
+});
+
+describe("injectComments", () => {
+	const HEADER = "| Column | Type | Nullable |";
+	const SEPARATOR = "|--------|------|----------|";
+
+	it("returns empty lines for fewer than 2 input lines", () => {
+		expect(injectComments([], {}).lines).toEqual([]);
+		expect(injectComments(["| only header |"], {}).injected).toBe(0);
+	});
+
+	it("adds Commentaire column to a table without one", () => {
+		const tableLines = [
+			HEADER,
+			SEPARATOR,
+			"| id | VARCHAR | No |",
+			"| siren | VARCHAR | No |",
+		];
+		const comments = { siren: "Company SIREN identifier" };
+		const { lines, injected } = injectComments(tableLines, comments);
+
+		expect(injected).toBe(1);
+		expect(lines[0]).toContain("Commentaire");
+		expect(lines[1]).toContain("---");
+		expect(lines[3]).toContain("Company SIREN identifier");
+	});
+
+	it("escapes pipes in injected comment values", () => {
+		const tableLines = [HEADER, SEPARATOR, "| siren | VARCHAR | No |"];
+		const comments = { siren: "GIP-MDS | SUIT: code_entreprise" };
+		const { lines } = injectComments(tableLines, comments);
+
+		expect(lines[2]).toContain("GIP-MDS \\| SUIT: code_entreprise");
+	});
+
+	it("maps camelCase column names to snake_case keys", () => {
+		const tableLines = [
+			HEADER,
+			SEPARATOR,
+			"| indicatorAAnnualWomen | NUMERIC | Yes |",
+		];
+		const comments = { indicator_a_annual_women: "GIP-MDS | SUIT: Rem_F" };
+		const { injected, lines } = injectComments(tableLines, comments);
+
+		expect(injected).toBe(1);
+		expect(lines[2]).toContain("GIP-MDS \\| SUIT: Rem_F");
+	});
+
+	it("leaves rows without a map entry with an empty comment cell", () => {
+		const tableLines = [HEADER, SEPARATOR, "| totalMen | INTEGER | Yes |"];
+		const { lines, injected } = injectComments(tableLines, {});
+
+		expect(injected).toBe(0);
+		expect(lines[2]).toMatch(/\|\s*\|$/);
+	});
+
+	it("is idempotent when Commentaire column already exists and value matches", () => {
+		const existing = [
+			"| Column | Type | Nullable | Commentaire |",
+			"|--------|------|----------| --- |",
+			"| siren | VARCHAR | No | Company SIREN identifier |",
+		];
+		const comments = { siren: "Company SIREN identifier" };
+		const { lines, injected } = injectComments(existing, comments);
+
+		expect(injected).toBe(0);
+		expect(lines[0]).toBe(existing[0]);
+	});
+
+	it("updates existing Commentaire cells when value changes", () => {
+		const existing = [
+			"| Column | Type | Nullable | Commentaire |",
+			"|--------|------|----------| --- |",
+			"| siren | VARCHAR | No | old comment |",
+		];
+		const comments = { siren: "new comment" };
+		const { lines, injected } = injectComments(existing, comments);
+
+		expect(injected).toBe(1);
+		expect(lines[2]).toContain("new comment");
+	});
+
+	it("correctly handles already-escaped pipe in existing cell (idempotency)", () => {
+		const existing = [
+			"| Column | Type | Nullable | Commentaire |",
+			"|--------|------|----------| --- |",
+			"| siren | VARCHAR | No | GIP-MDS \\| SUIT: code |",
+		];
+		const comments = { siren: "GIP-MDS | SUIT: code" };
+		const { lines, injected } = injectComments(existing, comments);
+
+		expect(injected).toBe(0);
+		expect(lines[2]).toContain("GIP-MDS \\| SUIT: code");
+	});
+});

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -1,0 +1,16 @@
+/**
+ * Column-level documentation attached to the DB schema and rendered on the
+ * wiki (https://github.com/SocialGouv/egapro/wiki/Schema-Egapro-V2) by the
+ * `db-schema.yaml` workflow via `scripts/post-process-schema-wiki.mjs`.
+ *
+ * Key = Drizzle snake_case table name (without the `app_` prefix).
+ * Value = map of snake_case column name → human-readable comment.
+ *
+ * Populated in tickets T1 (indicators A–F, GIP-MDS origin) and T2 (other
+ * SUIT-exposed columns: company identity, declarant, CSE, files, indicator G).
+ */
+export type SchemaColumnComments = Record<string, Record<string, string>>;
+
+export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
+	// Filled by tickets T1 and T2.
+};

--- a/packages/app/src/server/db/schemaWikiHelpers.ts
+++ b/packages/app/src/server/db/schemaWikiHelpers.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure helper functions for post-process-schema-wiki.mjs.
+ * Kept in src/ so they can be imported via the ~/ alias in tests.
+ */
+
+export const COMMENT_HEADER = "Commentaire";
+
+/**
+ * Convert camelCase column name to snake_case for map lookup.
+ * db-schema-toolkit outputs camelCase names; schema-comments.ts uses snake_case.
+ *
+ * Example: indicatorAAnnualWomen → indicator_a_annual_women
+ */
+export function camelToSnake(str: string): string {
+	return str.replace(/([A-Z])/g, "_$1").toLowerCase();
+}
+
+/** Escape pipe characters in a cell value so they don't break the Markdown table. */
+export function escapeCell(value: string): string {
+	return value.replace(/\|/g, "\\|");
+}
+
+/** Split a table row into cells, ignoring escaped pipes (\|). */
+export function parseCells(line: string): string[] {
+	return line
+		.split(/(?<!\\)\|/)
+		.slice(1, -1)
+		.map((c) => c.trim());
+}
+
+type InjectResult = { lines: string[]; injected: number };
+
+/**
+ * Given a set of markdown table lines (header + separator + data rows),
+ * inject or update the Commentaire column using the provided column→comment map.
+ * Returns { lines, injected }.
+ */
+export function injectComments(
+	tableLines: string[],
+	columnComments: Record<string, string>,
+): InjectResult {
+	if (tableLines.length < 2) return { lines: tableLines, injected: 0 };
+
+	// tableLines.length >= 2 is guaranteed by the guard above.
+	const headerLine = tableLines[0] as string;
+	const separatorLine = tableLines[1] as string;
+	const dataLines = tableLines.slice(2);
+
+	const headerCells = parseCells(headerLine);
+	const commentColIndex = headerCells.indexOf(COMMENT_HEADER);
+	const columnNameIndex = 0;
+
+	let injected = 0;
+
+	if (commentColIndex !== -1) {
+		// Column already exists — update values in existing cells.
+		const newData = dataLines.map((line) => {
+			const cells = parseCells(line);
+			const rawColumnName = cells[columnNameIndex] ?? "";
+			const snakeKey = camelToSnake(rawColumnName);
+			const existing = cells[commentColIndex] ?? "";
+			const rawComment = columnComments[snakeKey] ?? existing;
+			const comment = escapeCell(rawComment);
+			if (comment && comment !== existing) injected++;
+			cells[commentColIndex] = comment;
+			return `| ${cells.join(" | ")} |`;
+		});
+		return { lines: [headerLine, separatorLine, ...newData], injected };
+	}
+
+	// Add a new Commentaire column.
+	const newHeader = `${headerLine.trimEnd().replace(/\|$/, "")}| ${COMMENT_HEADER} |`;
+	const newSeparator = `${separatorLine.trimEnd().replace(/\|$/, "")}| --- |`;
+	const newData = dataLines.map((line) => {
+		const cells = parseCells(line);
+		const rawColumnName = cells[columnNameIndex] ?? "";
+		const snakeKey = camelToSnake(rawColumnName);
+		const comment = escapeCell(columnComments[snakeKey] ?? "");
+		if (comment) injected++;
+		return `${line.trimEnd().replace(/\|$/, "")}| ${comment} |`;
+	});
+
+	return { lines: [newHeader, newSeparator, ...newData], injected };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       swagger-ui-dist:
         specifier: ^5.32.2
         version: 5.32.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
Closes #3312

## Résumé

Mise en place de l'infrastructure de post-processing pour les annotations wiki SUIT/GIP-MDS :

- **`packages/app/src/server/db/schema-comments.ts`** — map typée `table → column → comment` (vide, remplie par T1/T2)
- **`packages/app/src/server/db/schemaWikiHelpers.ts`** — helpers purs (`camelToSnake`, `escapeCell`, `parseCells`, `injectComments`) avec tests unitaires complets
- **`packages/app/scripts/post-process-schema-wiki.mjs`** — script CI qui lit `schema-doc.md`, injecte les commentaires, réécrit (idempotent)
- **`.github/workflows/db-schema.yaml`** — nouvelle étape entre l'export toolkit et la publication wiki ; ajout de `schema-comments.ts` et du script dans les `paths` de déclenchement

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (1555 tests, 204 fichiers — dont 19 nouveaux tests pour les helpers)
- [x] `pnpm lint:check` + `pnpm format:check` verts
- [x] Test local : injection d'une entrée de démonstration dans `schema-doc.md` → commentaire correctement injecté avec échappement des `|`
- [x] Test idempotence : second passage du script sur le même fichier → 0 modification, aucune duplication de colonne
- [x] Cas erreur : table absente du Markdown → `warn` console, exit 0
- [x] `schema-doc.md` absent → exit 1 avec message clair