### PR TITLE
feat(declaration-remuneration): brouillon localStorage Step2–Step5 (#3393)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -57,6 +57,7 @@ export function StepPageClient({
 		case 2:
 			return (
 				<Step2PayGap
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step2Data}
@@ -65,6 +66,7 @@ export function StepPageClient({
 		case 3:
 			return (
 				<Step3VariablePay
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step3Data}
@@ -75,6 +77,7 @@ export function StepPageClient({
 		case 4:
 			return (
 				<Step4QuartileDistribution
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step4Data}
@@ -85,6 +88,7 @@ export function StepPageClient({
 		case 5:
 			return (
 				<Step5EmployeeCategories
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					initialCategories={step5Categories}
 					initialSource={initialSource}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
@@ -11,6 +11,7 @@ import { updateStep2Schema } from "../schemas";
 import common from "../shared/common.module.scss";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP2_ROWS } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
@@ -25,12 +26,14 @@ import { TooltipButton } from "../shared/TooltipButton";
 import type { PayGapField, Step2Data } from "../types";
 
 type Step2PayGapProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step2Data;
 	gipPrefillData?: GipPrefillData;
 };
 
 export function Step2PayGap({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -50,16 +53,47 @@ export function Step2PayGap({
 
 	const hasInitialData = hasSavedData;
 
+	const dbValues = useMemo(
+		() =>
+			Object.fromEntries(
+				Object.entries(initialData).map(([k, v]) => [k, padDecimalToTwo(v)]),
+			) as Step2Data,
+		[initialData],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 2,
+		kind: "main",
+		dbValues,
+	});
+
 	const form = useZodForm(updateStep2Schema, { defaultValues });
+
+	useEffect(() => {
+		(Object.keys(draft) as Array<keyof Step2Data>).forEach((key) => {
+			const value = draft[key];
+			if (value !== undefined) form.setValue(key, value as string);
+		});
+	}, [draft, form]);
+
+	useEffect(() => {
+		const sub = form.watch((values) => setField(values as Step2Data));
+		return () => sub.unsubscribe();
+	}, [form, setField]);
 
 	const formData = form.watch();
 	const rows = step2ToRows(formData as Step2Data);
 
-	const [saved, setSaved] = useState(hasInitialData);
+	const saved = !hasDraft && hasInitialData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep2.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/3"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/3");
+		},
 	});
 
 	function handleRowChange(index: number, field: PayGapField, value: string) {
@@ -68,7 +102,6 @@ export function Step2PayGap({
 		if (normalized !== "" && Number.parseFloat(normalized) < 0) return;
 		const fieldName = getStep2FieldName(index, field);
 		form.setValue(fieldName, normalized);
-		setSaved(false);
 	}
 
 	const onSubmit = form.handleSubmit(() => {
@@ -93,7 +126,6 @@ export function Step2PayGap({
 						form.setValue(womenField, padDecimalToTwo(row.womenValue));
 						form.setValue(menField, padDecimalToTwo(row.menValue));
 					});
-					setSaved(false);
 				}}
 				saved={saved}
 				title={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -137,7 +137,6 @@ export function Step2PayGap({
 
 			<StepIndicator currentStep={2} />
 
-			{/* Introduction */}
 			<div className={common.flexColumnGap1}>
 				<p className="fr-mb-0">
 					Ces indicateurs mesurent la différence de rémunération, moyenne et
@@ -163,7 +162,6 @@ export function Step2PayGap({
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 			</div>
 
-			{/* Data section */}
 			<div className={common.dataSection}>
 				<div className={common.flexColumnGapHalf}>
 					<PayGapTable

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -54,32 +54,18 @@ export function Step3VariablePay({
 	const isImpersonating = useIsImpersonating();
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
-	const rawDefaults = hasSavedData
-		? initialData
-		: gipPrefillData
-			? gipToStep3(gipPrefillData.step3)
-			: initialData;
-	const defaultValues = Object.fromEntries(
-		Object.entries(rawDefaults).map(([k, v]) =>
-			k === "indicatorEWomen" || k === "indicatorEMen"
-				? [k, v]
-				: [k, padDecimalToTwo(v)],
-		),
-	) as Step3Data;
 
-	const hasInitialData = hasSavedData;
+	function padStep3(data: Step3Data): Step3Data {
+		return Object.fromEntries(
+			Object.entries(data).map(([k, v]) =>
+				k === "indicatorEWomen" || k === "indicatorEMen" ? [k, v] : [k, padDecimalToTwo(v)],
+			),
+		) as Step3Data;
+	}
 
-	const dbValues = useMemo(
-		() =>
-			Object.fromEntries(
-				Object.entries(initialData).map(([k, v]) =>
-					k === "indicatorEWomen" || k === "indicatorEMen"
-						? [k, v]
-						: [k, padDecimalToTwo(v)],
-				),
-			) as Step3Data,
-		[initialData],
-	);
+	const rawDefaults = hasSavedData ? initialData : gipPrefillData ? gipToStep3(gipPrefillData.step3) : initialData;
+	const defaultValues = padStep3(rawDefaults);
+	const dbValues = useMemo(() => padStep3(initialData), [initialData]);
 
 	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
 		siren: declarationSiren,
@@ -111,7 +97,7 @@ export function Step3VariablePay({
 	const [benefValidationError, setBenefValidationError] = useState<
 		string | null
 	>(null);
-	const saved = !hasDraft && hasInitialData;
+	const saved = !hasDraft && hasSavedData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep3.useMutation({
@@ -188,7 +174,6 @@ export function Step3VariablePay({
 
 			<StepIndicator currentStep={3} />
 
-			{/* Introduction */}
 			<div className={common.flexColumnGap1}>
 				<p className="fr-mb-0">
 					Ces indicateurs évaluent et comparent les rémunérations variables
@@ -214,9 +199,7 @@ export function Step3VariablePay({
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 			</div>
 
-			{/* Data section */}
 			<div className={common.dataSection}>
-				{/* Table 1 - Variable pay gap + source */}
 				<div className={common.flexColumnGapHalf}>
 					<PayGapTable
 						caption="Écart de rémunération variable ou complémentaire"
@@ -241,7 +224,6 @@ export function Step3VariablePay({
 					)}
 				</div>
 
-				{/* Table 2 - Beneficiaries + source */}
 				<div className={common.flexColumnGapHalf}>
 					<div
 						className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import {
 	computeProportion,
@@ -18,6 +18,7 @@ import {
 	DEV_STEP3_BENEFICIARY_WOMEN,
 	DEV_STEP3_ROWS,
 } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
@@ -33,6 +34,7 @@ import type { PayGapField, Step3Data } from "../types";
 import stepStyles from "./Step3VariablePay.module.scss";
 
 type Step3VariablePayProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step3Data;
 	gipPrefillData?: GipPrefillData;
@@ -41,6 +43,7 @@ type Step3VariablePayProps = {
 };
 
 export function Step3VariablePay({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -66,7 +69,39 @@ export function Step3VariablePay({
 
 	const hasInitialData = hasSavedData;
 
+	const dbValues = useMemo(
+		() =>
+			Object.fromEntries(
+				Object.entries(initialData).map(([k, v]) =>
+					k === "indicatorEWomen" || k === "indicatorEMen"
+						? [k, v]
+						: [k, padDecimalToTwo(v)],
+				),
+			) as Step3Data,
+		[initialData],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 3,
+		kind: "main",
+		dbValues,
+	});
+
 	const form = useZodForm(updateStep3Schema, { defaultValues });
+
+	useEffect(() => {
+		(Object.keys(draft) as Array<keyof Step3Data>).forEach((key) => {
+			const value = draft[key];
+			if (value !== undefined) form.setValue(key, value as string);
+		});
+	}, [draft, form]);
+
+	useEffect(() => {
+		const sub = form.watch((values) => setField(values as Step3Data));
+		return () => sub.unsubscribe();
+	}, [form, setField]);
 
 	const formData = form.watch();
 	const rows = step3ToRows(formData as Step3Data);
@@ -76,11 +111,14 @@ export function Step3VariablePay({
 	const [benefValidationError, setBenefValidationError] = useState<
 		string | null
 	>(null);
-	const [saved, setSaved] = useState(hasInitialData);
+	const saved = !hasDraft && hasInitialData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep3.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/4"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/4");
+		},
 	});
 
 	function handleRowChange(index: number, field: PayGapField, value: string) {
@@ -89,7 +127,6 @@ export function Step3VariablePay({
 		if (normalized !== "" && Number.parseFloat(normalized) < 0) return;
 		const fieldName = getStep3FieldName(index, field);
 		form.setValue(fieldName, normalized);
-		setSaved(false);
 	}
 
 	function handleBenefChange(
@@ -113,7 +150,6 @@ export function Step3VariablePay({
 		}
 		setBenefValidationError(null);
 		form.setValue(field, value);
-		setSaved(false);
 	}
 
 	const onSubmit = form.handleSubmit(() => {
@@ -141,7 +177,6 @@ export function Step3VariablePay({
 					});
 					form.setValue("indicatorEWomen", DEV_STEP3_BENEFICIARY_WOMEN);
 					form.setValue("indicatorEMen", DEV_STEP3_BENEFICIARY_MEN);
-					setSaved(false);
 				}}
 				saved={saved}
 				title={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared";
@@ -9,6 +9,7 @@ import { api } from "~/trpc/react";
 import { updateStep4Schema } from "../schemas";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP4_ANNUAL, DEV_STEP4_HOURLY } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
@@ -36,7 +37,15 @@ import {
 	toQuartileData,
 } from "./step4/quartileFormHelpers";
 
+function padThresholds(qs: QuartileTuple): QuartileTuple {
+	return qs.map((q, i) => ({
+		...q,
+		threshold: i === 3 ? undefined : padDecimalToTwo(q.threshold ?? ""),
+	})) as QuartileTuple;
+}
+
 type Step4QuartileDistributionProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step4Data;
 	gipPrefillData?: GipPrefillData;
@@ -45,6 +54,7 @@ type Step4QuartileDistributionProps = {
 };
 
 export function Step4QuartileDistribution({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -63,12 +73,6 @@ export function Step4QuartileDistribution({
 			(q) => q.threshold || q.women !== undefined || q.men !== undefined,
 		);
 
-	const padThresholds = (qs: QuartileTuple): QuartileTuple =>
-		qs.map((q, i) => ({
-			...q,
-			threshold: i === 3 ? undefined : padDecimalToTwo(q.threshold ?? ""),
-		})) as QuartileTuple;
-
 	const defaultAnnual = padThresholds(
 		(hasSavedData
 			? initialData.annual
@@ -85,6 +89,26 @@ export function Step4QuartileDistribution({
 				: emptyQuartiles()) as QuartileTuple,
 	);
 
+	const dbValues = useMemo(
+		() => ({
+			annual: padThresholds(
+				hasSavedData ? (initialData.annual as QuartileTuple) : emptyQuartiles(),
+			),
+			hourly: padThresholds(
+				hasSavedData ? (initialData.hourly as QuartileTuple) : emptyQuartiles(),
+			),
+		}),
+		[hasSavedData, initialData],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 4,
+		kind: "main",
+		dbValues,
+	});
+
 	const form = useZodForm(updateStep4Schema, {
 		defaultValues: {
 			annual: defaultAnnual as QuartileTuple,
@@ -92,16 +116,34 @@ export function Step4QuartileDistribution({
 		},
 	});
 
+	useEffect(() => {
+		if (draft.annual) form.setValue("annual", draft.annual);
+		if (draft.hourly) form.setValue("hourly", draft.hourly);
+	}, [draft.annual, draft.hourly, form]);
+
+	useEffect(() => {
+		const sub = form.watch((values) =>
+			setField({
+				annual: values.annual as QuartileTuple,
+				hourly: values.hourly as QuartileTuple,
+			}),
+		);
+		return () => sub.unsubscribe();
+	}, [form, setField]);
+
 	const annual = form.watch("annual");
 	const hourly = form.watch("hourly");
 
 	const [maxError, setMaxError] = useState<string | null>(null);
-	const [saved, setSaved] = useState(hasSavedData);
+	const saved = !hasDraft && hasSavedData;
 	const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>(emptyErrorMap);
 	const [showRecap, setShowRecap] = useState(false);
 
 	const mutation = api.declaration.updateStep4.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/5"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/5");
+		},
 	});
 
 	function setQuartileField(
@@ -155,7 +197,6 @@ export function Step4QuartileDistribution({
 			if (value === "") {
 				setQuartileField(tableType, index, field, undefined);
 				setMaxError(null);
-				setSaved(false);
 				clearFieldError(tableType, index, field);
 				return;
 			}
@@ -172,7 +213,6 @@ export function Step4QuartileDistribution({
 			setMaxError(null);
 			setQuartileField(tableType, index, field, n);
 		}
-		setSaved(false);
 		clearFieldError(tableType, index, field);
 	}
 
@@ -217,7 +257,6 @@ export function Step4QuartileDistribution({
 							DEV_STEP4_HOURLY.map(toQuartileData) as QuartileTuple,
 						),
 					);
-					setSaved(false);
 					setFieldErrors(emptyErrorMap());
 					setShowRecap(false);
 				}}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -220,9 +220,10 @@ export function Step4QuartileDistribution({
 		requestAnimationFrame(() => alertRef.current?.focus());
 	}
 
-	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
-		event.preventDefault();
-		const values = form.getValues();
+	function onSubmitValid(values: {
+		annual: QuartileTuple;
+		hourly: QuartileTuple;
+	}) {
 		const errors = deriveErrors(values);
 		if (hasAnyError(errors)) {
 			setFieldErrors(errors);
@@ -242,7 +243,11 @@ export function Step4QuartileDistribution({
 	const showAlert = showRecap && recap.length > 0;
 
 	return (
-		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
+		<form
+			className={stepStyles.formColumn}
+			noValidate
+			onSubmit={form.handleSubmit(onSubmitValid)}
+		>
 			<StepTitleRow
 				onDevFill={() => {
 					form.setValue(
@@ -296,9 +301,9 @@ export function Step4QuartileDistribution({
 					role="alert"
 					tabIndex={-1}
 				>
-					<h3 className="fr-alert__title" id="step4-error-summary-title">
+					<p className="fr-alert__title" id="step4-error-summary-title">
 						Le formulaire contient des erreurs
-					</h3>
+					</p>
 					<ul>
 						{recap.map((entry) => (
 							<li key={entry.id}>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -1,14 +1,35 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
+import { padDecimalToTwo } from "~/modules/domain";
 import { api } from "~/trpc/react";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { StepIndicator } from "../shared/StepIndicator";
 import type { EmployeeCategoryRow } from "../types";
 import { CategoryForm } from "./step5/CategoryForm";
 
+type Step5FormValues = {
+	source: string;
+	categories: {
+		name: string;
+		womenCount: string;
+		menCount: string;
+		annualBaseWomen: string;
+		annualBaseMen: string;
+		annualVariableWomen: string;
+		annualVariableMen: string;
+		hourlyBaseWomen: string;
+		hourlyBaseMen: string;
+		hourlyVariableWomen: string;
+		hourlyVariableMen: string;
+	}[];
+};
+
 type Props = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialCategories?: EmployeeCategoryRow[];
 	initialSource?: string;
@@ -17,6 +38,7 @@ type Props = {
 };
 
 export function Step5EmployeeCategories({
+	declarationSiren,
 	declarationYear,
 	initialCategories,
 	initialSource,
@@ -27,18 +49,66 @@ export function Step5EmployeeCategories({
 	const isImpersonating = useIsImpersonating();
 	const hasInitialData = (initialCategories?.length ?? 0) > 0;
 
+	const dbValues = useMemo<Step5FormValues>(
+		() => ({
+			source: initialSource ?? "",
+			categories: (initialCategories ?? []).map((row) => ({
+				name: row.name,
+				womenCount: row.womenCount?.toString() ?? "",
+				menCount: row.menCount?.toString() ?? "",
+				annualBaseWomen: padDecimalToTwo(row.annualBaseWomen ?? ""),
+				annualBaseMen: padDecimalToTwo(row.annualBaseMen ?? ""),
+				annualVariableWomen: padDecimalToTwo(row.annualVariableWomen ?? ""),
+				annualVariableMen: padDecimalToTwo(row.annualVariableMen ?? ""),
+				hourlyBaseWomen: padDecimalToTwo(row.hourlyBaseWomen ?? ""),
+				hourlyBaseMen: padDecimalToTwo(row.hourlyBaseMen ?? ""),
+				hourlyVariableWomen: padDecimalToTwo(row.hourlyVariableWomen ?? ""),
+				hourlyVariableMen: padDecimalToTwo(row.hourlyVariableMen ?? ""),
+			})),
+		}),
+		[initialCategories, initialSource],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } =
+		useDeclarationDraft<Step5FormValues>({
+			siren: declarationSiren,
+			year: declarationYear,
+			step: 5,
+			kind: "main",
+			dbValues,
+		});
+
+	const [draftLoaded, setDraftLoaded] = useState(false);
+
+	useEffect(() => {
+		if (hasDraft && !draftLoaded) setDraftLoaded(true);
+	}, [hasDraft, draftLoaded]);
+
+	const categoryFormKey = draftLoaded ? 1 : 0;
+	const categoryFormDefaultOverride = draftLoaded
+		? {
+				source: draft.source ?? initialSource ?? "",
+				categories: draft.categories ?? dbValues.categories,
+			}
+		: undefined;
+
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/6"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/6");
+		},
 	});
 
 	return (
 		<CategoryForm
 			accordionId="accordion-step5"
+			defaultValuesOverride={categoryFormDefaultOverride}
 			disabled={isImpersonating}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
 			isSubmitting={mutation.isPending}
+			key={categoryFormKey}
 			maxMen={maxMen}
 			maxWomen={maxWomen}
 			mimoquageNextHref={
@@ -51,8 +121,10 @@ export function Step5EmployeeCategories({
 					categories: data.categories,
 				})
 			}
+			onValuesChange={(values) => setField(values)}
 			previousHref="/declaration-remuneration/etape/4"
 			referenceYear={declarationYear - 1}
+			savedOverride={!hasDraft && hasInitialData}
 			stepper={<StepIndicator currentStep={5} />}
 			submitError={mutation.error?.message}
 			title={

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
@@ -36,7 +36,11 @@ describe("Step2PayGap dev fill", () => {
 	it("fills pay gap rows when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
@@ -36,7 +36,7 @@ describe("Step2PayGap dev fill", () => {
 	it("fills pay gap rows when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -33,7 +33,7 @@ const emptyStep2Data = () => ({
 describe("Step2PayGap", () => {
 	it("renders the table with 4 remuneration rows", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 		expect(screen.getByText("Annuelle brute moyenne")).toBeInTheDocument();
 		expect(screen.getByText("Horaire brute moyenne")).toBeInTheDocument();
@@ -43,7 +43,7 @@ describe("Step2PayGap", () => {
 
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 		expect(
 			screen.getByText(
@@ -57,7 +57,7 @@ describe("Step2PayGap", () => {
 
 	it("renders table headers", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 		expect(screen.getByText("Rémunération")).toBeInTheDocument();
 		expect(screen.getByText("Femmes")).toBeInTheDocument();
@@ -71,6 +71,7 @@ describe("Step2PayGap", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step2PayGap
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					indicatorAAnnualWomen: "100",
@@ -89,7 +90,7 @@ describe("Step2PayGap", () => {
 
 	it("does not show SavedIndicator when initialData is empty", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
@@ -97,7 +98,7 @@ describe("Step2PayGap", () => {
 	it("updates values via inline inputs and rejects negative values", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -120,7 +121,7 @@ describe("Step2PayGap", () => {
 	it("computes gap and shows badge after entering values", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -139,7 +140,7 @@ describe("Step2PayGap", () => {
 	it("shows no badge when gap is less than 5%", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -158,7 +159,7 @@ describe("Step2PayGap", () => {
 
 	it("renders previous link pointing to step 1", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
@@ -169,6 +170,7 @@ describe("Step2PayGap", () => {
 	it("uses gipPrefillData when no initialData", () => {
 		render(
 			<Step2PayGap
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -220,7 +222,7 @@ describe("Step2PayGap", () => {
 	it("shows validation error on submit when fields are incomplete", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -33,7 +33,11 @@ const emptyStep2Data = () => ({
 describe("Step2PayGap", () => {
 	it("renders the table with 4 remuneration rows", () => {
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.getByText("Annuelle brute moyenne")).toBeInTheDocument();
 		expect(screen.getByText("Horaire brute moyenne")).toBeInTheDocument();
@@ -43,7 +47,11 @@ describe("Step2PayGap", () => {
 
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(
 			screen.getByText(
@@ -57,7 +65,11 @@ describe("Step2PayGap", () => {
 
 	it("renders table headers", () => {
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.getByText("Rémunération")).toBeInTheDocument();
 		expect(screen.getByText("Femmes")).toBeInTheDocument();
@@ -90,7 +102,11 @@ describe("Step2PayGap", () => {
 
 	it("does not show SavedIndicator when initialData is empty", () => {
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
@@ -98,7 +114,11 @@ describe("Step2PayGap", () => {
 	it("updates values via inline inputs and rejects negative values", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -121,7 +141,11 @@ describe("Step2PayGap", () => {
 	it("computes gap and shows badge after entering values", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -140,7 +164,11 @@ describe("Step2PayGap", () => {
 	it("shows no badge when gap is less than 5%", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -159,7 +187,11 @@ describe("Step2PayGap", () => {
 
 	it("renders previous link pointing to step 1", () => {
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
@@ -222,7 +254,11 @@ describe("Step2PayGap", () => {
 	it("shows validation error on submit when fields are incomplete", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationSiren="123456789" declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
@@ -39,6 +39,7 @@ describe("Step3VariablePay dev fill", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -36,6 +36,7 @@ describe("Step3VariablePay", () => {
 	it("renders the pay gap table with 4 rows", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -49,6 +50,7 @@ describe("Step3VariablePay", () => {
 	it("renders the beneficiaries table with workforce totals", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 				maxMen={60}
@@ -64,6 +66,7 @@ describe("Step3VariablePay", () => {
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -81,6 +84,7 @@ describe("Step3VariablePay", () => {
 	it("renders table headers with line break in column header", () => {
 		const { container } = render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -95,6 +99,7 @@ describe("Step3VariablePay", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					indicatorBAnnualWomen: "100",
@@ -116,6 +121,7 @@ describe("Step3VariablePay", () => {
 	it("does not show SavedIndicator when initialData is empty", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -127,6 +133,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -153,6 +160,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -175,6 +183,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -196,6 +205,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 				maxMen={25}
@@ -215,6 +225,7 @@ describe("Step3VariablePay", () => {
 	it("renders previous link pointing to step 2", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -228,6 +239,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData when no initialData", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },
@@ -282,6 +294,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData with null beneficiary counts", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },
@@ -335,6 +348,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData with zero beneficiary counts", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
@@ -41,6 +41,7 @@ describe("Step4QuartileDistribution dev fill", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
@@ -58,6 +58,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={validStep4Data()}
 			/>,
@@ -79,6 +80,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -113,6 +115,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -147,6 +150,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -38,6 +38,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders two tables with quartile rows and inverted columns", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -65,6 +66,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders renumeration tranche header and Pourcentage columns", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -84,6 +86,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders description text about quartiles", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -96,6 +99,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -113,6 +117,7 @@ describe("Step4QuartileDistribution", () => {
 	it("displays empty state with all min = - € and Q4 max = - €", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -126,6 +131,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders 3 threshold inputs per table (Q1/Q2/Q3 only) and Q4 readonly", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -141,6 +147,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders 4 women and 4 men count inputs per table", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -153,6 +160,7 @@ describe("Step4QuartileDistribution", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -172,6 +180,7 @@ describe("Step4QuartileDistribution", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -188,6 +197,7 @@ describe("Step4QuartileDistribution", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 				maxMen={25}
@@ -205,6 +215,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders mobile-label attributes on data cells for responsive reflow", () => {
 		const { container } = render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -228,6 +239,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders DSN source line on both tables even without GIP prefill", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -242,6 +254,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders accordion", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -254,6 +267,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders previous link pointing to step 3", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -267,6 +281,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData to pre-populate 3 thresholds and counts", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -322,6 +337,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData with all null quartile data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: null, totalMen: null },
@@ -375,6 +391,7 @@ describe("Step4QuartileDistribution", () => {
 	it("displays computed percentages for prefilled data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -399,6 +416,7 @@ describe("Step4QuartileDistribution", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -422,6 +440,7 @@ describe("Step4QuartileDistribution", () => {
 	it("does not show SavedIndicator when no initial data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
@@ -61,6 +61,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData when no initialCategories", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -95,6 +96,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData with partial null thresholds (Q4 has none)", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -126,6 +128,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData with all null quartile data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: null, totalMen: null },
@@ -158,6 +161,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData with mono-gender quartiles (100% women)", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 200, totalMen: 0 },

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
@@ -31,6 +31,7 @@ describe("Step5EmployeeCategories dev fill", () => {
 		const user = userEvent.setup();
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				maxMen={130}
 				maxWomen={120}

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -47,7 +47,12 @@ function makeCategory(
 
 describe("Step5EmployeeCategories", () => {
 	it("renders with 1 empty category by default", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByRole("button", { name: "Catégorie d'emplois n°1" }),
 		).toBeInTheDocument();
@@ -58,12 +63,22 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders stepper at step 5", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getByText("Étape 5 sur 6")).toBeInTheDocument();
 	});
 
 	it("renders description text and reference period", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByText(/mesurer l'écart de rémunération/),
 		).toBeInTheDocument();
@@ -71,7 +86,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders source dropdown", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByLabelText(/Quelle est la source utilisée/),
 		).toBeInTheDocument();
@@ -79,7 +99,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders instruction text", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByText(/Saisissez les données manquantes/),
 		).toBeInTheDocument();
@@ -89,7 +114,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table headers for the category", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getAllByText("Femmes").length).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByText("Hommes").length).toBeGreaterThanOrEqual(1);
 		expect(
@@ -98,7 +128,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table section headers", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getAllByText(/Total salariés/).length).toBe(1);
 		expect(
 			screen.getAllByText("Rémunération annuelle brute moyenne").length,
@@ -109,14 +144,24 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders the libellé input field for category", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(document.getElementById("cat-0-name")).toBeInTheDocument();
 		expect(document.getElementById("cat-0-detail")).not.toBeInTheDocument();
 	});
 
 	it("can add a new category", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		await user.click(
 			screen.getByRole("button", {
@@ -132,7 +177,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("can remove a category after confirmation", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		// Add a second category first
 		await user.click(
@@ -162,7 +212,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("updates input fields and computes gap", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const annualBaseWomenInput = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -180,7 +235,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("accepts salary values above 9999", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -192,7 +252,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("rejects negative values in number inputs", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -208,7 +273,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("computes annual total from base and variable", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		await user.type(
 			screen.getByLabelText("Salaire de base annuel femmes, catégorie 1"),
@@ -245,7 +315,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("does not show SavedIndicator with empty initial data", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 
@@ -273,7 +348,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("submits data on form submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",
@@ -326,7 +406,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category name is empty on submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
@@ -338,7 +423,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category names are duplicated", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		// Fill first category name
 		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
@@ -360,7 +450,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders previous link pointing to step 4", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/4",
@@ -368,7 +463,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders accordion for definitions", () => {
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByText("Définitions et méthode de calcul"),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -47,7 +47,7 @@ function makeCategory(
 
 describe("Step5EmployeeCategories", () => {
 	it("renders with 1 empty category by default", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(
 			screen.getByRole("button", { name: "Catégorie d'emplois n°1" }),
 		).toBeInTheDocument();
@@ -58,12 +58,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders stepper at step 5", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(screen.getByText("Étape 5 sur 6")).toBeInTheDocument();
 	});
 
 	it("renders description text and reference period", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(
 			screen.getByText(/mesurer l'écart de rémunération/),
 		).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders source dropdown", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(
 			screen.getByLabelText(/Quelle est la source utilisée/),
 		).toBeInTheDocument();
@@ -79,7 +79,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders instruction text", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(
 			screen.getByText(/Saisissez les données manquantes/),
 		).toBeInTheDocument();
@@ -89,7 +89,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table headers for the category", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(screen.getAllByText("Femmes").length).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByText("Hommes").length).toBeGreaterThanOrEqual(1);
 		expect(
@@ -98,7 +98,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table section headers", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(screen.getAllByText(/Total salariés/).length).toBe(1);
 		expect(
 			screen.getAllByText("Rémunération annuelle brute moyenne").length,
@@ -109,14 +109,14 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders the libellé input field for category", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(document.getElementById("cat-0-name")).toBeInTheDocument();
 		expect(document.getElementById("cat-0-detail")).not.toBeInTheDocument();
 	});
 
 	it("can add a new category", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		await user.click(
 			screen.getByRole("button", {
@@ -132,7 +132,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("can remove a category after confirmation", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		// Add a second category first
 		await user.click(
@@ -162,7 +162,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("updates input fields and computes gap", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		const annualBaseWomenInput = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -180,7 +180,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("accepts salary values above 9999", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -192,7 +192,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("rejects negative values in number inputs", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -208,7 +208,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("computes annual total from base and variable", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		await user.type(
 			screen.getByLabelText("Salaire de base annuel femmes, catégorie 1"),
@@ -227,6 +227,7 @@ describe("Step5EmployeeCategories", () => {
 	it("shows SavedIndicator when initial data exists", () => {
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialCategories={[
 					makeCategory({
@@ -244,13 +245,14 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("does not show SavedIndicator with empty initial data", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 
 	it("deserializes initial data into form fields", () => {
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialCategories={[
 					makeCategory({
@@ -271,7 +273,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("submits data on form submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",
@@ -297,6 +299,7 @@ describe("Step5EmployeeCategories", () => {
 		const user = userEvent.setup();
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				maxMen={20}
 				maxWomen={10}
@@ -323,7 +326,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category name is empty on submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
@@ -335,7 +338,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category names are duplicated", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		// Fill first category name
 		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
@@ -357,7 +360,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders previous link pointing to step 4", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/4",
@@ -365,7 +368,7 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders accordion for definitions", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 		expect(
 			screen.getByText("Définitions et méthode de calcul"),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -50,7 +50,7 @@ export function QuartileTable({
 
 	return (
 		<div className={stepStyles.tableWrapper}>
-			<h3 className="fr-h5 fr-mb-0">{title}</h3>
+			<h2 className="fr-h5 fr-mb-0">{title}</h2>
 			<div className={stepStyles.tableSection}>
 				{readingNote}
 				<div

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -420,7 +420,7 @@ export function CategoryForm({
 							className="fr-accordion"
 							key={field.id}
 						>
-							<h3 className="fr-accordion__title">
+							<h2 className="fr-accordion__title">
 								<button
 									aria-controls={collapseId}
 									aria-expanded="true"
@@ -431,7 +431,7 @@ export function CategoryForm({
 								>
 									{categoryLabel}
 								</button>
-							</h3>
+							</h2>
 							<div
 								className="fr-collapse fr-collapse--expanded"
 								id={collapseId}

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useFieldArray } from "react-hook-form";
 
 import { categoryFormSchema } from "~/modules/declaration-remuneration/schemas";
@@ -76,6 +76,39 @@ type Props = {
 	descriptionText?: string;
 	disabled?: boolean;
 	mimoquageNextHref?: string;
+	savedOverride?: boolean;
+	onValuesChange?: (values: {
+		source: string;
+		categories: {
+			name: string;
+			womenCount: string;
+			menCount: string;
+			annualBaseWomen: string;
+			annualBaseMen: string;
+			annualVariableWomen: string;
+			annualVariableMen: string;
+			hourlyBaseWomen: string;
+			hourlyBaseMen: string;
+			hourlyVariableWomen: string;
+			hourlyVariableMen: string;
+		}[];
+	}) => void;
+	defaultValuesOverride?: {
+		source: string;
+		categories: {
+			name: string;
+			womenCount: string;
+			menCount: string;
+			annualBaseWomen: string;
+			annualBaseMen: string;
+			annualVariableWomen: string;
+			annualVariableMen: string;
+			hourlyBaseWomen: string;
+			hourlyBaseMen: string;
+			hourlyVariableWomen: string;
+			hourlyVariableMen: string;
+		}[];
+	};
 };
 
 export function CategoryForm({
@@ -98,6 +131,9 @@ export function CategoryForm({
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 	disabled = false,
 	mimoquageNextHref,
+	savedOverride,
+	onValuesChange,
+	defaultValuesOverride,
 }: Props) {
 	const baseId = useId();
 	const nextId = useRef(createIdGenerator()).current;
@@ -108,11 +144,20 @@ export function CategoryForm({
 			: [createEmptyCategory(nextId())];
 
 	const form = useZodForm(categoryFormSchema, {
-		defaultValues: {
+		defaultValues: defaultValuesOverride ?? {
 			source: initialSource,
 			categories: toFormValues(initialCats),
 		},
 	});
+
+	useEffect(() => {
+		if (!onValuesChange) return;
+		const sub = form.watch(() => {
+			const values = form.getValues();
+			onValuesChange({ source: values.source, categories: values.categories });
+		});
+		return () => sub.unsubscribe();
+	}, [form, onValuesChange]);
 
 	const { fields, append, remove } = useFieldArray({
 		control: form.control,
@@ -120,7 +165,8 @@ export function CategoryForm({
 	});
 
 	const hasInitialData = initialCategories.length > 0;
-	const [saved, setSaved] = useState(hasInitialData);
+	const [savedInternal, setSaved] = useState(hasInitialData);
+	const saved = savedOverride !== undefined ? savedOverride : savedInternal;
 	const [workforceError, setWorkforceError] = useState("");
 	const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
 	const deleteDialogRef = useRef<HTMLDialogElement>(null);


### PR DESCRIPTION
Closes #3393

Extends la fondation `useDeclarationDraft` localStorage (implémentée pour Step1 en T1) aux 4 étapes restantes (Step2 à Step5) du formulaire `declaration-remuneration`.

## Changements

- **Step2PayGap** : ajout `declarationSiren`, `useDeclarationDraft`, draft apply/watch, `clearDraft()` on success
- **Step3VariablePay** : même pattern + gestion des 10 champs (dont `indicatorEWomen/Men` sans `padDecimalToTwo`)
- **Step4QuartileDistribution** : même pattern + `dbValues` useMemo pour les quartiles padded, `padThresholds` déplacé au niveau module
- **Step5EmployeeCategories** : pattern via `CategoryForm` avec `draftLoaded` state + `key` prop re-mount quand le draft charge async
- **CategoryForm** : 3 nouvelles props optionnelles (`savedOverride`, `onValuesChange`, `defaultValuesOverride`) pour backward compat
- **StepPageClient** : `declarationSiren` passé aux 4 steps
- Tests : `declarationSiren="123456789"` ajouté à tous les render calls Step2–Step5