### PR TITLE
fix(declaration): merge category Nom + Détail into single Libellé (#3324)

### DIFF
--- a/packages/app/drizzle/0030_drop_job_category_detail.sql
+++ b/packages/app/drizzle/0030_drop_job_category_detail.sql
@@ -1,0 +1,4 @@
+-- Drop the `detail` column from app_job_category. The category field was
+-- merged into a single "Libellé" input on the rémunération-by-category step
+-- (issue #3324) — `name` now carries the full label and `detail` is unused.
+ALTER TABLE "app_job_category" DROP COLUMN IF EXISTS "detail";

--- a/packages/app/drizzle/meta/0030_snapshot.json
+++ b/packages/app/drizzle/meta/0030_snapshot.json
@@ -1,2202 +1,2123 @@
 {
-  "id": "727dcdbe-4408-45c0-9748-0ad2e07a65e4",
-  "prevId": "ce556b36-26fe-4e6b-a0e3-4e7406c301d2",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.app_admin_impersonation_event": {
-      "name": "app_admin_impersonation_event",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "admin_user_id": {
-          "name": "admin_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stopped_at": {
-          "name": "stopped_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "admin_impersonation_event_admin_started_idx": {
-          "name": "admin_impersonation_event_admin_started_idx",
-          "columns": [
-            {
-              "expression": "admin_user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "started_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
-          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "admin_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_admin_impersonation_event_siren_app_company_siren_fk": {
-          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_campaign_deadline": {
-      "name": "app_campaign_deadline",
-      "schema": "",
-      "columns": {
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "gip_publication_date": {
-          "name": "gip_publication_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "campaign_start_date": {
-          "name": "campaign_start_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decl1_modification_deadline": {
-          "name": "decl1_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_justification_deadline": {
-          "name": "decl1_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_joint_evaluation_deadline": {
-          "name": "decl1_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_modification_deadline": {
-          "name": "decl2_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_justification_deadline": {
-          "name": "decl2_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_joint_evaluation_deadline": {
-          "name": "decl2_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_company": {
-      "name": "app_company",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "address": {
-          "name": "address",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "naf_code": {
-          "name": "naf_code",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce": {
-          "name": "workforce",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "has_cse": {
-          "name": "has_cse",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion": {
-      "name": "app_cse_opinion",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "gap_consulted": {
-          "name": "gap_consulted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion": {
-          "name": "opinion",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion_date": {
-          "name": "opinion_date",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_declaration_idx": {
-          "name": "cse_opinion_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_decl_number_type_idx": {
-          "name": "cse_opinion_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration": {
-      "name": "app_declaration",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declarant_id": {
-          "name": "declarant_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "total_women": {
-          "name": "total_women",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total_men": {
-          "name": "total_men",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "remuneration_score": {
-          "name": "remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_remuneration_score": {
-          "name": "variable_remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "quartile_score": {
-          "name": "quartile_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "category_score": {
-          "name": "category_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "compliance_path": {
-          "name": "compliance_path",
-          "type": "varchar(30)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_women": {
-          "name": "indicator_a_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_men": {
-          "name": "indicator_a_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_women": {
-          "name": "indicator_a_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_men": {
-          "name": "indicator_a_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_women": {
-          "name": "indicator_b_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_men": {
-          "name": "indicator_b_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_women": {
-          "name": "indicator_b_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_men": {
-          "name": "indicator_b_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_women": {
-          "name": "indicator_c_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_men": {
-          "name": "indicator_c_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_women": {
-          "name": "indicator_c_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_men": {
-          "name": "indicator_c_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_women": {
-          "name": "indicator_d_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_men": {
-          "name": "indicator_d_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_women": {
-          "name": "indicator_d_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_men": {
-          "name": "indicator_d_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_women": {
-          "name": "indicator_e_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_men": {
-          "name": "indicator_e_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold1": {
-          "name": "indicator_f_annual_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold2": {
-          "name": "indicator_f_annual_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold3": {
-          "name": "indicator_f_annual_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold4": {
-          "name": "indicator_f_annual_threshold4",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women1": {
-          "name": "indicator_f_annual_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women2": {
-          "name": "indicator_f_annual_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women3": {
-          "name": "indicator_f_annual_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women4": {
-          "name": "indicator_f_annual_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men1": {
-          "name": "indicator_f_annual_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men2": {
-          "name": "indicator_f_annual_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men3": {
-          "name": "indicator_f_annual_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men4": {
-          "name": "indicator_f_annual_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold1": {
-          "name": "indicator_f_hourly_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold2": {
-          "name": "indicator_f_hourly_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold3": {
-          "name": "indicator_f_hourly_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold4": {
-          "name": "indicator_f_hourly_threshold4",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women1": {
-          "name": "indicator_f_hourly_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women2": {
-          "name": "indicator_f_hourly_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women3": {
-          "name": "indicator_f_hourly_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women4": {
-          "name": "indicator_f_hourly_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men1": {
-          "name": "indicator_f_hourly_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men2": {
-          "name": "indicator_f_hourly_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men3": {
-          "name": "indicator_f_hourly_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men4": {
-          "name": "indicator_f_hourly_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "'draft'"
-        },
-        "second_declaration_step": {
-          "name": "second_declaration_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_declaration_status": {
-          "name": "second_declaration_status",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_start": {
-          "name": "second_decl_reference_period_start",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_end": {
-          "name": "second_decl_reference_period_end",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "compliance_completed_at": {
-          "name": "compliance_completed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cse_opinion_completed_at": {
-          "name": "cse_opinion_completed_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "submitted_at": {
-          "name": "submitted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "declaration_declarant_idx": {
-          "name": "declaration_declarant_idx",
-          "columns": [
-            {
-              "expression": "declarant_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "declaration_submitted_at_idx": {
-          "name": "declaration_submitted_at_idx",
-          "columns": [
-            {
-              "expression": "submitted_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_siren_app_company_siren_fk": {
-          "name": "app_declaration_siren_app_company_siren_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_declaration_declarant_id_app_user_id_fk": {
-          "name": "app_declaration_declarant_id_app_user_id_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "declarant_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "declaration_siren_year_idx": {
-          "name": "declaration_siren_year_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "siren",
-            "year"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_employee_category": {
-      "name": "app_employee_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "job_category_id": {
-          "name": "job_category_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_type": {
-          "name": "declaration_type",
-          "type": "declaration_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "women_count": {
-          "name": "women_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count": {
-          "name": "men_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_women": {
-          "name": "annual_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_men": {
-          "name": "annual_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_women": {
-          "name": "annual_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_men": {
-          "name": "annual_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_women": {
-          "name": "hourly_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_men": {
-          "name": "hourly_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_women": {
-          "name": "hourly_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_men": {
-          "name": "hourly_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_employee_category_job_category_id_app_job_category_id_fk": {
-          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
-          "tableFrom": "app_employee_category",
-          "tableTo": "app_job_category",
-          "columnsFrom": [
-            "job_category_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "employee_category_job_type_idx": {
-          "name": "employee_category_job_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "job_category_id",
-            "declaration_type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_export": {
-      "name": "app_export",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "version": {
-          "name": "version",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'v1'"
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "s3_key": {
-          "name": "s3_key",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "row_count": {
-          "name": "row_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "export_year_version_idx": {
-          "name": "export_year_version_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "year",
-            "version"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_file": {
-      "name": "app_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_path": {
-          "name": "file_path",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "uploaded_at": {
-          "name": "uploaded_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "file_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "file_declaration_idx": {
-          "name": "file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "file_joint_eval_unique": {
-          "name": "file_joint_eval_unique",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"type\" = 'joint_evaluation'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_gip_mds_data": {
-      "name": "app_gip_mds_data",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "imported_at": {
-          "name": "imported_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_start": {
-          "name": "period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_end": {
-          "name": "period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce_ema": {
-          "name": "workforce_ema",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_global": {
-          "name": "men_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_global": {
-          "name": "women_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_hourly_global": {
-          "name": "men_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_hourly_global": {
-          "name": "women_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_variable": {
-          "name": "men_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_variable": {
-          "name": "women_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_women": {
-          "name": "global_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_men": {
-          "name": "global_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_women": {
-          "name": "global_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_men": {
-          "name": "global_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_women": {
-          "name": "variable_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_men": {
-          "name": "variable_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_women": {
-          "name": "variable_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_men": {
-          "name": "variable_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_women": {
-          "name": "global_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_men": {
-          "name": "global_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_women": {
-          "name": "global_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_men": {
-          "name": "global_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_women": {
-          "name": "variable_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_men": {
-          "name": "variable_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_women": {
-          "name": "variable_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_men": {
-          "name": "variable_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold1": {
-          "name": "annual_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold2": {
-          "name": "annual_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold3": {
-          "name": "annual_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold4": {
-          "name": "annual_quartile_threshold4",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold1": {
-          "name": "hourly_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold2": {
-          "name": "hourly_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold3": {
-          "name": "hourly_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold4": {
-          "name": "hourly_quartile_threshold4",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_index": {
-          "name": "confidence_index",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_exotic_contracts": {
-          "name": "confidence_exotic_contracts",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_unit_measure": {
-          "name": "confidence_unit_measure",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_suspension_ratio": {
-          "name": "confidence_suspension_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_suspensions": {
-          "name": "confidence_long_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_end_suspensions": {
-          "name": "confidence_no_end_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_sick_leave_ratio": {
-          "name": "confidence_sick_leave_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_sick_leave": {
-          "name": "confidence_long_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_sick_leave": {
-          "name": "confidence_no_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota250": {
-          "name": "confidence_quota250",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota0": {
-          "name": "confidence_quota0",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_multi_year": {
-          "name": "confidence_multi_year",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_fp_ratio": {
-          "name": "confidence_fp_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_remuneration": {
-          "name": "confidence_extreme_remuneration",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_rate": {
-          "name": "confidence_extreme_rate",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "gip_mds_data_siren_idx": {
-          "name": "gip_mds_data_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_gip_mds_data_siren_app_company_siren_fk": {
-          "name": "app_gip_mds_data_siren_app_company_siren_fk",
-          "tableFrom": "app_gip_mds_data",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_gip_mds_data_siren_year_pk": {
-          "name": "app_gip_mds_data_siren_year_pk",
-          "columns": [
-            "siren",
-            "year"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_global_setting": {
-      "name": "app_global_setting",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "default": 1
-        },
-        "active_campaign_year": {
-          "name": "active_campaign_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_global_setting_updated_by_app_user_id_fk": {
-          "name": "app_global_setting_updated_by_app_user_id_fk",
-          "tableFrom": "app_global_setting",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "updated_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_job_category": {
-      "name": "app_job_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category_index": {
-          "name": "category_index",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source": {
-          "name": "source",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_job_category_declaration_id_app_declaration_id_fk": {
-          "name": "app_job_category_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_job_category",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "job_category_declaration_index_idx": {
-          "name": "job_category_declaration_index_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "category_index"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_referent": {
-      "name": "app_referent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "region": {
-          "name": "region",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county": {
-          "name": "county",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "referent_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "principal": {
-          "name": "principal",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "substitute_name": {
-          "name": "substitute_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "substitute_email": {
-          "name": "substitute_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "referent_region_idx": {
-          "name": "referent_region_idx",
-          "columns": [
-            {
-              "expression": "region",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user_company": {
-      "name": "app_user_company",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "user_company_user_id_idx": {
-          "name": "user_company_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_user_company_user_id_app_user_id_fk": {
-          "name": "app_user_company_user_id_app_user_id_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_user_company_siren_app_company_siren_fk": {
-          "name": "app_user_company_siren_app_company_siren_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_user_company_user_id_siren_pk": {
-          "name": "app_user_company_user_id_siren_pk",
-          "columns": [
-            "user_id",
-            "siren"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user": {
-      "name": "app_user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "first_name": {
-          "name": "first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_name": {
-          "name": "last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "phone": {
-          "name": "phone",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_admin": {
-          "name": "is_admin",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "audit.action_log": {
-      "name": "action_log",
-      "schema": "audit",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_email": {
-          "name": "user_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "action": {
-          "name": "action",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category": {
-          "name": "category",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_type": {
-          "name": "resource_type",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "resource_id": {
-          "name": "resource_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "varchar(45)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration_ms": {
-          "name": "duration_ms",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "action_log_created_at_idx": {
-          "name": "action_log_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_user_idx": {
-          "name": "action_log_user_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_siren_idx": {
-          "name": "action_log_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_action_idx": {
-          "name": "action_log_action_idx",
-          "columns": [
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_category_created_at_idx": {
-          "name": "action_log_category_created_at_idx",
-          "columns": [
-            {
-              "expression": "category",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.declaration_type": {
-      "name": "declaration_type",
-      "schema": "public",
-      "values": [
-        "initial",
-        "correction"
-      ]
-    },
-    "public.file_type": {
-      "name": "file_type",
-      "schema": "public",
-      "values": [
-        "cse_opinion",
-        "joint_evaluation"
-      ]
-    },
-    "public.referent_type": {
-      "name": "referent_type",
-      "schema": "public",
-      "values": [
-        "email",
-        "url"
-      ]
-    }
-  },
-  "schemas": {
-    "audit": "audit"
-  },
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "727dcdbe-4408-45c0-9748-0ad2e07a65e4",
+	"prevId": "ce556b36-26fe-4e6b-a0e3-4e7406c301d2",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_path": {
+					"name": "compliance_path",
+					"type": "varchar(30)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold4": {
+					"name": "indicator_f_annual_threshold4",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold4": {
+					"name": "indicator_f_hourly_threshold4",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_status": {
+					"name": "second_declaration_status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"compliance_completed_at": {
+					"name": "compliance_completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_opinion_completed_at": {
+					"name": "cse_opinion_completed_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"submitted_at": {
+					"name": "submitted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_submitted_at_idx": {
+					"name": "declaration_submitted_at_idx",
+					"columns": [
+						{
+							"expression": "submitted_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"declaration_siren_year_idx": {
+					"name": "declaration_siren_year_idx",
+					"nullsNotDistinct": false,
+					"columns": ["siren", "year"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold4": {
+					"name": "annual_quartile_threshold4",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold4": {
+					"name": "hourly_quartile_threshold4",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/packages/app/drizzle/meta/0030_snapshot.json
+++ b/packages/app/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,2202 @@
+{
+  "id": "727dcdbe-4408-45c0-9748-0ad2e07a65e4",
+  "prevId": "ce556b36-26fe-4e6b-a0e3-4e7406c301d2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_admin_impersonation_event": {
+      "name": "app_admin_impersonation_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_impersonation_event_admin_started_idx": {
+          "name": "admin_impersonation_event_admin_started_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_admin_impersonation_event_siren_app_company_siren_fk": {
+          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_campaign_deadline": {
+      "name": "app_campaign_deadline",
+      "schema": "",
+      "columns": {
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gip_publication_date": {
+          "name": "gip_publication_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_start_date": {
+          "name": "campaign_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decl1_modification_deadline": {
+          "name": "decl1_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_justification_deadline": {
+          "name": "decl1_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_joint_evaluation_deadline": {
+          "name": "decl1_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_modification_deadline": {
+          "name": "decl2_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_justification_deadline": {
+          "name": "decl2_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_joint_evaluation_deadline": {
+          "name": "decl2_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_company": {
+      "name": "app_company",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naf_code": {
+          "name": "naf_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce": {
+          "name": "workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_cse": {
+          "name": "has_cse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion": {
+      "name": "app_cse_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gap_consulted": {
+          "name": "gap_consulted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_date": {
+          "name": "opinion_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_declaration_idx": {
+          "name": "cse_opinion_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_decl_number_type_idx": {
+          "name": "cse_opinion_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration": {
+      "name": "app_declaration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_women": {
+          "name": "total_women",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_men": {
+          "name": "total_men",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remuneration_score": {
+          "name": "remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_remuneration_score": {
+          "name": "variable_remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quartile_score": {
+          "name": "quartile_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_score": {
+          "name": "category_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compliance_path": {
+          "name": "compliance_path",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_women": {
+          "name": "indicator_a_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_men": {
+          "name": "indicator_a_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_women": {
+          "name": "indicator_a_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_men": {
+          "name": "indicator_a_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_women": {
+          "name": "indicator_b_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_men": {
+          "name": "indicator_b_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_women": {
+          "name": "indicator_b_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_men": {
+          "name": "indicator_b_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_women": {
+          "name": "indicator_c_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_men": {
+          "name": "indicator_c_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_women": {
+          "name": "indicator_c_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_men": {
+          "name": "indicator_c_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_women": {
+          "name": "indicator_d_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_men": {
+          "name": "indicator_d_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_women": {
+          "name": "indicator_d_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_men": {
+          "name": "indicator_d_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_women": {
+          "name": "indicator_e_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_men": {
+          "name": "indicator_e_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold1": {
+          "name": "indicator_f_annual_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold2": {
+          "name": "indicator_f_annual_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold3": {
+          "name": "indicator_f_annual_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold4": {
+          "name": "indicator_f_annual_threshold4",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women1": {
+          "name": "indicator_f_annual_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women2": {
+          "name": "indicator_f_annual_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women3": {
+          "name": "indicator_f_annual_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women4": {
+          "name": "indicator_f_annual_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men1": {
+          "name": "indicator_f_annual_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men2": {
+          "name": "indicator_f_annual_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men3": {
+          "name": "indicator_f_annual_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men4": {
+          "name": "indicator_f_annual_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold1": {
+          "name": "indicator_f_hourly_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold2": {
+          "name": "indicator_f_hourly_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold3": {
+          "name": "indicator_f_hourly_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold4": {
+          "name": "indicator_f_hourly_threshold4",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women1": {
+          "name": "indicator_f_hourly_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women2": {
+          "name": "indicator_f_hourly_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women3": {
+          "name": "indicator_f_hourly_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women4": {
+          "name": "indicator_f_hourly_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men1": {
+          "name": "indicator_f_hourly_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men2": {
+          "name": "indicator_f_hourly_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men3": {
+          "name": "indicator_f_hourly_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men4": {
+          "name": "indicator_f_hourly_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "second_declaration_step": {
+          "name": "second_declaration_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_declaration_status": {
+          "name": "second_declaration_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_start": {
+          "name": "second_decl_reference_period_start",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_end": {
+          "name": "second_decl_reference_period_end",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compliance_completed_at": {
+          "name": "compliance_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cse_opinion_completed_at": {
+          "name": "cse_opinion_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "declaration_declarant_idx": {
+          "name": "declaration_declarant_idx",
+          "columns": [
+            {
+              "expression": "declarant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "declaration_submitted_at_idx": {
+          "name": "declaration_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_siren_app_company_siren_fk": {
+          "name": "app_declaration_siren_app_company_siren_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_declaration_declarant_id_app_user_id_fk": {
+          "name": "app_declaration_declarant_id_app_user_id_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "declaration_siren_year_idx": {
+          "name": "declaration_siren_year_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "siren",
+            "year"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_employee_category": {
+      "name": "app_employee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_category_id": {
+          "name": "job_category_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_type": {
+          "name": "declaration_type",
+          "type": "declaration_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "women_count": {
+          "name": "women_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count": {
+          "name": "men_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_women": {
+          "name": "annual_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_men": {
+          "name": "annual_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_women": {
+          "name": "annual_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_men": {
+          "name": "annual_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_women": {
+          "name": "hourly_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_men": {
+          "name": "hourly_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_women": {
+          "name": "hourly_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_men": {
+          "name": "hourly_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_employee_category_job_category_id_app_job_category_id_fk": {
+          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
+          "tableFrom": "app_employee_category",
+          "tableTo": "app_job_category",
+          "columnsFrom": [
+            "job_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employee_category_job_type_idx": {
+          "name": "employee_category_job_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_category_id",
+            "declaration_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_export": {
+      "name": "app_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "export_year_version_idx": {
+          "name": "export_year_version_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_file": {
+      "name": "app_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "file_declaration_idx": {
+          "name": "file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_joint_eval_unique": {
+          "name": "file_joint_eval_unique",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"type\" = 'joint_evaluation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_gip_mds_data": {
+      "name": "app_gip_mds_data",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_ema": {
+          "name": "workforce_ema",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_global": {
+          "name": "men_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_global": {
+          "name": "women_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_hourly_global": {
+          "name": "men_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_hourly_global": {
+          "name": "women_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_variable": {
+          "name": "men_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_variable": {
+          "name": "women_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_women": {
+          "name": "global_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_men": {
+          "name": "global_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_women": {
+          "name": "global_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_men": {
+          "name": "global_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_women": {
+          "name": "variable_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_men": {
+          "name": "variable_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_women": {
+          "name": "variable_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_men": {
+          "name": "variable_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_women": {
+          "name": "global_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_men": {
+          "name": "global_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_women": {
+          "name": "global_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_men": {
+          "name": "global_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_women": {
+          "name": "variable_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_men": {
+          "name": "variable_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_women": {
+          "name": "variable_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_men": {
+          "name": "variable_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold1": {
+          "name": "annual_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold2": {
+          "name": "annual_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold3": {
+          "name": "annual_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold4": {
+          "name": "annual_quartile_threshold4",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold1": {
+          "name": "hourly_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold2": {
+          "name": "hourly_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold3": {
+          "name": "hourly_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold4": {
+          "name": "hourly_quartile_threshold4",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_index": {
+          "name": "confidence_index",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_exotic_contracts": {
+          "name": "confidence_exotic_contracts",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_unit_measure": {
+          "name": "confidence_unit_measure",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_suspension_ratio": {
+          "name": "confidence_suspension_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_suspensions": {
+          "name": "confidence_long_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_end_suspensions": {
+          "name": "confidence_no_end_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_sick_leave_ratio": {
+          "name": "confidence_sick_leave_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_sick_leave": {
+          "name": "confidence_long_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_sick_leave": {
+          "name": "confidence_no_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota250": {
+          "name": "confidence_quota250",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota0": {
+          "name": "confidence_quota0",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_multi_year": {
+          "name": "confidence_multi_year",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_fp_ratio": {
+          "name": "confidence_fp_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_remuneration": {
+          "name": "confidence_extreme_remuneration",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_rate": {
+          "name": "confidence_extreme_rate",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gip_mds_data_siren_idx": {
+          "name": "gip_mds_data_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_gip_mds_data_siren_app_company_siren_fk": {
+          "name": "app_gip_mds_data_siren_app_company_siren_fk",
+          "tableFrom": "app_gip_mds_data",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_gip_mds_data_siren_year_pk": {
+          "name": "app_gip_mds_data_siren_year_pk",
+          "columns": [
+            "siren",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_global_setting": {
+      "name": "app_global_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "active_campaign_year": {
+          "name": "active_campaign_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_global_setting_updated_by_app_user_id_fk": {
+          "name": "app_global_setting_updated_by_app_user_id_fk",
+          "tableFrom": "app_global_setting",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_job_category": {
+      "name": "app_job_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_index": {
+          "name": "category_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_job_category_declaration_id_app_declaration_id_fk": {
+          "name": "app_job_category_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_job_category",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_category_declaration_index_idx": {
+          "name": "job_category_declaration_index_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "category_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_referent": {
+      "name": "app_referent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "referent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "substitute_name": {
+          "name": "substitute_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "substitute_email": {
+          "name": "substitute_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "referent_region_idx": {
+          "name": "referent_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user_company": {
+      "name": "app_user_company",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_company_user_id_idx": {
+          "name": "user_company_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_company_user_id_app_user_id_fk": {
+          "name": "app_user_company_user_id_app_user_id_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_company_siren_app_company_siren_fk": {
+          "name": "app_user_company_siren_app_company_siren_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_user_company_user_id_siren_pk": {
+          "name": "app_user_company_user_id_siren_pk",
+          "columns": [
+            "user_id",
+            "siren"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user": {
+      "name": "app_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "audit.action_log": {
+      "name": "action_log",
+      "schema": "audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_log_created_at_idx": {
+          "name": "action_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_user_idx": {
+          "name": "action_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_siren_idx": {
+          "name": "action_log_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_action_idx": {
+          "name": "action_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_category_created_at_idx": {
+          "name": "action_log_category_created_at_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.declaration_type": {
+      "name": "declaration_type",
+      "schema": "public",
+      "values": [
+        "initial",
+        "correction"
+      ]
+    },
+    "public.file_type": {
+      "name": "file_type",
+      "schema": "public",
+      "values": [
+        "cse_opinion",
+        "joint_evaluation"
+      ]
+    },
+    "public.referent_type": {
+      "name": "referent_type",
+      "schema": "public",
+      "values": [
+        "email",
+        "url"
+      ]
+    }
+  },
+  "schemas": {
+    "audit": "audit"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
 			"when": 1776100000000,
 			"tag": "0029_add_declaration_submitted_at",
 			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1777379362370,
+			"tag": "0030_drop_job_category_detail",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/app/declaration-remuneration/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/etape/[step]/page.tsx
@@ -125,7 +125,6 @@ export default async function StepPage({ params }: StepPageProps) {
 			)
 		: (data.previousYearCategories?.categories.map((cat) => ({
 				name: cat.name,
-				detail: cat.detail,
 				womenCount: null,
 				menCount: null,
 				annualBaseWomen: null,

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -137,7 +137,7 @@ test.describe("Declaration workflow", () => {
 		).toBeVisible();
 
 		// Verify category 1 form fields
-		await expect(page.getByRole("textbox", { name: "Nom" })).toBeVisible();
+		await expect(page.getByRole("textbox", { name: "Libellé" })).toBeVisible();
 		await expect(
 			page.getByRole("textbox", { name: "Effectif femmes, catégorie 1" }),
 		).toBeVisible();

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -248,26 +248,23 @@ export async function insertPreviousYearDeclaration(yearsBack = 1) {
 				id: PREV_YEAR_JOB_CATEGORY_IDS[0],
 				index: 0,
 				name: "Cadres dirigeants",
-				detail: "Directeurs et cadres supérieurs",
 			},
 			{
 				id: PREV_YEAR_JOB_CATEGORY_IDS[1],
 				index: 1,
 				name: "Ingénieurs et cadres",
-				detail: "Ingénieurs, chefs de projet, managers",
 			},
 			{
 				id: PREV_YEAR_JOB_CATEGORY_IDS[2],
 				index: 2,
 				name: "Techniciens",
-				detail: "Techniciens qualifiés",
 			},
 		];
 
 		for (const cat of categories) {
 			await sql`
-				INSERT INTO app_job_category (id, declaration_id, category_index, name, detail, source)
-				VALUES (${cat.id}, ${declId}, ${cat.index}, ${cat.name}, ${cat.detail}, 'convention-collective')
+				INSERT INTO app_job_category (id, declaration_id, category_index, name, source)
+				VALUES (${cat.id}, ${declId}, ${cat.index}, ${cat.name}, 'convention-collective')
 				ON CONFLICT DO NOTHING
 			`;
 		}

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -106,7 +106,7 @@ export async function completeDeclaration(
 	});
 	if (await sourceSelect.isVisible({ timeout: 1_000 }).catch(() => false)) {
 		await sourceSelect.selectOption("convention-collective");
-		await page.getByRole("textbox", { name: "Nom" }).fill("Catégorie test");
+		await page.getByRole("textbox", { name: "Libellé" }).fill("Catégorie test");
 		await page
 			.getByRole("textbox", { name: "Effectif femmes, catégorie 1" })
 			.fill("10");

--- a/packages/app/src/e2e/previous-year-categories.e2e.ts
+++ b/packages/app/src/e2e/previous-year-categories.e2e.ts
@@ -30,11 +30,9 @@ async function assertStep5PrefilledWithSeedData(page: Page) {
 	).toBeVisible();
 	await expect(page.getByRole("button", { name: /Techniciens/ })).toBeVisible();
 
-	// Detail pre-filled, numeric fields empty
+	// Libellé pre-filled, numeric fields empty
 	await page.getByRole("button", { name: /Cadres dirigeants/ }).click();
-	await expect(page.locator("#cat-0-detail")).toHaveValue(
-		"Directeurs et cadres supérieurs",
-	);
+	await expect(page.locator("#cat-0-name")).toHaveValue("Cadres dirigeants");
 	await expect(
 		page.getByRole("textbox", { name: "Effectif femmes, catégorie 1" }),
 	).toHaveValue("");
@@ -57,7 +55,7 @@ test.describe("Previous year categories prefill", () => {
 			await deletePreviousYearDeclaration(1);
 		});
 
-		test("pre-fills category names, details and source with empty numeric fields", async ({
+		test("pre-fills category names and source with empty numeric fields", async ({
 			page,
 		}) => {
 			await goToStep5(page);

--- a/packages/app/src/modules/declaration-remuneration/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/schemas.ts
@@ -71,7 +71,6 @@ export const updateEmployeeCategoriesSchema = z.object({
 	categories: z.array(
 		z.object({
 			name: z.string().min(1),
-			detail: z.string(),
 			data: employeeCategoryDataSchema,
 		}),
 	),
@@ -81,7 +80,6 @@ export const updateEmployeeCategoriesSchema = z.object({
 
 export const categoryFormEntrySchema = z.object({
 	name: z.string(),
-	detail: z.string(),
 	womenCount: z.string(),
 	menCount: z.string(),
 	annualBaseWomen: z.string(),

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/devFillData.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/devFillData.test.ts
@@ -37,8 +37,8 @@ describe("devFillData", () => {
 		expect(DEV_STEP4_HOURLY).toHaveLength(4);
 	});
 
-	it("Step5 source is convention-collective", () => {
-		expect(DEV_STEP5_SOURCE).toBe("convention-collective");
+	it("Step5 source is accord-entreprise", () => {
+		expect(DEV_STEP5_SOURCE).toBe("accord-entreprise");
 	});
 
 	it("createDevStep5Categories returns 4 categories with sequential IDs", () => {

--- a/packages/app/src/modules/declaration-remuneration/shared/devFillData.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/devFillData.ts
@@ -40,7 +40,7 @@ export const DEV_STEP4_HOURLY = [
 ];
 
 // Step 5 - Employee categories
-export const DEV_STEP5_SOURCE = "convention-collective";
+export const DEV_STEP5_SOURCE = "accord-entreprise";
 
 /**
  * Reference workforce ratios used to distribute totals across categories.
@@ -86,7 +86,6 @@ export function createDevStep5Categories(
 		{
 			id: nextId(),
 			name: "Ouvriers",
-			detail: "Opérateurs, manutentionnaires",
 			womenCount: String(womenCounts[0]),
 			menCount: String(menCounts[0]),
 			annualBaseWomen: "24000",
@@ -101,7 +100,6 @@ export function createDevStep5Categories(
 		{
 			id: nextId(),
 			name: "Employés",
-			detail: "Assistants, secrétaires",
 			womenCount: String(womenCounts[1]),
 			menCount: String(menCounts[1]),
 			annualBaseWomen: "27000",
@@ -116,7 +114,6 @@ export function createDevStep5Categories(
 		{
 			id: nextId(),
 			name: "Techniciens et agents de maîtrise",
-			detail: "Contremaîtres, techniciens",
 			womenCount: String(womenCounts[2]),
 			menCount: String(menCounts[2]),
 			annualBaseWomen: "35000",
@@ -131,7 +128,6 @@ export function createDevStep5Categories(
 		{
 			id: nextId(),
 			name: "Ingénieurs et cadres",
-			detail: "Responsables, directeurs",
 			womenCount: String(womenCounts[3]),
 			menCount: String(menCounts[3]),
 			annualBaseWomen: "48000",

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -31,7 +31,6 @@ function makeCategory(
 ): EmployeeCategoryRow {
 	return {
 		name: "",
-		detail: "",
 		womenCount: null,
 		menCount: null,
 		annualBaseWomen: null,
@@ -105,10 +104,10 @@ describe("Step5EmployeeCategories", () => {
 		expect(screen.getAllByText("Rémunération horaire brute").length).toBe(1);
 	});
 
-	it("renders name and detail input fields for category", () => {
+	it("renders the libellé input field for category", () => {
 		render(<Step5EmployeeCategories declarationYear={2025} />);
 		expect(document.getElementById("cat-0-name")).toBeInTheDocument();
-		expect(document.getElementById("cat-0-detail")).toBeInTheDocument();
+		expect(document.getElementById("cat-0-detail")).not.toBeInTheDocument();
 	});
 
 	it("can add a new category", async () => {
@@ -228,14 +227,13 @@ describe("Step5EmployeeCategories", () => {
 				initialCategories={[
 					makeCategory({
 						name: "Ingénieurs",
-						detail: "Dev",
 						womenCount: 10,
 						menCount: 15,
 						annualBaseWomen: "3000",
 						annualBaseMen: "3200",
 					}),
 				]}
-				initialSource="autre"
+				initialSource="accord-entreprise"
 			/>,
 		);
 		expect(screen.getByText("Enregistré")).toBeInTheDocument();
@@ -253,31 +251,25 @@ describe("Step5EmployeeCategories", () => {
 				initialCategories={[
 					makeCategory({
 						name: "Cadres",
-						detail: "Managers",
 						womenCount: 5,
 						menCount: 8,
 					}),
 				]}
-				initialSource="convention-collective"
+				initialSource="accord-entreprise"
 			/>,
 		);
 
-		const nameInput = screen.getByLabelText("Nom", {
+		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",
 		});
 		expect(nameInput).toHaveValue("Cadres");
-
-		const detailInput = screen.getByLabelText("Détail des emplois", {
-			selector: "#cat-0-detail",
-		});
-		expect(detailInput).toHaveValue("Managers");
 	});
 
 	it("submits data on form submit", async () => {
 		const user = userEvent.setup();
 		render(<Step5EmployeeCategories declarationYear={2025} />);
 
-		const nameInput = screen.getByLabelText("Nom", {
+		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",
 		});
 		await user.type(nameInput, "Techniciens");

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -42,7 +42,6 @@ function makeCategory(
 ): EmployeeCategoryRow {
 	return {
 		name: "",
-		detail: "",
 		womenCount: null,
 		menCount: null,
 		annualBaseWomen: null,
@@ -353,7 +352,6 @@ describe("Step6Review", () => {
 				step5Categories={[
 					makeCategory({
 						name: "Ingénieurs",
-						detail: "Dev",
 						womenCount: 10,
 						menCount: 15,
 						annualBaseWomen: "3000",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -74,7 +74,7 @@ export function SecondDeclarationStep2Form({
 				});
 			}}
 			previousHref={`${BASE_PATH}/etape/1`}
-			readOnlyNameDetail
+			readOnlyLabel
 			referencePeriodPicker={
 				<ReferencePeriodPicker
 					disabled={isImpersonating}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -22,7 +22,6 @@ function makeCategory(
 ): EmployeeCategoryRow {
 	return {
 		name: "",
-		detail: "",
 		womenCount: null,
 		menCount: null,
 		annualBaseWomen: null,
@@ -40,7 +39,6 @@ function makeCategory(
 const mockCategories: EmployeeCategoryRow[] = [
 	makeCategory({
 		name: "Ouvriers",
-		detail: "Opérateurs de production",
 		womenCount: 50,
 		menCount: 60,
 		annualBaseWomen: "19114",
@@ -70,34 +68,21 @@ describe("SecondDeclarationStep2Form", () => {
 		expect(screen.getByText("Étape 2 sur 3")).toBeInTheDocument();
 	});
 
-	it("displays category name as read-only text", () => {
+	it("displays category label as read-only text", () => {
 		render(
 			<SecondDeclarationStep2Form
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		expect(screen.getByText("Nom :")).toBeInTheDocument();
+		expect(screen.getByText("Libellé :")).toBeInTheDocument();
 		expect(
 			screen.getByRole("button", {
 				name: "Catégorie d'emplois n°1 : Ouvriers",
 			}),
 		).toBeInTheDocument();
 		expect(screen.getByText("Ouvriers")).toBeInTheDocument();
-		expect(screen.queryByLabelText("Nom")).not.toBeInTheDocument();
-	});
-
-	it("displays detail as read-only text", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-			/>,
-		);
-		expect(screen.getByText("Opérateurs de production")).toBeInTheDocument();
-		expect(
-			screen.queryByLabelText("Détail des emplois"),
-		).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Libellé")).not.toBeInTheDocument();
 	});
 
 	it("displays source as read-only text", () => {
@@ -160,7 +145,6 @@ describe("SecondDeclarationStep2Form", () => {
 		const secondDeclData: EmployeeCategoryRow[] = [
 			makeCategory({
 				name: "Techniciens",
-				detail: "Senior",
 				womenCount: 30,
 				menCount: 40,
 				annualBaseWomen: "25000",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -42,7 +42,6 @@ function makeCategory(
 ): EmployeeCategoryRow {
 	return {
 		name: "",
-		detail: "",
 		womenCount: null,
 		menCount: null,
 		annualBaseWomen: null,
@@ -60,7 +59,6 @@ function makeCategory(
 const mockCategories: EmployeeCategoryRow[] = [
 	makeCategory({
 		name: "Ingénieurs",
-		detail: "Dev",
 		womenCount: 10,
 		menCount: 15,
 		annualBaseWomen: "3000",

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -46,7 +46,6 @@ function createIdGenerator() {
 function toFormValues(cats: EmployeeCategory[]) {
 	return cats.map((c) => ({
 		name: c.name,
-		detail: c.detail,
 		womenCount: c.womenCount,
 		menCount: c.menCount,
 		annualBaseWomen: padDecimalToTwo(c.annualBaseWomen),
@@ -75,7 +74,7 @@ type Props = {
 	onSubmit: (data: EmployeeCategorySubmitData) => void;
 	isSubmitting: boolean;
 	submitError?: string | null;
-	readOnlyNameDetail?: boolean;
+	readOnlyLabel?: boolean;
 	referencePeriodPicker?: ReactNode;
 	descriptionText?: string;
 	siren?: string;
@@ -98,7 +97,7 @@ export function CategoryForm({
 	onSubmit,
 	isSubmitting,
 	submitError,
-	readOnlyNameDetail = false,
+	readOnlyLabel = false,
 	referencePeriodPicker,
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 	siren,
@@ -276,7 +275,7 @@ export function CategoryForm({
 			<div className={stepStyles.categoryBlock}>
 				<p className="fr-mb-0">{descriptionText}</p>
 
-				{readOnlyNameDetail ? (
+				{readOnlyLabel ? (
 					<p className="fr-mb-0">
 						Source utilisée pour déterminer les catégories d&apos;emplois :{" "}
 						<span className="fr-text--bold">
@@ -343,7 +342,7 @@ export function CategoryForm({
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 			</div>
 
-			{!readOnlyNameDetail && (
+			{!readOnlyLabel && (
 				<CategoryImportExport
 					disabled={disabled}
 					getCategories={() =>
@@ -385,80 +384,31 @@ export function CategoryForm({
 								id={collapseId}
 							>
 								<div className={stepStyles.categoryBlock}>
-									{!readOnlyNameDetail && fields.length > 1 && (
-										<div className={stepStyles.categoryFooter}>
-											<button
-												className="fr-btn fr-btn--tertiary fr-icon-delete-line fr-btn--icon-left fr-btn--sm"
-												disabled={disabled}
-												onClick={() => askRemoveCategory(index)}
-												type="button"
-											>
-												Supprimer
-											</button>
-										</div>
-									)}
-
-									{readOnlyNameDetail ? (
-										<>
-											<p className="fr-mb-0">
-												<span className="fr-text--bold">Nom : </span>
-												{cat?.name}
-											</p>
-											<p className="fr-mb-0">
-												<span className="fr-text--bold">
-													Détail des emplois :{" "}
-												</span>
-												{cat?.detail}
-											</p>
-										</>
+									{readOnlyLabel ? (
+										<p className="fr-mb-0">
+											<span className="fr-text--bold">Libellé : </span>
+											{cat?.name}
+										</p>
 									) : (
-										<>
-											<div className="fr-input-group fr-mb-0">
-												<label
-													className="fr-label"
-													htmlFor={`cat-${index}-name`}
-												>
-													Nom
-												</label>
-												<input
-													className="fr-input"
-													disabled={disabled}
-													id={`cat-${index}-name`}
-													{...form.register(`categories.${index}.name`)}
-													onChange={(e) => {
-														form.setValue(
-															`categories.${index}.name`,
-															e.target.value,
-														);
-														setSaved(false);
-													}}
-													type="text"
-												/>
-											</div>
-
-											<div className="fr-input-group fr-mb-0">
-												<label
-													className="fr-label"
-													htmlFor={`cat-${index}-detail`}
-												>
-													Détail des emplois
-												</label>
-												<input
-													className="fr-input"
-													disabled={disabled}
-													id={`cat-${index}-detail`}
-													{...form.register(`categories.${index}.detail`)}
-													onChange={(e) => {
-														form.setValue(
-															`categories.${index}.detail`,
-															e.target.value,
-														);
-														setSaved(false);
-													}}
-													type="text"
-												/>
-											</div>
-										</>
+										<div className="fr-input-group fr-mb-0">
+											<label className="fr-label" htmlFor={`cat-${index}-name`}>
+												Libellé
+											</label>
+											<input
+												className="fr-input"
+												disabled={disabled}
+												id={`cat-${index}-name`}
+												{...form.register(`categories.${index}.name`)}
+												onChange={(e) => {
+													form.setValue(
+														`categories.${index}.name`,
+														e.target.value,
+													);
+													setSaved(false);
+												}}
+												type="text"
+											/>
+										</div>
 									)}
 
 									<CategoryDataTable
@@ -470,6 +420,19 @@ export function CategoryForm({
 										onDecimalBlur={handleDecimalBlur}
 										onPositiveNumberChange={handlePositiveNumberChange}
 									/>
+
+									{!readOnlyLabel && fields.length > 1 && (
+										<div className={stepStyles.deleteRow}>
+											<button
+												className="fr-btn fr-btn--tertiary fr-icon-delete-line fr-btn--icon-left fr-btn--sm"
+												disabled={disabled}
+												onClick={() => askRemoveCategory(index)}
+												type="button"
+											>
+												Supprimer
+											</button>
+										</div>
+									)}
 								</div>
 							</div>
 						</section>
@@ -481,7 +444,7 @@ export function CategoryForm({
 				<p className="fr-text--bold fr-mb-0">
 					Nombre de catégories : {fields.length}
 				</p>
-				{!readOnlyNameDetail && (
+				{!readOnlyLabel && (
 					<button
 						className="fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left"
 						disabled={disabled}

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/categoryFileHandler.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/categoryFileHandler.test.ts
@@ -12,7 +12,6 @@ function makeCategory(
 	return {
 		id,
 		name,
-		detail: "",
 		womenCount: "",
 		menCount: "",
 		annualBaseWomen: "",
@@ -50,7 +49,6 @@ describe("generateTemplate", () => {
 	it("generates a CSV with current categories data", async () => {
 		const categories = [
 			makeCategory(0, "Cadres", {
-				detail: "Direction",
 				womenCount: "10",
 				menCount: "15",
 				annualBaseWomen: "45000.50",
@@ -63,7 +61,6 @@ describe("generateTemplate", () => {
 
 		expect(lines.length).toBe(2);
 		expect(lines[1]).toContain("Cadres");
-		expect(lines[1]).toContain("Direction");
 		expect(lines[1]).toContain("10");
 		expect(lines[1]).toContain("45000.50");
 	});
@@ -73,7 +70,6 @@ describe("parseImportFile — XLSX", () => {
 	it("round-trips: generate then parse XLSX", async () => {
 		const original = [
 			makeCategory(0, "Ouvriers", {
-				detail: "Production",
 				womenCount: "50",
 				menCount: "60",
 				annualBaseWomen: "30000",
@@ -94,7 +90,6 @@ describe("parseImportFile — XLSX", () => {
 
 		expect(result.categories).toHaveLength(2);
 		expect(result.categories[0]?.name).toBe("Ouvriers");
-		expect(result.categories[0]?.detail).toBe("Production");
 		expect(result.categories[0]?.womenCount).toBe("50");
 		expect(result.categories[0]?.annualBaseWomen).toBe("30000");
 		expect(result.categories[1]?.name).toBe("Cadres");
@@ -108,10 +103,10 @@ describe("parseImportFile — CSV", () => {
 	}
 
 	const headers =
-		"Nom de la catégorie;Détail des emplois;Effectif femmes;Effectif hommes;Annuel base femmes (€);Annuel base hommes (€);Annuel variable femmes (€);Annuel variable hommes (€);Horaire base femmes (€);Horaire base hommes (€);Horaire variable femmes (€);Horaire variable hommes (€)";
+		"Nom de la catégorie;Effectif femmes;Effectif hommes;Annuel base femmes (€);Annuel base hommes (€);Annuel variable femmes (€);Annuel variable hommes (€);Horaire base femmes (€);Horaire base hommes (€);Horaire variable femmes (€);Horaire variable hommes (€)";
 
 	it("parses a valid CSV file", async () => {
-		const csv = `${headers}\nOuvriers;Production;50;60;30000;31000;;;;;\nCadres;;20;25;;;;;;;;;`;
+		const csv = `${headers}\nOuvriers;50;60;30000;31000;;;;;\nCadres;20;25;;;;;;;;;`;
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -124,7 +119,7 @@ describe("parseImportFile — CSV", () => {
 	});
 
 	it("normalizes comma decimals to dots", async () => {
-		const csv = `${headers}\nOuvriers;;10;12;30 000,50;31000;;;;;`;
+		const csv = `${headers}\nOuvriers;10;12;30 000,50;31000;;;;;`;
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -134,7 +129,7 @@ describe("parseImportFile — CSV", () => {
 	});
 
 	it("skips rows with empty name", async () => {
-		const csv = `${headers}\nOuvriers;;10;12;;;;;;\n;;5;8;;;;;;`;
+		const csv = `${headers}\nOuvriers;10;12;;;;;;\n;5;8;;;;;;`;
 		const result = await parseImportFile(csvFile(csv));
 
 		expect(result.ok).toBe(true);
@@ -176,7 +171,6 @@ describe("parseImportFile — CSV", () => {
 	it("round-trips: generate then parse CSV", async () => {
 		const original = [
 			makeCategory(0, "Techniciens", {
-				detail: "Maintenance",
 				womenCount: "30",
 				menCount: "40",
 				hourlyBaseWomen: "18.50",
@@ -194,7 +188,6 @@ describe("parseImportFile — CSV", () => {
 
 		expect(result.categories).toHaveLength(1);
 		expect(result.categories[0]?.name).toBe("Techniciens");
-		expect(result.categories[0]?.detail).toBe("Maintenance");
 		expect(result.categories[0]?.hourlyBaseWomen).toBe("18.50");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/categoryFileHandler.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/categoryFileHandler.ts
@@ -6,7 +6,6 @@ import type { EmployeeCategory } from "./categorySerializer";
 /** Column definitions for the import/export template. */
 const TEMPLATE_COLUMNS = [
 	{ key: "name", header: "Nom de la catégorie" },
-	{ key: "detail", header: "Détail des emplois" },
 	{ key: "womenCount", header: "Effectif femmes" },
 	{ key: "menCount", header: "Effectif hommes" },
 	{ key: "annualBaseWomen", header: "Annuel base femmes (€)" },
@@ -52,7 +51,7 @@ export async function generateTemplate(
 
 type TemplateRow = Record<TemplateKey, string | number>;
 
-type MinimalCategory = { name: string; detail: string };
+type MinimalCategory = { name: string };
 
 function isFullCategory(
 	cat: EmployeeCategory | MinimalCategory,
@@ -64,12 +63,11 @@ function buildTemplateRows(categories: EmployeeCategory[]): TemplateRow[] {
 	const cats: Array<EmployeeCategory | MinimalCategory> =
 		categories.length > 0 && categories.some((c) => c.name.trim())
 			? categories
-			: DEFAULT_CATEGORIES.map((name) => ({ name, detail: "" }));
+			: DEFAULT_CATEGORIES.map((name) => ({ name }));
 
 	return cats.map((cat) => {
 		const row: TemplateRow = {
 			name: cat.name,
-			detail: cat.detail,
 			womenCount: "",
 			menCount: "",
 			annualBaseWomen: "",
@@ -398,7 +396,6 @@ function buildCategoryFromRow(
 	return {
 		id,
 		name: get("name").trim(),
-		detail: get("detail").trim(),
 		womenCount: normalizeDecimal(get("womenCount")),
 		menCount: normalizeDecimal(get("menCount")),
 		annualBaseWomen: normalizeDecimal(get("annualBaseWomen")),

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/categorySerializer.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/categorySerializer.ts
@@ -6,7 +6,6 @@ import type {
 export type EmployeeCategory = {
 	id: number;
 	name: string;
-	detail: string;
 	womenCount: string;
 	menCount: string;
 	annualBaseWomen: string;
@@ -21,7 +20,6 @@ export type EmployeeCategory = {
 
 const EMPTY_FIELDS = {
 	name: "",
-	detail: "",
 	womenCount: "",
 	menCount: "",
 	annualBaseWomen: "",
@@ -45,7 +43,6 @@ export function fromDatabaseRows(
 	return rows.map((row) => ({
 		id: nextId(),
 		name: row.name,
-		detail: row.detail,
 		womenCount: row.womenCount?.toString() ?? "",
 		menCount: row.menCount?.toString() ?? "",
 		annualBaseWomen: row.annualBaseWomen ?? "",
@@ -77,7 +74,6 @@ export function toSubmitData(
 		source,
 		categories: categories.map((cat) => ({
 			name: cat.name,
-			detail: cat.detail,
 			data: {
 				womenCount: toInt(cat.womenCount),
 				menCount: toInt(cat.menCount),

--- a/packages/app/src/modules/declaration-remuneration/types.ts
+++ b/packages/app/src/modules/declaration-remuneration/types.ts
@@ -61,7 +61,6 @@ export type PayGapRow = {
 
 export type EmployeeCategoryRow = {
 	name: string;
-	detail: string;
 	womenCount: number | null;
 	menCount: number | null;
 	annualBaseWomen: string | null;
@@ -78,7 +77,6 @@ export type EmployeeCategorySubmitData = {
 	source: string;
 	categories: Array<{
 		name: string;
-		detail: string;
 		data: {
 			womenCount?: number;
 			menCount?: number;

--- a/packages/app/src/modules/declarationPdf/__tests__/DeclarationPdfDocument.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/DeclarationPdfDocument.test.tsx
@@ -163,7 +163,6 @@ const declarationPdfData: DeclarationPdfData = {
 	step5Categories: [
 		{
 			name: "Ingénieurs",
-			detail: "",
 			womenCount: 5,
 			menCount: 8,
 			annualBaseWomen: "55000",

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -191,7 +191,6 @@ describe("buildIndicatorG", () => {
 		const entries: IndicatorGEntry[] = [
 			{
 				categoryName: "Ouvriers",
-				detail: "Opérateurs",
 				declarationType: "initial",
 				womenCount: 40,
 				menCount: 45,
@@ -206,7 +205,6 @@ describe("buildIndicatorG", () => {
 			},
 			{
 				categoryName: "Ouvriers",
-				detail: "Opérateurs",
 				declarationType: "correction",
 				womenCount: 42,
 				menCount: 44,
@@ -272,7 +270,6 @@ describe("assembleDeclaration", () => {
 		const indicatorG: IndicatorGEntry[] = [
 			{
 				categoryName: "Cadres",
-				detail: null,
 				declarationType: "initial",
 				womenCount: 50,
 				menCount: 60,
@@ -287,7 +284,6 @@ describe("assembleDeclaration", () => {
 			},
 			{
 				categoryName: "Cadres",
-				detail: null,
 				declarationType: "correction",
 				womenCount: 52,
 				menCount: 58,

--- a/packages/app/src/modules/export/__tests__/generateXlsx.test.ts
+++ b/packages/app/src/modules/export/__tests__/generateXlsx.test.ts
@@ -99,7 +99,6 @@ function makeIndicatorGRow(
 		declarationType: "initial",
 		categoryIndex: 0,
 		categoryName: "Ouvriers",
-		categoryDetail: "Production",
 		categorySource: "predefined",
 		womenCount: 40,
 		menCount: 45,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -33,7 +33,6 @@ import {
 
 export type IndicatorGEntry = {
 	categoryName: string;
-	detail: string | null;
 	declarationType: string;
 	womenCount: number | null;
 	menCount: number | null;
@@ -175,7 +174,6 @@ export function buildIndicators(row: DeclarationRow) {
 function toIndicatorGCategory(entry: IndicatorGEntry) {
 	return {
 		Nom_categorie: entry.categoryName,
-		Detail_categorie: entry.detail,
 		Effectif_F: entry.womenCount,
 		Effectif_H: entry.menCount,
 		Rem_annuelle_base_F: entry.annualBaseWomen,

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -20,10 +20,6 @@ const indicatorGCategorySchema = {
 			type: "string",
 			description: "Libellé CSP (ex. 'Ouvriers', 'Ingénieurs et cadres')",
 		},
-		Detail_categorie: {
-			type: ["string", "null"],
-			description: "Précision éventuelle sur la catégorie",
-		},
 		Effectif_F: { type: ["integer", "null"] },
 		Effectif_H: { type: ["integer", "null"] },
 		Rem_annuelle_base_F: { type: ["string", "null"] },

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -140,7 +140,6 @@ export async function fetchIndicatorGByDeclaration(
 		.select({
 			declarationId: jobCategories.declarationId,
 			categoryName: jobCategories.name,
-			detail: jobCategories.detail,
 			declarationType: employeeCategories.declarationType,
 			womenCount: employeeCategories.womenCount,
 			menCount: employeeCategories.menCount,
@@ -199,7 +198,6 @@ export async function buildIndicatorGRows(
 			declarationType: employeeCategories.declarationType,
 			categoryIndex: jobCategories.categoryIndex,
 			categoryName: jobCategories.name,
-			categoryDetail: jobCategories.detail,
 			categorySource: jobCategories.source,
 			womenCount: employeeCategories.womenCount,
 			menCount: employeeCategories.menCount,

--- a/packages/app/src/modules/export/shared/constants.ts
+++ b/packages/app/src/modules/export/shared/constants.ts
@@ -132,7 +132,6 @@ export const INDICATOR_G_COLUMNS: Array<{
 	{ key: "declarationType", header: "Type_declaration" },
 	{ key: "categoryIndex", header: "Index_categorie" },
 	{ key: "categoryName", header: "Nom_categorie" },
-	{ key: "categoryDetail", header: "Detail_categorie" },
 	{ key: "categorySource", header: "Source" },
 	{ key: "womenCount", header: "Effectif_F" },
 	{ key: "menCount", header: "Effectif_H" },

--- a/packages/app/src/modules/export/types.ts
+++ b/packages/app/src/modules/export/types.ts
@@ -116,7 +116,6 @@ export type IndicatorGRow = {
 	declarationType: "initial" | "correction";
 	categoryIndex: number;
 	categoryName: string;
-	categoryDetail: string | null;
 	categorySource: string;
 	womenCount: number | null;
 	menCount: number | null;

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -624,7 +624,6 @@ describe("declarationRouter", () => {
 			categories: [
 				{
 					name: "Cadres",
-					detail: "Senior",
 					data: { womenCount: 10, menCount: 15 },
 				},
 			],
@@ -663,7 +662,6 @@ describe("declarationRouter", () => {
 				categories: [
 					{
 						name: "Cadres",
-						detail: "Senior",
 						data: { womenCount: 12, menCount: 18 },
 					},
 				],

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -74,7 +74,6 @@ describe("mapToEmployeeCategoryRows", () => {
 		declarationId: "decl-1",
 		categoryIndex: 0,
 		name: "Cadres",
-		detail: "Senior",
 		source: "dads",
 		createdAt: new Date(),
 	};
@@ -142,14 +141,6 @@ describe("mapToEmployeeCategoryRows", () => {
 
 		expect(result[0]?.womenCount).toBeNull();
 	});
-
-	it("uses empty string for null detail", () => {
-		const jobs = [{ ...baseJob, detail: null }];
-
-		const result = mapToEmployeeCategoryRows(jobs, [], "initial");
-
-		expect(result[0]?.detail).toBe("");
-	});
 });
 
 describe("fetchAllCategories", () => {
@@ -201,7 +192,6 @@ describe("fetchAllCategories", () => {
 describe("fetchPreviousYearJobCategories", () => {
 	type JobCategoryRow = {
 		name: string;
-		detail: string | null;
 		source: string;
 		categoryIndex: number;
 	};
@@ -264,14 +254,12 @@ describe("fetchPreviousYearJobCategories", () => {
 		const tx = makeTx("decl-2024", [
 			{
 				name: "Employés",
-				detail: "Support",
-				source: "convention-collective",
+				source: "accord-entreprise",
 				categoryIndex: 1,
 			},
 			{
 				name: "Cadres",
-				detail: "Managers",
-				source: "convention-collective",
+				source: "accord-entreprise",
 				categoryIndex: 0,
 			},
 		]);
@@ -279,31 +267,9 @@ describe("fetchPreviousYearJobCategories", () => {
 		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
 
 		expect(result).toEqual({
-			source: "convention-collective",
-			categories: [
-				{ name: "Cadres", detail: "Managers" },
-				{ name: "Employés", detail: "Support" },
-			],
+			source: "accord-entreprise",
+			categories: [{ name: "Cadres" }, { name: "Employés" }],
 		});
-	});
-
-	it("uses empty string for null detail", async () => {
-		const { fetchPreviousYearJobCategories } = await import(
-			"../declarationHelpers"
-		);
-
-		const tx = makeTx("decl-2024", [
-			{
-				name: "Cadres",
-				detail: null,
-				source: "autre",
-				categoryIndex: 0,
-			},
-		]);
-
-		const result = await fetchPreviousYearJobCategories(tx, "123456789", 2026);
-
-		expect(result?.categories[0]?.detail).toBe("");
 	});
 });
 

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -367,7 +367,6 @@ export const declarationRouter = createTRPCRouter({
 								declarationId: declaration.id,
 								categoryIndex: i,
 								name: cat.name,
-								detail: cat.detail || null,
 								source: input.source,
 							})
 							.returning();

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -160,7 +160,6 @@ export async function fetchPreviousYearJobCategories(
 	const jobs = await tx
 		.select({
 			name: jobCategories.name,
-			detail: jobCategories.detail,
 			source: jobCategories.source,
 			categoryIndex: jobCategories.categoryIndex,
 		})
@@ -174,7 +173,6 @@ export async function fetchPreviousYearJobCategories(
 		source,
 		categories: sorted.map((j) => ({
 			name: j.name,
-			detail: j.detail ?? "",
 		})),
 	};
 }
@@ -196,7 +194,6 @@ export function mapToEmployeeCategoryRows(
 			);
 			return {
 				name: job.name,
-				detail: job.detail ?? "",
 				womenCount: emp?.womenCount ?? null,
 				menCount: emp?.menCount ?? null,
 				annualBaseWomen: emp?.annualBaseWomen ?? null,

--- a/packages/app/src/server/db/__tests__/schema-comments.test.ts
+++ b/packages/app/src/server/db/__tests__/schema-comments.test.ts
@@ -100,7 +100,6 @@ describe("SCHEMA_COLUMN_COMMENTS", () => {
 	it("annotates indicator G job_category columns without GIP-MDS prefix", () => {
 		const jobCat = SCHEMA_COLUMN_COMMENTS.job_category;
 		expect(jobCat?.name).toBe("SUIT: Indicateurs.G.Nom_categorie");
-		expect(jobCat?.detail).toBe("SUIT: Indicateurs.G.Detail_categorie");
 	});
 
 	it("does not annotate job_category internal columns (not in SUIT JSON)", () => {

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -129,7 +129,6 @@ export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
 	},
 	job_category: {
 		name: "SUIT: Indicateurs.G.Nom_categorie",
-		detail: "SUIT: Indicateurs.G.Detail_categorie",
 	},
 	employee_category: {
 		women_count: "SUIT: Indicateurs.G.Effectif_F",

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -164,7 +164,6 @@ export const jobCategories = createTable(
 			.references(() => declarations.id),
 		categoryIndex: d.integer().notNull(),
 		name: d.varchar({ length: 255 }).notNull(),
-		detail: d.varchar({ length: 500 }),
 		source: d.varchar({ length: 50 }).notNull(),
 	}),
 	(t) => [


### PR DESCRIPTION
fix #3324 (data layer split — UI polish in stacked PR)

## Summary
- Merge **Nom** + **Détail des emplois** into a single **Libellé** field on step 5.
- Drop `app_job_category.detail` via drizzle migration `0030_drop_job_category_detail.sql`.
- Update export, PDF, recap, second-declaration and OpenAPI surfaces to drop the field everywhere it was exposed.

This PR is the **data-layer half** of the #3324 polish work. UI polish (dropdown, buttons, scroll, table greys, a11y, SSR fix) lives in the stacked PR `feat/issue-3324-ui-polish`.

## ⚠️ Migration / data note
`0030_drop_job_category_detail.sql` does an **irreversible `DROP COLUMN`** on `app_job_category.detail`. Existing draft and submitted declarations lose any text held in `detail` (the field was merged into `name`). Per the issue brief this is intentional, but downstream API consumers reading `Detail_categorie` from the OpenAPI export will silently stop seeing it — worth a heads-up to BI / third-party integrators in the release notes.

## Test plan
- [ ] Step 5 renders a single **Libellé** input per category; existing draft data displays the previous `name` value.
- [ ] `pnpm db:migrate` runs cleanly on a database that still has the `detail` column.
- [ ] Recap (Step 6) and the generated PDF/XLSX no longer surface the `detail` field.
- [ ] OpenAPI export no longer exposes `Detail_categorie`.