### PR TITLE
fix(declaration): friendly error when source is missing on indicator …

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/schemas.ts
@@ -93,7 +93,12 @@ export const categoryFormEntrySchema = z.object({
 });
 
 export const categoryFormSchema = z.object({
-	source: z.string(),
+	source: z
+		.string()
+		.min(
+			1,
+			"Veuillez sélectionner la source utilisée pour déterminer les catégories d'emplois.",
+		),
 	categories: z.array(categoryFormEntrySchema),
 });
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -278,12 +278,17 @@ describe("Step5EmployeeCategories", () => {
 		});
 		await user.type(nameInput, "Techniciens");
 
+		await user.selectOptions(
+			screen.getByLabelText(/Quelle est la source utilisée/),
+			"accord-entreprise",
+		);
+
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
 		expect(mockMutate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				declarationType: "initial",
-				source: expect.any(String),
+				source: "accord-entreprise",
 				categories: expect.arrayContaining([
 					expect.objectContaining({
 						name: "Techniciens",
@@ -291,6 +296,23 @@ describe("Step5EmployeeCategories", () => {
 				]),
 			}),
 		);
+	});
+
+	it("shows a friendly error when source is not selected", async () => {
+		const user = userEvent.setup();
+		render(<Step5EmployeeCategories declarationYear={2025} />);
+
+		const nameInput = screen.getByLabelText("Libellé", {
+			selector: "#cat-0-name",
+		});
+		await user.type(nameInput, "Techniciens");
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		expect(
+			screen.getByText(/veuillez sélectionner la source/i),
+		).toBeInTheDocument();
+		expect(mockMutate).not.toHaveBeenCalled();
 	});
 
 	it("shows error when workforce totals do not match step 1", async () => {
@@ -306,6 +328,11 @@ describe("Step5EmployeeCategories", () => {
 		// Fill required name first
 		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
 		await user.type(nameInput, "Cadres");
+
+		await user.selectOptions(
+			screen.getByLabelText(/Quelle est la source utilisée/),
+			"accord-entreprise",
+		);
 
 		const womenInput = screen.getByLabelText("Effectif femmes, catégorie 1");
 		const menInput = screen.getByLabelText("Effectif hommes, catégorie 1");
@@ -325,6 +352,11 @@ describe("Step5EmployeeCategories", () => {
 		const user = userEvent.setup();
 		render(<Step5EmployeeCategories declarationYear={2025} />);
 
+		await user.selectOptions(
+			screen.getByLabelText(/Quelle est la source utilisée/),
+			"accord-entreprise",
+		);
+
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
 		expect(
@@ -340,6 +372,11 @@ describe("Step5EmployeeCategories", () => {
 		// Fill first category name
 		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
 		await user.type(nameInput, "Cadres");
+
+		await user.selectOptions(
+			screen.getByLabelText(/Quelle est la source utilisée/),
+			"accord-entreprise",
+		);
 
 		// Add second category and give same name
 		await user.click(

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -207,6 +207,7 @@ export function CategoryForm({
 	}
 
 	const categories = form.watch("categories");
+	const sourceError = form.formState.errors.source?.message;
 
 	const handleFormSubmit = form.handleSubmit((data) => {
 		setWorkforceError("");
@@ -295,18 +296,26 @@ export function CategoryForm({
 						</span>
 					</p>
 				) : (
-					<div className={`fr-select-group ${stepStyles.sourceSelectGroup}`}>
+					<div
+						className={`fr-select-group ${
+							sourceError ? "fr-select-group--error" : ""
+						} ${stepStyles.sourceSelectGroup}`}
+					>
 						<label className="fr-label" htmlFor="source-select">
 							Quelle est la source utilisée pour déterminer les catégories
 							d&apos;emplois ?
 						</label>
 						<select
+							aria-describedby={sourceError ? "source-error" : undefined}
+							aria-invalid={Boolean(sourceError)}
 							className="fr-select"
 							disabled={disabled}
 							id="source-select"
 							{...form.register("source")}
 							onChange={(e) => {
-								form.setValue("source", e.target.value);
+								form.setValue("source", e.target.value, {
+									shouldValidate: true,
+								});
 								setSaved(false);
 							}}
 						>
@@ -319,6 +328,11 @@ export function CategoryForm({
 								</option>
 							))}
 						</select>
+						{sourceError && (
+							<p className="fr-error-text" id="source-error">
+								{sourceError}
+							</p>
+						)}
 					</div>
 				)}
 


### PR DESCRIPTION
The client-side categoryFormSchema accepted an empty `source`, so submitting without picking a "référentiel des catégories d'emplois" sent the request to the server, which rejected it and surfaced the raw Zod issue array as the error message. Tighten the schema with `.min(1, ...)` so validation fires on the client and renders an inline DSFR error next to the select.