### PR TITLE
feat(epic): auto-cleanup worktrees + /open skill for local PR testing

### DIFF
--- a/.claude/skills/open/SKILL.md
+++ b/.claude/skills/open/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: open
+description: "Recreate a worktree for a given PR to test it locally — useful after /epic auto-cleaned the worktree. Usage: /open <PR>"
+---
+
+# /open <PR>
+
+Recreate the egapro worktree associated with a PR — typically one that was auto-cleaned by `/epic` after the sub-agent returned `validated`. Use this to **test the PR's code locally** : run the dev server, exercise the feature, debug issues before merging.
+
+## Arguments
+
+`$ARGUMENTS` — PR number (`#3341`, `3341`). Required.
+
+---
+
+## Ton rôle
+
+Tu es **un thin wrapper**. Toute la logique est dans `scripts/orchestration/open_worktree.sh`. Tu dois :
+
+1. Valider que l'argument est un nombre de PR
+2. Lancer le script
+3. Relayer son output à l'utilisateur (path + URLs)
+
+```bash
+PR=$ARGUMENTS  # strip leading #
+PR=${PR#\#}
+
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: argument must be a PR number"
+    exit 1
+fi
+
+bash scripts/orchestration/open_worktree.sh "$PR"
+```
+
+Le script :
+- Résout la branche head + le ticket linked + l'epic parent
+- Choisit le premier slot libre dans `[0, EPIC_MAX_PARALLEL[`
+- Recrée le worktree (idempotent : réutilise s'il existe)
+- Lance `setup-worktree.sh` si `.env.local` est manquant (pnpm install + docker stack + migrations)
+- Affiche le path + les URLs (dev server, maildev, minio, postgres)
+
+---
+
+## Cas d'usage typiques
+
+- **Tester une PR ouverte** avant de la merger : `/open 3341` → worktree recréé, dev server prêt sur `http://localhost:3001` (ou autre selon le slot)
+- **Reprendre un debug** sur une PR rejetée par CI : `/open <PR>` puis `cd <path>` et bidouiller
+- **Reproduire un bug** sur le code d'une PR mergée mais qui pose problème en preprod : `/open <PR>` même après merge — la branche reste sur le remote
+
+---
+
+## Limitations
+
+- Si tous les slots `[0, EPIC_MAX_PARALLEL[` sont occupés (par d'autres worktrees actifs), le script retourne une erreur. Libérer un slot via `git worktree remove ../egapro-epic*-tXXX` ou augmenter `EPIC_MAX_PARALLEL`.
+- Si la PR a été créée hors de la pipeline `/epic` (pas de ticket lié, pas d'epic parent), le script échoue. Cas limite — créer le worktree à la main dans ce cas.
+
+---
+
+## Référence
+
+- Script : `scripts/orchestration/open_worktree.sh`
+- Setup docker : `scripts/setup-worktree.sh`
+- Cleanup auto par la pipeline : `scripts/orchestration/cleanup_terminal_worktrees.sh` (appelé à chaque tick par `epic_loop.sh`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ Quality checks run **automatically** après chaque itération de code — pas de
 | `/epic <N1> [<N2> ...]` | Lance le bash loop driver `scripts/orchestration/epic_loop.sh` en background sur les epics donnés. Main context libre. |
 | `/code <N>` | Exécute un seul ticket via `code-dev` (debug, fix). Parse le retour JSON strict, ré-invoque en Opus si `needs_opus_escalation`. |
 | `/report [<N> ...]` | Dashboard live des agents actifs + état des sous-tickets de l'epic. Pure bash, zéro LLM. |
+| `/open <PR>` | Recrée un worktree local pour une PR (typique après auto-cleanup de `/epic`) — utile pour tester la PR avant merge. |
 | `/review` | Traite les commentaires de revue posés après passage en `In review` (human + bots) |
 
 Workflow standard : `/ticket "..."` pour concevoir, puis `/epic <N>` pour exécuter en parallèle (suivi via `/report`). `/review` prend le relais quand les humains commentent les PR sorties de `In review`.
@@ -186,10 +187,14 @@ Tous les scripts shell portent leur propre header `--help`-friendly. La pipeline
 
 | Script | Rôle |
 |---|---|
-| `epic_loop.sh` | Loop driver background. Tick = plan → spawn N `claude` CLIs en parallèle (budget USD isolé) → aggregate JSON returns → process. Plafond `EPIC_LOOP_MAX_TICKS=30`. |
+| `epic_loop.sh` | Loop driver background. Tick = cleanup terminal worktrees → plan → spawn N `claude` CLIs en parallèle (budget USD isolé) → aggregate JSON returns → process. Plafond `EPIC_LOOP_MAX_TICKS=30`. |
+| `cleanup_terminal_worktrees.sh` | Scan les worktrees `egapro-epic<E>-t<N>` ; teardown + remove ceux dont le ticket est en `In review` ou `Done`. Appelé à chaque tick par `epic_loop.sh` pour libérer les slots dynamiquement. |
 | `dispatch_plan.sh` | Calcule la JSON list des tickets dispatchables : parse `## Depends on`, applique le stacked PR pattern, alloue les indices libres dans `[0, EPIC_MAX_PARALLEL[`. |
 | `process_tick_result.sh` | Applique les mutations board selon le statut JSON retourné par `code-dev`. Compteur `attempt=N` pour anti-boucle 3 refacto consécutifs → `dispatch=escalate`. |
 | `set_ticket_status.sh` | Encapsule les 3 GraphQL calls de `rules/github-board.md`. **Refuse explicitement la transition `Done`** (user-only). |
+| `create_linked_branch.sh` | Crée une branche linkée à l'issue via `createLinkedBranch` GraphQL — la PR sera auto-attachée à la sidebar Development de l'issue. |
+| `open_worktree.sh` | Recrée un worktree pour une PR donnée (skill `/open <PR>`). Utile pour tester localement après auto-cleanup. |
+| `refresh_pr_link.sh` | Force GitHub à re-parser le `Closes #N` d'une PR (workaround pour le retarget post-merge stacked). |
 | `cache_gh.sh` | TTL wrapper sur `gh` pour amortir les rate limits (clé `epic_<N>_full` partagée entre `dispatch_plan` et `epic_state`, TTL 300s). |
 | `log_event.sh` | Logging append-only par agent, rolling 50 lignes, sous `.claude/state/epic_run/agents/`. |
 | `epic_state.sh` | Tableau compact des sous-tickets d'un epic (status board + last log event + retries + PR liée). |

--- a/scripts/orchestration/cleanup_terminal_worktrees.sh
+++ b/scripts/orchestration/cleanup_terminal_worktrees.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# cleanup_terminal_worktrees.sh <epic_N1> [<epic_N2> ...]
+#
+# Scans worktrees matching egapro-epic<E>-t<N> for the given epics, queries
+# each ticket's board status, and tears down + removes the worktree if the
+# ticket is in a terminal pipeline state (In review or Done).
+#
+# Called by epic_loop.sh at the BEGINNING of each tick — before
+# dispatch_plan — so that slots get freed dynamically. Important when an
+# epic has more tickets than EPIC_MAX_PARALLEL (default 5): without this,
+# the 6th ticket can never enter the loop because all slots stay busy
+# until the user manually cleans them up.
+#
+# 'Cleanable' definition: PR is green and bot reviews have been addressed.
+# This is exactly what code-dev returning `validated` guarantees, which is
+# also what triggers the board transition to 'In review'. So checking the
+# board status is enough.
+#
+# Idempotent. No-op if no worktree matches or none is in terminal state.
+
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <epic_N1> [<epic_N2> ...]" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Build a regex from the epic args
+EPICS_REGEX=""
+for epic in "$@"; do
+    [ -n "$EPICS_REGEX" ] && EPICS_REGEX="${EPICS_REGEX}|"
+    EPICS_REGEX="${EPICS_REGEX}${epic}"
+done
+
+# For each worktree matching the given epics, check the ticket status
+while IFS= read -r path; do
+    [ -n "$path" ] || continue
+
+    name=$(basename "$path")
+    if ! [[ "$name" =~ ^egapro-epic([0-9]+)-t([0-9]+)$ ]]; then
+        continue
+    fi
+
+    epic="${BASH_REMATCH[1]}"
+    ticket="${BASH_REMATCH[2]}"
+
+    # Filter: only care about worktrees whose epic is in the args
+    if ! echo "$epic" | grep -qE "^(${EPICS_REGEX})$"; then
+        continue
+    fi
+
+    # Query the ticket's board status. Use the bulk GraphQL pattern from
+    # rules/github-board.md (snippet 3) to find the project item, then
+    # extract the Status single-select value.
+    STATUS=$(gh api graphql -f query='
+        query($owner:String!, $repo:String!, $n:Int!) {
+          repository(owner:$owner, name:$repo) {
+            issue(number:$n) {
+              projectItems(first: 5) {
+                nodes {
+                  project { id }
+                  fieldValues(first: 10) {
+                    nodes {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        field { ... on ProjectV2SingleSelectField { name } }
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }' -f owner=SocialGouv -f repo=egapro -F n="$ticket" \
+        --jq '.data.repository.issue.projectItems.nodes[] | select(.project.id == "PVT_kwDOAh0HH84BFsK7") | .fieldValues.nodes[]? | select(.field.name == "Status") | .name' 2>/dev/null | head -1)
+
+    case "$STATUS" in
+        "In review"|"Done")
+            echo "[cleanup_terminal_worktrees] $name (ticket #$ticket = $STATUS) → teardown + remove" >&2
+            (cd "$path" && bash "$REPO_ROOT/scripts/teardown-worktree.sh" >&2 2>&1) || true
+            git worktree remove --force "$path" >&2 2>&1 || true
+            ;;
+        *)
+            # In progress / To Do / Backlog → keep the worktree
+            :
+            ;;
+    esac
+done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -202,6 +202,12 @@ while [ $TICK -lt $MAX_TICKS ]; do
     PLAN_FILE="$TICK_DIR/tick_${TICK}_plan.json"
     RESULT_FILE="$TICK_DIR/tick_${TICK}_result.json"
 
+    # 0. Free up worktree slots whose ticket has reached a terminal pipeline
+    # state (In review or Done). Critical for epics with > EPIC_MAX_PARALLEL
+    # tickets — without this, slots stay busy until manual cleanup and the
+    # remaining tickets can never be dispatched.
+    bash "$SCRIPT_DIR/cleanup_terminal_worktrees.sh" $EPICS >/dev/null 2>&1 || true
+
     # 1. Compute the plan
     bash "$SCRIPT_DIR/dispatch_plan.sh" $EPICS > "$PLAN_FILE"
 

--- a/scripts/orchestration/open_worktree.sh
+++ b/scripts/orchestration/open_worktree.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# open_worktree.sh <pr_number>
+#
+# Recreate the egapro worktree for a given PR — used after the pipeline
+# has auto-cleaned the worktree (when the ticket transitioned to In review
+# or Done) but the user wants to test the PR locally.
+#
+# Workflow:
+# 1. Resolve PR head branch + linked issue from GitHub
+# 2. Resolve the issue's parent epic
+# 3. Path = ../egapro-epic<EPIC>-t<TICKET>  (same convention as /epic)
+# 4. Pick first free worktree index in [0, EPIC_MAX_PARALLEL[
+# 5. git worktree add (or reuse if already present)
+# 6. setup-worktree.sh <index>  (pnpm install + docker stack + migrations)
+# 7. Print path + dev URLs
+#
+# Idempotent: if the worktree already exists at the expected path, reuse it.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <pr_number>" >&2
+    exit 2
+fi
+
+PR="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MAX_PARALLEL="${EPIC_MAX_PARALLEL:-5}"
+
+# 1. Resolve PR head branch + closing issue
+PR_INFO=$(gh api graphql -f query='
+    query($owner:String!, $repo:String!, $n:Int!) {
+      repository(owner:$owner, name:$repo) {
+        pullRequest(number:$n) {
+          headRefName
+          state
+          closingIssuesReferences(first: 1) { nodes { number } }
+        }
+      }
+    }' -f owner=SocialGouv -f repo=egapro -F n="$PR")
+
+HEAD_BRANCH=$(echo "$PR_INFO" | jq -r '.data.repository.pullRequest.headRefName')
+PR_STATE=$(echo "$PR_INFO" | jq -r '.data.repository.pullRequest.state')
+TICKET=$(echo "$PR_INFO" | jq -r '.data.repository.pullRequest.closingIssuesReferences.nodes[0].number // empty')
+
+if [ -z "$HEAD_BRANCH" ] || [ "$HEAD_BRANCH" = "null" ]; then
+    echo "ERROR: PR #$PR not found" >&2
+    exit 1
+fi
+
+# Fallback: parse the body for "Closes #N" if closingIssuesReferences is empty
+# (e.g. PR targets a non-default branch and the link wasn't established).
+if [ -z "$TICKET" ]; then
+    BODY=$(gh pr view "$PR" --json body --jq '.body')
+    TICKET=$(echo "$BODY" | grep -ioE '(closes|resolves|fixes) #[0-9]+' | head -1 | grep -oE '[0-9]+' | head -1)
+fi
+
+if [ -z "$TICKET" ]; then
+    echo "ERROR: cannot infer ticket from PR #$PR (no Closes/Resolves/Fixes keyword in body and no closing issue link)" >&2
+    exit 1
+fi
+
+# 2. Resolve epic parent of the issue
+EPIC=$(gh api graphql -f query='
+    query($owner:String!, $repo:String!, $n:Int!) {
+      repository(owner:$owner, name:$repo) {
+        issue(number:$n) {
+          parent { number }
+        }
+      }
+    }' -f owner=SocialGouv -f repo=egapro -F n="$TICKET" \
+    --jq '.data.repository.issue.parent.number // empty')
+
+if [ -z "$EPIC" ]; then
+    echo "ERROR: ticket #$TICKET has no parent epic" >&2
+    exit 1
+fi
+
+# 3. Compute path
+WT_PATH="${REPO_ROOT}/../egapro-epic${EPIC}-t${TICKET}"
+WT_PATH=$(realpath -m "$WT_PATH")
+
+# 4. Pick free worktree index
+declare -A INDEX_BUSY
+for i in $(seq 0 $((MAX_PARALLEL - 1))); do
+    INDEX_BUSY[$i]=0
+done
+
+while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$(basename "$path")" in egapro-epic*-t*) ;; *) continue ;; esac
+    ENV_FILE="$path/packages/app/.env.local"
+    [ -f "$ENV_FILE" ] || continue
+    PORT_LINE=$(grep '^PORT=' "$ENV_FILE" | head -1 | cut -d= -f2)
+    [[ "$PORT_LINE" =~ ^[0-9]+$ ]] || continue
+    IDX=$((PORT_LINE - 3001))
+    if [ "$IDX" -ge 0 ] && [ "$IDX" -lt "$MAX_PARALLEL" ]; then
+        INDEX_BUSY[$IDX]=1
+    fi
+done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+
+INDEX=""
+for i in $(seq 0 $((MAX_PARALLEL - 1))); do
+    if [ "${INDEX_BUSY[$i]}" = "0" ]; then
+        INDEX=$i
+        break
+    fi
+done
+
+if [ -z "$INDEX" ]; then
+    echo "ERROR: no free worktree slot ([0, $MAX_PARALLEL[ all busy). Free one with 'git worktree remove' or raise EPIC_MAX_PARALLEL." >&2
+    exit 1
+fi
+
+# 5. Create or reuse the worktree
+echo "[open_worktree] PR #$PR — branch $HEAD_BRANCH — ticket #$TICKET (epic #$EPIC) — index $INDEX" >&2
+
+if [ ! -d "$WT_PATH" ]; then
+    (cd "$REPO_ROOT" && git fetch origin "$HEAD_BRANCH") >&2
+    (cd "$REPO_ROOT" && git worktree add "$WT_PATH" "$HEAD_BRANCH") >&2 || \
+        (cd "$REPO_ROOT" && git worktree add --detach "$WT_PATH" "origin/$HEAD_BRANCH" >&2 && cd "$WT_PATH" && git checkout "$HEAD_BRANCH" >&2)
+else
+    echo "[open_worktree] reusing existing worktree at $WT_PATH" >&2
+    (cd "$WT_PATH" && git fetch origin "$HEAD_BRANCH" && git checkout "$HEAD_BRANCH" && git pull --ff-only origin "$HEAD_BRANCH") >&2 || true
+fi
+
+# 6. setup-worktree.sh if not already provisioned
+if [ ! -f "$WT_PATH/packages/app/.env.local" ]; then
+    (cd "$WT_PATH" && bash "$REPO_ROOT/scripts/setup-worktree.sh" "$INDEX") >&2
+else
+    echo "[open_worktree] .env.local already present — skipping setup" >&2
+fi
+
+# 7. Report
+APP_PORT=$((3001 + INDEX))
+cat <<EOF
+
+✓ Worktree ready
+
+  Path        : $WT_PATH
+  Branch      : $HEAD_BRANCH
+  PR          : #$PR (state: $PR_STATE)
+  Ticket      : #$TICKET (epic #$EPIC)
+  Slot index  : $INDEX
+  Dev server  : http://localhost:$APP_PORT  (run via: cd $WT_PATH && pnpm dev:app)
+
+  Maildev    : http://localhost:$((1200 + 10 * INDEX))
+  Minio      : http://localhost:$((9100 + 10 * INDEX))  (console: $((9101 + 10 * INDEX)))
+  Postgres   : localhost:$((5500 + 10 * INDEX))
+EOF


### PR DESCRIPTION
## Summary

- **Auto-cleanup worktrees** : `cleanup_terminal_worktrees.sh` appelé à chaque tick par `epic_loop.sh`. Quand un ticket atteint `In review` ou `Done`, son worktree est teardown + supprimé automatiquement → libère le slot dynamiquement. Critique pour les epics avec plus de `EPIC_MAX_PARALLEL` tickets : sans ça, les slots restent occupés et le 6ᵉ ticket ne peut jamais entrer dans la boucle.
- **Nouveau skill `/open <PR>`** : recrée le worktree d'une PR (typiquement après auto-cleanup) pour tester localement avant merge. Idempotent, réutilise l'existant si présent.

## Files

- `scripts/orchestration/cleanup_terminal_worktrees.sh` : nouveau, scan + teardown + remove
- `scripts/orchestration/open_worktree.sh` : nouveau, logique du skill `/open`
- `scripts/orchestration/epic_loop.sh` : appelle `cleanup_terminal_worktrees` au début de chaque tick
- `.claude/skills/open/SKILL.md` : nouveau thin wrapper
- `CLAUDE.md` : doc skills + table des scripts orchestration

## Trade-off

L'auto-cleanup supprime l'env de dev local dès qu'un sub-agent retourne `validated`. Si tu veux tester la PR localement, lance `/open <PR>` (1 commande, recreate setup-worktree complet en ~30s avec cache pnpm chaud).

## Test plan

- [ ] Smoke test : un epic avec 6+ tickets dispatchables progresse au-delà de la 5ᵉ slot grâce à l'auto-cleanup
- [ ] `/open <PR>` recrée un worktree fonctionnel (dev server démarre)
- [ ] `/open <PR>` réutilise un worktree existant sans re-setup (idempotence)
- [ ] `/open <PR>` échoue proprement si tous les slots sont occupés