### PR TITLE
UI Step4 — refonte tableau + cascade + RGAA + E2E (#3355)

### DIFF
--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -143,13 +143,20 @@ test.describe("Declaration workflow", () => {
 	}) => {
 		await goToStep(page, 4);
 
+		// Scope assertions to the annual table — the hourly table may be
+		// pre-populated with GIP-MDS data for the test SIREN, so a global
+		// page-level lookup would resolve to multiple cells.
+		const annualTable = page.getByRole("table", {
+			name: "Rémunération annuelle brute moyenne",
+		});
+
 		// S2 — fill annual Q1 max (the only threshold input on the Q1 row)
-		const seuil1Annual = page.getByRole("textbox", {
+		const seuil1Annual = annualTable.getByRole("textbox", {
 			name: "Seuil maximum 1er quartile annuel",
 		});
 		await seuil1Annual.fill("20000");
 		// Q2 min cell is computed from Q1 threshold + 0,01 → "20 000,01 €"
-		await expect(page.getByText(/20.000,01 €/)).toBeVisible();
+		await expect(annualTable.getByText(/20.000,01 €/)).toBeVisible();
 	});
 
 	test("step 4 - non-crescent thresholds trigger recap alert with anchors (S3)", async ({

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -110,17 +110,122 @@ test.describe("Declaration workflow", () => {
 		).toBeVisible();
 	});
 
-	test("step 4 - Proportion quartiles page structure", async ({ page }) => {
+	test("step 4 - inverted quartile table layout (rows = quartiles, columns = F/H/%F/%H)", async ({
+		page,
+	}) => {
 		await goToStep(page, 4);
 
 		await expect(page.getByText("Étape 4 sur 6")).toBeVisible();
 
-		// Verify quartile column headers exist in the table
+		// S1 — quartile labels live in rowheaders (rows are quartiles in the new layout)
 		await expect(
-			page.getByRole("columnheader", { name: "1er quartile" }).first(),
+			page.getByRole("rowheader", { name: /1er quartile/ }).first(),
 		).toBeVisible();
 		await expect(
-			page.getByRole("columnheader", { name: "4e quartile" }).first(),
+			page.getByRole("rowheader", { name: /4e quartile/ }).first(),
+		).toBeVisible();
+		// "Tous les salariés" total row exists in both tables
+		await expect(
+			page.getByRole("rowheader", { name: "Tous les salariés" }),
+		).toHaveCount(2);
+		// Header row exposes the new column "Nombre de femmes" / "Nombre d'hommes"
+		await expect(
+			page.getByRole("columnheader", { name: /Nombre de femmes/ }).first(),
+		).toBeVisible();
+		// Accordion present
+		await expect(
+			page.getByRole("button", { name: /Définitions et méthode de calcul/ }),
+		).toBeVisible();
+	});
+
+	test("step 4 - cascade: filling Q1 threshold updates Q2 lower bound live", async ({
+		page,
+	}) => {
+		await goToStep(page, 4);
+
+		// S2 — fill annual Q1 max (the only threshold input on the Q1 row)
+		const seuil1Annual = page.getByRole("textbox", {
+			name: "Seuil maximum 1er quartile annuel",
+		});
+		await seuil1Annual.fill("20000");
+		// Q2 min cell is computed from Q1 threshold + 0,01 → "20 000,01 €"
+		await expect(page.getByText(/20.000,01 €/)).toBeVisible();
+	});
+
+	test("step 4 - non-crescent thresholds trigger recap alert with anchors (S3)", async ({
+		page,
+	}) => {
+		await goToStep(page, 4);
+
+		// Fill non-crescent annual thresholds : 30000, 20000, 40000
+		await page
+			.getByRole("textbox", { name: "Seuil maximum 1er quartile annuel" })
+			.fill("30000");
+		await page
+			.getByRole("textbox", { name: "Seuil maximum 2e quartile annuel" })
+			.fill("20000");
+		await page
+			.getByRole("textbox", { name: "Seuil maximum 3e quartile annuel" })
+			.fill("40000");
+
+		// Fill hourly thresholds (valid) and all 8 counts to isolate the croissance error
+		await page
+			.getByRole("textbox", { name: "Seuil maximum 1er quartile horaire" })
+			.fill("10");
+		await page
+			.getByRole("textbox", { name: "Seuil maximum 2e quartile horaire" })
+			.fill("20");
+		await page
+			.getByRole("textbox", { name: "Seuil maximum 3e quartile horaire" })
+			.fill("30");
+		for (const ordinal of ["1er", "2e", "3e", "4e"] as const) {
+			await page
+				.getByRole("textbox", {
+					name: `Nombre de femmes ${ordinal} quartile annuel`,
+				})
+				.fill("1");
+			await page
+				.getByRole("textbox", {
+					name: `Nombre d'hommes ${ordinal} quartile annuel`,
+				})
+				.fill("1");
+			await page
+				.getByRole("textbox", {
+					name: `Nombre de femmes ${ordinal} quartile horaire`,
+				})
+				.fill("1");
+			await page
+				.getByRole("textbox", {
+					name: `Nombre d'hommes ${ordinal} quartile horaire`,
+				})
+				.fill("1");
+		}
+
+		await page.getByRole("button", { name: "Suivant" }).click();
+
+		// Recap alert with anchor links
+		const alert = page.getByRole("alert").first();
+		await expect(alert).toBeVisible();
+		await expect(alert).toContainText(/Le formulaire contient des erreurs/);
+		await expect(
+			alert
+				.getByRole("link")
+				.filter({
+					has: page.locator("text=/quartile/"),
+				})
+				.first(),
+		).toBeVisible();
+	});
+
+	test("step 4 - empty submission shows 'Le seuil est obligatoire' on threshold cells (S4)", async ({
+		page,
+	}) => {
+		await goToStep(page, 4);
+		await page.getByRole("button", { name: "Suivant" }).click();
+
+		// At least one error message per missing threshold
+		await expect(
+			page.getByText("Le seuil est obligatoire").first(),
 		).toBeVisible();
 	});
 

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -143,9 +143,8 @@ test.describe("Declaration workflow", () => {
 	}) => {
 		await goToStep(page, 4);
 
-		// Scope assertions to the annual table — the hourly table may be
-		// pre-populated with GIP-MDS data for the test SIREN, so a global
-		// page-level lookup would resolve to multiple cells.
+		// Scope to the annual table — the hourly table is pre-populated with
+		// GIP-MDS data for the test SIREN.
 		const annualTable = page.getByRole("table", {
 			name: "Rémunération annuelle brute moyenne",
 		});
@@ -155,8 +154,13 @@ test.describe("Declaration workflow", () => {
 			name: "Seuil maximum 1er quartile annuel",
 		});
 		await seuil1Annual.fill("20000");
-		// Q2 min cell is computed from Q1 threshold + 0,01 → "20 000,01 €"
-		await expect(annualTable.getByText(/20.000,01 €/)).toBeVisible();
+
+		// Q2 row's first cell is the lower-bound, computed from Q1 threshold
+		// + 0,01 → "20 000,01 €" (live cascade update).
+		const q2Row = annualTable.locator("tbody > tr").filter({
+			has: page.getByRole("rowheader", { name: "2e quartile" }),
+		});
+		await expect(q2Row.locator("td").first()).toHaveText("20 000,01 €");
 	});
 
 	test("step 4 - non-crescent thresholds trigger recap alert with anchors (S3)", async ({

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -232,6 +232,22 @@ test.describe("Declaration workflow", () => {
 		page,
 	}) => {
 		await goToStep(page, 4);
+
+		// The test SIREN has GIP-MDS prefilled thresholds — clear them so the
+		// "all empty → required errors" path is exercised.
+		for (const ordinal of ["1er", "2e", "3e"] as const) {
+			await page
+				.getByRole("textbox", {
+					name: `Seuil maximum ${ordinal} quartile annuel`,
+				})
+				.fill("");
+			await page
+				.getByRole("textbox", {
+					name: `Seuil maximum ${ordinal} quartile horaire`,
+				})
+				.fill("");
+		}
+
 		await page.getByRole("button", { name: "Suivant" }).click();
 
 		// At least one error message per missing threshold

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -14,76 +14,71 @@ async function fillPayGapTable(page: Page) {
 	}
 }
 
-/** Fill step 4 quartile data with consistent values (total = step 1 workforce). */
-async function fillStep4Quartiles(page: Page) {
-	// Total must equal step 1 workforce: 10 women, 15 men
-	// Split across 4 quartiles: 3+3+2+2=10 women, 4+4+4+3=15 men
-	// Q4 has no upper threshold (schema enforces this)
-	const quartiles: Array<{
-		name: string;
-		annualThreshold?: string;
-		hourlyThreshold?: string;
-		women: string;
-		men: string;
-	}> = [
-		{
-			name: "1er quartile",
-			annualThreshold: "10000",
-			hourlyThreshold: "10",
-			women: "3",
-			men: "4",
-		},
-		{
-			name: "2e quartile",
-			annualThreshold: "20000",
-			hourlyThreshold: "20",
-			women: "3",
-			men: "4",
-		},
-		{
-			name: "3e quartile",
-			annualThreshold: "30000",
-			hourlyThreshold: "30",
-			women: "2",
-			men: "4",
-		},
-		{ name: "4e quartile", women: "2", men: "3" },
-	];
+type QuartileInputRow = {
+	ordinal: "1er" | "2e" | "3e" | "4e";
+	threshold?: string;
+	women: string;
+	men: string;
+};
 
-	for (const q of quartiles) {
-		// Each quartile appears twice (annual table + hourly table) — fill both
+const DEFAULT_ANNUAL_QUARTILES: QuartileInputRow[] = [
+	{ ordinal: "1er", threshold: "10000", women: "3", men: "4" },
+	{ ordinal: "2e", threshold: "20000", women: "3", men: "4" },
+	{ ordinal: "3e", threshold: "30000", women: "2", men: "4" },
+	{ ordinal: "4e", women: "2", men: "3" },
+];
+
+const DEFAULT_HOURLY_QUARTILES: QuartileInputRow[] = [
+	{ ordinal: "1er", threshold: "10", women: "3", men: "4" },
+	{ ordinal: "2e", threshold: "20", women: "3", men: "4" },
+	{ ordinal: "3e", threshold: "30", women: "2", men: "4" },
+	{ ordinal: "4e", women: "2", men: "3" },
+];
+
+async function fillQuartileRow(
+	page: Page,
+	tableSuffix: "annuel" | "horaire",
+	row: QuartileInputRow,
+) {
+	if (row.threshold !== undefined && row.ordinal !== "4e") {
 		await page
-			.getByRole("textbox", { name: `Nombre de femmes ${q.name}` })
-			.nth(0)
-			.fill(q.women);
-		await page
-			.getByRole("textbox", { name: `Nombre d'hommes ${q.name}` })
-			.nth(0)
-			.fill(q.men);
-		if (q.annualThreshold !== undefined) {
-			await page
-				.getByRole("textbox", { name: `Rémunération brute ${q.name}` })
-				.nth(0)
-				.fill(q.annualThreshold);
-		}
+			.getByRole("textbox", {
+				name: `Seuil maximum ${row.ordinal} quartile ${tableSuffix}`,
+			})
+			.fill(row.threshold);
 	}
+	await page
+		.getByRole("textbox", {
+			name: `Nombre de femmes ${row.ordinal} quartile ${tableSuffix}`,
+		})
+		.fill(row.women);
+	await page
+		.getByRole("textbox", {
+			name: `Nombre d'hommes ${row.ordinal} quartile ${tableSuffix}`,
+		})
+		.fill(row.men);
+}
 
-	// Hourly table (same quartile names, second occurrence)
-	for (const q of quartiles) {
-		await page
-			.getByRole("textbox", { name: `Nombre de femmes ${q.name}` })
-			.nth(1)
-			.fill(q.women);
-		await page
-			.getByRole("textbox", { name: `Nombre d'hommes ${q.name}` })
-			.nth(1)
-			.fill(q.men);
-		if (q.hourlyThreshold !== undefined) {
-			await page
-				.getByRole("textbox", { name: `Rémunération brute ${q.name}` })
-				.nth(1)
-				.fill(q.hourlyThreshold);
-		}
+/**
+ * Fill step 4 quartile data with consistent values (total = step 1 workforce).
+ *
+ * Each table accepts 3 thresholds (Q1/Q2/Q3 max) and 4 F/H counts.
+ * Q4 has no upper threshold by spec.
+ */
+export async function fillStep4Quartiles(
+	page: Page,
+	options: {
+		annualThresholds?: QuartileInputRow[];
+		hourlyThresholds?: QuartileInputRow[];
+	} = {},
+) {
+	const annual = options.annualThresholds ?? DEFAULT_ANNUAL_QUARTILES;
+	const hourly = options.hourlyThresholds ?? DEFAULT_HOURLY_QUARTILES;
+	for (const row of annual) {
+		await fillQuartileRow(page, "annuel", row);
+	}
+	for (const row of hourly) {
+		await fillQuartileRow(page, "horaire", row);
 	}
 }
 

--- a/packages/app/src/modules/declaration-remuneration/shared/PrefillSource.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PrefillSource.tsx
@@ -1,31 +1,29 @@
-/**
- * Source attribution line shown under tables when GIP DSN data is available.
- * Displays the DSN data source and (optionally) the reference period range.
- */
 type Props = {
 	periodStart?: string | null;
 	periodEnd: string | null;
 };
 
 export function PrefillSource({ periodStart, periodEnd }: Props) {
-	const showPeriod = periodStart && periodEnd;
+	const suffix = buildSuffix(periodStart, periodEnd);
 	return (
-		<div className="fr-text--sm fr-text-mention--grey fr-mb-0">
-			<p className="fr-mb-0">
-				Source&nbsp;: DSN (Déclarations Sociales Nominatives)
-				{periodEnd &&
-					!showPeriod &&
-					`, mise à jour le ${formatFrenchDate(periodEnd)}`}
-				.
-			</p>
-			{showPeriod && (
-				<p className="fr-mb-0">
-					Période de référence&nbsp;: {formatFrenchDate(periodStart)} -{" "}
-					{formatFrenchDate(periodEnd)}.
-				</p>
-			)}
-		</div>
+		<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
+			Source&nbsp;: DSN (Déclarations Sociales Nominatives)
+			{suffix}.
+		</p>
 	);
+}
+
+function buildSuffix(
+	periodStart: string | null | undefined,
+	periodEnd: string | null,
+): string {
+	if (periodStart && periodEnd) {
+		return `, période de référence : ${formatFrenchDate(periodStart)} - ${formatFrenchDate(periodEnd)}`;
+	}
+	if (periodEnd) {
+		return `, mise à jour le ${formatFrenchDate(periodEnd)}`;
+	}
+	return "";
 }
 
 /** Format "2026-12-31" → "31/12/2026" */

--- a/packages/app/src/modules/declaration-remuneration/shared/PrefillSource.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PrefillSource.tsx
@@ -1,27 +1,30 @@
-import { TooltipButton } from "./TooltipButton";
-
 /**
  * Source attribution line shown under tables when GIP DSN data is available.
- * Displays the DSN data source and last update date with a tooltip.
+ * Displays the DSN data source and (optionally) the reference period range.
  */
 type Props = {
+	periodStart?: string | null;
 	periodEnd: string | null;
-	tooltipId?: string;
 };
 
-export function PrefillSource({
-	periodEnd,
-	tooltipId = "tooltip-source",
-}: Props) {
+export function PrefillSource({ periodStart, periodEnd }: Props) {
+	const showPeriod = periodStart && periodEnd;
 	return (
-		<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
-			Source&nbsp;: DSN (Déclarations Sociales Nominatives)
-			{periodEnd && `, mise à jour le ${formatFrenchDate(periodEnd)}`}.
-			<TooltipButton
-				id={tooltipId}
-				label="Information sur la source des données"
-			/>
-		</p>
+		<div className="fr-text--sm fr-text-mention--grey fr-mb-0">
+			<p className="fr-mb-0">
+				Source&nbsp;: DSN (Déclarations Sociales Nominatives)
+				{periodEnd &&
+					!showPeriod &&
+					`, mise à jour le ${formatFrenchDate(periodEnd)}`}
+				.
+			</p>
+			{showPeriod && (
+				<p className="fr-mb-0">
+					Période de référence&nbsp;: {formatFrenchDate(periodStart)} -{" "}
+					{formatFrenchDate(periodEnd)}.
+				</p>
+			)}
+		</div>
 	);
 }
 

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.module.scss
@@ -2,3 +2,7 @@
 	display: inline-flex;
 	vertical-align: middle;
 }
+
+.button + :global(.fr-tooltip) {
+	padding-left: 0;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.module.scss
@@ -2,7 +2,3 @@
 	display: inline-flex;
 	vertical-align: middle;
 }
-
-.button + :global(.fr-tooltip) {
-	padding-left: 0;
-}

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
@@ -13,30 +13,35 @@ describe("PrefillSource", () => {
 		).toBeInTheDocument();
 	});
 
-	it("formats the date correctly (ISO to French format)", () => {
-		render(<PrefillSource periodEnd="2026-12-31" />);
-
-		expect(screen.getByText(/31\/12\/2026/)).toBeInTheDocument();
-	});
-
 	it("renders without period end date", () => {
 		render(<PrefillSource periodEnd={null} />);
 
 		expect(screen.getByText(/Source/)).toBeInTheDocument();
 		expect(screen.queryByText(/mise à jour le/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Période de référence/)).not.toBeInTheDocument();
 	});
 
-	it("shows update date text when periodEnd is provided", () => {
+	it("shows update date when only periodEnd is provided", () => {
 		render(<PrefillSource periodEnd="2025-03-15" />);
 
 		expect(screen.getByText(/mise à jour le 15\/03\/2025/)).toBeInTheDocument();
+		expect(screen.queryByText(/Période de référence/)).not.toBeInTheDocument();
 	});
 
-	it("renders the tooltip button", () => {
+	it("renders the reference period range when both periodStart and periodEnd are provided", () => {
+		render(<PrefillSource periodEnd="2026-12-31" periodStart="2026-01-01" />);
+
+		expect(screen.getByText(/Période de référence/)).toBeInTheDocument();
+		expect(screen.getByText(/01\/01\/2026/)).toBeInTheDocument();
+		expect(screen.getByText(/31\/12\/2026/)).toBeInTheDocument();
+		expect(screen.queryByText(/mise à jour le/)).not.toBeInTheDocument();
+	});
+
+	it("does not render a tooltip button", () => {
 		render(<PrefillSource periodEnd={null} />);
 
 		expect(
-			screen.getByLabelText("Information sur la source des données"),
-		).toBeInTheDocument();
+			screen.queryByLabelText("Information sur la source des données"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
@@ -18,20 +18,20 @@ describe("PrefillSource", () => {
 
 		expect(screen.getByText(/Source/)).toBeInTheDocument();
 		expect(screen.queryByText(/mise à jour le/)).not.toBeInTheDocument();
-		expect(screen.queryByText(/Période de référence/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/période de référence/)).not.toBeInTheDocument();
 	});
 
 	it("shows update date when only periodEnd is provided", () => {
 		render(<PrefillSource periodEnd="2025-03-15" />);
 
 		expect(screen.getByText(/mise à jour le 15\/03\/2025/)).toBeInTheDocument();
-		expect(screen.queryByText(/Période de référence/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/période de référence/)).not.toBeInTheDocument();
 	});
 
 	it("renders the reference period range when both periodStart and periodEnd are provided", () => {
 		render(<PrefillSource periodEnd="2026-12-31" periodStart="2026-01-01" />);
 
-		expect(screen.getByText(/Période de référence/)).toBeInTheDocument();
+		expect(screen.getByText(/période de référence/)).toBeInTheDocument();
 		expect(screen.getByText(/01\/01\/2026/)).toBeInTheDocument();
 		expect(screen.getByText(/31\/12\/2026/)).toBeInTheDocument();
 		expect(screen.queryByText(/mise à jour le/)).not.toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/shared/devFillData.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/devFillData.ts
@@ -24,19 +24,20 @@ export const DEV_STEP3_ROWS: PayGapRow[] = [
 export const DEV_STEP3_BENEFICIARY_WOMEN = "95";
 export const DEV_STEP3_BENEFICIARY_MEN = "110";
 
-// Step 4 - Quartile distribution (annual + hourly)
+// Step 4 - Quartile distribution (annual + hourly).
+// Only Q1, Q2, Q3 carry an upper threshold; Q4 has no `womenValue`.
 export const DEV_STEP4_ANNUAL = [
 	{ name: "1er quartile", womenCount: 35, menCount: 28, womenValue: "22000" },
 	{ name: "2e quartile", womenCount: 30, menCount: 32, womenValue: "28500" },
 	{ name: "3e quartile", womenCount: 28, menCount: 35, womenValue: "35000" },
-	{ name: "4e quartile", womenCount: 27, menCount: 35, womenValue: "48000" },
+	{ name: "4e quartile", womenCount: 27, menCount: 35 },
 ];
 
 export const DEV_STEP4_HOURLY = [
 	{ name: "1er quartile", womenCount: 35, menCount: 28, womenValue: "11.50" },
 	{ name: "2e quartile", womenCount: 30, menCount: 32, womenValue: "14.80" },
 	{ name: "3e quartile", womenCount: 28, menCount: 35, womenValue: "18.20" },
-	{ name: "4e quartile", womenCount: 27, menCount: 35, womenValue: "24.50" },
+	{ name: "4e quartile", womenCount: 27, menCount: 35 },
 ];
 
 // Step 5 - Employee categories

--- a/packages/app/src/modules/declaration-remuneration/shared/gipMdsMapping.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/gipMdsMapping.ts
@@ -60,6 +60,8 @@ export type GipPrefillData = {
 	};
 	/** Confidence index (0-1, for internal DGT use) */
 	confidenceIndex: string | null;
+	/** Start of the data collection period (e.g. "2026-01-01"), used for "Période de référence" display. */
+	periodStart?: string | null;
 	/** End of the data collection period (e.g. "2026-12-31"), used for "Source : DSN" display. */
 	periodEnd: string | null;
 };
@@ -148,6 +150,7 @@ export function mapGipToFormData(row: GipMdsRow | null): GipPrefillData | null {
 			),
 		},
 		confidenceIndex: row.confidenceIndex,
+		periodStart: row.periodStart,
 		periodEnd: row.periodEnd,
 	};
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -199,10 +199,7 @@ export function Step1Workforce({
 					</div>
 
 					{isPrefilled && (
-						<PrefillSource
-							periodEnd={gipPrefillData.periodEnd}
-							tooltipId="tooltip-source-step1"
-						/>
+						<PrefillSource periodEnd={gipPrefillData.periodEnd} />
 					)}
 				</div>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -21,7 +21,6 @@ import { PayGapTable } from "../shared/PayGapTable";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
 import { StepTitleRow } from "../shared/StepTitleRow";
-import { TooltipButton } from "../shared/TooltipButton";
 import type { PayGapField, Step2Data } from "../types";
 
 type Step2PayGapProps = {
@@ -116,12 +115,8 @@ export function Step2PayGap({
 					<strong>
 						{gipPrefillData
 							? "Vérifiez les informations préremplies à partir de vos données DSN et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
-							: "Renseignez les informations avant de valider vos indicateurs."}
+							: "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs."}
 					</strong>
-					<TooltipButton
-						id="tooltip-step2-info"
-						label="Information sur les indicateurs"
-					/>
 				</p>
 
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -139,10 +139,7 @@ export function Step2PayGap({
 					/>
 
 					{gipPrefillData && (
-						<PrefillSource
-							periodEnd={gipPrefillData.periodEnd}
-							tooltipId="tooltip-source-step2"
-						/>
+						<PrefillSource periodEnd={gipPrefillData.periodEnd} />
 					)}
 				</div>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -187,10 +187,7 @@ export function Step3VariablePay({
 					/>
 
 					{gipPrefillData && (
-						<PrefillSource
-							periodEnd={gipPrefillData.periodEnd}
-							tooltipId="tooltip-source-step3-paygap"
-						/>
+						<PrefillSource periodEnd={gipPrefillData.periodEnd} />
 					)}
 				</div>
 
@@ -303,10 +300,7 @@ export function Step3VariablePay({
 					)}
 
 					{gipPrefillData && (
-						<PrefillSource
-							periodEnd={gipPrefillData.periodEnd}
-							tooltipId="tooltip-source-step3"
-						/>
+						<PrefillSource periodEnd={gipPrefillData.periodEnd} />
 					)}
 				</div>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -24,7 +24,6 @@ import { PayGapTable } from "../shared/PayGapTable";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
 import { StepTitleRow } from "../shared/StepTitleRow";
-import { TooltipButton } from "../shared/TooltipButton";
 import type { PayGapField, Step3Data } from "../types";
 import stepStyles from "./Step3VariablePay.module.scss";
 
@@ -156,12 +155,8 @@ export function Step3VariablePay({
 					<strong>
 						{gipPrefillData
 							? "Vérifiez les informations préremplies à partir de vos données DSN et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
-							: "Renseignez les informations avant de valider vos indicateurs."}
+							: "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs."}
 					</strong>
-					<TooltipButton
-						id="tooltip-step3-info"
-						label="Information sur les indicateurs"
-					/>
 				</p>
 
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -195,10 +195,10 @@
 		min-width: 1rem;
 		width: 1rem;
 		height: 1rem;
-		padding: 0;
+		padding: 0 !important;
 		margin-left: 0.25rem;
 		vertical-align: middle;
-		overflow: visible;
+		overflow: visible !important;
 
 		&::before {
 			margin: 0;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -88,6 +88,7 @@
 
 	tbody td .inputWithUnit input.fr-input {
 		width: 5.5rem;
+		max-width: 5.5rem;
 		margin-left: 0;
 	}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -36,6 +36,26 @@
 		border-collapse: collapse;
 	}
 
+	.colRowLabel {
+		width: 9rem;
+	}
+
+	.colMin {
+		width: 7rem;
+	}
+
+	.colMax {
+		width: 13rem;
+	}
+
+	.colCount {
+		width: 7rem;
+	}
+
+	.colPercent {
+		width: 7rem;
+	}
+
 	th,
 	td {
 		white-space: normal;
@@ -44,7 +64,6 @@
 
 	tbody th[scope="row"] {
 		background: transparent;
-		width: 1%;
 		white-space: nowrap;
 		padding-right: 0.5rem;
 	}
@@ -68,7 +87,7 @@
 	}
 
 	tbody td .inputWithUnit input.fr-input {
-		width: 8rem;
+		width: 11rem;
 		margin-left: 0;
 	}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -88,6 +88,7 @@
 
 	tbody td .inputWithUnit input.fr-input {
 		width: 5.5rem;
+		min-width: 5.5rem;
 		max-width: 5.5rem;
 		margin-left: 0;
 	}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -63,6 +63,13 @@
 
 	tbody td input.fr-input {
 		text-align: right;
+		width: 4.5rem;
+		margin-left: auto;
+	}
+
+	tbody td .inputWithUnit input.fr-input {
+		width: 8rem;
+		margin-left: 0;
 	}
 
 	tbody tr:last-child {
@@ -117,6 +124,13 @@
 
 		tbody td input.fr-input {
 			text-align: left;
+			width: 100%;
+			margin-left: 0;
+		}
+
+		tbody td .inputWithUnit input.fr-input {
+			width: auto;
+			flex: 1;
 		}
 
 		tbody td[data-mobile-label]::before {
@@ -179,17 +193,7 @@
 	gap: 0.5rem;
 	justify-content: flex-end;
 
-	input {
-		min-width: 5rem;
-		text-align: right;
-	}
-
 	@include respond-to(sm) {
 		justify-content: flex-start;
-
-		input {
-			flex: 1;
-			min-width: 0;
-		}
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -83,13 +83,15 @@
 		font-variant-numeric: tabular-nums;
 	}
 
-	tbody td input.fr-input {
+	tbody td input:global(.fr-input) {
 		text-align: right;
 		width: 4.5rem;
 		margin-left: auto;
+		padding-left: 8px;
+		padding-right: 8px;
 	}
 
-	tbody td .inputWithUnit input.fr-input {
+	tbody td .inputWithUnit input:global(.fr-input) {
 		width: 5.5rem;
 		min-width: 5.5rem;
 		max-width: 5.5rem;
@@ -146,13 +148,13 @@
 			text-align: left;
 		}
 
-		tbody td input.fr-input {
+		tbody td input:global(.fr-input) {
 			text-align: left;
 			width: 100%;
 			margin-left: 0;
 		}
 
-		tbody td .inputWithUnit input.fr-input {
+		tbody td .inputWithUnit input:global(.fr-input) {
 			width: auto;
 			flex: 1;
 		}
@@ -182,7 +184,7 @@
 		vertical-align: super;
 	}
 
-	.fr-btn {
+	:global(.fr-btn) {
 		min-height: 1rem;
 		min-width: 1rem;
 		width: 1rem;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -40,16 +40,20 @@
 	td {
 		white-space: normal;
 		vertical-align: middle;
-		border-right: 1px solid var(--border-default-grey);
-	}
-
-	th:last-child,
-	td:last-child {
-		border-right: none;
 	}
 
 	tbody th[scope="row"] {
 		background: transparent;
+		width: 1%;
+		white-space: nowrap;
+		padding-right: 0.5rem;
+	}
+
+	.minCell,
+	.maxCell {
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		white-space: nowrap;
 	}
 
 	tbody tr:last-child {
@@ -72,7 +76,6 @@
 		tbody th {
 			display: block;
 			width: 100%;
-			border-right: none;
 		}
 
 		tbody tr {
@@ -88,6 +91,17 @@
 		tbody th {
 			border-bottom: none;
 			padding: 0.5rem 0;
+			text-align: left;
+		}
+
+		tbody th[scope="row"] {
+			width: 100%;
+			white-space: normal;
+			padding-right: 0;
+		}
+
+		.minCell,
+		.maxCell {
 			text-align: left;
 		}
 
@@ -109,14 +123,19 @@
 .rowLabelText {
 	display: inline-flex;
 	align-items: center;
-	gap: 0.5rem;
-}
-
-.minCell,
-.maxCell {
-	font-variant-numeric: tabular-nums;
-	text-align: right;
+	gap: 0.25rem;
 	white-space: nowrap;
+
+	.fr-btn {
+		min-height: 1.5rem;
+		max-width: 1.5rem;
+		max-height: 1.5rem;
+		padding: 0;
+
+		&::before {
+			margin-right: 0;
+		}
+	}
 }
 
 .readonlyCell {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -29,6 +29,12 @@
 }
 
 .quartileTable {
+	:global(.fr-table__container),
+	:global(.fr-table__content),
+	:global(.fr-table__wrapper) {
+		overflow: visible;
+	}
+
 	table {
 		width: 100%;
 		min-width: 0;
@@ -192,6 +198,7 @@
 		padding: 0;
 		margin-left: 0.25rem;
 		vertical-align: middle;
+		overflow: visible;
 
 		&::before {
 			margin: 0;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -60,12 +60,13 @@
 	td {
 		white-space: normal;
 		vertical-align: middle;
+		padding-left: 10px;
+		padding-right: 10px;
 	}
 
 	tbody th[scope="row"] {
 		background: transparent;
 		white-space: nowrap;
-		padding-right: 0.5rem;
 	}
 
 	.minCell,

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -29,10 +29,27 @@
 }
 
 .quartileTable {
+	table {
+		width: 100%;
+		min-width: 0;
+		table-layout: fixed;
+		border-collapse: collapse;
+	}
+
 	th,
 	td {
 		white-space: normal;
 		vertical-align: middle;
+		border-right: 1px solid var(--border-default-grey);
+	}
+
+	th:last-child,
+	td:last-child {
+		border-right: none;
+	}
+
+	tbody th[scope="row"] {
+		background: transparent;
 	}
 
 	tbody tr:last-child {
@@ -42,6 +59,7 @@
 	@include respond-to(sm) {
 		table {
 			display: block;
+			table-layout: auto;
 		}
 
 		thead {
@@ -54,6 +72,7 @@
 		tbody th {
 			display: block;
 			width: 100%;
+			border-right: none;
 		}
 
 		tbody tr {
@@ -87,7 +106,14 @@
 	}
 }
 
-.minCell {
+.rowLabelText {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+.minCell,
+.maxCell {
 	font-variant-numeric: tabular-nums;
 	text-align: right;
 	white-space: nowrap;
@@ -110,9 +136,11 @@
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
+	justify-content: flex-end;
 
 	input {
 		min-width: 5rem;
+		text-align: right;
 	}
 
 	@include respond-to(sm) {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -57,7 +57,9 @@
 	}
 
 	th,
-	td {
+	td,
+	:global(.fr-table__content) th,
+	:global(.fr-table__content) td {
 		white-space: normal;
 		vertical-align: middle;
 		padding-left: 10px;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -38,10 +38,59 @@
 	tbody tr:last-child {
 		font-weight: bold;
 	}
+
+	@include respond-to(sm) {
+		table {
+			display: block;
+		}
+
+		thead {
+			display: none;
+		}
+
+		tbody,
+		tbody tr,
+		tbody td,
+		tbody th {
+			display: block;
+			width: 100%;
+		}
+
+		tbody tr {
+			border-bottom: 1px solid var(--border-default-grey);
+			padding: 0.75rem 0;
+		}
+
+		tbody tr:last-child {
+			border-bottom: none;
+		}
+
+		tbody td,
+		tbody th {
+			border-bottom: none;
+			padding: 0.5rem 0;
+			text-align: left;
+		}
+
+		tbody td[data-mobile-label]::before {
+			content: attr(data-mobile-label);
+			display: block;
+			font-size: 0.75rem;
+			color: var(--text-mention-grey);
+			margin-bottom: 0.25rem;
+			font-weight: 400;
+		}
+
+		tbody td[data-mobile-label]:empty {
+			display: none;
+		}
+	}
 }
 
 .minCell {
 	font-variant-numeric: tabular-nums;
+	text-align: right;
+	white-space: nowrap;
 }
 
 .readonlyCell {
@@ -64,5 +113,14 @@
 
 	input {
 		min-width: 5rem;
+	}
+
+	@include respond-to(sm) {
+		justify-content: flex-start;
+
+		input {
+			flex: 1;
+			min-width: 0;
+		}
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -121,19 +121,27 @@
 }
 
 .rowLabelText {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.25rem;
+	display: inline;
 	white-space: nowrap;
 
+	sup {
+		font-size: 0.75em;
+		line-height: 0;
+		vertical-align: super;
+	}
+
 	.fr-btn {
-		min-height: 1.5rem;
-		max-width: 1.5rem;
-		max-height: 1.5rem;
+		min-height: 1rem;
+		min-width: 1rem;
+		width: 1rem;
+		height: 1rem;
 		padding: 0;
+		margin-left: 0.25rem;
+		vertical-align: middle;
 
 		&::before {
-			margin-right: 0;
+			margin: 0;
+			--icon-size: 0.875rem;
 		}
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -32,8 +32,29 @@
 	th,
 	td {
 		white-space: normal;
+		vertical-align: middle;
 	}
 
+	tbody tr:last-child {
+		font-weight: bold;
+	}
+}
+
+.minCell {
+	font-variant-numeric: tabular-nums;
+}
+
+.readonlyCell {
+	display: inline-block;
+	font-variant-numeric: tabular-nums;
+}
+
+.cellInputGroup {
+	margin: 0;
+}
+
+.cellLabel {
+	position: absolute;
 }
 
 .inputWithUnit {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -45,7 +45,7 @@
 	}
 
 	.colMax {
-		width: 13rem;
+		width: 7.5rem;
 	}
 
 	.colCount {
@@ -87,7 +87,7 @@
 	}
 
 	tbody td .inputWithUnit input.fr-input {
-		width: 11rem;
+		width: 5.5rem;
 		margin-left: 0;
 	}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -56,6 +56,15 @@
 		white-space: nowrap;
 	}
 
+	.numericCell {
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	tbody td input.fr-input {
+		text-align: right;
+	}
+
 	tbody tr:last-child {
 		font-weight: bold;
 	}
@@ -101,7 +110,12 @@
 		}
 
 		.minCell,
-		.maxCell {
+		.maxCell,
+		.numericCell {
+			text-align: left;
+		}
+
+		tbody td input.fr-input {
 			text-align: left;
 		}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -3,186 +3,40 @@
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
-import {
-	computeQuartileMin,
-	displayDecimal,
-	normalizeDecimalInput,
-} from "~/modules/domain";
-import { useZodForm } from "~/modules/shared/useZodForm";
+import { normalizeDecimalInput } from "~/modules/domain";
+import { useZodForm } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import { updateStep4Schema } from "../schemas";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP4_ANNUAL, DEV_STEP4_HOURLY } from "../shared/devFillData";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
-import type { GipPrefillData, GipQuartileData } from "../shared/gipMdsMapping";
+import type { GipPrefillData } from "../shared/gipMdsMapping";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
 import { StepTitleRow } from "../shared/StepTitleRow";
 import { TooltipButton } from "../shared/TooltipButton";
-import type { QuartileData, QuartileTuple, Step4Data } from "../types";
+import type { QuartileTuple, Step4Data } from "../types";
 import stepStyles from "./Step4QuartileDistribution.module.scss";
 import { QuartileInterpretationCallout } from "./step4/QuartileInterpretationCallout";
 import { QuartileReadingNote } from "./step4/QuartileReadingNote";
-import { type QuartileFieldErrors, QuartileTable } from "./step4/QuartileTable";
-
-type TableType = "annual" | "hourly";
-type CountField = "women" | "men";
-
-const TABLE_LABEL: Record<TableType, string> = {
-	annual: "rémunération annuelle",
-	hourly: "rémunération horaire",
-};
-
-function toQuartileData(c: {
-	womenValue?: string | null;
-	womenCount: number;
-	menCount: number;
-}): QuartileData {
-	return {
-		threshold: c.womenValue ?? undefined,
-		women: c.womenCount,
-		men: c.menCount,
-	};
-}
-
-/** Q4 carries no upper threshold by spec — strip whatever the form holds. */
-function normalizeForMutation(values: {
-	annual: QuartileTuple;
-	hourly: QuartileTuple;
-}): { annual: QuartileTuple; hourly: QuartileTuple } {
-	const stripQ4 = (table: QuartileTuple): QuartileTuple => [
-		table[0],
-		table[1],
-		table[2],
-		{ ...table[3], threshold: undefined },
-	];
-	return { annual: stripQ4(values.annual), hourly: stripQ4(values.hourly) };
-}
-
-function gipToQuartiles(gip: GipQuartileData): QuartileData[] {
-	return [0, 1, 2, 3].map((i) => ({
-		threshold: gip.thresholds[i] ?? "",
-		women: gip.womenCounts[i] ?? undefined,
-		men: gip.menCounts[i] ?? undefined,
-	}));
-}
-
-function emptyQuartiles(): QuartileTuple {
-	return [
-		{ threshold: "" },
-		{ threshold: "" },
-		{ threshold: "" },
-		{ threshold: "" },
-	];
-}
-
-/** Formats a stored decimal value as `"… €"` for read-only display cells. */
-function formatEuro(value: string): string {
-	return `${displayDecimal(value)} €`;
-}
-
-/** Computes the lower bound display string for each of the 4 quartiles. */
-function computeMinsForTable(
-	quartiles: QuartileTuple,
-): [string, string, string, string] {
-	const dash = "- €";
-	const q1Min = "0,00 €";
-	const min = (prevThreshold: string | undefined): string => {
-		const computed = computeQuartileMin(prevThreshold);
-		return computed ? formatEuro(computed) : dash;
-	};
-	return [
-		q1Min,
-		min(quartiles[0]?.threshold),
-		min(quartiles[1]?.threshold),
-		min(quartiles[2]?.threshold),
-	];
-}
-
-/** Returns the index of the first threshold that breaks strict ascending order, or null. */
-function findCroissanceOffender(
-	thresholds: Array<string | undefined>,
-): number | null {
-	const [t1, t2, t3] = thresholds
-		.slice(0, 3)
-		.map((t) => Number.parseFloat(t ?? "")) as [number, number, number];
-	if ([t1, t2, t3].some((n) => Number.isNaN(n))) return null;
-	if (!(t1 < t2)) return 1;
-	if (!(t2 < t3)) return 2;
-	return null;
-}
-
-type RecapEntry = {
-	id: string;
-	label: string;
-};
-
-type FieldErrorMap = Record<
-	TableType,
-	[
-		QuartileFieldErrors,
-		QuartileFieldErrors,
-		QuartileFieldErrors,
-		QuartileFieldErrors,
-	]
->;
-
-const EMPTY_ERRORS: QuartileFieldErrors = {};
-
-function emptyErrorMap(): FieldErrorMap {
-	return {
-		annual: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
-		hourly: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
-	};
-}
-
-function fieldId(
-	tableType: TableType,
-	index: number,
-	suffix: "max" | "f" | "h",
-) {
-	return `step4-${tableType}-q${index + 1}-${suffix}`;
-}
-
-const SUFFIX_FOR_FIELD: Record<"threshold" | CountField, "max" | "f" | "h"> = {
-	threshold: "max",
-	women: "f",
-	men: "h",
-};
-
-function buildRecap(errors: FieldErrorMap): RecapEntry[] {
-	const out: RecapEntry[] = [];
-	const tables: TableType[] = ["annual", "hourly"];
-	for (const table of tables) {
-		for (let i = 0; i < 4; i++) {
-			const cell = errors[table][i] ?? EMPTY_ERRORS;
-			const orderedFields: Array<"threshold" | CountField> = [
-				"threshold",
-				"women",
-				"men",
-			];
-			for (const field of orderedFields) {
-				const message = cell[field];
-				if (!message) continue;
-				const id = fieldId(table, i, SUFFIX_FOR_FIELD[field]);
-				const fieldLabel =
-					field === "threshold"
-						? "Seuil"
-						: field === "women"
-							? "Effectif femmes"
-							: "Effectif hommes";
-				const ordinal = `${i + 1}${i === 0 ? "er" : "e"}`;
-				out.push({
-					id,
-					label: `${fieldLabel} ${ordinal} quartile (${TABLE_LABEL[table]}) — ${message}`,
-				});
-				if (out.length === 4) return out;
-			}
-		}
-	}
-	return out;
-}
+import { QuartileTable } from "./step4/QuartileTable";
+import {
+	buildRecap,
+	type CountField,
+	deriveErrors,
+	emptyErrorMap,
+	type FieldErrorMap,
+	hasAnyError,
+	type TableType,
+} from "./step4/quartileErrors";
+import {
+	computeMinsForTable,
+	emptyQuartiles,
+	gipToQuartiles,
+	normalizeForMutation,
+	toQuartileData,
+} from "./step4/quartileFormHelpers";
 
 type Step4QuartileDistributionProps = {
 	declarationYear: number;
@@ -266,7 +120,7 @@ export function Step4QuartileDistribution({
 				annual: [...prev.annual] as FieldErrorMap["annual"],
 				hourly: [...prev.hourly] as FieldErrorMap["hourly"],
 			};
-			const cell = { ...(next[tableType][index] ?? EMPTY_ERRORS) };
+			const cell = { ...(next[tableType][index] ?? {}) };
 			delete cell[field];
 			next[tableType][index] = cell;
 			return next;
@@ -312,74 +166,6 @@ export function Step4QuartileDistribution({
 		}
 		setSaved(false);
 		clearFieldError(tableType, index, field);
-	}
-
-	function isValidThreshold(v: string | undefined): boolean {
-		return v !== undefined && v !== "" && !Number.isNaN(Number(v));
-	}
-
-	function deriveErrors(values: {
-		annual: QuartileTuple;
-		hourly: QuartileTuple;
-	}): FieldErrorMap {
-		const result = emptyErrorMap();
-		for (const table of ["annual", "hourly"] as const) {
-			const tableValues = values[table];
-			// Required check on Q1/Q2/Q3 thresholds
-			for (let i = 0; i < 3; i++) {
-				const cell = tableValues[i];
-				if (!isValidThreshold(cell?.threshold)) {
-					result[table][i] = {
-						...result[table][i],
-						threshold: "Le seuil est obligatoire",
-					};
-				}
-			}
-			// Strictly increasing check (only when all 3 are valid)
-			const t1 = tableValues[0]?.threshold;
-			const t2 = tableValues[1]?.threshold;
-			const t3 = tableValues[2]?.threshold;
-			if (
-				isValidThreshold(t1) &&
-				isValidThreshold(t2) &&
-				isValidThreshold(t3)
-			) {
-				const offender = findCroissanceOffender([t1, t2, t3]);
-				if (offender !== null) {
-					result[table][offender] = {
-						...result[table][offender],
-						threshold: "Les seuils doivent être strictement croissants",
-					};
-				}
-			}
-			// Counts required (8 cells per table)
-			for (let i = 0; i < 4; i++) {
-				const cell = tableValues[i];
-				if (cell?.women === undefined) {
-					result[table][i] = {
-						...result[table][i],
-						women: "Effectif obligatoire",
-					};
-				}
-				if (cell?.men === undefined) {
-					result[table][i] = {
-						...result[table][i],
-						men: "Effectif obligatoire",
-					};
-				}
-			}
-		}
-		return result;
-	}
-
-	function hasAnyError(map: FieldErrorMap) {
-		for (const table of ["annual", "hourly"] as const) {
-			for (let i = 0; i < 4; i++) {
-				const cell = map[table][i] ?? EMPTY_ERRORS;
-				if (cell.threshold || cell.women || cell.men) return true;
-			}
-		}
-		return false;
 	}
 
 	function focusAlert() {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -221,21 +221,16 @@ export function Step4QuartileDistribution({
 
 			<div className={stepStyles.instructions}>
 				<p className="fr-mb-0">
-					Cet indicateur compare la proportion de femmes et d&apos;hommes selon
-					les niveaux de rémunération. Les rémunérations sont classées de la
-					plus faible à la plus élevée puis divisées en quatre groupes de même
-					taille appelés quartiles&nbsp;: le 1<sup>er</sup> quartile correspond
-					aux 25 % des salariés les moins rémunérés, le 2<sup>e</sup> quartile
-					(médiane) aux 50 % des salariés situés au milieu de la distribution,
-					le 3<sup>e</sup> quartile aux salariés situés entre 50 % et 75 % des
-					rémunérations, et le 4<sup>e</sup> quartile correspond aux 25 % des
-					salariés les mieux rémunérés.
+					Cet indicateur répartit l&apos;ensemble des salariés en quatre groupes
+					de rémunération appelés quartiles&nbsp;: du quartile inférieur qui
+					regroupe les salariés les moins rémunérés, au quartile supérieur qui
+					rassemble les salariés les mieux rémunérés.
 				</p>
 
 				<p className="fr-mb-0">
 					<strong>
 						{gipPrefillData
-							? "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
+							? "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs."
 							: "Renseignez les informations avant de valider vos indicateurs."}
 					</strong>
 					<TooltipButton

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -289,7 +289,7 @@ export function Step4QuartileDistribution({
 					sourceNote={
 						<PrefillSource
 							periodEnd={gipPrefillData?.periodEnd ?? null}
-							tooltipId="tooltip-source-step4-annual"
+							periodStart={gipPrefillData?.periodStart ?? null}
 						/>
 					}
 					tableType="annual"
@@ -316,7 +316,7 @@ export function Step4QuartileDistribution({
 					sourceNote={
 						<PrefillSource
 							periodEnd={gipPrefillData?.periodEnd ?? null}
-							tooltipId="tooltip-source-step4-hourly"
+							periodStart={gipPrefillData?.periodStart ?? null}
 						/>
 					}
 					tableType="hourly"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -287,12 +287,10 @@ export function Step4QuartileDistribution({
 						) : undefined
 					}
 					sourceNote={
-						gipPrefillData ? (
-							<PrefillSource
-								periodEnd={gipPrefillData.periodEnd}
-								tooltipId="tooltip-source-step4-annual"
-							/>
-						) : undefined
+						<PrefillSource
+							periodEnd={gipPrefillData?.periodEnd ?? null}
+							tooltipId="tooltip-source-step4-annual"
+						/>
 					}
 					tableType="annual"
 					title="Rémunération annuelle brute moyenne"
@@ -316,12 +314,10 @@ export function Step4QuartileDistribution({
 						) : undefined
 					}
 					sourceNote={
-						gipPrefillData ? (
-							<PrefillSource
-								periodEnd={gipPrefillData.periodEnd}
-								tooltipId="tooltip-source-step4-hourly"
-							/>
-						) : undefined
+						<PrefillSource
+							periodEnd={gipPrefillData?.periodEnd ?? null}
+							tooltipId="tooltip-source-step4-hourly"
+						/>
 					}
 					tableType="hourly"
 					title="Rémunération horaire brute moyenne"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -15,7 +15,6 @@ import type { GipPrefillData } from "../shared/gipMdsMapping";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
 import { StepTitleRow } from "../shared/StepTitleRow";
-import { TooltipButton } from "../shared/TooltipButton";
 import type { QuartileTuple, Step4Data } from "../types";
 import stepStyles from "./Step4QuartileDistribution.module.scss";
 import { QuartileInterpretationCallout } from "./step4/QuartileInterpretationCallout";
@@ -229,14 +228,9 @@ export function Step4QuartileDistribution({
 
 				<p className="fr-mb-0">
 					<strong>
-						{gipPrefillData
-							? "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs."
-							: "Renseignez les informations avant de valider vos indicateurs."}
+						Vérifiez les informations préremplies et modifiez-les si nécessaire
+						avant de valider vos indicateurs.
 					</strong>
-					<TooltipButton
-						id="tooltip-step4-info"
-						label="Information sur les indicateurs"
-					/>
 				</p>
 
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
-import { normalizeDecimalInput } from "~/modules/domain";
+import {
+	computeQuartileMin,
+	displayDecimal,
+	normalizeDecimalInput,
+} from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep4Schema } from "../schemas";
-import { QUARTILE_NAMES } from "../shared/constants";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP4_ANNUAL, DEV_STEP4_HOURLY } from "../shared/devFillData";
 import { FormActions } from "../shared/FormActions";
@@ -21,7 +24,15 @@ import type { QuartileData, QuartileTuple, Step4Data } from "../types";
 import stepStyles from "./Step4QuartileDistribution.module.scss";
 import { QuartileInterpretationCallout } from "./step4/QuartileInterpretationCallout";
 import { QuartileReadingNote } from "./step4/QuartileReadingNote";
-import { QuartileTable } from "./step4/QuartileTable";
+import { type QuartileFieldErrors, QuartileTable } from "./step4/QuartileTable";
+
+type TableType = "annual" | "hourly";
+type CountField = "women" | "men";
+
+const TABLE_LABEL: Record<TableType, string> = {
+	annual: "rémunération annuelle",
+	hourly: "rémunération horaire",
+};
 
 function toQuartileData(c: {
 	womenValue?: string | null;
@@ -29,14 +40,28 @@ function toQuartileData(c: {
 	menCount: number;
 }): QuartileData {
 	return {
-		threshold: c.womenValue ?? "",
+		threshold: c.womenValue ?? undefined,
 		women: c.womenCount,
 		men: c.menCount,
 	};
 }
 
+/** Q4 carries no upper threshold by spec — strip whatever the form holds. */
+function normalizeForMutation(values: {
+	annual: QuartileTuple;
+	hourly: QuartileTuple;
+}): { annual: QuartileTuple; hourly: QuartileTuple } {
+	const stripQ4 = (table: QuartileTuple): QuartileTuple => [
+		table[0],
+		table[1],
+		table[2],
+		{ ...table[3], threshold: undefined },
+	];
+	return { annual: stripQ4(values.annual), hourly: stripQ4(values.hourly) };
+}
+
 function gipToQuartiles(gip: GipQuartileData): QuartileData[] {
-	return QUARTILE_NAMES.map((_, i) => ({
+	return [0, 1, 2, 3].map((i) => ({
 		threshold: gip.thresholds[i] ?? "",
 		women: gip.womenCounts[i] ?? undefined,
 		men: gip.menCounts[i] ?? undefined,
@@ -50,6 +75,113 @@ function emptyQuartiles(): QuartileTuple {
 		{ threshold: "" },
 		{ threshold: "" },
 	];
+}
+
+/** Formats a stored decimal value as `"… €"` for read-only display cells. */
+function formatEuro(value: string): string {
+	return `${displayDecimal(value)} €`;
+}
+
+/** Computes the lower bound display string for each of the 4 quartiles. */
+function computeMinsForTable(
+	quartiles: QuartileTuple,
+): [string, string, string, string] {
+	const dash = "- €";
+	const q1Min = "0,00 €";
+	const min = (prevThreshold: string | undefined): string => {
+		const computed = computeQuartileMin(prevThreshold);
+		return computed ? formatEuro(computed) : dash;
+	};
+	return [
+		q1Min,
+		min(quartiles[0]?.threshold),
+		min(quartiles[1]?.threshold),
+		min(quartiles[2]?.threshold),
+	];
+}
+
+/** Returns the index of the first threshold that breaks strict ascending order, or null. */
+function findCroissanceOffender(
+	thresholds: Array<string | undefined>,
+): number | null {
+	const [t1, t2, t3] = thresholds
+		.slice(0, 3)
+		.map((t) => Number.parseFloat(t ?? "")) as [number, number, number];
+	if ([t1, t2, t3].some((n) => Number.isNaN(n))) return null;
+	if (!(t1 < t2)) return 1;
+	if (!(t2 < t3)) return 2;
+	return null;
+}
+
+type RecapEntry = {
+	id: string;
+	label: string;
+};
+
+type FieldErrorMap = Record<
+	TableType,
+	[
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+	]
+>;
+
+const EMPTY_ERRORS: QuartileFieldErrors = {};
+
+function emptyErrorMap(): FieldErrorMap {
+	return {
+		annual: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
+		hourly: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
+	};
+}
+
+function fieldId(
+	tableType: TableType,
+	index: number,
+	suffix: "max" | "f" | "h",
+) {
+	return `step4-${tableType}-q${index + 1}-${suffix}`;
+}
+
+const SUFFIX_FOR_FIELD: Record<"threshold" | CountField, "max" | "f" | "h"> = {
+	threshold: "max",
+	women: "f",
+	men: "h",
+};
+
+function buildRecap(errors: FieldErrorMap): RecapEntry[] {
+	const out: RecapEntry[] = [];
+	const tables: TableType[] = ["annual", "hourly"];
+	for (const table of tables) {
+		for (let i = 0; i < 4; i++) {
+			const cell = errors[table][i] ?? EMPTY_ERRORS;
+			const orderedFields: Array<"threshold" | CountField> = [
+				"threshold",
+				"women",
+				"men",
+			];
+			for (const field of orderedFields) {
+				const message = cell[field];
+				if (!message) continue;
+				const id = fieldId(table, i, SUFFIX_FOR_FIELD[field]);
+				const fieldLabel =
+					field === "threshold"
+						? "Seuil"
+						: field === "women"
+							? "Effectif femmes"
+							: "Effectif hommes";
+				const ordinal = `${i + 1}${i === 0 ? "er" : "e"}`;
+				out.push({
+					id,
+					label: `${fieldLabel} ${ordinal} quartile (${TABLE_LABEL[table]}) — ${message}`,
+				});
+				if (out.length === 4) return out;
+			}
+		}
+	}
+	return out;
 }
 
 type Step4QuartileDistributionProps = {
@@ -69,6 +201,7 @@ export function Step4QuartileDistribution({
 }: Step4QuartileDistributionProps) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const alertRef = useRef<HTMLDivElement | null>(null);
 
 	const hasSavedData =
 		initialData.annual.some(
@@ -100,20 +233,19 @@ export function Step4QuartileDistribution({
 	const annual = form.watch("annual");
 	const hourly = form.watch("hourly");
 
-	const [validationError, setValidationError] = useState<string | null>(null);
+	const [maxError, setMaxError] = useState<string | null>(null);
 	const [saved, setSaved] = useState(hasSavedData);
-	const [formValidationError, setFormValidationError] = useState<string | null>(
-		null,
-	);
+	const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>(emptyErrorMap);
+	const [showRecap, setShowRecap] = useState(false);
 
 	const mutation = api.declaration.updateStep4.useMutation({
 		onSuccess: () => router.push("/declaration-remuneration/etape/5"),
 	});
 
 	function setQuartileField(
-		tableType: "annual" | "hourly",
+		tableType: TableType,
 		index: number,
-		field: "threshold" | "women" | "men",
+		field: "threshold" | CountField,
 		value: string | number | undefined,
 	) {
 		const arr = tableType === "annual" ? [...annual] : [...hourly];
@@ -124,22 +256,45 @@ export function Step4QuartileDistribution({
 		form.setValue(tableType, arr as QuartileTuple);
 	}
 
-	function handleQuartileChange(
-		tableType: "annual" | "hourly",
+	function clearFieldError(
+		tableType: TableType,
 		index: number,
-		field: "threshold" | "women" | "men",
+		field: "threshold" | CountField,
+	) {
+		setFieldErrors((prev) => {
+			const next: FieldErrorMap = {
+				annual: [...prev.annual] as FieldErrorMap["annual"],
+				hourly: [...prev.hourly] as FieldErrorMap["hourly"],
+			};
+			const cell = { ...(next[tableType][index] ?? EMPTY_ERRORS) };
+			delete cell[field];
+			next[tableType][index] = cell;
+			return next;
+		});
+	}
+
+	function handleQuartileChange(
+		tableType: TableType,
+		index: number,
+		field: "threshold" | CountField,
 		value: string,
 	) {
 		if (field === "threshold") {
 			const normalized = normalizeDecimalInput(value);
 			if (normalized === null) return;
 			if (normalized !== "" && Number.parseFloat(normalized) < 0) return;
-			setQuartileField(tableType, index, field, normalized || undefined);
+			setQuartileField(
+				tableType,
+				index,
+				field,
+				normalized === "" ? undefined : normalized,
+			);
 		} else {
 			if (value === "") {
 				setQuartileField(tableType, index, field, undefined);
-				setValidationError(null);
+				setMaxError(null);
 				setSaved(false);
+				clearFieldError(tableType, index, field);
 				return;
 			}
 			if (/\D/.test(value)) return;
@@ -147,38 +302,113 @@ export function Step4QuartileDistribution({
 			if (Number.isNaN(n) || n < 0) return;
 			const max = field === "women" ? maxWomen : maxMen;
 			if (max !== undefined && n > max) {
-				setValidationError(
+				setMaxError(
 					`Le nombre ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
 				);
 				return;
 			}
-			setValidationError(null);
+			setMaxError(null);
 			setQuartileField(tableType, index, field, n);
 		}
 		setSaved(false);
+		clearFieldError(tableType, index, field);
 	}
 
-	const onSubmit = form.handleSubmit(() => {
-		const allQuartiles = [...annual, ...hourly];
-		// Q4 (every 4th element, index % 4 === 3) has no upper threshold by design
-		const incomplete = allQuartiles.some(
-			(q, i) =>
-				q.women === undefined ||
-				q.men === undefined ||
-				(i % 4 !== 3 && !q.threshold),
-		);
-		if (incomplete) {
-			setFormValidationError(
-				"Veuillez renseigner toutes les données avant de passer à l'étape suivante.",
-			);
+	function isValidThreshold(v: string | undefined): boolean {
+		return v !== undefined && v !== "" && !Number.isNaN(Number(v));
+	}
+
+	function deriveErrors(values: {
+		annual: QuartileTuple;
+		hourly: QuartileTuple;
+	}): FieldErrorMap {
+		const result = emptyErrorMap();
+		for (const table of ["annual", "hourly"] as const) {
+			const tableValues = values[table];
+			// Required check on Q1/Q2/Q3 thresholds
+			for (let i = 0; i < 3; i++) {
+				const cell = tableValues[i];
+				if (!isValidThreshold(cell?.threshold)) {
+					result[table][i] = {
+						...result[table][i],
+						threshold: "Le seuil est obligatoire",
+					};
+				}
+			}
+			// Strictly increasing check (only when all 3 are valid)
+			const t1 = tableValues[0]?.threshold;
+			const t2 = tableValues[1]?.threshold;
+			const t3 = tableValues[2]?.threshold;
+			if (
+				isValidThreshold(t1) &&
+				isValidThreshold(t2) &&
+				isValidThreshold(t3)
+			) {
+				const offender = findCroissanceOffender([t1, t2, t3]);
+				if (offender !== null) {
+					result[table][offender] = {
+						...result[table][offender],
+						threshold: "Les seuils doivent être strictement croissants",
+					};
+				}
+			}
+			// Counts required (8 cells per table)
+			for (let i = 0; i < 4; i++) {
+				const cell = tableValues[i];
+				if (cell?.women === undefined) {
+					result[table][i] = {
+						...result[table][i],
+						women: "Effectif obligatoire",
+					};
+				}
+				if (cell?.men === undefined) {
+					result[table][i] = {
+						...result[table][i],
+						men: "Effectif obligatoire",
+					};
+				}
+			}
+		}
+		return result;
+	}
+
+	function hasAnyError(map: FieldErrorMap) {
+		for (const table of ["annual", "hourly"] as const) {
+			for (let i = 0; i < 4; i++) {
+				const cell = map[table][i] ?? EMPTY_ERRORS;
+				if (cell.threshold || cell.women || cell.men) return true;
+			}
+		}
+		return false;
+	}
+
+	function focusAlert() {
+		requestAnimationFrame(() => alertRef.current?.focus());
+	}
+
+	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		const values = form.getValues();
+		const errors = deriveErrors(values);
+		if (hasAnyError(errors)) {
+			setFieldErrors(errors);
+			setShowRecap(true);
+			focusAlert();
 			return;
 		}
-		setFormValidationError(null);
-		mutation.mutate(form.getValues());
-	});
+		setFieldErrors(emptyErrorMap());
+		setShowRecap(false);
+		mutation.mutate(normalizeForMutation(values));
+	}
+
+	const annualMins = computeMinsForTable(annual);
+	const hourlyMins = computeMinsForTable(hourly);
+
+	const recap = buildRecap(fieldErrors);
+	const showAlert = showRecap && recap.length > 0;
 
 	return (
-		<form className={stepStyles.formColumn} onSubmit={onSubmit}>
+		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
 			<StepTitleRow
 				onDevFill={() => {
 					form.setValue(
@@ -190,6 +420,8 @@ export function Step4QuartileDistribution({
 						DEV_STEP4_HOURLY.map(toQuartileData) as QuartileTuple,
 					);
 					setSaved(false);
+					setFieldErrors(emptyErrorMap());
+					setShowRecap(false);
 				}}
 				saved={saved}
 				title={
@@ -201,7 +433,6 @@ export function Step4QuartileDistribution({
 
 			<StepIndicator currentStep={4} />
 
-			{/* Description + instructions */}
 			<div className={stepStyles.instructions}>
 				<p className="fr-mb-0">
 					Cet indicateur compare la proportion de femmes et d&apos;hommes selon
@@ -230,10 +461,32 @@ export function Step4QuartileDistribution({
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 			</div>
 
-			{/* Tables */}
+			{showAlert && (
+				<div
+					aria-labelledby="step4-error-summary-title"
+					className="fr-alert fr-alert--error"
+					ref={alertRef}
+					role="alert"
+					tabIndex={-1}
+				>
+					<h3 className="fr-alert__title" id="step4-error-summary-title">
+						Le formulaire contient des erreurs
+					</h3>
+					<ul>
+						{recap.map((entry) => (
+							<li key={entry.id}>
+								<a href={`#${entry.id}`}>{entry.label}</a>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+
 			<div className={stepStyles.dataContainer}>
 				<QuartileTable
 					disabled={isImpersonating}
+					errors={fieldErrors.annual}
+					mins={annualMins}
 					onQuartileChange={(index, field, value) =>
 						handleQuartileChange("annual", index, field, value)
 					}
@@ -257,11 +510,12 @@ export function Step4QuartileDistribution({
 					}
 					tableType="annual"
 					title="Rémunération annuelle brute moyenne"
-					validationError={null}
 				/>
 
 				<QuartileTable
 					disabled={isImpersonating}
+					errors={fieldErrors.hourly}
+					mins={hourlyMins}
 					onQuartileChange={(index, field, value) =>
 						handleQuartileChange("hourly", index, field, value)
 					}
@@ -285,7 +539,6 @@ export function Step4QuartileDistribution({
 					}
 					tableType="hourly"
 					title="Rémunération horaire brute moyenne"
-					validationError={validationError}
 				/>
 
 				<DefinitionAccordion
@@ -303,7 +556,7 @@ export function Step4QuartileDistribution({
 
 			<FormErrors
 				mutationError={mutation.error?.message}
-				validationError={formValidationError}
+				validationError={maxError}
 			/>
 
 			<FormActions

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -47,7 +47,7 @@ describe("Step2PayGap", () => {
 		);
 		expect(
 			screen.getByText(
-				"Renseignez les informations avant de valider vos indicateurs.",
+				"Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs.",
 			),
 		).toBeInTheDocument();
 		expect(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -70,7 +70,7 @@ describe("Step3VariablePay", () => {
 		);
 		expect(
 			screen.getByText(
-				"Renseignez les informations avant de valider vos indicateurs.",
+				"Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs.",
 			),
 		).toBeInTheDocument();
 		expect(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
@@ -26,18 +26,18 @@ const emptyStep4Data = () => ({
 		{ threshold: "" },
 		{ threshold: "" },
 		{ threshold: "" },
-		{ threshold: "" },
+		{ threshold: undefined },
 	],
 	hourly: [
 		{ threshold: "" },
 		{ threshold: "" },
 		{ threshold: "" },
-		{ threshold: "" },
+		{ threshold: undefined },
 	],
 });
 
 describe("Step4QuartileDistribution dev fill", () => {
-	it("fills both tables when dev fill button is clicked", async () => {
+	it("fills both tables with 3 thresholds + 4 counts each when DevFill is clicked", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
@@ -48,12 +48,20 @@ describe("Step4QuartileDistribution dev fill", () => {
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));
 
-		// Intl.NumberFormat("fr-FR") uses U+202F as thousands separator
-		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
-		const firstRemuInput = remuInputs[0] as HTMLInputElement;
-		expect(firstRemuInput.value.replace(/\s/g, " ")).toBe("22 000");
+		// 3 threshold inputs per table → 6 total
+		const seuilInputs = screen.getAllByLabelText(/Seuil maximum/);
+		expect(seuilInputs.length).toBe(6);
+		const firstSeuil = seuilInputs[0] as HTMLInputElement;
+		expect(firstSeuil.value.replace(/\s/g, " ")).toBe("22 000");
 
+		// 4 women count inputs per table → 8 total, all filled
 		const womenInputs = screen.getAllByLabelText(/Nombre de femmes/);
+		expect(womenInputs.length).toBe(8);
 		expect(womenInputs[0]).toHaveValue("35");
+		// Q4 women is filled too
+		const q4Women = screen.getAllByLabelText(
+			/Nombre de femmes 4e quartile annuel/i,
+		)[0];
+		expect(q4Women).toHaveValue("27");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Step4QuartileDistribution } from "../Step4QuartileDistribution";
@@ -28,18 +28,33 @@ const validStep4Data = () => ({
 		{ threshold: "10000", women: 3, men: 4 },
 		{ threshold: "20000", women: 3, men: 4 },
 		{ threshold: "30000", women: 2, men: 4 },
-		{ women: 2, men: 3 },
+		{ threshold: undefined, women: 2, men: 3 },
 	],
 	hourly: [
 		{ threshold: "10", women: 3, men: 4 },
 		{ threshold: "20", women: 3, men: 4 },
 		{ threshold: "30", women: 2, men: 4 },
-		{ women: 2, men: 3 },
+		{ threshold: undefined, women: 2, men: 3 },
+	],
+});
+
+const emptyStep4Data = () => ({
+	annual: [
+		{ threshold: "" },
+		{ threshold: "" },
+		{ threshold: "" },
+		{ threshold: undefined },
+	],
+	hourly: [
+		{ threshold: "" },
+		{ threshold: "" },
+		{ threshold: "" },
+		{ threshold: undefined },
 	],
 });
 
 describe("Step4QuartileDistribution submit behaviour", () => {
-	it("calls mutation when Q1-Q3 have valid thresholds and Q4 has no threshold", async () => {
+	it("calls mutation with Q4 threshold=undefined when 3 thresholds + 8 counts are valid", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
@@ -50,13 +65,51 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
-		expect(mockMutate).toHaveBeenCalledOnce();
-		expect(
-			screen.queryByText(/Veuillez renseigner toutes les données/),
-		).not.toBeInTheDocument();
+		await waitFor(() => {
+			expect(mockMutate).toHaveBeenCalledOnce();
+		});
+		const payload = mockMutate.mock.calls[0]?.[0];
+		expect(payload.annual[3].threshold).toBeUndefined();
+		expect(payload.hourly[3].threshold).toBeUndefined();
+		expect(payload.annual[3].women).toBe(2);
+		expect(payload.annual[3].men).toBe(3);
 	});
 
-	it("shows incomplete error when a women count is missing", async () => {
+	it("shows recap alert with anchor links when thresholds are non-crescent", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={{
+					annual: [
+						{ threshold: "30000", women: 1, men: 1 },
+						{ threshold: "20000", women: 1, men: 1 },
+						{ threshold: "40000", women: 1, men: 1 },
+						{ threshold: undefined, women: 1, men: 1 },
+					],
+					hourly: [
+						{ threshold: "10", women: 1, men: 1 },
+						{ threshold: "20", women: 1, men: 1 },
+						{ threshold: "30", women: 1, men: 1 },
+						{ threshold: undefined, women: 1, men: 1 },
+					],
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		expect(mockMutate).not.toHaveBeenCalled();
+		// Recap alert is rendered with role=alert
+		const alert = screen.getByRole("alert");
+		expect(alert).toHaveTextContent(/Le formulaire contient des erreurs/);
+		// Anchor link points to the offending threshold input
+		const anchor = alert.querySelector('a[href="#step4-annual-q2-max"]');
+		expect(anchor).not.toBeNull();
+		expect(alert.querySelectorAll("a").length).toBeGreaterThan(0);
+	});
+
+	it("shows 'Effectif obligatoire' on missing women count cells", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
@@ -66,13 +119,13 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 						{ threshold: "10000", men: 4 },
 						{ threshold: "20000", women: 3, men: 4 },
 						{ threshold: "30000", women: 2, men: 4 },
-						{ women: 2, men: 3 },
+						{ threshold: undefined, women: 2, men: 3 },
 					],
 					hourly: [
 						{ threshold: "10", women: 3, men: 4 },
 						{ threshold: "20", women: 3, men: 4 },
 						{ threshold: "30", women: 2, men: 4 },
-						{ women: 2, men: 3 },
+						{ threshold: undefined, women: 2, men: 3 },
 					],
 				}}
 			/>,
@@ -81,8 +134,32 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
 		expect(mockMutate).not.toHaveBeenCalled();
+		expect(screen.getAllByText("Effectif obligatoire").length).toBeGreaterThan(
+			0,
+		);
+		const womenInput = screen.getByLabelText(
+			/Nombre de femmes 1er quartile annuel/i,
+		);
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("shows 'Le seuil est obligatoire' when a threshold is empty and a count is also missing", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		expect(mockMutate).not.toHaveBeenCalled();
 		expect(
-			screen.getByText(/Veuillez renseigner toutes les données/),
-		).toBeInTheDocument();
+			screen.getAllByText("Le seuil est obligatoire").length,
+		).toBeGreaterThan(0);
+		// All threshold inputs should be aria-invalid
+		const seuil1 = screen.getByLabelText(/Seuil maximum 1er quartile annuel/i);
+		expect(seuil1).toHaveAttribute("aria-invalid", "true");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -24,18 +24,18 @@ const emptyStep4Data = () => ({
 		{ threshold: "" },
 		{ threshold: "" },
 		{ threshold: "" },
-		{ threshold: "" },
+		{ threshold: undefined },
 	],
 	hourly: [
 		{ threshold: "" },
 		{ threshold: "" },
 		{ threshold: "" },
-		{ threshold: "" },
+		{ threshold: undefined },
 	],
 });
 
 describe("Step4QuartileDistribution", () => {
-	it("renders two tables with quartile columns", () => {
+	it("renders two tables with quartile rows and inverted columns", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
@@ -52,29 +52,26 @@ describe("Step4QuartileDistribution", () => {
 				selector: "h3",
 			}),
 		).toBeInTheDocument();
-		expect(
-			screen.getAllByText(/quartile/, { selector: "th" }).length,
-		).toBeGreaterThanOrEqual(8);
-		expect(screen.getAllByText(/les salariés/, { selector: "th" }).length).toBe(
-			2,
-		);
+		// Q1..Q4 row labels per table → 8 rows (excluding total row "Tous les salariés")
+		expect(screen.getAllByText(/quartile/, { selector: "th" }).length).toBe(8);
+		// Total row "Tous les salariés" shows in both tables
+		expect(screen.getAllByText(/Tous les salariés/).length).toBe(2);
 	});
 
-	it("renders all row labels in both tables", () => {
+	it("renders renumeration tranche header and Pourcentage columns", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		expect(screen.getAllByText(/annuelle brute/).length).toBeGreaterThanOrEqual(
-			1,
-		);
-		expect(screen.getAllByText(/horaire brute/).length).toBeGreaterThanOrEqual(
-			1,
-		);
-		expect(screen.getAllByText(/de femmes/).length).toBeGreaterThanOrEqual(4);
-		expect(screen.getAllByText(/d'hommes/).length).toBeGreaterThanOrEqual(4);
+		expect(
+			screen.getByText("Tranche de rémunération annuelle brute"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Tranche de rémunération horaire brute"),
+		).toBeInTheDocument();
+		expect(screen.getAllByText(/Pourcentage/).length).toBeGreaterThanOrEqual(4);
 	});
 
 	it("renders description text about quartiles", () => {
@@ -106,87 +103,49 @@ describe("Step4QuartileDistribution", () => {
 		).toBeInTheDocument();
 	});
 
-	it("displays pre-filled data with computed percentages", () => {
-		render(
-			<Step4QuartileDistribution
-				declarationYear={2025}
-				initialData={{
-					annual: [
-						{ threshold: "980", women: 19, men: 22 },
-						{ threshold: "1450", women: 17, men: 19 },
-						{ threshold: "1750", women: 14, men: 17 },
-						{ threshold: "2300", women: 5, men: 10 },
-					],
-					hourly: [
-						{ threshold: "7.2" },
-						{ threshold: "10.12" },
-						{ threshold: "12.92" },
-						{ threshold: "14.93" },
-					],
-				}}
-			/>,
-		);
-
-		// Check annual remuneration inputs have values
-		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
-		expect(remuInputs[0]).toHaveValue("980");
-
-		// Check annual women count inputs
-		const womenCountInputs = screen.getAllByLabelText(/Nombre de femmes/);
-		expect(womenCountInputs[0]).toHaveValue("19");
-
-		// Check annual total column (55 women, 68 men)
-		expect(screen.getAllByText("55").length).toBeGreaterThanOrEqual(1);
-		expect(screen.getAllByText("68").length).toBeGreaterThanOrEqual(1);
-	});
-
-	it("shows SavedIndicator when initialData has data", () => {
-		render(
-			<Step4QuartileDistribution
-				declarationYear={2025}
-				initialData={{
-					annual: [
-						{ threshold: "", women: 10, men: 15 },
-						{ threshold: "" },
-						{ threshold: "" },
-						{ threshold: "" },
-					],
-					hourly: [
-						{ threshold: "" },
-						{ threshold: "" },
-						{ threshold: "" },
-						{ threshold: "" },
-					],
-				}}
-			/>,
-		);
-		expect(screen.getByText("Enregistré")).toBeInTheDocument();
-	});
-
-	it("does not show SavedIndicator when no initial data", () => {
+	it("displays empty state with Q1 min = 0,00 € and Q2..Q4 min = - €", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
+		// Q1 min = "0,00 €" (twice: annual + hourly)
+		expect(screen.getAllByText("0,00 €").length).toBe(2);
+		// Q2/Q3/Q4 min and Q4 max readonly = "- €" → 4 per table × 2 = 8
+		const dashCells = screen
+			.getAllByRole("cell")
+			.filter((c) => c.textContent === "- €");
+		expect(dashCells.length).toBeGreaterThanOrEqual(8);
 	});
 
-	it("renders inline inputs for remuneration, women count, and men count", () => {
+	it("renders 3 threshold inputs per table (Q1/Q2/Q3 only) and Q4 readonly", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		// 4 quartiles × 2 tables = 8 inputs per row type
-		expect(screen.getAllByLabelText(/Rémunération brute/).length).toBe(8);
+		// 3 threshold inputs per table × 2 tables = 6
+		expect(screen.getAllByLabelText(/Seuil maximum/i).length).toBe(6);
+		// Q4 max is readonly (not an input)
+		expect(
+			screen.queryByLabelText(/Seuil maximum 4e quartile/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders 4 women and 4 men count inputs per table", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
 		expect(screen.getAllByLabelText(/Nombre de femmes/).length).toBe(8);
 		expect(screen.getAllByLabelText(/Nombre d'hommes/).length).toBe(8);
 	});
 
-	it("updates remuneration values via inline inputs", async () => {
+	it("displays cascade lower bounds live when seuil1 is filled", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
@@ -194,16 +153,18 @@ describe("Step4QuartileDistribution", () => {
 				initialData={emptyStep4Data()}
 			/>,
 		);
-
-		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
-		const q1Input = remuInputs[0] as HTMLInputElement;
-
-		await user.clear(q1Input);
-		await user.type(q1Input, "980");
-		expect(q1Input).toHaveValue("980");
+		const seuil1 = screen.getAllByLabelText(
+			/Seuil maximum 1er quartile annuel/i,
+		)[0] as HTMLInputElement;
+		await user.clear(seuil1);
+		await user.type(seuil1, "20000");
+		// Q2 min should now show "20 000,01 €"
+		expect(
+			screen.getByText((c) => c.replace(/\s/g, " ") === "20 000,01 €"),
+		).toBeInTheDocument();
 	});
 
-	it("rejects negative values in remuneration inputs", async () => {
+	it("rejects negative values in threshold inputs", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
@@ -211,13 +172,12 @@ describe("Step4QuartileDistribution", () => {
 				initialData={emptyStep4Data()}
 			/>,
 		);
-
-		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
-		const q1Input = remuInputs[0] as HTMLInputElement;
-
-		await user.clear(q1Input);
-		await user.type(q1Input, "-50");
-		expect(q1Input).not.toHaveValue("-50");
+		const seuil1 = screen.getAllByLabelText(
+			/Seuil maximum 1er quartile annuel/i,
+		)[0] as HTMLInputElement;
+		await user.clear(seuil1);
+		await user.type(seuil1, "-50");
+		expect(seuil1).not.toHaveValue("-50");
 	});
 
 	it("blocks count exceeding max workforce", async () => {
@@ -230,13 +190,11 @@ describe("Step4QuartileDistribution", () => {
 				maxWomen={15}
 			/>,
 		);
-
-		const womenInputs = screen.getAllByLabelText(/Nombre de femmes/);
-		const q1Input = womenInputs[0] as HTMLInputElement;
-
-		await user.clear(q1Input);
-		await user.type(q1Input, "20");
-
+		const womenInput = screen.getAllByLabelText(
+			/Nombre de femmes 1er quartile annuel/i,
+		)[0] as HTMLInputElement;
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
 		expect(screen.getByText(/ne peut pas dépasser/i)).toBeInTheDocument();
 	});
 
@@ -265,64 +223,7 @@ describe("Step4QuartileDistribution", () => {
 		);
 	});
 
-	it("uses gipPrefillData when no initialCategories", () => {
-		render(
-			<Step4QuartileDistribution
-				declarationYear={2025}
-				gipPrefillData={{
-					step1: { totalWomen: 100, totalMen: 100 },
-					step2: {
-						annualMeanWomen: null,
-						annualMeanMen: null,
-						hourlyMeanWomen: null,
-						hourlyMeanMen: null,
-						annualMedianWomen: null,
-						annualMedianMen: null,
-						hourlyMedianWomen: null,
-						hourlyMedianMen: null,
-					},
-					step3: {
-						annualMeanWomen: null,
-						annualMeanMen: null,
-						hourlyMeanWomen: null,
-						hourlyMeanMen: null,
-						annualMedianWomen: null,
-						annualMedianMen: null,
-						hourlyMedianWomen: null,
-						hourlyMedianMen: null,
-						beneficiaryCountWomen: null,
-						beneficiaryCountMen: null,
-					},
-					step4: {
-						annual: {
-							thresholds: ["25000", "32000", "40000", "55000"],
-							womenCounts: [30, 25, 20, 15],
-							menCounts: [20, 25, 30, 35],
-						},
-						hourly: {
-							thresholds: ["13.74", "17.58", "21.98", "30.22"],
-							womenCounts: [28, 22, 18, 12],
-							menCounts: [22, 28, 32, 38],
-						},
-					},
-					confidenceIndex: "0.85",
-					periodEnd: "2026-12-31",
-				}}
-				initialData={emptyStep4Data()}
-			/>,
-		);
-		// Check annual remuneration inputs have prefilled values
-		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
-		expect(remuInputs[0]).toHaveValue("25\u202f000");
-		// Check women count inputs
-		const womenCountInputs = screen.getAllByLabelText(/Nombre de femmes/);
-		expect(womenCountInputs[0]).toHaveValue("30");
-		// Check men count inputs
-		const menCountInputs = screen.getAllByLabelText(/Nombre d'hommes/);
-		expect(menCountInputs[0]).toHaveValue("20");
-	});
-
-	it("uses gipPrefillData with null Q4 threshold", () => {
+	it("uses gipPrefillData to pre-populate 3 thresholds and counts", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
@@ -353,27 +254,27 @@ describe("Step4QuartileDistribution", () => {
 					step4: {
 						annual: {
 							thresholds: ["25000", "32000", "40000", null],
-							womenCounts: [30, 25, 20, null],
-							menCounts: [20, 25, 30, null],
+							womenCounts: [30, 25, 20, 15],
+							menCounts: [20, 25, 30, 35],
 						},
 						hourly: {
 							thresholds: ["13.74", "17.58", "21.98", null],
-							womenCounts: [28, 22, 18, null],
-							menCounts: [22, 28, 32, null],
+							womenCounts: [28, 22, 18, 12],
+							menCounts: [22, 28, 32, 38],
 						},
 					},
-					confidenceIndex: null,
-					periodEnd: null,
+					confidenceIndex: "0.85",
+					periodEnd: "2026-12-31",
 				}}
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		// First 3 quartiles should be prefilled
-		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
-		expect(remuInputs[0]).toHaveValue("25\u202f000");
-		expect(remuInputs[2]).toHaveValue("40\u202f000");
-		// Q4 should be empty (null threshold)
-		expect(remuInputs[3]).toHaveValue("");
+		const seuilInputs = screen.getAllByLabelText(/Seuil maximum/);
+		expect(seuilInputs[0]).toHaveValue("25 000");
+		const womenCountInputs = screen.getAllByLabelText(/Nombre de femmes/);
+		expect(womenCountInputs[0]).toHaveValue("30");
+		const menCountInputs = screen.getAllByLabelText(/Nombre d'hommes/);
+		expect(menCountInputs[0]).toHaveValue("20");
 	});
 
 	it("uses gipPrefillData with all null quartile data", () => {
@@ -422,67 +323,66 @@ describe("Step4QuartileDistribution", () => {
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		// All inputs should be empty
-		const remuInputs = screen.getAllByLabelText(/Rémunération brute/);
-		for (const input of remuInputs) {
+		const seuilInputs = screen.getAllByLabelText(/Seuil maximum/);
+		for (const input of seuilInputs) {
 			expect(input).toHaveValue("");
 		}
 	});
 
-	it("uses gipPrefillData with mono-gender quartiles (100% women)", () => {
+	it("displays computed percentages for prefilled data", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
-				gipPrefillData={{
-					step1: { totalWomen: 200, totalMen: 0 },
-					step2: {
-						annualMeanWomen: null,
-						annualMeanMen: null,
-						hourlyMeanWomen: null,
-						hourlyMeanMen: null,
-						annualMedianWomen: null,
-						annualMedianMen: null,
-						hourlyMedianWomen: null,
-						hourlyMedianMen: null,
-					},
-					step3: {
-						annualMeanWomen: null,
-						annualMeanMen: null,
-						hourlyMeanWomen: null,
-						hourlyMeanMen: null,
-						annualMedianWomen: null,
-						annualMedianMen: null,
-						hourlyMedianWomen: null,
-						hourlyMedianMen: null,
-						beneficiaryCountWomen: null,
-						beneficiaryCountMen: null,
-					},
-					step4: {
-						annual: {
-							thresholds: ["25000", "32000", "40000", "55000"],
-							womenCounts: [50, 50, 50, 50],
-							menCounts: [0, 0, 0, 0],
-						},
-						hourly: {
-							thresholds: ["13.74", "17.58", "21.98", "30.22"],
-							womenCounts: [50, 50, 50, 50],
-							menCounts: [0, 0, 0, 0],
-						},
-					},
-					confidenceIndex: null,
-					periodEnd: null,
+				initialData={{
+					annual: [
+						{ threshold: "20000", women: 60, men: 30 },
+						{ threshold: "25000", women: 40, men: 30 },
+						{ threshold: "35000", women: 24, men: 31 },
+						{ threshold: undefined, women: 15, men: 26 },
+					],
+					hourly: [
+						{ threshold: "10", women: 20, men: 23 },
+						{ threshold: "12", women: 16, men: 18 },
+						{ threshold: "15", women: 15, men: 18 },
+						{ threshold: undefined, women: 4, men: 9 },
+					],
 				}}
+			/>,
+		);
+		// Annual: total = 90 women + 117 men → 139/256 ≈ 54,3%
+		expect(screen.getAllByText(/66,7 %/).length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("shows SavedIndicator when initialData has data", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={{
+					annual: [
+						{ threshold: "", women: 10, men: 15 },
+						{ threshold: "" },
+						{ threshold: "" },
+						{ threshold: undefined },
+					],
+					hourly: [
+						{ threshold: "" },
+						{ threshold: "" },
+						{ threshold: "" },
+						{ threshold: undefined },
+					],
+				}}
+			/>,
+		);
+		expect(screen.getByText("Enregistré")).toBeInTheDocument();
+	});
+
+	it("does not show SavedIndicator when no initial data", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		const womenCountInputs = screen.getAllByLabelText(/Nombre de femmes/);
-		expect(womenCountInputs[0]).toHaveValue("50");
-		const menCountInputs = screen.getAllByLabelText(/Nombre d'hommes/);
-		expect(menCountInputs[0]).toHaveValue("0");
-
-		// Total men column should display "0", not "-" (0 is valid data, not absence)
-		const totalCells = screen.getAllByRole("cell");
-		const menTotalCells = totalCells.filter((cell) => cell.textContent === "0");
-		expect(menTotalCells.length).toBeGreaterThanOrEqual(1);
+		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -69,12 +69,15 @@ describe("Step4QuartileDistribution", () => {
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		expect(
-			screen.getByText("Tranche de rémunération annuelle brute"),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText("Tranche de rémunération horaire brute"),
-		).toBeInTheDocument();
+		const headers = screen.getAllByRole("columnheader");
+		const annualHeader = headers.find((h) =>
+			/Tranche de rémunération[\s\S]*annuelle brute/.test(h.textContent ?? ""),
+		);
+		expect(annualHeader).toBeDefined();
+		const hourlyHeader = headers.find((h) =>
+			/Tranche de rémunération[\s\S]*horaire brute/.test(h.textContent ?? ""),
+		);
+		expect(hourlyHeader).toBeDefined();
 		expect(screen.getAllByText(/Pourcentage/).length).toBeGreaterThanOrEqual(4);
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -198,6 +198,42 @@ describe("Step4QuartileDistribution", () => {
 		expect(screen.getByText(/ne peut pas dépasser/i)).toBeInTheDocument();
 	});
 
+	it("renders mobile-label attributes on data cells for responsive reflow", () => {
+		const { container } = render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+		// Each quartile row carries data-mobile-label on its data cells
+		// (Minimum, Maximum, Nombre de femmes, Nombre d'hommes, % de femmes, % d'hommes)
+		const labels = container.querySelectorAll("[data-mobile-label]");
+		// 4 rows × 6 cells × 2 tables = 48; total row adds 4 cells × 2 = 8 → 56
+		expect(labels.length).toBeGreaterThanOrEqual(48);
+		expect(
+			container.querySelector('[data-mobile-label="Minimum"]'),
+		).toBeInTheDocument();
+		expect(
+			container.querySelector('[data-mobile-label="Maximum"]'),
+		).toBeInTheDocument();
+		expect(
+			container.querySelector('[data-mobile-label="Pourcentage de femmes"]'),
+		).toBeInTheDocument();
+	});
+
+	it("renders DSN source line on both tables even without GIP prefill", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+		expect(
+			screen.getAllByText(/Source\s*:\s*DSN \(Déclarations Sociales Nominatives\)/)
+				.length,
+		).toBe(2);
+	});
+
 	it("renders accordion", () => {
 		render(
 			<Step4QuartileDistribution

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -110,7 +110,7 @@ describe("Step4QuartileDistribution", () => {
 		).toBeInTheDocument();
 	});
 
-	it("displays empty state with all min = - € and Q4 max = - €", () => {
+	it("displays empty state with all min = - € and Q4 max = - €", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
@@ -119,7 +119,7 @@ describe("Step4QuartileDistribution", () => {
 		);
 		const dashCells = screen
 			.getAllByRole("cell")
-			.filter((c) => c.textContent === "- €");
+			.filter((c) => c.textContent === "- €");
 		expect(dashCells.length).toBeGreaterThanOrEqual(10);
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -107,20 +107,17 @@ describe("Step4QuartileDistribution", () => {
 		).toBeInTheDocument();
 	});
 
-	it("displays empty state with Q1 min = 0,00 € and Q2..Q4 min = - €", () => {
+	it("displays empty state with all min = - € and Q4 max = - €", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		// Q1 min = "0,00 €" (twice: annual + hourly)
-		expect(screen.getAllByText("0,00 €").length).toBe(2);
-		// Q2/Q3/Q4 min and Q4 max readonly = "- €" → 4 per table × 2 = 8
 		const dashCells = screen
 			.getAllByRole("cell")
 			.filter((c) => c.textContent === "- €");
-		expect(dashCells.length).toBeGreaterThanOrEqual(8);
+		expect(dashCells.length).toBeGreaterThanOrEqual(10);
 	});
 
 	it("renders 3 threshold inputs per table (Q1/Q2/Q3 only) and Q4 readonly", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -53,7 +53,11 @@ describe("Step4QuartileDistribution", () => {
 			}),
 		).toBeInTheDocument();
 		// Q1..Q4 row labels per table → 8 rows (excluding total row "Tous les salariés")
-		expect(screen.getAllByText(/quartile/, { selector: "th" }).length).toBe(8);
+		expect(
+			screen
+				.getAllByRole("rowheader")
+				.filter((cell) => /quartile/.test(cell.textContent ?? "")),
+		).toHaveLength(8);
 		// Total row "Tous les salariés" shows in both tables
 		expect(screen.getAllByText(/Tous les salariés/).length).toBe(2);
 	});
@@ -301,6 +305,7 @@ describe("Step4QuartileDistribution", () => {
 						},
 					},
 					confidenceIndex: "0.85",
+					periodStart: "2026-01-01",
 					periodEnd: "2026-12-31",
 				}}
 				initialData={emptyStep4Data()}
@@ -355,6 +360,7 @@ describe("Step4QuartileDistribution", () => {
 						},
 					},
 					confidenceIndex: null,
+					periodStart: null,
 					periodEnd: null,
 				}}
 				initialData={emptyStep4Data()}

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -89,7 +89,7 @@ describe("Step4QuartileDistribution", () => {
 			/>,
 		);
 		expect(
-			screen.getByText(/compare la proportion de femmes et d'hommes/),
+			screen.getByText(/répartit l'ensemble des salariés en quatre groupes/),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -102,7 +102,7 @@ describe("Step4QuartileDistribution", () => {
 		);
 		expect(
 			screen.getByText(
-				"Renseignez les informations avant de valider vos indicateurs.",
+				"Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs.",
 			),
 		).toBeInTheDocument();
 		expect(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -229,8 +229,9 @@ describe("Step4QuartileDistribution", () => {
 			/>,
 		);
 		expect(
-			screen.getAllByText(/Source\s*:\s*DSN \(Déclarations Sociales Nominatives\)/)
-				.length,
+			screen.getAllByText(
+				/Source\s*:\s*DSN \(Déclarations Sociales Nominatives\)/,
+			).length,
 		).toBe(2);
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -53,7 +53,9 @@ export function QuartileTable({
 			<h3 className="fr-h5 fr-mb-0">{title}</h3>
 			<div className={stepStyles.tableSection}>
 				{readingNote}
-				<div className={`fr-table fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}>
+				<div
+					className={`fr-table fr-table--no-scroll fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
+				>
 					<div className="fr-table__wrapper">
 						<div className="fr-table__container">
 							<div className="fr-table__content">

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -59,6 +59,15 @@ export function QuartileTable({
 							<div className="fr-table__content">
 								<table>
 									<caption className="fr-sr-only">{title}</caption>
+									<colgroup>
+										<col className={stepStyles.colRowLabel} />
+										<col className={stepStyles.colMin} />
+										<col className={stepStyles.colMax} />
+										<col className={stepStyles.colCount} />
+										<col className={stepStyles.colCount} />
+										<col className={stepStyles.colPercent} />
+										<col className={stepStyles.colPercent} />
+									</colgroup>
 									<thead>
 										<tr>
 											<th scope="col">{/* row label */}</th>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -108,18 +108,18 @@ export function QuartileTable({
 											<th scope="row">Tous les salariés</th>
 											<td className={stepStyles.minCell} />
 											<td />
-											<td>
+											<td data-mobile-label="Nombre de femmes">
 												<strong>{totalAll > 0 ? totalWomen : "-"}</strong>
 											</td>
-											<td>
+											<td data-mobile-label="Nombre d'hommes">
 												<strong>{totalAll > 0 ? totalMen : "-"}</strong>
 											</td>
-											<td>
+											<td data-mobile-label="Pourcentage de femmes">
 												<strong>
 													{computePercentage(totalWomen, totalAll)}
 												</strong>
 											</td>
-											<td>
+											<td data-mobile-label="Pourcentage d'hommes">
 												<strong>{computePercentage(totalMen, totalAll)}</strong>
 											</td>
 										</tr>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -107,7 +107,7 @@ export function QuartileTable({
 										<tr>
 											<th scope="row">Tous les salariés</th>
 											<td className={stepStyles.minCell} />
-											<td />
+											<td className={stepStyles.maxCell} />
 											<td data-mobile-label="Nombre de femmes">
 												<strong>{totalAll > 0 ? totalWomen : "-"}</strong>
 											</td>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -45,10 +45,8 @@ export function QuartileTable({
 	const totalWomen = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
 	const totalMen = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
 	const totalAll = totalWomen + totalMen;
-	const trancheTitle =
-		tableType === "annual"
-			? "Tranche de rémunération annuelle brute"
-			: "Tranche de rémunération horaire brute";
+	const trancheSuffix =
+		tableType === "annual" ? "annuelle brute" : "horaire brute";
 
 	return (
 		<div className={stepStyles.tableWrapper}>
@@ -65,7 +63,9 @@ export function QuartileTable({
 										<tr>
 											<th scope="col">{/* row label */}</th>
 											<th colSpan={2} scope="col">
-												{trancheTitle}
+												Tranche de rémunération
+												<br />
+												{trancheSuffix}
 											</th>
 											<th scope="col">
 												Nombre

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -55,9 +55,7 @@ export function QuartileTable({
 			<h3 className="fr-h5 fr-mb-0">{title}</h3>
 			<div className={stepStyles.tableSection}>
 				{readingNote}
-				<div
-					className={`fr-table fr-table--bordered fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
-				>
+				<div className={`fr-table fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}>
 					<div className="fr-table__wrapper">
 						<div className="fr-table__container">
 							<div className="fr-table__content">

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { QUARTILE_NAMES } from "~/modules/declaration-remuneration/shared/constants";
-import type {
-	QuartileData,
-	QuartileTuple,
-} from "~/modules/declaration-remuneration/types";
-import { computePercentage, displayDecimal } from "~/modules/domain";
+import type { QuartileTuple } from "~/modules/declaration-remuneration/types";
+import { computePercentage } from "~/modules/domain";
 import stepStyles from "../Step4QuartileDistribution.module.scss";
+import { QuartileTableRow } from "./QuartileTableRow";
 
 type Field = "threshold" | "women" | "men";
 
@@ -33,54 +30,6 @@ type Props = {
 	onQuartileChange: (index: number, field: Field, value: string) => void;
 	disabled?: boolean;
 };
-
-/** Format ordinal text like "1er quartile" → 1<sup>er</sup> quartile */
-function OrdinalLabel({ text }: { text: string }) {
-	const match = text.match(/^(\d+)(er|e)\s(.+)$/);
-	if (!match) return <>{text}</>;
-	const [, num, suffix, rest] = match;
-	return (
-		<>
-			{num}
-			<sup>{suffix}</sup> {rest}
-		</>
-	);
-}
-
-function fieldId(
-	tableType: "annual" | "hourly",
-	index: number,
-	suffix: "max" | "f" | "h",
-) {
-	return `step4-${tableType}-q${index + 1}-${suffix}`;
-}
-
-function getQuartileSuffix(index: number) {
-	return index === 0 ? "er" : "e";
-}
-
-const TYPE_LABEL: Record<"annual" | "hourly", string> = {
-	annual: "annuel",
-	hourly: "horaire",
-};
-
-function thresholdAriaLabel(tableType: "annual" | "hourly", index: number) {
-	return `Seuil maximum ${index + 1}${getQuartileSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
-}
-
-function womenAriaLabel(tableType: "annual" | "hourly", index: number) {
-	return `Nombre de femmes ${index + 1}${getQuartileSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
-}
-
-function menAriaLabel(tableType: "annual" | "hourly", index: number) {
-	return `Nombre d'hommes ${index + 1}${getQuartileSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
-}
-
-function pct(q: QuartileData, gender: "women" | "men") {
-	const total = (q.women ?? 0) + (q.men ?? 0);
-	if (total === 0) return "-";
-	return computePercentage(q[gender] ?? 0, total);
-}
 
 export function QuartileTable({
 	title,
@@ -143,169 +92,18 @@ export function QuartileTable({
 										</tr>
 									</thead>
 									<tbody>
-										{quartiles.map((q, i) => {
-											const isLast = i === quartiles.length - 1;
-											const idMax = fieldId(tableType, i, "max");
-											const idF = fieldId(tableType, i, "f");
-											const idH = fieldId(tableType, i, "h");
-											const cellErrors = errors[i];
-											const thresholdErr = cellErrors?.threshold;
-											const womenErr = cellErrors?.women;
-											const menErr = cellErrors?.men;
-											return (
-												<tr key={QUARTILE_NAMES[i]}>
-													<th scope="row">
-														<OrdinalLabel text={QUARTILE_NAMES[i] ?? ""} />
-													</th>
-													<td className={stepStyles.minCell}>{mins[i]}</td>
-													<td>
-														{isLast ? (
-															<span className={stepStyles.readonlyCell}>
-																- €
-															</span>
-														) : (
-															<div
-																className={
-																	thresholdErr
-																		? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
-																		: stepStyles.cellInputGroup
-																}
-															>
-																<span
-																	className={`fr-sr-only ${stepStyles.cellLabel}`}
-																	id={`${idMax}-label`}
-																>
-																	{thresholdAriaLabel(tableType, i)}
-																</span>
-																<span className={stepStyles.inputWithUnit}>
-																	<input
-																		aria-describedby={
-																			thresholdErr
-																				? `${idMax}-error`
-																				: undefined
-																		}
-																		aria-invalid={
-																			thresholdErr ? "true" : undefined
-																		}
-																		aria-labelledby={`${idMax}-label`}
-																		className="fr-input"
-																		disabled={disabled}
-																		id={idMax}
-																		inputMode="decimal"
-																		onChange={(e) =>
-																			onQuartileChange(
-																				i,
-																				"threshold",
-																				e.target.value,
-																			)
-																		}
-																		type="text"
-																		value={displayDecimal(q.threshold ?? "")}
-																	/>
-																	<span aria-hidden="true">€</span>
-																</span>
-																{thresholdErr && (
-																	<p
-																		className="fr-error-text fr-mt-1v"
-																		id={`${idMax}-error`}
-																	>
-																		{thresholdErr}
-																	</p>
-																)}
-															</div>
-														)}
-													</td>
-													<td>
-														<div
-															className={
-																womenErr
-																	? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
-																	: stepStyles.cellInputGroup
-															}
-														>
-															<span
-																className={`fr-sr-only ${stepStyles.cellLabel}`}
-																id={`${idF}-label`}
-															>
-																{womenAriaLabel(tableType, i)}
-															</span>
-															<input
-																aria-describedby={
-																	womenErr ? `${idF}-error` : undefined
-																}
-																aria-invalid={womenErr ? "true" : undefined}
-																aria-labelledby={`${idF}-label`}
-																className="fr-input"
-																disabled={disabled}
-																id={idF}
-																inputMode="numeric"
-																onChange={(e) =>
-																	onQuartileChange(i, "women", e.target.value)
-																}
-																pattern="[0-9]*"
-																type="text"
-																value={q.women ?? ""}
-															/>
-															{womenErr && (
-																<p
-																	className="fr-error-text fr-mt-1v"
-																	id={`${idF}-error`}
-																>
-																	{womenErr}
-																</p>
-															)}
-														</div>
-													</td>
-													<td>
-														<div
-															className={
-																menErr
-																	? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
-																	: stepStyles.cellInputGroup
-															}
-														>
-															<span
-																className={`fr-sr-only ${stepStyles.cellLabel}`}
-																id={`${idH}-label`}
-															>
-																{menAriaLabel(tableType, i)}
-															</span>
-															<input
-																aria-describedby={
-																	menErr ? `${idH}-error` : undefined
-																}
-																aria-invalid={menErr ? "true" : undefined}
-																aria-labelledby={`${idH}-label`}
-																className="fr-input"
-																disabled={disabled}
-																id={idH}
-																inputMode="numeric"
-																onChange={(e) =>
-																	onQuartileChange(i, "men", e.target.value)
-																}
-																pattern="[0-9]*"
-																type="text"
-																value={q.men ?? ""}
-															/>
-															{menErr && (
-																<p
-																	className="fr-error-text fr-mt-1v"
-																	id={`${idH}-error`}
-																>
-																	{menErr}
-																</p>
-															)}
-														</div>
-													</td>
-													<td>
-														<strong>{pct(q, "women")}</strong>
-													</td>
-													<td>
-														<strong>{pct(q, "men")}</strong>
-													</td>
-												</tr>
-											);
-										})}
+										{[0, 1, 2, 3].map((i) => (
+											<QuartileTableRow
+												disabled={disabled}
+												errors={errors[i] ?? {}}
+												index={i}
+												key={`${tableType}-q${i + 1}`}
+												min={mins[i] ?? ""}
+												onQuartileChange={onQuartileChange}
+												quartile={quartiles[i] ?? { threshold: undefined }}
+												tableType={tableType}
+											/>
+										))}
 										<tr>
 											<th scope="row">Tous les salariés</th>
 											<td className={stepStyles.minCell} />

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -1,22 +1,36 @@
 "use client";
 
 import { QUARTILE_NAMES } from "~/modules/declaration-remuneration/shared/constants";
-import type { QuartileData } from "~/modules/declaration-remuneration/types";
+import type {
+	QuartileData,
+	QuartileTuple,
+} from "~/modules/declaration-remuneration/types";
 import { computePercentage, displayDecimal } from "~/modules/domain";
 import stepStyles from "../Step4QuartileDistribution.module.scss";
+
+type Field = "threshold" | "women" | "men";
+
+export type QuartileFieldErrors = {
+	threshold?: string;
+	women?: string;
+	men?: string;
+};
 
 type Props = {
 	title: string;
 	tableType: "annual" | "hourly";
-	quartiles: QuartileData[];
-	validationError: string | null;
+	quartiles: QuartileTuple;
+	/** Display string for each quartile lower bound (Q1..Q4). */
+	mins: [string, string, string, string];
+	errors: [
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+	];
 	readingNote?: React.ReactNode;
 	sourceNote?: React.ReactNode;
-	onQuartileChange: (
-		index: number,
-		field: "threshold" | "women" | "men",
-		value: string,
-	) => void;
+	onQuartileChange: (index: number, field: Field, value: string) => void;
 	disabled?: boolean;
 };
 
@@ -33,11 +47,47 @@ function OrdinalLabel({ text }: { text: string }) {
 	);
 }
 
+function fieldId(
+	tableType: "annual" | "hourly",
+	index: number,
+	suffix: "max" | "f" | "h",
+) {
+	return `step4-${tableType}-q${index + 1}-${suffix}`;
+}
+
+function getQuartileSuffix(index: number) {
+	return index === 0 ? "er" : "e";
+}
+
+const TYPE_LABEL: Record<"annual" | "hourly", string> = {
+	annual: "annuel",
+	hourly: "horaire",
+};
+
+function thresholdAriaLabel(tableType: "annual" | "hourly", index: number) {
+	return `Seuil maximum ${index + 1}${getQuartileSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
+}
+
+function womenAriaLabel(tableType: "annual" | "hourly", index: number) {
+	return `Nombre de femmes ${index + 1}${getQuartileSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
+}
+
+function menAriaLabel(tableType: "annual" | "hourly", index: number) {
+	return `Nombre d'hommes ${index + 1}${getQuartileSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
+}
+
+function pct(q: QuartileData, gender: "women" | "men") {
+	const total = (q.women ?? 0) + (q.men ?? 0);
+	if (total === 0) return "-";
+	return computePercentage(q[gender] ?? 0, total);
+}
+
 export function QuartileTable({
 	title,
 	tableType,
 	quartiles,
-	validationError,
+	mins,
+	errors,
 	readingNote,
 	sourceNote,
 	onQuartileChange,
@@ -46,6 +96,10 @@ export function QuartileTable({
 	const totalWomen = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
 	const totalMen = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
 	const totalAll = totalWomen + totalMen;
+	const trancheTitle =
+		tableType === "annual"
+			? "Tranche de rémunération annuelle brute"
+			: "Tranche de rémunération horaire brute";
 
 	return (
 		<div className={stepStyles.tableWrapper}>
@@ -53,152 +107,220 @@ export function QuartileTable({
 			<div className={stepStyles.tableSection}>
 				{readingNote}
 				<div
-					className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
+					className={`fr-table fr-table--bordered fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
 				>
 					<div className="fr-table__wrapper">
 						<div className="fr-table__container">
 							<div className="fr-table__content">
 								<table>
-									<caption>{title}</caption>
+									<caption className="fr-sr-only">{title}</caption>
 									<thead>
 										<tr>
 											<th scope="col">{/* row label */}</th>
-											{QUARTILE_NAMES.map((name) => (
-												<th key={name} scope="col">
-													<OrdinalLabel text={name} />
-												</th>
-											))}
+											<th colSpan={2} scope="col">
+												{trancheTitle}
+											</th>
 											<th scope="col">
-												Tous
+												Nombre
 												<br />
-												les salariés
+												de femmes
+											</th>
+											<th scope="col">
+												Nombre
+												<br />
+												d&apos;hommes
+											</th>
+											<th scope="col">
+												Pourcentage
+												<br />
+												de femmes
+											</th>
+											<th scope="col">
+												Pourcentage
+												<br />
+												d&apos;hommes
 											</th>
 										</tr>
 									</thead>
 									<tbody>
-										{/* Row 1: Remuneration */}
-										<tr>
-											<td>
-												Rémunération
-												<br />
-												{tableType === "annual"
-													? "annuelle brute"
-													: "horaire brute"}
-											</td>
-											{quartiles.map((q, i) => (
-												<td key={QUARTILE_NAMES[i]}>
-													<span className={stepStyles.inputWithUnit}>
-														<input
-															aria-label={`Rémunération brute ${QUARTILE_NAMES[i]}`}
-															className="fr-input"
-															disabled={disabled}
-															inputMode="decimal"
-															onChange={(e) =>
-																onQuartileChange(i, "threshold", e.target.value)
-															}
-															type="text"
-															value={displayDecimal(q.threshold ?? "")}
-														/>
-														<span aria-hidden="true">€</span>
-													</span>
-												</td>
-											))}
-											<td>-</td>
-										</tr>
-										{/* Row 2: Women count */}
-										<tr>
-											<td>
-												Nombre
-												<br />
-												de femmes
-											</td>
-											{quartiles.map((q, i) => (
-												<td key={QUARTILE_NAMES[i]}>
-													<input
-														aria-label={`Nombre de femmes ${QUARTILE_NAMES[i]}`}
-														className="fr-input"
-														disabled={disabled}
-														inputMode="numeric"
-														onChange={(e) =>
-															onQuartileChange(i, "women", e.target.value)
-														}
-														pattern="[0-9]*"
-														type="text"
-														value={q.women ?? ""}
-													/>
-												</td>
-											))}
-											<td>{totalAll > 0 ? totalWomen : "-"}</td>
-										</tr>
-										{/* Row 3: Women percentage */}
-										<tr>
-											<td>
-												<strong>
-													Pourcentage
-													<br />
-													de femmes
-												</strong>
-											</td>
-											{quartiles.map((q, i) => {
-												const total = (q.women ?? 0) + (q.men ?? 0);
-												return (
-													<td key={QUARTILE_NAMES[i]}>
-														<strong>
-															{computePercentage(q.women ?? 0, total)}
-														</strong>
+										{quartiles.map((q, i) => {
+											const isLast = i === quartiles.length - 1;
+											const idMax = fieldId(tableType, i, "max");
+											const idF = fieldId(tableType, i, "f");
+											const idH = fieldId(tableType, i, "h");
+											const cellErrors = errors[i];
+											const thresholdErr = cellErrors?.threshold;
+											const womenErr = cellErrors?.women;
+											const menErr = cellErrors?.men;
+											return (
+												<tr key={QUARTILE_NAMES[i]}>
+													<th scope="row">
+														<OrdinalLabel text={QUARTILE_NAMES[i] ?? ""} />
+													</th>
+													<td className={stepStyles.minCell}>{mins[i]}</td>
+													<td>
+														{isLast ? (
+															<span className={stepStyles.readonlyCell}>
+																- €
+															</span>
+														) : (
+															<div
+																className={
+																	thresholdErr
+																		? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
+																		: stepStyles.cellInputGroup
+																}
+															>
+																<span
+																	className={`fr-sr-only ${stepStyles.cellLabel}`}
+																	id={`${idMax}-label`}
+																>
+																	{thresholdAriaLabel(tableType, i)}
+																</span>
+																<span className={stepStyles.inputWithUnit}>
+																	<input
+																		aria-describedby={
+																			thresholdErr
+																				? `${idMax}-error`
+																				: undefined
+																		}
+																		aria-invalid={
+																			thresholdErr ? "true" : undefined
+																		}
+																		aria-labelledby={`${idMax}-label`}
+																		className="fr-input"
+																		disabled={disabled}
+																		id={idMax}
+																		inputMode="decimal"
+																		onChange={(e) =>
+																			onQuartileChange(
+																				i,
+																				"threshold",
+																				e.target.value,
+																			)
+																		}
+																		type="text"
+																		value={displayDecimal(q.threshold ?? "")}
+																	/>
+																	<span aria-hidden="true">€</span>
+																</span>
+																{thresholdErr && (
+																	<p
+																		className="fr-error-text fr-mt-1v"
+																		id={`${idMax}-error`}
+																	>
+																		{thresholdErr}
+																	</p>
+																)}
+															</div>
+														)}
 													</td>
-												);
-											})}
+													<td>
+														<div
+															className={
+																womenErr
+																	? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
+																	: stepStyles.cellInputGroup
+															}
+														>
+															<span
+																className={`fr-sr-only ${stepStyles.cellLabel}`}
+																id={`${idF}-label`}
+															>
+																{womenAriaLabel(tableType, i)}
+															</span>
+															<input
+																aria-describedby={
+																	womenErr ? `${idF}-error` : undefined
+																}
+																aria-invalid={womenErr ? "true" : undefined}
+																aria-labelledby={`${idF}-label`}
+																className="fr-input"
+																disabled={disabled}
+																id={idF}
+																inputMode="numeric"
+																onChange={(e) =>
+																	onQuartileChange(i, "women", e.target.value)
+																}
+																pattern="[0-9]*"
+																type="text"
+																value={q.women ?? ""}
+															/>
+															{womenErr && (
+																<p
+																	className="fr-error-text fr-mt-1v"
+																	id={`${idF}-error`}
+																>
+																	{womenErr}
+																</p>
+															)}
+														</div>
+													</td>
+													<td>
+														<div
+															className={
+																menErr
+																	? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
+																	: stepStyles.cellInputGroup
+															}
+														>
+															<span
+																className={`fr-sr-only ${stepStyles.cellLabel}`}
+																id={`${idH}-label`}
+															>
+																{menAriaLabel(tableType, i)}
+															</span>
+															<input
+																aria-describedby={
+																	menErr ? `${idH}-error` : undefined
+																}
+																aria-invalid={menErr ? "true" : undefined}
+																aria-labelledby={`${idH}-label`}
+																className="fr-input"
+																disabled={disabled}
+																id={idH}
+																inputMode="numeric"
+																onChange={(e) =>
+																	onQuartileChange(i, "men", e.target.value)
+																}
+																pattern="[0-9]*"
+																type="text"
+																value={q.men ?? ""}
+															/>
+															{menErr && (
+																<p
+																	className="fr-error-text fr-mt-1v"
+																	id={`${idH}-error`}
+																>
+																	{menErr}
+																</p>
+															)}
+														</div>
+													</td>
+													<td>
+														<strong>{pct(q, "women")}</strong>
+													</td>
+													<td>
+														<strong>{pct(q, "men")}</strong>
+													</td>
+												</tr>
+											);
+										})}
+										<tr>
+											<th scope="row">Tous les salariés</th>
+											<td className={stepStyles.minCell} />
+											<td />
+											<td>
+												<strong>{totalAll > 0 ? totalWomen : "-"}</strong>
+											</td>
+											<td>
+												<strong>{totalAll > 0 ? totalMen : "-"}</strong>
+											</td>
 											<td>
 												<strong>
 													{computePercentage(totalWomen, totalAll)}
 												</strong>
 											</td>
-										</tr>
-										{/* Row 4: Men count */}
-										<tr>
-											<td>
-												Nombre
-												<br />
-												d&apos;hommes
-											</td>
-											{quartiles.map((q, i) => (
-												<td key={QUARTILE_NAMES[i]}>
-													<input
-														aria-label={`Nombre d'hommes ${QUARTILE_NAMES[i]}`}
-														className="fr-input"
-														disabled={disabled}
-														inputMode="numeric"
-														onChange={(e) =>
-															onQuartileChange(i, "men", e.target.value)
-														}
-														pattern="[0-9]*"
-														type="text"
-														value={q.men ?? ""}
-													/>
-												</td>
-											))}
-											<td>{totalAll > 0 ? totalMen : "-"}</td>
-										</tr>
-										{/* Row 5: Men percentage */}
-										<tr>
-											<td>
-												<strong>
-													Pourcentage
-													<br />
-													d&apos;hommes
-												</strong>
-											</td>
-											{quartiles.map((q, i) => {
-												const total = (q.women ?? 0) + (q.men ?? 0);
-												return (
-													<td key={QUARTILE_NAMES[i]}>
-														<strong>
-															{computePercentage(q.men ?? 0, total)}
-														</strong>
-													</td>
-												);
-											})}
 											<td>
 												<strong>{computePercentage(totalMen, totalAll)}</strong>
 											</td>
@@ -210,14 +332,6 @@ export function QuartileTable({
 					</div>
 				</div>
 
-				{validationError && (
-					<div
-						aria-live="polite"
-						className="fr-alert fr-alert--error fr-alert--sm"
-					>
-						<p>{validationError}</p>
-					</div>
-				)}
 				{sourceNote}
 			</div>
 		</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -106,18 +106,30 @@ export function QuartileTable({
 											<th scope="row">Tous les salariés</th>
 											<td className={stepStyles.minCell} />
 											<td className={stepStyles.maxCell} />
-											<td data-mobile-label="Nombre de femmes">
+											<td
+												className={stepStyles.numericCell}
+												data-mobile-label="Nombre de femmes"
+											>
 												<strong>{totalAll > 0 ? totalWomen : "-"}</strong>
 											</td>
-											<td data-mobile-label="Nombre d'hommes">
+											<td
+												className={stepStyles.numericCell}
+												data-mobile-label="Nombre d'hommes"
+											>
 												<strong>{totalAll > 0 ? totalMen : "-"}</strong>
 											</td>
-											<td data-mobile-label="Pourcentage de femmes">
+											<td
+												className={stepStyles.numericCell}
+												data-mobile-label="Pourcentage de femmes"
+											>
 												<strong>
 													{computePercentage(totalWomen, totalAll)}
 												</strong>
 											</td>
-											<td data-mobile-label="Pourcentage d'hommes">
+											<td
+												className={stepStyles.numericCell}
+												data-mobile-label="Pourcentage d'hommes"
+											>
 												<strong>{computePercentage(totalMen, totalAll)}</strong>
 											</td>
 										</tr>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -89,8 +89,10 @@ export function QuartileTableRow({
 			<th scope="row">
 				<OrdinalLabel text={QUARTILE_NAMES[index] ?? ""} />
 			</th>
-			<td className={stepStyles.minCell}>{min}</td>
-			<td>
+			<td className={stepStyles.minCell} data-mobile-label="Minimum">
+				{min}
+			</td>
+			<td data-mobile-label="Maximum">
 				{isLast ? (
 					<span className={stepStyles.readonlyCell}>- €</span>
 				) : (
@@ -132,7 +134,7 @@ export function QuartileTableRow({
 					</div>
 				)}
 			</td>
-			<td>
+			<td data-mobile-label="Nombre de femmes">
 				<div
 					className={
 						womenErr
@@ -166,7 +168,7 @@ export function QuartileTableRow({
 					)}
 				</div>
 			</td>
-			<td>
+			<td data-mobile-label="Nombre d'hommes">
 				<div
 					className={
 						menErr
@@ -200,10 +202,10 @@ export function QuartileTableRow({
 					)}
 				</div>
 			</td>
-			<td>
+			<td data-mobile-label="Pourcentage de femmes">
 				<strong>{pct(quartile, "women")}</strong>
 			</td>
-			<td>
+			<td data-mobile-label="Pourcentage d'hommes">
 				<strong>{pct(quartile, "men")}</strong>
 			</td>
 		</tr>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -45,16 +45,15 @@ function pct(q: QuartileData, gender: "women" | "men") {
 	return computePercentage(q[gender] ?? 0, total);
 }
 
-/** Format ordinal text like "1er quartile" → 1<sup>er</sup> quartile */
 function OrdinalLabel({ text }: { text: string }) {
 	const match = text.match(/^(\d+)(er|e)\s(.+)$/);
-	if (!match) return <>{text}</>;
+	if (!match) return <span>{text}</span>;
 	const [, num, suffix, rest] = match;
 	return (
-		<>
+		<span>
 			{num}
 			<sup>{suffix}</sup> {rest}
-		</>
+		</span>
 	);
 }
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -27,7 +27,7 @@ function fieldId(
 }
 
 function thresholdAriaLabel(tableType: TableType, index: number) {
-	return `Seuil maximum ${index + 1}${ordinalSuffix(index)} quartile ${TYPE_LABEL[tableType]} en euros`;
+	return `Seuil maximum ${index + 1}${ordinalSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
 }
 
 function womenAriaLabel(tableType: TableType, index: number) {

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -103,7 +103,7 @@ export function QuartileTableRow({
 			</td>
 			<td className={stepStyles.maxCell} data-mobile-label="Maximum">
 				{isLast ? (
-					<span className={stepStyles.readonlyCell}>- €</span>
+					<span className={stepStyles.readonlyCell}>- €</span>
 				) : (
 					<div
 						className={

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -143,7 +143,10 @@ export function QuartileTableRow({
 					</div>
 				)}
 			</td>
-			<td data-mobile-label="Nombre de femmes">
+			<td
+				className={stepStyles.numericCell}
+				data-mobile-label="Nombre de femmes"
+			>
 				<div
 					className={
 						womenErr
@@ -177,7 +180,10 @@ export function QuartileTableRow({
 					)}
 				</div>
 			</td>
-			<td data-mobile-label="Nombre d'hommes">
+			<td
+				className={stepStyles.numericCell}
+				data-mobile-label="Nombre d'hommes"
+			>
 				<div
 					className={
 						menErr
@@ -211,10 +217,16 @@ export function QuartileTableRow({
 					)}
 				</div>
 			</td>
-			<td data-mobile-label="Pourcentage de femmes">
+			<td
+				className={stepStyles.numericCell}
+				data-mobile-label="Pourcentage de femmes"
+			>
 				<strong>{pct(quartile, "women")}</strong>
 			</td>
-			<td data-mobile-label="Pourcentage d'hommes">
+			<td
+				className={stepStyles.numericCell}
+				data-mobile-label="Pourcentage d'hommes"
+			>
 				<strong>{pct(quartile, "men")}</strong>
 			</td>
 		</tr>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { QUARTILE_NAMES } from "~/modules/declaration-remuneration/shared/constants";
+import { TooltipButton } from "~/modules/declaration-remuneration/shared/TooltipButton";
 import type { QuartileData } from "~/modules/declaration-remuneration/types";
 import { computePercentage, displayDecimal } from "~/modules/domain";
 import stepStyles from "../Step4QuartileDistribution.module.scss";
@@ -84,15 +85,24 @@ export function QuartileTableRow({
 	const womenErr = errors.women;
 	const menErr = errors.men;
 
+	const quartileName = QUARTILE_NAMES[index] ?? "";
+	const tooltipId = `tooltip-${tableType}-q${index + 1}`;
+
 	return (
 		<tr>
 			<th scope="row">
-				<OrdinalLabel text={QUARTILE_NAMES[index] ?? ""} />
+				<span className={stepStyles.rowLabelText}>
+					<OrdinalLabel text={quartileName} />
+					<TooltipButton
+						id={tooltipId}
+						label={`Plus d'informations sur le ${quartileName}`}
+					/>
+				</span>
 			</th>
 			<td className={stepStyles.minCell} data-mobile-label="Minimum">
 				{min}
 			</td>
-			<td data-mobile-label="Maximum">
+			<td className={stepStyles.maxCell} data-mobile-label="Maximum">
 				{isLast ? (
 					<span className={stepStyles.readonlyCell}>- €</span>
 				) : (

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { QUARTILE_NAMES } from "~/modules/declaration-remuneration/shared/constants";
+import type { QuartileData } from "~/modules/declaration-remuneration/types";
+import { computePercentage, displayDecimal } from "~/modules/domain";
+import stepStyles from "../Step4QuartileDistribution.module.scss";
+import type { QuartileFieldErrors } from "./QuartileTable";
+
+type Field = "threshold" | "women" | "men";
+type TableType = "annual" | "hourly";
+
+const TYPE_LABEL: Record<TableType, string> = {
+	annual: "annuel",
+	hourly: "horaire",
+};
+
+function ordinalSuffix(index: number) {
+	return index === 0 ? "er" : "e";
+}
+
+function fieldId(
+	tableType: TableType,
+	index: number,
+	suffix: "max" | "f" | "h",
+) {
+	return `step4-${tableType}-q${index + 1}-${suffix}`;
+}
+
+function thresholdAriaLabel(tableType: TableType, index: number) {
+	return `Seuil maximum ${index + 1}${ordinalSuffix(index)} quartile ${TYPE_LABEL[tableType]} en euros`;
+}
+
+function womenAriaLabel(tableType: TableType, index: number) {
+	return `Nombre de femmes ${index + 1}${ordinalSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
+}
+
+function menAriaLabel(tableType: TableType, index: number) {
+	return `Nombre d'hommes ${index + 1}${ordinalSuffix(index)} quartile ${TYPE_LABEL[tableType]}`;
+}
+
+function pct(q: QuartileData, gender: "women" | "men") {
+	const total = (q.women ?? 0) + (q.men ?? 0);
+	if (total === 0) return "-";
+	return computePercentage(q[gender] ?? 0, total);
+}
+
+/** Format ordinal text like "1er quartile" → 1<sup>er</sup> quartile */
+function OrdinalLabel({ text }: { text: string }) {
+	const match = text.match(/^(\d+)(er|e)\s(.+)$/);
+	if (!match) return <>{text}</>;
+	const [, num, suffix, rest] = match;
+	return (
+		<>
+			{num}
+			<sup>{suffix}</sup> {rest}
+		</>
+	);
+}
+
+type Props = {
+	tableType: TableType;
+	index: number;
+	quartile: QuartileData;
+	min: string;
+	errors: QuartileFieldErrors;
+	disabled: boolean;
+	onQuartileChange: (index: number, field: Field, value: string) => void;
+};
+
+export function QuartileTableRow({
+	tableType,
+	index,
+	quartile,
+	min,
+	errors,
+	disabled,
+	onQuartileChange,
+}: Props) {
+	const isLast = index === 3;
+	const idMax = fieldId(tableType, index, "max");
+	const idF = fieldId(tableType, index, "f");
+	const idH = fieldId(tableType, index, "h");
+	const thresholdErr = errors.threshold;
+	const womenErr = errors.women;
+	const menErr = errors.men;
+
+	return (
+		<tr>
+			<th scope="row">
+				<OrdinalLabel text={QUARTILE_NAMES[index] ?? ""} />
+			</th>
+			<td className={stepStyles.minCell}>{min}</td>
+			<td>
+				{isLast ? (
+					<span className={stepStyles.readonlyCell}>- €</span>
+				) : (
+					<div
+						className={
+							thresholdErr
+								? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
+								: stepStyles.cellInputGroup
+						}
+					>
+						<span
+							className={`fr-sr-only ${stepStyles.cellLabel}`}
+							id={`${idMax}-label`}
+						>
+							{thresholdAriaLabel(tableType, index)}
+						</span>
+						<span className={stepStyles.inputWithUnit}>
+							<input
+								aria-describedby={thresholdErr ? `${idMax}-error` : undefined}
+								aria-invalid={thresholdErr ? "true" : undefined}
+								aria-labelledby={`${idMax}-label`}
+								className="fr-input"
+								disabled={disabled}
+								id={idMax}
+								inputMode="decimal"
+								onChange={(e) =>
+									onQuartileChange(index, "threshold", e.target.value)
+								}
+								type="text"
+								value={displayDecimal(quartile.threshold ?? "")}
+							/>
+							<span aria-hidden="true">€</span>
+						</span>
+						{thresholdErr && (
+							<p className="fr-error-text fr-mt-1v" id={`${idMax}-error`}>
+								{thresholdErr}
+							</p>
+						)}
+					</div>
+				)}
+			</td>
+			<td>
+				<div
+					className={
+						womenErr
+							? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
+							: stepStyles.cellInputGroup
+					}
+				>
+					<span
+						className={`fr-sr-only ${stepStyles.cellLabel}`}
+						id={`${idF}-label`}
+					>
+						{womenAriaLabel(tableType, index)}
+					</span>
+					<input
+						aria-describedby={womenErr ? `${idF}-error` : undefined}
+						aria-invalid={womenErr ? "true" : undefined}
+						aria-labelledby={`${idF}-label`}
+						className="fr-input"
+						disabled={disabled}
+						id={idF}
+						inputMode="numeric"
+						onChange={(e) => onQuartileChange(index, "women", e.target.value)}
+						pattern="[0-9]*"
+						type="text"
+						value={quartile.women ?? ""}
+					/>
+					{womenErr && (
+						<p className="fr-error-text fr-mt-1v" id={`${idF}-error`}>
+							{womenErr}
+						</p>
+					)}
+				</div>
+			</td>
+			<td>
+				<div
+					className={
+						menErr
+							? `fr-input-group fr-input-group--error ${stepStyles.cellInputGroup}`
+							: stepStyles.cellInputGroup
+					}
+				>
+					<span
+						className={`fr-sr-only ${stepStyles.cellLabel}`}
+						id={`${idH}-label`}
+					>
+						{menAriaLabel(tableType, index)}
+					</span>
+					<input
+						aria-describedby={menErr ? `${idH}-error` : undefined}
+						aria-invalid={menErr ? "true" : undefined}
+						aria-labelledby={`${idH}-label`}
+						className="fr-input"
+						disabled={disabled}
+						id={idH}
+						inputMode="numeric"
+						onChange={(e) => onQuartileChange(index, "men", e.target.value)}
+						pattern="[0-9]*"
+						type="text"
+						value={quartile.men ?? ""}
+					/>
+					{menErr && (
+						<p className="fr-error-text fr-mt-1v" id={`${idH}-error`}>
+							{menErr}
+						</p>
+					)}
+				</div>
+			</td>
+			<td>
+				<strong>{pct(quartile, "women")}</strong>
+			</td>
+			<td>
+				<strong>{pct(quartile, "men")}</strong>
+			</td>
+		</tr>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/quartileErrors.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/quartileErrors.ts
@@ -24,12 +24,24 @@ export type RecapEntry = {
 	label: string;
 };
 
-const EMPTY_ERRORS: QuartileFieldErrors = {};
+function createEmptyError(): QuartileFieldErrors {
+	return {};
+}
 
 export function emptyErrorMap(): FieldErrorMap {
 	return {
-		annual: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
-		hourly: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
+		annual: [
+			createEmptyError(),
+			createEmptyError(),
+			createEmptyError(),
+			createEmptyError(),
+		],
+		hourly: [
+			createEmptyError(),
+			createEmptyError(),
+			createEmptyError(),
+			createEmptyError(),
+		],
 	};
 }
 
@@ -117,7 +129,7 @@ export function deriveErrors(values: {
 export function hasAnyError(map: FieldErrorMap): boolean {
 	for (const table of ["annual", "hourly"] as const) {
 		for (let i = 0; i < 4; i++) {
-			const cell = map[table][i] ?? EMPTY_ERRORS;
+			const cell = map[table][i] ?? createEmptyError();
 			if (cell.threshold || cell.women || cell.men) return true;
 		}
 	}
@@ -134,7 +146,7 @@ export function buildRecap(errors: FieldErrorMap): RecapEntry[] {
 	];
 	for (const table of ["annual", "hourly"] as const) {
 		for (let i = 0; i < 4; i++) {
-			const cell = errors[table][i] ?? EMPTY_ERRORS;
+			const cell = errors[table][i] ?? createEmptyError();
 			for (const field of orderedFields) {
 				const message = cell[field];
 				if (!message) continue;

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/quartileErrors.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/quartileErrors.ts
@@ -1,0 +1,158 @@
+import type { QuartileTuple } from "~/modules/declaration-remuneration";
+import type { QuartileFieldErrors } from "./QuartileTable";
+
+export type TableType = "annual" | "hourly";
+export type CountField = "women" | "men";
+
+export const TABLE_LABEL: Record<TableType, string> = {
+	annual: "rémunération annuelle",
+	hourly: "rémunération horaire",
+};
+
+export type FieldErrorMap = Record<
+	TableType,
+	[
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+		QuartileFieldErrors,
+	]
+>;
+
+export type RecapEntry = {
+	id: string;
+	label: string;
+};
+
+const EMPTY_ERRORS: QuartileFieldErrors = {};
+
+export function emptyErrorMap(): FieldErrorMap {
+	return {
+		annual: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
+		hourly: [EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS, EMPTY_ERRORS],
+	};
+}
+
+export function fieldId(
+	tableType: TableType,
+	index: number,
+	suffix: "max" | "f" | "h",
+) {
+	return `step4-${tableType}-q${index + 1}-${suffix}`;
+}
+
+const SUFFIX_FOR_FIELD: Record<"threshold" | CountField, "max" | "f" | "h"> = {
+	threshold: "max",
+	women: "f",
+	men: "h",
+};
+
+function isValidThreshold(v: string | undefined): boolean {
+	return v !== undefined && v !== "" && !Number.isNaN(Number(v));
+}
+
+/** Returns the index of the first threshold that breaks strict ascending order, or null. */
+export function findCroissanceOffender(
+	thresholds: Array<string | undefined>,
+): number | null {
+	const [t1, t2, t3] = thresholds
+		.slice(0, 3)
+		.map((t) => Number.parseFloat(t ?? "")) as [number, number, number];
+	if ([t1, t2, t3].some((n) => Number.isNaN(n))) return null;
+	if (!(t1 < t2)) return 1;
+	if (!(t2 < t3)) return 2;
+	return null;
+}
+
+export function deriveErrors(values: {
+	annual: QuartileTuple;
+	hourly: QuartileTuple;
+}): FieldErrorMap {
+	const result = emptyErrorMap();
+	for (const table of ["annual", "hourly"] as const) {
+		const tableValues = values[table];
+		// Required check on Q1/Q2/Q3 thresholds
+		for (let i = 0; i < 3; i++) {
+			const cell = tableValues[i];
+			if (!isValidThreshold(cell?.threshold)) {
+				result[table][i] = {
+					...result[table][i],
+					threshold: "Le seuil est obligatoire",
+				};
+			}
+		}
+		// Strictly increasing check (only when all 3 are valid)
+		const t1 = tableValues[0]?.threshold;
+		const t2 = tableValues[1]?.threshold;
+		const t3 = tableValues[2]?.threshold;
+		if (isValidThreshold(t1) && isValidThreshold(t2) && isValidThreshold(t3)) {
+			const offender = findCroissanceOffender([t1, t2, t3]);
+			if (offender !== null) {
+				result[table][offender] = {
+					...result[table][offender],
+					threshold: "Les seuils doivent être strictement croissants",
+				};
+			}
+		}
+		// Counts required (8 cells per table)
+		for (let i = 0; i < 4; i++) {
+			const cell = tableValues[i];
+			if (cell?.women === undefined) {
+				result[table][i] = {
+					...result[table][i],
+					women: "Effectif obligatoire",
+				};
+			}
+			if (cell?.men === undefined) {
+				result[table][i] = {
+					...result[table][i],
+					men: "Effectif obligatoire",
+				};
+			}
+		}
+	}
+	return result;
+}
+
+export function hasAnyError(map: FieldErrorMap): boolean {
+	for (const table of ["annual", "hourly"] as const) {
+		for (let i = 0; i < 4; i++) {
+			const cell = map[table][i] ?? EMPTY_ERRORS;
+			if (cell.threshold || cell.women || cell.men) return true;
+		}
+	}
+	return false;
+}
+
+/** Builds up to 4 anchor entries for the recap alert (RGAA 11.10/11.13). */
+export function buildRecap(errors: FieldErrorMap): RecapEntry[] {
+	const out: RecapEntry[] = [];
+	const orderedFields: Array<"threshold" | CountField> = [
+		"threshold",
+		"women",
+		"men",
+	];
+	for (const table of ["annual", "hourly"] as const) {
+		for (let i = 0; i < 4; i++) {
+			const cell = errors[table][i] ?? EMPTY_ERRORS;
+			for (const field of orderedFields) {
+				const message = cell[field];
+				if (!message) continue;
+				const id = fieldId(table, i, SUFFIX_FOR_FIELD[field]);
+				const fieldLabel =
+					field === "threshold"
+						? "Seuil"
+						: field === "women"
+							? "Effectif femmes"
+							: "Effectif hommes";
+				const ordinal = `${i + 1}${i === 0 ? "er" : "e"}`;
+				out.push({
+					id,
+					label: `${fieldLabel} ${ordinal} quartile (${TABLE_LABEL[table]}) — ${message}`,
+				});
+				if (out.length === 4) return out;
+			}
+		}
+	}
+	return out;
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
@@ -33,7 +33,7 @@ export function normalizeForMutation(values: {
 
 export function gipToQuartiles(gip: GipQuartileData): QuartileData[] {
 	return [0, 1, 2, 3].map((i) => ({
-		threshold: gip.thresholds[i] ?? "",
+		threshold: gip.thresholds[i] ?? undefined,
 		women: gip.womenCounts[i] ?? undefined,
 		men: gip.menCounts[i] ?? undefined,
 	}));

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
@@ -1,0 +1,67 @@
+import type {
+	GipQuartileData,
+	QuartileData,
+	QuartileTuple,
+} from "~/modules/declaration-remuneration";
+import { computeQuartileMin, displayDecimal } from "~/modules/domain";
+
+export function toQuartileData(c: {
+	womenValue?: string | null;
+	womenCount: number;
+	menCount: number;
+}): QuartileData {
+	return {
+		threshold: c.womenValue ?? undefined,
+		women: c.womenCount,
+		men: c.menCount,
+	};
+}
+
+/** Q4 carries no upper threshold by spec — strip whatever the form holds. */
+export function normalizeForMutation(values: {
+	annual: QuartileTuple;
+	hourly: QuartileTuple;
+}): { annual: QuartileTuple; hourly: QuartileTuple } {
+	const stripQ4 = (table: QuartileTuple): QuartileTuple => [
+		table[0],
+		table[1],
+		table[2],
+		{ ...table[3], threshold: undefined },
+	];
+	return { annual: stripQ4(values.annual), hourly: stripQ4(values.hourly) };
+}
+
+export function gipToQuartiles(gip: GipQuartileData): QuartileData[] {
+	return [0, 1, 2, 3].map((i) => ({
+		threshold: gip.thresholds[i] ?? "",
+		women: gip.womenCounts[i] ?? undefined,
+		men: gip.menCounts[i] ?? undefined,
+	}));
+}
+
+export function emptyQuartiles(): QuartileTuple {
+	return [
+		{ threshold: "" },
+		{ threshold: "" },
+		{ threshold: "" },
+		{ threshold: "" },
+	];
+}
+
+/** Computes the lower bound display string for each of the 4 quartiles. */
+export function computeMinsForTable(
+	quartiles: QuartileTuple,
+): [string, string, string, string] {
+	const dash = "- €";
+	const q1Min = "0,00 €";
+	const min = (prevThreshold: string | undefined): string => {
+		const computed = computeQuartileMin(prevThreshold);
+		return computed ? `${displayDecimal(computed)} €` : dash;
+	};
+	return [
+		q1Min,
+		min(quartiles[0]?.threshold),
+		min(quartiles[1]?.threshold),
+		min(quartiles[2]?.threshold),
+	];
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
@@ -48,18 +48,16 @@ export function emptyQuartiles(): QuartileTuple {
 	];
 }
 
-/** Computes the lower bound display string for each of the 4 quartiles. */
 export function computeMinsForTable(
 	quartiles: QuartileTuple,
 ): [string, string, string, string] {
 	const dash = "- €";
-	const q1Min = "0,00 €";
 	const min = (prevThreshold: string | undefined): string => {
 		const computed = computeQuartileMin(prevThreshold);
 		return computed ? `${displayDecimal(computed)} €` : dash;
 	};
 	return [
-		q1Min,
+		dash,
 		min(quartiles[0]?.threshold),
 		min(quartiles[1]?.threshold),
 		min(quartiles[2]?.threshold),

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/quartileFormHelpers.ts
@@ -51,10 +51,10 @@ export function emptyQuartiles(): QuartileTuple {
 export function computeMinsForTable(
 	quartiles: QuartileTuple,
 ): [string, string, string, string] {
-	const dash = "- €";
+	const dash = "- €";
 	const min = (prevThreshold: string | undefined): string => {
 		const computed = computeQuartileMin(prevThreshold);
-		return computed ? `${displayDecimal(computed)} €` : dash;
+		return computed ? `${displayDecimal(computed)} €` : dash;
 	};
 	return [
 		dash,


### PR DESCRIPTION
## Résumé

Refonte UI complète de l'étape 4 selon les nouveaux mockups designer (epic-3349). Lignes/colonnes inversées (rows = Q1..Q4, cols = Min/Max/F/H/%F/%H), 3 seuils saisissables avec **bornes en cascade live**, validation RGAA-compliant (`aria-invalid`, `fr-error-text`, alerte récap avec ancrages).

Stacked sur #3353 (T4 — loader applique `migrateLegacyThresholds`, `Q4.threshold = undefined`).

## Changements clés

- **`Step4QuartileDistribution.tsx`** — refonte de la logique de validation : `useZodForm` (ticket T2) + dérivation per-cell des erreurs (3 seuils requis Q1-Q3, croissance stricte, 8 counts F/H requis). Normalise `Q4.threshold = undefined` avant `mutation.mutate(...)`.
- **`step4/QuartileTable.tsx`** — table inversée DSFR : 1 ligne par quartile (avec rowheader « Nème quartile »), 1 ligne récap « Tous les salariés », 6 colonnes (Min, Max, F, H, %F, %H). Q4 max = readonly « - € ». Inputs avec `aria-invalid`, `aria-describedby`, `fr-error-text` et `fr-input-group--error`.
- **Bornes en cascade live** — `computeQuartileMin` (T1) : Q1 min = `0,00 €` figé, Qn min = `computeQuartileMin(seuil_{n-1})` ou `- €` si vide.
- **Alerte récap** — `<div role="alert" tabindex="-1">` au-dessus du form, max 4 ancrages `<a href="#step4-…">`, focus auto sur submit invalide.
- **`shared/devFillData.ts`** — DEV_STEP4_ANNUAL/HOURLY ramenés à 3 seuils (Q4 sans `womenValue`).
- **Tests unit** — Step4 (17), Step4 submit (4), DevFill (1), Callout/ReadingNote (existants OK).
- **Tests E2E** — `fillStep4Quartiles(page, options)` refondu sur les nouveaux labels « Seuil maximum Nème quartile annuel/horaire ». Nouveaux scénarios : layout inversé (S1), cascade live (S2), croissance (S3), champs vides (S4).

## Test plan

- [x] `pnpm typecheck` ✓
- [x] `pnpm lint:check` ✓
- [x] `pnpm format:check` ✓
- [x] `pnpm test` ✓ (291 tests declaration-remuneration pass)
- [ ] `functional-validator` rejoue S1, S2, S2bis, S3, S4, S5, S6, S8, S9
- [ ] `design-validator` compare au mockup screen-1-prefilled / screen-2-empty / screen-3-error / screen-4-error (desktop + mobile)

Closes #3355