### PR TITLE
feat(pipeline): /implement auto-launches /report dynamic loop

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -103,10 +103,25 @@ Workflow identique à l'ex-`/epic` :
    nohup bash scripts/orchestration/epic_loop.sh $EPICS > "$LOG_FILE" 2>&1 &
    PID=$!
    disown
-   echo "epic_loop lancé en background (PID $PID, log: $LOG_FILE). Suivi via /report."
+   echo "epic_loop lancé en background (PID $PID, log: $LOG_FILE)."
    ```
 
-4. Rendre la main immédiatement (pas de polling — utiliser `/report`).
+4. **Lancer l'auto-report dynamique** — invoquer le skill `/loop` avec args `/report <N>` (mode dynamic-pacing, pas d'intervalle fixe).
+   ```
+   Skill("loop", args="/report <N>")
+   ```
+   Le `/loop` va run `/report <N>` immédiatement, puis re-schedule un wakeup avec délai adaptatif (60-3600s) basé sur ce que `/report` observe. À chaque wakeup, après le rendu du dashboard, **vérifier la condition d'arrêt** : la PR finale `epic/<N> → alpha` est-elle ouverte ?
+   ```bash
+   gh pr list --repo SocialGouv/egapro --base alpha --head "epic/<N>" --state open --json number --jq 'length'
+   ```
+   Si > 0 → omettre `ScheduleWakeup` → loop s'arrête. Sinon → re-schedule.
+
+   Cadence recommandée :
+   - **Activité récente côté logs** (phase qui bouge, agent qui spawn) → 60-270s (cache prompt warm)
+   - **État stable** (agent silent, rien à observer) → 1200-1800s (un seul cache miss)
+   - **Sortie 5 min** → toujours mauvais choix (300s = cache miss sans amortissement)
+
+5. Rendre la main immédiatement (le /loop continue en arrière-plan, t'auto-rapporte jusqu'à fin de l'epic).
 
 > **Note** : le main worktree reste sur `epic/<N>` pendant toute la durée du loop (ticks + final PR). Pour faire du travail sur `alpha` en parallèle (hotfix, autre branche), monter un worktree dédié (`git worktree add /tmp/egapro-alpha alpha`). À la fin de l'epic — quand la PR finale est mergée sur alpha — basculer manuellement le main worktree avec `git checkout alpha && git pull`.
 
@@ -153,8 +168,8 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
 
 ## Suivi de la progression (mode epic)
 
-- `/report` — dashboard live agents actifs + état du board
-- `/report <N>` — état détaillé des sous-tickets de l'epic
+- **Auto-report `/loop /report <N>`** lancé automatiquement à l'étape 4 — délivre des dashboards adaptatifs jusqu'à la fin de l'epic, puis s'auto-arrête (cf. condition d'arrêt en step 4)
+- `/report <N>` — déclencher manuellement à tout moment pour un check on-demand (n'interfère pas avec le loop dynamique)
 - `tail -f /tmp/epic_loop_<EPICS_KEY>.log`
 - `ls .claude/state/epic_run/ticks/<EPICS_KEY>/` — JSON des ticks (plan + result + agent returns)
 

--- a/.claude/skills/report/SKILL.md
+++ b/.claude/skills/report/SKILL.md
@@ -42,10 +42,27 @@ bash scripts/orchestration/epic_state.sh <N1> [<N2> ...]
 Le dashboard est déjà formaté par les scripts. Tu n'as qu'à :
 
 1. Exécuter les commandes bash ci-dessus
-2. **Copier-coller la sortie telle quelle** à l'utilisateur
-3. Ajouter **au maximum 2 lignes de commentaire** en tête si tu remarques quelque chose d'important (ex: « Attention, 2 agents inactifs > 20 min — probablement stuck »)
+2. **Re-rendre les tableaux en markdown propre** (colonnes alignées, headers `|` syntax). L'UI utilisateur rend mal les tableaux bash bruts (── boxes, alignement à espaces multiples).
+3. **Joindre une analyse** : interprétation de l'état actuel, qui bouge, qui est bloqué, prochaine étape attendue.
 
-**Ne PAS reformater** la sortie du script. Le format texte-table est voulu pour la lisibilité terminal.
+> Note : la version « copier-coller la sortie telle quelle » a été remplacée par cette mouture markdown + analyse. Les scripts bash restent la source de vérité — la donnée vient toujours d'eux, ne pas inventer.
+
+## Mode auto-report (lancé depuis /loop, e.g. par /implement)
+
+Quand `/report` est invoqué via `/loop` (mode dynamic-pacing), il devient l'élément central d'un suivi automatique pendant la durée d'un `/implement` epic. À chaque iteration :
+
+1. Run `/report <N>` (rendu markdown + analyse comme ci-dessus)
+2. **Vérifier la condition d'arrêt** : la PR finale `epic/<N> → alpha` est-elle ouverte ?
+   ```bash
+   gh pr list --repo SocialGouv/egapro --base alpha --head "epic/<N>" --state open --json number --jq 'length'
+   ```
+   - Retourne `> 0` → l'epic est terminé (loop driver a appelé `open_epic_final_pr.sh`). **Omettre `ScheduleWakeup`** → loop s'arrête. Annoncer à l'utilisateur.
+   - Retourne `0` → re-schedule un wakeup avec délai adaptatif (cf. ci-dessous).
+3. **Picking du délai adaptatif** :
+   - **Activité récente** (logs avec event dans les 5 min, agent qui spawn/transition de phase) → 60-270s (cache prompt warm)
+   - **État stable** (agent log-silent, rien d'actionable) → 1200-1800s (un seul cache miss couvre une longue fenêtre)
+   - **300s = NEVER** : worst-of-both case (cache miss sans amortissement)
+4. La cadence DOIT s'adapter à ce que tu OBSERVES, pas à un timer fixe. Lis le delta de coût (`*` indicateur live), l'âge du dernier event, l'état de la PR — décide en fonction.
 
 ## Ajustement des seuils
 
@@ -74,7 +91,7 @@ Dans ce cas le script affiche `(Aucun epic en cours)`. Si `<N>` est fourni en ar
 
 ## Règles
 
-- **Zéro LLM processing** quand les scripts suffisent. Si l'utilisateur demande un rapport standard, c'est juste `bash` + affichage.
-- **Interventions LLM autorisées** : commentaire analytique (max 2 lignes) en tête du rapport pour signaler un pattern important (plusieurs agents stuck, epic bientôt finie, etc.).
-- **Ne pas interroger GitHub** pour des données que les logs per-agent ont déjà (last_event, retries). GitHub n'est sollicité que via `epic_state.sh` pour le status board.
-- **Ne pas dispatcher ni prendre de décision d'orchestration** pendant un `/report` — l'utilisateur décide ensuite.
+- **Données d'entrée = scripts bash** (`render_dashboard.sh`, `epic_state.sh`). Toujours les exécuter, ne pas inventer la donnée.
+- **Rendu = markdown propre + analyse** (cf. « Format du rapport »). Ne pas dump la sortie bash brute.
+- **Ne pas interroger GitHub** pour des données que les logs per-agent ont déjà (last_event, retries). GitHub n'est sollicité que via `epic_state.sh` pour le board ET via le check d'arrêt de loop (mode auto-report).
+- **Ne pas dispatcher ni prendre de décision d'orchestration** pendant un `/report` — l'utilisateur décide ensuite. Exception : en mode auto-report, décider du délai du prochain wakeup ET de l'arrêt du loop.


### PR DESCRIPTION
## Summary

Today, `/implement` (epic mode) spawns `epic_loop.sh` in background and tells the user "suivi via /report manually". Two friction points:

1. The user has to remember to call `/report` periodically, or set up an external cron — neither convenient.
2. They also need adaptive cadence (more frequent when stuff moves, less when stable), not a fixed interval.

This PR makes `/implement` launch a self-terminating dynamic `/loop /report <N>` automatically right after the loop driver spawns.

## Changes

**`.claude/skills/implement/SKILL.md`** — adds step 4 in epic mode:
```
Skill("loop", args="/report <N>")
```
Step 5 (rendre la main) is renumbered. Suivi de progression mentions the auto-loop.

**`.claude/skills/report/SKILL.md`** — two reworks:
- **Format du rapport** is now markdown rendering + analysis (the previous "raw bash output + ≤ 2 lines commentary" rule produced sparse, hard-to-read output for users with markdown-rendering UIs).
- **Mode auto-report** section : when `/report` is invoked from `/loop`, after the dashboard render it checks `gh pr list --base alpha --head epic/<N> --state open` — if a PR exists (i.e. `open_epic_final_pr.sh` ran successfully = epic done), the agent omits `ScheduleWakeup` and the loop self-terminates. Adaptive cadence guidance is documented (60-270s when active, 1200-1800s when stable, never 300s).

## Net effect

`/implement <epic>` now starts a self-monitoring report loop that auto-paces and auto-terminates when the integration PR opens. No user polling required.

## Test plan

- [ ] CI green
- [ ] After merge, run `/implement <epic>` end-to-end ; verify reports auto-fire and loop stops cleanly when final PR is opened