### PR TITLE
chore(pipeline): observability — phase events, live cost, stuck detection

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -29,15 +29,18 @@ L'agent reçoit un mode du skill `/analyse` :
 
 ## Workflow — modes `epic-create` / `epic-enrich`
 
+**Agent-id pour le logging** : `architect-<EPIC_N>`.
+
+0. `bash scripts/orchestration/log_event.sh architect-<EPIC_N> START "mode=<epic-create|epic-enrich>"`.
 1. **Lire** epic (body + commentaires `## Besoin métier`, `## Analyse PO`) + URL Figma + fichiers source pertinents. Pour les epics UI, parcourir Figma via `mcp__figma-dev__get_figma_data` pour identifier les écrans/composants à découper en tickets.
-2. **Cartographier** — modules, patterns existants, fichiers à toucher.
+2. **Cartographier** — modules, patterns existants, fichiers à toucher. Logger `MAPPING`.
 3. **Découper + établir le DAG de dépendances** :
    - Chaque ticket = unité cohérente (≤ 8 critères d'acceptation)
    - Pour chaque paire de tickets, identifier si A doit être livré avant B
    - Ces dépendances iront dans la section `Depends on` du body
    - **Filtrer les non-tickets** (voir « Éligibilité d'un ticket » ci-dessous) : toute tâche sans changement de code concret devient une case à cocher sur l'epic, pas une sub-issue
-4. **Draft inline** montré à l'utilisateur : titre, résumé 1 ligne, fichiers impactés, dépendances.
-5. **Validation utilisateur EXPLICITE** : « valides-tu ce découpage ? ». Pas d'auto-validation.
+4. **Draft inline** montré à l'utilisateur : titre, résumé 1 ligne, fichiers impactés, dépendances. Logger `BREAKDOWN_READY "tickets=<N>"`.
+5. **Validation utilisateur EXPLICITE** : logger `AWAITING_VALIDATION`. « valides-tu ce découpage ? ». Pas d'auto-validation.
 6. **Sur approbation** :
    - **`epic-create`** : créer toutes les sub-issues via `gh issue create` en un passage
    - **`epic-enrich`** : pour chaque sub-issue existante, décider :
@@ -50,7 +53,7 @@ L'agent reçoit un mode du skill `/analyse` :
    - Section `Depends on` dans chaque body listant les tickets parents (format `- #<N>`)
    - Label `complexe` uniquement si refacto multi-fichiers, perf critique, algo non trivial → déclenche Opus dans `code-dev`
    - Sur erreur partielle (rate limit, timeout) : **ne pas retenter à l'aveugle** — relire ce qui a déjà été créé, compléter uniquement le reste, mentionner le recovery dans le rapport.
-7. **Commentaire final sur l'epic** : `[Validation utilisateur] Architecture validée — N tickets créés, prêt pour /implement`.
+7. **Commentaire final sur l'epic** : `[Validation utilisateur] Architecture validée — N tickets créés, prêt pour /implement`. Logger `ISSUES_CREATED "count=<N>"` puis `COMPLETE`.
 
 ---
 
@@ -58,7 +61,10 @@ L'agent reçoit un mode du skill `/analyse` :
 
 L'objectif : transformer une task vague en un spec exécutable, **sans découpage**, en posant un seul commentaire `## Analyse architecte` sur l'issue. Le body de la task **reste intact** — `code-dev` lira `body + commentaire` pour reconstituer le spec.
 
-1. **Lire** le body de la task + tous les commentaires + fichiers source pertinents. Si UI : `mcp__figma-dev__get_figma_data` sur l'URL Figma fournie.
+**Agent-id pour le logging** : `architect-<TASK_N>`.
+
+0. `bash scripts/orchestration/log_event.sh architect-<TASK_N> START "mode=task"`.
+1. **Lire** le body de la task + tous les commentaires + fichiers source pertinents. Si UI : `mcp__figma-dev__get_figma_data` sur l'URL Figma fournie. Logger `MAPPING` une fois la cartographie initiale faite.
 
 2. **Q&A utilisateur si la task est trop floue**. Avant de produire le moindre spec, vérifier que les éléments suivants sont identifiables :
    - Quel(s) fichier(s) le `code-dev` va modifier ?
@@ -70,7 +76,7 @@ L'objectif : transformer une task vague en un spec exécutable, **sans découpag
 
 3. **Cartographier** la zone de code touchée.
 
-4. **Draft inline du spec** au format `rules/ticket-spec-format.md`, montré à l'utilisateur :
+4. **Draft inline du spec** au format `rules/ticket-spec-format.md`, montré à l'utilisateur (logger `BREAKDOWN_READY "files=<N>"`) :
    - Contexte (1-3 phrases)
    - Fichiers impactés
    - Changement attendu (précis : props, méthodes, types de retour, comportement)
@@ -96,7 +102,7 @@ L'objectif : transformer une task vague en un spec exécutable, **sans découpag
    - **Si user accepte** : convertir l'issue type Task → Feature via la mutation GraphQL `updateIssueIssueType` (cf. `rules/github-board.md` snippet 7, ID Feature = `IT_kwDOAh0HH84Aa_K4`), poster un commentaire `[Architect] Converti en Feature — relancer /analyse #N pour le découpage`, puis **exiter le mode task** (ne pas poster d'analyse architecte). L'utilisateur relancera `/analyse #N` qui passera automatiquement en mode `epic-create`.
    - **Si user refuse** : poursuivre en mode task malgré le scope. Mentionner dans le draft que le ticket est volumineux et appliquer le label `complexe` (Opus) systématiquement.
 
-6. **Validation utilisateur EXPLICITE** : « valides-tu cette analyse ? ». Itérer si besoin.
+6. **Validation utilisateur EXPLICITE** : logger `AWAITING_VALIDATION`. « valides-tu cette analyse ? ». Itérer si besoin.
 
 7. **Sur approbation** : poster un seul commentaire sur la task (pas de modification du body) :
    ```bash
@@ -109,7 +115,7 @@ L'objectif : transformer une task vague en un spec exécutable, **sans découpag
    ```
    Appliquer le label `complexe` si > 5 fichiers ou refacto multi-modules attendu (op. via `gh issue edit --add-label`).
 
-8. **Commentaire final** : `[Validation utilisateur] Analyse validée — prêt pour /implement`.
+8. **Commentaire final** : `[Validation utilisateur] Analyse validée — prêt pour /implement`. Logger `ANALYSIS_POSTED` puis `COMPLETE`.
 
 ---
 

--- a/.claude/agents/bug-analyst/AGENT.md
+++ b/.claude/agents/bug-analyst/AGENT.md
@@ -27,6 +27,10 @@ Le **body de l'issue est intact** — l'analyse vit dans un commentaire séparé
 
 ## Workflow
 
+**Agent-id pour le logging** : `bug-analyst-<BUG_N>`.
+
+`bash scripts/orchestration/log_event.sh bug-analyst-<BUG_N> START` au tout début, avant la lecture du body.
+
 ### 0. Q&A si l'issue est trop floue
 
 Avant tout effort de repro, lire le body. Si la description manque d'éléments essentiels — pas de scénario reproductible, pas d'indication d'env, pas de URL ou comportement attendu —, **poser 1 à 3 questions ciblées à l'utilisateur** :
@@ -40,13 +44,13 @@ Avant tout effort de repro, lire le body. Si la description manque d'éléments 
 
 ### 1. Choisir la sous-stratégie de reproduction
 
-Trois cas, à décider d'après le body et les réponses Q&A :
+Trois cas, à décider d'après le body et les réponses Q&A. Logger l'event correspondant à la sous-stratégie retenue : `REPRO_LOCAL` / `REPRO_ENV` / `REPRO_VISUAL`.
 
-| Sous-stratégie | Quand | Outils |
-|---|---|---|
-| **Fonctionnel local** | Bug observable sur la branche `alpha` en local | Worktree `alpha` + `pnpm dev:app` + Playwright |
-| **Env-specific** | Bug uniquement sur un env de review / preprod (ex : intégration ProConnect, déploiement, secret manquant) | `kubectl logs` + Playwright sur l'URL de l'env |
-| **Visual mismatch (Figma ↔ app)** | L'utilisateur signale un écart entre une page de l'app et son design Figma | Worktree `alpha` + `pnpm dev:app` + Playwright + `figma-dev` MCP |
+| Sous-stratégie | Event | Quand | Outils |
+|---|---|---|---|
+| **Fonctionnel local** | `REPRO_LOCAL` | Bug observable sur la branche `alpha` en local | Worktree `alpha` + `pnpm dev:app` + Playwright |
+| **Env-specific** | `REPRO_ENV` | Bug uniquement sur un env de review / preprod (ex : intégration ProConnect, déploiement, secret manquant) | `kubectl logs` + Playwright sur l'URL de l'env |
+| **Visual mismatch (Figma ↔ app)** | `REPRO_VISUAL` | L'utilisateur signale un écart entre une page de l'app et son design Figma | Worktree `alpha` + `pnpm dev:app` + Playwright + `figma-dev` MCP |
 
 ### 2a. Fonctionnel local
 
@@ -87,7 +91,11 @@ kubectl -n <namespace> describe pod <pod>
 
 Ne pas se contenter du symptôme — voir `rules/bug-fix-workflow.md`. Lire le code en amont (stack trace, appelants, schémas Zod, migrations). Pour les régressions, `git log -p <file>` sur la zone incriminée pour voir si un commit récent introduit le bug.
 
+Une fois identifiée : logger `ROOT_CAUSE_FOUND "file=<path:line>"`.
+
 ### 4. Poster l'analyse
+
+Logger `ANALYSIS_POSTED` juste après le `gh issue comment`.
 
 ```bash
 gh issue comment "$BUG_N" --body-file <(cat <<'EOF'
@@ -112,9 +120,9 @@ EOF
 
 ### 5. Validation utilisateur EXPLICITE
 
-Demander en chat : « Tu valides cette analyse pour passer à `/implement` ? » Itérer si l'utilisateur conteste.
+Logger `AWAITING_VALIDATION`. Demander en chat : « Tu valides cette analyse pour passer à `/implement` ? » Itérer si l'utilisateur conteste.
 
-Sur approbation : poster `[Validation utilisateur] Analyse validée — prêt pour /implement` en commentaire et retourner.
+Sur approbation : poster `[Validation utilisateur] Analyse validée — prêt pour /implement` en commentaire, logger `COMPLETE`, et retourner.
 
 ## Contraintes
 

--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -22,12 +22,14 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
 
 0. **Logger START** — `bash scripts/orchestration/log_event.sh code-dev-<N> START "worktree=<path> base=<base-branch>"`. Voir la section « Logging events » plus bas pour la liste complète.
 
-1. **Vérifier le format du ticket** — lire le body **et** les commentaires. La source du spec dépend du type d'issue :
+1. **Vérifier le format du ticket** — `bash scripts/orchestration/log_event.sh code-dev-<N> ANALYSIS_START`. Lire le body **et** les commentaires. La source du spec dépend du type d'issue :
    - **Type Feature (sub-issue d'epic)** → spec dans le **body** au format `rules/ticket-spec-format.md`
    - **Type Task** → body = description originale de l'utilisateur (intacte) ; spec dans le **commentaire `## Analyse architecte`** (le plus récent si plusieurs)
    - **Type Bug** → body = rapport de bug de l'utilisateur ; spec dans le **commentaire `## Analyse du bug`** (posté par `bug-analyst`)
 
-   Si le spec attendu est manquant (pas de body conforme pour Feature, pas de commentaire `## Analyse architecte` pour Task, pas de `## Analyse du bug` pour Bug) → remettre le ticket en **To Do** avec un commentaire listant les manques, et retourner `{"status":"refacto","ticket":<N>,"reason":"spec missing — run /analyse first"}`. **Ne pas improviser.**
+   Si le spec attendu est manquant (pas de body conforme pour Feature, pas de commentaire `## Analyse architecte` pour Task, pas de `## Analyse du bug` pour Bug) → logger `ANALYSIS_FAIL "reason=spec missing"`, remettre le ticket en **To Do** avec un commentaire listant les manques, et retourner `{"status":"refacto","ticket":<N>,"reason":"spec missing — run /analyse first"}`. **Ne pas improviser.**
+
+   Sinon → logger `ANALYSIS_OK "format=<feature|task|bug>"` avant de continuer.
 
 2. **Si bug** (issue type Bug ou label `bug`) — appliquer `rules/bug-fix-workflow.md` : test qui échoue **avant** le fix. Pour les bugs de type "visual mismatch Figma ↔ app", le test n'est pas un test automatisé classique (cf. section visual mismatch de `bug-fix-workflow.md`) — la validation est la relecture structurelle Figma.
 
@@ -41,22 +43,22 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
 
 4.5. **Sanity check stack docker** — vérifier que `packages/app/.env.local` existe et contient `COMPOSE_PROJECT_NAME=egapro-wt-*`. Si absent → `scripts/setup-worktree.sh <index> [<extras>]` (où `<extras>` vient du parsing de la section `## Requires services` du ticket). Si `/epic` ou `/code` a déjà lancé le setup, l'étape est un no-op.
 
-5. **Implémenter** :
+5. **Implémenter** — `bash scripts/orchestration/log_event.sh code-dev-<N> DEV_START "attempt=1"` au début. Sur reprise après un RETRY de 9a/9b/9c/9d, incrémenter `attempt`.
    - Modifier les fichiers listés dans le ticket
    - Respecter `packages/app/CLAUDE.md` et les rules projet
    - **Aucun commentaire dans le code écrit ou modifié** — voir `rules/code-quality.md` section "No comments by default". Pas de JSDoc, pas de `// fetch user`, pas de `// for ticket #N`, pas de TODO/FIXME, pas de header de section. Seule exception : un `// ` court qui explique un WHY non-évident (workaround documenté, invariant subtil). Si le commentaire paraphrase le code juste en dessous, supprimer.
    - `pnpm typecheck` après chaque modif de types/schemas
    - `nextjs_call(get_errors)` si dev server tourne
    - **Tests unitaires : 100% de couverture sur le code produit** (statements, branches, functions, lines). Vérifier via `pnpm test --coverage` + lecture du rapport — chaque fichier modifié ou créé doit être à 100%. Pas de « ça couvre assez » : 100% strict.
-   - Logger `IMPLEMENT_OK` quand typecheck + tests passent localement.
+   - Logger `DEV_OK "attempt=<K>"` quand typecheck + tests passent localement.
 
-6. **Quality gates (ticket reste en In progress)** — déléguer en parallèle aux 4 agents existants :
+6. **Quality gates (ticket reste en In progress)** — `bash scripts/orchestration/log_event.sh code-dev-<N> VALIDATION_START "attempt=1"`. Déléguer en parallèle aux 4 agents existants :
    - `validator` (typecheck + test + lint + format)
    - `structural-auditor`
    - `rgaa-auditor` (si `.tsx` modifié)
    - `security-auditor` (si server files modifiés)
 
-   Corriger toutes les findings. Re-run jusqu'au vert. Logger `QUALITY_OK` quand les 4 agents PASS.
+   Corriger toutes les findings. Re-run jusqu'au vert. À chaque nouvelle itération sur un finding : logger `VALIDATION_START "attempt=<K+1>"` avant la re-run. Logger `VALIDATION_OK "attempt=<K>"` quand les 4 agents PASS.
 
 7. **Vérification visuelle Figma** (si UI touchée) — la fidélité au design est **ta** responsabilité, plus de `design-validator` externe :
    - **Lecture structurelle (le cœur du travail)** : pour chaque URL citée dans la section `## Référence Figma` du ticket, appeler `mcp__figma-dev__get_figma_data` (équivalent `get_design_context`) sur le node-id pour récupérer l'arbre des nodes — couleurs (`fill`), typographies (`fontSize`, `fontWeight`, `textStyle`), espacements (`itemSpacing`, `gap`), hiérarchie, contenu verbatim. Vérifier que ton implémentation **mappe précisément chaque propriété** : couleur Figma → DSFR token / classe, `fontSize` → `fr-text--xs/sm/lg/xl`, `fontWeight ≥ 600` → `<strong>`, `itemSpacing` → `fr-m{b,t,r,l}-Xw`. Suivre `rules/figma-workflow.md` (Phases 1–3) pour la checklist exhaustive.
@@ -87,15 +89,17 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
 
 9. **Validations en parallèle** — 3 axes simultanés, tous doivent être verts avant de passer à l'étape 10.
 
-   **9a. Validator IA** — invoquer `functional-validator` (rejoue les scénarios PO dans le dev server). Il commente sur le ticket.
-   - `RETRY` (max 2) → corriger + push
+   **9a. Validator IA** — `bash scripts/orchestration/log_event.sh code-dev-<N> FUNCTIONAL_START "attempt=1"`. Invoquer `functional-validator` (rejoue les scénarios PO dans le dev server). Il commente sur le ticket.
+   - `RETRY` (max 2) → logger `FUNCTIONAL_START "attempt=<K+1>"`, corriger + push
    - `REFACTO` après 3 RETRY → ticket → **To Do** avec diagnostic
+   - PASS → logger `FUNCTIONAL_OK "attempt=<K>"`
    - Pas de `design-validator` séparé : la fidélité visuelle vs. Figma est vérifiée par `code-dev` lui-même à l'étape 7 (voir `rules/figma-workflow.md`).
 
-   **9b. CI GitHub Actions** — watch du pipeline auto-déclenché par le push :
+   **9b. CI GitHub Actions** — `bash scripts/orchestration/log_event.sh code-dev-<N> CI_WAIT "pr=<PR>"`. Watch du pipeline auto-déclenché par le push :
    - Polling : `gh pr checks <PR> --watch` (ou `gh run list --branch <branch>`)
-   - Si un check est rouge : `gh run view <run-id> --log-failed`, identifier la cause, corriger, push, reboucler
+   - Si un check est rouge : logger `CI_FAIL "pr=<PR> failed=<check-name>"`, `gh run view <run-id> --log-failed`, identifier la cause, corriger, push, **logger `CI_WAIT "pr=<PR>"` à nouveau** pour la new attempt
    - Ne jamais marquer la PR `ready` tant qu'un check CI est rouge
+   - Quand toutes les checks sont vertes : logger `CI_OK "pr=<PR>"`
    - **Attendre que TOUTES les checks aient une conclusion**, pas juste la majorité. Certains checks lents (notamment `Deploy on Kubernetes 🐳 / 🐳 Deploy Review on Kubernetes`) se lancent ou se terminent **après** Build / Lint / Tests. Sortir de 9b dès que les checks "core" sont verts laisse une fenêtre où un check Deploy peut basculer en FAILURE alors que tu as déjà retourné `validated`.
 
    Critère de sortie de 9b (à valider explicitement avant de passer à 9c) :
@@ -105,12 +109,13 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
    ```
    Doit retourner `true`. Toute conclusion `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, ou conclusion vide (check encore en cours) → on attend / on corrige.
 
-   **9c. SonarCloud** — le bot `sonarcloud[bot]` commente sur la PR avec un lien dashboard :
-   - Si `Quality Gate: Failed` → ouvrir le dashboard via `mcp__playwright__browser_navigate`, lire les issues (bugs, code smells, duplications, coverage), corriger, push
+   **9c. SonarCloud** — `bash scripts/orchestration/log_event.sh code-dev-<N> SONAR_WAIT "pr=<PR>"`. Le bot `sonarcloud[bot]` commente sur la PR avec un lien dashboard :
+   - Si `Quality Gate: Failed` → logger `SONAR_FAIL "pr=<PR>"`, ouvrir le dashboard via `mcp__playwright__browser_navigate`, lire les issues (bugs, code smells, duplications, coverage), corriger, push, re-logger `SONAR_WAIT "pr=<PR>"`
    - Si le bot n'a pas encore commenté, attendre avant de `gh pr ready`
    - Seuils critiques bloquants : bugs, vulnérabilités, security hotspots non reviewed
+   - Quand Quality Gate Passed → logger `SONAR_OK "pr=<PR>"`
 
-   **9d. Cycle review unique** — déclenché **une seule fois**, **uniquement** après que 9a + 9b + 9c sont **tous verts** (vérifie explicitement le critère jq de 9b : toutes conclusions SUCCESS / SKIPPED / NEUTRAL, sans exception).
+   **9d. Cycle review unique** — `bash scripts/orchestration/log_event.sh code-dev-<N> BOT_WAIT "pr=<PR>"`. Déclenché **une seule fois**, **uniquement** après que 9a + 9b + 9c sont **tous verts** (vérifie explicitement le critère jq de 9b : toutes conclusions SUCCESS / SKIPPED / NEUTRAL, sans exception).
 
    ### 9d.1 — Wait borné pour les reviews bot (avec debounce)
 
@@ -216,6 +221,8 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
 
    ### 9d.3 — Sortie de la phase 9d
 
+   Logger `BOT_REPLIED "pr=<PR> comments=<K>"` (où K = nombre de threads adressés).
+
    - **Si aucun fix appliqué** (aucun push) → passer immédiatement à l'étape 10 (retour `validated`)
    - **Si au moins un push** → poll `gh pr checks <PR> --watch` jusqu'à ce que la nouvelle CI/Sonar repassent **toutes vertes** (même critère jq qu'en 9b, timeout poll : 10 min). Ensuite passer à l'étape 10.
 
@@ -261,19 +268,34 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
 
 ## Logging events
 
-Calls `bash scripts/orchestration/log_event.sh code-dev-<N> <EVENT> [msg]`. Logger aux **transitions d'état** seulement (pas chaque Read/Edit/grep). Les events alimentent `/report`.
+Calls `bash scripts/orchestration/log_event.sh code-dev-<N> <EVENT> [msg]`. Logger aux **transitions de phase** seulement (pas chaque Read/Edit/grep). Les events alimentent `/report` (table d'agents actifs + drill-down stuck).
 
-| Event | Quand |
-|---|---|
-| `START` | Début, après réception du prompt (étape 0) |
-| `IMPLEMENT_OK` | Code écrit, typecheck + tests locaux verts (étape 5) |
-| `QUALITY_OK` | Les 4 auditors PASS (étape 6) |
-| `PR_DRAFT` | PR draft ouverte (étape 8), `msg=pr=<NNN>` |
-| `RETRY` | Début d'une itération de fix sur un verdict RETRY (étape 9), `msg=axis=<axe> attempt=<K>` |
-| `ESCALATED` | Avant retour `needs_opus_escalation` (étape 9, mode Sonnet épuisé) |
-| `STUCK` | Avant retour `refacto` (étape 9, mode Opus épuisé) |
-| `PR_READY` | `gh pr ready` réussi (étape 10), `msg=pr=<NNN>` |
-| `COMPLETE` | Avant retour `validated` (étape 10) |
+| Event | Quand | msg |
+|---|---|---|
+| `START` | Début, après réception du prompt (étape 0) | `worktree=<path> base=<branch>` |
+| `ANALYSIS_START` | Étape 1 — début lecture body+commentaires | — |
+| `ANALYSIS_OK` | Étape 1 — spec valide trouvée | `format=<feature\|task\|bug>` |
+| `ANALYSIS_FAIL` | Étape 1 — spec manquant, retour refacto | `reason=<résumé>` |
+| `DEV_START` | Étape 5 — début implémentation, à chaque retry | `attempt=<K>` |
+| `DEV_OK` | Étape 5 — typecheck + tests locaux verts | `attempt=<K>` |
+| `VALIDATION_START` | Étape 6 — début quality gates, à chaque retry | `attempt=<K>` |
+| `VALIDATION_OK` | Étape 6 — les 4 auditors PASS | `attempt=<K>` |
+| `PR_DRAFT` | Étape 8 — PR draft ouverte | `pr=<P>` |
+| `FUNCTIONAL_START` | Étape 9a — début functional-validator | `attempt=<K>` |
+| `FUNCTIONAL_OK` | Étape 9a — PASS | `attempt=<K>` |
+| `CI_WAIT` | Étape 9b — début (ou re-début après push) du watch CI | `pr=<P>` |
+| `CI_FAIL` | Étape 9b — un check rouge identifié | `pr=<P> failed=<check-name>` |
+| `CI_OK` | Étape 9b — toutes les checks vertes | `pr=<P>` |
+| `SONAR_WAIT` | Étape 9c — attente du commentaire sonarcloud | `pr=<P>` |
+| `SONAR_FAIL` | Étape 9c — Quality Gate Failed | `pr=<P>` |
+| `SONAR_OK` | Étape 9c — Quality Gate Passed | `pr=<P>` |
+| `BOT_WAIT` | Étape 9d — début du wait borné pour reviews bots | `pr=<P>` |
+| `BOT_REPLIED` | Étape 9d.3 — tous les threads post-push adressés | `pr=<P> comments=<K>` |
+| `RETRY` | Début d'une itération de fix sur un verdict RETRY (étape 9) | `axis=<axe> attempt=<K>` |
+| `ESCALATED` | Avant retour `needs_opus_escalation` (étape 9, Sonnet épuisé) | — |
+| `STUCK` | Avant retour `refacto` (étape 9, Opus épuisé) | — |
+| `PR_READY` | Étape 10 — `gh pr ready` réussi | `pr=<P>` |
+| `COMPLETE` | Étape 10 — avant retour `validated` | — |
 
 ## Format de retour OBLIGATOIRE (dernier message)
 

--- a/.claude/agents/product-owner/AGENT.md
+++ b/.claude/agents/product-owner/AGENT.md
@@ -45,29 +45,40 @@ La séparation **body / besoin / analyse** permet à l'utilisateur (et aux relec
 
 ## Workflow
 
+**Agent-id pour le logging** : `po-<EPIC_N>` en mode enrich, `po-pending` en mode create avant que l'epic n'ait un numéro (renommer le log file après `gh issue create` via `mv .claude/state/epic_run/agents/po-pending.log .claude/state/epic_run/agents/po-<N>.log`).
+
 ### Mode `create`
+
+0. `bash scripts/orchestration/log_event.sh po-pending START "mode=create"`.
 
 1. **Q&A fonctionnel** — poser 3 à 5 questions ciblées pour lever les ambiguïtés :
    - utilisateurs cibles, règles métier aux bornes (ex : 49 / 50 / 99 salariés)
    - intégration avec features existantes (parcours déclaration, CSE…)
    - critères de succès observables
 
-2. **Draft inline** des trois artefacts (body / besoin métier / analyse PO), montrés à l'utilisateur avant tout commit GitHub. Présenter chaque bloc séparément pour que l'utilisateur puisse corriger l'un sans toucher aux autres.
+   Logger `QA_DONE` après réception des réponses utilisateur.
 
-3. **Validation utilisateur EXPLICITE** — poser la question « valides-tu cette rédaction ? » et **attendre une réponse affirmative claire** de l'utilisateur avant tout `gh issue create` (pas d'auto-validation, pas de « je suppose que oui », pas d'enchaînement silencieux). Itérer autant que nécessaire (souvent : besoin métier OK mais découpage des scénarios à ajuster).
+2. **Draft inline** des trois artefacts (body / besoin métier / analyse PO), montrés à l'utilisateur avant tout commit GitHub. Présenter chaque bloc séparément pour que l'utilisateur puisse corriger l'un sans toucher aux autres. Logger `BUSINESS_NEED_DRAFTED` puis `ANALYSIS_DRAFTED` au fur et à mesure.
+
+3. **Validation utilisateur EXPLICITE** — logger `AWAITING_VALIDATION`, poser la question « valides-tu cette rédaction ? » et **attendre une réponse affirmative claire** de l'utilisateur avant tout `gh issue create` (pas d'auto-validation, pas de « je suppose que oui », pas d'enchaînement silencieux). Itérer autant que nécessaire (souvent : besoin métier OK mais découpage des scénarios à ajuster).
 
 4. **Sur approbation uniquement — Création GitHub** (snippets exacts dans `rules/github-board.md`) :
    - `gh issue create --label Epic` avec **body = citation de la demande utilisateur originale** (préfixée `> ` ou en bloc `quote`). Pas plus.
+   - **Renommer le log file** : `mv .claude/state/epic_run/agents/po-pending.log .claude/state/epic_run/agents/po-<N>.log`
+   - Logger `ISSUE_CREATED "epic=<N>"` (sur le nouveau path)
    - Ajouter au project `EGAPRO V2` avec status **Backlog** (op. 1+2+4 de `github-board.md`)
    - Appliquer le type **Feature** (op. 7 de `github-board.md`)
    - **Premier commentaire** : `gh issue comment <N> --body-file <tmpfile>` avec le bloc `## Besoin métier`
    - **Deuxième commentaire** : `gh issue comment <N> --body-file <tmpfile>` avec le bloc `## Analyse PO` (user stories + scénarios + hors scope + critères d'acceptation)
    - Poster commentaire `[Validation utilisateur] Epic validé — prêt pour phase architect`
+   - Logger `COMPLETE "epic=<N> scenarios=<S1,S2,...>"`
    - Retourner le numéro d'issue à l'appelant (`/analyse`)
 
 ### Mode `enrich`
 
-1. **Lire l'existant** — parcourir le snapshot JSON fourni par `/analyse` : body, labels, state, **tous les commentaires** dans l'ordre chronologique. Identifier explicitement :
+0. `bash scripts/orchestration/log_event.sh po-<EPIC_N> START "mode=enrich"`.
+
+1. **Lire l'existant** — logger `READING_EXISTING`. Parcourir le snapshot JSON fourni par `/analyse` : body, labels, state, **tous les commentaires** dans l'ordre chronologique. Identifier explicitement :
    - Y a-t-il déjà un `## Besoin métier` ? Date ?
    - Y a-t-il déjà un `## Analyse PO` ? Quelle liste de scénarios `S1, S2, …` ?
    - L'issue a-t-elle déjà été validée (`[Validation utilisateur] Epic validé`) ?
@@ -81,7 +92,7 @@ La séparation **body / besoin / analyse** permet à l'utilisateur (et aux relec
 
 3. **Q&A ciblé** (court) — uniquement sur les zones d'incertitude introduites par `EXTRA_CONTEXT`. Ne pas re-questionner ce qui est déjà tranché dans les commentaires existants.
 
-4. **Présenter le plan d'amendement** à l'utilisateur sous forme de diff explicite :
+4. **Présenter le plan d'amendement** à l'utilisateur sous forme de diff explicite (logger `AMENDMENT_PLAN_DRAFTED`) :
    ```
    ## Plan d'amendement de l'epic #<N>
 
@@ -102,7 +113,7 @@ La séparation **body / besoin / analyse** permet à l'utilisateur (et aux relec
    - ajouter au project EGAPRO V2 en statut Backlog (manquant)
    ```
 
-5. **Validation utilisateur EXPLICITE** sur ce plan — même règle qu'en mode create. Itérer si besoin.
+5. **Validation utilisateur EXPLICITE** sur ce plan — logger `AWAITING_VALIDATION`. Même règle qu'en mode create. Itérer si besoin.
 
 6. **Sur approbation uniquement — application GitHub** :
    - **Ne jamais effacer** un commentaire historique. Préférer ajouter un commentaire `## Besoin métier (révisé YYYY-MM-DD)` qui pointe vers le précédent (`> Révise le commentaire du <date> · raison : <résumé EXTRA_CONTEXT>`)
@@ -110,6 +121,7 @@ La séparation **body / besoin / analyse** permet à l'utilisateur (et aux relec
    - Si promotion en epic nécessaire : appliquer type Feature, ajouter au project en Backlog, label `Epic`. Si l'issue est en `Open` mais en dehors du board, l'ajouter (op. 1+2+4 de `rules/github-board.md`).
    - Le **body** n'est édité que si `EXTRA_CONTEXT` change la demande utilisateur originale ; sinon il reste tel quel.
    - Poster commentaire `[Validation utilisateur] Epic enrichi — prêt pour phase architect`
+   - Logger `COMPLETE "epic=<N> scenarios=<S1,S2,...>"`
    - Retourner le numéro d'issue à l'appelant (`/analyse`) avec la liste des scénarios **finale** (anciens conservés + nouveaux), pour que la phase architect sache ce qui a changé.
 
 ## Contraintes

--- a/.claude/skills/report/SKILL.md
+++ b/.claude/skills/report/SKILL.md
@@ -19,7 +19,13 @@ description: "Dashboard d'avancement des epics en cours. Thin wrapper sur les sc
 bash scripts/orchestration/render_dashboard.sh
 ```
 
-Ce script pur bash lit `.claude/state/epic_run/agents/*.log`, trie les agents par inactivité (stuck en tête), affiche les derniers events de chacun, et signale les agents inactifs depuis plus de 10 minutes.
+Ce script pur bash lit `.claude/state/epic_run/agents/*.log`, calcule pour chaque agent son statut (`healthy` / `slow` / `stuck`) via `agent_status.sh`, son coût LLM (live ou estimate) via `compute_cost.sh`, et rend une table compacte :
+
+```
+AGENT  TICKET  PHASE  ATTEMPT  AGE  MODEL  EST. $  REASON
+```
+
+Les agents flagués 🔴 stuck déclenchent automatiquement un drill-down (last 20 events, shell command actif, git status du worktree, dernier check CI failed, dernier comment PR) — fourni par `agent_drilldown.sh`. Les ⚠ slow sont juste mentionnés dans la table sans drill-down.
 
 **Cas avec epic(s) en argument — ajouter l'état des sous-tickets** :
 
@@ -41,13 +47,21 @@ Le dashboard est déjà formaté par les scripts. Tu n'as qu'à :
 
 **Ne PAS reformater** la sortie du script. Le format texte-table est voulu pour la lisibilité terminal.
 
-## Ajustement du seuil d'inactivité
+## Ajustement des seuils
 
-Par défaut, un agent est flaggé inactif après 10 minutes sans nouvel event. Pour ajuster :
+Les seuils stuck/slow sont définis dans `agent_status.sh` (variables d'env) :
 
 ```bash
-INACTIVITY_THRESHOLD_SEC=300 bash scripts/orchestration/render_dashboard.sh   # seuil 5 min
+SLOW_THRESHOLD_SEC=300 \
+STUCK_PHASE_SEC=1200 \
+STUCK_BOT_SEC=900 \
+bash scripts/orchestration/render_dashboard.sh
 ```
+
+Règles de décision (voir `agent_status.sh`) :
+- 🔴 **stuck** : ≥ 3 RETRY sur le même axis · CI_FAIL ≥ 3 fois consécutifs sur le même check · BOT_WAIT > 15min sans BOT_REPLIED · phase stalled > 20min · process gone (fallback)
+- ⚠ **slow** : log silent > 5min, process alive, pas de pattern stuck identifié
+- ✓ **healthy** : activité log récente OU process actif
 
 ## Cas où les logs sont vides
 

--- a/scripts/orchestration/agent_drilldown.sh
+++ b/scripts/orchestration/agent_drilldown.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
+# agent_drilldown.sh <agent-id>
+#
+# Dumps everything we can cheaply gather about a stuck agent — meant to be
+# called by render_dashboard.sh when an agent is flagged 🔴.
+#
+# Sections:
+#   1. Status summary (from agent_status.sh)
+#   2. Last 20 events from the agent's log
+#   3. Active shell command (process tree introspection)
+#   4. git status of the agent's worktree (code-dev only)
+#   5. Last failed CI run (code-dev only, gh + jq)
+#   6. Last bot/human comment on the PR (code-dev only)
+#
+# Pure bash — no LLM. Reads from local files + gh + git only.
+#
+# Env:
+#   EGAPRO_STATE_ROOT — override state dir
+
+set -euo pipefail
+
+AGENT_ID="${1:?agent-id required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+STATE_ROOT="${EGAPRO_STATE_ROOT:-${REPO_ROOT}/.claude/state/epic_run}"
+LOG_FILE="${STATE_ROOT}/agents/${AGENT_ID}.log"
+
+echo "═══ DRILL-DOWN: ${AGENT_ID} ═══"
+echo ""
+
+# 1. Status summary
+echo "▸ Status"
+if STATUS_OUT=$(EGAPRO_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/agent_status.sh" "$AGENT_ID" 2>/dev/null); then
+    echo "$STATUS_OUT" | sed 's/^/  /'
+else
+    echo "  (agent_status.sh failed)"
+fi
+echo ""
+
+# 2. Last 20 events
+echo "▸ Last 20 events"
+if [ -f "$LOG_FILE" ]; then
+    tail -n 20 "$LOG_FILE" | sed 's/^/  /'
+else
+    echo "  (no log file)"
+fi
+echo ""
+
+# 3. Active shell command at process-tree level
+echo "▸ Active shell command"
+case "$AGENT_ID" in
+    code-dev-*)
+        TICKET="${AGENT_ID##*-}"
+        CLAUDE_PID=$(ps -eo pid,cmd 2>/dev/null \
+            | awk -v t="Ticket #${TICKET}" '$0 ~ t && $0 !~ /timeout/ && $0 !~ /grep/ && $0 !~ /awk/ {print $1; exit}')
+        if [ -n "$CLAUDE_PID" ]; then
+            CURRENT="$CLAUDE_PID"
+            LAST_CMD=""
+            DEPTH=0
+            while [ "$DEPTH" -lt 20 ]; do
+                CHILD=$(pgrep -P "$CURRENT" 2>/dev/null | head -1)
+                [ -z "$CHILD" ] && break
+                CURRENT="$CHILD"
+                LAST_CMD=$(ps -p "$CURRENT" -o cmd= 2>/dev/null | head -1)
+                DEPTH=$((DEPTH + 1))
+            done
+            if [ -n "$LAST_CMD" ]; then
+                echo "  $LAST_CMD" | head -c 200
+                echo ""
+            else
+                echo "  (claude process alive, no shell subprocess — likely thinking)"
+            fi
+        else
+            echo "  (no live claude process for this ticket)"
+        fi
+        ;;
+    *)
+        echo "  (drill-down for active shell only meaningful for code-dev)"
+        ;;
+esac
+echo ""
+
+# 4 + 5 + 6: code-dev specific GitHub state
+case "$AGENT_ID" in
+    code-dev-*)
+        TICKET="${AGENT_ID##*-}"
+
+        # 4. git status of the worktree (find by branch convention)
+        echo "▸ Worktree git status"
+        # Look for any worktree whose branch ref starts with ticket/<TICKET>-
+        WT_PATH=$(git -C "$REPO_ROOT" worktree list 2>/dev/null \
+            | awk -v t="ticket/${TICKET}-" '$3 ~ "\\["t {print $1; exit}' || true)
+        if [ -n "$WT_PATH" ] && [ -d "$WT_PATH" ]; then
+            echo "  worktree: $WT_PATH"
+            git -C "$WT_PATH" status --short 2>/dev/null | head -20 | sed 's/^/  /'
+            LAST_COMMIT=$(git -C "$WT_PATH" log -1 --oneline 2>/dev/null | head -c 100 || true)
+            [ -n "$LAST_COMMIT" ] && echo "  last commit: $LAST_COMMIT"
+        else
+            echo "  (no live worktree for ticket #${TICKET})"
+        fi
+        echo ""
+
+        # 5 + 6 require the PR number
+        PR_INFO=$(gh pr list --state all --limit 100 --json number,state,headRefName,statusCheckRollup 2>/dev/null \
+            | jq -r --arg t "ticket/${TICKET}-" '
+                .[] | select(.headRefName | startswith($t)) |
+                "\(.number)|\(.state)"' \
+            | head -1)
+        if [ -n "$PR_INFO" ]; then
+            PR_NUM=$(echo "$PR_INFO" | cut -d'|' -f1)
+            PR_STATE=$(echo "$PR_INFO" | cut -d'|' -f2)
+
+            # 5. Last failed CI run
+            echo "▸ Last failed CI check on PR #${PR_NUM} (${PR_STATE})"
+            FAILED_CHECK=$(gh pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null \
+                | jq -r '.statusCheckRollup[] | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED") | "\(.name)|\(.detailsUrl)"' \
+                | head -1 || true)
+            if [ -n "$FAILED_CHECK" ]; then
+                CHECK_NAME=$(echo "$FAILED_CHECK" | cut -d'|' -f1)
+                CHECK_URL=$(echo "$FAILED_CHECK" | cut -d'|' -f2)
+                echo "  failed check: $CHECK_NAME"
+                echo "  details: $CHECK_URL"
+                # Try to extract the run id from the URL and dump 30 lines of failed log
+                RUN_ID=$(echo "$CHECK_URL" | grep -oE '/runs/[0-9]+' | grep -oE '[0-9]+' | head -1 || true)
+                if [ -n "$RUN_ID" ]; then
+                    echo "  --- last 30 lines of failed log ---"
+                    gh run view "$RUN_ID" --log-failed 2>/dev/null | tail -n 30 | sed 's/^/  /' || echo "  (gh run view failed)"
+                fi
+            else
+                echo "  (no failed checks)"
+            fi
+            echo ""
+
+            # 6. Last comment on PR (any author)
+            echo "▸ Last comment on PR #${PR_NUM}"
+            LAST_COMMENT=$(gh api "repos/SocialGouv/egapro/issues/${PR_NUM}/comments" 2>/dev/null \
+                | jq -r '. | sort_by(.created_at) | last | "\(.user.login) at \(.created_at):\n\(.body)"' \
+                | head -c 500 || true)
+            if [ -n "$LAST_COMMENT" ] && [ "$LAST_COMMENT" != "null" ]; then
+                echo "$LAST_COMMENT" | sed 's/^/  /'
+            else
+                echo "  (no comments yet)"
+            fi
+            echo ""
+        else
+            echo "▸ PR state"
+            echo "  (no PR found for ticket #${TICKET})"
+            echo ""
+        fi
+        ;;
+esac

--- a/scripts/orchestration/agent_status.sh
+++ b/scripts/orchestration/agent_status.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
+# agent_status.sh <agent-id>
+#
+# Computes the health status of an agent and prints a single line on stdout:
+#
+#     STATUS=<healthy|slow|stuck>
+#     REASON=<short label>
+#     PHASE=<last-event-name>
+#     PHASE_AGE_SEC=<int>
+#     RETRIES=<int>
+#     LIFETIME_SEC=<int>
+#
+# Decision rules:
+#   stuck — at least one of:
+#     (a) process dead AND last event ∉ {COMPLETE, STUCK, ESCALATED, ANALYSIS_FAIL}
+#     (b) ≥ 3 RETRY events on the same axis (DEV / VALIDATION / FUNCTIONAL / CI / SONAR / BOT)
+#     (c) > 20 min in same phase without any progression event between start/ok
+#     (d) BOT_WAIT > 15 min without BOT_REPLIED
+#     (e) ≥ 3 consecutive CI_FAIL on the same check name
+#   slow — log silent for 5–15 min, process alive, no active subprocess
+#   healthy — anything else (recent activity OR live process actively shelling out)
+#
+# Env:
+#   EGAPRO_STATE_ROOT — override state dir (default: derived from script path)
+#   STUCK_PHASE_SEC   — threshold (c) in seconds (default 1200 = 20 min)
+#   STUCK_BOT_SEC     — threshold (d) in seconds (default 900  = 15 min)
+#   SLOW_THRESHOLD_SEC — log-silence threshold for "slow" (default 300 = 5 min)
+
+set -euo pipefail
+
+AGENT_ID="${1:?agent-id required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+STATE_ROOT="${EGAPRO_STATE_ROOT:-${REPO_ROOT}/.claude/state/epic_run}"
+LOG_FILE="${STATE_ROOT}/agents/${AGENT_ID}.log"
+
+STUCK_PHASE_SEC="${STUCK_PHASE_SEC:-1200}"
+STUCK_BOT_SEC="${STUCK_BOT_SEC:-900}"
+SLOW_THRESHOLD_SEC="${SLOW_THRESHOLD_SEC:-300}"
+
+if [ ! -f "$LOG_FILE" ]; then
+    printf "STATUS=stuck\nREASON=no-log\nPHASE=-\nPHASE_AGE_SEC=0\nRETRIES=0\nLIFETIME_SEC=0\n"
+    exit 0
+fi
+
+NOW=$(date '+%s')
+TODAY=$(date '+%Y-%m-%d')
+
+hms_to_epoch() {
+    local hms="$1"
+    date -d "${TODAY} ${hms}" '+%s' 2>/dev/null \
+        || date -j -f "%Y-%m-%d %H:%M:%S" "${TODAY} ${hms}" '+%s' 2>/dev/null \
+        || echo 0
+}
+
+# Helper: parse "[HH:MM:SS][EVENT] msg" into "<epoch> <event> <msg>".
+parsed_log() {
+    awk -v today="$TODAY" '
+        match($0, /^\[([0-9:]+)\]\[([A-Z_0-9]+)\] ?(.*)$/, m) {
+            print m[1], m[2], m[3]
+        }
+    ' "$LOG_FILE"
+}
+
+# First & last event timestamps (for lifetime + phase age)
+FIRST_HMS=$(head -1 "$LOG_FILE" | grep -oE '^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\]' | tr -d '[]' || echo "")
+LAST_LINE=$(tail -1 "$LOG_FILE")
+LAST_HMS=$(echo "$LAST_LINE" | grep -oE '^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\]' | tr -d '[]' || echo "")
+LAST_EVENT=$(echo "$LAST_LINE" | grep -oE '\[[A-Z_0-9]+\]' | head -1 | tr -d '[]' || echo "")
+LAST_MSG=$(echo "$LAST_LINE" | sed -E 's/^\[[^]]+\]\[[^]]+\] ?//')
+
+# Lifetime anchor: prefer the .start file (full epoch, written on first event).
+# Fall back to HMS parsing for legacy logs without a .start companion.
+START_FILE="${STATE_ROOT}/agents/${AGENT_ID}.start"
+if [ -f "$START_FILE" ]; then
+    START_EPOCH=$(cat "$START_FILE" 2>/dev/null || echo 0)
+else
+    START_EPOCH=$(hms_to_epoch "$FIRST_HMS")
+fi
+[ -z "$START_EPOCH" ] || [ "$START_EPOCH" = "0" ] && START_EPOCH=$NOW
+[ "$START_EPOCH" -gt "$NOW" ] && START_EPOCH=$((NOW - 1))
+
+# Log-age = NOW - log file mtime (stable, doesn't depend on HMS round-trip).
+file_mtime() {
+    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null || echo 0
+}
+LAST_EPOCH=$(file_mtime "$LOG_FILE")
+[ "$LAST_EPOCH" = "0" ] && LAST_EPOCH=$NOW
+[ "$LAST_EPOCH" -gt "$NOW" ] && LAST_EPOCH=$NOW
+
+LIFETIME=$((NOW - START_EPOCH))
+LOG_AGE=$((NOW - LAST_EPOCH))
+
+# Retry count
+RETRIES=$(awk '/\[RETRY\]/ {c++} END {print c+0}' "$LOG_FILE")
+
+# Process liveness — same logic as render_dashboard.sh
+process_alive() {
+    case "$AGENT_ID" in
+        epic-orchestrator-*)
+            local KEY="${AGENT_ID#epic-orchestrator-}"
+            pgrep -af "epic_loop.sh.*${KEY}" >/dev/null 2>&1
+            ;;
+        code-dev-*)
+            local TICKET="${AGENT_ID##*-}"
+            ps -ef | grep -E "Ticket #${TICKET}([^0-9]|\$)" | grep -v grep >/dev/null 2>&1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Terminal events: nominal end states. Not a "stuck" signal even if process is gone.
+case "$LAST_EVENT" in
+    COMPLETE|STUCK|ESCALATED|ANALYSIS_FAIL)
+        # If the agent's terminal state is itself an alarm (STUCK / ANALYSIS_FAIL),
+        # surface that. COMPLETE / ESCALATED = nominal.
+        case "$LAST_EVENT" in
+            STUCK|ANALYSIS_FAIL)
+                printf "STATUS=stuck\nREASON=terminal-%s\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+                    "$(echo $LAST_EVENT | tr A-Z a-z)" "$LAST_EVENT" "$LOG_AGE" "$RETRIES" "$LIFETIME"
+                ;;
+            *)
+                printf "STATUS=healthy\nREASON=done-%s\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+                    "$(echo $LAST_EVENT | tr A-Z a-z)" "$LAST_EVENT" "$LOG_AGE" "$RETRIES" "$LIFETIME"
+                ;;
+        esac
+        exit 0
+        ;;
+esac
+
+# Specific stuck signals first (b/c/d/e), so the report surfaces the actual
+# cause. Generic "process-gone" is the fallback when no specific pattern matches.
+
+# Rule (b) — ≥ 3 RETRY events on the same axis (parses "axis=<name> attempt=K")
+RETRY_AXIS_COUNT=$(awk '
+    /\[RETRY\]/ {
+        match($0, /axis=([a-zA-Z_-]+)/, m)
+        if (m[1] != "") count[m[1]]++
+    }
+    END {
+        max = 0
+        for (a in count) if (count[a] > max) { max = count[a]; axis = a }
+        print max " " axis
+    }
+' "$LOG_FILE")
+RETRY_MAX=$(echo "$RETRY_AXIS_COUNT" | awk '{print $1}')
+RETRY_AXIS=$(echo "$RETRY_AXIS_COUNT" | awk '{print $2}')
+if [ "${RETRY_MAX:-0}" -ge 3 ]; then
+    printf "STATUS=stuck\nREASON=retry-loop-%s\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+        "$RETRY_AXIS" "$LAST_EVENT" "$LOG_AGE" "$RETRIES" "$LIFETIME"
+    exit 0
+fi
+
+# Rule (e) — ≥ 3 consecutive CI_FAIL on the same check name
+CI_FAIL_STREAK=$(awk '
+    /\[CI_(FAIL|OK|WAIT)\]/ {
+        if ($0 ~ /\[CI_FAIL\]/) {
+            match($0, /failed=([^ ]+)/, m)
+            if (m[1] == prev) streak++; else { streak = 1; prev = m[1] }
+            if (streak > best) { best = streak; best_check = m[1] }
+        } else {
+            streak = 0; prev = ""
+        }
+    }
+    END { print (best+0) " " best_check }
+' "$LOG_FILE")
+CI_STREAK_N=$(echo "$CI_FAIL_STREAK" | awk '{print $1}')
+CI_STREAK_CHECK=$(echo "$CI_FAIL_STREAK" | awk '{print $2}')
+if [ "${CI_STREAK_N:-0}" -ge 3 ]; then
+    printf "STATUS=stuck\nREASON=ci-fail-loop-%s\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+        "$CI_STREAK_CHECK" "$LAST_EVENT" "$LOG_AGE" "$RETRIES" "$LIFETIME"
+    exit 0
+fi
+
+# Rule (d) — BOT_WAIT > STUCK_BOT_SEC without BOT_REPLIED after
+LAST_BOT_WAIT=$(grep '\[BOT_WAIT\]' "$LOG_FILE" | tail -1 | grep -oE '^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\]' | tr -d '[]' || echo "")
+if [ -n "$LAST_BOT_WAIT" ]; then
+    BOT_WAIT_EPOCH=$(hms_to_epoch "$LAST_BOT_WAIT")
+    AFTER_BOT=$(awk -v ts="$LAST_BOT_WAIT" '
+        $0 ~ "\\["ts"\\]" { found=1; next }
+        found && /\[BOT_REPLIED\]/ { print "yes"; exit }
+    ' "$LOG_FILE")
+    BOT_AGE=$((NOW - BOT_WAIT_EPOCH))
+    if [ "$AFTER_BOT" != "yes" ] && [ "$BOT_AGE" -gt "$STUCK_BOT_SEC" ]; then
+        printf "STATUS=stuck\nREASON=bot-wait-timeout\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+            "BOT_WAIT" "$BOT_AGE" "$RETRIES" "$LIFETIME"
+        exit 0
+    fi
+fi
+
+# Rule (c) — > STUCK_PHASE_SEC since the last START-style phase event
+# Phase-START events: ANALYSIS_START, DEV_START, VALIDATION_START, FUNCTIONAL_START,
+# CI_WAIT, SONAR_WAIT, BOT_WAIT
+PHASE_START_RE='\[(ANALYSIS_START|DEV_START|VALIDATION_START|FUNCTIONAL_START|CI_WAIT|SONAR_WAIT|BOT_WAIT)\]'
+LAST_PHASE_LINE=$(grep -E "$PHASE_START_RE" "$LOG_FILE" | tail -1 || echo "")
+if [ -n "$LAST_PHASE_LINE" ]; then
+    LAST_PHASE_HMS=$(echo "$LAST_PHASE_LINE" | grep -oE '^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\]' | tr -d '[]')
+    LAST_PHASE_NAME=$(echo "$LAST_PHASE_LINE" | grep -oE '\[[A-Z_0-9]+\]' | head -1 | tr -d '[]')
+    LAST_PHASE_EPOCH=$(hms_to_epoch "$LAST_PHASE_HMS")
+    PHASE_AGE=$((NOW - LAST_PHASE_EPOCH))
+
+    PHASE_OK_NAME="${LAST_PHASE_NAME/_START/_OK}"
+    [ "$LAST_PHASE_NAME" = "CI_WAIT" ] && PHASE_OK_NAME="CI_OK"
+    [ "$LAST_PHASE_NAME" = "SONAR_WAIT" ] && PHASE_OK_NAME="SONAR_OK"
+    [ "$LAST_PHASE_NAME" = "BOT_WAIT" ] && PHASE_OK_NAME="BOT_REPLIED"
+
+    REACHED_OK=$(awk -v ts="$LAST_PHASE_HMS" -v ok="$PHASE_OK_NAME" '
+        $0 ~ "\\["ts"\\]" { found=1; next }
+        found && $0 ~ "\\["ok"\\]" { print "yes"; exit }
+    ' "$LOG_FILE")
+    if [ "$REACHED_OK" != "yes" ] && [ "$PHASE_AGE" -gt "$STUCK_PHASE_SEC" ]; then
+        printf "STATUS=stuck\nREASON=phase-stalled-%s\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+            "$LAST_PHASE_NAME" "$LAST_PHASE_NAME" "$PHASE_AGE" "$RETRIES" "$LIFETIME"
+        exit 0
+    fi
+fi
+
+# Rule (a) — process dead, no specific pattern matched above
+if ! process_alive; then
+    printf "STATUS=stuck\nREASON=process-gone\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+        "$LAST_EVENT" "$LOG_AGE" "$RETRIES" "$LIFETIME"
+    exit 0
+fi
+
+# Slow: log silent > SLOW_THRESHOLD_SEC, process alive
+if [ "$LOG_AGE" -gt "$SLOW_THRESHOLD_SEC" ]; then
+    printf "STATUS=slow\nREASON=log-silent\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+        "$LAST_EVENT" "$LOG_AGE" "$RETRIES" "$LIFETIME"
+    exit 0
+fi
+
+printf "STATUS=healthy\nREASON=active\nPHASE=%s\nPHASE_AGE_SEC=%d\nRETRIES=%d\nLIFETIME_SEC=%d\n" \
+    "$LAST_EVENT" "$LOG_AGE" "$RETRIES" "$LIFETIME"

--- a/scripts/orchestration/compute_cost.sh
+++ b/scripts/orchestration/compute_cost.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
+# compute_cost.sh <agent-id>
+#
+# Computes the cumulative LLM cost for an agent and prints two lines on stdout:
+#
+#     COST_USD=<float>
+#     COST_KIND=<exact|live|estimate>
+#
+#   exact    — taken from a final `{"type":"result", "total_cost_usd": ...}`
+#              event in the agent's stream-json trace (run finished cleanly)
+#   live     — summed from `{"type":"assistant", "message":{"usage": ...}}`
+#              events using model rates (run still in flight)
+#   estimate — no JSONL trace at all (e.g. PO / architect / bug-analyst that
+#              run inside the parent Claude Code session); approximated from
+#              elapsed time × per-minute rate of the inferred model
+#
+# Stateless: every call recomputes from current files.
+#
+# Resolution order for the JSONL trace:
+#   1. tick_*_agent_<TICKET>.json under .claude/state/epic_run/ticks/*/
+#      (sums across all ticks — re-dispatched code-devs accumulate)
+#   2. Fallback: time × rate of an inferred model
+#
+# Env:
+#   EGAPRO_STATE_ROOT — override state dir (default: derived from script path)
+
+set -euo pipefail
+
+AGENT_ID="${1:?agent-id required (e.g. code-dev-123)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+STATE_ROOT="${EGAPRO_STATE_ROOT:-${REPO_ROOT}/.claude/state/epic_run}"
+LOG_FILE="${STATE_ROOT}/agents/${AGENT_ID}.log"
+
+# Per-million-token rates (USD). Updated 2026-05.
+# Sonnet 4.6 (≤200K context):
+sonnet_rate_input=3
+sonnet_rate_output=15
+sonnet_rate_cache_read='0.30'
+sonnet_rate_cache_write='3.75'
+# Opus 4.7 (≤200K context):
+opus_rate_input=15
+opus_rate_output=75
+opus_rate_cache_read='1.50'
+opus_rate_cache_write='18.75'
+# Haiku 4.5 (small fast — included for completeness):
+haiku_rate_input=1
+haiku_rate_output=5
+haiku_rate_cache_read='0.10'
+haiku_rate_cache_write='1.25'
+
+# Per-minute approximation when no JSONL is available (PO/architect/bug-analyst).
+# Calibrated rough average — refined as we collect data.
+sonnet_per_min='0.30'
+opus_per_min='2.00'
+haiku_per_min='0.10'
+
+# ---- 1. Find the JSONL trace files for this agent ----
+# code-dev-<TICKET> → all tick_*_agent_<TICKET>.json across all ticks
+TRACE_FILES=()
+case "$AGENT_ID" in
+    code-dev-*)
+        TICKET="${AGENT_ID#code-dev-}"
+        # Iterate all tick dirs (one per epic key)
+        if [ -d "${STATE_ROOT}/ticks" ]; then
+            while IFS= read -r f; do
+                TRACE_FILES+=("$f")
+            done < <(find "${STATE_ROOT}/ticks" -name "tick_*_agent_${TICKET}.json" 2>/dev/null)
+        fi
+        ;;
+esac
+
+# ---- 2. If we have JSONL traces → exact or live cost ----
+if [ "${#TRACE_FILES[@]}" -gt 0 ]; then
+    TOTAL=0
+    KIND="live"
+    HAS_RESULT=0
+
+    for f in "${TRACE_FILES[@]}"; do
+        [ -s "$f" ] || continue
+
+        # Detect the model from the first system event (subtype=init carries model_id).
+        MODEL=$(grep '"type":"system"' "$f" 2>/dev/null \
+            | head -1 \
+            | jq -r '.model // empty' 2>/dev/null || true)
+
+        # Pick rates by model family. Default to Sonnet if unknown.
+        case "$MODEL" in
+            *opus*)   I=$opus_rate_input  ; O=$opus_rate_output  ; CR=$opus_rate_cache_read  ; CW=$opus_rate_cache_write ;;
+            *haiku*)  I=$haiku_rate_input ; O=$haiku_rate_output ; CR=$haiku_rate_cache_read ; CW=$haiku_rate_cache_write ;;
+            *)        I=$sonnet_rate_input; O=$sonnet_rate_output; CR=$sonnet_rate_cache_read; CW=$sonnet_rate_cache_write ;;
+        esac
+
+        # Prefer the authoritative `result.total_cost_usd` if present.
+        FILE_RESULT=$(grep '"type":"result"' "$f" 2>/dev/null | tail -1 || true)
+        if [ -n "$FILE_RESULT" ]; then
+            FILE_COST=$(echo "$FILE_RESULT" | jq -r '.total_cost_usd // 0' 2>/dev/null || echo 0)
+            TOTAL=$(awk "BEGIN { printf \"%.6f\", ${TOTAL} + ${FILE_COST} }")
+            HAS_RESULT=1
+            continue
+        fi
+
+        # No result event yet → sum from each assistant turn's usage block.
+        FILE_COST=$(jq -r --arg i "$I" --arg o "$O" --arg cr "$CR" --arg cw "$CW" '
+            select(.type == "assistant") | .message.usage // {} |
+            (
+                ((.input_tokens // 0)               * ($i  | tonumber) / 1000000) +
+                ((.output_tokens // 0)              * ($o  | tonumber) / 1000000) +
+                ((.cache_read_input_tokens // 0)    * ($cr | tonumber) / 1000000) +
+                ((.cache_creation_input_tokens // 0)* ($cw | tonumber) / 1000000)
+            )
+        ' "$f" 2>/dev/null | awk '{ s += $1 } END { printf "%.6f", s+0 }')
+        TOTAL=$(awk "BEGIN { printf \"%.6f\", ${TOTAL} + ${FILE_COST} }")
+    done
+
+    [ "$HAS_RESULT" = "1" ] && KIND="exact"
+    printf "COST_USD=%.4f\nCOST_KIND=%s\n" "$TOTAL" "$KIND"
+    exit 0
+fi
+
+# ---- 3. No JSONL → time-based estimation from the agent's own log ----
+if [ ! -f "$LOG_FILE" ]; then
+    printf "COST_USD=0.0000\nCOST_KIND=estimate\n"
+    exit 0
+fi
+
+# Per-min rate by agent-type. PO / architect / bug-analyst are opus by spec.
+PER_MIN="$sonnet_per_min"
+case "$AGENT_ID" in
+    po-*|architect-*|bug-analyst-*) PER_MIN="$opus_per_min" ;;
+esac
+
+# Lifetime: first event → last event if last is terminal, else first → now.
+# Terminal events freeze cost (the agent isn't burning tokens anymore even if
+# the user takes hours to look at the log). Non-terminal: time since start.
+# Anchors: <id>.start file (full epoch, written by log_event.sh on first call)
+# for the start time, and the log file's mtime for the freeze point.
+
+NOW_EPOCH=$(date '+%s')
+
+LAST_LINE=$(tail -1 "$LOG_FILE" 2>/dev/null || true)
+LAST_EVENT=$(echo "$LAST_LINE" | grep -oE '\[[A-Z_0-9]+\]' | head -1 | tr -d '[]' || true)
+
+# Terminal events: agent has stopped. Freeze cost at the log file's last mtime.
+case "$LAST_EVENT" in
+    COMPLETE|STUCK|ESCALATED|ANALYSIS_FAIL) IS_TERMINAL=1 ;;
+    *) IS_TERMINAL=0 ;;
+esac
+
+# Start anchor: the .start file (full epoch). Fall back to log mtime if missing.
+START_FILE="${STATE_ROOT}/agents/${AGENT_ID}.start"
+if [ -f "$START_FILE" ]; then
+    START_EPOCH=$(cat "$START_FILE" 2>/dev/null || echo 0)
+else
+    START_EPOCH=$(stat -c '%Y' "$LOG_FILE" 2>/dev/null || stat -f '%m' "$LOG_FILE" 2>/dev/null || echo 0)
+fi
+[ -z "$START_EPOCH" ] || [ "$START_EPOCH" = "0" ] && START_EPOCH=$NOW_EPOCH
+[ "$START_EPOCH" -gt "$NOW_EPOCH" ] && START_EPOCH=$NOW_EPOCH
+
+if [ "$IS_TERMINAL" = "1" ]; then
+    END_EPOCH=$(stat -c '%Y' "$LOG_FILE" 2>/dev/null || stat -f '%m' "$LOG_FILE" 2>/dev/null || echo "$NOW_EPOCH")
+else
+    END_EPOCH=$NOW_EPOCH
+fi
+[ "$END_EPOCH" -lt "$START_EPOCH" ] && END_EPOCH=$START_EPOCH
+
+ELAPSED_MIN=$(awk "BEGIN { printf \"%.4f\", (${END_EPOCH} - ${START_EPOCH}) / 60 }")
+COST=$(awk "BEGIN { printf \"%.4f\", ${ELAPSED_MIN} * ${PER_MIN} }")
+
+printf "COST_USD=%s\nCOST_KIND=estimate\n" "$COST"

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -231,11 +231,16 @@ Ton dernier message DOIT être uniquement ce JSON (rien d'autre, pas de prose)."
     # CLAUDECODE=1 would otherwise abort the nested CLI to prevent runtime
     # collisions). The sub-agent runs in its own process tree with its own
     # budget, so the anti-nesting guard does not apply here.
+    # stream-json emits a JSONL trace (one event per turn) instead of a single
+    # wrapper at the end. compute_cost.sh tails the file to derive the live
+    # cost; the final `{"type":"result", ...}` line carries total_cost_usd
+    # for the authoritative number.
     $TIMEOUT_PREFIX env -u CLAUDECODE claude \
         --agent "$AGENT" \
         --model "$MODEL" \
         --print \
-        --output-format json \
+        --output-format stream-json \
+        --verbose \
         --dangerously-skip-permissions \
         --max-budget-usd "$BUDGET" \
         "$PROMPT" \
@@ -395,16 +400,25 @@ while [ $TICK -lt $MAX_TICKS ]; do
         for ticket in "${!AGENT_FILES[@]}"; do
             file="${AGENT_FILES[$ticket]}"
 
-            # The claude CLI emits a wrapper {result, is_error, ...}. Extract .result
-            # and try to parse it as the strict JSON contract.
+            # The claude CLI emits a JSONL trace (--output-format stream-json).
+            # The final `result` event carries the assistant's last message
+            # text (`.result`) and an error flag (`.is_error`).
+            # If the stream was cut short (timeout, killed, budget exhaustion)
+            # there may be no result line — fall back to the last assistant
+            # message text so we can at least diagnose what happened.
             RESULT_TEXT=""
             CLI_ERROR="false"
             if [ -s "$file" ]; then
-                if jq -e '.result' "$file" >/dev/null 2>&1; then
-                    RESULT_TEXT=$(jq -r '.result // ""' "$file")
-                    CLI_ERROR=$(jq -r '.is_error // false' "$file")
+                RESULT_LINE=$(grep '"type":"result"' "$file" | tail -1 || true)
+                if [ -n "$RESULT_LINE" ] && echo "$RESULT_LINE" | jq -e '.result' >/dev/null 2>&1; then
+                    RESULT_TEXT=$(echo "$RESULT_LINE" | jq -r '.result // ""')
+                    CLI_ERROR=$(echo "$RESULT_LINE" | jq -r '.is_error // false')
                 else
-                    RESULT_TEXT=$(head -c 500 "$file")
+                    LAST_ASSISTANT=$(grep '"type":"assistant"' "$file" | tail -1 || true)
+                    if [ -n "$LAST_ASSISTANT" ]; then
+                        RESULT_TEXT=$(echo "$LAST_ASSISTANT" | jq -r '[.message.content[]? | .text? // empty] | join(" ")' 2>/dev/null | head -c 500)
+                    fi
+                    [ -z "$RESULT_TEXT" ] && RESULT_TEXT="(stream cut short — no result event in $file)"
                     CLI_ERROR="true"
                 fi
             else

--- a/scripts/orchestration/log_event.sh
+++ b/scripts/orchestration/log_event.sh
@@ -9,32 +9,50 @@ fi
 # log_event.sh <agent-id> <event-type> [message]
 #
 # Appends a structured event to the agent's log file under
-# .claude/state/epic_run/agents/<agent-id>.log (rolling 50 lines).
+# .claude/state/epic_run/agents/<agent-id>.log (rolling 200 lines).
 #
-# Agent-id format: <agent-type>-<ticket>   (e.g. code-dev-123, validator-123)
+# Agent-id format: <agent-type>-<ticket>   (e.g. code-dev-123, architect-42)
 # Special: epic-orchestrator-<EPICS_KEY>  (e.g. epic-orchestrator-42 or 42_43)
 #
 # === CALLING DISCIPLINE ===
-# Agents log at SIGNIFICANT STATE TRANSITIONS only — not every Read/grep/MCP
-# call. The log feeds /report, which surfaces stuck or inactive agents.
+# Agents log at PHASE TRANSITIONS only — not every Read/grep/MCP call.
+# The log feeds /report, which surfaces stuck or inactive agents and
+# computes per-agent cost & lifetime.
 #
 # Mandatory events for every agent:
 #   START       — at the beginning, after receiving the prompt
-#   COMPLETE    — nominal end (PR ready / In review / verdict PASS / etc.)
+#   COMPLETE    — nominal end (PR ready / verdict posted / issues created)
 #   STUCK       — gave up after retries / consecutive failures
 #   ESCALATED   — auto-escalation Sonnet → Opus
 #
-# Recommended (visibility for /report):
-#   PROGRESS    — intermediate milestones, max 2-3 per workflow
-#   RETRY       — start of an iteration after validator feedback
-#   VERDICT     — validators only (PASS / RETRY / REFACTO)
+# code-dev specific (with attempt=K when iterating):
+#   ANALYSIS_START / ANALYSIS_OK / ANALYSIS_FAIL  (step 1: ticket spec check)
+#   DEV_START / DEV_OK                            (step 5: implementation)
+#   VALIDATION_START / VALIDATION_OK              (step 6: 4 quality auditors)
+#   FUNCTIONAL_START / FUNCTIONAL_OK              (step 9a: functional-validator)
+#   CI_WAIT / CI_OK / CI_FAIL                     (step 9b: GitHub Actions)
+#   SONAR_WAIT / SONAR_OK / SONAR_FAIL            (step 9c: SonarCloud)
+#   BOT_WAIT / BOT_REPLIED                        (step 9d: bot reviews)
+#   PR_DRAFT, PR_READY                            (steps 8, 10)
+#   RETRY                                         (step 9 retries)
 #
-# Specialized (context-dependent):
-#   IMPLEMENT_OK, TYPECHECK_OK, TEST_OK             (code-dev)
-#   PR_DRAFT, PR_READY                              (code-dev)
-#   FUNCTIONAL_PASS, DESIGN_PASS                    (code-dev)
-#   TICK_DISPATCH, TICK_DONE, USER_INTERVENTION    (epic-orchestrator)
-#   AGENT_SPAWN, MERGE_FAIL, REBASE_FAIL           (epic-orchestrator)
+# product-owner specific:
+#   QA_DONE, BUSINESS_NEED_DRAFTED, ANALYSIS_DRAFTED, AWAITING_VALIDATION,
+#   ISSUE_CREATED                                 (mode create)
+#   READING_EXISTING, AMENDMENT_PLAN_DRAFTED      (mode enrich)
+#
+# architect specific:
+#   MAPPING, BREAKDOWN_READY                      (mode epic-*)
+#   ISSUES_CREATED, ANALYSIS_POSTED               (mode epic-*, task)
+#   AWAITING_VALIDATION                           (all modes)
+#
+# bug-analyst specific:
+#   REPRO_LOCAL, REPRO_ENV, REPRO_VISUAL          (sub-strategies)
+#   ROOT_CAUSE_FOUND, ANALYSIS_POSTED, AWAITING_VALIDATION
+#
+# epic-orchestrator specific:
+#   TICK_DISPATCH, TICK_AGENTS_DONE, USER_INTERVENTION
+#   AGENT_SPAWN, MERGE_FAIL, REBASE_CONFLICT, REBASE_ERROR
 #
 # Usage:
 #   bash scripts/orchestration/log_event.sh code-dev-123 START "worktree=epic42-t123"
@@ -62,7 +80,15 @@ LOG_DIR="${STATE_ROOT}/agents"
 mkdir -p "$LOG_DIR"
 
 LOG_FILE="${LOG_DIR}/${AGENT_ID}.log"
+START_FILE="${LOG_DIR}/${AGENT_ID}.start"
 TS=$(date '+%H:%M:%S')
+
+# First event ever for this agent → record full epoch start time.
+# This is the authoritative lifetime anchor (the rolling 200-line log can drop
+# the original START line on long runs, and HMS-only timestamps lose the date).
+if [ ! -f "$START_FILE" ]; then
+    date '+%s' > "$START_FILE"
+fi
 
 if [ -n "$MSG" ]; then
     LINE="[${TS}][${EVENT_TYPE}] ${MSG}"
@@ -72,9 +98,10 @@ fi
 
 echo "$LINE" >> "$LOG_FILE"
 
-# Rolling window: keep last 50 lines
-if [ "$(wc -l < "$LOG_FILE")" -gt 50 ]; then
-    tail -n 50 "$LOG_FILE" > "${LOG_FILE}.tmp" && mv "${LOG_FILE}.tmp" "$LOG_FILE"
+# Rolling window: keep last 200 lines (raised from 50 to allow drill-down on
+# stuck agents — see /report skill).
+if [ "$(wc -l < "$LOG_FILE")" -gt 200 ]; then
+    tail -n 200 "$LOG_FILE" > "${LOG_FILE}.tmp" && mv "${LOG_FILE}.tmp" "$LOG_FILE"
 fi
 
 # stderr only — callers may pipe stdout

--- a/scripts/orchestration/render_dashboard.sh
+++ b/scripts/orchestration/render_dashboard.sh
@@ -8,207 +8,231 @@ if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
 fi
 # render_dashboard.sh
 #
-# Formats the /report dashboard from .claude/state/epic_run/.
-# Pure bash, no LLM needed. The /report skill calls this directly.
+# Renders the /report dashboard from .claude/state/epic_run/.
+# Pure bash — composes outputs of agent_status.sh, compute_cost.sh, and
+# agent_drilldown.sh. The /report skill calls this directly.
 #
-# Displays:
-#   - Active agents (non-terminal state), sorted by inactivity (most inactive first)
-#   - Each agent's last 4 events
-#   - Alerts for agents inactive > INACTIVITY_THRESHOLD_SEC (default 600 = 10 min)
-#   - Cross-agent recent events (chronological, last 10)
+# Sections:
+#   1. ACTIVE AGENTS table (one row per non-terminal agent):
+#        AGENT · TICKET · PHASE · ATTEMPT · AGE · MODEL · EST. $ · STATUS
+#   2. AUTO DRILL-DOWN — for every agent flagged 🔴 stuck, dumps the full
+#      drill-down output below the table (agent_drilldown.sh)
+#   3. RECENT EVENTS (cross-agent, chronological, last 10)
 #
 # Env:
-#   EGAPRO_STATE_ROOT         — state dir (default: derived from script path)
-#   INACTIVITY_THRESHOLD_SEC  — alert threshold in seconds (default: 600 = 10 min)
+#   EGAPRO_STATE_ROOT — state dir (default: derived from script path)
 
 set -euo pipefail
-
-# Mac compat: GNU stat uses `-c '%Y'`; BSD/macOS stat uses `-f '%m'`.
-file_mtime() {
-    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null || echo 0
-}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 STATE_ROOT="${EGAPRO_STATE_ROOT:-${REPO_ROOT}/.claude/state/epic_run}"
 LOG_DIR="${STATE_ROOT}/agents"
-THRESHOLD="${INACTIVITY_THRESHOLD_SEC:-600}"
 
 if [ ! -d "$LOG_DIR" ] || [ -z "$(ls -A "$LOG_DIR" 2>/dev/null)" ]; then
     echo "(Aucun epic en cours — .claude/state/epic_run/agents/ vide)"
     exit 0
 fi
 
-NOW_TS=$(date '+%s')
+# ---- Helpers ----
+fmt_age() {
+    local sec="$1"
+    if [ "$sec" -lt 60 ]; then
+        echo "${sec}s"
+    elif [ "$sec" -lt 3600 ]; then
+        echo "$((sec / 60))m"
+    else
+        printf "%dh%02dm" $((sec / 3600)) $(( (sec % 3600) / 60 ))
+    fi
+}
 
-ACTIVE=()
-ALERTS=()
+# Parse the latest "attempt=K" tag from the log (the agent's current retry index)
+last_attempt() {
+    local log="$1"
+    awk '
+        match($0, /attempt=([0-9]+)/, m) { last = m[1] }
+        END { if (last != "") print last; else print "-" }
+    ' "$log"
+}
 
-# Helper: is the agent's underlying OS process still alive?
-# Sub-agents (code-dev, validators, ...) are claude CLIs whose cmdline
-# contains "Ticket #<N>". The orchestrator is an epic_loop.sh whose cmdline
-# contains the epics key. Returns 0 if alive, 1 if not.
-process_alive() {
-    local AID="$1"
-    case "$AID" in
-        epic-orchestrator-*)
-            local KEY="${AID#epic-orchestrator-}"
-            pgrep -af "epic_loop.sh.*${KEY}" >/dev/null 2>&1
-            ;;
-        *-[0-9]*)
-            local TICKET="${AID##*-}"
-            ps -ef | grep -E "Ticket #${TICKET}([^0-9]|\$)" | grep -v grep >/dev/null 2>&1
-            ;;
+# Extract the ticket number from agent-id (everything after the last dash, if numeric).
+ticket_of() {
+    local id="$1"
+    case "$id" in
+        epic-orchestrator-*) echo "${id#epic-orchestrator-}" ;;
+        po-pending) echo "?" ;;
         *)
-            return 1
+            local maybe="${id##*-}"
+            [[ "$maybe" =~ ^[0-9]+$ ]] && echo "$maybe" || echo "-"
             ;;
     esac
 }
 
-# Helper: PR info ("PR #<N> [<state>]") for a code-dev agent's ticket — matches
-# any PR whose head ref starts with `ticket/<N>-`. Empty if no PR yet (or for
-# non-code-dev agents). 1 gh API call per call.
-agent_pr_info() {
-    local AID="$1"
-    case "$AID" in
-        code-dev-[0-9]*)
-            local TICKET="${AID##*-}"
-            gh pr list --state all --limit 100 --json number,state,headRefName 2>/dev/null \
-                | jq -r --arg t "ticket/${TICKET}-" '.[] | select(.headRefName | startswith($t)) | "PR #\(.number) [\(.state | ascii_downcase)]"' \
-                | head -1
+# Infer the model. For code-dev, look up the latest tick JSONL. For others,
+# use the agent-type → model convention from CLAUDE.md.
+model_of() {
+    local id="$1"
+    case "$id" in
+        code-dev-*)
+            local ticket
+            ticket=$(ticket_of "$id")
+            local f
+            f=$(find "${STATE_ROOT}/ticks" -name "tick_*_agent_${ticket}.json" 2>/dev/null | tail -1)
+            if [ -n "$f" ] && [ -s "$f" ]; then
+                local m
+                m=$(grep '"type":"system"' "$f" | head -1 | jq -r '.model // empty' 2>/dev/null || true)
+                if [ -n "$m" ]; then
+                    case "$m" in
+                        *opus*) echo "opus" ;;
+                        *haiku*) echo "haiku" ;;
+                        *) echo "sonnet" ;;
+                    esac
+                    return
+                fi
+            fi
+            echo "sonnet"
             ;;
+        po-*|architect-*|bug-analyst-*) echo "opus" ;;
+        epic-orchestrator-*) echo "-" ;;
+        *) echo "?" ;;
     esac
 }
 
-# Helper: deepest non-claude descendant of an agent's claude CLI — useful to
-# see what the agent is awaiting (e.g. "gh pr checks 3401 --watch").
-# Returns truncated cmdline (first 100 chars) or empty if claude has no live
-# subprocess at the moment.
-agent_active_command() {
-    local AID="$1"
-    case "$AID" in
-        code-dev-[0-9]*)
-            local TICKET="${AID##*-}"
-            local CLAUDE_PID
-            CLAUDE_PID=$(ps -eo pid,cmd 2>/dev/null \
-                | awk -v t="Ticket #${TICKET}" '$0 ~ t && $0 !~ /timeout/ && $0 !~ /grep/ && $0 !~ /awk/ {print $1; exit}')
-            [ -z "$CLAUDE_PID" ] && return
-            local CURRENT="$CLAUDE_PID"
-            local LAST_CMD=""
-            local DEPTH=0
-            while [ "$DEPTH" -lt 20 ]; do
-                local CHILD
-                CHILD=$(pgrep -P "$CURRENT" 2>/dev/null | head -1)
-                [ -z "$CHILD" ] && break
-                CURRENT="$CHILD"
-                LAST_CMD=$(ps -p "$CURRENT" -o cmd= 2>/dev/null | head -1)
-                DEPTH=$((DEPTH + 1))
-            done
-            [ -n "$LAST_CMD" ] && echo "${LAST_CMD:0:100}"
-            ;;
+# Status icon for the table
+status_icon() {
+    case "$1" in
+        healthy) echo "✓" ;;
+        slow)    echo "⚠" ;;
+        stuck)   echo "🔴" ;;
+        *)       echo "?" ;;
     esac
 }
+
+# ---- 1. Build the table rows ----
+ROWS=()        # status|agent|ticket|phase|attempt|age|model|cost|reason
+STUCK_IDS=()   # agent-ids flagged 🔴 (for drill-down section)
+
+file_mtime() {
+    stat -c '%Y' "$1" 2>/dev/null || stat -f '%m' "$1" 2>/dev/null || echo 0
+}
+
+NOW_EPOCH=$(date '+%s')
+LEGACY_STALE_SEC="${LEGACY_STALE_SEC:-3600}"
 
 for log in "$LOG_DIR"/*.log; do
     [ -f "$log" ] || continue
-    AGENT_ID=$(basename "$log" .log)
+    AID=$(basename "$log" .log)
 
-    # Skip if terminal state in last event
+    # Skip nominal terminal agents to keep the dashboard focused on what's "in flight".
     LAST_LINE=$(tail -n 1 "$log" 2>/dev/null || echo "")
-    LAST_EVENT=$(echo "$LAST_LINE" | grep -oE '\[[A-Z_0-9]+\]' | head -1 | tr -d '[]' || true)
-
+    LAST_EVENT=$(echo "$LAST_LINE" | grep -oE '\[[A-Z_0-9]+\]' | head -1 | tr -d '[]' || echo "")
     case "$LAST_EVENT" in
-        COMPLETE|STUCK|ESCALATED) continue ;;
+        COMPLETE|ESCALATED) continue ;;
     esac
 
-    MTIME=$(file_mtime "$log")
-    INACTIVITY=$((NOW_TS - MTIME))
-
-    ACTIVE+=("${AGENT_ID}|${INACTIVITY}|${log}")
-
-    # Only alert if both: log is stale AND no live process backs the agent.
-    # A silent-but-running agent (Sonnet ignores log_event calls, common) is
-    # NOT a real stuck — its cmdline is still in `ps`.
-    if [ "$INACTIVITY" -gt "$THRESHOLD" ] && ! process_alive "$AGENT_ID"; then
-        MIN=$((INACTIVITY / 60))
-        ALERTS+=("⚠ ${AGENT_ID} : inactif ${MIN} min, process gone (seuil $((THRESHOLD / 60)) min)")
+    # Skip legacy / abandoned agents: log mtime > LEGACY_STALE_SEC AND no .start file
+    # (predates the .start convention) AND no live process. These pollute the
+    # dashboard with phantom "stuck" rows from previous runs.
+    LOG_MTIME=$(file_mtime "$log")
+    LOG_AGE=$((NOW_EPOCH - LOG_MTIME))
+    if [ ! -f "${LOG_DIR}/${AID}.start" ] && [ "$LOG_AGE" -gt "$LEGACY_STALE_SEC" ]; then
+        continue
     fi
+
+    # Status
+    STATUS_OUT=$(EGAPRO_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/agent_status.sh" "$AID" 2>/dev/null || echo "")
+    STATUS=$(echo "$STATUS_OUT" | grep '^STATUS=' | cut -d= -f2)
+    REASON=$(echo "$STATUS_OUT" | grep '^REASON=' | cut -d= -f2)
+    PHASE=$(echo "$STATUS_OUT" | grep '^PHASE=' | cut -d= -f2)
+    LIFETIME_SEC=$(echo "$STATUS_OUT" | grep '^LIFETIME_SEC=' | cut -d= -f2)
+
+    # Cost
+    COST_OUT=$(EGAPRO_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/compute_cost.sh" "$AID" 2>/dev/null || echo "")
+    COST_USD=$(echo "$COST_OUT" | grep '^COST_USD=' | cut -d= -f2)
+    COST_KIND=$(echo "$COST_OUT" | grep '^COST_KIND=' | cut -d= -f2)
+    case "$COST_KIND" in
+        exact)    COST_DISPLAY=$(printf "\$%.2f" "$COST_USD") ;;
+        live)     COST_DISPLAY=$(printf "\$%.2f*" "$COST_USD") ;;   # live (still running)
+        estimate) COST_DISPLAY=$(printf "~\$%.2f" "$COST_USD") ;;   # rough estimate
+        *)        COST_DISPLAY="-" ;;
+    esac
+
+    TICKET=$(ticket_of "$AID")
+    MODEL=$(model_of "$AID")
+    ATTEMPT=$(last_attempt "$log")
+    AGE=$(fmt_age "${LIFETIME_SEC:-0}")
+    ICON=$(status_icon "${STATUS:-?}")
+
+    ROWS+=("${STATUS}|${ICON}|${AID}|${TICKET}|${PHASE}|${ATTEMPT}|${AGE}|${MODEL}|${COST_DISPLAY}|${REASON}")
+    [ "$STATUS" = "stuck" ] && STUCK_IDS+=("$AID")
 done
 
-echo "═══ ACTIVE AGENTS (${#ACTIVE[@]}) ═══"
+# Sort: stuck first, then slow, then healthy. Within each, longest-lived first.
+# Each row: STATUS|ICON|AID|TICKET|PHASE|ATTEMPT|AGE|MODEL|COST|REASON
+# Strip STATUS from the output (first field) so the rendering loop's column
+# indices line up with ICON|AID|TICKET|...
+IFS=$'\n' SORTED=($(printf "%s\n" "${ROWS[@]}" | awk -F'|' '
+    BEGIN { OFS="|" }
+    {
+        rank = ($1 == "stuck") ? 0 : ($1 == "slow") ? 1 : 2
+        rest = $2
+        for (i = 3; i <= NF; i++) rest = rest "|" $i
+        print rank "|" rest
+    }
+' | sort -t'|' -k1,1n | cut -d'|' -f2-))
+unset IFS
+
+# ---- Render table ----
+echo "═══ ACTIVE AGENTS (${#ROWS[@]}) ═══"
 echo ""
 
-if [ "${#ACTIVE[@]}" -eq 0 ]; then
-    echo "  (aucun agent actif — tous en état terminal ou logs vides)"
+if [ "${#ROWS[@]}" -eq 0 ]; then
+    echo "  (aucun agent actif — tous en état terminal)"
     echo ""
 else
-    # Sort by inactivity descending (most inactive first)
-    IFS=$'\n' SORTED=($(printf "%s\n" "${ACTIVE[@]}" | sort -t'|' -k2 -nr))
-    unset IFS
+    # Header
+    printf "  %-2s %-22s %-7s %-18s %-8s %-6s %-7s %-8s %s\n" \
+        "" "AGENT" "TICKET" "PHASE" "ATTEMPT" "AGE" "MODEL" "EST. $" "REASON"
+    printf "  %-2s %-22s %-7s %-18s %-8s %-6s %-7s %-8s %s\n" \
+        "──" "──────────────────────" "───────" "──────────────────" "────────" "──────" "───────" "────────" "──────"
 
     for entry in "${SORTED[@]}"; do
-        AGENT_ID=$(echo "$entry" | cut -d'|' -f1)
-        INACTIVITY=$(echo "$entry" | cut -d'|' -f2)
-        LOG=$(echo "$entry" | cut -d'|' -f3-)
+        ICON=$(echo "$entry" | cut -d'|' -f1)
+        AID=$(echo "$entry" | cut -d'|' -f2)
+        TICKET=$(echo "$entry" | cut -d'|' -f3)
+        PHASE=$(echo "$entry" | cut -d'|' -f4)
+        ATTEMPT=$(echo "$entry" | cut -d'|' -f5)
+        AGE=$(echo "$entry" | cut -d'|' -f6)
+        MODEL=$(echo "$entry" | cut -d'|' -f7)
+        COST=$(echo "$entry" | cut -d'|' -f8)
+        REASON=$(echo "$entry" | cut -d'|' -f9-)
+        printf "  %-2s %-22s %-7s %-18s %-8s %-6s %-7s %-8s %s\n" \
+            "$ICON" "$AID" "$TICKET" "$PHASE" "$ATTEMPT" "$AGE" "$MODEL" "$COST" "$REASON"
+    done
+    echo ""
+    echo "  Légende : ✓ healthy  ⚠ slow (silent log)  🔴 stuck"
+    echo "           \$X.XX exact  \$X.XX* live  ~\$X.XX estimate"
+    echo ""
+fi
 
-        if [ "$INACTIVITY" -lt 60 ]; then
-            AGE="${INACTIVITY}s ago"
-        else
-            AGE="$((INACTIVITY / 60)) min ago"
-        fi
-
-        IS_LIVE=0
-        if [ "$INACTIVITY" -gt "$THRESHOLD" ]; then
-            if process_alive "$AGENT_ID"; then
-                FLAG="○ live (log silent)"
-                IS_LIVE=1
-            else
-                FLAG="⚠ INACTIF"
-            fi
-        else
-            FLAG="✓"
-            IS_LIVE=1
-        fi
-
-        # Enrich live agents with PR info (if a PR was opened) so that
-        # "log silent" doesn't mean "lost track of what the agent did".
-        if [ "$IS_LIVE" = "1" ]; then
-            PR_INFO=$(agent_pr_info "$AGENT_ID")
-            [ -n "$PR_INFO" ] && FLAG="$FLAG · $PR_INFO"
-        fi
-
-        RETRIES=$(awk '/\[RETRY/ {c++} END {print c+0}' "$LOG")
-
-        printf "%s · %s · %s · retries=%d\n" "$AGENT_ID" "$AGE" "$FLAG" "$RETRIES"
-        tail -n 4 "$LOG" | sed 's/^/  /'
-
-        # Show what the agent is currently awaiting at process level — works
-        # even when the agent log is silent. Skip if the process tree has no
-        # subprocess (claude is computing internally, no shell call active).
-        if [ "$IS_LIVE" = "1" ]; then
-            CURRENT_CMD=$(agent_active_command "$AGENT_ID")
-            [ -n "$CURRENT_CMD" ] && printf "  └─ awaiting: %s\n" "$CURRENT_CMD"
-        fi
-
+# ---- 2. Auto drill-down for stuck agents ----
+if [ "${#STUCK_IDS[@]}" -gt 0 ]; then
+    echo "═══ DRILL-DOWN (${#STUCK_IDS[@]} agent(s) stuck) ═══"
+    echo ""
+    for sid in "${STUCK_IDS[@]}"; do
+        EGAPRO_STATE_ROOT="$STATE_ROOT" bash "$SCRIPT_DIR/agent_drilldown.sh" "$sid"
         echo ""
     done
 fi
 
-# Cross-agent recent events
+# ---- 3. Cross-agent recent events ----
 echo "═══ RECENT EVENTS (cross-agent, last 10) ═══"
 {
     for log in "$LOG_DIR"/*.log; do
         [ -f "$log" ] || continue
-        AGENT_ID=$(basename "$log" .log)
-        awk -v aid="$AGENT_ID" '{print $0 " <" aid ">"}' "$log"
+        AID=$(basename "$log" .log)
+        awk -v aid="$AID" '{print $0 " <" aid ">"}' "$log"
     done
 } | sort | tail -n 10 | sed 's/^/  /'
 echo ""
-
-if [ ${#ALERTS[@]} -gt 0 ]; then
-    echo "═══ ALERTS ═══"
-    for alert in "${ALERTS[@]}"; do
-        echo "  $alert"
-    done
-fi


### PR DESCRIPTION
## Pourquoi

Aujourd'hui `/report` se contente d'afficher les 4 derniers events bruts par agent. Pour un epic avec ~10 sub-tickets en parallèle, on ne sait pas en un coup d'œil :
- où en est chaque agent (phase courante, n° de retry)
- combien de tokens il a brûlé depuis son démarrage
- s'il est en train de travailler ou stuck (et **pourquoi** stuck)

Cette PR remplace la vue logs bruts par une table de santé + un drill-down auto sur les agents 🔴.

## Aperçu

```
═══ ACTIVE AGENTS (3) ═══

     AGENT                  TICKET  PHASE              ATTEMPT  AGE    MODEL   EST. $   REASON
  ── ────────────────────── ─────── ────────────────── ──────── ────── ─────── ──────── ──────
  🔴 code-dev-3401          3401    CI_FAIL            -        12m    sonnet  $0.80*   ci-fail-loop-lint
  ⚠ code-dev-3402          3402    DEV_START          2        4m     sonnet  $0.20*   log-silent
  ✓ architect-3380         3380    BREAKDOWN_READY    -        2m     opus    ~$0.15   active

  Légende : ✓ healthy  ⚠ slow (silent log)  🔴 stuck
           \$X.XX exact  \$X.XX* live  ~\$X.XX estimate
```

Sous la table, drill-down automatique pour chaque 🔴 : last 20 events, shell command actif (process tree), git status du worktree, dernier check CI failed (avec 30 lignes de log), dernier comment PR.

## Changements

| Fichier | Rôle |
|---|---|
| `log_event.sh` | Rolling 50→200, ancrage `<id>.start` (epoch UNIX) pour un lifetime stable même quand le log roule |
| `agents/{code-dev,product-owner,architect,bug-analyst}/AGENT.md` | Events de phase aux transitions (\`ANALYSIS_*\`, \`DEV_*\`, \`VALIDATION_*\`, \`CI_*\`, \`SONAR_*\`, \`BOT_*\` avec \`attempt=K\`) |
| `epic_loop.sh` | Sub-agent CLI passe à \`--output-format stream-json --verbose\` (trace JSONL consultable live) ; verdict extrait du dernier event \`result\` |
| `compute_cost.sh` (nouveau) | 3 modes — **exact** (\`result.total_cost_usd\`), **live** (somme \`assistant.usage\` × tarifs Sonnet/Opus/Haiku), **estimate** (temps × rate per-min pour PO/architect/bug-analyst qui tournent dans la session parent) |
| `agent_status.sh` (nouveau) | Règles \`healthy\`/\`slow\`/\`stuck\` ordonnées : retry-loop → ci-fail-loop → bot-wait-timeout → phase-stalled → process-gone (fallback) |
| `agent_drilldown.sh` (nouveau) | Dump on-demand pour un agent stuck — pure bash + gh + git, zéro LLM |
| `render_dashboard.sh` | Tri stuck→slow→healthy, auto drill-down sous la table pour les 🔴, filtre legacy (sans \`.start\` + log mtime > 1h) |
| `skills/report/SKILL.md` | Doc à jour, seuils stuck/slow exposés via env (\`STUCK_PHASE_SEC\`, \`STUCK_BOT_SEC\`, \`SLOW_THRESHOLD_SEC\`) |

## Discipline tokens

Tout est **pure bash** — \`compute_cost.sh\`, \`agent_status.sh\`, \`agent_drilldown.sh\`, \`render_dashboard.sh\` n'invoquent jamais de LLM. La skill \`/report\` reste un thin wrapper qui copie-colle la sortie. Le LLM intervient au plus pour 2 lignes d'analyse en tête s'il repère un pattern (3 agents stuck sur la même cause CI, etc.).

## Test plan

- [ ] \`bash scripts/orchestration/render_dashboard.sh\` tourne sans erreur (vérifié sur l'état actuel)
- [ ] Sur le prochain run d'epic, vérifier que la table affiche bien les phases (\`DEV_START\`, \`CI_WAIT\`, etc.) au lieu des events historiques
- [ ] Vérifier que le coût \`live\` se met à jour en temps réel pendant l'exécution d'un \`code-dev\` (le JSONL grossit)
- [ ] Vérifier que les agents stuck sont triés en tête avec un drill-down lisible
- [ ] Vérifier que le filtre legacy ne masque pas les agents en cours