### PR TITLE
fix(pipeline): 3 bugs orchestration epic — dispatch gating, /implement worktree, PR-issue link

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -80,9 +80,25 @@ L'objectif : transformer une task vague en un spec exécutable, **sans découpag
    - Depends on (rare en task — la plupart des tasks sont autonomes)
    - Requires services (rare — typiquement core stack suffit)
 
-5. **Validation utilisateur EXPLICITE** : « valides-tu cette analyse ? ». Itérer si besoin.
+5. **Évaluation du scope** — avant de demander la validation utilisateur, comparer le draft à ces seuils. Une task standard est une **unité cohérente exécutable par un seul `code-dev`**. Si **au moins un** seuil est franchement dépassé, le ticket doit basculer en Feature (epic) plutôt qu'en task :
 
-6. **Sur approbation** : poster un seul commentaire sur la task (pas de modification du body) :
+   - \> 8 critères d'acceptation
+   - \> 5 fichiers à modifier
+   - Refacto multi-modules (touche plusieurs `~/modules/*` distincts, ou couches multiples comme domain + UI + tRPC + tests + scripts)
+   - Création d'un nouveau sous-module (nouveau dossier sous `~/modules/<feature>/<sous-module>/`)
+   - Plus d'un flow utilisateur indépendant impacté (ex : Step1 du parcours principal + JointEvaluationForm + CompliancePathChoice)
+   - Présence de dépendances internes naturelles (foundation → câblage répétitif sur N forms) qui se découperaient en T1 + T2 + T3 parallélisables
+
+   **Cas limite** : un spec avec exactement 8 critères et 5 fichiers reste une task. Le dépassement doit être franc, pas marginal.
+
+   **Si dépassement** :
+   - Présenter le constat au user en 2-3 lignes : « Le scope dépasse une task standard ([raison concrète : X fichiers, Y modules touchés, Z critères]). Je recommande de convertir cette issue en Feature et de relancer `/analyse` en mode epic-create pour découper en sub-tasks parallélisables. »
+   - **Si user accepte** : convertir l'issue type Task → Feature via la mutation GraphQL `updateIssueIssueType` (cf. `rules/github-board.md` snippet 7, ID Feature = `IT_kwDOAh0HH84Aa_K4`), poster un commentaire `[Architect] Converti en Feature — relancer /analyse #N pour le découpage`, puis **exiter le mode task** (ne pas poster d'analyse architecte). L'utilisateur relancera `/analyse #N` qui passera automatiquement en mode `epic-create`.
+   - **Si user refuse** : poursuivre en mode task malgré le scope. Mentionner dans le draft que le ticket est volumineux et appliquer le label `complexe` (Opus) systématiquement.
+
+6. **Validation utilisateur EXPLICITE** : « valides-tu cette analyse ? ». Itérer si besoin.
+
+7. **Sur approbation** : poster un seul commentaire sur la task (pas de modification du body) :
    ```bash
    gh issue comment "$TASK_N" --body-file <(cat <<'EOF'
    ## Analyse architecte
@@ -93,7 +109,7 @@ L'objectif : transformer une task vague en un spec exécutable, **sans découpag
    ```
    Appliquer le label `complexe` si > 5 fichiers ou refacto multi-modules attendu (op. via `gh issue edit --add-label`).
 
-7. **Commentaire final** : `[Validation utilisateur] Analyse validée — prêt pour /implement`.
+8. **Commentaire final** : `[Validation utilisateur] Analyse validée — prêt pour /implement`.
 
 ---
 

--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -67,19 +67,19 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
 8. **PR draft** via `gh pr create --draft --base <base-branch>` :
    - Base = la `<base-branch>` reçue en input (sans le préfixe `origin/`) — `epic/<EPIC_N>` (sub-issue d'epic) ou `alpha` (Task / Bug standalone)
    - Body : `Closes #NNN` **sur la première ligne** (obligatoire pour que le force-link de l'étape 8.5 fonctionne), suivi du résumé, test plan, screenshots
-   - **Note auto-close** : `Closes #N` ne déclenche l'auto-close du ticket que sur merge dans la branche par défaut (`master`) ; sur le merge dans `epic/<N>` ou `alpha`, le ticket reste ouvert jusqu'à la release `alpha → master`. Le force-link ci-dessous ne corrige pas ça — il sert uniquement à faire apparaître la PR dans la sidebar Development de l'issue.
+   - **Note auto-close** : `Closes #N` ne déclenche l'auto-close du ticket que sur merge dans la branche par défaut (`alpha`). Pour une PR de sub-issue ciblant `epic/<N>`, le ticket reste ouvert jusqu'à ce que la PR finale `epic/<N> → alpha` merge — son body recopie `Closes #N` pour chaque sub-issue, ce qui déclenche l'auto-close de toutes en un coup. Le force-link ci-dessous ne corrige pas ça — il sert uniquement à faire apparaître la PR dans la sidebar Development de l'issue dès sa création.
    - **Ticket reste en In progress** pendant les validators
    - Logger `PR_DRAFT` avec le numéro de PR.
 
 8.5. **Force le lien formel PR ↔ issue** :
 
-   GitHub n'enregistre `closingIssuesReferences` (la liste qui peuple la sidebar « Development » de l'issue) **que** si la PR a été créée avec `--base master` (la branche par défaut). Comme on cible `epic/<N>` ou `alpha`, le `Closes #N` reste dans le body sans créer le lien formel. Workaround : flip la base sur `master` puis revenir.
+   GitHub n'enregistre `closingIssuesReferences` (la liste qui peuple la sidebar « Development » de l'issue) **que** si la PR a été créée avec `--base <default-branch>` (`alpha` actuellement). Comme on cible `epic/<N>`, le `Closes #N` reste dans le body sans créer le lien formel. Workaround : flip la base sur la default branch puis revenir. Le script lit la default branch dynamiquement (pas de hardcoding `master` ou `alpha`).
 
    ```bash
    bash scripts/orchestration/force_pr_issue_link.sh <PR_N>
    ```
 
-   Le script est idempotent (skip si lien déjà en place ou si la PR cible déjà master) et vérifie via GraphQL après le flip que `closingIssuesReferences` est non-vide. **Coût** : ~2 runs CI supplémentaires par flip (workflows `pull_request: types: [edited|synchronize]` se redéclenchent à chaque changement de base) — donc on l'appelle une seule fois, juste après `gh pr create`.
+   Le script est idempotent (skip si lien déjà en place ou si la PR cible déjà la default branch) et vérifie via GraphQL après le flip que `closingIssuesReferences` est non-vide. **Coût** : ~2 runs CI supplémentaires par flip (workflows `pull_request: types: [edited|synchronize]` se redéclenchent à chaque changement de base) — donc on l'appelle une seule fois, juste après `gh pr create`.
 
    Si le script échoue (`exit 1`) avec « Closes keyword missing » → ton body n'a pas `Closes #N` sur la première ligne, le corriger via `gh pr edit --body` puis re-run le script.
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -76,7 +76,28 @@ Workflow identique à l'ex-`/epic` :
    ```
    Si oui : avertir, proposer (a) attendre via `/report`, (b) `pkill -f "epic_loop.sh.*${EPICS_KEY}"` puis relancer, (c) annuler.
 
-2. Lancer le bash loop driver en background :
+2. **Aligner le main worktree sur `epic/<N>`** — la pipeline orchestrate doit tourner sur la branche d'intégration de l'epic, pas depuis `alpha` ni un worktree dédié. Sinon : `rebase_epic_branch.sh` entre ticks plante (`epic/<N> is already used by worktree at ...`), et l'état dans `.claude/state/epic_run/` finit sur le mauvais worktree (cassant `/report`).
+   ```bash
+   # Sécurité : refuser si working tree dirty (commit/stash d'abord)
+   if [ -n "$(git status --porcelain)" ]; then
+       echo "ERROR: working tree dirty — commit ou stash avant /implement <N>"
+       exit 1
+   fi
+
+   # S'assurer que la branche d'intégration existe sur origin (idempotent)
+   bash scripts/orchestration/ensure_epic_branch.sh "$ISSUE_N"
+
+   # Checkout epic/<N> sur le main worktree
+   git fetch origin "epic/${ISSUE_N}" --quiet
+   if git rev-parse --verify --quiet "epic/${ISSUE_N}" >/dev/null; then
+       git checkout "epic/${ISSUE_N}"
+       git pull --ff-only origin "epic/${ISSUE_N}"
+   else
+       git checkout -B "epic/${ISSUE_N}" "origin/epic/${ISSUE_N}"
+   fi
+   ```
+
+3. Lancer le bash loop driver en background **depuis le main worktree** (qui est désormais sur `epic/<N>`) :
    ```bash
    LOG_FILE="/tmp/epic_loop_${EPICS_KEY}.log"
    nohup bash scripts/orchestration/epic_loop.sh $EPICS > "$LOG_FILE" 2>&1 &
@@ -85,7 +106,9 @@ Workflow identique à l'ex-`/epic` :
    echo "epic_loop lancé en background (PID $PID, log: $LOG_FILE). Suivi via /report."
    ```
 
-3. Rendre la main immédiatement (pas de polling — utiliser `/report`).
+4. Rendre la main immédiatement (pas de polling — utiliser `/report`).
+
+> **Note** : le main worktree reste sur `epic/<N>` pendant toute la durée du loop (ticks + final PR). Pour faire du travail sur `alpha` en parallèle (hotfix, autre branche), monter un worktree dédié (`git worktree add /tmp/egapro-alpha alpha`). À la fin de l'epic — quand la PR finale est mergée sur alpha — basculer manuellement le main worktree avec `git checkout alpha && git pull`.
 
 ### Mode task ou bug — code-dev synchrone foreground
 

--- a/scripts/orchestration/dispatch_plan.sh
+++ b/scripts/orchestration/dispatch_plan.sh
@@ -17,14 +17,17 @@ fi
 #   ]
 #
 # Every ticket targets `origin/epic/<N>`. A ticket whose `Depends on`
-# references a parent ticket is dispatchable as soon as the parent's PR has
-# been squash-merged into epic/<N> — detected by the absence of the parent's
-# `ticket/<parent>-*` branch on origin (GitHub auto-deletes the head branch
-# on squash-merge). Until then the child stays blocked.
+# references a parent ticket is dispatchable as soon as the parent's PR
+# has been squash-merged into epic/<N>. We detect this with two combined
+# signals: (a) the parent's `ticket/<parent>-*` branch is gone from
+# origin (auto-deleted on squash-merge), AND (b) a merged PR with that
+# head ref exists on epic/<N>. Both are required — (a) alone would
+# false-positive on parents that haven't been dispatched yet (their
+# branch hasn't been created either, so it's also "absent").
 #
 # The board status of the parent is purely decorative (the user owns the
-# In review / Done transitions); the canonical signal is **branch presence
-# on origin**.
+# In review / Done transitions); the canonical signal is the merged PR
+# record on epic/<N>.
 #
 # Logic:
 #   1. Detect busy worktree indices from existing worktrees `egapro-epic*-t*`
@@ -161,16 +164,27 @@ for EPIC_N in "$@"; do
         ' | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)
 
         # Resolve deps: each parent must be squash-merged into epic/<N>.
-        # Repo settings auto-delete the head branch on merge, so parent
-        # ticket branch absence on origin == merged. The board status is
-        # decorative (humans own In review / Done) — branch presence is
-        # the canonical signal.
+        # We confirm with two signals: (a) the parent's `ticket/<dep>-*`
+        # branch is gone from origin (auto-deleted on squash-merge), AND
+        # (b) a merged PR with that head ref exists on epic/<N>. Both are
+        # required to disambiguate "merged" from "never started" — a
+        # parent that hasn't been dispatched yet also has no branch, so
+        # signal (a) alone would falsely unblock the child.
         BASE_BRANCH="origin/epic/${EPIC_N}"
         BLOCKED=0
         for DEP in $DEPS; do
             DEP_BRANCH=$(git ls-remote --heads origin "ticket/${DEP}-*" 2>/dev/null | awk '{print $2}' | head -1 || true)
             if [ -n "$DEP_BRANCH" ]; then
-                # Branch still on origin → not yet squash-merged → child blocked
+                # Branch still on origin → in flight → child blocked
+                BLOCKED=1
+                break
+            fi
+            # Branch absent → confirm parent was actually merged (vs.
+            # never started) by looking for a merged PR with that head.
+            DEP_PR_MERGED=$(gh pr list --base "epic/${EPIC_N}" --state merged --json headRefName \
+                --jq "[.[] | select(.headRefName | startswith(\"ticket/${DEP}-\"))] | length" 2>/dev/null || echo "0")
+            if [ "$DEP_PR_MERGED" = "0" ]; then
+                # No merged PR for this dep → parent never finished → child blocked
                 BLOCKED=1
                 break
             fi

--- a/scripts/orchestration/force_pr_issue_link.sh
+++ b/scripts/orchestration/force_pr_issue_link.sh
@@ -12,14 +12,18 @@ fi
 #
 # GitHub's auto-linker (the one that populates closingIssuesReferences and
 # creates the ConnectedEvent so the PR shows up in the issue's Development
-# sidebar) only fires when the PR base is the repository's **default branch**
-# (`master`). Our PRs target `alpha` or `epic/<N>`, so the `Closes #N` keyword
-# stays in the body but no formal link is created at `gh pr create` time.
+# sidebar) only fires when the PR base is the repository's **default branch**.
+# Our sub-task PRs target `epic/<N>`, so the `Closes #N` keyword stays in the
+# body but no formal link is created at `gh pr create` time.
 #
-# Workaround: flip the PR base to `master`, wait, flip it back. The linker
-# fires on the master flip, and the link persists across the second flip.
-# There is no public GraphQL/REST mutation for the link itself (the GitHub
-# web UI's "Link an issue" button uses a private mutation).
+# Workaround: flip the PR base to the default branch, wait, flip it back. The
+# linker fires on the default-branch flip, and the link persists across the
+# second flip. There is no public GraphQL/REST mutation for the link itself
+# (the GitHub web UI's "Link an issue" button uses a private mutation).
+#
+# The default branch is read dynamically — historically the repo used
+# `master` and now uses `alpha`, so hardcoding either one would silently
+# break the workaround.
 #
 # Idempotent: if the link is already in place (closingIssuesReferences not
 # empty) this script exits 0 without flipping.
@@ -42,15 +46,22 @@ fi
 
 PR="$1"
 
+# Resolve the repo's default branch — auto-linker only fires there.
+DEFAULT_BRANCH=$(gh repo view SocialGouv/egapro --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "")
+if [ -z "$DEFAULT_BRANCH" ]; then
+    echo "[force_pr_issue_link] ERROR: cannot resolve default branch of repo" >&2
+    exit 2
+fi
+
 ORIG_BASE=$(gh pr view "$PR" --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "")
 if [ -z "$ORIG_BASE" ]; then
     echo "[force_pr_issue_link] ERROR: cannot read base of PR #$PR" >&2
     exit 2
 fi
 
-# If already on master, the auto-linker fired at creation time
-if [ "$ORIG_BASE" = "master" ]; then
-    echo "[force_pr_issue_link] PR #$PR base is already master — no flip needed" >&2
+# If already on default branch, the auto-linker fired at creation time
+if [ "$ORIG_BASE" = "$DEFAULT_BRANCH" ]; then
+    echo "[force_pr_issue_link] PR #$PR base is already $DEFAULT_BRANCH (default) — no flip needed" >&2
     exit 0
 fi
 
@@ -78,8 +89,8 @@ if ! echo "$BODY" | grep -qiE '(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+
     exit 1
 fi
 
-echo "[force_pr_issue_link] flipping PR #$PR base $ORIG_BASE → master to fire the auto-linker" >&2
-gh pr edit "$PR" --base master >/dev/null
+echo "[force_pr_issue_link] flipping PR #$PR base $ORIG_BASE → $DEFAULT_BRANCH to fire the auto-linker" >&2
+gh pr edit "$PR" --base "$DEFAULT_BRANCH" >/dev/null
 sleep 3
 gh pr edit "$PR" --base "$ORIG_BASE" >/dev/null
 sleep 2

--- a/scripts/orchestration/open_epic_final_pr.sh
+++ b/scripts/orchestration/open_epic_final_pr.sh
@@ -69,10 +69,16 @@ ${SUB_LINES:-_(aucun sous-ticket trouvé)_}
 - Branche d'intégration : \`${BRANCH}\` (rebasée régulièrement sur \`alpha\` pendant l'exécution)
 - Une fois cette PR mergée dans \`alpha\`, les sous-tickets se fermeront automatiquement à la prochaine release (\`alpha → master\`) via les \`Closes #N\` ci-dessus."
 
+# Conventional-commits prefix so the Semantic PR check passes (alpha base
+# requires a `<type>(<scope>): <subject>` shape). We pick `feat(epic)` since
+# every epic delivers user-facing changes ; the epic number then disambiguates
+# multiple in-flight epics.
+PR_TITLE="feat(epic): #${EPIC} — ${EPIC_TITLE}"
+
 PR_URL=$(gh pr create \
     --base alpha \
     --head "$BRANCH" \
-    --title "Epic #${EPIC} — ${EPIC_TITLE}" \
+    --title "$PR_TITLE" \
     --body "$BODY" 2>&1) || {
     echo "[open_epic_final_pr] ERROR: gh pr create failed:" >&2
     echo "$PR_URL" >&2

--- a/scripts/orchestration/rebase_epic_branch.sh
+++ b/scripts/orchestration/rebase_epic_branch.sh
@@ -12,9 +12,13 @@ fi
 # unrelated PRs land on alpha during the epic's execution. Force-with-lease
 # pushes the rebased branch.
 #
-# Operates inside a dedicated temp worktree at /tmp/egapro-rebase-epic<N> so
-# the main repo's working tree stays untouched. The temp worktree is reused
-# across calls.
+# If a worktree is already on `epic/<N>` (the main worktree on `/implement`
+# epic mode is, by design), the rebase happens **in-place** in that worktree.
+# Otherwise, it operates inside a dedicated temp worktree at
+# /tmp/egapro-rebase-epic<N> reused across calls. Git refuses to check out
+# the same branch in two worktrees, so we must reuse rather than create.
+# In-place rebase requires the worktree to be clean — if dirty, the script
+# refuses (exit 1) rather than silently losing the user's edits.
 #
 # Called by epic_loop.sh between ticks (in NEW-mode epics only).
 #
@@ -35,25 +39,45 @@ EPIC="$1"
 BRANCH="epic/${EPIC}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-WT="/tmp/egapro-rebase-epic${EPIC}"
 
 (cd "$REPO_ROOT" && git fetch --quiet origin alpha "$BRANCH") >&2 || {
     echo "[rebase_epic_branch] ERROR: git fetch origin alpha $BRANCH failed" >&2
     exit 1
 }
 
-if [ ! -d "$WT" ]; then
-    git -C "$REPO_ROOT" worktree add --force "$WT" "origin/${BRANCH}" >&2 || {
-        echo "[rebase_epic_branch] ERROR: cannot add worktree at $WT" >&2
+# Detect if any worktree (including main) already has `epic/<N>` checked out.
+# Git refuses to check out the same branch in two worktrees, so we must reuse
+# the existing one. The main worktree being on epic/<N> is the expected state
+# under `/implement` mode epic (since the related fix to that skill).
+EXISTING_WT=$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null \
+    | awk -v b="refs/heads/${BRANCH}" '
+        /^worktree / { wt = $2 }
+        /^branch / && $2 == b { print wt; exit }
+    ')
+
+if [ -n "$EXISTING_WT" ]; then
+    if [ -n "$(git -C "$EXISTING_WT" status --porcelain)" ]; then
+        echo "[rebase_epic_branch] ERROR: worktree at $EXISTING_WT is on $BRANCH but dirty — refuse to rebase (would lose uncommitted edits)" >&2
         exit 1
-    }
+    fi
+    WT="$EXISTING_WT"
+    echo "[rebase_epic_branch] in-place rebase in existing worktree at $WT" >&2
+else
+    WT="/tmp/egapro-rebase-epic${EPIC}"
+    if [ ! -d "$WT" ]; then
+        git -C "$REPO_ROOT" worktree add --force "$WT" "origin/${BRANCH}" >&2 || {
+            echo "[rebase_epic_branch] ERROR: cannot add worktree at $WT" >&2
+            exit 1
+        }
+    fi
 fi
 
 cd "$WT"
 
 git fetch --quiet origin "$BRANCH" >&2 || true
+# Already on $BRANCH if reusing an existing worktree — checkout is a no-op then.
 if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
-    git checkout "$BRANCH" >&2
+    git checkout "$BRANCH" >&2 2>/dev/null || true
 else
     git checkout -b "$BRANCH" "origin/${BRANCH}" >&2
 fi

--- a/scripts/orchestration/render_dashboard.sh
+++ b/scripts/orchestration/render_dashboard.sh
@@ -66,6 +66,50 @@ process_alive() {
     esac
 }
 
+# Helper: PR info ("PR #<N> [<state>]") for a code-dev agent's ticket — matches
+# any PR whose head ref starts with `ticket/<N>-`. Empty if no PR yet (or for
+# non-code-dev agents). 1 gh API call per call.
+agent_pr_info() {
+    local AID="$1"
+    case "$AID" in
+        code-dev-[0-9]*)
+            local TICKET="${AID##*-}"
+            gh pr list --state all --limit 100 --json number,state,headRefName 2>/dev/null \
+                | jq -r --arg t "ticket/${TICKET}-" '.[] | select(.headRefName | startswith($t)) | "PR #\(.number) [\(.state | ascii_downcase)]"' \
+                | head -1
+            ;;
+    esac
+}
+
+# Helper: deepest non-claude descendant of an agent's claude CLI — useful to
+# see what the agent is awaiting (e.g. "gh pr checks 3401 --watch").
+# Returns truncated cmdline (first 100 chars) or empty if claude has no live
+# subprocess at the moment.
+agent_active_command() {
+    local AID="$1"
+    case "$AID" in
+        code-dev-[0-9]*)
+            local TICKET="${AID##*-}"
+            local CLAUDE_PID
+            CLAUDE_PID=$(ps -eo pid,cmd 2>/dev/null \
+                | awk -v t="Ticket #${TICKET}" '$0 ~ t && $0 !~ /timeout/ && $0 !~ /grep/ && $0 !~ /awk/ {print $1; exit}')
+            [ -z "$CLAUDE_PID" ] && return
+            local CURRENT="$CLAUDE_PID"
+            local LAST_CMD=""
+            local DEPTH=0
+            while [ "$DEPTH" -lt 20 ]; do
+                local CHILD
+                CHILD=$(pgrep -P "$CURRENT" 2>/dev/null | head -1)
+                [ -z "$CHILD" ] && break
+                CURRENT="$CHILD"
+                LAST_CMD=$(ps -p "$CURRENT" -o cmd= 2>/dev/null | head -1)
+                DEPTH=$((DEPTH + 1))
+            done
+            [ -n "$LAST_CMD" ] && echo "${LAST_CMD:0:100}"
+            ;;
+    esac
+}
+
 for log in "$LOG_DIR"/*.log; do
     [ -f "$log" ] || continue
     AGENT_ID=$(basename "$log" .log)
@@ -114,20 +158,39 @@ else
             AGE="$((INACTIVITY / 60)) min ago"
         fi
 
+        IS_LIVE=0
         if [ "$INACTIVITY" -gt "$THRESHOLD" ]; then
             if process_alive "$AGENT_ID"; then
                 FLAG="○ live (log silent)"
+                IS_LIVE=1
             else
                 FLAG="⚠ INACTIF"
             fi
         else
             FLAG="✓"
+            IS_LIVE=1
+        fi
+
+        # Enrich live agents with PR info (if a PR was opened) so that
+        # "log silent" doesn't mean "lost track of what the agent did".
+        if [ "$IS_LIVE" = "1" ]; then
+            PR_INFO=$(agent_pr_info "$AGENT_ID")
+            [ -n "$PR_INFO" ] && FLAG="$FLAG · $PR_INFO"
         fi
 
         RETRIES=$(awk '/\[RETRY/ {c++} END {print c+0}' "$LOG")
 
         printf "%s · %s · %s · retries=%d\n" "$AGENT_ID" "$AGE" "$FLAG" "$RETRIES"
         tail -n 4 "$LOG" | sed 's/^/  /'
+
+        # Show what the agent is currently awaiting at process level — works
+        # even when the agent log is silent. Skip if the process tree has no
+        # subprocess (claude is computing internally, no shell call active).
+        if [ "$IS_LIVE" = "1" ]; then
+            CURRENT_CMD=$(agent_active_command "$AGENT_ID")
+            [ -n "$CURRENT_CMD" ] && printf "  └─ awaiting: %s\n" "$CURRENT_CMD"
+        fi
+
         echo ""
     done
 fi


### PR DESCRIPTION
Pipeline fixes accumulés pendant la run epic 3205. Indépendants du contenu applicatif de l'epic — landing sur alpha pour bénéficier aux runs futurs sans attendre le merge de l'epic.

## 3 commits

### 1. \`fix(pipeline): dispatch_plan gate children on merged PR, not branch absence alone\`

Avant : \`dispatch_plan.sh\` considérait un parent comme « squash-mergé » dès que sa branche \`ticket/<parent>-*\` n'était pas sur origin. Au tick 0, avant que tout ticket ne soit dispatché, les branches n'existent pas encore — résultat, les enfants étaient dispatchés en parallèle de leur parent et se cassaient (no foundation à importer).

Après : 2 signaux combinés requis pour unblock — branche absente **ET** PR mergée avec head matching trouvée. Disambigue \"jamais démarré\" vs \"squash-mergé\".

### 2. \`fix(pipeline): /implement epic mode aligns main worktree on epic/<N>\`

Avant : la skill ne précisait rien sur la branche du main worktree au lancement. Lancée depuis alpha → \`rebase_epic_branch.sh\` plantait entre ticks (\"epic/<N> already used by worktree at ...\") et l'état \`.claude/state/epic_run/\` finissait sur le mauvais worktree (cassait \`/report\`).

Après : pre-flight checkout de \`epic/<N>\` sur le main worktree (avec garde-fou si working tree dirty) avant de lancer le loop driver.

### 3. \`fix(pipeline): force_pr_issue_link reads default branch dynamically\`

Avant : le script flipper la base de la PR vers \`master\` hardcodé pour fire l'auto-linker GitHub. Mais la default branch du repo est \`alpha\` (historiquement \`master\`), donc le flip vers master ne firait pas l'auto-linker — les sub-task PRs des epics restaient sans lien formel à leur issue (sidebar « Development » vide).

Après : lecture dynamique de la default branch via \`gh repo view --json defaultBranchRef\`. Code-dev AGENT.md mis à jour en cohérence.

## Test plan

- [ ] CI verts
- [ ] Aucun changement applicatif (purement orchestration / outillage CLI)
- [ ] À la prochaine run \`/implement <epic>\`, le main worktree devrait switcher sur \`epic/<N>\` automatiquement
- [ ] À la prochaine création de PR sub-task, le link \`closingIssuesReferences\` devrait apparaître (sidebar « Development » de l'issue parent)