### PR TITLE
chore(ci): mirror docs/ to GitHub wiki on alpha/master push

### DIFF
--- a/.github/workflows/sync-docs-to-wiki.yaml
+++ b/.github/workflows/sync-docs-to-wiki.yaml
@@ -1,0 +1,58 @@
+name: Sync docs to wiki
+
+on:
+  push:
+    branches: [master, alpha]
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+concurrency:
+  cancel-in-progress: true
+  group: "${{ github.workflow }}"
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Mirror docs/ to GitHub Wiki
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Clone wiki
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git" /tmp/wiki
+
+      - name: Mirror markdown files
+        shell: bash
+        run: |
+          shopt -s nullglob
+          for f in docs/*.md; do
+            base=$(basename "$f" .md)
+            page="${base^}.md"
+            cp "$f" "/tmp/wiki/${page}"
+            echo "  $f -> ${page}"
+          done
+
+      - name: Mirror images directory if present
+        run: |
+          if [ -d "docs/images" ]; then
+            mkdir -p /tmp/wiki/images
+            rsync -a --delete docs/images/ /tmp/wiki/images/
+            echo "Mirrored docs/images/ -> /tmp/wiki/images/"
+          fi
+
+      - name: Commit and push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          cd /tmp/wiki
+          git add -A
+          git diff --cached --quiet \
+            || git commit -m "Sync docs from ${{ github.ref_name }} ($(echo ${{ github.sha }} | cut -c1-7))"
+          git push

--- a/.github/workflows/sync-docs-to-wiki.yaml
+++ b/.github/workflows/sync-docs-to-wiki.yaml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   cancel-in-progress: true
-  group: "${{ github.workflow }}"
+  group: "${{ github.workflow }}-${{ github.ref }}"
 
 permissions:
   contents: write
@@ -26,7 +26,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.wiki.git" /tmp/wiki
+          # Keep the token out of the process argument list (visible in `ps aux`)
+          # by writing it to ~/.netrc instead of inlining it in the clone URL.
+          echo "machine github.com login x-access-token password ${GITHUB_TOKEN}" > ~/.netrc
+          chmod 600 ~/.netrc
+          git clone "https://github.com/${{ github.repository }}.wiki.git" /tmp/wiki
 
       - name: Mirror markdown files
         shell: bash
@@ -34,7 +38,8 @@ jobs:
           shopt -s nullglob
           for f in docs/*.md; do
             base=$(basename "$f" .md)
-            page="${base^}.md"
+            # Portable first-letter uppercase (avoids ${var^} which needs Bash 4+)
+            page="$(echo "${base:0:1}" | tr '[:lower:]' '[:upper:]')${base:1}.md"
             cp "$f" "/tmp/wiki/${page}"
             echo "  $f -> ${page}"
           done
@@ -53,6 +58,19 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           cd /tmp/wiki
           git add -A
-          git diff --cached --quiet \
-            || git commit -m "Sync docs from ${{ github.ref_name }} ($(echo ${{ github.sha }} | cut -c1-7))"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to sync."
+            exit 0
+          fi
+          git commit -m "Sync docs from ${{ github.ref_name }} ($(echo ${{ github.sha }} | cut -c1-7))"
+          # Retry with rebase to survive a concurrent push from another wiki-syncing
+          # workflow (e.g. db-schema.yaml committing at the same time).
+          for i in 1 2 3; do
+            if git pull --rebase origin HEAD && git push origin HEAD; then
+              exit 0
+            fi
+            echo "Push attempt $i failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "All push attempts failed." >&2
+          exit 1


### PR DESCRIPTION
## Résumé

Ajoute le workflow `.github/workflows/sync-docs-to-wiki.yaml` qui **miroite** automatiquement le dossier `docs/` du repo vers le **wiki GitHub** à chaque push sur `alpha` ou `master` (ou via `workflow_dispatch`).

Cette PR est la **brique infra** du système doc à 2 niveaux décidé pour l'epic #3176 :

- Source de vérité : `docs/*.md` versionné dans le repo (PRs #3389, #3390, #3391 fournissent le contenu initial)
- Diffusion : le wiki est rempli automatiquement par ce workflow (sans IA, déterministe)

## Mécanisme

Calque sur le workflow existant [`db-schema.yaml`](.github/workflows/db-schema.yaml) :

1. Trigger : `push` sur `alpha`/`master` quand un fichier dans `docs/**` change (+ `workflow_dispatch` manuel)
2. Clone du repo wiki via `${GITHUB_TOKEN}` (permissions `contents: write`)
3. Mapping `docs/<name>.md` → page wiki `<Name>.md` (première lettre majuscule, dashes préservés) :
   - `docs/features.md` → page wiki `Features`
   - `docs/architecture.md` → page wiki `Architecture`
   - `docs/parcours-utilisateurs.md` → page wiki `Parcours-utilisateurs`
4. Sync optionnel `docs/images/` → `/wiki/images/` (avec `rsync --delete` pour propager les suppressions)
5. Commit + push **uniquement si le diff est non vide** (`git diff --cached --quiet || git commit ...`)

## Pages wiki **non touchées** par ce workflow

- `Spec-V2` — rédigée à la main, restera vivante côté wiki UI
- `Schema-Egapro-V2` — déjà auto-générée par `db-schema.yaml` (sans conflit, fichier source différent)
- `Home`, `_Sidebar`, `_Footer` — gérés via UI ou hors scope

Le workflow ne supprime jamais de pages wiki — il met seulement à jour celles dont il a un fichier source dans `docs/`.

## Conséquence pour l'équipe

À partir du merge de cette PR :

- **Toute édition manuelle dans l'UI du wiki sur les pages synchronisées sera écrasée au prochain push `docs/`**. Règle d'équipe : pour les pages `Features`, `Architecture`, `Parcours-utilisateurs`, on édite le repo via PR, jamais le wiki.
- Les pages hors scope (Spec-V2, Home, Sidebar, etc.) restent éditables via l'UI.

## Suite

- [ ] PR 4 (cette PR) — workflow de sync
- [ ] PRs #3389 / #3390 / #3391 — fichiers `docs/*.md` initiaux (déjà ouvertes)
- [ ] **Livraison B (à scoper séparément)** : skill `/doc` (humain) + agent `doc-writer` invoqué en fin d'`epic_loop.sh` pour régénérer les `docs/*.md` à partir du diff `epic/<N>` vs `alpha`

Recommandation de merge : **cette PR avant les 3 docs**, pour que le wiki soit alimenté dès la première arrivée de `docs/*.md` sur `alpha`.

## Test plan

- [ ] Vérifier la syntaxe du workflow YAML (parsé localement OK)
- [ ] Mapping `docs/foo-bar.md → Foo-bar.md` testé localement (bash 5+ `${var^}`)
- [ ] Après merge sur `alpha` : confirmer que le wiki contient les 3 nouvelles pages (`Features`, `Architecture`, `Parcours-utilisateurs`) avec le contenu attendu
- [ ] Vérifier que `Spec-V2` et `Schema-Egapro-V2` restent inchangées
- [ ] Tester un `workflow_dispatch` manuel pour confirmer le bon fonctionnement hors push

Related : #3176