### PR TITLE
fix(my-space): align Mon Espace UI with Figma feedback (#3319)

### DIFF
--- a/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
@@ -106,7 +106,7 @@ export function UserAccountMenu({
 			<button
 				aria-expanded={isOpen}
 				aria-haspopup="menu"
-				className="fr-btn fr-btn--tertiary-no-outline fr-icon-account-circle-line fr-btn--icon-left"
+				className="fr-btn fr-btn--tertiary fr-icon-account-circle-line fr-btn--icon-left"
 				onClick={() => setIsOpen((prev) => !prev)}
 				ref={buttonRef}
 				type="button"

--- a/packages/app/src/modules/my-space/ArchivesSection.tsx
+++ b/packages/app/src/modules/my-space/ArchivesSection.tsx
@@ -14,7 +14,7 @@ export function ArchivesSection() {
 						/>
 					</div>
 					<div className="fr-col">
-						<p className="fr-text--bold fr-mb-1v">Archives</p>
+						<p className="fr-text--bold fr-mb-1w">Archives</p>
 						<p className="fr-text--sm fr-mb-0">
 							Récupérer vos anciennes déclarations de l'index de l'égalité
 							professionnelle femmes-hommes.

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
@@ -1,5 +1,10 @@
 .banner {
 	background-color: var(--background-alt-blue-france);
+
+	:global(.fr-breadcrumb) {
+		margin-top: 0;
+		margin-bottom: 2rem;
+	}
 }
 
 .infoRow {

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -25,55 +25,53 @@ export function CompanyInfoBanner({ company }: Props) {
 					]}
 				/>
 
-				<div className="fr-mt-4w">
-					<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">
-						<div className="fr-col">
-							<h2 className="fr-h4 fr-mb-0">{company.name}</h2>
-						</div>
-						<div className="fr-col-auto">
-							<button
-								aria-controls={COMPANY_EDIT_MODAL_ID}
-								className="fr-btn fr-btn--tertiary-no-outline fr-icon-edit-line fr-btn--icon-left"
-								data-fr-opened="false"
-								type="button"
-							>
-								Modifier
-							</button>
-						</div>
+				<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">
+					<div className="fr-col">
+						<h2 className="fr-h4 fr-mb-0">{company.name}</h2>
 					</div>
+					<div className="fr-col-auto">
+						<button
+							aria-controls={COMPANY_EDIT_MODAL_ID}
+							className="fr-btn fr-btn--tertiary-no-outline fr-icon-edit-line fr-btn--icon-left"
+							data-fr-opened="false"
+							type="button"
+						>
+							Modifier
+						</button>
+					</div>
+				</div>
 
-					<div className={`${styles.infoRow} fr-mb-1w`}>
+				<div className={`${styles.infoRow} fr-mb-1w`}>
+					<p className={styles.datapoint}>
+						SIREN : <strong>{formatSiren(company.siren)}</strong>
+					</p>
+					{company.address && (
 						<p className={styles.datapoint}>
-							SIREN : <strong>{formatSiren(company.siren)}</strong>
+							Adresse : <strong>{formatAddress(company.address)}</strong>
 						</p>
-						{company.address && (
-							<p className={styles.datapoint}>
-								Adresse : <strong>{formatAddress(company.address)}</strong>
-							</p>
-						)}
-					</div>
+					)}
+				</div>
 
-					<div className={styles.infoRow}>
-						{company.nafCode && (
-							<p className={styles.datapoint}>
-								Code NAF : <strong>{company.nafCode}</strong>
-							</p>
-						)}
-						{company.workforce !== null && (
-							<p className={styles.datapoint}>
-								Effectif annuel moyen en {currentYear} :{" "}
-								<strong>{company.workforce}</strong>
-							</p>
-						)}
+				<div className={styles.infoRow}>
+					{company.nafCode && (
 						<p className={styles.datapoint}>
-							Existence d'un CSE :{" "}
-							{company.hasCse !== null ? (
-								<strong>{company.hasCse ? "Oui" : "Non"}</strong>
-							) : (
-								<StatusBadge status="to_complete" />
-							)}
+							Code NAF : <strong>{company.nafCode}</strong>
 						</p>
-					</div>
+					)}
+					{company.workforce !== null && (
+						<p className={styles.datapoint}>
+							Effectif annuel moyen en {currentYear} :{" "}
+							<strong>{company.workforce}</strong>
+						</p>
+					)}
+					<p className={styles.datapoint}>
+						Existence d'un CSE :{" "}
+						{company.hasCse !== null ? (
+							<strong>{company.hasCse ? "Oui" : "Non"}</strong>
+						) : (
+							<StatusBadge status="to_complete" />
+						)}
+					</p>
 				</div>
 			</div>
 		</div>

--- a/packages/app/src/modules/my-space/DeclarationLink.tsx
+++ b/packages/app/src/modules/my-space/DeclarationLink.tsx
@@ -2,11 +2,12 @@
 
 import { useIsImpersonating } from "~/modules/auth";
 import { hasRequiredDeclarationInfo } from "~/modules/domain";
-
 import { DECLARATION_PROCESS_PANEL_ID } from "./DeclarationProcessPanel";
+import styles from "./DeclarationsSection.module.scss";
 import type { DeclarationType } from "./types";
 
 const MISSING_INFO_MODAL_ID = "missing-info-modal";
+const linkClass = `fr-link ${styles.linkUnderlined}`;
 
 type Props = {
 	type: DeclarationType;
@@ -26,7 +27,7 @@ export function DeclarationLink({ type, userPhone, hasCse, children }: Props) {
 		return (
 			<button
 				aria-controls={MISSING_INFO_MODAL_ID}
-				className="fr-link"
+				className={linkClass}
 				data-declaration-type={type}
 				data-fr-opened="false"
 				type="button"
@@ -41,7 +42,7 @@ export function DeclarationLink({ type, userPhone, hasCse, children }: Props) {
 		return (
 			<button
 				aria-controls={DECLARATION_PROCESS_PANEL_ID}
-				className="fr-link"
+				className={linkClass}
 				data-fr-opened="false"
 				type="button"
 			>
@@ -52,7 +53,7 @@ export function DeclarationLink({ type, userPhone, hasCse, children }: Props) {
 
 	// Representation: placeholder (no route yet)
 	return (
-		<button className="fr-link" type="button">
+		<button className={linkClass} type="button">
 			{children}
 		</button>
 	);

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
@@ -168,10 +168,26 @@
 	gap: 1.5rem;
 }
 
+.helpSection :global(.fr-hr),
+.helpSection hr {
+	margin: 0;
+	padding: 0;
+}
+
 .helpLinks {
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
+}
+
+.helpLinks :global(.fr-link),
+.helpLinks a,
+.helpLinks button {
+	text-decoration: underline;
+}
+
+.historyLink {
+	text-decoration: underline;
 }
 
 // Documents panel — custom card list

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
@@ -194,31 +194,42 @@
 }
 
 .documentCard {
-	border: 1px solid var(--border-default-grey);
-	background-color: var(--background-default-grey);
-	padding: 1.5rem;
 	display: flex;
 	flex-direction: column;
-	gap: 0.75rem;
+	gap: 1rem;
 	width: 100%;
 	min-width: 0;
 	box-sizing: border-box;
+	border: 1px solid var(--border-default-grey);
+	background-color: var(--background-default-grey);
+	background-image: none;
+	padding: 1.5rem;
+	color: inherit;
+	text-decoration: none;
+	transition: background-color 0.15s ease-in-out;
+
+	&:hover,
+	&:focus-visible {
+		background-color: var(--background-alt-grey);
+	}
 }
 
-.documentCard a.documentCardTitle {
-	display: block;
-	width: 100%;
-	max-width: 100%;
-	min-width: 0;
+.documentCardBody {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.documentCardTitle {
 	font-family: inherit;
 	font-size: 1.25rem;
 	font-weight: 700;
 	line-height: 1.75rem;
+	margin: 0;
 	color: var(--text-title-blue-france);
 	overflow-wrap: anywhere;
 	word-break: break-word;
 	white-space: normal;
-	background-image: none;
 }
 
 .documentCardFooter {
@@ -226,6 +237,10 @@
 	align-items: center;
 	justify-content: space-between;
 	gap: 1rem;
+}
+
+.documentCardArrow {
+	color: var(--text-action-high-blue-france);
 }
 
 // Footer

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
@@ -1,5 +1,10 @@
 // Override DSFR modal to act as a right-side full-height panel
 .sidePanel {
+	// Reset white-space inherited from the <td> ancestor when the panel is
+	// rendered inline next to the trigger button inside a DSFR table cell
+	// (table cells are nowrap by default).
+	white-space: normal;
+
 	// Remove DSFR default modal centering & padding
 	&:global(.fr-modal) {
 		// Allow click-through on backdrop area (DSFR handles close on backdrop)
@@ -172,6 +177,10 @@
 .helpSection hr {
 	margin: 0;
 	padding: 0;
+	// DSFR draws the line via a 100% 1px background-image; the parent reset
+	// here zeroes its default --text-spacing padding, so we must give the hr
+	// an explicit height for the line to be visible.
+	height: 1px;
 }
 
 .helpLinks {
@@ -180,24 +189,35 @@
 	gap: 1rem;
 }
 
+// Buttons styled as links don't get DSFR's [href]-driven underline, so draw it
+// explicitly. Using a background-image gradient (rather than text-decoration)
+// matches DSFR's native link underline thickness/offset across browsers.
 .helpLinks :global(.fr-link),
 .helpLinks a,
 .helpLinks button {
-	text-decoration: underline;
+	text-decoration: none;
+	background-image: linear-gradient(0deg, currentColor, currentColor);
+	background-position: 0 100%;
+	background-repeat: no-repeat;
+	background-size: 100% 1px;
 }
 
 .historyLink {
-	text-decoration: underline;
+	text-decoration: none;
+	background-image: linear-gradient(0deg, currentColor, currentColor);
+	background-position: 0 100%;
+	background-repeat: no-repeat;
+	background-size: 100% 1px;
 }
 
-// Documents panel — custom card list
+// Documents panel — list of fr-card--download cards
 .documentList {
 	list-style: none;
 	padding: 0;
 	margin: 0;
 	display: flex;
 	flex-direction: column;
-	gap: 1rem;
+	gap: 1.5rem;
 	width: 100%;
 	min-width: 0;
 }
@@ -207,56 +227,6 @@
 	margin: 0;
 	width: 100%;
 	min-width: 0;
-}
-
-.documentCard {
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-	width: 100%;
-	min-width: 0;
-	box-sizing: border-box;
-	border: 1px solid var(--border-default-grey);
-	background-color: var(--background-default-grey);
-	background-image: none;
-	padding: 1.5rem;
-	color: inherit;
-	text-decoration: none;
-	transition: background-color 0.15s ease-in-out;
-
-	&:hover,
-	&:focus-visible {
-		background-color: var(--background-alt-grey);
-	}
-}
-
-.documentCardBody {
-	display: flex;
-	flex-direction: column;
-	gap: 0.5rem;
-}
-
-.documentCardTitle {
-	font-family: inherit;
-	font-size: 1.25rem;
-	font-weight: 700;
-	line-height: 1.75rem;
-	margin: 0;
-	color: var(--text-title-blue-france);
-	overflow-wrap: anywhere;
-	word-break: break-word;
-	white-space: normal;
-}
-
-.documentCardFooter {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 1rem;
-}
-
-.documentCardArrow {
-	color: var(--text-action-high-blue-france);
 }
 
 // Footer

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.module.scss
@@ -202,7 +202,20 @@
 	background-size: 100% 1px;
 }
 
+.lastAction {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.875rem;
+	line-height: 1.5rem;
+	color: var(--text-mention-grey);
+}
+
 .historyLink {
+	display: inline;
+	font-size: 0.875rem;
+	line-height: 1.5rem;
 	text-decoration: none;
 	background-image: linear-gradient(0deg, currentColor, currentColor);
 	background-position: 0 100%;

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -114,15 +114,21 @@ function PanelHeader({
 			<h2 className="fr-h5 fr-mb-1w" id={PANEL_TITLE_ID}>
 				Démarche des indicateurs de rémunération {year}
 			</h2>
-			{lastActionDate && (
-				<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
-					<span
-						aria-hidden="true"
-						className="fr-icon-time-line fr-icon--sm fr-mr-1v"
-					/>
-					Dernière action le {lastActionDate}
-				</p>
-			)}
+			<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
+				{lastActionDate && (
+					<>
+						<span
+							aria-hidden="true"
+							className="fr-icon-time-line fr-icon--sm fr-mr-1v"
+						/>
+						Dernière action le {lastActionDate}
+						{" — "}
+					</>
+				)}
+				<a className={`fr-link ${styles.historyLink}`} href="#">
+					Voir l'historique
+				</a>
+			</p>
 		</div>
 	);
 }

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -114,21 +114,20 @@ function PanelHeader({
 			<h2 className="fr-h5 fr-mb-1w" id={PANEL_TITLE_ID}>
 				Démarche des indicateurs de rémunération {year}
 			</h2>
-			<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
+			<div className={styles.lastAction}>
 				{lastActionDate && (
 					<>
 						<span
 							aria-hidden="true"
-							className="fr-icon-time-line fr-icon--sm fr-mr-1v"
+							className="fr-icon-time-line fr-icon--sm"
 						/>
-						Dernière action le {lastActionDate}
-						{" — "}
+						<span>Dernière action le {lastActionDate}</span>
 					</>
 				)}
 				<button className={`fr-link ${styles.historyLink}`} type="button">
 					Voir l'historique
 				</button>
-			</p>
+			</div>
 		</div>
 	);
 }

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -125,9 +125,9 @@ function PanelHeader({
 						{" — "}
 					</>
 				)}
-				<a className={`fr-link ${styles.historyLink}`} href="#">
+				<button className={`fr-link ${styles.historyLink}`} type="button">
 					Voir l'historique
-				</a>
+				</button>
 			</p>
 		</div>
 	);

--- a/packages/app/src/modules/my-space/DeclarationsSection.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationsSection.module.scss
@@ -9,6 +9,18 @@
 	}
 }
 
+// DSFR JS sets --table-offset: calc(1px + 1rem) on .fr-table__wrapper to
+// reserve space above the table for the caption. Our captions are fr-sr-only,
+// so the reserved space appears as 17px of empty padding above the thead.
+// Override the variable on the wrapper so both the container padding-top and
+// the border overlay (.fr-table__wrapper::after) collapse together.
+.tableNoCaptionOffset :global(.fr-table__wrapper) {
+	// 0px (not 0): `calc(100% - 0)` is invalid in CSS — the calc on the
+	// pseudo-overlay's height needs a unit-bearing length, otherwise the
+	// border overlay collapses to height 0 and the table loses its borders.
+	--table-offset: 0px !important;
+}
+
 .linkUnderlined {
 	text-decoration: underline;
 }

--- a/packages/app/src/modules/my-space/DeclarationsSection.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationsSection.module.scss
@@ -1,0 +1,14 @@
+.tableSm {
+	font-size: 0.875rem;
+	line-height: 1.5rem;
+
+	th,
+	td {
+		font-size: 0.875rem;
+		line-height: 1.5rem;
+	}
+}
+
+.linkUnderlined {
+	text-decoration: underline;
+}

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -85,7 +85,7 @@ export function DeclarationsSection({
 
 	return (
 		<div className="fr-container fr-my-6w">
-			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3w">
+			<div className="fr-grid-row fr-grid-row--middle fr-mb-4w">
 				<div className="fr-col">
 					<h2 className="fr-mb-0">Démarche en cours</h2>
 				</div>
@@ -186,7 +186,7 @@ function DeclarationsTable({
 	hasCse,
 }: DeclarationsTableProps) {
 	return (
-		<div className="fr-table">
+		<div className={`fr-table ${styles.tableNoCaptionOffset}`}>
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">
 					<div className="fr-table__content">

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -9,6 +9,7 @@ import { Pagination } from "~/modules/shared/Pagination";
 
 import { DeclarationLink } from "./DeclarationLink";
 import { getDeclarationStepLabel } from "./DeclarationStepLabel";
+import styles from "./DeclarationsSection.module.scss";
 import {
 	DocumentsPanel,
 	getDocumentResourceCount,
@@ -86,7 +87,7 @@ export function DeclarationsSection({
 		<div className="fr-container fr-my-6w">
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3w">
 				<div className="fr-col">
-					<h2 className="fr-mb-0">En cours</h2>
+					<h2 className="fr-mb-0">Démarche en cours</h2>
 				</div>
 				{hasNoSanction && (
 					<div className="fr-col-auto">
@@ -189,7 +190,7 @@ function DeclarationsTable({
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">
 					<div className="fr-table__content">
-						<table>
+						<table className={styles.tableSm}>
 							<caption className="fr-sr-only">{caption}</caption>
 							<thead>
 								<tr>
@@ -197,7 +198,7 @@ function DeclarationsTable({
 									<th scope="col">Année</th>
 									<th scope="col">Étape</th>
 									<th scope="col">Échéance</th>
-									<th scope="col">Statut</th>
+									<th scope="col">État</th>
 									<th scope="col">Ressources</th>
 								</tr>
 							</thead>
@@ -228,7 +229,7 @@ function DeclarationsTable({
 													<>
 														<button
 															aria-controls={getDocumentsPanelId(declaration)}
-															className="fr-link"
+															className={`fr-link ${styles.linkUnderlined}`}
 															data-fr-opened="false"
 															type="button"
 														>

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -98,6 +98,7 @@ export function DocumentsPanel({ declaration }: Props) {
 							{resources.map((resource) => (
 								<li className={styles.documentItem} key={resource.href}>
 									<a
+										aria-label={`${resource.title} (PDF) — ${resource.subtitle}`}
 										className={styles.documentCard}
 										download
 										href={resource.href}

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -97,30 +97,21 @@ export function DocumentsPanel({ declaration }: Props) {
 						<ul className={styles.documentList}>
 							{resources.map((resource) => (
 								<li className={styles.documentItem} key={resource.href}>
-									<a
-										aria-label={`${resource.title} (PDF) — ${resource.subtitle}`}
-										className={styles.documentCard}
-										download
-										href={resource.href}
-									>
-										<div className={styles.documentCardBody}>
-											<p className={styles.documentCardTitle}>
-												{resource.title}
-											</p>
-											<p className="fr-text--sm fr-mb-0 fr-text-default--grey">
-												{resource.subtitle}
-											</p>
+									<div className="fr-card fr-card--sm fr-card--download fr-enlarge-link">
+										<div className="fr-card__body">
+											<div className="fr-card__content">
+												<h3 className="fr-card__title">
+													<a download href={resource.href}>
+														{resource.title}
+													</a>
+												</h3>
+												<p className="fr-card__desc">{resource.subtitle}</p>
+												<div className="fr-card__end">
+													<p className="fr-card__detail">PDF</p>
+												</div>
+											</div>
 										</div>
-										<div className={styles.documentCardFooter}>
-											<p className="fr-text--xs fr-text-mention--grey fr-mb-0">
-												PDF
-											</p>
-											<span
-												aria-hidden="true"
-												className={`fr-icon-download-line fr-icon--sm ${styles.documentCardArrow}`}
-											/>
-										</div>
-									</a>
+									</div>
 								</li>
 							))}
 						</ul>

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -97,27 +97,29 @@ export function DocumentsPanel({ declaration }: Props) {
 						<ul className={styles.documentList}>
 							{resources.map((resource) => (
 								<li className={styles.documentItem} key={resource.href}>
-									<div className={styles.documentCard}>
-										<a
-											className={styles.documentCardTitle}
-											download
-											href={resource.href}
-										>
-											{resource.title}
-										</a>
-										<p className="fr-text--sm fr-mb-0 fr-text-default--grey">
-											{resource.subtitle}
-										</p>
+									<a
+										className={styles.documentCard}
+										download
+										href={resource.href}
+									>
+										<div className={styles.documentCardBody}>
+											<p className={styles.documentCardTitle}>
+												{resource.title}
+											</p>
+											<p className="fr-text--sm fr-mb-0 fr-text-default--grey">
+												{resource.subtitle}
+											</p>
+										</div>
 										<div className={styles.documentCardFooter}>
 											<p className="fr-text--xs fr-text-mention--grey fr-mb-0">
 												PDF
 											</p>
 											<span
 												aria-hidden="true"
-												className="fr-icon-download-line fr-icon--sm"
+												className={`fr-icon-download-line fr-icon--sm ${styles.documentCardArrow}`}
 											/>
 										</div>
-									</div>
+									</a>
 								</li>
 							))}
 						</ul>

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -226,6 +226,20 @@ export function MissingInfoModal({ siren, userPhone, hasCse }: Props) {
 						)}
 					</div>
 					<div>
+						<div className={styles.helpSection}>
+							<hr className="fr-hr" />
+							<p className="fr-text--lg fr-text--bold fr-mb-0">
+								Pour vous aider
+							</p>
+							<div className={styles.helpLinks}>
+								<button className="fr-link" type="button">
+									Détail des étapes
+								</button>
+								<button className="fr-link" type="button">
+									Aides
+								</button>
+							</div>
+						</div>
 						<div className={styles.footer}>
 							<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
 								<li>

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -10,10 +10,11 @@ import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 
 import { DECLARATION_PROCESS_PANEL_ID } from "./DeclarationProcessPanel";
+import styles from "./DeclarationProcessPanel.module.scss";
 import { createMissingInfoSchema } from "./schemas";
 
-const MODAL_ID = "missing-info-modal";
-const MODAL_TITLE_ID = "missing-info-modal-title";
+export const MISSING_INFO_PANEL_ID = "missing-info-modal";
+const PANEL_TITLE_ID = "missing-info-modal-title";
 
 type Props = {
 	siren: string;
@@ -23,7 +24,7 @@ type Props = {
 
 function getDescription(needsPhone: boolean, needsCse: boolean): string {
 	if (needsPhone && needsCse) {
-		return "Pour continuer, vous devez renseigner un numéro de téléphone et indiquer si un CSE a été mis en place dans votre entreprise.";
+		return "Pour continuer, vous devez ajouter un numéro de téléphone à votre profil et nous indiquer si un CSE a été mis en place.";
 	}
 	if (needsPhone) {
 		return "Pour continuer, vous devez ajouter un numéro de téléphone à votre profil.";
@@ -65,7 +66,7 @@ export function MissingInfoModal({ siren, userPhone, hasCse }: Props) {
 	useEffect(() => {
 		const handler = (e: Event) => {
 			const target = (e.target as HTMLElement).closest<HTMLElement>(
-				`[aria-controls="${MODAL_ID}"]`,
+				`[aria-controls="${MISSING_INFO_PANEL_ID}"]`,
 			);
 			if (!target) return;
 			openerTypeRef.current =
@@ -134,131 +135,119 @@ export function MissingInfoModal({ siren, userPhone, hasCse }: Props) {
 
 	return (
 		<dialog
-			aria-labelledby={MODAL_TITLE_ID}
+			aria-labelledby={PANEL_TITLE_ID}
 			aria-modal="true"
-			className="fr-modal"
-			id={MODAL_ID}
+			className={`fr-modal ${styles.sidePanel}`}
+			id={MISSING_INFO_PANEL_ID}
 			ref={dialogRef}
 		>
-			<div className="fr-container fr-container--fluid fr-container-md">
-				<div className="fr-grid-row fr-grid-row--center">
-					<div className="fr-col-12 fr-col-md-8 fr-col-lg-6">
-						<div className="fr-modal__body">
-							<div className="fr-modal__header">
-								<button
-									aria-controls={MODAL_ID}
-									className="fr-btn--close fr-btn"
-									title="Fermer"
-									type="button"
-								>
-									Fermer
-								</button>
-							</div>
-							<div className="fr-modal__content">
-								<h2 className="fr-modal__title" id={MODAL_TITLE_ID}>
-									Informations manquantes
-								</h2>
-								<p className="fr-text--regular fr-mb-3w">
-									{getDescription(needsPhone, needsCse)}
-								</p>
-								{needsPhone && (
-									<PhoneField
-										error={phoneError}
-										inputId="missing-info-phone"
-										registration={form.register("phone")}
-									/>
-								)}
-								{needsCse && (
-									<fieldset
-										aria-describedby={
-											cseError ? "missing-info-cse-error" : undefined
-										}
-										className={
-											cseError
-												? "fr-fieldset fr-fieldset--error"
-												: "fr-fieldset"
-										}
-									>
-										<legend className="fr-fieldset__legend fr-text--regular">
-											Un CSE a-t-il été mis en place dans votre entreprise ?
-										</legend>
-										<div className="fr-fieldset__element">
-											<div className="fr-radio-group fr-radio-rich">
-												<input
-													id="missing-info-cse-yes"
-													type="radio"
-													value="true"
-													{...form.register("hasCse")}
-												/>
-												<label
-													className="fr-label"
-													htmlFor="missing-info-cse-yes"
-												>
-													Oui
-												</label>
-											</div>
-										</div>
-										<div className="fr-fieldset__element">
-											<div className="fr-radio-group fr-radio-rich">
-												<input
-													id="missing-info-cse-no"
-													type="radio"
-													value="false"
-													{...form.register("hasCse")}
-												/>
-												<label
-													className="fr-label"
-													htmlFor="missing-info-cse-no"
-												>
-													Non
-												</label>
-											</div>
-										</div>
-										{cseError && (
-											<div
-												className="fr-messages-group"
-												id="missing-info-cse-error"
-												role="alert"
-											>
-												<p className="fr-message fr-message--error">
-													{cseError}
-												</p>
-											</div>
-										)}
-									</fieldset>
-								)}
-								{submitError && (
+			<div className={styles.panelContainer}>
+				<div className={styles.panelHeader}>
+					<button
+						aria-controls={MISSING_INFO_PANEL_ID}
+						className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-btn--icon-right fr-icon-close-line"
+						title="Fermer"
+						type="button"
+					>
+						Fermer
+					</button>
+				</div>
+				<div className={styles.panelContent}>
+					<div>
+						<h2 className="fr-h5 fr-mb-3w" id={PANEL_TITLE_ID}>
+							Informations manquantes
+						</h2>
+						<p className="fr-text--regular fr-mb-3w">
+							{getDescription(needsPhone, needsCse)}
+						</p>
+						{needsPhone && (
+							<PhoneField
+								error={phoneError}
+								inputId="missing-info-phone"
+								registration={form.register("phone")}
+							/>
+						)}
+						{needsCse && (
+							<fieldset
+								aria-describedby={
+									cseError ? "missing-info-cse-error" : undefined
+								}
+								className={
+									cseError ? "fr-fieldset fr-fieldset--error" : "fr-fieldset"
+								}
+							>
+								<legend className="fr-fieldset__legend fr-text--regular">
+									Un CSE a-t-il été mis en place dans votre entreprise ?
+								</legend>
+								<div className="fr-fieldset__element">
+									<div className="fr-radio-group fr-radio-rich">
+										<input
+											id="missing-info-cse-yes"
+											type="radio"
+											value="true"
+											{...form.register("hasCse")}
+										/>
+										<label className="fr-label" htmlFor="missing-info-cse-yes">
+											Oui
+										</label>
+									</div>
+								</div>
+								<div className="fr-fieldset__element">
+									<div className="fr-radio-group fr-radio-rich">
+										<input
+											id="missing-info-cse-no"
+											type="radio"
+											value="false"
+											{...form.register("hasCse")}
+										/>
+										<label className="fr-label" htmlFor="missing-info-cse-no">
+											Non
+										</label>
+									</div>
+								</div>
+								{cseError && (
 									<div
-										aria-live="polite"
-										className="fr-alert fr-alert--error fr-mt-2w"
+										className="fr-messages-group"
+										id="missing-info-cse-error"
+										role="alert"
 									>
-										<p>{submitError}</p>
+										<p className="fr-message fr-message--error">{cseError}</p>
 									</div>
 								)}
+							</fieldset>
+						)}
+						{submitError && (
+							<div
+								aria-live="polite"
+								className="fr-alert fr-alert--error fr-mt-2w"
+							>
+								<p>{submitError}</p>
 							</div>
-							<div className="fr-modal__footer">
-								<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
-									<li>
-										<button
-											className="fr-btn"
-											disabled={isPending}
-											onClick={handleSave}
-											type="button"
-										>
-											Enregistrer
-										</button>
-									</li>
-									<li>
-										<button
-											aria-controls={MODAL_ID}
-											className="fr-btn fr-btn--secondary"
-											type="button"
-										>
-											Retour
-										</button>
-									</li>
-								</ul>
-							</div>
+						)}
+					</div>
+					<div>
+						<div className={styles.footer}>
+							<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+								<li>
+									<button
+										className="fr-btn"
+										disabled={isPending}
+										onClick={handleSave}
+										type="button"
+									>
+										Enregistrer
+									</button>
+								</li>
+								<li>
+									<button
+										aria-controls={MISSING_INFO_PANEL_ID}
+										className="fr-btn fr-btn--secondary"
+										type="button"
+									>
+										Retour
+									</button>
+								</li>
+							</ul>
 						</div>
 					</div>
 				</div>

--- a/packages/app/src/modules/my-space/StatusBadge.tsx
+++ b/packages/app/src/modules/my-space/StatusBadge.tsx
@@ -18,7 +18,7 @@ const BADGE_CONFIG: Record<
 	},
 	done: {
 		label: "Effectué",
-		className: "fr-badge fr-badge--sm fr-badge--success",
+		className: "fr-badge fr-badge--sm fr-badge--success fr-badge--no-icon",
 	},
 };
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -102,7 +102,7 @@ describe("CompanyDeclarationsPage", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders the 'En cours' heading", () => {
+	it("renders the 'Démarche en cours' heading", () => {
 		render(
 			<CompanyDeclarationsPage
 				campaignDeadlines={campaignDeadlines}
@@ -113,7 +113,7 @@ describe("CompanyDeclarationsPage", () => {
 			/>,
 		);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "En cours" }),
+			screen.getByRole("heading", { level: 2, name: "Démarche en cours" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -48,8 +48,13 @@ describe("DeclarationProcessPanel", () => {
 		it("renders the last action date", () => {
 			const { panel } = renderPanel("start");
 			expect(
-				panel.getByText("Dernière action le 12 mars 2026"),
+				panel.getByText(/Dernière action le 12 mars 2026/),
 			).toBeInTheDocument();
+		});
+
+		it("renders the history link", () => {
+			const { panel } = renderPanel("start");
+			expect(panel.getByText("Voir l'historique")).toBeInTheDocument();
 		});
 
 		it("renders the info alert", () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -60,10 +60,10 @@ function renderSection(
 }
 
 describe("DeclarationsSection", () => {
-	it("renders the 'En cours' heading", () => {
+	it("renders the 'Démarche en cours' heading", () => {
 		renderSection();
 		expect(
-			screen.getByRole("heading", { level: 2, name: "En cours" }),
+			screen.getByRole("heading", { level: 2, name: "Démarche en cours" }),
 		).toBeInTheDocument();
 	});
 
@@ -78,9 +78,9 @@ describe("DeclarationsSection", () => {
 		expect(screen.getAllByRole("columnheader", { name: "Étape" })).toHaveLength(
 			2,
 		);
-		expect(
-			screen.getAllByRole("columnheader", { name: "Statut" }),
-		).toHaveLength(2);
+		expect(screen.getAllByRole("columnheader", { name: "État" })).toHaveLength(
+			2,
+		);
 		expect(
 			screen.getAllByRole("columnheader", { name: "Échéance" }),
 		).toHaveLength(2);

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
@@ -49,7 +49,7 @@ describe("MissingInfoModal", () => {
 		);
 		expect(
 			screen.getByText(
-				"Pour continuer, vous devez renseigner un numéro de téléphone et indiquer si un CSE a été mis en place dans votre entreprise.",
+				"Pour continuer, vous devez ajouter un numéro de téléphone à votre profil et nous indiquer si un CSE a été mis en place.",
 			),
 		).toBeInTheDocument();
 	});

--- a/packages/app/src/modules/my-space/__tests__/StatusBadge.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/StatusBadge.test.tsx
@@ -22,12 +22,12 @@ describe("StatusBadge", () => {
 		expect(badge).toHaveClass("fr-badge--sm");
 	});
 
-	it("renders a success badge with icon for done status", () => {
+	it("renders a success badge without icon for done status", () => {
 		render(<StatusBadge status="done" />);
 		const badge = screen.getByText("Effectué");
 		expect(badge).toBeInTheDocument();
 		expect(badge).toHaveClass("fr-badge--success");
 		expect(badge).toHaveClass("fr-badge--sm");
-		expect(badge).not.toHaveClass("fr-badge--no-icon");
+		expect(badge).toHaveClass("fr-badge--no-icon");
 	});
 });

--- a/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
+++ b/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
@@ -135,7 +135,7 @@ describe("ProfileModal", () => {
 			screen.getByText("Numéro de téléphone (obligatoire)"),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText("Format attendu : 01 22 33 44 55"),
+			screen.getByText("Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55"),
 		).toBeInTheDocument();
 		const input = getPhoneInput();
 		expect(input).toHaveAttribute("type", "tel");
@@ -179,7 +179,9 @@ describe("ProfileModal", () => {
 				"#profile-phone-messages .fr-message--error",
 			);
 			expect(errorMessage).toBeInTheDocument();
-			expect(errorMessage).toHaveTextContent("Format attendu : 01 22 33 44 55");
+			expect(errorMessage).toHaveTextContent(
+				"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55",
+			);
 		});
 	});
 
@@ -190,7 +192,7 @@ describe("ProfileModal", () => {
 		});
 		fireEvent.submit(getForm());
 		await waitFor(() => {
-			expect(mockMutate).toHaveBeenCalledWith({ phone: "0122334455" });
+			expect(mockMutate).toHaveBeenCalledWith({ phone: "+33122334455" });
 		});
 	});
 

--- a/packages/app/src/modules/profile/__tests__/phone.test.ts
+++ b/packages/app/src/modules/profile/__tests__/phone.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	formatPhone,
+	normalizePhone,
+	phoneSchema,
+	toCanonicalPhone,
+} from "../phone";
+
+describe("normalizePhone", () => {
+	it("strips spaces, dots, and dashes", () => {
+		expect(normalizePhone("01 22 33-44.55")).toBe("0122334455");
+	});
+
+	it("preserves the leading +", () => {
+		expect(normalizePhone("+33 1 22 33 44 55")).toBe("+33122334455");
+	});
+});
+
+describe("toCanonicalPhone", () => {
+	it("converts a French local number to +33 international form", () => {
+		expect(toCanonicalPhone("01 22 33 44 55")).toBe("+33122334455");
+	});
+
+	it("keeps an international number unchanged", () => {
+		expect(toCanonicalPhone("+33 1 22 33 44 55")).toBe("+33122334455");
+	});
+
+	it("accepts a country code with 1 digit", () => {
+		expect(toCanonicalPhone("+1 555 123 4567")).toBe("+15551234567");
+	});
+
+	it("accepts a country code with 3 digits (Iceland)", () => {
+		expect(toCanonicalPhone("+354 555 1234")).toBe("+3545551234");
+	});
+
+	it("rejects a number that is too short", () => {
+		expect(toCanonicalPhone("0122")).toBeNull();
+	});
+
+	it("rejects a French local number without leading 0", () => {
+		expect(toCanonicalPhone("122334455")).toBeNull();
+	});
+
+	it("rejects letters", () => {
+		expect(toCanonicalPhone("01 22 ABC 44 55")).toBeNull();
+	});
+});
+
+describe("formatPhone", () => {
+	it("formats a French canonical number as +33 X XX XX XX XX", () => {
+		expect(formatPhone("+33122334455")).toBe("+33 1 22 33 44 55");
+	});
+
+	it("formats a non-French international number with default 2-digit CC", () => {
+		expect(formatPhone("+15551234567")).toBe("+15 55 12 34 56 7");
+	});
+
+	it("returns the input unchanged for a non-canonical value", () => {
+		expect(formatPhone("0122334455")).toBe("0122334455");
+	});
+});
+
+describe("phoneSchema", () => {
+	it("accepts a French local number with separators", () => {
+		expect(phoneSchema.parse("01 22 33-44.55")).toBe("+33122334455");
+	});
+
+	it("accepts an international number", () => {
+		expect(phoneSchema.parse("+33 1 22 33 44 55")).toBe("+33122334455");
+	});
+
+	it("rejects an invalid format", () => {
+		const result = phoneSchema.safeParse("123");
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toContain(
+				"01 22 33 44 55 ou +33 1 22 33 44 55",
+			);
+		}
+	});
+});

--- a/packages/app/src/modules/profile/__tests__/phone.test.ts
+++ b/packages/app/src/modules/profile/__tests__/phone.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	formatPhone,
+	formatPhoneInput,
 	normalizePhone,
 	phoneSchema,
 	toCanonicalPhone,
@@ -58,6 +59,40 @@ describe("formatPhone", () => {
 
 	it("returns the input unchanged for a non-canonical value", () => {
 		expect(formatPhone("0122334455")).toBe("0122334455");
+	});
+});
+
+describe("formatPhoneInput", () => {
+	it("groups French local digits as pairs", () => {
+		expect(formatPhoneInput("0122334455")).toBe("01 22 33 44 55");
+	});
+
+	it("formats partial French local input", () => {
+		expect(formatPhoneInput("0122")).toBe("01 22");
+		expect(formatPhoneInput("01223")).toBe("01 22 3");
+	});
+
+	it("preserves a leading + while typing", () => {
+		expect(formatPhoneInput("+")).toBe("+");
+		expect(formatPhoneInput("+3")).toBe("+3");
+		expect(formatPhoneInput("+33")).toBe("+33");
+	});
+
+	it("formats a French international number as +33 X XX XX XX XX", () => {
+		expect(formatPhoneInput("+33122334455")).toBe("+33 1 22 33 44 55");
+	});
+
+	it("formats a non-French international number with pair groups", () => {
+		expect(formatPhoneInput("+15551234567")).toBe("+15 55 12 34 56 7");
+	});
+
+	it("strips disallowed characters from input", () => {
+		expect(formatPhoneInput("01-22.33 44.55")).toBe("01 22 33 44 55");
+		expect(formatPhoneInput("01abc22")).toBe("01 22");
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(formatPhoneInput("")).toBe("");
 	});
 });
 

--- a/packages/app/src/modules/profile/phone.ts
+++ b/packages/app/src/modules/profile/phone.ts
@@ -1,20 +1,55 @@
 import { z } from "zod";
 
-/** Strip spaces, dots, and dashes from a phone string to get raw digits. */
+const FRENCH_LOCAL_REGEX = /^0\d{9}$/;
+const INTERNATIONAL_REGEX = /^\+\d{8,15}$/;
+const PHONE_ERROR = "Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55";
+
+/** Strip whitespace, dots, and dashes. Keeps + and digits. */
 export function normalizePhone(value: string): string {
-	return value.replace(/[\s.-]/g, "");
+	return value.replace(/[\s.\-]/g, "");
 }
 
-/** Regex for a 10-digit French phone number (after normalization). */
-export const phoneDigitsRegex = /^\d{10}$/;
-
-/** Format a 10-digit phone string into "XX XX XX XX XX". */
-export function formatPhone(digits: string): string {
-	return digits.replace(/(\d{2})(?=\d)/g, "$1 ");
+/**
+ * Convert any accepted input to canonical international form (+CC followed by
+ * national digits). Accepts French local (10 digits starting with 0, mapped to
+ * +33...) or international with leading +. Returns null if the input is not a
+ * valid phone number.
+ */
+export function toCanonicalPhone(value: string): string | null {
+	const normalized = normalizePhone(value);
+	if (INTERNATIONAL_REGEX.test(normalized)) return normalized;
+	if (FRENCH_LOCAL_REGEX.test(normalized)) return `+33${normalized.slice(1)}`;
+	return null;
 }
 
-/** Zod schema for validating French phone numbers (accepts spaces, dots, dashes). */
-export const phoneSchema = z
-	.string()
-	.transform(normalizePhone)
-	.pipe(z.string().regex(phoneDigitsRegex, "Format attendu : 01 22 33 44 55"));
+/**
+ * Format a canonical phone for display with pair-spacing. French numbers
+ * (+33 + 9 digits) follow the conventional "+33 X XX XX XX XX" layout; other
+ * numbers are split as "+CC NN NN NN…" with CC defaulting to 2 digits.
+ */
+export function formatPhone(canonical: string): string {
+	if (canonical.startsWith("+33") && canonical.length === 12) {
+		const n = canonical.slice(3);
+		return `+33 ${n[0]} ${n.slice(1, 3)} ${n.slice(3, 5)} ${n.slice(5, 7)} ${n.slice(7, 9)}`;
+	}
+	if (INTERNATIONAL_REGEX.test(canonical)) {
+		const cc = canonical.slice(1, 3);
+		const national = canonical.slice(3);
+		const grouped = national.match(/.{1,2}/g)?.join(" ") ?? national;
+		return `+${cc} ${grouped}`;
+	}
+	return canonical;
+}
+
+/**
+ * Zod schema validating French local or international phone numbers and
+ * normalizing them to the canonical "+CC…" form for storage.
+ */
+export const phoneSchema = z.string().transform((value, ctx) => {
+	const canonical = toCanonicalPhone(value);
+	if (canonical === null) {
+		ctx.addIssue({ code: "custom", message: PHONE_ERROR });
+		return z.NEVER;
+	}
+	return canonical;
+});

--- a/packages/app/src/modules/profile/phone.ts
+++ b/packages/app/src/modules/profile/phone.ts
@@ -6,7 +6,7 @@ const PHONE_ERROR = "Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55";
 
 /** Strip whitespace, dots, and dashes. Keeps + and digits. */
 export function normalizePhone(value: string): string {
-	return value.replace(/[\s.\-]/g, "");
+	return value.replace(/[\s.-]/g, "");
 }
 
 /**

--- a/packages/app/src/modules/profile/phone.ts
+++ b/packages/app/src/modules/profile/phone.ts
@@ -42,6 +42,36 @@ export function formatPhone(canonical: string): string {
 }
 
 /**
+ * Format a user-typed phone number with pair-spacing for live input display.
+ * Without a leading "+": treats the digits as a French local number and groups
+ * them as pairs ("01 22 33 44 55"). With a leading "+": uses international
+ * format with the French "+33 X XX XX XX XX" layout when CC=33, otherwise
+ * "+CC NN NN…". Tolerates partial input as the user types.
+ */
+export function formatPhoneInput(raw: string): string {
+	const hasPlus = raw.trimStart().startsWith("+");
+	const digits = raw.replace(/\D/g, "");
+	if (!hasPlus) {
+		return digits.match(/.{1,2}/g)?.join(" ") ?? "";
+	}
+	if (digits.length === 0) return "+";
+	if (digits.length <= 2) return `+${digits}`;
+	const cc = digits.slice(0, 2);
+	const rest = digits.slice(2);
+	if (cc === "33") {
+		const groups: string[] = ["+33"];
+		if (rest.length >= 1) groups.push(rest.slice(0, 1));
+		if (rest.length >= 2) groups.push(rest.slice(1, 3));
+		if (rest.length >= 4) groups.push(rest.slice(3, 5));
+		if (rest.length >= 6) groups.push(rest.slice(5, 7));
+		if (rest.length >= 8) groups.push(rest.slice(7, 9));
+		return groups.join(" ");
+	}
+	const grouped = rest.match(/.{1,2}/g)?.join(" ") ?? rest;
+	return `+${cc} ${grouped}`;
+}
+
+/**
  * Zod schema validating French local or international phone numbers and
  * normalizing them to the canonical "+CC…" form for storage.
  */

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -23,7 +23,9 @@ export function PhoneField({
 		>
 			<label className="fr-label" htmlFor={inputId}>
 				Numéro de téléphone (obligatoire)
-				<span className="fr-hint-text">Format attendu : 01 22 33 44 55</span>
+				<span className="fr-hint-text">
+					Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55
+				</span>
 			</label>
 			<input
 				aria-describedby={messagesId}

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import type { ChangeEvent } from "react";
 import type { UseFormRegisterReturn } from "react-hook-form";
+
+import { formatPhoneInput } from "~/modules/profile/phone";
 
 type PhoneFieldProps = {
 	className?: string;
@@ -16,6 +19,11 @@ export function PhoneField({
 	registration,
 }: PhoneFieldProps) {
 	const messagesId = `${inputId}-messages`;
+
+	function handleChange(event: ChangeEvent<HTMLInputElement>) {
+		event.target.value = formatPhoneInput(event.target.value);
+		void registration.onChange(event);
+	}
 
 	return (
 		<div
@@ -33,6 +41,7 @@ export function PhoneField({
 				id={inputId}
 				type="tel"
 				{...registration}
+				onChange={handleChange}
 			/>
 			<div aria-live="polite" className="fr-messages-group" id={messagesId}>
 				{error && <p className="fr-message fr-message--error">{error}</p>}


### PR DESCRIPTION
fix #3319

## Summary
- Header: "Mon espace" button switched to tertiary with outline.
- Declarations table: heading renamed "Démarche en cours", "Statut" → "État", SM text size, declaration & Documents links underlined, success badge no longer carries an icon.
- Archives: spacing increased between title and description.
- Documents panel: each card is now a single clickable `<a>` with hover state, blue download icon, and an `aria-label` carrying title + PDF + subtitle.
- Missing-info dialog converted to a right-side panel (reuses the existing `sidePanel`/`panelContainer` pattern); copy aligned with Figma.
- Phone schema now accepts French local (`0…`) and international (`+CC…`) numbers, normalises to canonical `+CC…` storage; PhoneField hint updated.
- Declaration process panel: "Voir l'historique" placeholder added near the last-action line, help links underlined, gap between "Pour vous aider" and the separator collapsed.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm lint:check && pnpm format:check`
- [ ] Visual: open `/mon-espace`, click a "Rémunération" link without a phone → side panel "Informations manquantes" appears (no longer a centered modal); enter `+33 6 12 34 56 78` → save chains into the declaration process panel.
- [ ] Visual: open the documents panel from a completed year — each card highlights on hover and downloads the PDF on click.