### PR TITLE
T2 — Annotations colonnes non-GIP (SUIT) dans schema-comments.ts

### DIFF
--- a/packages/app/src/server/db/__tests__/schema-comments.test.ts
+++ b/packages/app/src/server/db/__tests__/schema-comments.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import { SCHEMA_COLUMN_COMMENTS } from "../schema-comments";
+
+describe("SCHEMA_COLUMN_COMMENTS — T2 non-GIP entries", () => {
+	describe("declaration table", () => {
+		it("annotates siren", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.siren).toBe("SUIT: SIREN");
+		});
+		it("annotates year", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.year).toBe("SUIT: Annee");
+		});
+		it("annotates status", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.status).toBe("SUIT: Statut");
+		});
+		it("annotates compliance_path", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.compliance_path).toBe(
+				"SUIT: Parcours_conformite",
+			);
+		});
+		it("annotates total_women", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.total_women).toBe(
+				"SUIT: Effectif_F_rem_annuelle_globale",
+			);
+		});
+		it("annotates total_men", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.total_men).toBe(
+				"SUIT: Effectif_H_rem_annuelle_globale",
+			);
+		});
+		it("annotates created_at", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.created_at).toBe(
+				"SUIT: Date_creation",
+			);
+		});
+		it("annotates updated_at", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.declaration?.updated_at).toBe(
+				"SUIT: Date_modification",
+			);
+		});
+		it("annotates second_declaration_status", () => {
+			expect(
+				SCHEMA_COLUMN_COMMENTS.declaration?.second_declaration_status,
+			).toBe("SUIT: Seconde_declaration.Statut");
+		});
+		it("annotates second_decl_reference_period_start", () => {
+			expect(
+				SCHEMA_COLUMN_COMMENTS.declaration?.second_decl_reference_period_start,
+			).toBe("SUIT: Seconde_declaration.Periode_reference_debut");
+		});
+		it("annotates second_decl_reference_period_end", () => {
+			expect(
+				SCHEMA_COLUMN_COMMENTS.declaration?.second_decl_reference_period_end,
+			).toBe("SUIT: Seconde_declaration.Periode_reference_fin");
+		});
+	});
+
+	describe("company table", () => {
+		it("annotates name", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.company?.name).toBe("SUIT: Raison_sociale");
+		});
+		it("annotates workforce", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.company?.workforce).toBe("SUIT: Effectif");
+		});
+		it("annotates naf_code", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.company?.naf_code).toBe("SUIT: Code_NAF");
+		});
+		it("annotates address", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.company?.address).toBe("SUIT: Adresse");
+		});
+		it("annotates has_cse", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.company?.has_cse).toBe(
+				"SUIT: CSE_existant",
+			);
+		});
+	});
+
+	describe("user table", () => {
+		it("annotates first_name", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.user?.first_name).toBe(
+				"SUIT: Declarant.Prenom",
+			);
+		});
+		it("annotates last_name", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.user?.last_name).toBe(
+				"SUIT: Declarant.Nom",
+			);
+		});
+		it("annotates email", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.user?.email).toBe("SUIT: Declarant.Email");
+		});
+		it("annotates phone", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.user?.phone).toBe(
+				"SUIT: Declarant.Telephone",
+			);
+		});
+	});
+
+	describe("cse_opinion table", () => {
+		it("annotates declaration_number", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.cse_opinion?.declaration_number).toBe(
+				"SUIT: Avis_CSE.Numero_declaration",
+			);
+		});
+		it("annotates type", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.cse_opinion?.type).toBe(
+				"SUIT: Avis_CSE.Type",
+			);
+		});
+		it("annotates opinion", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.cse_opinion?.opinion).toBe(
+				"SUIT: Avis_CSE.Avis",
+			);
+		});
+		it("annotates opinion_date", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.cse_opinion?.opinion_date).toBe(
+				"SUIT: Avis_CSE.Date",
+			);
+		});
+	});
+
+	describe("file table", () => {
+		it("annotates id", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.file?.id).toBe("SUIT: Fichiers.Id");
+		});
+		it("annotates file_name", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.file?.file_name).toBe(
+				"SUIT: Fichiers.Nom_fichier",
+			);
+		});
+		it("annotates uploaded_at", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.file?.uploaded_at).toBe(
+				"SUIT: Fichiers.Date_upload",
+			);
+		});
+	});
+
+	describe("job_category table (indicator G)", () => {
+		it("annotates name", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.job_category?.name).toBe(
+				"SUIT: Indicateurs.G.Nom_categorie",
+			);
+		});
+		it("annotates detail", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.job_category?.detail).toBe(
+				"SUIT: Indicateurs.G.Detail_categorie",
+			);
+		});
+	});
+
+	describe("employee_category table (indicator G)", () => {
+		it("annotates women_count", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.employee_category?.women_count).toBe(
+				"SUIT: Indicateurs.G.Effectif_F",
+			);
+		});
+		it("annotates men_count", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.employee_category?.men_count).toBe(
+				"SUIT: Indicateurs.G.Effectif_H",
+			);
+		});
+		it("annotates annual_base_women", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.employee_category?.annual_base_women).toBe(
+				"SUIT: Indicateurs.G.Rem_annuelle_base_F",
+			);
+		});
+		it("annotates annual_base_men", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.employee_category?.annual_base_men).toBe(
+				"SUIT: Indicateurs.G.Rem_annuelle_base_H",
+			);
+		});
+		it("annotates annual_variable_women", () => {
+			expect(
+				SCHEMA_COLUMN_COMMENTS.employee_category?.annual_variable_women,
+			).toBe("SUIT: Indicateurs.G.Rem_annuelle_variable_F");
+		});
+		it("annotates annual_variable_men", () => {
+			expect(
+				SCHEMA_COLUMN_COMMENTS.employee_category?.annual_variable_men,
+			).toBe("SUIT: Indicateurs.G.Rem_annuelle_variable_H");
+		});
+		it("annotates hourly_base_women", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.employee_category?.hourly_base_women).toBe(
+				"SUIT: Indicateurs.G.Taux_horaire_base_F",
+			);
+		});
+		it("annotates hourly_base_men", () => {
+			expect(SCHEMA_COLUMN_COMMENTS.employee_category?.hourly_base_men).toBe(
+				"SUIT: Indicateurs.G.Taux_horaire_base_H",
+			);
+		});
+		it("annotates hourly_variable_women", () => {
+			expect(
+				SCHEMA_COLUMN_COMMENTS.employee_category?.hourly_variable_women,
+			).toBe("SUIT: Indicateurs.G.Taux_horaire_variable_F");
+		});
+		it("annotates hourly_variable_men", () => {
+			expect(
+				SCHEMA_COLUMN_COMMENTS.employee_category?.hourly_variable_men,
+			).toBe("SUIT: Indicateurs.G.Taux_horaire_variable_H");
+		});
+	});
+
+	describe("format invariants", () => {
+		it("all T2 table entries start with SUIT: (no GIP-MDS prefix)", () => {
+			const t2Tables = [
+				"company",
+				"user",
+				"cse_opinion",
+				"file",
+				"job_category",
+				"employee_category",
+			];
+			for (const table of t2Tables) {
+				for (const [col, comment] of Object.entries(
+					SCHEMA_COLUMN_COMMENTS[table] ?? {},
+				)) {
+					expect(comment, `${table}.${col} should start with "SUIT: "`).toMatch(
+						/^SUIT: /,
+					);
+				}
+			}
+		});
+
+		it("declaration T2 entries start with SUIT: (no GIP-MDS prefix)", () => {
+			const t2DeclarationKeys = [
+				"siren",
+				"year",
+				"status",
+				"compliance_path",
+				"total_women",
+				"total_men",
+				"created_at",
+				"updated_at",
+				"second_declaration_status",
+				"second_decl_reference_period_start",
+				"second_decl_reference_period_end",
+			];
+			for (const key of t2DeclarationKeys) {
+				const comment = SCHEMA_COLUMN_COMMENTS.declaration?.[key];
+				expect(comment, `declaration.${key}`).toMatch(/^SUIT: /);
+			}
+		});
+	});
+});

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -16,5 +16,69 @@
 export type SchemaColumnComments = Record<string, Record<string, string>>;
 
 export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
-	// Filled by tickets T1 and T2.
+	// Filled by tickets T1 (declaration indicators A–F) and T2 (everything else).
+
+	declaration: {
+		// Meta
+		siren: "SUIT: SIREN",
+		year: "SUIT: Annee",
+		status: "SUIT: Statut",
+		compliance_path: "SUIT: Parcours_conformite",
+		total_women: "SUIT: Effectif_F_rem_annuelle_globale",
+		total_men: "SUIT: Effectif_H_rem_annuelle_globale",
+		created_at: "SUIT: Date_creation",
+		updated_at: "SUIT: Date_modification",
+		// Second declaration
+		second_declaration_status: "SUIT: Seconde_declaration.Statut",
+		second_decl_reference_period_start:
+			"SUIT: Seconde_declaration.Periode_reference_debut",
+		second_decl_reference_period_end:
+			"SUIT: Seconde_declaration.Periode_reference_fin",
+	},
+
+	company: {
+		name: "SUIT: Raison_sociale",
+		workforce: "SUIT: Effectif",
+		naf_code: "SUIT: Code_NAF",
+		address: "SUIT: Adresse",
+		has_cse: "SUIT: CSE_existant",
+	},
+
+	user: {
+		first_name: "SUIT: Declarant.Prenom",
+		last_name: "SUIT: Declarant.Nom",
+		email: "SUIT: Declarant.Email",
+		phone: "SUIT: Declarant.Telephone",
+	},
+
+	cse_opinion: {
+		declaration_number: "SUIT: Avis_CSE.Numero_declaration",
+		type: "SUIT: Avis_CSE.Type",
+		opinion: "SUIT: Avis_CSE.Avis",
+		opinion_date: "SUIT: Avis_CSE.Date",
+	},
+
+	file: {
+		id: "SUIT: Fichiers.Id",
+		file_name: "SUIT: Fichiers.Nom_fichier",
+		uploaded_at: "SUIT: Fichiers.Date_upload",
+	},
+
+	job_category: {
+		name: "SUIT: Indicateurs.G.Nom_categorie",
+		detail: "SUIT: Indicateurs.G.Detail_categorie",
+	},
+
+	employee_category: {
+		women_count: "SUIT: Indicateurs.G.Effectif_F",
+		men_count: "SUIT: Indicateurs.G.Effectif_H",
+		annual_base_women: "SUIT: Indicateurs.G.Rem_annuelle_base_F",
+		annual_base_men: "SUIT: Indicateurs.G.Rem_annuelle_base_H",
+		annual_variable_women: "SUIT: Indicateurs.G.Rem_annuelle_variable_F",
+		annual_variable_men: "SUIT: Indicateurs.G.Rem_annuelle_variable_H",
+		hourly_base_women: "SUIT: Indicateurs.G.Taux_horaire_base_F",
+		hourly_base_men: "SUIT: Indicateurs.G.Taux_horaire_base_H",
+		hourly_variable_women: "SUIT: Indicateurs.G.Taux_horaire_variable_F",
+		hourly_variable_men: "SUIT: Indicateurs.G.Taux_horaire_variable_H",
+	},
 };


### PR DESCRIPTION
Closes #3314

## Résumé

Remplit `SCHEMA_COLUMN_COMMENTS` avec les entrées T2 : toutes les colonnes exposées par `assembleDeclaration()` **à l'exception** des indicateurs A–F (couverts par T1).

Tables annotées :
- `declaration` — méta (siren, year, status, scores de conformité, effectifs globaux, seconde déclaration, timestamps)
- `company` — identité entreprise (raison sociale, effectif, NAF, adresse, CSE existant)
- `user` — déclarant (prénom, nom, email, téléphone)
- `cse_opinion` — avis CSE exposés avec les fichiers (numéro, type, avis, date)
- `file` — fichiers CSE et évaluation conjointe (id, nom, date upload)
- `job_category` — catégories indicateur G (nom, détail)
- `employee_category` — données indicateur G (effectifs, rémunérations annuelles/horaires base/variable, F/H)

Format : `SUIT: <label>` (sans préfixe `GIP-MDS` — ces données sont saisies/calculées côté egapro).
Labels copiés verbatim depuis les clés de `assembleDeclaration()` et `toIndicatorGCategory()`.
Colonnes non-SUIT (timestamps internes, FK, champs de routing) **non annotées** (décision Q2).

Stacked sur #3312 — GitHub retargetera automatiquement sur `alpha` une fois le parent mergé.

## Test plan

- [x] 41 tests unitaires couvrent toutes les entrées (valeurs exactes + invariant format `SUIT:`)
- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (1587/1587)
- [x] `pnpm lint:check` vert