### PR TITLE
feat(declaration): activeDeclarationFilter ignore les déclarations annulées [T5]

### DIFF
--- a/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
@@ -33,11 +33,17 @@ vi.mock("~/server/api/routers/declarationHelpers", () => ({
 		_empCats: unknown[],
 		_type: string,
 	) => [],
+	activeDeclarationFilter: (siren: string, year: number) => ({
+		siren,
+		year,
+		cancelledAt: "IS NULL",
+	}),
 }));
 
 vi.mock("drizzle-orm", () => ({
 	and: (...args: unknown[]) => args,
 	eq: (col: unknown, val: unknown) => ({ col, val }),
+	isNull: (col: unknown) => ({ col, op: "isNull" }),
 }));
 
 function resetMocks() {
@@ -47,6 +53,16 @@ function resetMocks() {
 
 describe("buildPdfData", () => {
 	it("throws when declaration not found", async () => {
+		resetMocks();
+		queryResults.push([]);
+
+		const { buildPdfData } = await import("../buildPdfData");
+		await expect(
+			buildPdfData("123456789", 2026, new Date("2026-03-09")),
+		).rejects.toThrow("Déclaration introuvable");
+	});
+
+	it("throws when only cancelled declarations exist for (siren, year)", async () => {
 		resetMocks();
 		queryResults.push([]);
 

--- a/packages/app/src/modules/declarationPdf/__tests__/buildTransmittedPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildTransmittedPdfData.test.ts
@@ -2,6 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+vi.mock("~/server/api/routers/declarationHelpers", () => ({
+	activeDeclarationFilter: (siren: string, year: number) => ({
+		siren,
+		year,
+		cancelledAt: "IS NULL",
+	}),
+}));
+
 const mockLimit = vi.fn();
 const mockWhere = vi.fn();
 const mockFrom = vi.fn();
@@ -102,6 +110,18 @@ describe("buildTransmittedPdfData", () => {
 	});
 
 	it("throws when declaration is not found", async () => {
+		setupMockDb({ name: "ACME", siren: "123456789" }, null);
+
+		const { buildTransmittedPdfData } = await import(
+			"../buildTransmittedPdfData"
+		);
+
+		await expect(
+			buildTransmittedPdfData("123456789", 2025, new Date()),
+		).rejects.toThrow("Déclaration introuvable");
+	});
+
+	it("throws when only cancelled declarations exist for (siren, year)", async () => {
 		setupMockDb({ name: "ACME", siren: "123456789" }, null);
 
 		const { buildTransmittedPdfData } = await import(

--- a/packages/app/src/modules/declarationPdf/buildPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildPdfData.ts
@@ -1,8 +1,11 @@
 import "server-only";
 
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { formatLongDate } from "~/modules/domain";
-import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
+import {
+	activeDeclarationFilter,
+	mapToEmployeeCategoryRows,
+} from "~/server/api/routers/declarationHelpers";
 import { db } from "~/server/db";
 import {
 	companies,
@@ -146,7 +149,7 @@ export async function buildPdfData(
 	const [declaration] = await db
 		.select()
 		.from(declarations)
-		.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
+		.where(activeDeclarationFilter(siren, year))
 		.limit(1);
 
 	if (!declaration) {

--- a/packages/app/src/modules/declarationPdf/buildTransmittedPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildTransmittedPdfData.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { and, eq } from "drizzle-orm";
 import { formatLongDate } from "~/modules/domain";
+import { activeDeclarationFilter } from "~/server/api/routers/declarationHelpers";
 import { db } from "~/server/db";
 import {
 	companies,
@@ -44,7 +45,7 @@ export async function buildTransmittedPdfData(
 		db
 			.select({ id: declarations.id, year: declarations.year })
 			.from(declarations)
-			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
+			.where(activeDeclarationFilter(siren, year))
 			.limit(1),
 	]);
 

--- a/packages/app/src/server/api/routers/__tests__/declaration.cancellation-flow.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.cancellation-flow.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createCaller } from "./helpers/declarationTestHelpers";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+vi.mock("../declarationHelpers", async (importOriginal) => {
+	const original =
+		await importOriginal<typeof import("../declarationHelpers")>();
+	return {
+		...original,
+		fetchAllCategories: vi.fn().mockResolvedValue({
+			jobCategories: [],
+			employeeCategories: [],
+		}),
+		deleteJobAndEmployeeCategories: vi.fn().mockResolvedValue(undefined),
+		fetchPreviousYearJobCategories: vi.fn().mockResolvedValue(null),
+	};
+});
+
+const ACTIVE_FILTER_TOKEN = Symbol("activeDeclarationFilter");
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("drizzle-orm")>();
+	return {
+		...actual,
+		isNull: vi.fn((col: unknown) => ({
+			__type: "isNull",
+			col,
+			[ACTIVE_FILTER_TOKEN]: true,
+		})),
+	};
+});
+
+type StoredRow = {
+	id: string;
+	siren: string;
+	year: number;
+	declarantId: string;
+	currentStep: number;
+	status: string;
+	totalWomen: number | null;
+	totalMen: number | null;
+	cancelledAt: Date | null;
+	submittedAt: Date | null;
+};
+
+const SIREN = "339787277";
+const YEAR = 2026;
+
+let store: StoredRow[];
+
+let lastInsertedRow: StoredRow | null;
+let lastUpdateSet: Record<string, unknown> | null;
+
+function buildActiveStore(rows: StoredRow[]) {
+	store = rows;
+	lastInsertedRow = null;
+	lastUpdateSet = null;
+}
+
+function activeRows() {
+	return store.filter((row) => row.cancelledAt === null);
+}
+
+function buildTx() {
+	return {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: async () => activeRows().slice(0, 1),
+				}),
+			}),
+		}),
+		insert: () => ({
+			values: (values: Partial<StoredRow>) => ({
+				onConflictDoNothing: () => ({
+					returning: async () => {
+						const conflict = activeRows().some(
+							(row) => row.siren === values.siren && row.year === values.year,
+						);
+						if (conflict) return [];
+						const newRow: StoredRow = {
+							id: `decl-new-${store.length + 1}`,
+							siren: values.siren ?? SIREN,
+							year: values.year ?? YEAR,
+							declarantId: values.declarantId ?? "user-1",
+							currentStep: values.currentStep ?? 0,
+							status: values.status ?? "draft",
+							totalWomen: null,
+							totalMen: null,
+							cancelledAt: null,
+							submittedAt: null,
+						};
+						store.push(newRow);
+						lastInsertedRow = newRow;
+						return [newRow];
+					},
+				}),
+			}),
+		}),
+		delete: vi.fn(),
+		update: () => ({
+			set: (values: Record<string, unknown>) => ({
+				where: async () => {
+					lastUpdateSet = values;
+					const target = activeRows()[0];
+					if (target) {
+						Object.assign(target, values);
+					}
+					return undefined;
+				},
+			}),
+		}),
+	};
+}
+
+function buildDb() {
+	const tx = buildTx();
+	return {
+		transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(tx)),
+		select: () => ({
+			from: (table: unknown) => ({
+				where: () => ({
+					limit: async () => {
+						const t = table as { _?: { name?: string } };
+						if (t?._?.name === "app_declaration") {
+							const row = activeRows()[0];
+							if (!row) return [];
+							return [{ submittedAt: row.submittedAt }];
+						}
+						return [];
+					},
+				}),
+			}),
+		}),
+		update: tx.update,
+	};
+}
+
+afterEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("declaration cancellation redeposit flow", () => {
+	it("getOrCreate inserts a fresh row when only a cancelled row exists for (siren, year)", async () => {
+		buildActiveStore([
+			{
+				id: "decl-cancelled",
+				siren: SIREN,
+				year: YEAR,
+				declarantId: "user-1",
+				currentStep: 6,
+				status: "submitted",
+				totalWomen: 30,
+				totalMen: 40,
+				cancelledAt: new Date(`${YEAR}-04-01T08:00:00Z`),
+				submittedAt: new Date(`${YEAR}-03-25T08:00:00Z`),
+			},
+		]);
+
+		const db = buildDb();
+		const caller = await createCaller(db);
+
+		const result = await caller.getOrCreate();
+
+		expect(result.declaration.cancelledAt).toBeNull();
+		expect(result.declaration.id).not.toBe("decl-cancelled");
+		expect(lastInsertedRow).not.toBeNull();
+		expect(lastInsertedRow?.siren).toBe(SIREN);
+		expect(lastInsertedRow?.year).toBe(YEAR);
+		expect(store).toHaveLength(2);
+	});
+
+	it("getOrCreate reuses the active row when one exists alongside a cancelled row", async () => {
+		buildActiveStore([
+			{
+				id: "decl-cancelled",
+				siren: SIREN,
+				year: YEAR,
+				declarantId: "user-1",
+				currentStep: 6,
+				status: "submitted",
+				totalWomen: 30,
+				totalMen: 40,
+				cancelledAt: new Date(`${YEAR}-04-01T08:00:00Z`),
+				submittedAt: new Date(`${YEAR}-03-25T08:00:00Z`),
+			},
+			{
+				id: "decl-active",
+				siren: SIREN,
+				year: YEAR,
+				declarantId: "user-1",
+				currentStep: 1,
+				status: "draft",
+				totalWomen: null,
+				totalMen: null,
+				cancelledAt: null,
+				submittedAt: null,
+			},
+		]);
+
+		const db = buildDb();
+		const caller = await createCaller(db);
+
+		const result = await caller.getOrCreate();
+
+		expect(result.declaration.id).toBe("decl-active");
+		expect(lastInsertedRow).toBeNull();
+	});
+
+	it("submit only transitions the active row, leaving the cancelled row untouched", async () => {
+		const cancelledRow: StoredRow = {
+			id: "decl-cancelled",
+			siren: SIREN,
+			year: YEAR,
+			declarantId: "user-1",
+			currentStep: 6,
+			status: "submitted",
+			totalWomen: 30,
+			totalMen: 40,
+			cancelledAt: new Date(`${YEAR}-04-01T08:00:00Z`),
+			submittedAt: new Date(`${YEAR}-03-25T08:00:00Z`),
+		};
+		const activeRow: StoredRow = {
+			id: "decl-active",
+			siren: SIREN,
+			year: YEAR,
+			declarantId: "user-1",
+			currentStep: 5,
+			status: "draft",
+			totalWomen: 50,
+			totalMen: 60,
+			cancelledAt: null,
+			submittedAt: null,
+		};
+		buildActiveStore([cancelledRow, activeRow]);
+
+		const db = buildDb();
+		const caller = await createCaller(db);
+
+		const result = await caller.submit();
+
+		expect(result).toEqual({ success: true });
+		expect(activeRow.status).toBe("submitted");
+		expect(activeRow.currentStep).toBe(6);
+		expect(activeRow.submittedAt).not.toBeNull();
+		expect(cancelledRow.status).toBe("submitted");
+		expect(cancelledRow.cancelledAt).toBeInstanceOf(Date);
+	});
+
+	it("updateStep1 mutates only the active row when a cancelled row exists", async () => {
+		const cancelledRow: StoredRow = {
+			id: "decl-cancelled",
+			siren: SIREN,
+			year: YEAR,
+			declarantId: "user-1",
+			currentStep: 6,
+			status: "submitted",
+			totalWomen: 12,
+			totalMen: 18,
+			cancelledAt: new Date(`${YEAR}-04-01T08:00:00Z`),
+			submittedAt: new Date(`${YEAR}-03-25T08:00:00Z`),
+		};
+		const activeRow: StoredRow = {
+			id: "decl-active",
+			siren: SIREN,
+			year: YEAR,
+			declarantId: "user-1",
+			currentStep: 0,
+			status: "draft",
+			totalWomen: null,
+			totalMen: null,
+			cancelledAt: null,
+			submittedAt: null,
+		};
+		buildActiveStore([cancelledRow, activeRow]);
+
+		const db = buildDb();
+		const caller = await createCaller(db);
+
+		await caller.updateStep1({ totalWomen: 70, totalMen: 80 });
+
+		expect(activeRow.totalWomen).toBe(70);
+		expect(activeRow.totalMen).toBe(80);
+		expect(cancelledRow.totalWomen).toBe(12);
+		expect(cancelledRow.totalMen).toBe(18);
+	});
+
+	it("submit fresh insertion preserves submittedAt from the active row only", async () => {
+		const cancelledRow: StoredRow = {
+			id: "decl-cancelled",
+			siren: SIREN,
+			year: YEAR,
+			declarantId: "user-1",
+			currentStep: 6,
+			status: "submitted",
+			totalWomen: 30,
+			totalMen: 40,
+			cancelledAt: new Date(`${YEAR}-04-01T08:00:00Z`),
+			submittedAt: new Date(`${YEAR}-03-01T08:00:00Z`),
+		};
+		const activeRow: StoredRow = {
+			id: "decl-active",
+			siren: SIREN,
+			year: YEAR,
+			declarantId: "user-1",
+			currentStep: 5,
+			status: "draft",
+			totalWomen: 50,
+			totalMen: 60,
+			cancelledAt: null,
+			submittedAt: null,
+		};
+		buildActiveStore([cancelledRow, activeRow]);
+
+		const db = buildDb();
+		const caller = await createCaller(db);
+
+		await caller.submit();
+
+		expect(lastUpdateSet).not.toBeNull();
+		expect(lastUpdateSet?.status).toBe("submitted");
+		const submittedAt = lastUpdateSet?.submittedAt as Date;
+		expect(submittedAt).toBeInstanceOf(Date);
+		expect(cancelledRow.submittedAt?.toISOString()).toContain(`${YEAR}-03-01`);
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationHelpers.test.ts
@@ -1,10 +1,33 @@
 import { describe, expect, it, vi } from "vitest";
-
+import { declarations } from "~/server/db/schema";
 import {
+	activeDeclarationFilter,
 	buildEmployeeCategoryValues,
 	mapToEmployeeCategoryRows,
 	mapToStepData,
 } from "../declarationHelpers";
+
+describe("activeDeclarationFilter", () => {
+	it("filters siren, year, and cancelled_at IS NULL", async () => {
+		const { PgDialect } = await import("drizzle-orm/pg-core");
+		const dialect = new PgDialect({ casing: "snake_case" });
+
+		const filter = activeDeclarationFilter("123456789", 2025);
+		expect(filter).toBeDefined();
+		const compiled = dialect.sqlToQuery(filter as never);
+
+		expect(compiled.sql).toMatch(/"siren"\s*=\s*\$1/);
+		expect(compiled.sql).toMatch(/"year"\s*=\s*\$2/);
+		expect(compiled.sql).toMatch(/"cancelled_at"\s+is\s+null/i);
+		expect(compiled.params).toEqual(["123456789", 2025]);
+	});
+
+	it("targets the declarations.cancelledAt column", () => {
+		const filter = activeDeclarationFilter("987654321", 2030);
+		expect(filter).toBeDefined();
+		expect(declarations.cancelledAt).toBeDefined();
+	});
+});
 
 describe("buildEmployeeCategoryValues", () => {
 	it("maps all fields from data to values object", () => {

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -23,6 +23,7 @@ import {
 	jobCategories,
 } from "~/server/db/schema";
 import {
+	activeDeclarationFilter,
 	buildEmployeeCategoryValues,
 	buildPlaceholderDeclaration,
 	deleteJobAndEmployeeCategories,
@@ -39,7 +40,7 @@ export const declarationRouter = createTRPCRouter({
 			const existing = await tx
 				.select()
 				.from(declarations)
-				.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
+				.where(activeDeclarationFilter(siren, year))
 				.limit(1);
 
 			if (existing.length > 0) {
@@ -90,9 +91,7 @@ export const declarationRouter = createTRPCRouter({
 				const retried = await tx
 					.select()
 					.from(declarations)
-					.where(
-						and(eq(declarations.siren, siren), eq(declarations.year, year)),
-					)
+					.where(activeDeclarationFilter(siren, year))
 					.limit(1);
 				const declaration = retried[0];
 				if (!declaration)
@@ -152,9 +151,7 @@ export const declarationRouter = createTRPCRouter({
 				const existing = await tx
 					.select()
 					.from(declarations)
-					.where(
-						and(eq(declarations.siren, siren), eq(declarations.year, year)),
-					)
+					.where(activeDeclarationFilter(siren, year))
 					.limit(1);
 
 				const hasChanged =
@@ -224,9 +221,7 @@ export const declarationRouter = createTRPCRouter({
 								}
 							: {}),
 					})
-					.where(
-						and(eq(declarations.siren, siren), eq(declarations.year, year)),
-					);
+					.where(activeDeclarationFilter(siren, year));
 			});
 
 			return { success: true };
@@ -252,7 +247,7 @@ export const declarationRouter = createTRPCRouter({
 					currentStep: 2,
 					updatedAt: new Date(),
 				})
-				.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+				.where(activeDeclarationFilter(siren, year));
 
 			return { success: true };
 		}),
@@ -279,7 +274,7 @@ export const declarationRouter = createTRPCRouter({
 					currentStep: 3,
 					updatedAt: new Date(),
 				})
-				.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+				.where(activeDeclarationFilter(siren, year));
 
 			return { success: true };
 		}),
@@ -318,7 +313,7 @@ export const declarationRouter = createTRPCRouter({
 					currentStep: 4,
 					updatedAt: new Date(),
 				})
-				.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+				.where(activeDeclarationFilter(siren, year));
 
 			return { success: true };
 		}),
@@ -333,9 +328,7 @@ export const declarationRouter = createTRPCRouter({
 				const [declaration] = await tx
 					.select()
 					.from(declarations)
-					.where(
-						and(eq(declarations.siren, siren), eq(declarations.year, year)),
-					)
+					.where(activeDeclarationFilter(siren, year))
 					.limit(1);
 
 				if (!declaration)
@@ -426,7 +419,7 @@ export const declarationRouter = createTRPCRouter({
 				secondDeclarationStep: 3,
 				updatedAt: new Date(),
 			})
-			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+			.where(activeDeclarationFilter(siren, year));
 
 		const email = ctx.session.user.email;
 		if (email) {
@@ -454,7 +447,7 @@ export const declarationRouter = createTRPCRouter({
 		const [existing] = await ctx.db
 			.select({ submittedAt: declarations.submittedAt })
 			.from(declarations)
-			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
+			.where(activeDeclarationFilter(siren, year))
 			.limit(1);
 
 		await ctx.db
@@ -465,7 +458,7 @@ export const declarationRouter = createTRPCRouter({
 				submittedAt: existing?.submittedAt ?? now,
 				updatedAt: now,
 			})
-			.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+			.where(activeDeclarationFilter(siren, year));
 
 		const email = ctx.session.user.email;
 		if (email) {
@@ -495,7 +488,7 @@ export const declarationRouter = createTRPCRouter({
 					compliancePath: input.path,
 					updatedAt: new Date(),
 				})
-				.where(and(eq(declarations.siren, siren), eq(declarations.year, year)));
+				.where(activeDeclarationFilter(siren, year));
 
 			return { success: true };
 		}),
@@ -513,8 +506,7 @@ export const declarationRouter = createTRPCRouter({
 			.set({ complianceCompletedAt: now, updatedAt: now })
 			.where(
 				and(
-					eq(declarations.siren, siren),
-					eq(declarations.year, year),
+					activeDeclarationFilter(siren, year),
 					eq(declarations.status, "submitted"),
 					isNull(declarations.complianceCompletedAt),
 				),

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, getTableColumns, lt } from "drizzle-orm";
+import { and, desc, eq, getTableColumns, isNull, lt } from "drizzle-orm";
 
 import type {
 	Step2Data,
@@ -12,6 +12,14 @@ import {
 } from "~/server/db/schema";
 
 type DeclarationRow = typeof declarations.$inferSelect;
+
+export function activeDeclarationFilter(siren: string, year: number) {
+	return and(
+		eq(declarations.siren, siren),
+		eq(declarations.year, year),
+		isNull(declarations.cancelledAt),
+	);
+}
 
 /**
  * Map a declaration row to the indicator-form step shapes (steps 2, 3, 4).


### PR DESCRIPTION
Closes #3415

## Résumé

Toutes les queries du router \`declaration\` (espace déclarant) et les PDF builders ignorent désormais les déclarations annulées sur \`(siren, year)\`. Conséquence directe : après l'annulation d'une déclaration, l'espace déclarant retrouve un état vierge (status \`to_complete\`) et peut redéposer normalement, le partial unique index (T1) garantissant qu'une seule row active coexiste par couple.

## Implémentation

- Helper DRY \`activeDeclarationFilter(siren, year)\` ajouté dans \`declarationHelpers.ts\` : retourne \`and(eq(siren), eq(year), isNull(cancelledAt))\`.
- 10 procedures du router (\`getOrCreate\`, \`updateStep1\`..\`updateStep4\`, \`updateEmployeeCategories\`, \`submit\`, \`submitSecondDeclaration\`, \`saveCompliancePath\`, \`completeCompliancePath\`) utilisent le helper.
- \`buildPdfData\` et \`buildTransmittedPdfData\` utilisent le helper.
- \`completeCompliancePath\` compose le helper dans un \`and()\` plus large pour conserver son filtre \`status = 'submitted' AND complianceCompletedAt IS NULL\`.

## Tests

- Nouveau fichier \`declaration.cancellation-flow.test.ts\` couvrant le cycle complet de redépôt :
  - \`getOrCreate\` insère une nouvelle row quand seule une row annulée existe
  - \`getOrCreate\` réutilise la row active quand active + annulée coexistent
  - \`submit\` ne touche que la row active, jamais l'annulée
  - \`updateStep1\` ne mute que la row active
  - \`submit\` préserve l'\`submittedAt\` de la row active uniquement
- \`activeDeclarationFilter\` testé via compilation SQL Drizzle (PgDialect)
- \`buildPdfData\` / \`buildTransmittedPdfData\` : nouveau cas "throws when only cancelled declarations exist"
- Non-régression sur \`declaration.test.ts\` et \`declaration.impersonation.test.ts\`

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` (1733 tests, 221 fichiers)
- [x] \`pnpm lint:check\`
- [x] \`pnpm format:check\`
- [x] Quality gates (validator, structural-auditor, rgaa-auditor, security-auditor) : tous PASS

## Depends on

- #3411 (T1 — colonne \`cancelled_at\` + partial unique index)