### PR TITLE
fix(orchestration): macOS portability + tolerant verdict parser

### DIFF
--- a/scripts/orchestration/README.md
+++ b/scripts/orchestration/README.md
@@ -1,0 +1,65 @@
+# `scripts/orchestration/`
+
+Bash drivers used by the `/epic`, `/code`, `/report`, `/open` skills to dispatch tickets to sub-agents in parallel worktrees. See [`/Users/llf/.claude/rules/automation.md`](../../.claude/rules/automation.md) and [`.claude/skills/epic/SKILL.md`](../../.claude/skills/epic/SKILL.md) for the higher-level workflow.
+
+---
+
+## Prerequisites
+
+Beyond the project's standard `pnpm` / Docker setup, the orchestration scripts require:
+
+| Tool | Why | Linux | macOS |
+|---|---|---|---|
+| **bash 4+** | `declare -A` (associative arrays) used by `dispatch_plan.sh`, `epic_loop.sh`, `open_worktree.sh` | usually default | `brew install bash` (macOS ships `/bin/bash` 3.2 due to GPL licensing) |
+| **GNU `timeout`** | `epic_loop.sh` enforces a per-sub-agent wall-clock cap | from `coreutils`, default | `brew install coreutils` (provides `gtimeout`; the loop driver auto-detects either `gtimeout` or `timeout`) |
+| `jq` | JSON aggregation in every script | `apt install jq` | `brew install jq` |
+| `gh` | GitHub CLI (board mutations, PR management) | [official install](https://cli.github.com/) | `brew install gh` |
+
+### macOS one-shot install
+
+```bash
+brew install bash coreutils jq gh
+```
+
+The scripts include a defensive bash 4 re-exec guard at the top — if invoked under bash 3.2, they automatically re-exec via `/opt/homebrew/bin/bash` (or `/usr/local/bin/bash` on Intel Macs / Linuxbrew). If neither is found, they exit with a clear install hint.
+
+### Linux
+
+Distributions ship bash ≥ 4 and GNU `timeout` by default. No extra setup required.
+
+---
+
+## Running
+
+| Skill | What it does | When |
+|---|---|---|
+| `/epic <N>` | Spawn `epic_loop.sh` in background on the listed epic IDs | Conception phase done, ready to dispatch tickets |
+| `/code <N>` | Run a single ticket through `code-dev` (debug/fix mode, no loop) | Re-running a single failed ticket without the orchestrator |
+| `/report [<N>...]` | Live dashboard of agents + sub-tickets state | Anytime |
+| `/open <PR>` | Recreate a worktree for a given PR (post-`/epic` cleanup) | After auto-cleanup, when you want to test a PR locally |
+
+`epic_loop.sh` should be invoked with **`unset CLAUDECODE`** when run from inside another Claude Code session — the spawned `claude` CLI refuses nested sessions otherwise.
+
+```bash
+( unset CLAUDECODE ; nohup bash scripts/orchestration/epic_loop.sh 3372 > /tmp/epic_loop_3372.log 2>&1 & disown )
+```
+
+---
+
+## Files at a glance
+
+| Script | Role |
+|---|---|
+| `epic_loop.sh` | Loop driver: per-tick cleanup → plan → spawn N sub-agents in parallel → aggregate JSON returns → process |
+| `dispatch_plan.sh` | Compute the next-tick plan: parse `Depends on`, resolve stacked-PR base, allocate free indices |
+| `process_tick_result.sh` | Apply board mutations + attempt-counter anti-loop based on the JSON verdict per ticket |
+| `cleanup_terminal_worktrees.sh` | Tear down worktrees whose ticket reached `In review` / `Done` |
+| `open_worktree.sh` | Recreate a worktree for a given PR number (skill `/open <PR>`) |
+| `create_linked_branch.sh` | Create a GitHub-linked branch from an issue via `createLinkedBranch` GraphQL |
+| `set_ticket_status.sh` | Move a ticket between board statuses (refuses `Done` — user-only) |
+| `cache_gh.sh` | TTL-bounded `gh` cache to amortize rate limits |
+| `log_event.sh` | Append-only per-agent event log |
+| `epic_state.sh` | Compact tabular dump of an epic's sub-tickets state |
+| `render_dashboard.sh` | Live dashboard for `/report` |
+
+Each sub-script is `--help`-friendly via header comments.

--- a/scripts/orchestration/cache_gh.sh
+++ b/scripts/orchestration/cache_gh.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # cache_gh.sh <key> <ttl_sec> -- <command>
 #
 # TTL-based cache wrapper for any command (typically `gh`).

--- a/scripts/orchestration/cleanup_terminal_worktrees.sh
+++ b/scripts/orchestration/cleanup_terminal_worktrees.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # cleanup_terminal_worktrees.sh <epic_N1> [<epic_N2> ...]
 #
 # Scans worktrees matching egapro-epic<E>-t<N> for the given epics, queries

--- a/scripts/orchestration/create_linked_branch.sh
+++ b/scripts/orchestration/create_linked_branch.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # create_linked_branch.sh <ticket_number> <base_branch>
 #
 # Creates a branch officially "linked" to the GitHub issue (i.e. it shows up

--- a/scripts/orchestration/create_linked_branch.sh
+++ b/scripts/orchestration/create_linked_branch.sh
@@ -37,9 +37,11 @@ fi
 TICKET="$1"
 BASE="$2"
 
-# 1. Reuse existing branch if any (idempotent across re-runs)
+# 1. Reuse existing branch if any (idempotent across re-runs).
+# `head -1` SIGPIPEs upstream `sed`/`awk`, which under `set -o pipefail`
+# poisons `set -e`. `|| true` is the cheap fix.
 EXISTING=$(git ls-remote --heads origin "ticket/${TICKET}-*" 2>/dev/null \
-    | awk '{print $2}' | sed 's|refs/heads/||' | head -1)
+    | awk '{print $2}' | sed 's|refs/heads/||' | head -1 || true)
 if [ -n "$EXISTING" ]; then
     echo "[create_linked_branch] reusing existing branch: $EXISTING" >&2
     echo "$EXISTING"
@@ -52,12 +54,19 @@ TITLE=$(gh issue view "$TICKET" --json title --jq '.title')
 TITLE_TRIMMED=$(echo "$TITLE" | sed -E 's/^(T[0-9]+ *[—–-] *|\[[^]]+\] *)//')
 # Slugify: lowercase, ASCII-fold removes accents, non-alphanumeric → '-',
 # collapse runs of '-', trim leading/trailing '-', cap at 40 chars.
+# Truncation uses bash parameter expansion (not `head -c`) so a SIGPIPE
+# from a downstream pipe stage doesn't tank the pipeline under
+# `set -o pipefail` for long titles.
+# `|| true` swallows failures from any pipe stage (esp. macOS iconv,
+# which exits non-zero on some characters even with TRANSLIT) so a single
+# slugification quirk doesn't tank `set -o pipefail` and crash silently.
 SLUG=$(echo "$TITLE_TRIMMED" \
-    | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null \
+    | { iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null || cat; } \
     | tr '[:upper:]' '[:lower:]' \
     | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
-    | head -c 40 \
-    | sed -E 's/-+$//')
+    || true)
+SLUG="${SLUG:0:40}"
+SLUG="${SLUG%-}"
 
 if [ -z "$SLUG" ]; then
     SLUG="ticket"

--- a/scripts/orchestration/dispatch_plan.sh
+++ b/scripts/orchestration/dispatch_plan.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # dispatch_plan.sh <epic_N1> [<epic_N2> ...]
 #
 # Computes the next-tick dispatch plan for one or more active epics.

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -192,7 +192,19 @@ Ton dernier message DOIT être uniquement ce JSON (rien d'autre, pas de prose)."
     # The latter only makes the flag *available* for an interactive session;
     # in --print mode it has no effect, so the sub-agent hits unresolved
     # permission prompts on every gh / bash / pnpm call and aborts.
-    timeout "$AGENT_TIMEOUT" claude \
+    #
+    # Portability: macOS ships no `timeout`. Prefer GNU `gtimeout` from
+    # coreutils (`brew install coreutils`); fall back to `timeout` when
+    # coreutils is the system default (Linux). If neither is on PATH, run
+    # claude without a hard timeout — the loop's per-tick aggregation will
+    # still catch pathological cases.
+    local TIMEOUT_BIN=""
+    if command -v gtimeout >/dev/null 2>&1; then
+        TIMEOUT_BIN="gtimeout $AGENT_TIMEOUT"
+    elif command -v timeout >/dev/null 2>&1; then
+        TIMEOUT_BIN="timeout $AGENT_TIMEOUT"
+    fi
+    $TIMEOUT_BIN claude \
         --agent "$AGENT" \
         --model "$MODEL" \
         --print \

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # epic_loop.sh <epic_N1> [<epic_N2> ...]
 #
 # Bash loop driver for /epic orchestration. Runs in the background, ticking

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -343,9 +343,30 @@ while [ $TICK -lt $MAX_TICKS ]; do
                 CLI_ERROR="true"
             fi
 
+            # Tolerant verdict extraction:
+            # 1) Pure JSON (the strict contract).
+            # 2) JSON inside a ```json ... ``` markdown fence — common when the
+            #    sub-agent ignores "no prose" and adds a summary section.
+            # 3) The first {...} object in the text containing a `"status"` key.
+            # Otherwise fall through to a `failed` result with the raw output.
+            RESULT_JSON=""
             if echo "$RESULT_TEXT" | jq -e '.status' >/dev/null 2>&1; then
                 RESULT_JSON="$RESULT_TEXT"
             else
+                FENCED=$(echo "$RESULT_TEXT" | awk '
+                    /^```(json)?[[:space:]]*$/ { if (in_block) exit; in_block=1; next }
+                    in_block { print }
+                ')
+                if [ -n "$FENCED" ] && echo "$FENCED" | jq -e '.status' >/dev/null 2>&1; then
+                    RESULT_JSON="$FENCED"
+                else
+                    EXTRACTED=$(echo "$RESULT_TEXT" | grep -oE '\{[^{}]*"status"[^{}]*\}' | head -1 || true)
+                    if [ -n "$EXTRACTED" ] && echo "$EXTRACTED" | jq -e '.status' >/dev/null 2>&1; then
+                        RESULT_JSON="$EXTRACTED"
+                    fi
+                fi
+            fi
+            if [ -z "$RESULT_JSON" ]; then
                 ESCAPED=$(echo "$RESULT_TEXT" | jq -Rs '.' | head -c 500)
                 RESULT_JSON=$(jq -nc \
                     --argjson ticket "$ticket" \

--- a/scripts/orchestration/epic_state.sh
+++ b/scripts/orchestration/epic_state.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # epic_state.sh <epic_N1> [<epic_N2> ...]
 #
 # Compact status dump for one or more epics. Replaces N individual

--- a/scripts/orchestration/log_event.sh
+++ b/scripts/orchestration/log_event.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # log_event.sh <agent-id> <event-type> [message]
 #
 # Appends a structured event to the agent's log file under

--- a/scripts/orchestration/open_worktree.sh
+++ b/scripts/orchestration/open_worktree.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # open_worktree.sh <pr_number>
 #
 # Recreate the egapro worktree for a given PR — used after the pipeline

--- a/scripts/orchestration/process_tick_result.sh
+++ b/scripts/orchestration/process_tick_result.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # process_tick_result.sh <result_file>
 #
 # Reads a tick result file produced by epic_loop.sh and applies the side

--- a/scripts/orchestration/render_dashboard.sh
+++ b/scripts/orchestration/render_dashboard.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # render_dashboard.sh
 #
 # Formats the /report dashboard from .claude/state/epic_run/.

--- a/scripts/orchestration/set_ticket_status.sh
+++ b/scripts/orchestration/set_ticket_status.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
 # set_ticket_status.sh <ticket_number> <status_label>
 #
 # Moves an issue to the given status on the EGAPRO V2 GitHub project board.


### PR DESCRIPTION
## Summary

Trois bugs de portabilité macOS découverts en faisant tourner `epic_loop.sh` localement sur macOS default bash 3.2 — les scripts ne crashaient pas sur Linux CI mais empêchaient toute orchestration locale de progresser. Plus un parser intolérant qui re-dispatchait à l'infini les tickets pourtant validés.

### Fixes

- **bash 4+ re-exec guard** sur les 11 scripts orchestration (macOS ship `/bin/bash` 3.2 — incompatible avec `declare -A`). Le guard détecte la version, re-exec via brew bash si dispo, sinon affiche un message d'install clair.
- **SIGPIPE + pipefail** dans `create_linked_branch.sh` : `head -c 40 | sed` envoyait SIGPIPE upstream → `pipefail` propage non-zéro → `set -e` exit silencieux pour les tickets aux titres longs. Replacé par bash parameter expansion (`${SLUG:0:40}`). Fallback `|| cat` sur `iconv -t ASCII//TRANSLIT` (qui exit non-zéro sur certains caractères côté macOS).
- **`timeout` absent sur macOS** : `epic_loop.sh` invoquait `timeout` qui n'existe pas dans la base macOS — empêchait le spawn du `claude` CLI. Détection portable `gtimeout` (coreutils via brew) → fallback `timeout` (Linux distros) → fallback aucun timeout.
- **Tolerant verdict extraction** : l'aggregation parsait le retour du sub-agent avec un `jq -e '.status'` strict sur tout le texte. En pratique, `code-dev` retourne souvent le JSON dans un fence ```` ```json ... ``` ```` avec de la prose autour, ce qui faisait passer un run réussi en `failed` et déclenchait un re-dispatch infini. Extraction tolérante : pure JSON → fenced block → premier objet contenant `"status"` → fallback `failed`.
- **Doc** : ajout d'un `scripts/orchestration/README.md` documentant les prérequis macOS (`brew install bash coreutils jq gh`), le wrap `unset CLAUDECODE` pour invoquer `epic_loop.sh` depuis une session Claude Code, et un quick-reference des scripts.

Aucun changement de comportement sous Linux (CI inchangé) — les guards sont no-op quand `BASH_VERSINFO >= 4` et `gtimeout`/`timeout` sont déjà présents.

### Pour les contributeurs macOS

```bash
brew install bash coreutils jq gh
```

Détails et options dans le nouveau [`scripts/orchestration/README.md`](scripts/orchestration/README.md).

## Test plan

- [x] `bash scripts/orchestration/epic_loop.sh <epic>` démarre sur macOS sans crasher au tick 0
- [x] `dispatch_plan.sh` retourne un plan JSON valide (pas d'exit silencieux)
- [x] `create_linked_branch.sh` crée une branche pour un ticket à titre long (testé avec titre 65 chars)
- [x] Le sub-agent `code-dev` est correctement spawné et son verdict (même noyé dans de la prose) est correctement extrait
- [x] CI Linux inchangé (les guards sont no-op)

## Notes

Découvert pendant l'orchestration de l'epic [#3372](https://github.com/SocialGouv/egapro/issues/3372). Les 3 commits sont déjà présents sur `chore/ai-pipeline` (commits `62ef90c7`, `4a44d76b`, `a6f1efc9`) — ils y restent pour ne pas casser les bases des PR enfants ([#3375](https://github.com/SocialGouv/egapro/pull/3375), [#3376](https://github.com/SocialGouv/egapro/pull/3376)). Cette PR les remonte en parallèle vers `alpha` pour qu'ils profitent au reste du repo sans attendre la merge de `chore/ai-pipeline`.
