### PR TITLE
fix(declaration): align recap step + CSE modal with Figma (#3325)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
@@ -1,21 +1,84 @@
 .nextSteps {
 	display: flex;
 	flex-direction: column;
+	gap: 2rem;
+	padding: 2rem;
+	background: var(--background-alt-blue-france);
+	border-radius: 4px;
+}
+
+.nextStepsCompact {
+	display: flex;
+	flex-direction: column;
 	gap: 1rem;
 	padding: 1.875rem;
 	background: var(--background-alt-blue-france);
 	border-radius: 4px;
 }
 
-.separator {
-	border: none;
-	border-top: 1px solid var(--border-default-grey);
-	margin: 0;
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+
+	// Strip default browser <ul>/<ol> top/bottom margins so the section's
+	// flex gap is the only spacing between elements; otherwise the gap from
+	// the last bullet text to the next separator becomes 40px instead of 32px.
+	ul,
+	ol {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+
+	// DSFR adds `padding-bottom: 0.25rem` (4px) on every <li> which leaks
+	// below the visible text and breaks the symmetric 32px gap to a sibling
+	// separator. Remove it on the last item only so the gap stays exact.
+	ul > li:last-child,
+	ol > li:last-child {
+		padding-bottom: 0;
+	}
 }
 
-.buttonLink {
-	background-image: linear-gradient(0deg, currentColor, currentColor);
-	background-size: 100% 1px;
-	background-position: 0 100%;
-	background-repeat: no-repeat;
+.separator {
+	// DSFR styles <hr> via a 1px background-image gradient and adds
+	// `padding: var(--text-spacing)` which can leak from inherited body-text
+	// rules. Force a single clean 1px line by zeroing padding and dropping the
+	// border (the gradient stays for the visual line).
+	border: 0;
+	margin: 0;
+	padding: 0;
+	height: 1px;
+}
+
+.linksRow {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+// DSFR's `fr-link` applies the underline via the `[href]` selector,
+// which a <button> does not match. Replicate the same gradient-based
+// underline so the modal trigger button renders identically to an
+// adjacent <a class="fr-link">.
+.linkButton {
+	background:
+		linear-gradient(0deg, currentColor, currentColor) no-repeat 0
+			calc(100% - var(--underline-thickness, 0.0625em)) /
+			var(--underline-idle-width, 100%) var(--underline-thickness, 0.0625em);
+	border: 0;
+	padding: 0;
+	cursor: pointer;
+	font: inherit;
+}
+
+.alertHeader {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	align-items: flex-start;
+}
+
+.alertBadge {
+	text-transform: uppercase;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -17,50 +17,95 @@ export function NextStepsBox({
 	siren,
 	isSecondDeclaration,
 }: Props) {
+	const containerClass = isSecondDeclaration
+		? styles.nextStepsCompact
+		: styles.nextSteps;
+
 	return (
 		<>
-			<div className={styles.nextSteps}>
+			<div className={containerClass}>
 				<h3 className="fr-h4 fr-mb-0">Prochaines étapes</h3>
 
-				<p className="fr-mb-0">
-					Au cours du temps imparti pour réaliser votre déclaration, vous devez{" "}
-					<strong>
-						obligatoirement informer et consulter le CSE sur l&apos;exactitude
-						des données déclarées
-					</strong>
-					.
-				</p>
+				<div className={styles.section}>
+					{!isSecondDeclaration && (
+						<h4 className="fr-text--bold fr-text--md fr-mb-0">
+							Informer et consulter le CSE
+						</h4>
+					)}
 
-				<div>
 					<p className="fr-mb-0">
-						Le ou les avis du CSE devront être transmis sur le portail lors de
-						la dernière étape.
+						Au cours du temps imparti pour réaliser votre déclaration, vous
+						devez{" "}
+						<strong>
+							obligatoirement informer et consulter le CSE sur l&apos;exactitude
+							des données déclarées
+						</strong>
+						.
 					</p>
-					<div className="fr-mt-1w">
-						<button
-							aria-controls="update-cse-modal"
-							className={`fr-btn fr-btn--tertiary-no-outline fr-btn--sm ${styles.buttonLink}`}
-							data-fr-opened="false"
-							type="button"
-						>
-							Mettre à jour la présence d&apos;un CSE
-						</button>
-						<Link className="fr-link fr-ml-2w" href="/avis-cse">
-							Voir les modèles d&apos;avis CSE
-						</Link>
+
+					<div>
+						<p className="fr-mb-0">
+							Le ou les avis du CSE devront être transmis sur le portail lors de
+							la dernière étape.
+						</p>
+						<div className={`fr-mt-1w ${styles.linksRow}`}>
+							<button
+								aria-controls="update-cse-modal"
+								className={`fr-link ${styles.linkButton}`}
+								data-fr-opened="false"
+								type="button"
+							>
+								Mettre à jour l&apos;existence d&apos;un CSE
+							</button>
+							<Link className="fr-link" href="/avis-cse">
+								Voir les modèles d&apos;avis CSE
+							</Link>
+						</div>
 					</div>
 				</div>
 
+				{!isSecondDeclaration && hasGapsAboveThreshold && (
+					<hr className={styles.separator} />
+				)}
+
 				{hasGapsAboveThreshold && (
-					<>
-						<p className="fr-text--bold fr-mb-0">Des écarts ont été détectés</p>
+					<div className={styles.section}>
+						{isSecondDeclaration ? (
+							<p className="fr-text--bold fr-mb-0">
+								Des écarts ont été de nouveau détectés
+							</p>
+						) : (
+							<div className={styles.alertHeader}>
+								<p
+									className={`fr-badge fr-badge--warning fr-badge--sm ${styles.alertBadge}`}
+								>
+									Écarts détectés
+								</p>
+								<h4 className="fr-text--bold fr-text--md fr-mb-0">
+									Actions à engager
+								</h4>
+							</div>
+						)}
+
 						<p className="fr-mb-0">
 							Suite à l&apos;analyse de vos données de l&apos;indicateur par
 							catégorie de salariés,{" "}
-							<strong>des écarts &ge; 5 % ont été identifiés</strong>. Vous
-							devez engager un des parcours de mise en conformité suivant&nbsp;:
+							{isSecondDeclaration ? (
+								<>
+									<strong>des écarts &ge; 5 % ont été identifiés</strong>. Vous
+									devez{" "}
+									<strong>engager un des parcours de mise en conformité</strong>{" "}
+									suivant&nbsp;:
+								</>
+							) : (
+								<>
+									des écarts &ge; 5 % ont été identifiés. Vous devez engager un
+									des parcours de mise en conformité suivant&nbsp;:
+								</>
+							)}
 						</p>
-						<ul className="fr-text--md">
+
+						<ul>
 							<li>
 								<strong>
 									Justifier les écarts par des critères objectifs et non
@@ -75,55 +120,64 @@ export function NextStepsBox({
 							Si la justification n&apos;est pas possible par des critères
 							objectifs et non sexistes, vous pouvez&nbsp;:
 						</p>
-						<ul className="fr-text--md">
+						<ul>
 							{!isSecondDeclaration && (
 								<li>
-									Mettre en place des actions correctives et effectuer une
-									seconde déclaration dans un délai de 6 mois
+									<strong>
+										Mettre en place des actions correctives et effectuer une
+										seconde déclaration dans un délai de 6 mois
+									</strong>
 								</li>
 							)}
-							<li>Réaliser une évaluation conjointe des rémunérations</li>
+							<li>
+								<strong>
+									Réaliser une évaluation conjointe des rémunérations
+								</strong>
+							</li>
 						</ul>
-					</>
+					</div>
 				)}
 
 				<hr className={styles.separator} />
-				<p className="fr-text--bold fr-text--lg fr-mb-0">Pour vous aider</p>
-				<ul className="fr-raw-list fr-links-group">
-					<li>
-						<a
-							className="fr-link"
-							href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-							rel="noopener noreferrer"
-							target="_blank"
-						>
-							Qu&apos;entend-on par critères objectifs et non sexistes ?
-							<NewTabNotice />
-						</a>
-					</li>
-					<li>
-						<a
-							className="fr-link"
-							href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-							rel="noopener noreferrer"
-							target="_blank"
-						>
-							En savoir plus sur actions correctives et seconde déclaration
-							<NewTabNotice />
-						</a>
-					</li>
-					<li>
-						<a
-							className="fr-link"
-							href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-							rel="noopener noreferrer"
-							target="_blank"
-						>
-							En savoir plus sur évaluation conjointe des rémunérations
-							<NewTabNotice />
-						</a>
-					</li>
-				</ul>
+
+				<div className={styles.section}>
+					<h4 className="fr-text--bold fr-text--md fr-mb-0">Pour vous aider</h4>
+					<ul className="fr-raw-list fr-links-group">
+						<li>
+							<a
+								className="fr-link"
+								href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								rel="noopener noreferrer"
+								target="_blank"
+							>
+								Qu&apos;entend-on par critères objectifs et non sexistes ?
+								<NewTabNotice />
+							</a>
+						</li>
+						<li>
+							<a
+								className="fr-link"
+								href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								rel="noopener noreferrer"
+								target="_blank"
+							>
+								En savoir plus sur actions correctives et seconde déclaration
+								<NewTabNotice />
+							</a>
+						</li>
+						<li>
+							<a
+								className="fr-link"
+								href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								rel="noopener noreferrer"
+								target="_blank"
+							>
+								En savoir plus sur évaluation conjointe des rémunérations
+								<NewTabNotice />
+							</a>
+						</li>
+					</ul>
+				</div>
 			</div>
 
 			<UpdateCseModal siren={siren} />

--- a/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.module.scss
@@ -1,0 +1,41 @@
+// Title needs 32px gap below (Figma). DSFR's .fr-modal__title default
+// margin-bottom is 1rem (16px), so override here.
+.title {
+	margin-bottom: 2rem;
+}
+
+.toggleFieldset {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+
+// Question text: 18px regular, default grey color, 32px gap to buttons.
+.legend {
+	color: var(--text-default-grey);
+	margin-bottom: 2rem;
+	padding: 0;
+}
+
+.toggleGroup {
+	gap: 2rem;
+}
+
+.toggleBtn {
+	flex: 1;
+	justify-content: center;
+}
+
+// DSFR's desktop modal stacks content margin-bottom: 64px + footer
+// margin-top: -48px + footer padding-top: 32px (= 48px effective gap).
+// Per the Figma we want 32px above and 32px below the footer instead.
+// Use compound selectors to win specificity vs DSFR's media-query rules.
+.content.content {
+	margin-bottom: 0;
+}
+
+.footer.footer {
+	margin-top: 0;
+	padding: 2rem;
+}
+

--- a/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import { useReadOnlyGuard } from "~/modules/auth";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
+import styles from "./UpdateCseModal.module.scss";
 
 const MODAL_ID = "update-cse-modal";
 
@@ -56,31 +57,42 @@ export function UpdateCseModal({ siren }: Props) {
 									Fermer
 								</button>
 							</div>
-							<div className="fr-modal__content">
-								<h2 className="fr-modal__title" id="update-cse-modal-title">
+							<div className={`fr-modal__content ${styles.content}`}>
+								<h2
+									className={`fr-modal__title ${styles.title}`}
+									id="update-cse-modal-title"
+								>
 									Mettre à jour la présence d&apos;un CSE
 								</h2>
-								<p className="fr-text--bold">
-									Un CSE a-t-il été mis en place ?
-								</p>
-								<div className="fr-btns-group">
-									<button
-										className={`fr-btn fr-btn--tertiary${hasCse === true ? "" : "-no-outline"}`}
-										onClick={() => setHasCse(true)}
-										type="button"
+								<fieldset className={styles.toggleFieldset}>
+									<legend
+										className={`fr-text--regular fr-text--lg ${styles.legend}`}
 									>
-										Oui
-									</button>
-									<button
-										className={`fr-btn fr-btn--tertiary${hasCse === false ? "" : "-no-outline"}`}
-										onClick={() => setHasCse(false)}
-										type="button"
+										Un CSE a-t-il été mis en place&nbsp;?
+									</legend>
+									<div
+										className={`fr-btns-group fr-btns-group--inline ${styles.toggleGroup}`}
 									>
-										Non
-									</button>
-								</div>
+										<button
+											aria-pressed={hasCse === true}
+											className={`fr-btn ${hasCse === true ? "" : "fr-btn--tertiary"} ${styles.toggleBtn}`}
+											onClick={() => setHasCse(true)}
+											type="button"
+										>
+											Oui
+										</button>
+										<button
+											aria-pressed={hasCse === false}
+											className={`fr-btn ${hasCse === false ? "" : "fr-btn--tertiary"} ${styles.toggleBtn}`}
+											onClick={() => setHasCse(false)}
+											type="button"
+										>
+											Non
+										</button>
+									</div>
+								</fieldset>
 							</div>
-							<div className="fr-modal__footer">
+							<div className={`fr-modal__footer ${styles.footer}`}>
 								<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
 									<li>
 										<span>
@@ -95,9 +107,7 @@ export function UpdateCseModal({ siren }: Props) {
 												onClick={handleSave}
 												type="button"
 											>
-												{mutation.isPending
-													? "Enregistrement\u2026"
-													: "Enregistrer"}
+												{mutation.isPending ? "Enregistrement…" : "Enregistrer"}
 											</button>
 											{readOnlyGuard.tooltip}
 										</span>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
@@ -53,7 +53,3 @@
 .flex1 {
 	flex: 1;
 }
-
-.centeredLink {
-	align-self: center;
-}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
-import { DownloadDeclarationPdfButton } from "~/modules/declarationPdf";
 import { computeGap, GAP_ALERT_THRESHOLD } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
@@ -326,8 +324,6 @@ export function Step6Review({
 				)}
 			</div>
 
-			{isSubmitted && <DownloadDeclarationPdfButton year={declarationYear} />}
-
 			{/* Next steps callout when high gap detected */}
 			{highGap && declaration.siren && (
 				<NextStepsBox
@@ -348,10 +344,6 @@ export function Step6Review({
 					previousHref="/declaration-remuneration/etape/5"
 				/>
 			)}
-
-			<Link className={`fr-link ${stepStyles.centeredLink}`} href="/avis-cse">
-				Modèles d&apos;avis CSE
-			</Link>
 
 			{!isSubmitted && (
 				<SubmitDeclarationModal

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -3,16 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { Step6Review } from "../Step6Review";
 
-vi.mock("~/modules/declarationPdf", () => ({
-	DownloadDeclarationPdfButton: ({ year }: { year?: number }) => (
-		<a
-			href={year ? `/api/declaration-pdf?year=${year}` : "/api/declaration-pdf"}
-		>
-			Télécharger le récapitulatif (PDF)
-		</a>
-	),
-}));
-
 const mockSubmitMutate = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
@@ -449,27 +439,12 @@ describe("Step6Review", () => {
 		);
 	});
 
-	it("renders PDF download button when submitted", () => {
+	it("does not render PDF download button when submitted", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
 				isSubmitted
-				step2Data={emptyStep2Data()}
-				step3Data={emptyStep3Data()}
-				step4Data={emptyStep4Data()}
-			/>,
-		);
-		expect(
-			screen.getByRole("link", { name: /télécharger le récapitulatif/i }),
-		).toHaveAttribute("href", "/api/declaration-pdf?year=2025");
-	});
-
-	it("does not render PDF download button when not submitted", () => {
-		render(
-			<Step6Review
-				declaration={emptyDeclaration()}
-				declarationYear={2025}
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -505,7 +480,8 @@ describe("Step6Review", () => {
 			/>,
 		);
 		expect(screen.getByText("Prochaines étapes")).toBeInTheDocument();
-		expect(screen.getByText("Des écarts ont été détectés")).toBeInTheDocument();
+		expect(screen.getByText("Écarts détectés")).toBeInTheDocument();
+		expect(screen.getByText("Actions à engager")).toBeInTheDocument();
 		expect(
 			screen.getByText(/des écarts ≥ 5 % ont été identifiés/),
 		).toBeInTheDocument();
@@ -519,21 +495,6 @@ describe("Step6Review", () => {
 		expect(
 			screen.getByRole("link", { name: /évaluation conjointe/ }),
 		).toBeInTheDocument();
-	});
-
-	it("renders 'Modèles d'avis CSE' link", () => {
-		render(
-			<Step6Review
-				declaration={emptyDeclaration()}
-				declarationYear={2025}
-				step2Data={emptyStep2Data()}
-				step3Data={emptyStep3Data()}
-				step4Data={emptyStep4Data()}
-			/>,
-		);
-		expect(
-			screen.getByRole("link", { name: /Modèles d.*avis CSE/ }),
-		).toHaveAttribute("href", "/avis-cse");
 	});
 
 	it("does not show 'Prochaines étapes' callout when all gaps < 5%", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -210,7 +210,9 @@ describe("SecondDeclarationStep3Review", () => {
 				siren="532847196"
 			/>,
 		);
-		expect(screen.getByText("Des écarts ont été détectés")).toBeInTheDocument();
+		expect(
+			screen.getByText("Des écarts ont été de nouveau détectés"),
+		).toBeInTheDocument();
 	});
 
 	it("does not show gap warning when all gaps < 5%", () => {
@@ -239,7 +241,7 @@ describe("SecondDeclarationStep3Review", () => {
 			/>,
 		);
 		expect(
-			screen.queryByText("Des écarts ont été détectés"),
+			screen.queryByText("Des écarts ont été de nouveau détectés"),
 		).not.toBeInTheDocument();
 	});
 


### PR DESCRIPTION
Closes #3325.

## Summary

Aligne l'étape 6 (récapitulatif) de la déclaration de rémunération et la modale "Mettre à jour la présence d'un CSE" sur les nouveaux mockups Figma :
- [Récapitulatif – 1ère déclaration](https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=9326-226111&m=dev)
- [Récapitulatif – 2ème déclaration](https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=7548-86742&m=dev)
- [Modale "Mettre à jour la présence d'un CSE"](https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=7548-75650&m=dev)

### Step 6 – Récapitulatif

- Suppression du bouton "Télécharger le récapitulatif (PDF)" (item 1 du ticket).
- Suppression du lien "Modèles d'avis CSE" en bas de page (item 5).

### Bloc "Prochaines étapes" (`NextStepsBox`)

- Sous-titre `Informer et consulter le CSE` ajouté avant le 1er paragraphe.
- Liens `Mettre à jour l'existence d'un CSE` (bouton DSFR stylé en `fr-link`) + `Voir les modèles d'avis CSE` côte à côte, soulignés à l'identique (le souligné DSFR est appliqué via le sélecteur `[href]`, donc le `<button>` reproduit le même `linear-gradient` pour rester visuellement aligné avec l'`<a>`).
- Séparateur `<hr>` après les liens.
- Badge `Écarts détectés` (DSFR `fr-badge--warning fr-badge--sm`) au-dessus du titre `Actions à engager`.
- Liste des parcours de mise en conformité avec items en gras.
- `Pour vous aider` en `<h4>` 16px Bold (au lieu d'un `<p>` 18px précédemment).
- Espacement neutralisé sur les `<hr>` (DSFR injecte un `padding: var(--text-spacing)` + un double-trait via `border` et `background-image` qui rendaient les séparateurs trop épais et asymétriques) et sur les `<ul>`/`<li>` (margins navigateur + `padding-bottom: 4px` du dernier `<li>`) pour garantir 32px exacts au-dessus et en-dessous de chaque séparateur.

La 2ème déclaration garde sa structure simplifiée (badge / sous-titre / HR retirés, titre `Des écarts ont été de nouveau détectés`) pour matcher son propre Figma.

### Modale "Mettre à jour la présence d'un CSE" (`UpdateCseModal`)

- Titre conservé "Mettre à jour la présence d'un CSE" (Figma).
- Question "Un CSE a-t-il été mis en place ?" en 18px regular gris.
- Boutons `Oui` / `Non` en `fr-btn--tertiary` (outlined) au repos, `fr-btn` (bleu plein) sur l'option sélectionnée — `aria-pressed` posé pour les screen readers.
- Toggle wrappé dans un `<fieldset>` + `<legend>` pour la sémantique RGAA.
- Espacement aligné Figma : 32px entre titre / question / toggle, 32px en haut et en bas du footer (les marges et padding par défaut DSFR du `fr-modal__content` + `fr-modal__footer` sont neutralisés).

### Tests

- `Step6Review.test.tsx` : suppression des assertions PDF download + lien "Modèles d'avis CSE" obsolètes ; ajout des assertions `Écarts détectés` + `Actions à engager`.
- `SecondDeclarationStep3Review.test.tsx` : assertion mise à jour vers `Des écarts ont été de nouveau détectés`.

## Test plan

- [ ] `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check`, `pnpm test` passent en local.
- [ ] Step 6 visite manuelle : pas de bouton PDF, pas de lien "Modèles d'avis CSE" en bas de page.
- [ ] Bloc "Prochaines étapes" sur 1ère déclaration : sous-titre + HR + badge + symétrie 32px autour des deux séparateurs.
- [ ] Bloc "Prochaines étapes" sur 2ème déclaration (`/declaration-remuneration/seconde-declaration/etape/3`) : structure simplifiée, "Des écarts ont été de nouveau détectés".
- [ ] Modale CSE : titre + question, boutons Oui/Non identiques au repos, sélection visible (bleu), espacements 32px.
- [ ] RGAA : Tab focus sur les deux liens et le toggle, screen reader annonce `aria-pressed` correctement.