### PR TITLE
fix(declaration): previous link from récap goes back to step 5 when submitted (#3266)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -172,18 +172,15 @@ export function Step6Review({
 				/>
 			)}
 
-			{isSubmitted ? (
-				<FormActions
-					nextHref="/declaration-remuneration/parcours-conformite"
-					nextLabel="Suivant"
-					previousHref="/"
-				/>
-			) : (
-				<FormActions
-					nextLabel="Suivant"
-					previousHref="/declaration-remuneration/etape/5"
-				/>
-			)}
+			<FormActions
+				nextHref={
+					isSubmitted
+						? "/declaration-remuneration/parcours-conformite"
+						: undefined
+				}
+				nextLabel="Suivant"
+				previousHref="/declaration-remuneration/etape/5"
+			/>
 
 			{!isSubmitted && (
 				<SubmitDeclarationModal

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -416,7 +416,7 @@ describe("Step6Review", () => {
 		);
 	});
 
-	it("renders previous link to home and next link to compliance path when already submitted", () => {
+	it("renders previous link to step 5 and next link to compliance path when already submitted", () => {
 		render(
 			<Step6Review
 				declaration={emptyDeclaration()}
@@ -429,7 +429,7 @@ describe("Step6Review", () => {
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
-			"/",
+			"/declaration-remuneration/etape/5",
 		);
 		expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
 			"href",


### PR DESCRIPTION
Closes #3266

## Contexte

Sur l'étape 6 (récap) du parcours déclaration-rémunération, lorsque la déclaration était déjà soumise (`isSubmitted=true`), le bouton « Précédent » du `FormActions` pointait vers `/` (accueil) au lieu de `/declaration-remuneration/etape/5`. L'utilisateur sortait du parcours au lieu de revenir à l'étape précédente.

## Root cause

`Step6Review.tsx` avait un branchement explicite sur `isSubmitted` qui mettait à jour à la fois `nextHref` (légitime) **et** `previousHref` (involontaire, valeur `"/"`). Le branchement sur `previousHref` n'avait pas de raison d'être : revenir à l'étape 5 a du sens dans les deux modes.

## Fix

- `Step6Review.tsx` : `previousHref` est désormais toujours `/declaration-remuneration/etape/5`. Seul `nextHref` reste conditionnel (compliance path en mode submitted, `undefined` sinon — la modale de soumission prend le relais via `onSubmit`).
- `__tests__/Step6Review.test.tsx` : le test « previous link to home » documentait le comportement bugué — il a été remplacé par un test qui asserte que `previousHref="/declaration-remuneration/etape/5"` même quand `isSubmitted=true`.

## Test plan

- [x] Test unitaire de reproduction qui échouait sur `alpha` et passe après fix
- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (1649 tests)
- [x] `pnpm lint:check` + `pnpm format:check` verts

## Note review

Pas de référence Figma sur ce ticket — c'est un bug de navigation purement fonctionnel, pas un visual mismatch. Le test unitaire couvre les deux branches (`isSubmitted` true/false) du `previousHref`.