### PR TITLE
feat(epic): #3205 — Cache de la déclaration / Données deja entrées par l'utilisateur / Retour en arriere

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -48,6 +48,7 @@ export function StepPageClient({
 		case 1:
 			return (
 				<Step1Workforce
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step1Data}

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -57,6 +57,7 @@ export function StepPageClient({
 		case 2:
 			return (
 				<Step2PayGap
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step2Data}
@@ -65,6 +66,7 @@ export function StepPageClient({
 		case 3:
 			return (
 				<Step3VariablePay
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step3Data}
@@ -75,6 +77,7 @@ export function StepPageClient({
 		case 4:
 			return (
 				<Step4QuartileDistribution
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					gipPrefillData={gipPrefillData}
 					initialData={step4Data}
@@ -85,6 +88,7 @@ export function StepPageClient({
 		case 5:
 			return (
 				<Step5EmployeeCategories
+					declarationSiren={declaration.siren}
 					declarationYear={declaration.year}
 					initialCategories={step5Categories}
 					initialSource={initialSource}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/computeDraftDiff.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/computeDraftDiff.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDraftDiff } from "../computeDraftDiff";
+
+describe("computeDraftDiff", () => {
+	it("returns {} when all primitives are strictly equal", () => {
+		const current = { a: 1, b: "x", c: true };
+		const db = { a: 1, b: "x", c: true };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("includes only the differing primitive in the diff", () => {
+		const current = { a: 1, b: "x" };
+		const db = { a: 2, b: "x" };
+		expect(computeDraftDiff(current, db)).toEqual({ a: 1 });
+	});
+
+	it("returns {} for arrays of objects with identical content", () => {
+		const current = { categories: [{ name: "A", count: 3 }] };
+		const db = { categories: [{ name: "A", count: 3 }] };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("keeps the entire array when one cell differs", () => {
+		const current = {
+			categories: [
+				{ name: "A", count: 3 },
+				{ name: "B", count: 7 },
+			],
+		};
+		const db = {
+			categories: [
+				{ name: "A", count: 3 },
+				{ name: "B", count: 5 },
+			],
+		};
+		expect(computeDraftDiff(current, db)).toEqual({
+			categories: current.categories,
+		});
+	});
+
+	it("keeps the entire array when length differs", () => {
+		const current = { items: [1, 2, 3] };
+		const db = { items: [1, 2] };
+		expect(computeDraftDiff(current, db)).toEqual({ items: [1, 2, 3] });
+	});
+
+	it("returns {} for nested objects with identical content", () => {
+		const current = { meta: { a: 1, b: { c: 2 } } };
+		const db = { meta: { a: 1, b: { c: 2 } } };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("includes a differing nested object", () => {
+		const current = { meta: { a: 1, b: { c: 2 } } };
+		const db = { meta: { a: 1, b: { c: 3 } } };
+		expect(computeDraftDiff(current, db)).toEqual({ meta: current.meta });
+	});
+
+	it("treats null and undefined as equal", () => {
+		const current: Record<string, unknown> = { a: null, b: undefined };
+		const db: Record<string, unknown> = { a: undefined, b: null };
+		expect(computeDraftDiff(current, db)).toEqual({});
+	});
+
+	it("treats null vs primitive as different", () => {
+		const current: Record<string, unknown> = { a: 0 };
+		const db: Record<string, unknown> = { a: null };
+		expect(computeDraftDiff(current, db)).toEqual({ a: 0 });
+	});
+
+	it("treats array vs object as different", () => {
+		const current: Record<string, unknown> = { x: [] };
+		const db: Record<string, unknown> = { x: {} };
+		expect(computeDraftDiff(current, db)).toEqual({ x: [] });
+	});
+
+	it("detects difference when nested object key sets differ", () => {
+		const current: Record<string, unknown> = { meta: { a: 1, b: 2 } };
+		const db: Record<string, unknown> = { meta: { a: 1 } };
+		expect(computeDraftDiff(current, db)).toEqual({ meta: { a: 1, b: 2 } });
+	});
+
+	it("detects difference when same key count but distinct keys", () => {
+		const current: Record<string, unknown> = { meta: { a: 1, b: 2 } };
+		const db: Record<string, unknown> = { meta: { a: 1, c: 2 } };
+		expect(computeDraftDiff(current, db)).toEqual({ meta: { a: 1, b: 2 } });
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/draftStorage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/draftStorage.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DraftPayload } from "../draftSchema";
+import { clearDraft, readDraft, writeDraft } from "../draftStorage";
+
+const USER_ID = "user-1";
+const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}`;
+
+const FIXED_NOW = new Date("2026-03-15T12:00:00Z").getTime();
+
+function buildValidPayload(
+	overrides: Partial<DraftPayload> = {},
+): DraftPayload {
+	return {
+		siren: "123456789",
+		year: 2026,
+		step: 1,
+		kind: "main",
+		timestamp: FIXED_NOW - 1000,
+		fields: { totalWomen: 10 },
+		...overrides,
+	};
+}
+
+describe("draftStorage", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(FIXED_NOW));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	describe("readDraft", () => {
+		it("returns null when no key exists", () => {
+			expect(readDraft(USER_ID)).toBeNull();
+		});
+
+		it("purges and returns null on corrupt JSON", () => {
+			window.localStorage.setItem(STORAGE_KEY, "{not-json");
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("purges and returns null on Zod-invalid payload", () => {
+			window.localStorage.setItem(
+				STORAGE_KEY,
+				JSON.stringify({ siren: "abc", year: 2026 }),
+			);
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("purges and returns null when timestamp is older than 30 days", () => {
+			const expired = buildValidPayload({
+				timestamp: FIXED_NOW - 31 * 24 * 3600 * 1000,
+			});
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(expired));
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("purges and returns null when the campaign deadline has passed", () => {
+			vi.setSystemTime(new Date("2026-07-01T00:00:00Z").getTime());
+			const payload = buildValidPayload({
+				timestamp: new Date("2026-06-30T00:00:00Z").getTime(),
+				year: 2026,
+			});
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+			expect(readDraft(USER_ID)).toBeNull();
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("returns the parsed payload when valid and within deadlines", () => {
+			const payload = buildValidPayload();
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+			expect(readDraft(USER_ID)).toEqual(payload);
+		});
+	});
+
+	describe("writeDraft", () => {
+		it("persists the payload as JSON under the user-scoped key", () => {
+			const payload = buildValidPayload();
+			writeDraft(USER_ID, payload);
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
+				JSON.stringify(payload),
+			);
+		});
+
+		it("write then read round-trips identical content", () => {
+			const payload = buildValidPayload();
+			writeDraft(USER_ID, payload);
+			expect(readDraft(USER_ID)).toEqual(payload);
+		});
+	});
+
+	describe("clearDraft", () => {
+		it("removes the user-scoped key", () => {
+			writeDraft(USER_ID, buildValidPayload());
+			clearDraft(USER_ID);
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		});
+
+		it("is a no-op when the key does not exist", () => {
+			expect(() => clearDraft(USER_ID)).not.toThrow();
+		});
+	});
+
+	describe("SSR safety (window === undefined)", () => {
+		const originalWindow = globalThis.window;
+
+		beforeEach(() => {
+			Object.defineProperty(globalThis, "window", {
+				value: undefined,
+				writable: true,
+				configurable: true,
+			});
+		});
+
+		afterEach(() => {
+			Object.defineProperty(globalThis, "window", {
+				value: originalWindow,
+				writable: true,
+				configurable: true,
+			});
+		});
+
+		it("readDraft returns null without throwing", () => {
+			expect(readDraft(USER_ID)).toBeNull();
+		});
+
+		it("writeDraft is a no-op without throwing", () => {
+			expect(() => writeDraft(USER_ID, buildValidPayload())).not.toThrow();
+		});
+
+		it("clearDraft is a no-op without throwing", () => {
+			expect(() => clearDraft(USER_ID)).not.toThrow();
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/draftStorage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/draftStorage.test.ts
@@ -4,7 +4,9 @@ import type { DraftPayload } from "../draftSchema";
 import { clearDraft, readDraft, writeDraft } from "../draftStorage";
 
 const USER_ID = "user-1";
-const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}`;
+const SIREN = "123456789";
+const YEAR = 2026;
+const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}:${SIREN}:${YEAR}`;
 
 const FIXED_NOW = new Date("2026-03-15T12:00:00Z").getTime();
 
@@ -12,8 +14,8 @@ function buildValidPayload(
 	overrides: Partial<DraftPayload> = {},
 ): DraftPayload {
 	return {
-		siren: "123456789",
-		year: 2026,
+		siren: SIREN,
+		year: YEAR,
 		step: 1,
 		kind: "main",
 		timestamp: FIXED_NOW - 1000,
@@ -35,12 +37,12 @@ describe("draftStorage", () => {
 
 	describe("readDraft", () => {
 		it("returns null when no key exists", () => {
-			expect(readDraft(USER_ID)).toBeNull();
+			expect(readDraft(USER_ID, SIREN, YEAR)).toBeNull();
 		});
 
 		it("purges and returns null on corrupt JSON", () => {
 			window.localStorage.setItem(STORAGE_KEY, "{not-json");
-			expect(readDraft(USER_ID)).toBeNull();
+			expect(readDraft(USER_ID, SIREN, YEAR)).toBeNull();
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
 		});
 
@@ -49,7 +51,7 @@ describe("draftStorage", () => {
 				STORAGE_KEY,
 				JSON.stringify({ siren: "abc", year: 2026 }),
 			);
-			expect(readDraft(USER_ID)).toBeNull();
+			expect(readDraft(USER_ID, SIREN, YEAR)).toBeNull();
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
 		});
 
@@ -58,7 +60,7 @@ describe("draftStorage", () => {
 				timestamp: FIXED_NOW - 31 * 24 * 3600 * 1000,
 			});
 			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(expired));
-			expect(readDraft(USER_ID)).toBeNull();
+			expect(readDraft(USER_ID, SIREN, YEAR)).toBeNull();
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
 		});
 
@@ -69,21 +71,49 @@ describe("draftStorage", () => {
 				year: 2026,
 			});
 			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-			expect(readDraft(USER_ID)).toBeNull();
+			expect(readDraft(USER_ID, SIREN, YEAR)).toBeNull();
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
 		});
 
 		it("returns the parsed payload when valid and within deadlines", () => {
 			const payload = buildValidPayload();
 			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-			expect(readDraft(USER_ID)).toEqual(payload);
+			expect(readDraft(USER_ID, SIREN, YEAR)).toEqual(payload);
+		});
+
+		it("isolates drafts across different SIRENs for the same user", () => {
+			const otherSiren = "987654321";
+			const otherKey = `egapro:declaration-draft:${USER_ID}:${otherSiren}:${YEAR}`;
+			const payloadA = buildValidPayload({ fields: { totalWomen: 1 } });
+			const payloadB = buildValidPayload({
+				siren: otherSiren,
+				fields: { totalWomen: 2 },
+			});
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payloadA));
+			window.localStorage.setItem(otherKey, JSON.stringify(payloadB));
+			expect(readDraft(USER_ID, SIREN, YEAR)).toEqual(payloadA);
+			expect(readDraft(USER_ID, otherSiren, YEAR)).toEqual(payloadB);
+		});
+
+		it("isolates drafts across different years for the same user/siren", () => {
+			const otherYear = 2025;
+			const otherKey = `egapro:declaration-draft:${USER_ID}:${SIREN}:${otherYear}`;
+			const payloadA = buildValidPayload();
+			const payloadB = buildValidPayload({
+				year: otherYear,
+				timestamp: new Date("2025-04-01T00:00:00Z").getTime(),
+			});
+			vi.setSystemTime(new Date("2025-04-15T00:00:00Z").getTime());
+			window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payloadA));
+			window.localStorage.setItem(otherKey, JSON.stringify(payloadB));
+			expect(readDraft(USER_ID, SIREN, otherYear)).toEqual(payloadB);
 		});
 	});
 
 	describe("writeDraft", () => {
-		it("persists the payload as JSON under the user-scoped key", () => {
+		it("persists the payload as JSON under the user/siren/year-scoped key", () => {
 			const payload = buildValidPayload();
-			writeDraft(USER_ID, payload);
+			writeDraft(USER_ID, SIREN, YEAR, payload);
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBe(
 				JSON.stringify(payload),
 			);
@@ -91,20 +121,35 @@ describe("draftStorage", () => {
 
 		it("write then read round-trips identical content", () => {
 			const payload = buildValidPayload();
-			writeDraft(USER_ID, payload);
-			expect(readDraft(USER_ID)).toEqual(payload);
+			writeDraft(USER_ID, SIREN, YEAR, payload);
+			expect(readDraft(USER_ID, SIREN, YEAR)).toEqual(payload);
 		});
 	});
 
 	describe("clearDraft", () => {
-		it("removes the user-scoped key", () => {
-			writeDraft(USER_ID, buildValidPayload());
-			clearDraft(USER_ID);
+		it("removes the user/siren/year-scoped key", () => {
+			writeDraft(USER_ID, SIREN, YEAR, buildValidPayload());
+			clearDraft(USER_ID, SIREN, YEAR);
 			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
 		});
 
+		it("does not affect drafts of other SIRENs for the same user", () => {
+			const otherSiren = "987654321";
+			const otherKey = `egapro:declaration-draft:${USER_ID}:${otherSiren}:${YEAR}`;
+			writeDraft(USER_ID, SIREN, YEAR, buildValidPayload());
+			writeDraft(
+				USER_ID,
+				otherSiren,
+				YEAR,
+				buildValidPayload({ siren: otherSiren }),
+			);
+			clearDraft(USER_ID, SIREN, YEAR);
+			expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+			expect(window.localStorage.getItem(otherKey)).not.toBeNull();
+		});
+
 		it("is a no-op when the key does not exist", () => {
-			expect(() => clearDraft(USER_ID)).not.toThrow();
+			expect(() => clearDraft(USER_ID, SIREN, YEAR)).not.toThrow();
 		});
 	});
 
@@ -128,15 +173,17 @@ describe("draftStorage", () => {
 		});
 
 		it("readDraft returns null without throwing", () => {
-			expect(readDraft(USER_ID)).toBeNull();
+			expect(readDraft(USER_ID, SIREN, YEAR)).toBeNull();
 		});
 
 		it("writeDraft is a no-op without throwing", () => {
-			expect(() => writeDraft(USER_ID, buildValidPayload())).not.toThrow();
+			expect(() =>
+				writeDraft(USER_ID, SIREN, YEAR, buildValidPayload()),
+			).not.toThrow();
 		});
 
 		it("clearDraft is a no-op without throwing", () => {
-			expect(() => clearDraft(USER_ID)).not.toThrow();
+			expect(() => clearDraft(USER_ID, SIREN, YEAR)).not.toThrow();
 		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -1,0 +1,262 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DraftPayload } from "../draftSchema";
+import { useDeclarationDraft } from "../useDeclarationDraft";
+
+const useSessionMock = vi.mocked(useSession);
+
+const SIREN = "123456789";
+const YEAR = 2026;
+const USER_ID = "user-1";
+const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}`;
+
+const FIXED_NOW = new Date("2026-03-15T12:00:00Z").getTime();
+
+function buildPayload(overrides: Partial<DraftPayload> = {}): DraftPayload {
+	return {
+		siren: SIREN,
+		year: YEAR,
+		step: 1,
+		kind: "main",
+		timestamp: FIXED_NOW - 1000,
+		fields: { totalWomen: 10 },
+		...overrides,
+	};
+}
+
+type StepValues = { totalWomen: number; totalMen: number };
+
+const DB_VALUES: StepValues = { totalWomen: 0, totalMen: 0 };
+
+function setSession(
+	options: { userId?: string | null; impersonating?: boolean } = {},
+) {
+	const { userId = USER_ID, impersonating = false } = options;
+	useSessionMock.mockReturnValue({
+		data:
+			userId === null
+				? null
+				: ({
+						user: {
+							id: userId,
+							impersonation: impersonating
+								? { siren: "999999999", name: "X" }
+								: null,
+						},
+						expires: "",
+					} as never),
+		status: userId === null ? "unauthenticated" : "authenticated",
+		update: vi.fn(),
+	} as never);
+}
+
+describe("useDeclarationDraft", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(FIXED_NOW));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		useSessionMock.mockReset();
+	});
+
+	it("is a no-op when userId is null (logged out)", () => {
+		setSession({ userId: null });
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildPayload()));
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+
+		act(() => {
+			result.current.setField({ totalWomen: 99, totalMen: 0 });
+		});
+		expect(window.localStorage.length).toBe(1);
+
+		act(() => {
+			result.current.clearDraft();
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+	});
+
+	it("is a no-op when impersonating", () => {
+		setSession({ impersonating: true });
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildPayload()));
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+
+		act(() => {
+			result.current.setField({ totalWomen: 99, totalMen: 0 });
+			result.current.clearDraft();
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+	});
+
+	it("hydrates draft when payload matches (siren, year, step)", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ fields: { totalWomen: 10, totalMen: 5 } })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({ totalWomen: 10, totalMen: 5 });
+		expect(result.current.hasDraft).toBe(true);
+	});
+
+	it("does not hydrate when payload (siren, year, step) does not match — and does not purge", () => {
+		setSession();
+		const payload = buildPayload({ siren: "987654321" });
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+	});
+
+	it("does not hydrate when payload year does not match", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ year: 2025 })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("does not hydrate when payload step does not match", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ step: 2 })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("clears the draft when setField makes values match dbValues", () => {
+		setSession();
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+
+		act(() => {
+			result.current.setField({ totalWomen: 5, totalMen: 0 });
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+		expect(result.current.hasDraft).toBe(true);
+
+		act(() => {
+			result.current.setField({ totalWomen: 0, totalMen: 0 });
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("writes the diff (only differing keys) when setField is called", () => {
+		setSession();
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		act(() => {
+			result.current.setField({ totalWomen: 5, totalMen: 0 });
+		});
+		const stored = JSON.parse(
+			window.localStorage.getItem(STORAGE_KEY) ?? "{}",
+		) as DraftPayload;
+		expect(stored.fields).toEqual({ totalWomen: 5 });
+		expect(stored.siren).toBe(SIREN);
+		expect(stored.year).toBe(YEAR);
+		expect(stored.step).toBe(1);
+		expect(stored.kind).toBe("main");
+		expect(stored.timestamp).toBe(FIXED_NOW);
+	});
+
+	it("clearDraft removes the key and resets hasDraft", () => {
+		setSession();
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(buildPayload({ fields: { totalWomen: 10 } })),
+		);
+		const { result } = renderHook(() =>
+			useDeclarationDraft<StepValues>({
+				siren: SIREN,
+				year: YEAR,
+				step: 1,
+				kind: "main",
+				dbValues: DB_VALUES,
+			}),
+		);
+		expect(result.current.hasDraft).toBe(true);
+		act(() => {
+			result.current.clearDraft();
+		});
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		expect(result.current.hasDraft).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -10,7 +10,7 @@ const useSessionMock = vi.mocked(useSession);
 const SIREN = "123456789";
 const YEAR = 2026;
 const USER_ID = "user-1";
-const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}`;
+const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}:${SIREN}:${YEAR}`;
 
 const FIXED_NOW = new Date("2026-03-15T12:00:00Z").getTime();
 
@@ -112,7 +112,7 @@ describe("useDeclarationDraft", () => {
 		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
 	});
 
-	it("hydrates draft when payload matches (siren, year, step)", () => {
+	it("hydrates draft when payload step matches the current step", () => {
 		setSession();
 		window.localStorage.setItem(
 			STORAGE_KEY,
@@ -131,9 +131,9 @@ describe("useDeclarationDraft", () => {
 		expect(result.current.hasDraft).toBe(true);
 	});
 
-	it("does not hydrate when payload (siren, year, step) does not match — and does not purge", () => {
+	it("does not hydrate when payload step does not match — and does not purge", () => {
 		setSession();
-		const payload = buildPayload({ siren: "987654321" });
+		const payload = buildPayload({ step: 2 });
 		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
 		const { result } = renderHook(() =>
 			useDeclarationDraft<StepValues>({
@@ -149,11 +149,13 @@ describe("useDeclarationDraft", () => {
 		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
 	});
 
-	it("does not hydrate when payload year does not match", () => {
+	it("does not hydrate from a different SIREN's draft (key isolation)", () => {
 		setSession();
+		const otherSiren = "987654321";
+		const otherKey = `egapro:declaration-draft:${USER_ID}:${otherSiren}:${YEAR}`;
 		window.localStorage.setItem(
-			STORAGE_KEY,
-			JSON.stringify(buildPayload({ year: 2025 })),
+			otherKey,
+			JSON.stringify(buildPayload({ siren: otherSiren })),
 		);
 		const { result } = renderHook(() =>
 			useDeclarationDraft<StepValues>({
@@ -166,13 +168,16 @@ describe("useDeclarationDraft", () => {
 		);
 		expect(result.current.draft).toEqual({});
 		expect(result.current.hasDraft).toBe(false);
+		expect(window.localStorage.getItem(otherKey)).not.toBeNull();
 	});
 
-	it("does not hydrate when payload step does not match", () => {
+	it("does not hydrate from a different year's draft (key isolation)", () => {
 		setSession();
+		const otherYear = 2025;
+		const otherKey = `egapro:declaration-draft:${USER_ID}:${SIREN}:${otherYear}`;
 		window.localStorage.setItem(
-			STORAGE_KEY,
-			JSON.stringify(buildPayload({ step: 2 })),
+			otherKey,
+			JSON.stringify(buildPayload({ year: otherYear })),
 		);
 		const { result } = renderHook(() =>
 			useDeclarationDraft<StepValues>({
@@ -212,7 +217,7 @@ describe("useDeclarationDraft", () => {
 		expect(result.current.hasDraft).toBe(false);
 	});
 
-	it("writes the diff (only differing keys) when setField is called", () => {
+	it("writes the diff under the (user, siren, year)-scoped key", () => {
 		setSession();
 		const { result } = renderHook(() =>
 			useDeclarationDraft<StepValues>({

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/computeDraftDiff.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/computeDraftDiff.ts
@@ -1,0 +1,41 @@
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (a == null && b == null) return true;
+	if (a == null || b == null) return false;
+	const aIsArr = Array.isArray(a);
+	const bIsArr = Array.isArray(b);
+	if (aIsArr && bIsArr) {
+		if (a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i += 1) {
+			if (!deepEqual(a[i], b[i])) return false;
+		}
+		return true;
+	}
+	if (aIsArr !== bIsArr) return false;
+	if (typeof a === "object" && typeof b === "object") {
+		const aRecord = a as Record<string, unknown>;
+		const bRecord = b as Record<string, unknown>;
+		const keysA = Object.keys(aRecord);
+		const keysB = Object.keys(bRecord);
+		if (keysA.length !== keysB.length) return false;
+		for (const key of keysA) {
+			if (!Object.hasOwn(bRecord, key)) return false;
+			if (!deepEqual(aRecord[key], bRecord[key])) return false;
+		}
+		return true;
+	}
+	return false;
+}
+
+export function computeDraftDiff<T extends Record<string, unknown>>(
+	currentValues: T,
+	dbValues: T,
+): Partial<T> {
+	const diff: Partial<T> = {};
+	for (const key of Object.keys(currentValues) as Array<keyof T>) {
+		if (!deepEqual(currentValues[key], dbValues[key])) {
+			diff[key] = currentValues[key];
+		}
+	}
+	return diff;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/draftSchema.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/draftSchema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+import { sirenSchema } from "~/modules/admin/schemas";
+
+export const draftPayloadSchema = z.object({
+	siren: sirenSchema,
+	year: z.number().int(),
+	step: z.union([
+		z.number().int().min(1).max(6),
+		z.literal("second-1"),
+		z.literal("second-2"),
+		z.literal("joint"),
+		z.literal("compliance"),
+	]),
+	kind: z.enum(["main", "second", "joint", "compliance"]),
+	timestamp: z.number().int(),
+	fields: z.record(z.string(), z.unknown()),
+});
+
+export type DraftPayload = z.infer<typeof draftPayloadSchema>;
+
+export type DraftStep = DraftPayload["step"];
+export type DraftKind = DraftPayload["kind"];

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/draftStorage.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/draftStorage.ts
@@ -10,8 +10,8 @@ function getStorage(): Storage | null {
 	return window.localStorage;
 }
 
-function getStorageKey(userId: string): string {
-	return `${STORAGE_KEY_PREFIX}${userId}`;
+function getStorageKey(userId: string, siren: string, year: number): string {
+	return `${STORAGE_KEY_PREFIX}${userId}:${siren}:${year}`;
 }
 
 function isExpired(payload: DraftPayload, now: number): boolean {
@@ -22,10 +22,14 @@ function isExpired(payload: DraftPayload, now: number): boolean {
 	return now > deadline.getTime();
 }
 
-export function readDraft(userId: string): DraftPayload | null {
+export function readDraft(
+	userId: string,
+	siren: string,
+	year: number,
+): DraftPayload | null {
 	const storage = getStorage();
 	if (!storage) return null;
-	const key = getStorageKey(userId);
+	const key = getStorageKey(userId, siren, year);
 	const raw = storage.getItem(key);
 	if (raw === null) return null;
 	let parsed: unknown;
@@ -47,14 +51,19 @@ export function readDraft(userId: string): DraftPayload | null {
 	return result.data;
 }
 
-export function writeDraft(userId: string, payload: DraftPayload): void {
+export function writeDraft(
+	userId: string,
+	siren: string,
+	year: number,
+	payload: DraftPayload,
+): void {
 	const storage = getStorage();
 	if (!storage) return;
-	storage.setItem(getStorageKey(userId), JSON.stringify(payload));
+	storage.setItem(getStorageKey(userId, siren, year), JSON.stringify(payload));
 }
 
-export function clearDraft(userId: string): void {
+export function clearDraft(userId: string, siren: string, year: number): void {
 	const storage = getStorage();
 	if (!storage) return;
-	storage.removeItem(getStorageKey(userId));
+	storage.removeItem(getStorageKey(userId, siren, year));
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/draftStorage.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/draftStorage.ts
@@ -1,0 +1,60 @@
+import { getDefaultCampaignDeadlines } from "~/modules/domain";
+
+import { type DraftPayload, draftPayloadSchema } from "./draftSchema";
+
+const STORAGE_KEY_PREFIX = "egapro:declaration-draft:";
+const DRAFT_TTL_MS = 30 * 24 * 3600 * 1000;
+
+function getStorage(): Storage | null {
+	if (typeof window === "undefined") return null;
+	return window.localStorage;
+}
+
+function getStorageKey(userId: string): string {
+	return `${STORAGE_KEY_PREFIX}${userId}`;
+}
+
+function isExpired(payload: DraftPayload, now: number): boolean {
+	if (now - payload.timestamp > DRAFT_TTL_MS) return true;
+	const deadline = getDefaultCampaignDeadlines(
+		payload.year,
+	).decl1ModificationDeadline;
+	return now > deadline.getTime();
+}
+
+export function readDraft(userId: string): DraftPayload | null {
+	const storage = getStorage();
+	if (!storage) return null;
+	const key = getStorageKey(userId);
+	const raw = storage.getItem(key);
+	if (raw === null) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		storage.removeItem(key);
+		return null;
+	}
+	const result = draftPayloadSchema.safeParse(parsed);
+	if (!result.success) {
+		storage.removeItem(key);
+		return null;
+	}
+	if (isExpired(result.data, Date.now())) {
+		storage.removeItem(key);
+		return null;
+	}
+	return result.data;
+}
+
+export function writeDraft(userId: string, payload: DraftPayload): void {
+	const storage = getStorage();
+	if (!storage) return;
+	storage.setItem(getStorageKey(userId), JSON.stringify(payload));
+}
+
+export function clearDraft(userId: string): void {
+	const storage = getStorage();
+	if (!storage) return;
+	storage.removeItem(getStorageKey(userId));
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -36,13 +36,9 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 
 	useEffect(() => {
 		if (!isEnabled || userId === null) return;
-		const payload = readDraft(userId);
+		const payload = readDraft(userId, siren, year);
 		if (payload === null) return;
-		if (
-			payload.siren !== siren ||
-			payload.year !== year ||
-			payload.step !== step
-		) {
+		if (payload.step !== step) {
 			return;
 		}
 		const fields = payload.fields as Partial<T>;
@@ -55,11 +51,11 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			if (!isEnabled || userId === null) return;
 			const diff = computeDraftDiff(currentValues, dbValues);
 			if (Object.keys(diff).length === 0) {
-				clearDraft(userId);
+				clearDraft(userId, siren, year);
 				setHasDraft(false);
 				return;
 			}
-			writeDraft(userId, {
+			writeDraft(userId, siren, year, {
 				siren,
 				year,
 				step,
@@ -74,9 +70,9 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 
 	const clearDraftCallback = useCallback(() => {
 		if (!isEnabled || userId === null) return;
-		clearDraft(userId);
+		clearDraft(userId, siren, year);
 		setHasDraft(false);
-	}, [isEnabled, userId]);
+	}, [isEnabled, userId, siren, year]);
 
 	return useMemo(
 		() => ({

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { computeDraftDiff } from "./computeDraftDiff";
+import type { DraftKind, DraftStep } from "./draftSchema";
+import { clearDraft, readDraft, writeDraft } from "./draftStorage";
+
+type UseDeclarationDraftOptions<T extends Record<string, unknown>> = {
+	siren: string;
+	year: number;
+	step: DraftStep;
+	kind: DraftKind;
+	dbValues: T;
+};
+
+type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
+	draft: Partial<T>;
+	setField: (currentValues: T) => void;
+	clearDraft: () => void;
+	hasDraft: boolean;
+};
+
+export function useDeclarationDraft<T extends Record<string, unknown>>(
+	options: UseDeclarationDraftOptions<T>,
+): UseDeclarationDraftResult<T> {
+	const { siren, year, step, kind, dbValues } = options;
+	const session = useSession();
+	const userId = session.data?.user?.id ?? null;
+	const isImpersonating = Boolean(session.data?.user?.impersonation);
+	const isEnabled = userId !== null && !isImpersonating;
+
+	const [draft, setDraft] = useState<Partial<T>>({});
+	const [hasDraft, setHasDraft] = useState(false);
+
+	useEffect(() => {
+		if (!isEnabled || userId === null) return;
+		const payload = readDraft(userId);
+		if (payload === null) return;
+		if (
+			payload.siren !== siren ||
+			payload.year !== year ||
+			payload.step !== step
+		) {
+			return;
+		}
+		const fields = payload.fields as Partial<T>;
+		setDraft(fields);
+		setHasDraft(Object.keys(fields).length > 0);
+	}, [isEnabled, userId, siren, year, step]);
+
+	const setField = useCallback(
+		(currentValues: T) => {
+			if (!isEnabled || userId === null) return;
+			const diff = computeDraftDiff(currentValues, dbValues);
+			if (Object.keys(diff).length === 0) {
+				clearDraft(userId);
+				setHasDraft(false);
+				return;
+			}
+			writeDraft(userId, {
+				siren,
+				year,
+				step,
+				kind,
+				timestamp: Date.now(),
+				fields: diff,
+			});
+			setHasDraft(true);
+		},
+		[isEnabled, userId, siren, year, step, kind, dbValues],
+	);
+
+	const clearDraftCallback = useCallback(() => {
+		if (!isEnabled || userId === null) return;
+		clearDraft(userId);
+		setHasDraft(false);
+	}, [isEnabled, userId]);
+
+	return useMemo(
+		() => ({
+			draft,
+			setField,
+			clearDraft: clearDraftCallback,
+			hasDraft,
+		}),
+		[draft, setField, clearDraftCallback, hasDraft],
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useEffect, useMemo } from "react";
 import { Controller } from "react-hook-form";
 import { useIsImpersonating } from "~/modules/auth";
 import { saveCompliancePathSchema } from "~/modules/declaration-remuneration/schemas";
+import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import type { CampaignDeadlines } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -12,223 +14,30 @@ import { api } from "~/trpc/react";
 import common from "../shared/common.module.scss";
 import { FormActions } from "../shared/FormActions";
 import { SavedIndicator } from "../shared/SavedIndicator";
-import { CompliancePathOption } from "./compliancePath/CompliancePathOption";
+import {
+	FirstRoundOptions,
+	getCompliancePathHref,
+	SecondRoundOptions,
+} from "./compliancePath/CompliancePathOptions";
 import type { CompliancePathValue } from "./compliancePath/constants";
 import { DeclarationSuccessBanner } from "./compliancePath/DeclarationSuccessBanner";
 
 type Props = {
 	campaignDeadlines: CampaignDeadlines;
 	currentYear: number;
+	declarationSiren: string;
+	declarationYear: number;
 	email: string;
 	initialPath?: CompliancePathValue;
 	isSecondRound?: boolean;
 	pdfDownloadHref?: string;
 };
 
-function JointEvaluationOption({
-	checked,
-	deadline,
-	disabled,
-	onChange,
-}: {
-	checked: boolean;
-	deadline: Date;
-	disabled?: boolean;
-	onChange: () => void;
-}) {
-	return (
-		<div className="fr-fieldset__element">
-			<CompliancePathOption
-				checked={checked}
-				deadline={deadline}
-				disabled={disabled}
-				id="path-joint"
-				learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-				learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
-				name="compliance-path"
-				onChange={onChange}
-				title="Évaluation conjointe des rémunérations"
-				value="joint_evaluation"
-			>
-				<p className="fr-mb-0">
-					Vous choisissez de procéder à une évaluation conjointe des
-					rémunérations afin d&apos;identifier et de corriger les écarts
-					constatés :
-				</p>
-				<ul className="fr-mt-1w fr-mb-0">
-					<li>
-						Élaboration du rapport préalable (à déposer sur le portail Egapro)
-					</li>
-					<li>Analyse conjointe et définition des actions correctrices</li>
-					<li>
-						Mise en place de l&apos;accord collectif ou à défaut un plan
-						d&apos;action
-					</li>
-				</ul>
-			</CompliancePathOption>
-		</div>
-	);
-}
-
-function JustifyOption({
-	checked,
-	deadline,
-	disabled,
-	onChange,
-}: {
-	checked: boolean;
-	deadline: Date;
-	disabled?: boolean;
-	onChange: () => void;
-}) {
-	return (
-		<div className="fr-fieldset__element">
-			<CompliancePathOption
-				checked={checked}
-				deadline={deadline}
-				disabled={disabled}
-				id="path-justify"
-				name="compliance-path"
-				onChange={onChange}
-				title="Justifier les écarts de rémunération ≥ 5 %"
-				value="justify"
-			>
-				<p className="fr-mb-0">
-					Vous avez la possibilité de justifier vos écarts par des critères
-					objectifs et non sexistes :
-				</p>
-				<ul className="fr-mt-1w fr-mb-0">
-					<li>Informer et consulter votre CSE sur cette justification</li>
-					<li>Transmettre l&apos;avis du CSE</li>
-				</ul>
-			</CompliancePathOption>
-		</div>
-	);
-}
-
-function SecondRoundOptions({
-	disabled,
-	justificationDeadline,
-	jointEvaluationDeadline,
-	selectedPath,
-	setSelectedPath,
-}: {
-	disabled?: boolean;
-	justificationDeadline: Date;
-	jointEvaluationDeadline: Date;
-	selectedPath: CompliancePathValue | undefined;
-	setSelectedPath: (path: CompliancePathValue) => void;
-}) {
-	return (
-		<>
-			<JustifyOption
-				checked={selectedPath === "justify"}
-				deadline={justificationDeadline}
-				disabled={disabled}
-				onChange={() => setSelectedPath("justify")}
-			/>
-			<JointEvaluationOption
-				checked={selectedPath === "joint_evaluation"}
-				deadline={jointEvaluationDeadline}
-				disabled={disabled}
-				onChange={() => setSelectedPath("joint_evaluation")}
-			/>
-		</>
-	);
-}
-
-function FirstRoundOptions({
-	correctiveActionDeadline,
-	disabled,
-	jointEvaluationDeadline,
-	justificationDeadline,
-	selectedPath,
-	setSelectedPath,
-}: {
-	correctiveActionDeadline: Date;
-	disabled?: boolean;
-	jointEvaluationDeadline: Date;
-	justificationDeadline: Date;
-	selectedPath: CompliancePathValue | undefined;
-	setSelectedPath: (path: CompliancePathValue) => void;
-}) {
-	return (
-		<>
-			<JustifyOption
-				checked={selectedPath === "justify"}
-				deadline={justificationDeadline}
-				disabled={disabled}
-				onChange={() => setSelectedPath("justify")}
-			/>
-
-			<h3 className="fr-h6 fr-mt-3w fr-mb-0">
-				Si la justification n&apos;est pas possible par des critères objectifs
-				et non sexistes
-			</h3>
-
-			<div className="fr-fieldset__element fr-mt-2w">
-				<CompliancePathOption
-					checked={selectedPath === "corrective_action"}
-					deadline={correctiveActionDeadline}
-					disabled={disabled}
-					id="path-corrective"
-					learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-					learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
-					name="compliance-path"
-					onChange={() => setSelectedPath("corrective_action")}
-					title="Actions correctives et seconde déclaration"
-					value="corrective_action"
-				>
-					<p className="fr-mb-0">
-						Vous souhaitez mettre en place des actions correctives, puis
-						recalculer et redéclarer l&apos;indicateur par catégorie de salariés
-						:
-					</p>
-					<ul className="fr-mt-1w fr-mb-0">
-						<li>
-							Mettre en place des actions correctives par accord ou par plan
-							d&apos;action
-						</li>
-						<li>
-							Redéclarer l&apos;indicateur dans un délai de 6 mois après votre
-							première déclaration
-						</li>
-						<li>
-							Informer et consulter votre CSE sur l&apos;exactitude des données
-							et éventuellement, sur la justification des écarts ≥ 5 %
-						</li>
-						<li>Transmettre l&apos;avis ou les avis du CSE</li>
-					</ul>
-					<p className="fr-mt-1w fr-mb-0">
-						Si des écarts non justifiés persistent, vous devez engager une
-						évaluation conjointe des rémunérations.
-					</p>
-				</CompliancePathOption>
-			</div>
-
-			<JointEvaluationOption
-				checked={selectedPath === "joint_evaluation"}
-				deadline={jointEvaluationDeadline}
-				disabled={disabled}
-				onChange={() => setSelectedPath("joint_evaluation")}
-			/>
-		</>
-	);
-}
-
-function getCompliancePathHref(path: CompliancePathValue): string {
-	if (path === "corrective_action") {
-		return "/declaration-remuneration/parcours-conformite/etape/1";
-	}
-	if (path === "joint_evaluation") {
-		return "/declaration-remuneration/parcours-conformite/evaluation-conjointe";
-	}
-	return "/avis-cse";
-}
-
 export function CompliancePathChoice({
 	campaignDeadlines,
 	currentYear,
+	declarationSiren,
+	declarationYear,
 	email,
 	initialPath,
 	isSecondRound = false,
@@ -237,14 +46,40 @@ export function CompliancePathChoice({
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
 
+	const dbValues = useMemo(() => ({ path: initialPath }), [initialPath]);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: "compliance",
+		kind: "compliance",
+		dbValues,
+	});
+
 	const form = useZodForm(saveCompliancePathSchema, {
 		defaultValues: { path: initialPath },
 	});
 
+	useEffect(() => {
+		if (draft.path !== undefined) {
+			form.setValue("path", draft.path as CompliancePathValue);
+		}
+	}, [draft.path, form]);
+
+	useEffect(() => {
+		const sub = form.watch((values) =>
+			setField(values as { path: CompliancePathValue | undefined }),
+		);
+		return () => sub.unsubscribe();
+	}, [form, setField]);
+
 	const selectedPath = form.watch("path");
+	const hasInitialData = !!initialPath;
+	const saved = !hasDraft && hasInitialData;
 
 	const mutation = api.declaration.saveCompliancePath.useMutation({
 		onSuccess: (_, { path }) => {
+			clearDraft();
 			if (path === "corrective_action") {
 				router.push("/declaration-remuneration/parcours-conformite/etape/1");
 			} else if (path === "joint_evaluation") {
@@ -268,7 +103,7 @@ export function CompliancePathChoice({
 				<h1 className="fr-h4 fr-mb-0">
 					Déclaration des indicateurs de rémunération {currentYear}
 				</h1>
-				<SavedIndicator />
+				{saved && <SavedIndicator />}
 			</div>
 
 			<DeclarationSuccessBanner

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -72,6 +72,8 @@ export async function CompliancePathPage() {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={currentYear}
+				declarationSiren={data.declaration.siren}
+				declarationYear={currentYear}
 				email={email}
 				initialPath={
 					(data.declaration.compliancePath as

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -10,6 +10,7 @@ import { updateStep1Schema } from "../schemas";
 import common from "../shared/common.module.scss";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP1_CATEGORIES } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
@@ -22,12 +23,14 @@ import type { Step1Data } from "../types";
 import styles from "./Step1Workforce.module.scss";
 
 type Step1WorkforceProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step1Data;
 	gipPrefillData?: GipPrefillData;
 };
 
 export function Step1Workforce({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -38,18 +41,40 @@ export function Step1Workforce({
 
 	const hasInitialData = initialData.totalWomen > 0 || initialData.totalMen > 0;
 
-	const form = useZodForm(updateStep1Schema, {
-		defaultValues: {
+	const dbValues = useMemo(
+		() => ({
 			totalWomen: initialData.totalWomen,
 			totalMen: initialData.totalMen,
-		},
+		}),
+		[initialData.totalWomen, initialData.totalMen],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 1,
+		kind: "main",
+		dbValues,
+	});
+
+	const form = useZodForm(updateStep1Schema, {
+		defaultValues: dbValues,
 	});
 
 	const totalWomen = form.watch("totalWomen");
 	const totalMen = form.watch("totalMen");
 	const total = totalWomen + totalMen;
 
-	const [saved, setSaved] = useState(hasInitialData);
+	useEffect(() => {
+		if (typeof draft.totalWomen === "number") {
+			form.setValue("totalWomen", draft.totalWomen);
+		}
+		if (typeof draft.totalMen === "number") {
+			form.setValue("totalMen", draft.totalMen);
+		}
+	}, [draft.totalWomen, draft.totalMen, form]);
+
+	const saved = !hasDraft && hasInitialData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const [showResetWarning, setShowResetWarning] = useState(false);
 
@@ -58,7 +83,10 @@ export function Step1Workforce({
 	}
 
 	const mutation = api.declaration.updateStep1.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/2"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/2");
+		},
 	});
 
 	function parseIntegerInput(raw: string): number | null {
@@ -71,14 +99,14 @@ export function Step1Workforce({
 		const value = parseIntegerInput(e.target.value);
 		if (value === null) return;
 		form.setValue("totalWomen", value);
-		setSaved(false);
+		setField({ totalWomen: value, totalMen });
 	}
 
 	function handleMenChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const value = parseIntegerInput(e.target.value);
 		if (value === null) return;
 		form.setValue("totalMen", value);
-		setSaved(false);
+		setField({ totalWomen, totalMen: value });
 	}
 
 	const onSubmit = form.handleSubmit((data) => {
@@ -96,9 +124,11 @@ export function Step1Workforce({
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
 				onDevFill={() => {
-					form.setValue("totalWomen", DEV_STEP1_CATEGORIES[0]?.women ?? 50);
-					form.setValue("totalMen", DEV_STEP1_CATEGORIES[0]?.men ?? 50);
-					setSaved(false);
+					const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;
+					const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;
+					form.setValue("totalWomen", womenValue);
+					form.setValue("totalMen", menValue);
+					setField({ totalWomen: womenValue, totalMen: menValue });
 				}}
 				saved={saved}
 				title={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
@@ -11,6 +11,7 @@ import { updateStep2Schema } from "../schemas";
 import common from "../shared/common.module.scss";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP2_ROWS } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
@@ -25,12 +26,14 @@ import { TooltipButton } from "../shared/TooltipButton";
 import type { PayGapField, Step2Data } from "../types";
 
 type Step2PayGapProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step2Data;
 	gipPrefillData?: GipPrefillData;
 };
 
 export function Step2PayGap({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -50,16 +53,47 @@ export function Step2PayGap({
 
 	const hasInitialData = hasSavedData;
 
+	const dbValues = useMemo(
+		() =>
+			Object.fromEntries(
+				Object.entries(initialData).map(([k, v]) => [k, padDecimalToTwo(v)]),
+			) as Step2Data,
+		[initialData],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 2,
+		kind: "main",
+		dbValues,
+	});
+
 	const form = useZodForm(updateStep2Schema, { defaultValues });
+
+	useEffect(() => {
+		(Object.keys(draft) as Array<keyof Step2Data>).forEach((key) => {
+			const value = draft[key];
+			if (value !== undefined) form.setValue(key, value as string);
+		});
+	}, [draft, form]);
+
+	useEffect(() => {
+		const sub = form.watch((values) => setField(values as Step2Data));
+		return () => sub.unsubscribe();
+	}, [form, setField]);
 
 	const formData = form.watch();
 	const rows = step2ToRows(formData as Step2Data);
 
-	const [saved, setSaved] = useState(hasInitialData);
+	const saved = !hasDraft && hasInitialData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep2.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/3"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/3");
+		},
 	});
 
 	function handleRowChange(index: number, field: PayGapField, value: string) {
@@ -68,7 +102,6 @@ export function Step2PayGap({
 		if (normalized !== "" && Number.parseFloat(normalized) < 0) return;
 		const fieldName = getStep2FieldName(index, field);
 		form.setValue(fieldName, normalized);
-		setSaved(false);
 	}
 
 	const onSubmit = form.handleSubmit(() => {
@@ -93,7 +126,6 @@ export function Step2PayGap({
 						form.setValue(womenField, padDecimalToTwo(row.womenValue));
 						form.setValue(menField, padDecimalToTwo(row.menValue));
 					});
-					setSaved(false);
 				}}
 				saved={saved}
 				title={
@@ -105,7 +137,6 @@ export function Step2PayGap({
 
 			<StepIndicator currentStep={2} />
 
-			{/* Introduction */}
 			<div className={common.flexColumnGap1}>
 				<p className="fr-mb-0">
 					Ces indicateurs mesurent la différence de rémunération, moyenne et
@@ -131,7 +162,6 @@ export function Step2PayGap({
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 			</div>
 
-			{/* Data section */}
 			<div className={common.dataSection}>
 				<div className={common.flexColumnGapHalf}>
 					<PayGapTable

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -42,6 +42,16 @@ type Step3VariablePayProps = {
 	maxMen?: number;
 };
 
+function padStep3(data: Step3Data): Step3Data {
+	return Object.fromEntries(
+		Object.entries(data).map(([k, v]) =>
+			k === "indicatorEWomen" || k === "indicatorEMen"
+				? [k, v]
+				: [k, padDecimalToTwo(v)],
+		),
+	) as Step3Data;
+}
+
 export function Step3VariablePay({
 	declarationSiren,
 	declarationYear,
@@ -55,15 +65,11 @@ export function Step3VariablePay({
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
 
-	function padStep3(data: Step3Data): Step3Data {
-		return Object.fromEntries(
-			Object.entries(data).map(([k, v]) =>
-				k === "indicatorEWomen" || k === "indicatorEMen" ? [k, v] : [k, padDecimalToTwo(v)],
-			),
-		) as Step3Data;
-	}
-
-	const rawDefaults = hasSavedData ? initialData : gipPrefillData ? gipToStep3(gipPrefillData.step3) : initialData;
+	const rawDefaults = hasSavedData
+		? initialData
+		: gipPrefillData
+			? gipToStep3(gipPrefillData.step3)
+			: initialData;
 	const defaultValues = padStep3(rawDefaults);
 	const dbValues = useMemo(() => padStep3(initialData), [initialData]);
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import {
 	computeProportion,
@@ -18,6 +18,7 @@ import {
 	DEV_STEP3_BENEFICIARY_WOMEN,
 	DEV_STEP3_ROWS,
 } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
@@ -33,6 +34,7 @@ import type { PayGapField, Step3Data } from "../types";
 import stepStyles from "./Step3VariablePay.module.scss";
 
 type Step3VariablePayProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step3Data;
 	gipPrefillData?: GipPrefillData;
@@ -41,6 +43,7 @@ type Step3VariablePayProps = {
 };
 
 export function Step3VariablePay({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -51,22 +54,40 @@ export function Step3VariablePay({
 	const isImpersonating = useIsImpersonating();
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
-	const rawDefaults = hasSavedData
-		? initialData
-		: gipPrefillData
-			? gipToStep3(gipPrefillData.step3)
-			: initialData;
-	const defaultValues = Object.fromEntries(
-		Object.entries(rawDefaults).map(([k, v]) =>
-			k === "indicatorEWomen" || k === "indicatorEMen"
-				? [k, v]
-				: [k, padDecimalToTwo(v)],
-		),
-	) as Step3Data;
 
-	const hasInitialData = hasSavedData;
+	function padStep3(data: Step3Data): Step3Data {
+		return Object.fromEntries(
+			Object.entries(data).map(([k, v]) =>
+				k === "indicatorEWomen" || k === "indicatorEMen" ? [k, v] : [k, padDecimalToTwo(v)],
+			),
+		) as Step3Data;
+	}
+
+	const rawDefaults = hasSavedData ? initialData : gipPrefillData ? gipToStep3(gipPrefillData.step3) : initialData;
+	const defaultValues = padStep3(rawDefaults);
+	const dbValues = useMemo(() => padStep3(initialData), [initialData]);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 3,
+		kind: "main",
+		dbValues,
+	});
 
 	const form = useZodForm(updateStep3Schema, { defaultValues });
+
+	useEffect(() => {
+		(Object.keys(draft) as Array<keyof Step3Data>).forEach((key) => {
+			const value = draft[key];
+			if (value !== undefined) form.setValue(key, value as string);
+		});
+	}, [draft, form]);
+
+	useEffect(() => {
+		const sub = form.watch((values) => setField(values as Step3Data));
+		return () => sub.unsubscribe();
+	}, [form, setField]);
 
 	const formData = form.watch();
 	const rows = step3ToRows(formData as Step3Data);
@@ -76,11 +97,14 @@ export function Step3VariablePay({
 	const [benefValidationError, setBenefValidationError] = useState<
 		string | null
 	>(null);
-	const [saved, setSaved] = useState(hasInitialData);
+	const saved = !hasDraft && hasSavedData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep3.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/4"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/4");
+		},
 	});
 
 	function handleRowChange(index: number, field: PayGapField, value: string) {
@@ -89,7 +113,6 @@ export function Step3VariablePay({
 		if (normalized !== "" && Number.parseFloat(normalized) < 0) return;
 		const fieldName = getStep3FieldName(index, field);
 		form.setValue(fieldName, normalized);
-		setSaved(false);
 	}
 
 	function handleBenefChange(
@@ -113,7 +136,6 @@ export function Step3VariablePay({
 		}
 		setBenefValidationError(null);
 		form.setValue(field, value);
-		setSaved(false);
 	}
 
 	const onSubmit = form.handleSubmit(() => {
@@ -141,7 +163,6 @@ export function Step3VariablePay({
 					});
 					form.setValue("indicatorEWomen", DEV_STEP3_BENEFICIARY_WOMEN);
 					form.setValue("indicatorEMen", DEV_STEP3_BENEFICIARY_MEN);
-					setSaved(false);
 				}}
 				saved={saved}
 				title={
@@ -153,7 +174,6 @@ export function Step3VariablePay({
 
 			<StepIndicator currentStep={3} />
 
-			{/* Introduction */}
 			<div className={common.flexColumnGap1}>
 				<p className="fr-mb-0">
 					Ces indicateurs évaluent et comparent les rémunérations variables
@@ -179,9 +199,7 @@ export function Step3VariablePay({
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 			</div>
 
-			{/* Data section */}
 			<div className={common.dataSection}>
-				{/* Table 1 - Variable pay gap + source */}
 				<div className={common.flexColumnGapHalf}>
 					<PayGapTable
 						caption="Écart de rémunération variable ou complémentaire"
@@ -206,7 +224,6 @@ export function Step3VariablePay({
 					)}
 				</div>
 
-				{/* Table 2 - Beneficiaries + source */}
 				<div className={common.flexColumnGapHalf}>
 					<div
 						className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -220,10 +220,9 @@ export function Step4QuartileDistribution({
 		requestAnimationFrame(() => alertRef.current?.focus());
 	}
 
-	function onSubmitValid(values: {
-		annual: QuartileTuple;
-		hourly: QuartileTuple;
-	}) {
+	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		const values = form.getValues();
 		const errors = deriveErrors(values);
 		if (hasAnyError(errors)) {
 			setFieldErrors(errors);
@@ -243,11 +242,7 @@ export function Step4QuartileDistribution({
 	const showAlert = showRecap && recap.length > 0;
 
 	return (
-		<form
-			className={stepStyles.formColumn}
-			noValidate
-			onSubmit={form.handleSubmit(onSubmitValid)}
-		>
+		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
 			<StepTitleRow
 				onDevFill={() => {
 					form.setValue(
@@ -301,9 +296,9 @@ export function Step4QuartileDistribution({
 					role="alert"
 					tabIndex={-1}
 				>
-					<p className="fr-alert__title" id="step4-error-summary-title">
+					<h3 className="fr-alert__title" id="step4-error-summary-title">
 						Le formulaire contient des erreurs
-					</p>
+					</h3>
 					<ul>
 						{recap.map((entry) => (
 							<li key={entry.id}>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared";
@@ -9,6 +9,7 @@ import { api } from "~/trpc/react";
 import { updateStep4Schema } from "../schemas";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP4_ANNUAL, DEV_STEP4_HOURLY } from "../shared/devFillData";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
@@ -36,7 +37,15 @@ import {
 	toQuartileData,
 } from "./step4/quartileFormHelpers";
 
+function padThresholds(qs: QuartileTuple): QuartileTuple {
+	return qs.map((q, i) => ({
+		...q,
+		threshold: i === 3 ? undefined : padDecimalToTwo(q.threshold ?? ""),
+	})) as QuartileTuple;
+}
+
 type Step4QuartileDistributionProps = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialData: Step4Data;
 	gipPrefillData?: GipPrefillData;
@@ -45,6 +54,7 @@ type Step4QuartileDistributionProps = {
 };
 
 export function Step4QuartileDistribution({
+	declarationSiren,
 	declarationYear,
 	initialData,
 	gipPrefillData,
@@ -63,12 +73,6 @@ export function Step4QuartileDistribution({
 			(q) => q.threshold || q.women !== undefined || q.men !== undefined,
 		);
 
-	const padThresholds = (qs: QuartileTuple): QuartileTuple =>
-		qs.map((q, i) => ({
-			...q,
-			threshold: i === 3 ? undefined : padDecimalToTwo(q.threshold ?? ""),
-		})) as QuartileTuple;
-
 	const defaultAnnual = padThresholds(
 		(hasSavedData
 			? initialData.annual
@@ -85,6 +89,26 @@ export function Step4QuartileDistribution({
 				: emptyQuartiles()) as QuartileTuple,
 	);
 
+	const dbValues = useMemo(
+		() => ({
+			annual: padThresholds(
+				hasSavedData ? (initialData.annual as QuartileTuple) : emptyQuartiles(),
+			),
+			hourly: padThresholds(
+				hasSavedData ? (initialData.hourly as QuartileTuple) : emptyQuartiles(),
+			),
+		}),
+		[hasSavedData, initialData],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 4,
+		kind: "main",
+		dbValues,
+	});
+
 	const form = useZodForm(updateStep4Schema, {
 		defaultValues: {
 			annual: defaultAnnual as QuartileTuple,
@@ -92,16 +116,34 @@ export function Step4QuartileDistribution({
 		},
 	});
 
+	useEffect(() => {
+		if (draft.annual) form.setValue("annual", draft.annual);
+		if (draft.hourly) form.setValue("hourly", draft.hourly);
+	}, [draft.annual, draft.hourly, form]);
+
+	useEffect(() => {
+		const sub = form.watch((values) =>
+			setField({
+				annual: values.annual as QuartileTuple,
+				hourly: values.hourly as QuartileTuple,
+			}),
+		);
+		return () => sub.unsubscribe();
+	}, [form, setField]);
+
 	const annual = form.watch("annual");
 	const hourly = form.watch("hourly");
 
 	const [maxError, setMaxError] = useState<string | null>(null);
-	const [saved, setSaved] = useState(hasSavedData);
+	const saved = !hasDraft && hasSavedData;
 	const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>(emptyErrorMap);
 	const [showRecap, setShowRecap] = useState(false);
 
 	const mutation = api.declaration.updateStep4.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/5"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/5");
+		},
 	});
 
 	function setQuartileField(
@@ -155,7 +197,6 @@ export function Step4QuartileDistribution({
 			if (value === "") {
 				setQuartileField(tableType, index, field, undefined);
 				setMaxError(null);
-				setSaved(false);
 				clearFieldError(tableType, index, field);
 				return;
 			}
@@ -172,7 +213,6 @@ export function Step4QuartileDistribution({
 			setMaxError(null);
 			setQuartileField(tableType, index, field, n);
 		}
-		setSaved(false);
 		clearFieldError(tableType, index, field);
 	}
 
@@ -180,9 +220,10 @@ export function Step4QuartileDistribution({
 		requestAnimationFrame(() => alertRef.current?.focus());
 	}
 
-	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
-		event.preventDefault();
-		const values = form.getValues();
+	function onSubmitValid(values: {
+		annual: QuartileTuple;
+		hourly: QuartileTuple;
+	}) {
 		const errors = deriveErrors(values);
 		if (hasAnyError(errors)) {
 			setFieldErrors(errors);
@@ -202,7 +243,11 @@ export function Step4QuartileDistribution({
 	const showAlert = showRecap && recap.length > 0;
 
 	return (
-		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
+		<form
+			className={stepStyles.formColumn}
+			noValidate
+			onSubmit={form.handleSubmit(onSubmitValid)}
+		>
 			<StepTitleRow
 				onDevFill={() => {
 					form.setValue(
@@ -217,7 +262,6 @@ export function Step4QuartileDistribution({
 							DEV_STEP4_HOURLY.map(toQuartileData) as QuartileTuple,
 						),
 					);
-					setSaved(false);
 					setFieldErrors(emptyErrorMap());
 					setShowRecap(false);
 				}}
@@ -257,9 +301,9 @@ export function Step4QuartileDistribution({
 					role="alert"
 					tabIndex={-1}
 				>
-					<h3 className="fr-alert__title" id="step4-error-summary-title">
+					<p className="fr-alert__title" id="step4-error-summary-title">
 						Le formulaire contient des erreurs
-					</h3>
+					</p>
 					<ul>
 						{recap.map((entry) => (
 							<li key={entry.id}>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -1,14 +1,35 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
+import { padDecimalToTwo } from "~/modules/domain";
 import { api } from "~/trpc/react";
+import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { StepIndicator } from "../shared/StepIndicator";
 import type { EmployeeCategoryRow } from "../types";
 import { CategoryForm } from "./step5/CategoryForm";
 
+type Step5FormValues = {
+	source: string;
+	categories: {
+		name: string;
+		womenCount: string;
+		menCount: string;
+		annualBaseWomen: string;
+		annualBaseMen: string;
+		annualVariableWomen: string;
+		annualVariableMen: string;
+		hourlyBaseWomen: string;
+		hourlyBaseMen: string;
+		hourlyVariableWomen: string;
+		hourlyVariableMen: string;
+	}[];
+};
+
 type Props = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialCategories?: EmployeeCategoryRow[];
 	initialSource?: string;
@@ -17,6 +38,7 @@ type Props = {
 };
 
 export function Step5EmployeeCategories({
+	declarationSiren,
 	declarationYear,
 	initialCategories,
 	initialSource,
@@ -27,18 +49,66 @@ export function Step5EmployeeCategories({
 	const isImpersonating = useIsImpersonating();
 	const hasInitialData = (initialCategories?.length ?? 0) > 0;
 
+	const dbValues = useMemo<Step5FormValues>(
+		() => ({
+			source: initialSource ?? "",
+			categories: (initialCategories ?? []).map((row) => ({
+				name: row.name,
+				womenCount: row.womenCount?.toString() ?? "",
+				menCount: row.menCount?.toString() ?? "",
+				annualBaseWomen: padDecimalToTwo(row.annualBaseWomen ?? ""),
+				annualBaseMen: padDecimalToTwo(row.annualBaseMen ?? ""),
+				annualVariableWomen: padDecimalToTwo(row.annualVariableWomen ?? ""),
+				annualVariableMen: padDecimalToTwo(row.annualVariableMen ?? ""),
+				hourlyBaseWomen: padDecimalToTwo(row.hourlyBaseWomen ?? ""),
+				hourlyBaseMen: padDecimalToTwo(row.hourlyBaseMen ?? ""),
+				hourlyVariableWomen: padDecimalToTwo(row.hourlyVariableWomen ?? ""),
+				hourlyVariableMen: padDecimalToTwo(row.hourlyVariableMen ?? ""),
+			})),
+		}),
+		[initialCategories, initialSource],
+	);
+
+	const { draft, setField, clearDraft, hasDraft } =
+		useDeclarationDraft<Step5FormValues>({
+			siren: declarationSiren,
+			year: declarationYear,
+			step: 5,
+			kind: "main",
+			dbValues,
+		});
+
+	const [draftLoaded, setDraftLoaded] = useState(false);
+
+	useEffect(() => {
+		if (hasDraft && !draftLoaded) setDraftLoaded(true);
+	}, [hasDraft, draftLoaded]);
+
+	const categoryFormKey = draftLoaded ? 1 : 0;
+	const categoryFormDefaultOverride = draftLoaded
+		? {
+				source: draft.source ?? initialSource ?? "",
+				categories: draft.categories ?? dbValues.categories,
+			}
+		: undefined;
+
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
-		onSuccess: () => router.push("/declaration-remuneration/etape/6"),
+		onSuccess: () => {
+			clearDraft();
+			router.push("/declaration-remuneration/etape/6");
+		},
 	});
 
 	return (
 		<CategoryForm
 			accordionId="accordion-step5"
+			defaultValuesOverride={categoryFormDefaultOverride}
 			disabled={isImpersonating}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
 			isSubmitting={mutation.isPending}
+			key={categoryFormKey}
 			maxMen={maxMen}
 			maxWomen={maxWomen}
 			mimoquageNextHref={
@@ -51,8 +121,10 @@ export function Step5EmployeeCategories({
 					categories: data.categories,
 				})
 			}
+			onValuesChange={(values) => setField(values)}
 			previousHref="/declaration-remuneration/etape/4"
 			referenceYear={declarationYear - 1}
+			savedOverride={!hasDraft && hasInitialData}
 			stepper={<StepIndicator currentStep={5} />}
 			submitError={mutation.error?.message}
 			title={

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -6,6 +6,9 @@ import { CompliancePathChoice } from "../CompliancePathChoice";
 
 const campaignDeadlines = getDefaultCampaignDeadlines(2026);
 
+const DECLARATION_SIREN = "123456789";
+const DECLARATION_YEAR = 2026;
+
 const mockMutate = vi.fn();
 const mockPush = vi.fn();
 
@@ -49,6 +52,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 			/>,
 		);
@@ -65,6 +70,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 			/>,
 		);
@@ -84,6 +91,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 			/>,
 		);
@@ -96,6 +105,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 			/>,
 		);
@@ -112,6 +123,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 			/>,
 		);
@@ -138,6 +151,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 			/>,
 		);
@@ -164,6 +179,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 				initialPath="corrective_action"
 			/>,
@@ -179,6 +196,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 				isSecondRound={true}
 			/>,
@@ -196,6 +215,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
 			/>,
 		);
@@ -210,6 +231,8 @@ describe("CompliancePathChoice", () => {
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
 				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
 				email="john@company.fr"
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1DevFill.test.tsx
@@ -27,7 +27,11 @@ describe("Step1Workforce dev fill", () => {
 	it("fills workforce when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -24,7 +24,11 @@ const emptyStep1Data = () => ({ totalWomen: 0, totalMen: 0 });
 describe("Step1Workforce", () => {
 	it("renders default state with zero totals", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(screen.getByText("Nombre de salariés")).toBeInTheDocument();
 		const table = screen.getByRole("table");
@@ -38,7 +42,11 @@ describe("Step1Workforce", () => {
 
 	it("renders reference period and mandatory fields notice", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(
 			screen.getByText(/Période de référence pour le calcul des indicateurs/),
@@ -51,6 +59,7 @@ describe("Step1Workforce", () => {
 	it("renders initial data with correct values", () => {
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 10, totalMen: 20 }}
 			/>,
@@ -67,6 +76,7 @@ describe("Step1Workforce", () => {
 	it("shows SavedIndicator when initial data has values", () => {
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 5, totalMen: 3 }}
 			/>,
@@ -76,7 +86,11 @@ describe("Step1Workforce", () => {
 
 	it("does not show SavedIndicator when no initial data", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
@@ -84,7 +98,11 @@ describe("Step1Workforce", () => {
 	it("updates women/men values via inline inputs", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Nombre de femmes");
@@ -109,7 +127,11 @@ describe("Step1Workforce", () => {
 	it("validates total > 0 on submit", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });
@@ -122,6 +144,7 @@ describe("Step1Workforce", () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 10, totalMen: 20 }}
 			/>,
@@ -139,7 +162,11 @@ describe("Step1Workforce", () => {
 	it("shows validation error message when submitting with zero total", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });
@@ -154,7 +181,11 @@ describe("Step1Workforce", () => {
 
 	it("renders previous link pointing to home", () => {
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
@@ -165,6 +196,7 @@ describe("Step1Workforce", () => {
 	it("hides the reset warning by default", () => {
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
@@ -178,6 +210,7 @@ describe("Step1Workforce", () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Workforce
+				declarationSiren="123456789"
 				declarationYear={2026}
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
@@ -193,7 +226,11 @@ describe("Step1Workforce", () => {
 	it("does not show the reset warning when focusing an empty input", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step1Workforce declarationYear={2026} initialData={emptyStep1Data()} />,
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
 		);
 
 		await user.click(screen.getByLabelText("Nombre de femmes"));

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
@@ -36,7 +36,11 @@ describe("Step2PayGap dev fill", () => {
 	it("fills pay gap rows when dev fill button is clicked", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		await user.click(screen.getByRole("button", { name: "[DEV] Remplir" }));

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -33,7 +33,11 @@ const emptyStep2Data = () => ({
 describe("Step2PayGap", () => {
 	it("renders the table with 4 remuneration rows", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.getByText("Annuelle brute moyenne")).toBeInTheDocument();
 		expect(screen.getByText("Horaire brute moyenne")).toBeInTheDocument();
@@ -43,7 +47,11 @@ describe("Step2PayGap", () => {
 
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(
 			screen.getByText(
@@ -57,7 +65,11 @@ describe("Step2PayGap", () => {
 
 	it("renders table headers", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.getByText("Rémunération")).toBeInTheDocument();
 		expect(screen.getByText("Femmes")).toBeInTheDocument();
@@ -71,6 +83,7 @@ describe("Step2PayGap", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step2PayGap
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					indicatorAAnnualWomen: "100",
@@ -89,7 +102,11 @@ describe("Step2PayGap", () => {
 
 	it("does not show SavedIndicator when initialData is empty", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
@@ -97,7 +114,11 @@ describe("Step2PayGap", () => {
 	it("updates values via inline inputs and rejects negative values", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -120,7 +141,11 @@ describe("Step2PayGap", () => {
 	it("computes gap and shows badge after entering values", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -139,7 +164,11 @@ describe("Step2PayGap", () => {
 	it("shows no badge when gap is less than 5%", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const womenInput = screen.getByLabelText("Annuelle brute moyenne — Femmes");
@@ -158,7 +187,11 @@ describe("Step2PayGap", () => {
 
 	it("renders previous link pointing to step 1", () => {
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
@@ -169,6 +202,7 @@ describe("Step2PayGap", () => {
 	it("uses gipPrefillData when no initialData", () => {
 		render(
 			<Step2PayGap
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -220,7 +254,11 @@ describe("Step2PayGap", () => {
 	it("shows validation error on submit when fields are incomplete", async () => {
 		const user = userEvent.setup();
 		render(
-			<Step2PayGap declarationYear={2025} initialData={emptyStep2Data()} />,
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
 		);
 
 		const submitButton = screen.getByRole("button", { name: /suivant/i });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
@@ -39,6 +39,7 @@ describe("Step3VariablePay dev fill", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -36,6 +36,7 @@ describe("Step3VariablePay", () => {
 	it("renders the pay gap table with 4 rows", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -49,6 +50,7 @@ describe("Step3VariablePay", () => {
 	it("renders the beneficiaries table with workforce totals", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 				maxMen={60}
@@ -64,6 +66,7 @@ describe("Step3VariablePay", () => {
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -81,6 +84,7 @@ describe("Step3VariablePay", () => {
 	it("renders table headers with line break in column header", () => {
 		const { container } = render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -95,6 +99,7 @@ describe("Step3VariablePay", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					indicatorBAnnualWomen: "100",
@@ -116,6 +121,7 @@ describe("Step3VariablePay", () => {
 	it("does not show SavedIndicator when initialData is empty", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -127,6 +133,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -153,6 +160,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -175,6 +183,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -196,6 +205,7 @@ describe("Step3VariablePay", () => {
 		const user = userEvent.setup();
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 				maxMen={25}
@@ -215,6 +225,7 @@ describe("Step3VariablePay", () => {
 	it("renders previous link pointing to step 2", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep3Data()}
 			/>,
@@ -228,6 +239,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData when no initialData", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },
@@ -282,6 +294,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData with null beneficiary counts", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },
@@ -335,6 +348,7 @@ describe("Step3VariablePay", () => {
 	it("uses gipPrefillData with zero beneficiary counts", () => {
 		render(
 			<Step3VariablePay
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 80, totalMen: 100 },

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
@@ -41,6 +41,7 @@ describe("Step4QuartileDistribution dev fill", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
@@ -58,6 +58,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={validStep4Data()}
 			/>,
@@ -79,6 +80,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -113,6 +115,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -147,6 +150,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -38,6 +38,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders two tables with quartile rows and inverted columns", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -65,6 +66,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders renumeration tranche header and Pourcentage columns", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -84,6 +86,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders description text about quartiles", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -96,6 +99,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -113,6 +117,7 @@ describe("Step4QuartileDistribution", () => {
 	it("displays empty state with all min = - € and Q4 max = - €", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -126,6 +131,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders 3 threshold inputs per table (Q1/Q2/Q3 only) and Q4 readonly", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -141,6 +147,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders 4 women and 4 men count inputs per table", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -153,6 +160,7 @@ describe("Step4QuartileDistribution", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -172,6 +180,7 @@ describe("Step4QuartileDistribution", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -188,6 +197,7 @@ describe("Step4QuartileDistribution", () => {
 		const user = userEvent.setup();
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 				maxMen={25}
@@ -205,6 +215,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders mobile-label attributes on data cells for responsive reflow", () => {
 		const { container } = render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -228,6 +239,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders DSN source line on both tables even without GIP prefill", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -242,6 +254,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders accordion", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -254,6 +267,7 @@ describe("Step4QuartileDistribution", () => {
 	it("renders previous link pointing to step 3", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,
@@ -267,6 +281,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData to pre-populate 3 thresholds and counts", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -322,6 +337,7 @@ describe("Step4QuartileDistribution", () => {
 	it("uses gipPrefillData with all null quartile data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: null, totalMen: null },
@@ -375,6 +391,7 @@ describe("Step4QuartileDistribution", () => {
 	it("displays computed percentages for prefilled data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -399,6 +416,7 @@ describe("Step4QuartileDistribution", () => {
 	it("shows SavedIndicator when initialData has data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={{
 					annual: [
@@ -422,6 +440,7 @@ describe("Step4QuartileDistribution", () => {
 	it("does not show SavedIndicator when no initial data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialData={emptyStep4Data()}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
@@ -61,6 +61,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData when no initialCategories", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -95,6 +96,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData with partial null thresholds (Q4 has none)", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 100, totalMen: 100 },
@@ -126,6 +128,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData with all null quartile data", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: null, totalMen: null },
@@ -158,6 +161,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 	it("uses gipPrefillData with mono-gender quartiles (100% women)", () => {
 		render(
 			<Step4QuartileDistribution
+				declarationSiren="123456789"
 				declarationYear={2025}
 				gipPrefillData={{
 					step1: { totalWomen: 200, totalMen: 0 },

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
@@ -31,6 +31,7 @@ describe("Step5EmployeeCategories dev fill", () => {
 		const user = userEvent.setup();
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				maxMen={130}
 				maxWomen={120}

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -47,7 +47,12 @@ function makeCategory(
 
 describe("Step5EmployeeCategories", () => {
 	it("renders with 1 empty category by default", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByRole("button", { name: "Catégorie d'emplois n°1" }),
 		).toBeInTheDocument();
@@ -58,12 +63,22 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders stepper at step 5", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getByText("Étape 5 sur 6")).toBeInTheDocument();
 	});
 
 	it("renders description text and reference period", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByText(/mesurer l'écart de rémunération/),
 		).toBeInTheDocument();
@@ -71,7 +86,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders source dropdown", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByLabelText(/Quelle est la source utilisée/),
 		).toBeInTheDocument();
@@ -79,7 +99,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders instruction text", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByText(/Saisissez les données manquantes/),
 		).toBeInTheDocument();
@@ -89,7 +114,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table headers for the category", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getAllByText("Femmes").length).toBeGreaterThanOrEqual(1);
 		expect(screen.getAllByText("Hommes").length).toBeGreaterThanOrEqual(1);
 		expect(
@@ -98,7 +128,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders table section headers", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getAllByText(/Total salariés/).length).toBe(1);
 		expect(
 			screen.getAllByText("Rémunération annuelle brute moyenne").length,
@@ -109,14 +144,24 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders the libellé input field for category", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(document.getElementById("cat-0-name")).toBeInTheDocument();
 		expect(document.getElementById("cat-0-detail")).not.toBeInTheDocument();
 	});
 
 	it("can add a new category", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		await user.click(
 			screen.getByRole("button", {
@@ -132,7 +177,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("can remove a category after confirmation", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		// Add a second category first
 		await user.click(
@@ -162,7 +212,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("updates input fields and computes gap", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const annualBaseWomenInput = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -180,7 +235,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("accepts salary values above 9999", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -192,7 +252,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("rejects negative values in number inputs", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const input = screen.getByLabelText(
 			"Salaire de base annuel femmes, catégorie 1",
@@ -208,7 +273,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("computes annual total from base and variable", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		await user.type(
 			screen.getByLabelText("Salaire de base annuel femmes, catégorie 1"),
@@ -227,6 +297,7 @@ describe("Step5EmployeeCategories", () => {
 	it("shows SavedIndicator when initial data exists", () => {
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialCategories={[
 					makeCategory({
@@ -244,13 +315,19 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("does not show SavedIndicator with empty initial data", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
 	});
 
 	it("deserializes initial data into form fields", () => {
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialCategories={[
 					makeCategory({
@@ -271,7 +348,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("submits data on form submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",
@@ -297,6 +379,7 @@ describe("Step5EmployeeCategories", () => {
 		const user = userEvent.setup();
 		render(
 			<Step5EmployeeCategories
+				declarationSiren="123456789"
 				declarationYear={2025}
 				maxMen={20}
 				maxWomen={10}
@@ -323,7 +406,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category name is empty on submit", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		await user.click(screen.getByRole("button", { name: /suivant/i }));
 
@@ -335,7 +423,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows error when category names are duplicated", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		// Fill first category name
 		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
@@ -357,7 +450,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders previous link pointing to step 4", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/4",
@@ -365,7 +463,12 @@ describe("Step5EmployeeCategories", () => {
 	});
 
 	it("renders accordion for definitions", () => {
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 		expect(
 			screen.getByText("Définitions et méthode de calcul"),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
@@ -1,0 +1,203 @@
+import { CompliancePathOption } from "./CompliancePathOption";
+import type { CompliancePathValue } from "./constants";
+
+export function getCompliancePathHref(path: CompliancePathValue): string {
+	if (path === "corrective_action") {
+		return "/declaration-remuneration/parcours-conformite/etape/1";
+	}
+	if (path === "joint_evaluation") {
+		return "/declaration-remuneration/parcours-conformite/evaluation-conjointe";
+	}
+	return "/avis-cse";
+}
+
+export function JointEvaluationOption({
+	checked,
+	deadline,
+	disabled,
+	onChange,
+}: {
+	checked: boolean;
+	deadline: Date;
+	disabled?: boolean;
+	onChange: () => void;
+}) {
+	return (
+		<div className="fr-fieldset__element">
+			<CompliancePathOption
+				checked={checked}
+				deadline={deadline}
+				disabled={disabled}
+				id="path-joint"
+				learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+				learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
+				name="compliance-path"
+				onChange={onChange}
+				title="Évaluation conjointe des rémunérations"
+				value="joint_evaluation"
+			>
+				<p className="fr-mb-0">
+					Vous choisissez de procéder à une évaluation conjointe des
+					rémunérations afin d&apos;identifier et de corriger les écarts
+					constatés :
+				</p>
+				<ul className="fr-mt-1w fr-mb-0">
+					<li>
+						Élaboration du rapport préalable (à déposer sur le portail Egapro)
+					</li>
+					<li>Analyse conjointe et définition des actions correctrices</li>
+					<li>
+						Mise en place de l&apos;accord collectif ou à défaut un plan
+						d&apos;action
+					</li>
+				</ul>
+			</CompliancePathOption>
+		</div>
+	);
+}
+
+export function JustifyOption({
+	checked,
+	deadline,
+	disabled,
+	onChange,
+}: {
+	checked: boolean;
+	deadline: Date;
+	disabled?: boolean;
+	onChange: () => void;
+}) {
+	return (
+		<div className="fr-fieldset__element">
+			<CompliancePathOption
+				checked={checked}
+				deadline={deadline}
+				disabled={disabled}
+				id="path-justify"
+				name="compliance-path"
+				onChange={onChange}
+				title="Justifier les écarts de rémunération ≥ 5 %"
+				value="justify"
+			>
+				<p className="fr-mb-0">
+					Vous avez la possibilité de justifier vos écarts par des critères
+					objectifs et non sexistes :
+				</p>
+				<ul className="fr-mt-1w fr-mb-0">
+					<li>Informer et consulter votre CSE sur cette justification</li>
+					<li>Transmettre l&apos;avis du CSE</li>
+				</ul>
+			</CompliancePathOption>
+		</div>
+	);
+}
+
+export function SecondRoundOptions({
+	disabled,
+	justificationDeadline,
+	jointEvaluationDeadline,
+	selectedPath,
+	setSelectedPath,
+}: {
+	disabled?: boolean;
+	justificationDeadline: Date;
+	jointEvaluationDeadline: Date;
+	selectedPath: CompliancePathValue | undefined;
+	setSelectedPath: (path: CompliancePathValue) => void;
+}) {
+	return (
+		<>
+			<JustifyOption
+				checked={selectedPath === "justify"}
+				deadline={justificationDeadline}
+				disabled={disabled}
+				onChange={() => setSelectedPath("justify")}
+			/>
+			<JointEvaluationOption
+				checked={selectedPath === "joint_evaluation"}
+				deadline={jointEvaluationDeadline}
+				disabled={disabled}
+				onChange={() => setSelectedPath("joint_evaluation")}
+			/>
+		</>
+	);
+}
+
+export function FirstRoundOptions({
+	correctiveActionDeadline,
+	disabled,
+	jointEvaluationDeadline,
+	justificationDeadline,
+	selectedPath,
+	setSelectedPath,
+}: {
+	correctiveActionDeadline: Date;
+	disabled?: boolean;
+	jointEvaluationDeadline: Date;
+	justificationDeadline: Date;
+	selectedPath: CompliancePathValue | undefined;
+	setSelectedPath: (path: CompliancePathValue) => void;
+}) {
+	return (
+		<>
+			<JustifyOption
+				checked={selectedPath === "justify"}
+				deadline={justificationDeadline}
+				disabled={disabled}
+				onChange={() => setSelectedPath("justify")}
+			/>
+
+			<h3 className="fr-h6 fr-mt-3w fr-mb-0">
+				Si la justification n&apos;est pas possible par des critères objectifs
+				et non sexistes
+			</h3>
+
+			<div className="fr-fieldset__element fr-mt-2w">
+				<CompliancePathOption
+					checked={selectedPath === "corrective_action"}
+					deadline={correctiveActionDeadline}
+					disabled={disabled}
+					id="path-corrective"
+					learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+					learnMoreLabel="En savoir plus sur actions correctives et seconde déclaration"
+					name="compliance-path"
+					onChange={() => setSelectedPath("corrective_action")}
+					title="Actions correctives et seconde déclaration"
+					value="corrective_action"
+				>
+					<p className="fr-mb-0">
+						Vous souhaitez mettre en place des actions correctives, puis
+						recalculer et redéclarer l&apos;indicateur par catégorie de salariés
+						:
+					</p>
+					<ul className="fr-mt-1w fr-mb-0">
+						<li>
+							Mettre en place des actions correctives par accord ou par plan
+							d&apos;action
+						</li>
+						<li>
+							Redéclarer l&apos;indicateur dans un délai de 6 mois après votre
+							première déclaration
+						</li>
+						<li>
+							Informer et consulter votre CSE sur l&apos;exactitude des données
+							et éventuellement, sur la justification des écarts ≥ 5 %
+						</li>
+						<li>Transmettre l&apos;avis ou les avis du CSE</li>
+					</ul>
+					<p className="fr-mt-1w fr-mb-0">
+						Si des écarts non justifiés persistent, vous devez engager une
+						évaluation conjointe des rémunérations.
+					</p>
+				</CompliancePathOption>
+			</div>
+
+			<JointEvaluationOption
+				checked={selectedPath === "joint_evaluation"}
+				deadline={jointEvaluationDeadline}
+				disabled={disabled}
+				onChange={() => setSelectedPath("joint_evaluation")}
+			/>
+		</>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -2,29 +2,49 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useCallback } from "react";
 import { useReadOnlyGuard } from "~/modules/auth";
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
 import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
-import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
+import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { formatLongDate } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { FileUpload, useFileUploadForm } from "~/modules/shared";
 
 import { JointEvaluationSubmitModal } from "./JointEvaluationSubmitModal";
 
+const EMPTY_DB_VALUES = {} as Record<string, never>;
+
 type Props = {
 	declarationDate: string;
+	declarationSiren: string;
+	declarationYear: number;
 	hasCse: boolean | null;
 	jointEvaluationDeadline: Date;
 };
 
 export function JointEvaluationForm({
 	declarationDate,
+	declarationSiren,
+	declarationYear,
 	hasCse,
 	jointEvaluationDeadline,
 }: Props) {
 	const router = useRouter();
 	const readOnlyGuard = useReadOnlyGuard();
+
+	const { clearDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: "joint",
+		kind: "joint",
+		dbValues: EMPTY_DB_VALUES,
+	});
+
+	const onAllUploaded = useCallback(() => {
+		clearDraft();
+		router.push(getPostComplianceDestination(hasCse));
+	}, [clearDraft, hasCse, router]);
 
 	const {
 		closeModal,
@@ -37,7 +57,7 @@ export function JointEvaluationForm({
 		uploadError,
 	} = useFileUploadForm({
 		flowType: "joint_evaluation",
-		onAllUploaded: () => router.push(getPostComplianceDestination(hasCse)),
+		onAllUploaded,
 	});
 
 	return (
@@ -48,7 +68,6 @@ export function JointEvaluationForm({
 						Parcours de mise en conformité pour l&apos;indicateur par catégorie
 						de salariés
 					</h1>
-					<SavedIndicator />
 				</div>
 
 				<div className={common.flexColumnGap1}>

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
@@ -22,6 +22,8 @@ export async function JointEvaluationPage() {
 	return (
 		<JointEvaluationForm
 			declarationDate={declarationDate}
+			declarationSiren={data.declaration.siren}
+			declarationYear={currentYear}
 			hasCse={company.hasCse}
 			jointEvaluationDeadline={campaignDeadlines.decl1JointEvaluationDeadline}
 		/>

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -22,6 +22,8 @@ const { uploadFile: uploadFileMock } = (await import(
 
 const defaultProps = {
 	declarationDate: "01/06/2026",
+	declarationSiren: "123456789",
+	declarationYear: 2026,
 	hasCse: null as boolean | null,
 	jointEvaluationDeadline: new Date("2026-08-01T00:00:00"),
 };

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -31,8 +31,7 @@ export function SecondDeclarationStep1Info({
 		dbValues: EMPTY_DB_VALUES,
 	});
 
-	const hasInitialData = !!declarationDate;
-	const saved = !hasDraft && hasInitialData;
+	const saved = !hasDraft;
 
 	return (
 		<div className={common.flexColumnGap2}>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -1,19 +1,39 @@
+"use client";
+
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { formatLongDate } from "~/modules/domain";
 import { BASE_PATH } from "./constants";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
+const EMPTY_DB_VALUES = {} as Record<string, never>;
+
 type Props = {
 	declarationDate: string;
+	declarationSiren: string;
+	declarationYear: number;
 	modificationDeadline: Date;
 };
 
 export function SecondDeclarationStep1Info({
 	declarationDate,
+	declarationSiren,
+	declarationYear,
 	modificationDeadline,
 }: Props) {
+	const { hasDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: "second-1",
+		kind: "second",
+		dbValues: EMPTY_DB_VALUES,
+	});
+
+	const hasInitialData = !!declarationDate;
+	const saved = !hasDraft && hasInitialData;
+
 	return (
 		<div className={common.flexColumnGap2}>
 			<div className={common.flexBetween}>
@@ -21,7 +41,7 @@ export function SecondDeclarationStep1Info({
 					Parcours de mise en conformité pour l&apos;indicateur par catégorie de
 					salariés
 				</h1>
-				<SavedIndicator />
+				{saved && <SavedIndicator />}
 			</div>
 
 			<SecondDeclarationStepIndicator currentStep={1} />
@@ -50,8 +70,6 @@ export function SecondDeclarationStep1Info({
 		</div>
 	);
 }
-
-// -- Sub-components --
 
 function DeadlineBlock({
 	deadline,

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
@@ -60,9 +60,17 @@ export function SecondDeclarationStep2Form({
 		dbValues,
 	});
 
+	const didHydrate = useRef(false);
 	useEffect(() => {
+		if (didHydrate.current) return;
+		if (
+			typeof draft.startDate !== "string" &&
+			typeof draft.endDate !== "string"
+		)
+			return;
 		if (typeof draft.startDate === "string") setStartDate(draft.startDate);
 		if (typeof draft.endDate === "string") setEndDate(draft.endDate);
+		didHydrate.current = true;
 	}, [draft.startDate, draft.endDate]);
 
 	useEffect(() => {

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
+import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { api } from "~/trpc/react";
 import { CategoryForm } from "../step5/CategoryForm";
@@ -11,6 +12,7 @@ import { ReferencePeriodPicker } from "./ReferencePeriodPicker";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 type Props = {
+	declarationSiren: string;
 	declarationYear: number;
 	initialFirstDeclarationCategories: EmployeeCategoryRow[];
 	initialSecondDeclarationCategories?: EmployeeCategoryRow[];
@@ -20,6 +22,7 @@ type Props = {
 };
 
 export function SecondDeclarationStep2Form({
+	declarationSiren,
 	declarationYear,
 	initialFirstDeclarationCategories,
 	initialSecondDeclarationCategories,
@@ -41,8 +44,36 @@ export function SecondDeclarationStep2Form({
 	const hasSavedSecondDeclaration =
 		(initialSecondDeclarationCategories?.length ?? 0) > 0;
 
+	const dbValues = useMemo(
+		() => ({
+			startDate: initialStartDate ?? "",
+			endDate: initialEndDate ?? "",
+		}),
+		[initialStartDate, initialEndDate],
+	);
+
+	const { draft, setField, clearDraft } = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: "second-2",
+		kind: "second",
+		dbValues,
+	});
+
+	useEffect(() => {
+		if (typeof draft.startDate === "string") setStartDate(draft.startDate);
+		if (typeof draft.endDate === "string") setEndDate(draft.endDate);
+	}, [draft.startDate, draft.endDate]);
+
+	useEffect(() => {
+		setField({ startDate, endDate });
+	}, [startDate, endDate, setField]);
+
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
-		onSuccess: () => router.push(`${BASE_PATH}/etape/3`),
+		onSuccess: () => {
+			clearDraft();
+			router.push(`${BASE_PATH}/etape/3`);
+		},
 	});
 
 	return (

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -63,6 +63,8 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 		return (
 			<SecondDeclarationStep1Info
 				declarationDate={declarationDate}
+				declarationSiren={data.declaration.siren}
+				declarationYear={currentYear}
 				modificationDeadline={campaignDeadlines.decl2ModificationDeadline}
 			/>
 		);
@@ -72,6 +74,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 		return (
 			<HydrateClient>
 				<SecondDeclarationStep2Form
+					declarationSiren={data.declaration.siren}
 					declarationYear={currentYear}
 					initialEndDate={
 						data.declaration.secondDeclReferencePeriodEnd ?? undefined

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
@@ -9,6 +9,8 @@ describe("SecondDeclarationStep1Info", () => {
 		render(
 			<SecondDeclarationStep1Info
 				declarationDate="01/06/2027"
+				declarationSiren="123456789"
+				declarationYear={2027}
 				modificationDeadline={modificationDeadline}
 			/>,
 		);
@@ -23,6 +25,8 @@ describe("SecondDeclarationStep1Info", () => {
 		render(
 			<SecondDeclarationStep1Info
 				declarationDate="01/06/2027"
+				declarationSiren="123456789"
+				declarationYear={2027}
 				modificationDeadline={modificationDeadline}
 			/>,
 		);
@@ -36,6 +40,8 @@ describe("SecondDeclarationStep1Info", () => {
 		render(
 			<SecondDeclarationStep1Info
 				declarationDate="01/06/2027"
+				declarationSiren="123456789"
+				declarationYear={2027}
 				modificationDeadline={modificationDeadline}
 			/>,
 		);
@@ -46,6 +52,8 @@ describe("SecondDeclarationStep1Info", () => {
 		render(
 			<SecondDeclarationStep1Info
 				declarationDate="01/06/2027"
+				declarationSiren="123456789"
+				declarationYear={2027}
 				modificationDeadline={modificationDeadline}
 			/>,
 		);
@@ -58,6 +66,8 @@ describe("SecondDeclarationStep1Info", () => {
 		render(
 			<SecondDeclarationStep1Info
 				declarationDate="01/06/2027"
+				declarationSiren="123456789"
+				declarationYear={2027}
 				modificationDeadline={modificationDeadline}
 			/>,
 		);
@@ -73,6 +83,8 @@ describe("SecondDeclarationStep1Info", () => {
 		render(
 			<SecondDeclarationStep1Info
 				declarationDate="01/06/2027"
+				declarationSiren="123456789"
+				declarationYear={2027}
 				modificationDeadline={modificationDeadline}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -56,6 +56,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("renders the title and step indicator", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
@@ -71,6 +72,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("displays category label as read-only text", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
@@ -88,6 +90,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("displays source as read-only text", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 				initialSource="accord-entreprise"
@@ -105,6 +108,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("renders reference period date pickers", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
@@ -119,6 +123,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("does not render add category button (read-only categories)", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
@@ -131,6 +136,7 @@ describe("SecondDeclarationStep2Form", () => {
 	it("renders previous link to step 1", () => {
 		render(
 			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
@@ -160,6 +166,7 @@ describe("SecondDeclarationStep2Form", () => {
 
 		render(
 			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
 				declarationYear={2025}
 				initialFirstDeclarationCategories={mockCategories}
 				initialSecondDeclarationCategories={secondDeclData}

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -50,7 +50,7 @@ export function QuartileTable({
 
 	return (
 		<div className={stepStyles.tableWrapper}>
-			<h2 className="fr-h5 fr-mb-0">{title}</h2>
+			<h3 className="fr-h5 fr-mb-0">{title}</h3>
 			<div className={stepStyles.tableSection}>
 				{readingNote}
 				<div

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -50,7 +50,7 @@ export function QuartileTable({
 
 	return (
 		<div className={stepStyles.tableWrapper}>
-			<h3 className="fr-h5 fr-mb-0">{title}</h3>
+			<h2 className="fr-h5 fr-mb-0">{title}</h2>
 			<div className={stepStyles.tableSection}>
 				{readingNote}
 				<div

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useCallback, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useFieldArray } from "react-hook-form";
 
 import { categoryFormSchema } from "~/modules/declaration-remuneration/schemas";
@@ -76,6 +76,39 @@ type Props = {
 	descriptionText?: string;
 	disabled?: boolean;
 	mimoquageNextHref?: string;
+	savedOverride?: boolean;
+	onValuesChange?: (values: {
+		source: string;
+		categories: {
+			name: string;
+			womenCount: string;
+			menCount: string;
+			annualBaseWomen: string;
+			annualBaseMen: string;
+			annualVariableWomen: string;
+			annualVariableMen: string;
+			hourlyBaseWomen: string;
+			hourlyBaseMen: string;
+			hourlyVariableWomen: string;
+			hourlyVariableMen: string;
+		}[];
+	}) => void;
+	defaultValuesOverride?: {
+		source: string;
+		categories: {
+			name: string;
+			womenCount: string;
+			menCount: string;
+			annualBaseWomen: string;
+			annualBaseMen: string;
+			annualVariableWomen: string;
+			annualVariableMen: string;
+			hourlyBaseWomen: string;
+			hourlyBaseMen: string;
+			hourlyVariableWomen: string;
+			hourlyVariableMen: string;
+		}[];
+	};
 };
 
 export function CategoryForm({
@@ -98,6 +131,9 @@ export function CategoryForm({
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 	disabled = false,
 	mimoquageNextHref,
+	savedOverride,
+	onValuesChange,
+	defaultValuesOverride,
 }: Props) {
 	const baseId = useId();
 	const nextId = useRef(createIdGenerator()).current;
@@ -108,11 +144,20 @@ export function CategoryForm({
 			: [createEmptyCategory(nextId())];
 
 	const form = useZodForm(categoryFormSchema, {
-		defaultValues: {
+		defaultValues: defaultValuesOverride ?? {
 			source: initialSource,
 			categories: toFormValues(initialCats),
 		},
 	});
+
+	useEffect(() => {
+		if (!onValuesChange) return;
+		const sub = form.watch(() => {
+			const values = form.getValues();
+			onValuesChange({ source: values.source, categories: values.categories });
+		});
+		return () => sub.unsubscribe();
+	}, [form, onValuesChange]);
 
 	const { fields, append, remove } = useFieldArray({
 		control: form.control,
@@ -120,7 +165,8 @@ export function CategoryForm({
 	});
 
 	const hasInitialData = initialCategories.length > 0;
-	const [saved, setSaved] = useState(hasInitialData);
+	const [savedInternal, setSaved] = useState(hasInitialData);
+	const saved = savedOverride !== undefined ? savedOverride : savedInternal;
 	const [workforceError, setWorkforceError] = useState("");
 	const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
 	const deleteDialogRef = useRef<HTMLDialogElement>(null);
@@ -374,7 +420,7 @@ export function CategoryForm({
 							className="fr-accordion"
 							key={field.id}
 						>
-							<h3 className="fr-accordion__title">
+							<h2 className="fr-accordion__title">
 								<button
 									aria-controls={collapseId}
 									aria-expanded="true"
@@ -385,7 +431,7 @@ export function CategoryForm({
 								>
 									{categoryLabel}
 								</button>
-							</h3>
+							</h2>
 							<div
 								className="fr-collapse fr-collapse--expanded"
 								id={collapseId}


### PR DESCRIPTION
Intégration finale de l'epic #3205 — **Cache de la déclaration / Données deja entrées par l'utilisateur / Retour en arriere**.

Cette PR rassemble les commits squashés de chaque sous-ticket validé par la pipeline. Chaque sous-ticket a déjà passé : CI verte, validators IA (validator / structural-auditor / rgaa-auditor / security-auditor / functional-validator), Sonar Quality Gate, et réponse aux review bots. La fidélité visuelle vs. Figma a été vérifiée par `code-dev` lui-même via le MCP `figma-dev`. Cette PR est le **point unique de revue humaine** pour l'epic.

## Sous-tickets

- Closes #3392 — Brouillon localStorage déclaration : foundation + Step1
- Closes #3393 — Brouillon localStorage déclaration : Step2 à Step5
- Closes #3394 — Brouillon localStorage déclaration : flows annexes (second / joint / compliance)

## Notes

- Branche d'intégration : `epic/3205` (rebasée régulièrement sur `alpha` pendant l'exécution)
- Une fois cette PR mergée dans `alpha`, les sous-tickets se fermeront automatiquement à la prochaine release (`alpha → master`) via les `Closes #N` ci-dessus.