### PR TITLE
feat(declaration): calcul + persistance pourcentages au submit (T2)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/__tests__/computeIndicatorPercentages.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/computeIndicatorPercentages.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+
+import { computeIndicatorPercentages } from "../shared/computeIndicatorPercentages";
+
+const nominalRow = {
+	indicatorAAnnualWomen: "100",
+	indicatorAAnnualMen: "110",
+	indicatorAHourlyWomen: "20",
+	indicatorAHourlyMen: "22",
+	indicatorBAnnualWomen: "50",
+	indicatorBAnnualMen: "55",
+	indicatorBHourlyWomen: "10",
+	indicatorBHourlyMen: "11",
+	indicatorCAnnualWomen: "95",
+	indicatorCAnnualMen: "105",
+	indicatorCHourlyWomen: "18",
+	indicatorCHourlyMen: "20",
+	indicatorDAnnualWomen: "45",
+	indicatorDAnnualMen: "50",
+	indicatorDHourlyWomen: "9",
+	indicatorDHourlyMen: "10",
+	indicatorEWomen: "30",
+	indicatorEMen: "70",
+	indicatorFAnnualWomen1: 10,
+	indicatorFAnnualWomen2: 20,
+	indicatorFAnnualWomen3: 30,
+	indicatorFAnnualWomen4: 40,
+	indicatorFAnnualMen1: 90,
+	indicatorFAnnualMen2: 80,
+	indicatorFAnnualMen3: 70,
+	indicatorFAnnualMen4: 60,
+	indicatorFHourlyWomen1: 5,
+	indicatorFHourlyWomen2: 15,
+	indicatorFHourlyWomen3: 25,
+	indicatorFHourlyWomen4: 35,
+	indicatorFHourlyMen1: 95,
+	indicatorFHourlyMen2: 85,
+	indicatorFHourlyMen3: 75,
+	indicatorFHourlyMen4: 65,
+};
+
+describe("computeIndicatorPercentages", () => {
+	describe("S1 — nominal case, all values present", () => {
+		it("computes globalAnnualMeanGap correctly", () => {
+			const result = computeIndicatorPercentages(nominalRow);
+			expect(result.globalAnnualMeanGap).toBeCloseTo((110 - 100) / 110);
+		});
+
+		it("computes all 8 gaps with no nulls", () => {
+			const result = computeIndicatorPercentages(nominalRow);
+			expect(result.globalAnnualMeanGap).not.toBeNull();
+			expect(result.globalHourlyMeanGap).not.toBeNull();
+			expect(result.variableAnnualMeanGap).not.toBeNull();
+			expect(result.variableHourlyMeanGap).not.toBeNull();
+			expect(result.globalAnnualMedianGap).not.toBeNull();
+			expect(result.globalHourlyMedianGap).not.toBeNull();
+			expect(result.variableAnnualMedianGap).not.toBeNull();
+			expect(result.variableHourlyMedianGap).not.toBeNull();
+		});
+
+		it("computes variableProportionWomen and variableProportionMen", () => {
+			const result = computeIndicatorPercentages(nominalRow);
+			expect(result.variableProportionWomen).toBeCloseTo(30 / 100);
+			expect(result.variableProportionMen).toBeCloseTo(70 / 100);
+		});
+
+		it("computes annual quartile 1 proportions", () => {
+			const result = computeIndicatorPercentages(nominalRow);
+			expect(result.annualQuartile1ProportionWomen).toBeCloseTo(10 / 100);
+			expect(result.annualQuartile1ProportionMen).toBeCloseTo(90 / 100);
+		});
+
+		it("computes all 16 F proportions with no nulls", () => {
+			const result = computeIndicatorPercentages(nominalRow);
+			expect(result.annualQuartile1ProportionWomen).not.toBeNull();
+			expect(result.annualQuartile2ProportionWomen).not.toBeNull();
+			expect(result.annualQuartile3ProportionWomen).not.toBeNull();
+			expect(result.annualQuartile4ProportionWomen).not.toBeNull();
+			expect(result.annualQuartile1ProportionMen).not.toBeNull();
+			expect(result.annualQuartile2ProportionMen).not.toBeNull();
+			expect(result.annualQuartile3ProportionMen).not.toBeNull();
+			expect(result.annualQuartile4ProportionMen).not.toBeNull();
+			expect(result.hourlyQuartile1ProportionWomen).not.toBeNull();
+			expect(result.hourlyQuartile2ProportionWomen).not.toBeNull();
+			expect(result.hourlyQuartile3ProportionWomen).not.toBeNull();
+			expect(result.hourlyQuartile4ProportionWomen).not.toBeNull();
+			expect(result.hourlyQuartile1ProportionMen).not.toBeNull();
+			expect(result.hourlyQuartile2ProportionMen).not.toBeNull();
+			expect(result.hourlyQuartile3ProportionMen).not.toBeNull();
+			expect(result.hourlyQuartile4ProportionMen).not.toBeNull();
+		});
+	});
+
+	describe("S3 (révisé) — signed ratio for 4.5% gap", () => {
+		it("globalAnnualMeanGap is positive ratio when men > women", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorAAnnualWomen: "105",
+				indicatorAAnnualMen: "110",
+			});
+			expect(result.globalAnnualMeanGap).toBeCloseTo((110 - 105) / 110);
+		});
+	});
+
+	describe("S4 — NULL inputs yield NULL outputs", () => {
+		it("returns null for globalAnnualMeanGap when women is null", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorAAnnualWomen: null,
+			});
+			expect(result.globalAnnualMeanGap).toBeNull();
+		});
+
+		it("returns null for globalAnnualMeanGap when men is null", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorAAnnualMen: null,
+			});
+			expect(result.globalAnnualMeanGap).toBeNull();
+		});
+
+		it("other gaps remain computed when one gap has null inputs", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorAAnnualWomen: null,
+			});
+			expect(result.globalHourlyMeanGap).not.toBeNull();
+			expect(result.variableAnnualMeanGap).not.toBeNull();
+		});
+
+		it("returns null proportions for quartile with total zero", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorFAnnualWomen1: 0,
+				indicatorFAnnualMen1: 0,
+			});
+			expect(result.annualQuartile1ProportionWomen).toBeNull();
+			expect(result.annualQuartile1ProportionMen).toBeNull();
+		});
+
+		it("other quartile proportions remain when one quartile is zero total", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorFAnnualWomen1: 0,
+				indicatorFAnnualMen1: 0,
+			});
+			expect(result.annualQuartile2ProportionWomen).not.toBeNull();
+		});
+
+		it("returns null E proportions when total is zero", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorEWomen: "0",
+				indicatorEMen: "0",
+			});
+			expect(result.variableProportionWomen).toBeNull();
+			expect(result.variableProportionMen).toBeNull();
+		});
+
+		it("returns null for F proportions when count inputs are null", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorFAnnualWomen1: null,
+			});
+			expect(result.annualQuartile1ProportionWomen).toBeNull();
+			expect(result.annualQuartile1ProportionMen).toBeNull();
+		});
+
+		it("returns null E proportions when women count is null", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorEWomen: null,
+			});
+			expect(result.variableProportionWomen).toBeNull();
+			expect(result.variableProportionMen).toBeNull();
+		});
+
+		it("returns null E proportions when men count is null", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorEMen: null,
+			});
+			expect(result.variableProportionWomen).toBeNull();
+			expect(result.variableProportionMen).toBeNull();
+		});
+
+		it("returns null E proportions for non-numeric string inputs", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorEWomen: "abc",
+			});
+			expect(result.variableProportionWomen).toBeNull();
+			expect(result.variableProportionMen).toBeNull();
+		});
+	});
+
+	describe("sign — negative gap when women earn more", () => {
+		it("variableAnnualMeanGap is negative when women > men", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorBAnnualWomen: "120",
+				indicatorBAnnualMen: "100",
+			});
+			expect(result.variableAnnualMeanGap).toBeCloseTo(-0.2);
+		});
+	});
+
+	describe("rounding — F proportions rounded to 4 decimal places", () => {
+		it("proportion of 1/3 rounds to 0.3333", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorFAnnualWomen1: 1,
+				indicatorFAnnualMen1: 2,
+			});
+			expect(result.annualQuartile1ProportionWomen).toBe(0.3333);
+		});
+
+		it("proportion of 2/3 rounds to 0.6667", () => {
+			const result = computeIndicatorPercentages({
+				...nominalRow,
+				indicatorFAnnualWomen1: 1,
+				indicatorFAnnualMen1: 2,
+			});
+			expect(result.annualQuartile1ProportionMen).toBe(0.6667);
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -13,6 +13,7 @@ export {
 	updateStep4Schema,
 } from "./schemas";
 export { ComplianceCompletionEffect } from "./shared/ComplianceCompletionEffect";
+export { computeIndicatorPercentages } from "./shared/computeIndicatorPercentages";
 export { DevFillButton } from "./shared/DevFillButton";
 export { GAP_LEVEL_LABELS, gapBadgeClass } from "./shared/gapBadge";
 export type {

--- a/packages/app/src/modules/declaration-remuneration/shared/computeIndicatorPercentages.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/computeIndicatorPercentages.ts
@@ -1,0 +1,194 @@
+import { computeGapRatio } from "~/modules/domain";
+
+type DeclarationRowSubset = {
+	indicatorAAnnualWomen: string | null;
+	indicatorAAnnualMen: string | null;
+	indicatorAHourlyWomen: string | null;
+	indicatorAHourlyMen: string | null;
+	indicatorBAnnualWomen: string | null;
+	indicatorBAnnualMen: string | null;
+	indicatorBHourlyWomen: string | null;
+	indicatorBHourlyMen: string | null;
+	indicatorCAnnualWomen: string | null;
+	indicatorCAnnualMen: string | null;
+	indicatorCHourlyWomen: string | null;
+	indicatorCHourlyMen: string | null;
+	indicatorDAnnualWomen: string | null;
+	indicatorDAnnualMen: string | null;
+	indicatorDHourlyWomen: string | null;
+	indicatorDHourlyMen: string | null;
+	indicatorEWomen: string | null;
+	indicatorEMen: string | null;
+	indicatorFAnnualWomen1: number | null;
+	indicatorFAnnualWomen2: number | null;
+	indicatorFAnnualWomen3: number | null;
+	indicatorFAnnualWomen4: number | null;
+	indicatorFAnnualMen1: number | null;
+	indicatorFAnnualMen2: number | null;
+	indicatorFAnnualMen3: number | null;
+	indicatorFAnnualMen4: number | null;
+	indicatorFHourlyWomen1: number | null;
+	indicatorFHourlyWomen2: number | null;
+	indicatorFHourlyWomen3: number | null;
+	indicatorFHourlyWomen4: number | null;
+	indicatorFHourlyMen1: number | null;
+	indicatorFHourlyMen2: number | null;
+	indicatorFHourlyMen3: number | null;
+	indicatorFHourlyMen4: number | null;
+};
+
+type ComputedPercentages = {
+	globalAnnualMeanGap: number | null;
+	globalHourlyMeanGap: number | null;
+	variableAnnualMeanGap: number | null;
+	variableHourlyMeanGap: number | null;
+	globalAnnualMedianGap: number | null;
+	globalHourlyMedianGap: number | null;
+	variableAnnualMedianGap: number | null;
+	variableHourlyMedianGap: number | null;
+	variableProportionWomen: number | null;
+	variableProportionMen: number | null;
+	annualQuartile1ProportionWomen: number | null;
+	annualQuartile2ProportionWomen: number | null;
+	annualQuartile3ProportionWomen: number | null;
+	annualQuartile4ProportionWomen: number | null;
+	annualQuartile1ProportionMen: number | null;
+	annualQuartile2ProportionMen: number | null;
+	annualQuartile3ProportionMen: number | null;
+	annualQuartile4ProportionMen: number | null;
+	hourlyQuartile1ProportionWomen: number | null;
+	hourlyQuartile2ProportionWomen: number | null;
+	hourlyQuartile3ProportionWomen: number | null;
+	hourlyQuartile4ProportionWomen: number | null;
+	hourlyQuartile1ProportionMen: number | null;
+	hourlyQuartile2ProportionMen: number | null;
+	hourlyQuartile3ProportionMen: number | null;
+	hourlyQuartile4ProportionMen: number | null;
+};
+
+function gapOrNull(women: string | null, men: string | null): number | null {
+	if (women === null || men === null) return null;
+	return computeGapRatio(women, men);
+}
+
+function proportionFromCounts(
+	women: number | null,
+	men: number | null,
+): { women: number | null; men: number | null } {
+	if (women === null || men === null) return { women: null, men: null };
+	const total = women + men;
+	if (total === 0) return { women: null, men: null };
+	return {
+		women: Math.round((women / total) * 10_000) / 10_000,
+		men: Math.round((men / total) * 10_000) / 10_000,
+	};
+}
+
+function proportionFromStrings(
+	women: string | null,
+	men: string | null,
+): { women: number | null; men: number | null } {
+	if (women === null || men === null) return { women: null, men: null };
+	const w = Number(women);
+	const m = Number(men);
+	if (Number.isNaN(w) || Number.isNaN(m)) return { women: null, men: null };
+	const total = w + m;
+	if (total === 0) return { women: null, men: null };
+	return {
+		women: w / total,
+		men: m / total,
+	};
+}
+
+export function computeIndicatorPercentages(
+	row: DeclarationRowSubset,
+): ComputedPercentages {
+	const eProps = proportionFromStrings(row.indicatorEWomen, row.indicatorEMen);
+
+	const fAnnual1 = proportionFromCounts(
+		row.indicatorFAnnualWomen1,
+		row.indicatorFAnnualMen1,
+	);
+	const fAnnual2 = proportionFromCounts(
+		row.indicatorFAnnualWomen2,
+		row.indicatorFAnnualMen2,
+	);
+	const fAnnual3 = proportionFromCounts(
+		row.indicatorFAnnualWomen3,
+		row.indicatorFAnnualMen3,
+	);
+	const fAnnual4 = proportionFromCounts(
+		row.indicatorFAnnualWomen4,
+		row.indicatorFAnnualMen4,
+	);
+
+	const fHourly1 = proportionFromCounts(
+		row.indicatorFHourlyWomen1,
+		row.indicatorFHourlyMen1,
+	);
+	const fHourly2 = proportionFromCounts(
+		row.indicatorFHourlyWomen2,
+		row.indicatorFHourlyMen2,
+	);
+	const fHourly3 = proportionFromCounts(
+		row.indicatorFHourlyWomen3,
+		row.indicatorFHourlyMen3,
+	);
+	const fHourly4 = proportionFromCounts(
+		row.indicatorFHourlyWomen4,
+		row.indicatorFHourlyMen4,
+	);
+
+	return {
+		globalAnnualMeanGap: gapOrNull(
+			row.indicatorAAnnualWomen,
+			row.indicatorAAnnualMen,
+		),
+		globalHourlyMeanGap: gapOrNull(
+			row.indicatorAHourlyWomen,
+			row.indicatorAHourlyMen,
+		),
+		variableAnnualMeanGap: gapOrNull(
+			row.indicatorBAnnualWomen,
+			row.indicatorBAnnualMen,
+		),
+		variableHourlyMeanGap: gapOrNull(
+			row.indicatorBHourlyWomen,
+			row.indicatorBHourlyMen,
+		),
+		globalAnnualMedianGap: gapOrNull(
+			row.indicatorCAnnualWomen,
+			row.indicatorCAnnualMen,
+		),
+		globalHourlyMedianGap: gapOrNull(
+			row.indicatorCHourlyWomen,
+			row.indicatorCHourlyMen,
+		),
+		variableAnnualMedianGap: gapOrNull(
+			row.indicatorDAnnualWomen,
+			row.indicatorDAnnualMen,
+		),
+		variableHourlyMedianGap: gapOrNull(
+			row.indicatorDHourlyWomen,
+			row.indicatorDHourlyMen,
+		),
+		variableProportionWomen: eProps.women,
+		variableProportionMen: eProps.men,
+		annualQuartile1ProportionWomen: fAnnual1.women,
+		annualQuartile2ProportionWomen: fAnnual2.women,
+		annualQuartile3ProportionWomen: fAnnual3.women,
+		annualQuartile4ProportionWomen: fAnnual4.women,
+		annualQuartile1ProportionMen: fAnnual1.men,
+		annualQuartile2ProportionMen: fAnnual2.men,
+		annualQuartile3ProportionMen: fAnnual3.men,
+		annualQuartile4ProportionMen: fAnnual4.men,
+		hourlyQuartile1ProportionWomen: fHourly1.women,
+		hourlyQuartile2ProportionWomen: fHourly2.women,
+		hourlyQuartile3ProportionWomen: fHourly3.women,
+		hourlyQuartile4ProportionWomen: fHourly4.women,
+		hourlyQuartile1ProportionMen: fHourly1.men,
+		hourlyQuartile2ProportionMen: fHourly2.men,
+		hourlyQuartile3ProportionMen: fHourly3.men,
+		hourlyQuartile4ProportionMen: fHourly4.men,
+	};
+}

--- a/packages/app/src/modules/domain/__tests__/gap.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gap.test.ts
@@ -2,10 +2,41 @@ import { describe, expect, it } from "vitest";
 
 import {
 	computeGap,
+	computeGapRatio,
 	computeTotal,
 	gapLevel,
 	hasGapsAboveThreshold,
 } from "../shared/gap";
+
+describe("computeGapRatio", () => {
+	it("returns positive ratio when men earn more", () => {
+		expect(computeGapRatio("100", "110")).toBeCloseTo((110 - 100) / 110);
+	});
+
+	it("returns negative ratio when women earn more", () => {
+		expect(computeGapRatio("110", "100")).toBeCloseTo(-0.1);
+	});
+
+	it("returns 0 for equal values", () => {
+		expect(computeGapRatio("100", "100")).toBe(0);
+	});
+
+	it("returns null when women value is empty", () => {
+		expect(computeGapRatio("", "100")).toBeNull();
+	});
+
+	it("returns null when men value is zero (division by zero)", () => {
+		expect(computeGapRatio("100", "0")).toBeNull();
+	});
+
+	it("returns null when men value is empty", () => {
+		expect(computeGapRatio("100", "")).toBeNull();
+	});
+
+	it("returns null for non-numeric women value", () => {
+		expect(computeGapRatio("abc", "100")).toBeNull();
+	});
+});
 
 describe("computeGap", () => {
 	it("computes gap as absolute percentage", () => {

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -48,6 +48,7 @@ export {
 // Gap business rules (calculations & threshold classification)
 export {
 	computeGap,
+	computeGapRatio,
 	computeTotal,
 	gapLevel,
 	hasGapsAboveThreshold,

--- a/packages/app/src/modules/domain/shared/gap.ts
+++ b/packages/app/src/modules/domain/shared/gap.ts
@@ -18,6 +18,18 @@ import type { GapLevel } from "../types";
 import { GAP_ALERT_THRESHOLD } from "./constants";
 import { parseNumber } from "./number";
 
+/** Compute signed gap ratio: (men - women) / men. Returns null if invalid or men is 0. Range: typically -1..1.
+ *  Sign convention: positive when men earn more (typical case), negative when women earn more. */
+export function computeGapRatio(
+	womenVal: string,
+	menVal: string,
+): number | null {
+	const w = parseNumber(womenVal);
+	const m = parseNumber(menVal);
+	if (Number.isNaN(w) || Number.isNaN(m) || m === 0) return null;
+	return (m - w) / m;
+}
+
 /** Compute gap as absolute percentage: |((men - women) / men) * 100|. Returns null if inputs are invalid or men is zero. */
 export function computeGap(womenVal: string, menVal: string): number | null {
 	const w = parseNumber(womenVal);

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -224,8 +224,46 @@ describe("declarationRouter", () => {
 	});
 
 	describe("submit", () => {
+		const mockDeclarationWithIndicators = {
+			submittedAt: null,
+			indicatorAAnnualWomen: "100",
+			indicatorAAnnualMen: "110",
+			indicatorAHourlyWomen: "20",
+			indicatorAHourlyMen: "22",
+			indicatorBAnnualWomen: "50",
+			indicatorBAnnualMen: "55",
+			indicatorBHourlyWomen: "10",
+			indicatorBHourlyMen: "11",
+			indicatorCAnnualWomen: "95",
+			indicatorCAnnualMen: "105",
+			indicatorCHourlyWomen: "18",
+			indicatorCHourlyMen: "20",
+			indicatorDAnnualWomen: "45",
+			indicatorDAnnualMen: "50",
+			indicatorDHourlyWomen: "9",
+			indicatorDHourlyMen: "10",
+			indicatorEWomen: "30",
+			indicatorEMen: "70",
+			indicatorFAnnualWomen1: 10,
+			indicatorFAnnualWomen2: 20,
+			indicatorFAnnualWomen3: 30,
+			indicatorFAnnualWomen4: 40,
+			indicatorFAnnualMen1: 90,
+			indicatorFAnnualMen2: 80,
+			indicatorFAnnualMen3: 70,
+			indicatorFAnnualMen4: 60,
+			indicatorFHourlyWomen1: 5,
+			indicatorFHourlyWomen2: 15,
+			indicatorFHourlyWomen3: 25,
+			indicatorFHourlyWomen4: 35,
+			indicatorFHourlyMen1: 95,
+			indicatorFHourlyMen2: 85,
+			indicatorFHourlyMen3: 75,
+			indicatorFHourlyMen4: 65,
+		};
+
 		it("sets status to submitted and step to 6", async () => {
-			const mockDb = createMockDb();
+			const mockDb = createMockDb([mockDeclarationWithIndicators]);
 			const caller = await createCaller(mockDb);
 
 			const result = await caller.submit();
@@ -237,6 +275,48 @@ describe("declarationRouter", () => {
 					currentStep: 6,
 				}),
 			);
+		});
+
+		it("persists computed percentage columns on submit", async () => {
+			const mockDb = createMockDb([mockDeclarationWithIndicators]);
+			const caller = await createCaller(mockDb);
+
+			await caller.submit();
+
+			const setCall = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(setCall).toBeDefined();
+
+			const expectedGlobalAnnualMeanGap = (110 - 100) / 110;
+			expect(Number(setCall.globalAnnualMeanGap)).toBeCloseTo(
+				expectedGlobalAnnualMeanGap,
+			);
+
+			const expectedVariableProportionWomen = 30 / 100;
+			expect(Number(setCall.variableProportionWomen)).toBeCloseTo(
+				expectedVariableProportionWomen,
+			);
+
+			const expectedAnnualQ1ProportionWomen = 10 / 100;
+			expect(Number(setCall.annualQuartile1ProportionWomen)).toBeCloseTo(
+				expectedAnnualQ1ProportionWomen,
+			);
+		});
+
+		it("persists null percentage columns as null when inputs are null", async () => {
+			const mockDb = createMockDb([
+				{
+					...mockDeclarationWithIndicators,
+					indicatorAAnnualWomen: null,
+					indicatorAAnnualMen: null,
+				},
+			]);
+			const caller = await createCaller(mockDb);
+
+			await caller.submit();
+
+			const setCall = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(setCall).toBeDefined();
+			expect(setCall.globalAnnualMeanGap).toBeNull();
 		});
 
 		it("throws when siret is missing", async () => {

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -8,6 +8,7 @@ import {
 	updateStep3Schema,
 	updateStep4Schema,
 } from "~/modules/declaration-remuneration/schemas";
+import { computeIndicatorPercentages } from "~/modules/declaration-remuneration/shared/computeIndicatorPercentages";
 import { mapGipToFormData } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import { getCurrentYear } from "~/modules/domain";
 import {
@@ -452,18 +453,65 @@ export const declarationRouter = createTRPCRouter({
 		// Preserve the very first submission date — resubmissions after
 		// corrections must not move the campaign progression curve.
 		const [existing] = await ctx.db
-			.select({ submittedAt: declarations.submittedAt })
+			.select({
+				submittedAt: declarations.submittedAt,
+				indicatorAAnnualWomen: declarations.indicatorAAnnualWomen,
+				indicatorAAnnualMen: declarations.indicatorAAnnualMen,
+				indicatorAHourlyWomen: declarations.indicatorAHourlyWomen,
+				indicatorAHourlyMen: declarations.indicatorAHourlyMen,
+				indicatorBAnnualWomen: declarations.indicatorBAnnualWomen,
+				indicatorBAnnualMen: declarations.indicatorBAnnualMen,
+				indicatorBHourlyWomen: declarations.indicatorBHourlyWomen,
+				indicatorBHourlyMen: declarations.indicatorBHourlyMen,
+				indicatorCAnnualWomen: declarations.indicatorCAnnualWomen,
+				indicatorCAnnualMen: declarations.indicatorCAnnualMen,
+				indicatorCHourlyWomen: declarations.indicatorCHourlyWomen,
+				indicatorCHourlyMen: declarations.indicatorCHourlyMen,
+				indicatorDAnnualWomen: declarations.indicatorDAnnualWomen,
+				indicatorDAnnualMen: declarations.indicatorDAnnualMen,
+				indicatorDHourlyWomen: declarations.indicatorDHourlyWomen,
+				indicatorDHourlyMen: declarations.indicatorDHourlyMen,
+				indicatorEWomen: declarations.indicatorEWomen,
+				indicatorEMen: declarations.indicatorEMen,
+				indicatorFAnnualWomen1: declarations.indicatorFAnnualWomen1,
+				indicatorFAnnualWomen2: declarations.indicatorFAnnualWomen2,
+				indicatorFAnnualWomen3: declarations.indicatorFAnnualWomen3,
+				indicatorFAnnualWomen4: declarations.indicatorFAnnualWomen4,
+				indicatorFAnnualMen1: declarations.indicatorFAnnualMen1,
+				indicatorFAnnualMen2: declarations.indicatorFAnnualMen2,
+				indicatorFAnnualMen3: declarations.indicatorFAnnualMen3,
+				indicatorFAnnualMen4: declarations.indicatorFAnnualMen4,
+				indicatorFHourlyWomen1: declarations.indicatorFHourlyWomen1,
+				indicatorFHourlyWomen2: declarations.indicatorFHourlyWomen2,
+				indicatorFHourlyWomen3: declarations.indicatorFHourlyWomen3,
+				indicatorFHourlyWomen4: declarations.indicatorFHourlyWomen4,
+				indicatorFHourlyMen1: declarations.indicatorFHourlyMen1,
+				indicatorFHourlyMen2: declarations.indicatorFHourlyMen2,
+				indicatorFHourlyMen3: declarations.indicatorFHourlyMen3,
+				indicatorFHourlyMen4: declarations.indicatorFHourlyMen4,
+			})
 			.from(declarations)
 			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
 			.limit(1);
+
+		if (!existing) throw new TRPCError({ code: "NOT_FOUND" });
+
+		const percentages = computeIndicatorPercentages(existing);
+		const percentagesForDb = Object.fromEntries(
+			Object.entries(percentages).map(([k, v]) => [
+				k,
+				v === null ? null : v.toString(),
+			]),
+		);
 
 		await ctx.db
 			.update(declarations)
 			.set({
 				status: "submitted",
 				currentStep: 6,
-				submittedAt: existing?.submittedAt ?? now,
+				submittedAt: existing.submittedAt ?? now,
 				updatedAt: now,
+				...percentagesForDb,
 			})
 			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
 


### PR DESCRIPTION
Closes #3397

## Changements

- `computeGapRatio(women, men)` dans `~/modules/domain/shared/gap.ts` : ratio signé `(men - women) / men`, renvoie `null` si entrées invalides ou `men === 0`
- `computeIndicatorPercentages(row)` dans `~/modules/declaration-remuneration/shared/computeIndicatorPercentages.ts` : fonction pure calculant les 26 colonnes pourcentage (8 écarts de rémunération signés, 2 proportions variables, 16 proportions quartile)
- Branchement dans `declaration.submit` : SELECT de tous les champs indicateurs → appel `computeIndicatorPercentages` → cast `number|null → string|null` → spread dans `update().set()`

## Tests

- 7 cas unitaires pour `computeGapRatio` (positif, négatif, zéro, null, division par zéro)
- Couverture complète de `computeIndicatorPercentages` : cas nominal, signe, nulls, totaux zéro, arrondi à 4 décimales
- 3 cas tRPC pour `declaration.submit` : colonnes percentages persistées avec valeurs correctes, colonnes null quand inputs null

## Test plan

- `pnpm test` — 218 fichiers, 1713 tests, tous verts
- Assertions tRPC sur `globalAnnualMeanGap`, `variableProportionWomen`, `annualQuartile1ProportionWomen`
- `pnpm typecheck` + `pnpm lint:check` + `pnpm format:check` — aucune erreur
