### PR TITLE
fix(login): refresh login page per Figma (#3318)

### DIFF
--- a/packages/app/src/e2e/login.e2e.ts
+++ b/packages/app/src/e2e/login.e2e.ts
@@ -13,6 +13,15 @@ test.describe("Login page", () => {
 			page.getByRole("button", { name: /s.identifier avec\s*proconnect/i }),
 		).toBeVisible();
 	});
+
+	test("hides the public help banner", async ({ page }) => {
+		await page.goto("/login");
+		await dismissCookieBanner(page);
+
+		await expect(
+			page.getByRole("region", { name: /ressources et aide/i }),
+		).toHaveCount(0);
+	});
 });
 
 test.describe("ProConnect authentication flow", () => {

--- a/packages/app/src/modules/layout/PublicChrome.tsx
+++ b/packages/app/src/modules/layout/PublicChrome.tsx
@@ -9,6 +9,7 @@ import { ResourceBanner } from "./ResourceBanner";
  * Renders the public help banner + footer on every route except the backoffice.
  * Admin pages (`/admin/**`) get a stripped-down chrome so the sidebar + admin
  * content fill the viewport without competing with public navigation.
+ * The login page keeps the footer but hides the help banner per Figma spec.
  */
 export function PublicChrome() {
 	const pathname = usePathname();
@@ -17,9 +18,10 @@ export function PublicChrome() {
 	if (pathname === "/admin" || pathname?.startsWith("/admin/")) {
 		return null;
 	}
+	const showResourceBanner = pathname !== "/login";
 	return (
 		<>
-			<ResourceBanner />
+			{showResourceBanner && <ResourceBanner />}
 			<Footer />
 		</>
 	);

--- a/packages/app/src/modules/layout/__tests__/PublicChrome.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/PublicChrome.test.tsx
@@ -50,4 +50,13 @@ describe("PublicChrome", () => {
 		).toBeInTheDocument();
 		expect(screen.getByRole("contentinfo")).toBeInTheDocument();
 	});
+
+	it("hides ResourceBanner on /login but keeps the Footer", () => {
+		(usePathname as Mock).mockReturnValue("/login");
+		render(<PublicChrome />);
+		expect(
+			screen.queryByRole("region", { name: /ressources et aide/i }),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole("contentinfo")).toBeInTheDocument();
+	});
 });

--- a/packages/app/src/modules/login/LoginAccordion.tsx
+++ b/packages/app/src/modules/login/LoginAccordion.tsx
@@ -28,13 +28,17 @@ export function LoginAccordion() {
 				<p>Créez un compte en quelques étapes simples :</p>
 				<ol>
 					<li>
+						Cliquez d'abord sur le bouton{" "}
+						<strong>"S'identifier avec ProConnect"</strong>
+					</li>
+					<li>
 						Confirmez votre adresse email à l'aide du code de validation reçu
 					</li>
 					<li>Choisissez un mot de passe</li>
-					<li>Entrez le SIRET de votre organisation</li>
+					<li>Entrez le SIRET du siège social de votre entreprise</li>
 					<li>Complétez vos informations personnelles</li>
+					<li>Votre compte est créé !</li>
 				</ol>
-				<p>Votre compte est créé !</p>
 			</div>
 		</section>
 	);

--- a/packages/app/src/modules/login/__tests__/LoginAccordion.test.tsx
+++ b/packages/app/src/modules/login/__tests__/LoginAccordion.test.tsx
@@ -36,4 +36,25 @@ describe("LoginAccordion", () => {
 		expect(container.querySelector(".fr-accordion__title")).toBeInTheDocument();
 		expect(container.querySelector(".fr-collapse")).toBeInTheDocument();
 	});
+
+	it("lists the six account creation steps in order, ending with the success step", () => {
+		const { container } = render(<LoginAccordion />);
+		const items = container.querySelectorAll("ol > li");
+		expect(items).toHaveLength(6);
+		expect(items[0]?.textContent).toMatch(
+			/cliquez d'abord sur le bouton.*s'identifier avec proconnect/i,
+		);
+		expect(items[3]?.textContent).toMatch(
+			/entrez le siret du siège social de votre entreprise/i,
+		);
+		expect(items[5]?.textContent).toMatch(/votre compte est créé/i);
+	});
+
+	it("emphasizes the ProConnect button label in the first step", () => {
+		const { container } = render(<LoginAccordion />);
+		const firstItem = container.querySelector("ol > li:first-child");
+		expect(firstItem?.querySelector("strong")?.textContent).toBe(
+			'"S\'identifier avec ProConnect"',
+		);
+	});
 });


### PR DESCRIPTION
fix #3318

## Summary
- Hide the public `ResourceBanner` ("Ressources et aide") on `/login` while keeping the `Footer`, per the Figma mockup.
- Update `LoginAccordion` copy to match Figma: prepend the "Cliquez d'abord sur le bouton "S'identifier avec ProConnect"" step, refine SIRET wording to "siège social de votre entreprise", and fold "Votre compte est créé !" into the ordered list as the final step.

## Test plan
- [ ] Visit `/login` — the help banner is gone, footer still renders.
- [ ] Visit any other public page (`/`, `/aide`, `/mon-espace`) — the help banner still renders.
- [ ] Open the "Vous n'avez pas de compte ?" accordion — six numbered steps in the new order, first step's button label is bold.
- [ ] `/admin/*` chrome unchanged (no banner, no footer).