### PR TITLE
fix(pipeline): force code-dev to log phase events as a blocking discipline

### DIFF
--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -18,6 +18,12 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
   - **Task ou Bug standalone** (sans parent epic) : `origin/alpha` direct. La PR sera mergée à la main par l'humain après revue.
 - **Working branch** (assigned by `/implement`) — déjà créée sur GitHub par l'orchestrateur via `createLinkedBranch` GraphQL et **officiellement linkée à l'issue** (sidebar Development). Le force-link PR↔issue (étape 8.5) ajoute également la PR à la sidebar dès qu'elle est créée.
 
+## Discipline de logging (BLOCKING)
+
+À chaque transition de phase tu DOIS exécuter `bash scripts/orchestration/log_event.sh code-dev-<N> <EVENT> [msg]` **avant** de poursuivre la phase suivante. Sans ces events, le dashboard `/report` ne peut pas suivre ta progression et l'utilisateur croit que tu es stuck (il a déjà signalé le problème — c'est exactement pour éviter ça).
+
+Le logging n'est pas optionnel ni "à faire à la fin" : c'est une étape de la phase, au même titre qu'un `git push` ou un `gh pr create`. Si une phase a démarré et son event n'a pas été loggé, **arrête tout, logge, puis reprends**. Liste exhaustive en bas du document (« Logging events »).
+
 ## Workflow
 
 0. **Logger START** — `bash scripts/orchestration/log_event.sh code-dev-<N> START "worktree=<path> base=<base-branch>"`. Voir la section « Logging events » plus bas pour la liste complète.

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -193,6 +193,17 @@ Puis implémenter, push tes commits sur ${BRANCH}, créer la PR draft (\`gh pr c
 **Ne crée PAS une autre branche** (pas de \`checkout -b\`). La branche ${BRANCH} est déjà créée et linkée — utilise-la telle quelle.
 
 REGLES STRICTES (appliquer sans exception) :
+- **DISCIPLINE DE LOGGING (BLOCKING)** — à chaque transition de phase tu DOIS
+  exécuter \`bash scripts/orchestration/log_event.sh code-dev-${TICKET} <EVENT> [msg]\`
+  AVANT de commencer la phase suivante. Sans ces events, le dashboard /report
+  ne peut pas suivre ta progression et l'utilisateur croit que tu es stuck.
+  Events obligatoires dans l'ordre : START → ANALYSIS_START → ANALYSIS_OK
+  → DEV_START → DEV_OK → VALIDATION_START → VALIDATION_OK → PR_DRAFT
+  → FUNCTIONAL_START → FUNCTIONAL_OK → CI_WAIT → CI_OK → SONAR_WAIT → SONAR_OK
+  → BOT_WAIT → BOT_REPLIED → PR_READY → COMPLETE. (RETRY/CI_FAIL/SONAR_FAIL
+  à intercaler en cas d'itération, voir AGENT.md « Logging events ».)
+  Logger AVANT de poursuivre n'est pas optionnel — c'est une étape de la phase,
+  au même titre que git push ou gh pr create.
 - **N'invoque AUCUN skill built-in** (fewer-permission-prompts, update-config,
   claude-api, schedule, loop, etc.). Si une de ces skills semble utile, ignore-la
   et reste concentré sur le ticket.


### PR DESCRIPTION
## Summary

`code-dev` agent was implementing tickets correctly (commits, PRs, validators) but rarely calling `log_event.sh` between phases — leaving the `/report` dashboard stuck on the last orchestrator-emitted event (typically `STACK_READY`) for tens of minutes while the agent was actually progressing silently. Symptom: users see ⚠ slow / log-silent agents and assume they're stuck, when in reality the PR is already drafted and validators are running.

Root cause: the dispatch prompt and `AGENT.md` both mention logging at every phase, but neither marks it as a hard requirement. Sonnet treats it as advisory, optimizes for delivery, and skips the `log_event.sh` calls.

## Fix

Two reinforcements, both inert at runtime (string changes only):

1. **Dispatch prompt** (`scripts/orchestration/epic_loop.sh`) — add a `BLOCKING` rule with the explicit ordered list of events the agent must emit. Logging is framed as part of the phase, not an aside.
2. **AGENT.md** (`.claude/agents/code-dev/AGENT.md`) — new top-level `## Discipline de logging (BLOCKING)` section, placed before the numbered workflow steps so agents reading the spec see the rule first.

Effect applies to new `code-dev` spawns; currently-running agents are unaffected until re-dispatch.

## Test plan

- [ ] CI green
- [ ] After merge, observe a fresh `code-dev` spawn on an epic and verify per-phase events appear in `.claude/state/epic_run/agents/code-dev-<N>.log` (at least: START, ANALYSIS_OK, DEV_START, DEV_OK, VALIDATION_OK, PR_DRAFT, FUNCTIONAL_OK, CI_OK, SONAR_OK, BOT_REPLIED, PR_READY, COMPLETE)