### PR TITLE
feat(pipeline): doc-writer agent + /doc skill + epic_loop integration

### DIFF
--- a/.claude/agents/doc-writer/AGENT.md
+++ b/.claude/agents/doc-writer/AGENT.md
@@ -1,0 +1,210 @@
+# Doc Writer Agent
+
+Tu régénères la documentation utilisateur du repo (`docs/*.md`) à partir de l'état courant du code. Tu es invoqué soit par la pipeline d'orchestration `epic_loop.sh` (en fin d'epic, avant l'ouverture de la PR finale), soit par le skill `/doc` (humain, hors pipeline).
+
+Tu produis une **régénération from scratch** : pas d'édition incrémentale, pas de tentative de préservation de prose éditée à la main. La doc est un build artifact piloté par le code source.
+
+## Model & Tools
+
+- **Model:** sonnet (toujours — pas de label `complexe` qui basculerait en Opus)
+- **Tools:** Read, Write, Edit, Bash, Grep, Glob, Agent (pour déléguer l'exploration)
+
+## Inputs
+
+L'orchestration / le skill te fournit :
+
+- **Epic number ou branche** (`epic/<N>` typiquement) — la branche dont tu dois documenter le contenu
+- **Base branch** (`alpha` typiquement) — point de comparaison pour le diff
+- **Worktree path** (mode pipeline) ou **repo courant** (mode skill humain)
+
+Si tu es invoqué hors pipeline avec aucun input, opère sur le repo courant (HEAD vs `origin/alpha`).
+
+## Périmètre de la doc
+
+Tu maintiens les fichiers suivants dans `docs/` :
+
+| Fichier | Cible | Audience |
+|---|---|---|
+| `docs/features.md` | Vue d'ensemble par feature : objectif, routes, modules, règles métier | dev + PO/métier |
+| `docs/architecture.md` | Stack, structure, auth, tRPC, BDD, audit, sécurité, déploiement | dev (PO en survol) |
+| `docs/parcours-utilisateurs.md` | Personas + flux end-to-end par persona | dev + PO/métier |
+
+**Tu ne crées pas de nouveaux fichiers `.md` sans instruction explicite**. Si la couverture actuelle (3 fichiers) devient insuffisante, signale-le dans ton retour JSON via le champ `notes` mais ne pousse pas un nouveau fichier de ta propre initiative.
+
+Tu **ne touches pas** :
+
+- `README.md` racine (rédigé à la main)
+- `CLAUDE.md` racine et `packages/app/CLAUDE.md` (instructions agents)
+- `.claude/rules/*.md` (règles internes)
+- `docs/SUIT-API.md` (spec d'intégration externe rédigée à la main)
+- Toute autre `.md` sous `.kontinuous/`, `.github/`, `scripts/`
+
+## Workflow
+
+### 0. Logger START
+
+```bash
+bash scripts/orchestration/log_event.sh doc-writer-<epic_or_branch> START "base=<base> branch=<branch>"
+```
+
+### 1. Calcul du diff fonctionnel
+
+Identifier ce que la branche apporte vs la base, en filtrant le bruit :
+
+```bash
+# Liste des fichiers modifiés/ajoutés vs base
+git fetch origin <base-branch> --quiet
+CHANGED=$(git diff --name-only "origin/<base-branch>...HEAD")
+```
+
+**Heuristique no-op** : si l'ensemble `CHANGED` ne contient **aucun** fichier sous `packages/app/src/{app,modules,server}/`, c'est-à-dire que les changements sont purement infra (CI, scripts d'orchestration, doc, kontinuous, package.json sans schéma, …), retourner immédiatement :
+
+```json
+{"status":"no_changes","epic":<N>,"reason":"diff touches no application code"}
+```
+
+et ne pas pousser de commit.
+
+### 2. Cartographie du diff fonctionnel
+
+Si du code applicatif est touché, classifier les changements en 3 axes (un changement peut alimenter plusieurs axes) :
+
+| Axe | Signaux à chercher |
+|---|---|
+| **Features** | nouveau `src/app/<route>/page.tsx`, nouveau dossier `src/modules/<feature>/`, nouveau router tRPC `src/server/api/routers/<x>.ts`, nouvelle action audit dans `src/modules/audit/shared/actionKeys.ts`, nouveau schéma Zod dans `src/modules/<x>/schemas.ts` |
+| **Architecture** | changement dans `src/server/auth/`, `src/server/audit/`, `src/server/db/schema.ts`, `src/middleware.ts`, `src/instrumentation*.ts`, `src/env.js`, `.kontinuous/`, `docker-compose.yml`, `package.json` (deps), nouveau hook `.claude/hooks/`, nouveau workflow `.github/workflows/` |
+| **Parcours** | nouvelle route utilisateur, nouveau wizard step, nouveau branchement (taille entreprise, seuil, deadline), nouvelle persona admin, nouveau parcours complet |
+
+Pour identifier ces signaux, tu peux :
+
+- `git diff --name-only "origin/<base-branch>...HEAD"`
+- Lire les commits : `git log --oneline "origin/<base-branch>..HEAD"`
+- Lire des fichiers ciblés (le `page.tsx` ajouté, le router modifié, le schéma audit)
+- Déléguer une exploration via l'outil **Agent** (subagent_type=Explore) pour les diffs larges, en lui passant la liste des fichiers à analyser
+
+### 3. Régénération from scratch
+
+Pour chaque axe impacté, **régénère le fichier `docs/*.md` correspondant from scratch** :
+
+- Lis l'existant pour récupérer la structure (sommaire, sections, ton, format des tableaux) — c'est un guide, pas un constraint
+- Lis le code de la branche courante (pas seulement le diff — la doc reflète l'**état final**, pas le delta)
+- Réécris le markdown intégralement via `Write` (pas `Edit` partiels)
+
+**Règles de rédaction** :
+
+- **Français** (audience FR), sauf code/identifiants qui restent en anglais
+- Sommaire avec ancres internes en tête de fichier
+- Synthétique : 5–15 pages markdown par fichier (~ 400–800 lignes)
+- Tableaux pour les listes structurées (routes, schémas, règles)
+- Diagrammes Mermaid pour les flux non triviaux (≥ 3 branchements)
+- Liens internes entre les 3 docs (`features.md` ↔ `architecture.md` ↔ `parcours-utilisateurs.md`)
+- Pas d'emojis (sauf si déjà présents dans la version précédente et pertinents)
+- Vérifier les seuils / constantes contre `~/modules/domain/shared/` — ne **jamais** inventer un seuil ou un nom de constante
+- Pas de PII fictive révélée comme réelle (tu peux citer `test@fia1.fr` puisque c'est documenté publiquement dans le README)
+
+**Anti-hallucination** : pour toute affirmation factuelle (existence d'une route, d'un router, d'une constante, d'un middleware), **vérifie le code** via Read ou Grep avant de l'écrire. Mieux vaut une doc plus courte mais juste qu'une doc large avec des erreurs.
+
+### 4. Validation
+
+Après écriture :
+
+```bash
+pnpm format:check
+```
+
+Si du formatage est nécessaire (rare pour du markdown), `pnpm check:write` puis re-vérifier.
+
+Vérifier la cohérence :
+
+- Aucune ancre TOC ne pointe vers un titre inexistant
+- Aucun lien relatif ne pointe vers un fichier inexistant (`docs/images/...` notamment)
+- Les diagrammes Mermaid se compilent (visual review du code Mermaid — pas d'outil de validation simple en ligne de commande)
+
+### 5. Commit et push
+
+Sur la branche **courante** (le worktree est déjà sur `epic/<N>` ou la branche utilisateur en mode skill) :
+
+```bash
+# Liste les fichiers réellement modifiés
+git status --porcelain docs/
+
+# Si rien de changé — sortir en no_changes
+if [ -z "$(git status --porcelain docs/)" ]; then
+    # voir étape 1 / heuristique no-op : possible que le diff fonctionnel n'ait pas
+    # nécessité de réécriture
+    # retour JSON no_changes
+    exit 0
+fi
+
+git add docs/
+git commit -m "docs(epic-<N>): regenerate from current code state"
+git push origin HEAD
+```
+
+**En mode skill humain** (hors pipeline) : ne pas push automatiquement — laisser le commit local et signaler dans le retour. L'humain pousse lui-même quand il a relu.
+
+### 6. Logger COMPLETE et retourner JSON
+
+```bash
+bash scripts/orchestration/log_event.sh doc-writer-<epic_or_branch> COMPLETE "files=<list> commit=<sha>"
+```
+
+## Format de retour OBLIGATOIRE (dernier message)
+
+Le **dernier message** de l'agent doit être **exactement un de ces 4 JSON** — rien d'autre, pas de prose, pas de markdown autour. Le pipeline parse via `jq -e '.status'`.
+
+| Cas | JSON |
+|---|---|
+| Doc régénérée et commitée (mode pipeline : poussée ; mode skill : commit local) | `{"status":"updated","epic":<N_or_null>,"branch":"<branch>","files":["docs/features.md",...],"commit":"<sha>"}` |
+| Diff ne touche aucune feature / architecture / parcours → aucune doc à mettre à jour | `{"status":"no_changes","epic":<N_or_null>,"branch":"<branch>","reason":"<explication courte>"}` |
+| Rate limit API persistant | `{"status":"rate_limited","epic":<N_or_null>,"retry_in":<sec>}` |
+| Erreur technique (worktree corrompu, push refusé, etc.) | `{"status":"failed","epic":<N_or_null>,"reason":"<erreur>"}` |
+
+Le champ `notes` (optionnel) peut être ajouté pour signaler une observation au reviewer humain : nouveau fichier `.md` à envisager, lacune de couverture détectée, doute factuel non résolu.
+
+## Logging events
+
+Logger aux **transitions d'état** seulement :
+
+| Event | Quand |
+|---|---|
+| `START` | Début, après réception du prompt (étape 0) |
+| `DIFF_OK` | Diff calculé, axes identifiés (étape 2) |
+| `WRITE_OK` | Tous les fichiers `docs/` régénérés (étape 3) |
+| `COMMIT_OK` | Commit + push (mode pipeline) ou commit local (mode skill) (étape 5) |
+| `COMPLETE` | Avant retour JSON `updated` |
+| `NO_CHANGES` | Avant retour JSON `no_changes` |
+
+## Contraintes
+
+- **Régénération from scratch** sur les fichiers impactés — pas d'édition incrémentale qui essaierait de préserver une section humaine
+- **Aucun fichier hors `docs/`** modifié ; en particulier ne **jamais** toucher `README.md`, `CLAUDE.md`, `.claude/rules/`, `docs/SUIT-API.md`
+- **Aucun nouveau fichier `.md`** sans instruction explicite ; signaler via `notes` si la couverture actuelle est insuffisante
+- **Anti-hallucination** : tout fait factuel doit être vérifié dans le code (Read/Grep) avant d'apparaître dans la doc
+- **Pas de PR, pas de validators IA, pas de reviews bot** — tu commit + push (ou commit local en mode skill), c'est tout. La PR finale `epic/<N> → alpha` est ouverte par `open_epic_final_pr.sh` après ton retour.
+- **Idempotent** : ré-invoqué deux fois de suite sur le même état → 2e run retourne `no_changes`
+- **Mode pipeline** : push auto. **Mode skill** : commit local seulement, l'humain push.
+- **Ne jamais bypass** : pas de `--no-verify`, pas de `--no-gpg-sign`
+- **Public repo hygiene** — voir `.claude/rules/git-artefact-hygiene.md`. Aucun secret / PII / namespace K8s avec hash ne doit apparaître dans la doc générée.
+
+## Exemple de classification de diff
+
+Diff touchant `src/server/api/routers/declaration.ts` (nouvelle mutation `submitSecond`) + `src/modules/audit/shared/actionKeys.ts` (nouvelle action `DECLARATION_SUBMIT_SECOND`) + `src/app/declaration-remuneration/parcours-conformite/etape/[step]/page.tsx` (nouveau wizard step) :
+
+| Axe | Impacté ? | Pourquoi |
+|---|---|---|
+| Features | oui | Nouvelle procédure tRPC + section §4 (parcours conformité) à enrichir |
+| Architecture | oui (léger) | Nouvelle action audit → table §11.2 d'`architecture.md` à mettre à jour |
+| Parcours | oui | Nouveau step dans le parcours conformité de `parcours-utilisateurs.md` |
+
+Action : régénération des 3 fichiers.
+
+Diff touchant uniquement `.github/workflows/lighthouse.yaml` :
+
+| Axe | Impacté ? |
+|---|---|
+| Features | non |
+| Architecture | très léger (workflow CI déjà mentionné dans §14) — décide selon l'ampleur |
+| Parcours | non |
+
+Action : `no_changes` ou régénération minimale d'`architecture.md` selon le jugement.

--- a/.claude/skills/doc/SKILL.md
+++ b/.claude/skills/doc/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: doc
+description: "Régénère la documentation utilisateur (`docs/*.md`) à partir de l'état courant du code. Usage : /doc (sur la branche courante) ou /doc <issue#> (sur la branche linkée à un epic / ticket)."
+---
+
+# /doc
+
+**Régénération de la documentation utilisateur** du repo. Le skill délègue à l'agent `doc-writer` qui réécrit `docs/features.md`, `docs/architecture.md`, et `docs/parcours-utilisateurs.md` à partir de l'état courant du code.
+
+Le skill est l'entrée **humaine** ; l'entrée orchestrée (en fin d'epic) passe par `scripts/orchestration/run_doc_writer.sh` invoqué directement depuis `epic_loop.sh`.
+
+| Mode d'invocation | Comportement |
+|---|---|
+| `/doc` sans argument | Tourne sur la branche courante. Compare HEAD vs `origin/alpha`. **Commit local seulement** — l'humain pousse lui-même. |
+| `/doc <issue#>` | Tourne sur la branche d'un ticket / epic. Si `<issue#>` est un epic, opère sur `origin/epic/<N>`. Sinon opère sur la branche linkée à l'issue (sidebar Development). **Commit + push** automatique. |
+
+---
+
+## Step 0 — Pré-conditions
+
+Refuser si :
+
+- Le working tree est dirty (`git status --porcelain` non-vide) → demander à l'humain de commit/stash d'abord
+- La branche courante est `alpha` ou `master` directement → la doc est régénérée sur les branches feature, pas sur la branche stable
+
+```bash
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Working tree dirty — commit ou stash d'abord."
+    exit 1
+fi
+
+CURRENT=$(git branch --show-current)
+if [ "$CURRENT" = "alpha" ] || [ "$CURRENT" = "master" ]; then
+    echo "Refus : /doc ne tourne pas directement sur $CURRENT. Crée une branche dédiée."
+    exit 1
+fi
+```
+
+---
+
+## Step 1 — Résoudre la branche cible
+
+### Sans argument
+
+Branche cible = branche courante. Base de comparaison = `origin/alpha`.
+
+```bash
+git fetch origin alpha --quiet
+TARGET_BRANCH=$(git branch --show-current)
+BASE_BRANCH=alpha
+EPIC_N=null
+PUSH_AUTO=false  # commit local, l'humain push lui-même
+```
+
+### Avec un argument `<issue#>`
+
+```bash
+ISSUE_N="${ARGUMENTS%% *}"; ISSUE_N="${ISSUE_N#\#}"
+
+ISSUE_TYPE=$(gh issue view "$ISSUE_N" --json issueType --jq '.issueType.name')
+
+if [ "$ISSUE_TYPE" = "Feature" ]; then
+    # Epic → tourne sur la branche d'intégration
+    TARGET_BRANCH="epic/$ISSUE_N"
+    BASE_BRANCH=alpha
+    EPIC_N="$ISSUE_N"
+else
+    # Task / Bug → trouver la branche linkée à l'issue
+    TARGET_BRANCH=$(gh api graphql -f query='
+        query($owner:String!, $repo:String!, $n:Int!) {
+          repository(owner:$owner, name:$repo) {
+            issue(number:$n) {
+              linkedBranches(first:5) { nodes { ref { name } } }
+            }
+          }
+        }' -f owner=SocialGouv -f repo=egapro -F n=$ISSUE_N \
+        --jq '.data.repository.issue.linkedBranches.nodes[0].ref.name // empty')
+
+    if [ -z "$TARGET_BRANCH" ]; then
+        echo "Aucune branche linkée à l'issue #$ISSUE_N."
+        exit 1
+    fi
+
+    # Base = parent epic si l'issue est sub-issue d'un epic, sinon alpha
+    PARENT=$(gh api graphql -f query='...parent...' --jq '.parent.number // empty')
+    if [ -n "$PARENT" ]; then
+        BASE_BRANCH="epic/$PARENT"
+    else
+        BASE_BRANCH=alpha
+    fi
+    EPIC_N="${PARENT:-null}"
+fi
+
+PUSH_AUTO=true
+git fetch origin "$TARGET_BRANCH" "$BASE_BRANCH" --quiet
+git checkout "$TARGET_BRANCH"
+git pull --ff-only origin "$TARGET_BRANCH"
+```
+
+---
+
+## Step 2 — Invoquer l'agent `doc-writer`
+
+Inputs à passer à l'agent (via le prompt de subagent) :
+
+- `epic` : `$EPIC_N` (ou `null`)
+- `branch` : `$TARGET_BRANCH`
+- `base_branch` : `$BASE_BRANCH`
+- `mode` : `pipeline` si `PUSH_AUTO=true`, `skill` sinon
+- `worktree` : `.` (skill = repo courant ; pas de worktree dédié)
+
+L'agent suit `.claude/agents/doc-writer/AGENT.md` :
+
+1. Calcule le diff `<base>...HEAD`
+2. Heuristique no-op : si rien de fonctionnel n'a changé → retour `no_changes`
+3. Sinon : régénère from scratch les fichiers `docs/*.md` impactés
+4. Commit
+5. Push si `mode=pipeline`, sinon laisse le commit local
+
+L'agent retourne un JSON strict (4 cas possibles, voir AGENT.md).
+
+---
+
+## Step 3 — Parser le JSON retourné
+
+| `.status` | Action | Markdown affiché |
+|---|---|---|
+| `updated` | (mode skill) signaler le commit local non poussé ; (mode pipeline) signaler le push | `## Doc: UPDATED` + liste des fichiers + sha |
+| `no_changes` | aucune | `## Doc: NO_CHANGES` + reason |
+| `rate_limited` | proposer de retenter dans `retry_in` secondes | `## Doc: RATE_LIMITED` |
+| `failed` | propager l'erreur | `## Doc: FAILED` + raison |
+
+Si `notes` est présent dans le JSON, l'afficher tel quel à l'humain (ex : "couverture insuffisante, envisager `docs/api-publique.md`").
+
+En **mode skill** (commit local), terminer le message par :
+
+```
+Le commit a été créé localement. Relis le diff (`git show HEAD`) et push avec `git push` quand tu es prêt.
+```
+
+---
+
+## Quand utiliser `/doc`
+
+- **Hotfix sur `alpha` direct** : non, refusé par Step 0.
+- **Branche feature standalone** (sans epic) : `/doc` (sans arg) — utile après une grosse refacto.
+- **Sub-task d'un epic** : `/doc <ticket#>` ou laisse `epic_loop.sh` invoquer `doc-writer` automatiquement à la fin de l'epic. Cumul possible mais redondant.
+- **Avant d'ouvrir une PR feature manuelle** : `/doc` → relit le commit doc → push avec le reste.
+- **Régénération forcée** : invoquer `/doc <epic#>` après un merge important sur `alpha` pour resynchroniser le wiki dans la foulée.
+
+## Quand NE PAS utiliser `/doc`
+
+- Sur `alpha` ou `master` → refusé
+- Quand le diff vs base est uniquement du code de tests / CI / scripts d'orchestration → l'agent retournera `no_changes` de toutes façons, autant ne pas le lancer
+- Sur une branche en cours de travail (working tree dirty) → refusé
+
+---
+
+## Référence
+
+- Agent : `.claude/agents/doc-writer/AGENT.md`
+- Script orchestration (mode pipeline) : `scripts/orchestration/run_doc_writer.sh`
+- Workflow GitHub Action de sync wiki : `.github/workflows/sync-docs-to-wiki.yaml`
+- Décision architecturale : voir mémoire `project_doc_system`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Quality checks run **automatically** après chaque itération de code — pas de
 |---|---|
 | `code-dev` | Implémente un ticket end-to-end (Sonnet, ou Opus si label `complexe`). Lit le spec dans le body (Feature) ou le commentaire d'analyse (Task / Bug). Pour les tickets UI, vérifie lui-même la fidélité Figma via le MCP `figma-dev`. |
 | `functional-validator` | Rejoue les scénarios PO dans le dev server |
+| `doc-writer` | Régénère `docs/*.md` from scratch à partir de l'état courant du code. Invoqué par `epic_loop.sh` en fin d'epic (juste avant `open_epic_final_pr.sh`) ou par le skill `/doc` (humain). Sonnet, sans worktree dédié — opère sur la branche courante. |
 
 **Pipeline review** (invoqué par `/review`) :
 | Agent | Rôle |
@@ -194,8 +195,9 @@ Quality checks run **automatically** après chaque itération de code — pas de
 | `/report [<N> ...]` | Dashboard live des agents actifs + état des sous-tickets de l'epic. Pure bash, zéro LLM. |
 | `/open <PR>` | Recrée un worktree local pour une PR (typique après auto-cleanup de `/implement`) — utile pour tester la PR avant merge. |
 | `/review [<issue#>\|<PR#>]` | Adresse les commentaires de revue (humain + bots). Détecte le mode (epic / task / bug) selon le type d'issue ; en mode epic, traite toutes les sub-task PRs liées à la feature et applique les fixes sur `epic/<N>`. Délègue à l'agent `review-fixer` qui tourne en worktree. |
+| `/doc [<issue#>]` | Régénère `docs/features.md` / `architecture.md` / `parcours-utilisateurs.md` à partir de l'état courant du code. Sans arg : commit local sur la branche courante (l'humain push). Avec `<issue#>` (epic ou task) : se positionne sur la branche cible, commit + push. Délègue à l'agent `doc-writer`. Hors pipeline / en complément de l'invocation auto par `epic_loop.sh`. |
 
-Workflow standard : `/analyse <issue>` pour la conception (modes auto-détectés), puis `/implement <issue>` pour l'exécution. Le ticket reste en `In progress` même quand l'IA a fini — c'est l'utilisateur qui le bouge à `In review` puis `Done` à son rythme. `/review` prend le relais quand les humains commentent les PR.
+Workflow standard : `/analyse <issue>` pour la conception (modes auto-détectés), puis `/implement <issue>` pour l'exécution. Le ticket reste en `In progress` même quand l'IA a fini — c'est l'utilisateur qui le bouge à `In review` puis `Done` à son rythme. `/review` prend le relais quand les humains commentent les PR. `/doc` régénère la doc utilisateur depuis le code (auto en fin d'epic, manuel hors pipeline).
 
 ### Orchestration (`scripts/orchestration/`)
 
@@ -203,11 +205,12 @@ Tous les scripts shell portent leur propre header `--help`-friendly. Le mode epi
 
 | Script | Rôle |
 |---|---|
-| `epic_loop.sh` | Loop driver background. Tick = cleanup terminal worktrees → rebase epic branches → plan → spawn N `claude` CLIs en parallèle (budget USD isolé) → aggregate JSON returns → process. Plafond `EPIC_LOOP_MAX_TICKS=30`. À la fin, ouvre la PR finale `epic/<N> → alpha`. |
+| `epic_loop.sh` | Loop driver background. Tick = cleanup terminal worktrees → rebase epic branches → plan → spawn N `claude` CLIs en parallèle (budget USD isolé) → aggregate JSON returns → process. Plafond `EPIC_LOOP_MAX_TICKS=30`. À la fin, pour chaque epic : invoke `run_doc_writer.sh` (best-effort, non-blocking) puis `open_epic_final_pr.sh`. |
 | `ensure_epic_branch.sh` | Idempotent. Crée la branche d'intégration `epic/<N>` depuis `origin/alpha` si absente. Appelé au startup d'`epic_loop.sh` pour chaque epic NEW-mode. |
 | `merge_validated_ticket.sh` | Squash-merge la PR d'un ticket validé dans `epic/<N>` via `gh pr merge --squash`. Branche auto-supprimée par les settings repo. Sur conflit : commente la PR + remet le ticket en `In progress` (le pipeline redispatchera pour rebaser). |
 | `rebase_epic_branch.sh` | Entre ticks, rebase `epic/<N>` sur `origin/alpha` dans un worktree dédié (`/tmp/egapro-rebase-epic<N>`). Force-with-lease push. Sur conflit : commente l'epic + label `dispatch=escalate` + exit 2 (halt orchestration). |
 | `open_epic_final_pr.sh` | Ouvre (ou réutilise) la PR finale `epic/<N> → alpha` avec body listant chaque sub-ticket via `Closes #N`. Appelé en fin de loop pour la review humaine. |
+| `run_doc_writer.sh` | Invoque l'agent `doc-writer` sur `epic/<N>` (depuis le main worktree, pas de worktree dédié). Régénère `docs/*.md` from scratch et commit + push. Best-effort : un échec/rate-limit ne bloque pas l'ouverture de la PR finale. Budget Sonnet par défaut $5 (`EPIC_LOOP_BUDGET_DOC`). |
 | `cleanup_terminal_worktrees.sh` | Scan les worktrees `egapro-epic<E>-t<N>` ; teardown + remove ceux dont le ticket a été squash-mergé dans `epic/<N>` (signal canonique : la branche `ticket/<N>-*` est gone d'origin). Appelé à chaque tick par `epic_loop.sh` pour libérer les slots dynamiquement. |
 | `dispatch_plan.sh` | Calcule la JSON list des tickets dispatchables : parse `## Depends on`, gate les enfants dont le parent n'est pas encore squash-mergé dans `epic/<N>` (= sa branche n'existe plus sur origin), alloue les indices libres dans `[0, EPIC_MAX_PARALLEL[`. Base = `origin/epic/<N>` toujours. |
 | `process_tick_result.sh` | Applique les mutations board selon le statut JSON retourné par `code-dev`. Sur `validated` (NEW mode) → invoke `merge_validated_ticket.sh`. Compteur `attempt=N` pour anti-boucle 3 refacto consécutifs → `dispatch=escalate`. |

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -471,9 +471,23 @@ if [ $TICK -ge $MAX_TICKS ]; then
 fi
 
 # ---- Done: every sub-ticket squash-merged into epic/<N> ----
-# Open the final integration PR `epic/<N> → alpha` for each epic in scope
-# (idempotent — reuses an existing open PR if any).
+# For each epic in scope:
+#   1. Regenerate docs/*.md from the current state of epic/<N> (best-effort,
+#      non-blocking — a doc-writer failure just logs and continues).
+#   2. Open the final integration PR `epic/<N> → alpha` (idempotent —
+#      reuses an existing open PR if any).
 for N in $EPICS; do
+    # ---- Doc regeneration (best-effort, non-blocking) ----
+    set +e
+    bash "$SCRIPT_DIR/run_doc_writer.sh" "$N"
+    DOC_RC=$?
+    set -e
+    if [ "$DOC_RC" != "0" ]; then
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" DOC_WRITER_FAIL "epic=$N rc=$DOC_RC"
+        echo "WARN epic=$N: doc-writer exited $DOC_RC — final PR will be opened without doc updates" >&2
+    fi
+
+    # ---- Final integration PR ----
     set +e
     FINAL_PR=$(bash "$SCRIPT_DIR/open_epic_final_pr.sh" "$N" 2>/dev/null)
     OPEN_RC=$?

--- a/scripts/orchestration/run_doc_writer.sh
+++ b/scripts/orchestration/run_doc_writer.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#
+# Invokes the doc-writer agent on an epic integration branch (epic/<N>) to
+# regenerate `docs/*.md` from the current code state, then commits + pushes
+# on epic/<N>. Called by epic_loop.sh just before open_epic_final_pr.sh, so
+# the doc commit ships in the same final PR as the code.
+#
+# The agent runs from the **main worktree** (which epic_loop.sh keeps on
+# epic/<N> for the duration of the epic). No dedicated worktree, no docker
+# stack — doc-writer only reads files and writes markdown.
+#
+# Usage:
+#   bash scripts/orchestration/run_doc_writer.sh <epic_N>
+#
+# Exit codes:
+#   0  agent returned `updated` or `no_changes` (both successful outcomes)
+#   1  technical failure (claude CLI missing, malformed JSON, push refused)
+#   2  agent returned `rate_limited` (transient, caller may retry later)
+#
+# Hard rule: NEVER fails the epic. If doc-writer crashes or the API rate-
+# limits, the caller (epic_loop.sh) logs the issue and proceeds with
+# open_epic_final_pr.sh. Doc updates are nice-to-have, not blocking.
+#
+# Env (defaults shown):
+#   EPIC_LOOP_BUDGET_DOC      5      USD max for the doc-writer Sonnet run
+#   EPIC_LOOP_AGENT_TIMEOUT   1800   seconds max (30 min — doc tasks are short)
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <epic_N>" >&2
+    exit 1
+fi
+
+EPIC_N="$1"
+if ! [[ "$EPIC_N" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: epic number must be a positive integer (got: $EPIC_N)" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+AID="doc-writer-${EPIC_N}"
+
+BUDGET="${EPIC_LOOP_BUDGET_DOC:-5}"
+AGENT_TIMEOUT="${EPIC_LOOP_AGENT_TIMEOUT:-1800}"
+
+# ---- Verify we are on epic/<N> ----
+cd "$REPO_ROOT"
+CURRENT=$(git branch --show-current)
+EXPECTED="epic/${EPIC_N}"
+
+if [ "$CURRENT" != "$EXPECTED" ]; then
+    echo "ERROR: expected to run from $EXPECTED but currently on $CURRENT" >&2
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "wrong_branch=$CURRENT"
+    exit 1
+fi
+
+# ---- Pre-flight: working tree must be clean ----
+if [ -n "$(git status --porcelain)" ]; then
+    echo "ERROR: working tree dirty on $EXPECTED — refusing to invoke doc-writer" >&2
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "working_tree_dirty"
+    exit 1
+fi
+
+git fetch origin alpha "$EXPECTED" --quiet
+
+bash "$SCRIPT_DIR/log_event.sh" "$AID" START "epic=$EPIC_N branch=$EXPECTED"
+
+# ---- timeout binary detection (mirror epic_loop.sh) ----
+TIMEOUT_BIN=""
+if command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+fi
+TIMEOUT_PREFIX=""
+[ -n "$TIMEOUT_BIN" ] && TIMEOUT_PREFIX="$TIMEOUT_BIN $AGENT_TIMEOUT"
+
+# ---- Build prompt for the agent ----
+PROMPT="Tu es invoqué par la pipeline d'orchestration en fin d'epic #${EPIC_N}.
+
+Branche courante : ${EXPECTED} (le main worktree y a été aligné par /implement).
+Base de comparaison : origin/alpha
+Mode : pipeline (commit auto + push sur ${EXPECTED})
+
+Suivre STRICTEMENT le workflow de .claude/agents/doc-writer/AGENT.md :
+
+1. Calcule le diff fonctionnel (origin/alpha...HEAD).
+2. Heuristique no-op : si rien sous packages/app/src/{app,modules,server}/ n'a changé → retourne immédiatement {\"status\":\"no_changes\",\"epic\":${EPIC_N},\"reason\":\"...\"}.
+3. Sinon : régénère from scratch les fichiers docs/*.md impactés (features.md / architecture.md / parcours-utilisateurs.md). Lis le code de la branche, pas seulement le diff — la doc reflète l'état final.
+4. Vérifie chaque fait factuel (constantes, routes, schémas) contre le code via Read/Grep — aucune hallucination.
+5. pnpm format:check, puis check:write si besoin.
+6. git add docs/ && git commit -m \"docs(epic-${EPIC_N}): regenerate from current code state\" && git push origin HEAD.
+7. Retourne le JSON.
+
+REGLES STRICTES :
+- N'invoque AUCUN skill built-in (fewer-permission-prompts, update-config, etc.)
+- Ne modifie JAMAIS .claude/settings.json ni .claude/settings.local.json
+- Pas d'auto-mémoire (~/.claude/projects/.../memory/)
+- Aucun fichier hors docs/ ne doit être modifié
+- Pas de --no-verify, pas de --no-gpg-sign
+
+Format de retour OBLIGATOIRE — un seul de :
+  {\"status\":\"updated\",\"epic\":${EPIC_N},\"branch\":\"${EXPECTED}\",\"files\":[...],\"commit\":\"<sha>\"}
+  {\"status\":\"no_changes\",\"epic\":${EPIC_N},\"branch\":\"${EXPECTED}\",\"reason\":\"...\"}
+  {\"status\":\"rate_limited\",\"epic\":${EPIC_N},\"retry_in\":<sec>}
+  {\"status\":\"failed\",\"epic\":${EPIC_N},\"reason\":\"...\"}
+
+Ton dernier message DOIT être uniquement ce JSON (rien d'autre, pas de prose)."
+
+# ---- Spawn the agent ----
+TICK_DIR="$REPO_ROOT/.claude/state/epic_run/doc_writer/${EPIC_N}"
+mkdir -p "$TICK_DIR"
+AGENT_LOG="$TICK_DIR/run_$(date -u +%Y%m%dT%H%M%SZ).json"
+
+set +e
+$TIMEOUT_PREFIX env -u CLAUDECODE claude \
+    --agent doc-writer \
+    --model sonnet \
+    --print \
+    --output-format json \
+    --dangerously-skip-permissions \
+    --max-budget-usd "$BUDGET" \
+    "$PROMPT" \
+    > "$AGENT_LOG" 2>&1
+CLI_RC=$?
+set -e
+
+# ---- Parse JSON return ----
+# The claude CLI emits a wrapper {result, is_error, ...}. Extract .result then
+# parse the agent's last message for the strict-format JSON.
+if [ ! -s "$AGENT_LOG" ]; then
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "empty_output cli_rc=$CLI_RC"
+    echo "WARN doc-writer: empty output (rc=$CLI_RC) — continuing without doc update" >&2
+    exit 1
+fi
+
+RESULT_TEXT=$(jq -r '.result // empty' "$AGENT_LOG" 2>/dev/null || echo "")
+if [ -z "$RESULT_TEXT" ]; then
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "non_json_wrapper cli_rc=$CLI_RC"
+    echo "WARN doc-writer: malformed CLI wrapper output — continuing without doc update" >&2
+    exit 1
+fi
+
+# Extract the last JSON object from the agent's result text
+RESULT_JSON=$(echo "$RESULT_TEXT" | grep -oE '\{"status":"[^"]+"[^}]*\}' | tail -1)
+if [ -z "$RESULT_JSON" ]; then
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "no_status_json"
+    echo "WARN doc-writer: agent did not return a status JSON — continuing without doc update" >&2
+    exit 1
+fi
+
+STATUS=$(echo "$RESULT_JSON" | jq -r '.status' 2>/dev/null || echo "")
+
+case "$STATUS" in
+    updated)
+        FILES=$(echo "$RESULT_JSON" | jq -r '.files | join(",")' 2>/dev/null || echo "")
+        COMMIT=$(echo "$RESULT_JSON" | jq -r '.commit // ""' 2>/dev/null || echo "")
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" UPDATED "files=$FILES commit=$COMMIT"
+        echo "OK doc-writer epic=$EPIC_N: updated $FILES (commit $COMMIT)"
+        exit 0
+        ;;
+    no_changes)
+        REASON=$(echo "$RESULT_JSON" | jq -r '.reason // ""' 2>/dev/null || echo "")
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" NO_CHANGES "$REASON"
+        echo "OK doc-writer epic=$EPIC_N: no_changes ($REASON)"
+        exit 0
+        ;;
+    rate_limited)
+        RETRY=$(echo "$RESULT_JSON" | jq -r '.retry_in // 0' 2>/dev/null || echo "0")
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" RATE_LIMITED "retry_in=$RETRY"
+        echo "WARN doc-writer epic=$EPIC_N: rate_limited (retry_in=$RETRY) — skipping doc update" >&2
+        exit 2
+        ;;
+    failed|*)
+        REASON=$(echo "$RESULT_JSON" | jq -r '.reason // "unknown"' 2>/dev/null || echo "unknown")
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "$REASON"
+        echo "WARN doc-writer epic=$EPIC_N: failed ($REASON) — continuing without doc update" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Résumé

Livraison B du système de documentation (suite à #3389 / #3390 / #3391 / #3408).

Ajoute la **mise à jour automatique du contenu** des `docs/*.md` :

- **Agent `doc-writer`** (Sonnet) — régénère `docs/features.md` / `architecture.md` / `parcours-utilisateurs.md` from scratch à partir de l'état courant du code
- **Skill `/doc`** — entrée humaine pour invoquer la régénération hors pipeline
- **Intégration `epic_loop.sh`** — invocation auto de `doc-writer` en fin d'epic, juste avant `open_epic_final_pr.sh`, pour que le commit de doc parte dans la même PR que le code

Le wiki est ensuite mis à jour automatiquement par le workflow [#3408](https://github.com/SocialGouv/egapro/pull/3408) au merge sur `alpha`.

## Fichiers ajoutés / modifiés

| Fichier | Type | Rôle |
|---|---|---|
| `.claude/agents/doc-writer/AGENT.md` | nouveau | Définition de l'agent : workflow 5 étapes (diff → cartographie → régénération → validation → commit), JSON de retour strict (4 cas) |
| `.claude/skills/doc/SKILL.md` | nouveau | Skill humain : `/doc` (branche courante, commit local) ou `/doc <issue#>` (branche cible epic/task, commit + push) |
| `scripts/orchestration/run_doc_writer.sh` | nouveau | Launcher invoqué par `epic_loop.sh` ; spawn `claude --agent doc-writer --model sonnet` ; budget par défaut $5 (`EPIC_LOOP_BUDGET_DOC`) ; **best-effort, non-blocking** (un échec ne fait pas échouer l'epic) |
| `scripts/orchestration/epic_loop.sh` | modifié | Inject l'appel à `run_doc_writer.sh` dans la boucle finale, avant `open_epic_final_pr.sh` |
| `CLAUDE.md` | modifié | Mise à jour des 3 tables (agents pipeline exécution / skills / scripts d'orchestration) |

## Choix de design clés

| Décision | Pourquoi |
|---|---|
| **Régénération from scratch** (pas incrémentale) | Robustesse > préservation de prose éditée à la main. La doc est un build artifact piloté par le code. |
| **Pas de worktree dédié** pour `doc-writer` | Il ne touche que des `.md`, pas besoin de docker stack ni de port. Tourne dans le main worktree (déjà sur `epic/<N>`). Économie de temps + RAM. |
| **Best-effort en pipeline** | Un crash de `doc-writer` ne fait pas tomber l'epic. La PR finale s'ouvre quand même, sans le commit doc. L'utilisateur peut relancer manuellement via `/doc <epic#>`. |
| **Pas d'IA dans GH Actions** | Pas de token Claude OAuth dans les secrets repo. L'IA tourne uniquement en local via `epic_loop.sh` (orchestration humaine) ou skill `/doc`. |
| **Sonnet, pas Opus** | Tâche de pattern-following + summarization, pas de reasoning multi-étapes complexe. Budget $5 / epic est généreux. |
| **Anti-hallucination** | L'agent doit vérifier chaque fait factuel (constantes, routes, schémas) via Read/Grep avant de l'écrire. Mieux vaut une doc plus courte mais juste qu'une doc large avec erreurs. |

## Boucle de vie complète (mode epic)

```
/analyse <issue>             # PO + architect créent epic + sub-issues
   ↓
/implement <issue>           # nohup epic_loop.sh <N> > log &
   ↓                         # tick : dispatch → spawn code-dev N parallèle → 
   ↓                         #        process_tick_result (squash-merge dans epic/<N>)
   ↓                         # répété jusqu'à plus de tickets
   ↓
[fin de epic_loop.sh]
   ↓
run_doc_writer.sh <N>        # ⬅ NOUVEAU — régénère docs/, commit + push
   ↓
open_epic_final_pr.sh <N>    # PR finale `epic/<N> → alpha` (inclut le commit doc)
   ↓
[review humaine + merge sur alpha]
   ↓
sync-docs-to-wiki.yaml       # workflow GH Action (PR #3408) — pousse docs/ vers le wiki
```

## Suite de la mini-epic

- [x] PR docs initiales : [#3389](https://github.com/SocialGouv/egapro/pull/3389) / [#3390](https://github.com/SocialGouv/egapro/pull/3390) / [#3391](https://github.com/SocialGouv/egapro/pull/3391) (Livraison A — content)
- [x] Workflow sync wiki : [#3408](https://github.com/SocialGouv/egapro/pull/3408) (Livraison A — infra)
- [x] Agent + skill + intégration pipeline : cette PR (Livraison B)

## Test plan

- [ ] Relire `.claude/agents/doc-writer/AGENT.md` — workflow et JSON de retour clairs
- [ ] Relire `.claude/skills/doc/SKILL.md` — modes humain (sans arg / avec issue#) cohérents
- [ ] Relire `scripts/orchestration/run_doc_writer.sh` — gestion d'erreur best-effort, parsing JSON robuste
- [ ] Relire la patch `epic_loop.sh` — `set +e` autour des deux appels, log_event dans tous les chemins
- [ ] Vérifier que les 3 tables CLAUDE.md (agents, skills, orchestration) sont à jour
- [ ] **Smoke test** (en local après merge des PRs précédentes) : créer une mini-epic avec une seule task UI, lancer `/implement`, vérifier que `run_doc_writer.sh` est invoqué et que la PR finale contient un commit doc cohérent

## Notes

- Le skill `/doc` peut être utilisé hors epic pour un hotfix ou une refacto manuelle.
- `EPIC_LOOP_BUDGET_DOC=10 /implement 42` pour augmenter le budget si l'epic est très gros.
- Les pages wiki `Spec-V2` et `Schema-Egapro-V2` ne sont pas touchées (système séparé).

Related : #3176 #3389 #3390 #3391 #3408