### PR TITLE
feat: T1 — Annotations indicateurs A–F (GIP-MDS | SUIT) dans schema-comments.ts

### DIFF
--- a/packages/app/src/server/db/__tests__/schema-comments.test.ts
+++ b/packages/app/src/server/db/__tests__/schema-comments.test.ts
@@ -199,9 +199,21 @@ describe("SCHEMA_COLUMN_COMMENTS", () => {
 			c.replace("GIP-MDS | SUIT: ", ""),
 		);
 
+		const labelSet = new Set(ALL_SUIT_LABELS);
+
 		for (const label of ALL_SUIT_LABELS) {
 			const occurrences = commentValues.filter((v) => v === label).length;
 			expect(occurrences, `label "${label}"`).toBe(1);
+		}
+
+		// Reverse check: every value in the map must be a known canonical label.
+		// Catches typos that pass the format regex but aren't in apiLabels.ts.
+		for (const [column, value] of Object.entries(declarationComments ?? {})) {
+			const label = value.replace("GIP-MDS | SUIT: ", "");
+			expect(
+				labelSet.has(label),
+				`column "${column}" has unknown label "${label}"`,
+			).toBe(true);
 		}
 	});
 });

--- a/packages/app/src/server/db/__tests__/schema-comments.test.ts
+++ b/packages/app/src/server/db/__tests__/schema-comments.test.ts
@@ -1,7 +1,38 @@
 import { describe, expect, it } from "vitest";
+import {
+	INDICATOR_A_LABELS,
+	INDICATOR_B_LABELS,
+	INDICATOR_C_LABELS,
+	INDICATOR_D_LABELS,
+	INDICATOR_E_LABELS,
+	INDICATOR_F_ANNUAL_MEN_LABELS,
+	INDICATOR_F_ANNUAL_THRESHOLD_LABELS,
+	INDICATOR_F_ANNUAL_WOMEN_LABELS,
+	INDICATOR_F_HOURLY_MEN_LABELS,
+	INDICATOR_F_HOURLY_THRESHOLD_LABELS,
+	INDICATOR_F_HOURLY_WOMEN_LABELS,
+} from "~/modules/export/shared/apiLabels";
 import { SCHEMA_COLUMN_COMMENTS } from "../schema-comments";
 
+const ALL_SUIT_LABELS: readonly string[] = [
+	...Object.values(INDICATOR_A_LABELS),
+	...Object.values(INDICATOR_B_LABELS),
+	...Object.values(INDICATOR_C_LABELS),
+	...Object.values(INDICATOR_D_LABELS),
+	...Object.values(INDICATOR_E_LABELS),
+	...INDICATOR_F_ANNUAL_THRESHOLD_LABELS,
+	...INDICATOR_F_ANNUAL_WOMEN_LABELS,
+	...INDICATOR_F_ANNUAL_MEN_LABELS,
+	...INDICATOR_F_HOURLY_THRESHOLD_LABELS,
+	...INDICATOR_F_HOURLY_WOMEN_LABELS,
+	...INDICATOR_F_HOURLY_MEN_LABELS,
+];
+
 describe("SCHEMA_COLUMN_COMMENTS", () => {
+	const declarationComments = SCHEMA_COLUMN_COMMENTS.declaration;
+
+	// ── T2 tests (PR #3312 — SUIT meta columns) ──────────────────────────────
+
 	it("annotates declaration.siren as SUIT: SIREN (S1)", () => {
 		expect(SCHEMA_COLUMN_COMMENTS.declaration?.siren).toBe("SUIT: SIREN");
 	});
@@ -127,6 +158,50 @@ describe("SCHEMA_COLUMN_COMMENTS", () => {
 		for (const comment of allComments) {
 			expect(comment).toMatch(/^SUIT: /);
 			expect(comment).not.toContain("GIP-MDS");
+		}
+	});
+
+	// ── T1 tests (PR #3313 — Indicators A–F GIP-MDS | SUIT) ──────────────────
+
+	it("defines a declaration entry", () => {
+		expect(declarationComments).toBeDefined();
+		expect(typeof declarationComments).toBe("object");
+	});
+
+	it("annotates all indicator A–E columns (18 columns)", () => {
+		const aToEColumns = Object.keys(declarationComments ?? {}).filter((k) =>
+			/^indicator_[a-e]_/.test(k),
+		);
+		expect(aToEColumns).toHaveLength(18);
+	});
+
+	it("annotates all indicator F columns (24 columns)", () => {
+		const fColumns = Object.keys(declarationComments ?? {}).filter((k) =>
+			k.startsWith("indicator_f_"),
+		);
+		expect(fColumns).toHaveLength(24);
+	});
+
+	it("uses the strict format 'GIP-MDS | SUIT: <label>' for every indicator A–F comment", () => {
+		// Scoped to T1 columns only (`indicator_*`). T2 columns within `declaration`
+		// (siren, year, total_women, etc.) use the `SUIT: ...` format and are
+		// validated by the T2 tests above.
+		const t1Entries = Object.entries(declarationComments ?? {}).filter(
+			([col]) => col.startsWith("indicator_"),
+		);
+		for (const [column, comment] of t1Entries) {
+			expect(comment, `column ${column}`).toMatch(/^GIP-MDS \| SUIT: .+$/);
+		}
+	});
+
+	it("uses each SUIT label verbatim, exactly once (S4)", () => {
+		const commentValues = Object.values(declarationComments ?? {}).map((c) =>
+			c.replace("GIP-MDS | SUIT: ", ""),
+		);
+
+		for (const label of ALL_SUIT_LABELS) {
+			const occurrences = commentValues.filter((v) => v === label).length;
+			expect(occurrences, `label "${label}"`).toBe(1);
 		}
 	});
 });

--- a/packages/app/src/server/db/__tests__/schema-comments.test.ts
+++ b/packages/app/src/server/db/__tests__/schema-comments.test.ts
@@ -195,20 +195,26 @@ describe("SCHEMA_COLUMN_COMMENTS", () => {
 	});
 
 	it("uses each SUIT label verbatim, exactly once (S4)", () => {
-		const commentValues = Object.values(declarationComments ?? {}).map((c) =>
-			c.replace("GIP-MDS | SUIT: ", ""),
+		// Scoped to T1 columns only (`indicator_*`). T2 columns inside `declaration`
+		// (siren, year, total_women, …) use the bare `SUIT: …` format and are
+		// validated by the T2 per-key tests above.
+		const t1Entries = Object.entries(declarationComments ?? {}).filter(
+			([col]) => col.startsWith("indicator_"),
+		);
+		const t1CommentValues = t1Entries.map(([, v]) =>
+			v.replace("GIP-MDS | SUIT: ", ""),
 		);
 
 		const labelSet = new Set(ALL_SUIT_LABELS);
 
 		for (const label of ALL_SUIT_LABELS) {
-			const occurrences = commentValues.filter((v) => v === label).length;
+			const occurrences = t1CommentValues.filter((v) => v === label).length;
 			expect(occurrences, `label "${label}"`).toBe(1);
 		}
 
-		// Reverse check: every value in the map must be a known canonical label.
+		// Reverse check: every T1 value in the map must be a known canonical label.
 		// Catches typos that pass the format regex but aren't in apiLabels.ts.
-		for (const [column, value] of Object.entries(declarationComments ?? {})) {
+		for (const [column, value] of t1Entries) {
 			const label = value.replace("GIP-MDS | SUIT: ", "");
 			expect(
 				labelSet.has(label),

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -28,7 +28,80 @@ export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
 			"SUIT: Seconde_declaration.Periode_reference_debut",
 		second_decl_reference_period_end:
 			"SUIT: Seconde_declaration.Periode_reference_fin",
-		// ── Indicators A–F populated by T1 ──
+		// ── Indicators A–F (T1 — GIP-MDS → SUIT) ──
+		// Indicator A — mean global remuneration (GIP-MDS → SUIT)
+		indicator_a_annual_women: "GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_F",
+		indicator_a_annual_men: "GIP-MDS | SUIT: Rem_globale_annuelle_moyenne_H",
+		indicator_a_hourly_women: "GIP-MDS | SUIT: Taux_horaire_global_moyen_F",
+		indicator_a_hourly_men: "GIP-MDS | SUIT: Taux_horaire_global_moyen_H",
+		// Indicator B — mean variable remuneration (GIP-MDS → SUIT)
+		indicator_b_annual_women: "GIP-MDS | SUIT: Rem_variable_annuelle_moyenne_F",
+		indicator_b_annual_men: "GIP-MDS | SUIT: Rem_variable_annuelle_moyenne_H",
+		indicator_b_hourly_women: "GIP-MDS | SUIT: Taux_horaire_variable_moyen_F",
+		indicator_b_hourly_men: "GIP-MDS | SUIT: Taux_horaire_variable_moyen_H",
+		// Indicator C — median global remuneration (GIP-MDS → SUIT)
+		indicator_c_annual_women: "GIP-MDS | SUIT: Rem_globale_annuelle_médiane_F",
+		indicator_c_annual_men: "GIP-MDS | SUIT: Rem_globale_annuelle_médiane_H",
+		indicator_c_hourly_women: "GIP-MDS | SUIT: Taux_globale_annuelle_médiane_F",
+		indicator_c_hourly_men: "GIP-MDS | SUIT: Taux_globale_annuelle_médiane_H",
+		// Indicator D — median variable remuneration (GIP-MDS → SUIT)
+		indicator_d_annual_women: "GIP-MDS | SUIT: Rem_variable_annuelle_médiane_F",
+		indicator_d_annual_men: "GIP-MDS | SUIT: Rem_variable_annuelle_médiane_H",
+		indicator_d_hourly_women: "GIP-MDS | SUIT: Taux_horaire_variable_médian_F",
+		indicator_d_hourly_men: "GIP-MDS | SUIT: Taux_horaire_variable_médian_H",
+		// Indicator E — variable pay beneficiary counts (GIP-MDS → SUIT)
+		indicator_e_women: "GIP-MDS | SUIT: Effectif_F_rem_annuelle_variable",
+		indicator_e_men: "GIP-MDS | SUIT: Effectif_H_rem_annuelle_variable",
+		// Indicator F — quartile thresholds, annual (GIP-MDS → SUIT)
+		indicator_f_annual_threshold1: "GIP-MDS | SUIT: Seuil_Q1_Rem_globale",
+		indicator_f_annual_threshold2: "GIP-MDS | SUIT: Seuil_Q2_Rem_globale",
+		indicator_f_annual_threshold3: "GIP-MDS | SUIT: Seuil_Q3_Rem_globale",
+		indicator_f_annual_threshold4: "GIP-MDS | SUIT: Seuil_Q4_Rem_globale",
+		// Indicator F — quartile women proportions, annual (GIP-MDS → SUIT)
+		indicator_f_annual_women1:
+			"GIP-MDS | SUIT: Quartile1_Rem_globale_annuelle_proportion_F",
+		indicator_f_annual_women2:
+			"GIP-MDS | SUIT: Quartile2_Rem_globale_annuelle_proportion_F",
+		indicator_f_annual_women3:
+			"GIP-MDS | SUIT: Quartile3_Rem_globale_annuelle_proportion_F",
+		indicator_f_annual_women4:
+			"GIP-MDS | SUIT: Quartile4_Rem_globale_annuelle_proportion_F",
+		// Indicator F — quartile men proportions, annual (GIP-MDS → SUIT)
+		indicator_f_annual_men1:
+			"GIP-MDS | SUIT: Quartile1_Rem_globale_annuelle_proportion_H",
+		indicator_f_annual_men2:
+			"GIP-MDS | SUIT: Quartile2_Rem_globale_annuelle_proportion_H",
+		indicator_f_annual_men3:
+			"GIP-MDS | SUIT: Quartile3_Rem_globale_annuelle_proportion_H",
+		indicator_f_annual_men4:
+			"GIP-MDS | SUIT: Quartile4_Rem_globale_annuelle_proportion_H",
+		// Indicator F — quartile thresholds, hourly (GIP-MDS → SUIT)
+		indicator_f_hourly_threshold1:
+			"GIP-MDS | SUIT: Seuil_Q1_Taux_horaire_global",
+		indicator_f_hourly_threshold2:
+			"GIP-MDS | SUIT: Seuil_Q2_Taux_horaire_global",
+		indicator_f_hourly_threshold3:
+			"GIP-MDS | SUIT: Seuil_Q3_Taux_horaire_global",
+		indicator_f_hourly_threshold4:
+			"GIP-MDS | SUIT: Seuil_Q4_Taux_horaire_global",
+		// Indicator F — quartile women proportions, hourly (GIP-MDS → SUIT)
+		indicator_f_hourly_women1:
+			"GIP-MDS | SUIT: Quartile1_Taux_horaire_global_proportion_F",
+		indicator_f_hourly_women2:
+			"GIP-MDS | SUIT: Quartile2_Taux_horaire_global_proportion_F",
+		indicator_f_hourly_women3:
+			"GIP-MDS | SUIT: Quartile3_Taux_horaire_global_proportion_F",
+		indicator_f_hourly_women4:
+			"GIP-MDS | SUIT: Quartile4_Taux_horaire_global_proportion_F",
+		// Indicator F — quartile men proportions, hourly (GIP-MDS → SUIT)
+		indicator_f_hourly_men1:
+			"GIP-MDS | SUIT: Quartile1_Taux_horaire_global_proportion_H",
+		indicator_f_hourly_men2:
+			"GIP-MDS | SUIT: Quartile2_Taux_horaire_global_proportion_H",
+		indicator_f_hourly_men3:
+			"GIP-MDS | SUIT: Quartile3_Taux_horaire_global_proportion_H",
+		indicator_f_hourly_men4:
+			"GIP-MDS | SUIT: Quartile4_Taux_horaire_global_proportion_H",
 	},
 	company: {
 		name: "SUIT: Raison_sociale",


### PR DESCRIPTION
Closes #3313

## Résumé

Remplit `SCHEMA_COLUMN_COMMENTS` (introduit en T0/#3312) avec les 42 entrées pour les colonnes A–F de la table `declaration`.

Chaque commentaire suit le format strict `GIP-MDS | SUIT: <label>` en copiant les labels verbatim depuis `apiLabels.ts`.

**Couverture :**
- Indicateurs A–D : 4 colonnes chacun (annualWomen/Men, hourlyWomen/Men) — 16 colonnes
- Indicateur E : 2 colonnes (women, men)
- Indicateur F : 24 colonnes (4 seuils × 2 périodes + 8 proportions F/H × 2 périodes)
- **Total : 42 colonnes, 42 labels SUIT, chacun utilisé exactement 1 fois**

_Stacked on ticket/3312 — GitHub retargetera automatiquement sur `alpha` une fois le parent mergé._

## Plan de test

- [x] `pnpm typecheck` : vert (0 erreurs)
- [x] `pnpm test` : 1541/1541 tests passent
- [x] 5 tests unitaires dédiés dans `__tests__/schema-comments.test.ts` :
  - structure `declaration` présente
  - 18 colonnes A–E annotées
  - 24 colonnes F annotées
  - format `GIP-MDS | SUIT: ...` respecté
  - chaque label SUIT utilisé exactement 1 fois (S4)
- [x] Lint/format : vert