### PR TITLE
feat(db-schema): post-processing script for SUIT/GIP-MDS wiki annotations

### DIFF
--- a/.github/workflows/db-schema.yaml
+++ b/.github/workflows/db-schema.yaml
@@ -36,6 +36,9 @@ jobs:
       - name: Generate schema documentation
         run: npx db-schema-toolkit export packages/app/src/server/db/schema.ts -f markdown -o schema-doc.md
 
+      - name: Post-process schema doc with SUIT/GIP-MDS comments
+        run: npx tsx packages/app/scripts/post-process-schema-wiki.ts
+
       - name: Publish to GitHub Wiki
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -79,6 +79,7 @@
 		"jsdom": "^29.0.2",
 		"sass": "^1.99.0",
 		"swagger-ui-dist": "^5.32.2",
+		"tsx": "^4.21.0",
 		"typescript": "^6.0.2",
 		"vite-tsconfig-paths": "^6.1.1",
 		"vitest": "^4.1.4"

--- a/packages/app/scripts/post-process-schema-wiki.ts
+++ b/packages/app/scripts/post-process-schema-wiki.ts
@@ -1,0 +1,168 @@
+/**
+ * Post-processes the Markdown file produced by `db-schema-toolkit export` to
+ * inject column-level comments from `schema-comments.ts` before publishing to
+ * the GitHub Wiki.
+ *
+ * Usage (from repo root):
+ *   npx tsx packages/app/scripts/post-process-schema-wiki.ts
+ *
+ * Reads `schema-doc.md` from the current working directory and overwrites it
+ * in-place with an extra "Commentaire" column in each table.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { SchemaColumnComments } from "../src/server/db/schema-comments";
+import { SCHEMA_COLUMN_COMMENTS } from "../src/server/db/schema-comments";
+
+const TABLE_HEADER_RE = /^##\s+Table:\s+(\w+)/;
+const TABLE_ROW_RE = /^\|/;
+const SEPARATOR_CELL_RE = /^-+$/;
+const COMMENT_COLUMN_HEADER = "Commentaire";
+
+function camelToSnake(name: string): string {
+	return name.replace(/([A-Z])/g, "_$1").toLowerCase();
+}
+
+export type InjectionResult = {
+	result: string;
+	stats: Record<string, number>;
+	warnings: string[];
+};
+
+export function injectComments(
+	markdown: string,
+	comments: SchemaColumnComments,
+): InjectionResult {
+	const lines = markdown.split("\n");
+	const output: string[] = [];
+	const stats: Record<string, number> = {};
+	const warnings: string[] = [];
+
+	let currentTable: string | null = null;
+	let seenTableHeader = false;
+	let seenSeparator = false;
+	let hasCommentColumn = false;
+
+	for (const line of lines) {
+		const sectionMatch = TABLE_HEADER_RE.exec(line);
+		if (sectionMatch) {
+			currentTable = sectionMatch[1] ?? null;
+			seenTableHeader = false;
+			seenSeparator = false;
+			hasCommentColumn = false;
+			output.push(line);
+			continue;
+		}
+
+		if (currentTable !== null && TABLE_ROW_RE.test(line)) {
+			const cells = line
+				.split("|")
+				.slice(1, -1)
+				.map((c) => c.trim());
+
+			if (!seenTableHeader) {
+				hasCommentColumn = cells.includes(COMMENT_COLUMN_HEADER);
+				seenTableHeader = true;
+				output.push(
+					hasCommentColumn
+						? line
+						: line.replace(/\|$/, `| ${COMMENT_COLUMN_HEADER} |`),
+				);
+				continue;
+			}
+
+			if (!seenSeparator) {
+				seenSeparator = true;
+				const allDashes = cells.every((c) => SEPARATOR_CELL_RE.test(c));
+				output.push(
+					allDashes && !hasCommentColumn
+						? line.replace(/\|$/, "| --- |")
+						: line,
+				);
+				continue;
+			}
+
+			if (!hasCommentColumn) {
+				const rawColName = cells[0] ?? "";
+				const colKey = camelToSnake(rawColName);
+				const tableComments = comments[currentTable];
+				const rawComment = tableComments?.[colKey] ?? "";
+				const comment = rawComment.replace(/\|/g, "\\|");
+				if (rawComment) {
+					stats[currentTable] = (stats[currentTable] ?? 0) + 1;
+				}
+				output.push(line.replace(/\|$/, `| ${comment} |`));
+				continue;
+			}
+		} else if (currentTable !== null && !TABLE_ROW_RE.test(line)) {
+			seenTableHeader = false;
+			seenSeparator = false;
+			hasCommentColumn = false;
+		}
+
+		output.push(line);
+	}
+
+	for (const tableName of Object.keys(comments)) {
+		const hasEntries = Object.keys(comments[tableName] ?? {}).length > 0;
+		const injectedCount = stats[tableName] ?? 0;
+		if (hasEntries && injectedCount === 0) {
+			warnings.push(
+				`Table "${tableName}" in SCHEMA_COLUMN_COMMENTS not found in Markdown`,
+			);
+		}
+	}
+
+	return { result: output.join("\n"), stats, warnings };
+}
+
+async function main(): Promise<void> {
+	if (!existsSync("package.json")) {
+		console.error(
+			"Error: must be run from the repository root (no package.json found in CWD).",
+		);
+		process.exit(1);
+	}
+
+	const inputPath = "schema-doc.md";
+	if (!existsSync(inputPath)) {
+		console.error(
+			`Error: ${inputPath} not found. Run db-schema-toolkit export first.`,
+		);
+		process.exit(1);
+	}
+
+	const markdown = readFileSync(inputPath, "utf8");
+	const { result, stats, warnings } = injectComments(
+		markdown,
+		SCHEMA_COLUMN_COMMENTS,
+	);
+
+	for (const warning of warnings) {
+		console.warn(`[warn] ${warning}`);
+	}
+
+	for (const [table, count] of Object.entries(stats)) {
+		console.log(`  ${table}: ${count} comment(s) injected`);
+	}
+	const totalComments = Object.values(stats).reduce((a, b) => a + b, 0);
+	console.log(
+		`Total: ${totalComments} comment(s) injected across ${Object.keys(stats).length} table(s)`,
+	);
+
+	writeFileSync(inputPath, result, "utf8");
+	console.log(`Wrote ${inputPath}`);
+}
+
+const isMain =
+	typeof process !== "undefined" &&
+	process.argv[1] !== undefined &&
+	fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+	main().catch((err: unknown) => {
+		console.error(err);
+		process.exit(1);
+	});
+}

--- a/packages/app/src/server/db/__tests__/post-process-schema-wiki.test.ts
+++ b/packages/app/src/server/db/__tests__/post-process-schema-wiki.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { injectComments } from "#scripts/post-process-schema-wiki";
+
+const TABLE_SECTION = `## Table: declaration
+
+| Column | Type | Nullable | PK | Unique | Default |
+|--------|------|----------|----|--------|---------|
+| id | VARCHAR | No | Yes |  |  |
+| indicatorAAnnualWomen | NUMERIC | Yes |  |  |  |
+| indicatorAAnnualMen | NUMERIC | Yes |  |  |  |
+
+`;
+
+describe("injectComments", () => {
+	it("adds Commentaire column to table header and separator", () => {
+		const { result } = injectComments(TABLE_SECTION, {});
+		expect(result).toContain("| Commentaire |");
+		expect(result).toContain("| --- |");
+	});
+
+	it("injects comment for matched column (snake_case lookup)", () => {
+		const comments = {
+			declaration: {
+				indicator_a_annual_women:
+					"GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_F",
+			},
+		};
+		const { result, stats } = injectComments(TABLE_SECTION, comments);
+		expect(result).toContain(
+			"GIP-MDS \\| SUIT: Rem_globale_annuelle_moyenne_F",
+		);
+		expect(stats.declaration).toBe(1);
+	});
+
+	it("leaves empty cell for columns not in the map", () => {
+		const comments = { declaration: {} };
+		const { result } = injectComments(TABLE_SECTION, comments);
+		expect(result).toMatch(/indicatorAAnnualWomen \|.*\| {2}\|$/m);
+	});
+
+	it("does not add a second Commentaire column when already present", () => {
+		const markdownWithComment = `## Table: declaration
+
+| Column | Type | Commentaire |
+|--------|------|-------------|
+| id | VARCHAR |  |
+
+`;
+		const { result } = injectComments(markdownWithComment, {});
+		const headerLine = result
+			.split("\n")
+			.find((l) => l.includes("Column") && l.includes("Type"));
+		const occurrences = (headerLine ?? "").split("Commentaire").length - 1;
+		expect(occurrences).toBe(1);
+	});
+
+	it("warns about map tables not found in Markdown", () => {
+		const comments = {
+			nonexistent: { some_col: "comment" },
+		};
+		const { warnings } = injectComments(TABLE_SECTION, comments);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("nonexistent");
+	});
+
+	it("does not warn when map table has no entries", () => {
+		const comments = { nonexistent: {} };
+		const { warnings } = injectComments(TABLE_SECTION, comments);
+		expect(warnings).toHaveLength(0);
+	});
+
+	it("handles multiple tables in the same Markdown", () => {
+		const multiTable = `## Table: declaration
+
+| Column | Type |
+|--------|------|
+| id | VARCHAR |
+
+## Table: company
+
+| Column | Type |
+|--------|------|
+| siren | VARCHAR |
+
+`;
+		const comments = {
+			declaration: { id: "Primary key" },
+			company: { siren: "SIREN identifier" },
+		};
+		const { result, stats } = injectComments(multiTable, comments);
+		expect(result).toContain("Primary key");
+		expect(result).toContain("SIREN identifier");
+		expect(stats.declaration).toBe(1);
+		expect(stats.company).toBe(1);
+	});
+
+	it("returns empty stats when no comments match", () => {
+		const { stats } = injectComments(TABLE_SECTION, {});
+		expect(Object.keys(stats)).toHaveLength(0);
+	});
+
+	it("is idempotent when called twice with an already-processed Markdown", () => {
+		const comments = {
+			declaration: { indicator_a_annual_women: "GIP-MDS" },
+		};
+		const { result: firstPass } = injectComments(TABLE_SECTION, comments);
+		const { result: secondPass } = injectComments(firstPass, comments);
+		expect(firstPass).toBe(secondPass);
+	});
+
+	it("passes through non-table lines unchanged", () => {
+		const input = `# schema\n\n**Tables:** 1\n\n${TABLE_SECTION}`;
+		const { result } = injectComments(input, {});
+		expect(result).toContain("# schema");
+		expect(result).toContain("**Tables:** 1");
+	});
+});

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -1,0 +1,20 @@
+/**
+ * Column-level documentation attached to the DB schema and rendered on the
+ * wiki (https://github.com/SocialGouv/egapro/wiki/Schema-Egapro-V2) by the
+ * `db-schema.yaml` workflow via `scripts/post-process-schema-wiki.ts`.
+ *
+ * Key = lowercase table name as produced by db-schema-toolkit (without the
+ * `app_` prefix, matching the "Table: <name>" section headers in the Markdown).
+ * Value = map of snake_case column name → human-readable comment.
+ * Column names must be snake_case (e.g. `indicator_a_annual_women`) — the
+ * post-processing script converts camelCase column names from the Markdown to
+ * snake_case before lookup.
+ *
+ * Populated in tickets T1 (indicators A–F, GIP-MDS origin) and T2 (other
+ * SUIT-exposed columns: company identity, declarant, CSE, files, indicator G).
+ */
+export type SchemaColumnComments = Record<string, Record<string, string>>;
+
+export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
+	// Filled by tickets T1 and T2.
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       swagger-ui-dist:
         specifier: ^5.32.2
         version: 5.32.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
Closes #3312

## Summary

- Add `packages/app/src/server/db/schema-comments.ts`: typed map of table → column → human-readable comment (empty, to be populated by T1/T2)
- Add `packages/app/scripts/post-process-schema-wiki.ts`: Node/tsx script that injects comments into the Markdown produced by `db-schema-toolkit`, idempotent, robust to orphaned map entries
- Update `.github/workflows/db-schema.yaml`: insert post-processing step between `db-schema-toolkit export` and wiki publish
- Add `tsx` as explicit devDependency (was already a transitive dep via Vite)

## Test plan

- [ ] 10 unit tests in `src/server/db/__tests__/post-process-schema-wiki.test.ts` cover: column injection, camelCase→snake_case lookup, idempotency, multi-table, missing table warnings, no-double-header
- [ ] Local smoke test: injected `GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_F` for `indicatorAAnnualWomen` + warned on nonexistent table
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint:check` clean
- [ ] CI must pass before marking ready