### PR TITLE
feat(declaration-remuneration): brouillon localStorage foundation + Step1 (#3392)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -48,6 +48,7 @@ export function StepPageClient({
 		case 1:
 			return (
 				<Step1Workforce
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step1Data}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/computeDraftDiff.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/computeDraftDiff.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDraftDiff } from "../computeDraftDiff";
+
+describe("computeDraftDiff", () => {
+	it("returns {} when all primitives are strictly equal", () => {
+		const current = { a: 1, b: "x", c: true };
+		const db = { a: 1, b: "x", c: true };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("includes only the differing primitive in the diff", () => {
+		const current = { a: 1, b: "x" };
+		const db = { a: 2, b: "x" };
+		expect(computeDraftDiff(current, db)).toEqual({ a: 1 });
+	});
+
+	it("returns {} for arrays of objects with identical content", () => {
+		const current = { categories: [{ name: "A", count: 3 }] };
+		const db = { categories: [{ name: "A", count: 3 }] };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("keeps the entire array when one cell differs", () => {
+		const current = {
+			categories: [
+				{ name: "A", count: 3 },
+				{ name: "B", count: 7 },
+			],
+		};
+		const db = {
+			categories: [
+				{ name: "A", count: 3 },
+				{ name: "B", count: 5 },
+			],
+		};
+		expect(computeDraftDiff(current, db)).toEqual({
+			categories: current.categories,
+		});
+	});
+
+	it("keeps the entire array when length differs", () => {
+		const current = { items: [1, 2, 3] };
+		const db = { items: [1, 2] };
+		expect(computeDraftDiff(current, db)).toEqual({ items: [1, 2, 3] });
+	});
+
+	it("returns {} for nested objects with identical content", () => {
+		const current = { meta: { a: 1, b: { c: 2 } } };
+		const db = { meta: { a: 1, b: { c: 2 } } };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("includes a differing nested object", () => {
+		const current = { meta: { a: 1, b: { c: 2 } } };
+		const db = { meta: { a: 1, b: { c: 3 } } };
+		expect(computeDraftDiff(current, db)).toEqual({ meta: current.meta });
+	});
+
+	it("treats null and undefined as equal", () => {
+		const current: Record<string, unknown> = { a: null, b: undefined };
+		const db: Record<string, unknown> = { a: undefined, b: null };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("treats null vs primitive as different", () => {
+		const current: Record<string, unknown> = { a: 0 };
+		const db: Record<string, unknown> = { a: null };
+		expect(computeDraftDiff(current, db)).toEqual({ a: 0 });
+	});
+
+	it("treats array vs object as different", () => {
+		const current: Record<string, unknown> = { x: [] };
+		const db: Record<string, unknown> = { x: {} };
+		expect(computeDraftDiff(current, db)).toEqual({ x: [] });
+	});
+
+	it("detects difference when nested object key sets differ", () => {
+		const current: Record<string, unknown> = { meta: { a: 1, b: 2 } };
+		const db: Record<string, unknown> = { meta: { a: 1 } };
+		expect(computeDraftDiff(current, db)).toEqual({ meta: { a: 1, b: 2 } });
+	});
+
+	it("detects difference when same key count but distinct keys", () => {
+		const current: Record<string, unknown> = { meta: { a: 1, b: 2 } };
+		const db: Record<string, unknown> = { meta: { a: 1, c: 2 } };
+		expect(computeDraftDiff(current, db)).toEqual({ meta: { a: 1, b: 2 } });
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/draftStorage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/draftStorage.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DraftPayload } from "../draftSchema";
+import { clearDraft, readDraft, writeDraft } from "../draftStorage";
+
+const USER_ID = "user-1";
+const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}`;
+
+const FIXED_NOW = new Date("2026-03-15T12:00:00Z").getTime();
+
+function buildValidPayload(
+	overrides: Partial<DraftPayload> = {},
+): DraftPayload {
+	return {
+		siren: "123456789",
+		year: 2026,
+		step: 1,
+		kind: "main",
+		timestamp: FIXED_NOW - 1000,
+		fields: { totalWomen: 10 },
+		...overrides,
+	};
+}
+
+describe("draftStorage", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(FIXED_NOW));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("readDraft", () => {
+		it("returns null when no key exists", () => {
+			expect(readDraft(USER_ID)).toBeNull();
+		});
+
+		it("purges and returns null on corrupt JSON", () => {
+			window.localStorage.setItem(STORAGE_KEY, "{not-json");
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("purges and returns null on Zod-invalid payload", () => {
+			window.localStorage.setItem(
+				STORAGE_KEY,
+				JSON.stringify({ siren: "abc", year: 2026 }),
+			);
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("purges and returns null when timestamp is older than 30 days", () => {
+			const expired = buildValidPayload({
+				timestamp: FIXED_NOW - 31 * 24 * 3600 * 1000,
+			});
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(expired));
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("purges and returns null when the campaign deadline has passed", () => {
+			vi.setSystemTime(new Date("2026-07-01T00:00:00Z").getTime());
+			const payload = buildValidPayload({
+				timestamp: new Date("2026-06-30T00:00:00Z").getTime(),
+				year: 2026,
+			});
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("returns the parsed payload when valid and within deadlines", () => {
+			const payload = buildValidPayload();
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+			expect(readDraft(USER_ID)).toEqual(payload);
+		});
+	});
+
+	describe("writeDraft", () => {
+		it("persists the payload as JSON under the user-scoped key", () => {
+			const payload = buildValidPayload();
+			writeDraft(USER_ID, payload);
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
+				JSON.stringify(payload),
+			);
+		});
+
+		it("write then read round-trips identical content", () => {
+			const payload = buildValidPayload();
+			writeDraft(USER_ID, payload);
+			expect(readDraft(USER_ID)).toEqual(payload);
+		});
+	});
+
+	describe("clearDraft", () => {
+		it("removes the user-scoped key", () => {
+			writeDraft(USER_ID, buildValidPayload());
+			clearDraft(USER_ID);
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("is a no-op when the key does not exist", () => {
+			expect(() => clearDraft(USER_ID)).not.toThrow();
+		});
+	});
+
+	describe("SSR safety (window === undefined)", () => {
+		const originalWindow = globalThis.window;
+
+		beforeEach(() => {
+			Object.defineProperty(globalThis, "window", {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			});
+		});
+
+		afterEach(() => {
+			Object.defineProperty(globalThis, "window", {
+				value: originalWindow,
+				writable: true,
+				configurable: true,
+			});
+		});
+
+		it("readDraft returns null without throwing", () => {
+			expect(readDraft(USER_ID)).toBeNull();
+		});
+
+		it("writeDraft is a no-op without throwing", () => {
+			expect(() => writeDraft(USER_ID, buildValidPayload())).not.toThrow();
+		});
+
+		it("clearDraft is a no-op without throwing", () => {
+			expect(() => clearDraft(USER_ID)).not.toThrow();
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -1,0 +1,262 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DraftPayload } from "../draftSchema";
+import { useDeclarationDraft } from "../useDeclarationDraft";
+
+const useSessionMock = vi.mocked(useSession);
+
+const SIREN = "123456789";
+const YEAR = 2026;
+const USER_ID = "user-1";
+const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}`;
+
+const FIXED_NOW = new Date("2026-03-15T12:00:00Z").getTime();
+
+function buildPayload(overrides: Partial<DraftPayload> = {}): DraftPayload {
+	return {
+		siren: SIREN,
+		year: YEAR,
+		step: 1,
+		kind: "main",
+		timestamp: FIXED_NOW - 1000,
+		fields: { totalWomen: 10 },
+		...overrides,
+	};
+}
+
+type StepValues = { totalWomen: number; totalMen: number };
+
+const DB_VALUES: StepValues = { totalWomen: 0, totalMen: 0 };
+
+function setSession(
+	options: { userId?: string | null; impersonating?: boolean } = {},
+) {
+	const { userId = USER_ID, impersonating = false } = options;
+	useSessionMock.mockReturnValue({
+		data:
+			userId === null
+				? null
+				: ({
+						user: {
+							id: userId,
+							impersonation: impersonating
+								? { siren: "999999999", name: "X" }
+								: null,
+						},
+						expires: "",
+					} as never),
+		status: userId === null ? "unauthenticated" : "authenticated",
+		update: vi.fn(),
+	} as never);
+}
+
+describe("useDeclarationDraft", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(FIXED_NOW));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		useSessionMock.mockReset();
+	});
+
+	it("is a no-op when userId is null (logged out)", () => {
+		setSession({ userId: null });
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildPayload()));
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+
+		act(() => {
+			result.current.setField({ totalWomen: 99, totalMen: 0 });
+		});
+		expect(window.localStorage.length).toBe(1);
+
+		act(() => {
+			result.current.clearDraft();
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+	});
+
+	it("is a no-op when impersonating", () => {
+		setSession({ impersonating: true });
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildPayload()));
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+
+		act(() => {
+			result.current.setField({ totalWomen: 99, totalMen: 0 });
+			result.current.clearDraft();
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+	});
+
+	it("hydrates draft when payload matches (siren, year, step)", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ fields: { totalWomen: 10, totalMen: 5 } })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({ totalWomen: 10, totalMen: 5 });
+		expect(result.current.hasDraft).toBe(true);
+	});
+
+	it("does not hydrate when payload (siren, year, step) does not match — and does not purge", () => {
+		setSession();
+		const payload = buildPayload({ siren: "987654321" });
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+	});
+
+	it("does not hydrate when payload year does not match", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ year: 2025 })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("does not hydrate when payload step does not match", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ step: 2 })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("clears the draft when setField makes values match dbValues", () => {
+		setSession();
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+
+		act(() => {
+			result.current.setField({ totalWomen: 5, totalMen: 0 });
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+		expect(result.current.hasDraft).toBe(true);
+
+		act(() => {
+			result.current.setField({ totalWomen: 0, totalMen: 0 });
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("writes the diff (only differing keys) when setField is called", () => {
+		setSession();
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		act(() => {
+			result.current.setField({ totalWomen: 5, totalMen: 0 });
+		});
+		const stored = JSON.parse(
+			window.localStorage.getItem(STORAGE_KEY) ?? "{}",
+		) as DraftPayload;
+		expect(stored.fields).toEqual({ totalWomen: 5 });
+		expect(stored.siren).toBe(SIREN);
+		expect(stored.year).toBe(YEAR);
+		expect(stored.step).toBe(1);
+		expect(stored.kind).toBe("main");
+		expect(stored.timestamp).toBe(FIXED_NOW);
+	});
+
+	it("clearDraft removes the key and resets hasDraft", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ fields: { totalWomen: 10 } })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.hasDraft).toBe(true);
+		act(() => {
+			result.current.clearDraft();
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		expect(result.current.hasDraft).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/computeDraftDiff.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/computeDraftDiff.ts
@@ -1,0 +1,41 @@
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (a == null && b == null) return true;
+	if (a == null || b == null) return false;
+	const aIsArr = Array.isArray(a);
+	const bIsArr = Array.isArray(b);
+	if (aIsArr && bIsArr) {
+		if (a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i += 1) {
+			if (!deepEqual(a[i], b[i])) return false;
+		}
+		return true;
+	}
+	if (aIsArr !== bIsArr) return false;
+	if (typeof a === "object" && typeof b === "object") {
+		const aRecord = a as Record<string, unknown>;
+		const bRecord = b as Record<string, unknown>;
+		const keysA = Object.keys(aRecord);
+		const keysB = Object.keys(bRecord);
+		if (keysA.length !== keysB.length) return false;
+		for (const key of keysA) {
+			if (!Object.hasOwn(bRecord, key)) return false;
+			if (!deepEqual(aRecord[key], bRecord[key])) return false;
+		}
+		return true;
+	}
+	return false;
+}
+
+export function computeDraftDiff<T extends Record<string, unknown>>(
+	currentValues: T,
+	dbValues: T,
+): Partial<T> {
+	const diff: Partial<T> = {};
+	for (const key of Object.keys(currentValues) as Array<keyof T>) {
+		if (!deepEqual(currentValues[key], dbValues[key])) {
+			diff[key] = currentValues[key];
+		}
+	}
+	return diff;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/draftSchema.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/draftSchema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { sirenSchema } from "~/modules/admin/schemas";
+
+export const draftPayloadSchema = z.object({
+	siren: sirenSchema,
+	year: z.number().int(),
+	step: z.union([
+		z.number().int().min(1).max(6),
+		z.literal("second-1"),
+		z.literal("second-2"),
+		z.literal("joint"),
+		z.literal("compliance"),
+	]),
+	kind: z.enum(["main", "second", "joint", "compliance"]),
+	timestamp: z.number().int(),
+	fields: z.record(z.string(), z.unknown()),
+});
+
+export type DraftPayload = z.infer<typeof draftPayloadSchema>;
+
+export type DraftStep = DraftPayload["step"];
+export type DraftKind = DraftPayload["kind"];

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/draftStorage.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/draftStorage.ts
@@ -1,0 +1,60 @@
+import { getDefaultCampaignDeadlines } from "~/modules/domain";
+
+import { type DraftPayload, draftPayloadSchema } from "./draftSchema";
+
+const STORAGE_KEY_PREFIX = "egapro:declaration-draft:";
+const DRAFT_TTL_MS = 30 * 24 * 3600 * 1000;
+
+function getStorage(): Storage | null {
+	if (typeof window === "undefined") return null;
+	return window.localStorage;
+}
+
+function getStorageKey(userId: string): string {
+	return `${STORAGE_KEY_PREFIX}${userId}`;
+}
+
+function isExpired(payload: DraftPayload, now: number): boolean {
+	if (now - payload.timestamp > DRAFT_TTL_MS) return true;
+	const deadline = getDefaultCampaignDeadlines(
+		payload.year,
+	).decl1ModificationDeadline;
+	return now > deadline.getTime();
+}
+
+export function readDraft(userId: string): DraftPayload | null {
+	const storage = getStorage();
+	if (!storage) return null;
+	const key = getStorageKey(userId);
+	const raw = storage.getItem(key);
+	if (raw === null) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		storage.removeItem(key);
+		return null;
+	}
+	const result = draftPayloadSchema.safeParse(parsed);
+	if (!result.success) {
+		storage.removeItem(key);
+		return null;
+	}
+	if (isExpired(result.data, Date.now())) {
+		storage.removeItem(key);
+		return null;
+	}
+	return result.data;
+}
+
+export function writeDraft(userId: string, payload: DraftPayload): void {
+	const storage = getStorage();
+	if (!storage) return;
+	storage.setItem(getStorageKey(userId), JSON.stringify(payload));
+}
+
+export function clearDraft(userId: string): void {
+	const storage = getStorage();
+	if (!storage) return;
+	storage.removeItem(getStorageKey(userId));
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { computeDraftDiff } from "./computeDraftDiff";
+import type { DraftKind, DraftStep } from "./draftSchema";
+import { clearDraft, readDraft, writeDraft } from "./draftStorage";
+
+type UseDeclarationDraftOptions<T extends Record<string, unknown>> = {
+	siren: string;
+	year: number;
+	step: DraftStep;
+	kind: DraftKind;
+	dbValues: T;
+};
+
+type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
+	draft: Partial<T>;
+	setField: (currentValues: T) => void;
+	clearDraft: () => void;
+	hasDraft: boolean;
+};
+
+export function useDeclarationDraft<T extends Record<string, unknown>>(
+	options: UseDeclarationDraftOptions<T>,
+): UseDeclarationDraftResult<T> {
+	const { siren, year, step, kind, dbValues } = options;
+	const session = useSession();
+	const userId = session.data?.user?.id ?? null;
+	const isImpersonating = Boolean(session.data?.user?.impersonation);
+	const isEnabled = userId !== null && !isImpersonating;
+
+	const [draft, setDraft] = useState<Partial<T>>({});
+	const [hasDraft, setHasDraft] = useState(false);
+
+	useEffect(() => {
+		if (!isEnabled || userId === null) return;
+		const payload = readDraft(userId);
+		if (payload === null) return;
+		if (
+			payload.siren !== siren ||
+			payload.year !== year ||
+			payload.step !== step
+		) {
+			return;
+		}
+		const fields = payload.fields as Partial<T>;
+		setDraft(fields);
+		setHasDraft(Object.keys(fields).length > 0);
+	}, [isEnabled, userId, siren, year, step]);
+
+	const setField = useCallback(
+		(currentValues: T) => {
+			if (!isEnabled || userId === null) return;
+			const diff = computeDraftDiff(currentValues, dbValues);
+			if (Object.keys(diff).length === 0) {
+				clearDraft(userId);
+				setHasDraft(false);
+				return;
+			}
+			writeDraft(userId, {
+				siren,
+				year,
+				step,
+				kind,
+				timestamp: Date.now(),
+				fields: diff,
+			});
+			setHasDraft(true);
+		},
+		[isEnabled, userId, siren, year, step, kind, dbValues],
+	);
+
+	const clearDraftCallback = useCallback(() => {
+		if (!isEnabled || userId === null) return;
+		clearDraft(userId);
+		setHasDraft(false);
+	}, [isEnabled, userId]);
+
+	return useMemo(
+		() => ({
+			draft,
+			setField,
+			clearDraft: clearDraftCallback,
+			hasDraft,
+		}),
+		[draft, setField, clearDraftCallback, hasDraft],
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -10,6 +10,7 @@ import { updateStep1Schema } from "../schemas";
 import common from "../shared/common.module.scss";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP1_CATEGORIES } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
@@ -22,12 +23,14 @@ import type { Step1Data } from "../types";
 import styles from "./Step1Workforce.module.scss";
 
 type Step1WorkforceProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step1Data;
 	gipPrefillData?: GipPrefillData;
 };
 
 export function Step1Workforce({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -38,18 +41,40 @@ export function Step1Workforce({
 
 	const hasInitialData = initialData.totalWomen > 0 || initialData.totalMen > 0;
 
-	const form = useZodForm(updateStep1Schema, {
-		defaultValues: {
+	const dbValues = useMemo(
+		() => ({
 			totalWomen: initialData.totalWomen,
 			totalMen: initialData.totalMen,
-		},
+		}),
+		[initialData.totalWomen, initialData.totalMen],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 1,
+		kind: "main",
+		dbValues,
+	});
+
+	const form = useZodForm(updateStep1Schema, {
+		defaultValues: dbValues,
 	});
 
 	const totalWomen = form.watch("totalWomen");
 	const totalMen = form.watch("totalMen");
 	const total = totalWomen + totalMen;
 
-	const [saved, setSaved] = useState(hasInitialData);
+	useEffect(() => {
+		if (typeof draft.totalWomen === "number") {
+			form.setValue("totalWomen", draft.totalWomen);
+		}
+		if (typeof draft.totalMen === "number") {
+			form.setValue("totalMen", draft.totalMen);
+		}
+	}, [draft.totalWomen, draft.totalMen, form]);
+
+	const saved = !hasDraft && hasInitialData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const [showResetWarning, setShowResetWarning] = useState(false);
 
@@ -58,7 +83,10 @@ export function Step1Workforce({
 	}
 
 	const mutation = api.declaration.updateStep1.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/2"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/2");
+		},
 	});
 
 	function parseIntegerInput(raw: string): number | null {
@@ -71,14 +99,14 @@ export function Step1Workforce({
 		const value = parseIntegerInput(e.target.value);
 		if (value === null) return;
 		form.setValue("totalWomen", value);
-		setSaved(false);
+		setField({ totalWomen: value, totalMen });
 	}
 
 	function handleMenChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const value = parseIntegerInput(e.target.value);
 		if (value === null) return;
 		form.setValue("totalMen", value);
-		setSaved(false);
+		setField({ totalWomen, totalMen: value });
 	}
 
 	const onSubmit = form.handleSubmit((data) => {
@@ -96,9 +124,11 @@ export function Step1Workforce({
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
 				onDevFill={() => {
-					form.setValue("totalWomen", DEV_STEP1_CATEGORIES[0]?.women ?? 50);
-					form.setValue("totalMen", DEV_STEP1_CATEGORIES[0]?.men ?? 50);
-					setSaved(false);
+					const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;
+					const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;
+					form.setValue("totalWomen", womenValue);
+					form.setValue("totalMen", menValue);
+					setField({ totalWomen: womenValue, totalMen: menValue });
 				}}
 				saved={saved}
 				title={

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1DevFill.test.tsx
@@ -27,7 +27,11 @@ describe("Step1Workforce dev fill", () => {
 	it("fills workforce when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -24,7 +24,11 @@ const emptyStep1Data = () => ({ totalWomen: 0, totalMen: 0 });
 describe("Step1Workforce", () => {
 	it("renders default state with zero totals", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(screen.getByText("Nombre de salariés")).toBeInTheDocument();
 		const table = screen.getByRole("table");
@@ -38,7 +42,11 @@ describe("Step1Workforce", () => {
 
 	it("renders reference period and mandatory fields notice", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(
 			screen.getByText(/Période de référence pour le calcul des indicateurs/),
@@ -51,6 +59,7 @@ describe("Step1Workforce", () => {
 	it("renders initial data with correct values", () => {
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 10, totalMen: 20 }}
 			/>,
@@ -67,6 +76,7 @@ describe("Step1Workforce", () => {
 	it("shows SavedIndicator when initial data has values", () => {
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 5, totalMen: 3 }}
 			/>,
@@ -76,7 +86,11 @@ describe("Step1Workforce", () => {
 
 	it("does not show SavedIndicator when no initial data", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
@@ -84,7 +98,11 @@ describe("Step1Workforce", () => {
 	it("updates women/men values via inline inputs", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Nombre de femmes");
@@ -109,7 +127,11 @@ describe("Step1Workforce", () => {
 	it("validates total > 0 on submit", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });
@@ -122,6 +144,7 @@ describe("Step1Workforce", () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 10, totalMen: 20 }}
 			/>,
@@ -139,7 +162,11 @@ describe("Step1Workforce", () => {
 	it("shows validation error message when submitting with zero total", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });
@@ -154,7 +181,11 @@ describe("Step1Workforce", () => {
 
 	it("renders previous link pointing to home", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
@@ -165,6 +196,7 @@ describe("Step1Workforce", () => {
 	it("hides the reset warning by default", () => {
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
@@ -178,6 +210,7 @@ describe("Step1Workforce", () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
@@ -193,7 +226,11 @@ describe("Step1Workforce", () => {
 	it("does not show the reset warning when focusing an empty input", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		await user.click(screen.getByLabelText("Nombre de femmes"));


### PR DESCRIPTION
Closes #3392

## Résumé

Foundation du mécanisme de brouillon localStorage pour la déclaration de rémunération + câblage end-to-end sur **Step1Workforce** (preuve qu'on tient toute la boucle).

### Code ajouté (`shared/draft/`)

- `draftSchema.ts` — `draftPayloadSchema` Zod (siren / year / step / kind / timestamp / fields)
- `draftStorage.ts` — `readDraft` / `writeDraft` / `clearDraft`, clé `egapro:declaration-draft:<userId>`, purge silencieuse sur :
  - JSON corrompu / payload Zod invalide
  - TTL 30 jours dépassé
  - `decl1ModificationDeadline` de la campagne dépassée
  - SSR safe (`typeof window === "undefined"` → no-op)
- `computeDraftDiff.ts` — pure, primitive / object / array / null-undefined-equal. Si une seule cellule d'un array d'objets diffère → tout l'array est conservé.
- `useDeclarationDraft.ts` — hook qui lit le brouillon au mount si `(siren, year, step)` matchent, le réécrit avec le diff sur `setField`, et le purge quand current === db ou via `clearDraft()`. **No-op total** si `userId === null` ou si l'admin est en impersonation.

### Câblage Step1Workforce

- `useState(saved)` supprimé : `saved = !hasDraft && hasInitialData`
- `setField` appelé sur chaque `onChange` → diff vs valeurs DB → write/clear automatique
- `clearDraft()` appelé sur `mutation.onSuccess` (l'utilisateur a soumis, le brouillon n'a plus de raison d'exister)
- Hydratation des `defaultValues` du form via `useEffect` quand le hook livre des champs au mount
- Nouvelle prop `declarationSiren: string` (passée par `StepPageClient` depuis `declaration.siren`)

### Aucun appel `localStorage.*` direct

Toute lecture/écriture/suppression du localStorage pour ce flux passe par les 3 fonctions exportées de `draftStorage.ts`.

## Couverture

100% statements / branches / functions / lines sur les 4 fichiers du draft :

```
draftSchema.ts        100/100/100/100
draftStorage.ts       100/100/100/100
computeDraftDiff.ts   100/100/100/100
useDeclarationDraft.ts 100/100/100/100
```

34 tests unitaires sur les scénarios S2–S8 du ticket (S1, S5–S7 = validation manuelle PR via revue humaine).

## Out-of-scope volontaires

- T2 / T3 (câblage des autres steps `main` / `second` / `joint` / `compliance`) — viennent dans les tickets parallèles
- Mise à jour du barrel `index.ts` — l'API reste interne au sous-dossier `shared/draft/` pour ce ticket (aucun consommateur externe)

## Test plan

- [ ] CI verte (build, lint, format, typecheck, tests)
- [ ] SonarCloud Quality Gate vert
- [ ] Validation manuelle Step1 (S1, S2, S5, S6, S7) sur la review app
- [ ] S3, S4, S8 couverts par les tests unitaires
