### PR TITLE
fix(pipeline): config consolidée — postgres race + logging discipline + auto-report loop + non-interactive cmds

### DIFF
--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -18,6 +18,12 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
   - **Task ou Bug standalone** (sans parent epic) : `origin/alpha` direct. La PR sera mergée à la main par l'humain après revue.
 - **Working branch** (assigned by `/implement`) — déjà créée sur GitHub par l'orchestrateur via `createLinkedBranch` GraphQL et **officiellement linkée à l'issue** (sidebar Development). Le force-link PR↔issue (étape 8.5) ajoute également la PR à la sidebar dès qu'elle est créée.
 
+## Discipline de logging (BLOCKING)
+
+À chaque transition de phase tu DOIS exécuter `bash scripts/orchestration/log_event.sh code-dev-<N> <EVENT> [msg]` **avant** de poursuivre la phase suivante. Sans ces events, le dashboard `/report` ne peut pas suivre ta progression et l'utilisateur croit que tu es stuck (il a déjà signalé le problème — c'est exactement pour éviter ça).
+
+Le logging n'est pas optionnel ni "à faire à la fin" : c'est une étape de la phase, au même titre qu'un `git push` ou un `gh pr create`. Si une phase a démarré et son event n'a pas été loggé, **arrête tout, logge, puis reprends**. Liste exhaustive en bas du document (« Logging events »).
+
 ## Workflow
 
 0. **Logger START** — `bash scripts/orchestration/log_event.sh code-dev-<N> START "worktree=<path> base=<base-branch>"`. Voir la section « Logging events » plus bas pour la liste complète.

--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -18,6 +18,24 @@ You execute one pre-specified ticket end-to-end : edit code, write/update tests,
   - **Task ou Bug standalone** (sans parent epic) : `origin/alpha` direct. La PR sera mergée à la main par l'humain après revue.
 - **Working branch** (assigned by `/implement`) — déjà créée sur GitHub par l'orchestrateur via `createLinkedBranch` GraphQL et **officiellement linkée à l'issue** (sidebar Development). Le force-link PR↔issue (étape 8.5) ajoute également la PR à la sidebar dès qu'elle est créée.
 
+## Discipline non-interactive (BLOCKING)
+
+Les commandes susceptibles de prompter (drizzle-kit, gh sans `--yes`, prompts TUI custom) peuvent **hang indéfiniment** si stdin reçoit un TTY au lieu d'EOF. Symptôme observé : `pnpm db:generate` qui hang 1h+ parce que drizzle-kit détecte un schema diff ambigu et attend une réponse interactive.
+
+**Hard rules** :
+
+1. **Toute commande potentiellement interactive doit avoir stdin redirigé depuis `/dev/null`** :
+   ```bash
+   pnpm db:generate < /dev/null      # ✅
+   pnpm db:generate                   # ❌ peut hang si TTY visible
+   ```
+
+2. **Ne JAMAIS wrapper une commande dans `script -q -c '...'`** pour capturer son output. `script` crée un pseudo-TTY → la commande croit être en mode interactif et peut prompter. Préférer `2>&1 | tee /tmp/log` ou `2>&1 | head -50` directement.
+
+3. **Pour les commandes qui prennent > 30s** (db:migrate, pnpm install, build), wrapper avec `timeout` : `timeout 180 pnpm db:migrate < /dev/null`. Si timeout atteint → escalader (commenter le ticket, retourner verdict approprié).
+
+4. La règle **stdin redirect** s'applique aussi aux scripts pipeline qu'on appelle (ex: `bash scripts/orchestration/foo.sh < /dev/null` quand on n'est pas certain qu'ils ne prompteront pas).
+
 ## Discipline de logging (BLOCKING)
 
 À chaque transition de phase tu DOIS exécuter `bash scripts/orchestration/log_event.sh code-dev-<N> <EVENT> [msg]` **avant** de poursuivre la phase suivante. Sans ces events, le dashboard `/report` ne peut pas suivre ta progression et l'utilisateur croit que tu es stuck (il a déjà signalé le problème — c'est exactement pour éviter ça).

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -103,10 +103,25 @@ Workflow identique à l'ex-`/epic` :
    nohup bash scripts/orchestration/epic_loop.sh $EPICS > "$LOG_FILE" 2>&1 &
    PID=$!
    disown
-   echo "epic_loop lancé en background (PID $PID, log: $LOG_FILE). Suivi via /report."
+   echo "epic_loop lancé en background (PID $PID, log: $LOG_FILE)."
    ```
 
-4. Rendre la main immédiatement (pas de polling — utiliser `/report`).
+4. **Lancer l'auto-report dynamique** — invoquer le skill `/loop` avec args `/report <N>` (mode dynamic-pacing, pas d'intervalle fixe).
+   ```
+   Skill("loop", args="/report <N>")
+   ```
+   Le `/loop` va run `/report <N>` immédiatement, puis re-schedule un wakeup avec délai adaptatif (60-3600s) basé sur ce que `/report` observe. À chaque wakeup, après le rendu du dashboard, **vérifier la condition d'arrêt** : la PR finale `epic/<N> → alpha` est-elle ouverte ?
+   ```bash
+   gh pr list --repo SocialGouv/egapro --base alpha --head "epic/<N>" --state open --json number --jq 'length'
+   ```
+   Si > 0 → omettre `ScheduleWakeup` → loop s'arrête. Sinon → re-schedule.
+
+   Cadence recommandée :
+   - **Activité récente côté logs** (phase qui bouge, agent qui spawn) → 60-270s (cache prompt warm)
+   - **État stable** (agent silent, rien à observer) → 1200-1800s (un seul cache miss)
+   - **Sortie 5 min** → toujours mauvais choix (300s = cache miss sans amortissement)
+
+5. Rendre la main immédiatement (le /loop continue en arrière-plan, t'auto-rapporte jusqu'à fin de l'epic).
 
 > **Note** : le main worktree reste sur `epic/<N>` pendant toute la durée du loop (ticks + final PR). Pour faire du travail sur `alpha` en parallèle (hotfix, autre branche), monter un worktree dédié (`git worktree add /tmp/egapro-alpha alpha`). À la fin de l'epic — quand la PR finale est mergée sur alpha — basculer manuellement le main worktree avec `git checkout alpha && git pull`.
 
@@ -153,8 +168,8 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
 
 ## Suivi de la progression (mode epic)
 
-- `/report` — dashboard live agents actifs + état du board
-- `/report <N>` — état détaillé des sous-tickets de l'epic
+- **Auto-report `/loop /report <N>`** lancé automatiquement à l'étape 4 — délivre des dashboards adaptatifs jusqu'à la fin de l'epic, puis s'auto-arrête (cf. condition d'arrêt en step 4)
+- `/report <N>` — déclencher manuellement à tout moment pour un check on-demand (n'interfère pas avec le loop dynamique)
 - `tail -f /tmp/epic_loop_<EPICS_KEY>.log`
 - `ls .claude/state/epic_run/ticks/<EPICS_KEY>/` — JSON des ticks (plan + result + agent returns)
 

--- a/.claude/skills/report/SKILL.md
+++ b/.claude/skills/report/SKILL.md
@@ -42,10 +42,27 @@ bash scripts/orchestration/epic_state.sh <N1> [<N2> ...]
 Le dashboard est déjà formaté par les scripts. Tu n'as qu'à :
 
 1. Exécuter les commandes bash ci-dessus
-2. **Copier-coller la sortie telle quelle** à l'utilisateur
-3. Ajouter **au maximum 2 lignes de commentaire** en tête si tu remarques quelque chose d'important (ex: « Attention, 2 agents inactifs > 20 min — probablement stuck »)
+2. **Re-rendre les tableaux en markdown propre** (colonnes alignées, headers `|` syntax). L'UI utilisateur rend mal les tableaux bash bruts (── boxes, alignement à espaces multiples).
+3. **Joindre une analyse** : interprétation de l'état actuel, qui bouge, qui est bloqué, prochaine étape attendue.
 
-**Ne PAS reformater** la sortie du script. Le format texte-table est voulu pour la lisibilité terminal.
+> Note : la version « copier-coller la sortie telle quelle » a été remplacée par cette mouture markdown + analyse. Les scripts bash restent la source de vérité — la donnée vient toujours d'eux, ne pas inventer.
+
+## Mode auto-report (lancé depuis /loop, e.g. par /implement)
+
+Quand `/report` est invoqué via `/loop` (mode dynamic-pacing), il devient l'élément central d'un suivi automatique pendant la durée d'un `/implement` epic. À chaque iteration :
+
+1. Run `/report <N>` (rendu markdown + analyse comme ci-dessus)
+2. **Vérifier la condition d'arrêt** : la PR finale `epic/<N> → alpha` est-elle ouverte ?
+   ```bash
+   gh pr list --repo SocialGouv/egapro --base alpha --head "epic/<N>" --state open --json number --jq 'length'
+   ```
+   - Retourne `> 0` → l'epic est terminé (loop driver a appelé `open_epic_final_pr.sh`). **Omettre `ScheduleWakeup`** → loop s'arrête. Annoncer à l'utilisateur.
+   - Retourne `0` → re-schedule un wakeup avec délai adaptatif (cf. ci-dessous).
+3. **Picking du délai adaptatif** :
+   - **Activité récente** (logs avec event dans les 5 min, agent qui spawn/transition de phase) → 60-270s (cache prompt warm)
+   - **État stable** (agent log-silent, rien d'actionable) → 1200-1800s (un seul cache miss couvre une longue fenêtre)
+   - **300s = NEVER** : worst-of-both case (cache miss sans amortissement)
+4. La cadence DOIT s'adapter à ce que tu OBSERVES, pas à un timer fixe. Lis le delta de coût (`*` indicateur live), l'âge du dernier event, l'état de la PR — décide en fonction.
 
 ## Ajustement des seuils
 
@@ -74,7 +91,7 @@ Dans ce cas le script affiche `(Aucun epic en cours)`. Si `<N>` est fourni en ar
 
 ## Règles
 
-- **Zéro LLM processing** quand les scripts suffisent. Si l'utilisateur demande un rapport standard, c'est juste `bash` + affichage.
-- **Interventions LLM autorisées** : commentaire analytique (max 2 lignes) en tête du rapport pour signaler un pattern important (plusieurs agents stuck, epic bientôt finie, etc.).
-- **Ne pas interroger GitHub** pour des données que les logs per-agent ont déjà (last_event, retries). GitHub n'est sollicité que via `epic_state.sh` pour le status board.
-- **Ne pas dispatcher ni prendre de décision d'orchestration** pendant un `/report` — l'utilisateur décide ensuite.
+- **Données d'entrée = scripts bash** (`render_dashboard.sh`, `epic_state.sh`). Toujours les exécuter, ne pas inventer la donnée.
+- **Rendu = markdown propre + analyse** (cf. « Format du rapport »). Ne pas dump la sortie bash brute.
+- **Ne pas interroger GitHub** pour des données que les logs per-agent ont déjà (last_event, retries). GitHub n'est sollicité que via `epic_state.sh` pour le board ET via le check d'arrêt de loop (mode auto-report).
+- **Ne pas dispatcher ni prendre de décision d'orchestration** pendant un `/report` — l'utilisateur décide ensuite. Exception : en mode auto-report, décider du délai du prochain wakeup ET de l'arrêt du loop.

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -193,6 +193,17 @@ Puis implémenter, push tes commits sur ${BRANCH}, créer la PR draft (\`gh pr c
 **Ne crée PAS une autre branche** (pas de \`checkout -b\`). La branche ${BRANCH} est déjà créée et linkée — utilise-la telle quelle.
 
 REGLES STRICTES (appliquer sans exception) :
+- **DISCIPLINE DE LOGGING (BLOCKING)** — à chaque transition de phase tu DOIS
+  exécuter \`bash scripts/orchestration/log_event.sh code-dev-${TICKET} <EVENT> [msg]\`
+  AVANT de commencer la phase suivante. Sans ces events, le dashboard /report
+  ne peut pas suivre ta progression et l'utilisateur croit que tu es stuck.
+  Events obligatoires dans l'ordre : START → ANALYSIS_START → ANALYSIS_OK
+  → DEV_START → DEV_OK → VALIDATION_START → VALIDATION_OK → PR_DRAFT
+  → FUNCTIONAL_START → FUNCTIONAL_OK → CI_WAIT → CI_OK → SONAR_WAIT → SONAR_OK
+  → BOT_WAIT → BOT_REPLIED → PR_READY → COMPLETE. (RETRY/CI_FAIL/SONAR_FAIL
+  à intercaler en cas d'itération, voir AGENT.md « Logging events ».)
+  Logger AVANT de poursuivre n'est pas optionnel — c'est une étape de la phase,
+  au même titre que git push ou gh pr create.
 - **N'invoque AUCUN skill built-in** (fewer-permission-prompts, update-config,
   claude-api, schedule, loop, etc.). Si une de ces skills semble utile, ignore-la
   et reste concentré sur le ticket.

--- a/scripts/orchestration/rebase_epic_branch.sh
+++ b/scripts/orchestration/rebase_epic_branch.sh
@@ -56,8 +56,12 @@ EXISTING_WT=$(git -C "$REPO_ROOT" worktree list --porcelain 2>/dev/null \
     ')
 
 if [ -n "$EXISTING_WT" ]; then
-    if [ -n "$(git -C "$EXISTING_WT" status --porcelain)" ]; then
-        echo "[rebase_epic_branch] ERROR: worktree at $EXISTING_WT is on $BRANCH but dirty — refuse to rebase (would lose uncommitted edits)" >&2
+    # `-uno` (or --untracked-files=no) : we tolerate untracked files in the
+    # main worktree (e.g. `scripts/package.json` artifacts created by tooling
+    # outside of git's tracking) — they don't risk being lost by the rebase.
+    # Only reject if there are real tracked-but-uncommitted edits.
+    if [ -n "$(git -C "$EXISTING_WT" status --porcelain -uno)" ]; then
+        echo "[rebase_epic_branch] ERROR: worktree at $EXISTING_WT is on $BRANCH but has tracked-uncommitted edits — refuse to rebase (would lose them)" >&2
         exit 1
     fi
     WT="$EXISTING_WT"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -104,9 +104,14 @@ echo "[setup-worktree] Starting services: $SERVICES"
 docker compose --env-file "$ENV_FILE" up -d $SERVICES
 
 # Wait for Postgres health.
+# We check both internal (via docker exec) AND host-port reachability — on cold
+# start, pg_isready inside the container can return ready before Docker has
+# fully wired up the host port forwarding, causing drizzle-kit to fail with a
+# silent ECONNREFUSED hidden by its progress spinner.
 echo "[setup-worktree] Waiting for Postgres (port $POSTGRES_HOST_PORT)..."
 for _ in $(seq 1 60); do
-  if docker compose --env-file "$ENV_FILE" exec -T db pg_isready -U postgres >/dev/null 2>&1; then
+  if docker compose --env-file "$ENV_FILE" exec -T db pg_isready -U postgres >/dev/null 2>&1 \
+     && PGPASSWORD=postgres psql -h localhost -p "$POSTGRES_HOST_PORT" -U postgres -d egapro -c 'SELECT 1' >/dev/null 2>&1; then
     echo "[setup-worktree] Postgres ready."
     break
   fi
@@ -124,8 +129,23 @@ fi
 # Run Drizzle migrations against this worktree's DB.
 # drizzle-kit reads process.env directly and does not load .env.local
 # (unlike Next.js), so source the file into the subshell before running.
+# Retry up to 3 times: drizzle-kit's progress spinner hides errors, and
+# transient connect failures can occur on cold-start before Postgres is fully
+# accepting host-port queries even though pg_isready returned ready.
 echo "[setup-worktree] Applying migrations..."
-(cd packages/app && set -a && . ./.env.local && set +a && pnpm db:migrate)
+MIGRATE_OK=0
+for ATTEMPT in 1 2 3; do
+  if (cd packages/app && set -a && . ./.env.local && set +a && pnpm db:migrate); then
+    MIGRATE_OK=1
+    break
+  fi
+  echo "[setup-worktree] Migration attempt $ATTEMPT failed, retrying in 3s..." >&2
+  sleep 3
+done
+if [ "$MIGRATE_OK" -ne 1 ]; then
+  echo "[setup-worktree] Migrations failed after 3 attempts." >&2
+  exit 1
+fi
 
 echo ""
 echo "[setup-worktree] Done. Worktree $N ready."


### PR DESCRIPTION
## Summary

Consolidation des 4 fixes pipeline découverts pendant l'exécution de l'epic #3133 (Gestion du statut « annulé »). Remplace les PRs individuelles #3419, #3421, #3422 (à fermer après merge).

## Commits

| SHA | Sujet |
|---|---|
| `cda051da` | wait for Postgres host port + retry drizzle migration |
| `2e2a3732` | force code-dev to log phase events as a blocking discipline |
| `905cc3af` | /implement auto-launches /report dynamic loop |
| `60c84f34` | require stdin redirect for interactive commands (drizzle-kit hang) |

## Détails par commit

### 1. Postgres host-port race (`cda051da`)

`pg_isready` interne au container peut retourner ready avant que Docker ait fini de wirer le port forwarding hôte → drizzle-kit fail silencieusement (ECONNREFUSED caché par son spinner) lors de la migration. Symptôme : `STACK_FAIL` au premier dispatch d'un epic, alors que retry manuel sur stack tiède passe. **Fix** : `setup-worktree.sh` probe désormais `localhost:$PORT` via `psql 'SELECT 1'` en plus de `pg_isready`, ET la migration retry 3 fois avec backoff 3s.

### 2. Logging discipline (`2e2a3732`)

Le code-dev implémente correctement les tickets mais ne loggue pas les phases entre `STACK_READY` et le verdict final → dashboard `/report` reste sur l'état initial 1h+ alors que l'agent progresse silencieusement (commits, PR, validators). **Fix** : règle BLOCKING dans le dispatch prompt + nouvelle section « Discipline de logging » en tête de `code-dev/AGENT.md`.

### 3. Auto-report dynamique (`905cc3af`)

`/implement` lançait juste `epic_loop.sh` en background et invitait à utiliser `/report` manuellement. Friction. **Fix** : `/implement` lance désormais `Skill(\"loop\", args=\"/report <N>\")` en mode dynamic-pacing après le spawn du loop driver. À chaque wake, `/report` check la PR finale `epic/<N> → alpha` ; si elle existe → omet `ScheduleWakeup` → loop self-terminate. Cadence adaptative documentée (60-270s active, 1200-1800s stable, jamais 300s). En complément : `/report` SKILL.md gagne une section markdown rendering + analyse (la version « copier-coller bash brut » était trop sparse pour l'UI utilisateur).

### 4. Non-interactive discipline (`60c84f34`) — **nouveau**

Deadlock observé pendant T1 du même epic : agent a lancé `pnpm db:generate` wrappé dans `script -q -c '...'` pour capturer l'output. `script` crée un pseudo-TTY → drizzle-kit prompte sur un schema diff ambigu → personne ne peut répondre → hang 1h25m → claude tient le sub-process → orchestrateur bloqué sur l'exit du claude → epic gèle. **Fix** : section « Discipline non-interactive (BLOCKING) » en tête de `code-dev/AGENT.md` avec 3 règles dures (stdin < /dev/null pour les commandes potentiellement interactives, jamais de `script -q -c '...'`, timeout-wrap > 30s).

## Test plan

- [ ] CI green
- [ ] Après merge, `/implement <epic>` doit :
  - démarrer sans STACK_FAIL au premier ticket (1)
  - voir des events de phase (DEV_OK, VALIDATION_OK, PR_DRAFT, etc.) dans le log de code-dev (2)
  - lancer un loop /report auto-paçant qui s'arrête à l'ouverture de la PR finale (3)
  - ne plus hang sur drizzle-kit / commandes interactives (4)