### PR TITLE
fix(auth): proper OIDC RP-initiated logout (browser-side)

### DIFF
--- a/packages/app/src/app/api/auth/logout/callback/route.ts
+++ b/packages/app/src/app/api/auth/logout/callback/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { env } from "~/env";
+
+/**
+ * OIDC RP-initiated logout callback.
+ *
+ * Hit by ProConnect (via charon's logout dispatcher) after the IdP SSO
+ * cookie has been cleared. The local NextAuth cookie was already cleared
+ * by /api/auth/logout, so this route only redirects the user back to the
+ * home page.
+ */
+export function GET() {
+	const baseUrl = new URL(env.NEXTAUTH_URL).origin;
+	return NextResponse.redirect(new URL("/", baseUrl));
+}

--- a/packages/app/src/app/api/auth/logout/callback/route.ts
+++ b/packages/app/src/app/api/auth/logout/callback/route.ts
@@ -2,14 +2,6 @@ import { NextResponse } from "next/server";
 
 import { env } from "~/env";
 
-/**
- * OIDC RP-initiated logout callback.
- *
- * Hit by ProConnect (via charon's logout dispatcher) after the IdP SSO
- * cookie has been cleared. The local NextAuth cookie was already cleared
- * by /api/auth/logout, so this route only redirects the user back to the
- * home page.
- */
 export function GET() {
 	const baseUrl = new URL(env.NEXTAUTH_URL).origin;
 	return NextResponse.redirect(new URL("/", baseUrl));

--- a/packages/app/src/app/api/auth/logout/route.ts
+++ b/packages/app/src/app/api/auth/logout/route.ts
@@ -8,20 +8,6 @@ import { logAction } from "~/server/audit/log";
 import { buildRequestContext } from "~/server/audit/requestContext";
 import { fetchEndSessionEndpoint } from "~/server/auth/proconnect-logout";
 
-/**
- * Custom logout route. Performs a browser-side OIDC RP-initiated logout:
- *
- *   1. Audit the intent.
- *   2. Clear the local NextAuth session cookie on the redirect response.
- *   3. Redirect the browser to ProConnect's `end_session_endpoint` with
- *      `id_token_hint` (so the IdP knows which session to terminate) and
- *      `post_logout_redirect_uri` pointing back to /api/auth/logout/callback.
- *
- * The redirect MUST happen in the browser — a server-side fetch cannot
- * kill the IdP SSO cookie that lives in the user's browser. If the
- * end_session_endpoint cannot be discovered (issuer unreachable, etc.) we
- * fall back to a local-only logout and redirect home directly.
- */
 export async function GET(request: NextRequest) {
 	const token = await getToken({ req: request });
 	const baseUrl = new URL(env.NEXTAUTH_URL).origin;
@@ -46,11 +32,6 @@ export async function GET(request: NextRequest) {
 	const redirectTarget = await buildLogoutRedirectUrl(token?.id_token, baseUrl);
 	const response = NextResponse.redirect(redirectTarget);
 
-	// Clear the local NextAuth session cookie eagerly so the user is logged
-	// out of egapro even if the IdP round-trip never completes (network blip,
-	// user closes the tab, ProConnect outage). Set is used over delete because
-	// cookies.delete() omits the Secure flag, which browsers silently ignore
-	// on `__Secure-` prefixed cookies.
 	const isSecure = baseUrl.startsWith("https://");
 	const sessionCookieName = isSecure
 		? "__Secure-next-auth.session-token"

--- a/packages/app/src/app/api/auth/logout/route.ts
+++ b/packages/app/src/app/api/auth/logout/route.ts
@@ -6,25 +6,26 @@ import { AUDIT_ACTIONS } from "~/modules/audit";
 import { parseSiren } from "~/modules/domain";
 import { logAction } from "~/server/audit/log";
 import { buildRequestContext } from "~/server/audit/requestContext";
-import { terminateProConnectSession } from "~/server/auth/proconnect-logout";
+import { fetchEndSessionEndpoint } from "~/server/auth/proconnect-logout";
 
 /**
- * Custom logout route that terminates both the local NextAuth session
- * and the ProConnect OIDC session (server-side fire-and-forget).
+ * Custom logout route. Performs a browser-side OIDC RP-initiated logout:
  *
- * The browser is always redirected to / (home page) — the ProConnect end_session
- * is called server-side to avoid post_logout_redirect_uri registration issues.
+ *   1. Audit the intent.
+ *   2. Clear the local NextAuth session cookie on the redirect response.
+ *   3. Redirect the browser to ProConnect's `end_session_endpoint` with
+ *      `id_token_hint` (so the IdP knows which session to terminate) and
+ *      `post_logout_redirect_uri` pointing back to /api/auth/logout/callback.
+ *
+ * The redirect MUST happen in the browser — a server-side fetch cannot
+ * kill the IdP SSO cookie that lives in the user's browser. If the
+ * end_session_endpoint cannot be discovered (issuer unreachable, etc.) we
+ * fall back to a local-only logout and redirect home directly.
  */
 export async function GET(request: NextRequest) {
 	const token = await getToken({ req: request });
-	// Use the public origin from NEXTAUTH_URL to avoid localhost redirects behind reverse proxies
 	const baseUrl = new URL(env.NEXTAUTH_URL).origin;
 
-	// Audit the logout only if there was an active session — an unauthenticated
-	// GET to /api/auth/logout should not produce a spurious `auth.logout` row.
-	// `logAction` is awaited (not fire-and-forget) so the write is guaranteed
-	// to be persisted before the redirect response is issued. `logAction` is
-	// fail-safe internally, so a DB outage will not block logout.
 	if (token) {
 		const requestContext = buildRequestContext(request.headers);
 		const tokenWithEmail = token as typeof token & {
@@ -42,22 +43,18 @@ export async function GET(request: NextRequest) {
 		});
 	}
 
-	if (token?.id_token) {
-		// Terminate ProConnect OIDC session server-side (fire-and-forget)
-		await terminateProConnectSession(token.id_token);
-	}
+	const redirectTarget = await buildLogoutRedirectUrl(token?.id_token, baseUrl);
+	const response = NextResponse.redirect(redirectTarget);
 
-	const response = NextResponse.redirect(new URL("/", baseUrl));
-
-	// Delete the NextAuth session cookie directly on the redirect response
-	// to ensure the Set-Cookie header is included in the 307 response.
-	// Using cookies() from next/headers does not propagate to NextResponse.redirect().
+	// Clear the local NextAuth session cookie eagerly so the user is logged
+	// out of egapro even if the IdP round-trip never completes (network blip,
+	// user closes the tab, ProConnect outage). Set is used over delete because
+	// cookies.delete() omits the Secure flag, which browsers silently ignore
+	// on `__Secure-` prefixed cookies.
 	const isSecure = baseUrl.startsWith("https://");
 	const sessionCookieName = isSecure
 		? "__Secure-next-auth.session-token"
 		: "next-auth.session-token";
-	// Explicit set with matching attributes — cookies.delete() omits the Secure
-	// flag, so browsers silently ignore the deletion for __Secure- prefixed cookies.
 	response.cookies.set(sessionCookieName, "", {
 		expires: new Date(0),
 		path: "/",
@@ -67,4 +64,24 @@ export async function GET(request: NextRequest) {
 	});
 
 	return response;
+}
+
+async function buildLogoutRedirectUrl(
+	idToken: string | null | undefined,
+	baseUrl: string,
+): Promise<URL> {
+	if (!idToken) {
+		return new URL("/", baseUrl);
+	}
+	const endSessionEndpoint = await fetchEndSessionEndpoint();
+	if (!endSessionEndpoint) {
+		return new URL("/", baseUrl);
+	}
+	const url = new URL(endSessionEndpoint);
+	url.searchParams.set("id_token_hint", idToken);
+	url.searchParams.set(
+		"post_logout_redirect_uri",
+		`${baseUrl}/api/auth/logout/callback`,
+	);
+	return url;
 }

--- a/packages/app/src/e2e/login.e2e.ts
+++ b/packages/app/src/e2e/login.e2e.ts
@@ -36,16 +36,7 @@ test.describe("ProConnect authentication flow", () => {
 		await page.getByRole("button", { name: "Mon espace" }).click();
 		await page.getByRole("menuitem", { name: "Se déconnecter" }).click();
 
-		// OIDC RP-initiated logout: the browser must be redirected to the IdP's
-		// end_session_endpoint to kill the SSO cookie. Verify we land on it
-		// (the URL pattern is consistent across charon and direct-upstream setups).
 		await page.waitForURL(/session\/end|oauth\/logout/, { timeout: 10_000 });
-
-		// Force-navigate back to egapro. The IdP only auto-redirects to
-		// post_logout_redirect_uri if it is registered for the client — which is
-		// not necessarily the case in CI. Either way, the local session has been
-		// cleared by /api/auth/logout before the IdP redirect, so going home
-		// must expose the unauthenticated state.
 		await page.goto("/");
 
 		await expect(

--- a/packages/app/src/e2e/login.e2e.ts
+++ b/packages/app/src/e2e/login.e2e.ts
@@ -36,7 +36,18 @@ test.describe("ProConnect authentication flow", () => {
 		await page.getByRole("button", { name: "Mon espace" }).click();
 		await page.getByRole("menuitem", { name: "Se déconnecter" }).click();
 
-		await page.waitForURL(/\/$/, { timeout: 10_000 });
+		// OIDC RP-initiated logout: the browser must be redirected to the IdP's
+		// end_session_endpoint to kill the SSO cookie. Verify we land on it
+		// (the URL pattern is consistent across charon and direct-upstream setups).
+		await page.waitForURL(/session\/end|oauth\/logout/, { timeout: 10_000 });
+
+		// Force-navigate back to egapro. The IdP only auto-redirects to
+		// post_logout_redirect_uri if it is registered for the client — which is
+		// not necessarily the case in CI. Either way, the local session has been
+		// cleared by /api/auth/logout before the IdP redirect, so going home
+		// must expose the unauthenticated state.
+		await page.goto("/");
+
 		await expect(
 			page.getByRole("link", { name: "Se connecter" }),
 		).toBeVisible();

--- a/packages/app/src/e2e/logout.e2e.ts
+++ b/packages/app/src/e2e/logout.e2e.ts
@@ -10,16 +10,7 @@ test.describe("Logout flow", () => {
 		await page.getByRole("button", { name: "Mon espace" }).click();
 		await page.getByRole("menuitem", { name: "Se déconnecter" }).click();
 
-		// OIDC RP-initiated logout: the browser must be redirected to the IdP's
-		// end_session_endpoint to kill the SSO cookie. Verify we land on it
-		// (the URL pattern is consistent across charon and direct-upstream setups).
 		await page.waitForURL(/session\/end|oauth\/logout/, { timeout: 10_000 });
-
-		// Force-navigate back to egapro. The IdP only auto-redirects to
-		// post_logout_redirect_uri if it is registered for the client — which is
-		// not necessarily the case in CI. Either way, the local session has been
-		// cleared by /api/auth/logout before the IdP redirect, so going home
-		// must expose the unauthenticated state.
 		await page.goto("/");
 
 		await expect(

--- a/packages/app/src/e2e/logout.e2e.ts
+++ b/packages/app/src/e2e/logout.e2e.ts
@@ -10,7 +10,18 @@ test.describe("Logout flow", () => {
 		await page.getByRole("button", { name: "Mon espace" }).click();
 		await page.getByRole("menuitem", { name: "Se déconnecter" }).click();
 
-		await page.waitForURL(/\/$/, { timeout: 10_000 });
+		// OIDC RP-initiated logout: the browser must be redirected to the IdP's
+		// end_session_endpoint to kill the SSO cookie. Verify we land on it
+		// (the URL pattern is consistent across charon and direct-upstream setups).
+		await page.waitForURL(/session\/end|oauth\/logout/, { timeout: 10_000 });
+
+		// Force-navigate back to egapro. The IdP only auto-redirects to
+		// post_logout_redirect_uri if it is registered for the client — which is
+		// not necessarily the case in CI. Either way, the local session has been
+		// cleared by /api/auth/logout before the IdP redirect, so going home
+		// must expose the unauthenticated state.
+		await page.goto("/");
+
 		await expect(
 			page.getByRole("link", { name: "Se connecter" }),
 		).toBeVisible();

--- a/packages/app/src/server/auth/__tests__/logout-route.test.ts
+++ b/packages/app/src/server/auth/__tests__/logout-route.test.ts
@@ -9,16 +9,16 @@ vi.mock("next-auth/jwt", () => ({
 }));
 
 vi.mock("~/server/auth/proconnect-logout", () => ({
-	terminateProConnectSession: vi.fn(),
+	fetchEndSessionEndpoint: vi.fn(),
 }));
 
 vi.mock("~/server/audit/log", () => ({
 	logAction: (...args: unknown[]) => mockLogAction(...args),
 }));
 
-import { terminateProConnectSession } from "~/server/auth/proconnect-logout";
+import { fetchEndSessionEndpoint } from "~/server/auth/proconnect-logout";
 
-const mockTerminate = vi.mocked(terminateProConnectSession);
+const mockFetchEndSession = vi.mocked(fetchEndSessionEndpoint);
 
 // Dynamic import to ensure mocks are registered before the module loads
 const { GET } = await import("~/app/api/auth/logout/route");
@@ -32,15 +32,60 @@ function buildRequest() {
 describe("GET /api/auth/logout", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockFetchEndSession.mockResolvedValue(null);
 	});
 
-	it("redirects to the home page", async () => {
+	it("redirects to the home page when no session is active", async () => {
 		mockGetToken.mockResolvedValue(null);
 
 		const response = await GET(buildRequest());
 
 		expect(response.status).toBe(307);
 		expect(response.headers.get("Location")).toBe("http://localhost:3000/");
+	});
+
+	it("redirects to the home page when the session has no id_token", async () => {
+		mockGetToken.mockResolvedValue({ id: "user-123" });
+
+		const response = await GET(buildRequest());
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("Location")).toBe("http://localhost:3000/");
+		expect(mockFetchEndSession).not.toHaveBeenCalled();
+	});
+
+	it("redirects to the home page when end_session_endpoint cannot be discovered", async () => {
+		mockGetToken.mockResolvedValue({
+			id: "user-123",
+			id_token: "oidc-id-token",
+		});
+		mockFetchEndSession.mockResolvedValue(null);
+
+		const response = await GET(buildRequest());
+
+		expect(response.status).toBe(307);
+		expect(response.headers.get("Location")).toBe("http://localhost:3000/");
+	});
+
+	it("redirects to end_session_endpoint with id_token_hint and post_logout_redirect_uri when an id_token is present", async () => {
+		mockGetToken.mockResolvedValue({
+			id: "user-123",
+			id_token: "oidc-id-token",
+		});
+		mockFetchEndSession.mockResolvedValue(
+			"https://proconnect.example.com/api/v2/session/end",
+		);
+
+		const response = await GET(buildRequest());
+
+		expect(response.status).toBe(307);
+		const location = new URL(response.headers.get("Location") ?? "");
+		expect(location.origin).toBe("https://proconnect.example.com");
+		expect(location.pathname).toBe("/api/v2/session/end");
+		expect(location.searchParams.get("id_token_hint")).toBe("oidc-id-token");
+		expect(location.searchParams.get("post_logout_redirect_uri")).toBe(
+			"http://localhost:3000/api/auth/logout/callback",
+		);
 	});
 
 	it("deletes the session cookie on the response with correct attributes", async () => {
@@ -54,43 +99,6 @@ describe("GET /api/auth/logout", () => {
 		expect(setCookie).toContain("Path=/");
 		expect(setCookie).toContain("HttpOnly");
 		expect(setCookie).toContain("SameSite=lax");
-	});
-
-	it("calls terminateProConnectSession with id_token when present", async () => {
-		mockGetToken.mockResolvedValue({
-			id: "user-123",
-			id_token: "oidc-id-token",
-		});
-
-		await GET(buildRequest());
-
-		expect(mockTerminate).toHaveBeenCalledWith("oidc-id-token");
-	});
-
-	it("does not call terminateProConnectSession when no token", async () => {
-		mockGetToken.mockResolvedValue(null);
-
-		await GET(buildRequest());
-
-		expect(mockTerminate).not.toHaveBeenCalled();
-	});
-
-	it("does not call terminateProConnectSession when token has no id_token", async () => {
-		mockGetToken.mockResolvedValue({ id: "user-123" });
-
-		await GET(buildRequest());
-
-		expect(mockTerminate).not.toHaveBeenCalled();
-	});
-
-	it("propagates error when terminateProConnectSession fails", async () => {
-		mockGetToken.mockResolvedValue({
-			id: "user-123",
-			id_token: "oidc-id-token",
-		});
-		mockTerminate.mockRejectedValue(new Error("Network error"));
-
-		await expect(GET(buildRequest())).rejects.toThrow("Network error");
 	});
 
 	it("does not write an audit log when the request is unauthenticated", async () => {

--- a/packages/app/src/server/auth/__tests__/proconnect-logout.test.ts
+++ b/packages/app/src/server/auth/__tests__/proconnect-logout.test.ts
@@ -8,9 +8,9 @@ import {
 	vi,
 } from "vitest";
 
-import { terminateProConnectSession } from "../proconnect-logout";
+import { fetchEndSessionEndpoint } from "../proconnect-logout";
 
-describe("terminateProConnectSession", () => {
+describe("fetchEndSessionEndpoint", () => {
 	let originalFetch: typeof globalThis.fetch;
 	let mockFetch: MockInstance;
 
@@ -25,62 +25,35 @@ describe("terminateProConnectSession", () => {
 		globalThis.fetch = originalFetch;
 	});
 
-	it("calls end_session_endpoint with id_token_hint", async () => {
-		mockFetch
-			.mockResolvedValueOnce({
-				json: () =>
-					Promise.resolve({
-						end_session_endpoint:
-							"https://proconnect.example.com/api/v2/session/end",
-					}),
-			})
-			.mockResolvedValueOnce(new Response());
+	it("returns the end_session_endpoint advertised by the OIDC discovery doc", async () => {
+		mockFetch.mockResolvedValueOnce({
+			json: () =>
+				Promise.resolve({
+					end_session_endpoint:
+						"https://proconnect.example.com/api/v2/session/end",
+				}),
+		});
 
-		await terminateProConnectSession("test-id-token");
+		const url = await fetchEndSessionEndpoint();
 
-		expect(mockFetch).toHaveBeenCalledTimes(2);
-		// First call: OIDC discovery
+		expect(url).toBe("https://proconnect.example.com/api/v2/session/end");
+		expect(mockFetch).toHaveBeenCalledTimes(1);
 		expect(mockFetch.mock.calls[0]?.[0]).toContain(
 			".well-known/openid-configuration",
 		);
-		// Second call: end_session_endpoint with id_token_hint
-		const logoutUrl = new URL(mockFetch.mock.calls[1]?.[0] as string);
-		expect(logoutUrl.origin).toBe("https://proconnect.example.com");
-		expect(logoutUrl.searchParams.get("id_token_hint")).toBe("test-id-token");
 	});
 
-	it("returns early when end_session_endpoint is missing from discovery", async () => {
+	it("returns null when end_session_endpoint is missing from discovery", async () => {
 		mockFetch.mockResolvedValueOnce({
 			json: () => Promise.resolve({}),
 		});
 
-		await terminateProConnectSession("test-id-token");
-
-		// Only the discovery call, no logout call
-		expect(mockFetch).toHaveBeenCalledTimes(1);
+		await expect(fetchEndSessionEndpoint()).resolves.toBeNull();
 	});
 
-	it("silently fails when OIDC discovery fetch throws", async () => {
+	it("returns null when the discovery fetch throws", async () => {
 		mockFetch.mockRejectedValue(new Error("Network error"));
 
-		await expect(
-			terminateProConnectSession("test-id-token"),
-		).resolves.toBeUndefined();
-	});
-
-	it("silently fails when end_session fetch throws", async () => {
-		mockFetch
-			.mockResolvedValueOnce({
-				json: () =>
-					Promise.resolve({
-						end_session_endpoint:
-							"https://proconnect.example.com/api/v2/session/end",
-					}),
-			})
-			.mockRejectedValueOnce(new Error("Connection refused"));
-
-		await expect(
-			terminateProConnectSession("test-id-token"),
-		).resolves.toBeUndefined();
+		await expect(fetchEndSessionEndpoint()).resolves.toBeNull();
 	});
 });

--- a/packages/app/src/server/auth/proconnect-logout.ts
+++ b/packages/app/src/server/auth/proconnect-logout.ts
@@ -4,18 +4,6 @@ interface OidcConfig {
 	end_session_endpoint?: string;
 }
 
-/**
- * Discover ProConnect's `end_session_endpoint` from the OIDC well-known doc.
- *
- * Returns `null` if the issuer is not configured or the endpoint cannot be
- * resolved (network error, malformed response). Callers are expected to
- * fall back to a local-only logout in that case.
- *
- * The browser — not the server — must navigate to this endpoint with
- * `id_token_hint` and `post_logout_redirect_uri` for OIDC RP-initiated
- * logout to actually kill the IdP SSO cookie. A server-side fetch cannot
- * reach the cookie that lives in the user's browser.
- */
 export async function fetchEndSessionEndpoint(): Promise<string | null> {
 	if (!env.EGAPRO_PROCONNECT_ISSUER) {
 		return null;

--- a/packages/app/src/server/auth/proconnect-logout.ts
+++ b/packages/app/src/server/auth/proconnect-logout.ts
@@ -1,47 +1,32 @@
 import { env } from "~/env";
 
 interface OidcConfig {
-	end_session_endpoint: string;
+	end_session_endpoint?: string;
 }
 
 /**
- * Terminate the ProConnect OIDC session server-side.
+ * Discover ProConnect's `end_session_endpoint` from the OIDC well-known doc.
  *
- * Steps:
- * 1. Fetch the end_session_endpoint from the configured issuer (charon proxy)
- * 2. Call end_session_endpoint server-side with id_token_hint (fire-and-forget)
+ * Returns `null` if the issuer is not configured or the endpoint cannot be
+ * resolved (network error, malformed response). Callers are expected to
+ * fall back to a local-only logout in that case.
  *
- * The browser is NOT redirected to ProConnect — the caller handles the redirect
- * directly to / (home page). This avoids the post_logout_redirect_uri registration issue
- * with ProConnect (charon proxy does not handle end_session redirect flow).
- *
- * The local session is JWT-based (stateless) — clearing the cookie is handled by the caller.
- * Silently fails if ProConnect is unreachable.
+ * The browser — not the server — must navigate to this endpoint with
+ * `id_token_hint` and `post_logout_redirect_uri` for OIDC RP-initiated
+ * logout to actually kill the IdP SSO cookie. A server-side fetch cannot
+ * reach the cookie that lives in the user's browser.
  */
-export async function terminateProConnectSession(
-	idToken: string,
-): Promise<void> {
-	if (!env.EGAPRO_PROCONNECT_ISSUER || !env.EGAPRO_PROCONNECT_CLIENT_ID) {
-		return;
+export async function fetchEndSessionEndpoint(): Promise<string | null> {
+	if (!env.EGAPRO_PROCONNECT_ISSUER) {
+		return null;
 	}
-
-	// Use the configured issuer (charon proxy) to discover the end_session_endpoint
-	const wellKnownUrl = `${env.EGAPRO_PROCONNECT_ISSUER}/.well-known/openid-configuration`;
-
 	try {
-		const response = await fetch(wellKnownUrl);
+		const response = await fetch(
+			`${env.EGAPRO_PROCONNECT_ISSUER}/.well-known/openid-configuration`,
+		);
 		const config = (await response.json()) as OidcConfig;
-
-		if (!config.end_session_endpoint) {
-			return;
-		}
-
-		const logoutUrl = new URL(config.end_session_endpoint);
-		logoutUrl.searchParams.set("id_token_hint", idToken);
-
-		// Fire-and-forget: terminate the OIDC session on ProConnect server-side
-		await fetch(logoutUrl.toString());
+		return config.end_session_endpoint ?? null;
 	} catch {
-		// Silently fail — local session is already cleared
+		return null;
 	}
 }


### PR DESCRIPTION
Fixes #3348

## Summary

Fixes the bug where clicking "Se déconnecter" cleared the local NextAuth cookie but left the ProConnect SSO session alive — the next "S'identifier avec ProConnect" auto-logged the user back in via SSO, without prompting for credentials.

**Root cause** — `packages/app/src/server/auth/proconnect-logout.ts` (before) did a server-side `fetch()` to `end_session_endpoint`. That cannot kill the IdP SSO cookie, which lives in the user's browser, not on our server. OIDC RP-initiated logout requires a **browser** redirect.

## Changes

- `/api/auth/logout` now audits, clears the local cookie, and 302-redirects the **browser** to the upstream `end_session_endpoint` with `id_token_hint` + `post_logout_redirect_uri`
- New route `/api/auth/logout/callback` redirects home after the IdP completes the logout
- `proconnect-logout.ts` reduced to a single discovery helper (`fetchEndSessionEndpoint`)
- Falls back to local-only logout when the discovery doc cannot be fetched
- E2E tests `login.e2e.ts` and `logout.e2e.ts` updated to match the new flow (browser navigation through IdP)

## Dependencies (already deployed)

- charon https://github.com/SocialGouv/charon/pull/13 ✅ merged + deployed (`sha-b24aa77` confirmed live)
- infra-apps https://github.com/SocialGouv/infra-apps/pull/37 ✅ merged + deployed

## Remaining external step before this fix is validated end-to-end

- [ ] Register `https://egapro-charon.ovh.fabrique.social.gouv.fr/oauth/logout/callback` as a `post_logout_redirect_uri` on the egapro client at agent-connect (sandbox + prod). Tested manually on alpha: upstream currently returns `post_logout_redirect_uri not registered` — see issue #3348 for context.

## Test plan

- [ ] Registration done on agent-connect side
- [ ] Login on alpha
- [ ] Click "Se déconnecter" → user lands on egapro home (`/`)
- [ ] Click "S'identifier avec ProConnect" → ProConnect prompts for email + IdP credentials (no silent SSO re-login)
- [ ] Verify audit log row `auth.logout` is created
- [ ] Edge case: with discovery unreachable (block charon access at the network level), verify logout still completes locally and redirects to `/`

## Follow-up (not blocking)

Memoize the discovery doc fetch with a short TTL — currently each logout makes a fresh HTTP call to the issuer's `.well-known`. Performance, not security.