### PR TITLE
feat(export): Date_annulation + fenêtre temporelle composite [T7] (#3417)

### DIFF
--- a/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
+++ b/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
@@ -66,6 +66,7 @@ describe("buildExportRows", () => {
 			secondDeclReferencePeriodEnd: null,
 			createdAt: new Date("2027-03-15T10:00:00Z"),
 			updatedAt: new Date("2027-03-15T12:00:00Z"),
+			cancelledAt: null,
 			companyName: "ACME Corp",
 			workforce: 250,
 			nafCode: "62.02",
@@ -163,6 +164,7 @@ describe("buildExportRows", () => {
 			secondDeclReferencePeriodEnd: null,
 			createdAt: new Date("2027-03-15T10:00:00Z"),
 			updatedAt: new Date("2027-03-15T12:00:00Z"),
+			cancelledAt: null,
 			companyName: "BigCo",
 			workforce: 500,
 			nafCode: "70.10",
@@ -242,6 +244,7 @@ describe("buildExportRows", () => {
 			secondDeclReferencePeriodEnd: null,
 			createdAt: new Date("2027-03-15T10:00:00Z"),
 			updatedAt: new Date("2027-03-15T12:00:00Z"),
+			cancelledAt: null,
 			companyName: "ACME Corp",
 			workforce: 250,
 			nafCode: "62.02",
@@ -343,6 +346,7 @@ describe("buildExportRows", () => {
 			secondDeclReferencePeriodEnd: null,
 			createdAt: null,
 			updatedAt: null,
+			cancelledAt: null,
 			companyName: "NullCo",
 			workforce: null,
 			nafCode: null,
@@ -407,4 +411,106 @@ describe("buildExportRows", () => {
 			workforce: null,
 		});
 	});
+
+	it("should serialize cancelledAt as ISO string for cancelled declarations", async () => {
+		const dbRow = makeMinimalDbRow({
+			declarationId: "decl-cancelled",
+			siren: "555555555",
+			cancelledAt: new Date("2027-04-20T08:30:00Z"),
+			companyName: "CancelCo",
+			declarantFirstName: "Anne",
+			declarantLastName: "Lopez",
+			declarantEmail: "anne@cancelco.fr",
+			indicatorAAnnualWomen: "30000",
+			indicatorAAnnualMen: "32000",
+		});
+
+		mockWhere.mockResolvedValue([dbRow]);
+		mockJobWhere.mockResolvedValue([]);
+		mockCseWhere.mockResolvedValue([]);
+
+		const { buildExportRows } = await import("../buildExportRows");
+		const rows = await buildExportRows(mockDb as never, 2027);
+
+		expect(rows[0]).toMatchObject({
+			siren: "555555555",
+			cancelledAt: "2027-04-20T08:30:00.000Z",
+			indAAnnualWomen: "30000",
+			indAAnnualMen: "32000",
+		});
+	});
 });
+
+type DbRow = Record<string, unknown>;
+
+function makeMinimalDbRow(overrides: DbRow): DbRow {
+	return {
+		declarationId: "decl-1",
+		siren: "123456789",
+		year: 2027,
+		status: "submitted",
+		compliancePath: null,
+		totalWomen: null,
+		totalMen: null,
+		remunerationScore: null,
+		variableRemunerationScore: null,
+		quartileScore: null,
+		categoryScore: null,
+		secondDeclarationStatus: null,
+		secondDeclReferencePeriodStart: null,
+		secondDeclReferencePeriodEnd: null,
+		createdAt: new Date("2027-03-15T10:00:00Z"),
+		updatedAt: new Date("2027-03-15T12:00:00Z"),
+		cancelledAt: null,
+		companyName: "ACME",
+		workforce: null,
+		nafCode: null,
+		address: null,
+		hasCse: null,
+		declarantFirstName: null,
+		declarantLastName: null,
+		declarantEmail: "a@b.fr",
+		declarantPhone: null,
+		indicatorAAnnualWomen: null,
+		indicatorAAnnualMen: null,
+		indicatorAHourlyWomen: null,
+		indicatorAHourlyMen: null,
+		indicatorBAnnualWomen: null,
+		indicatorBAnnualMen: null,
+		indicatorBHourlyWomen: null,
+		indicatorBHourlyMen: null,
+		indicatorCAnnualWomen: null,
+		indicatorCAnnualMen: null,
+		indicatorCHourlyWomen: null,
+		indicatorCHourlyMen: null,
+		indicatorDAnnualWomen: null,
+		indicatorDAnnualMen: null,
+		indicatorDHourlyWomen: null,
+		indicatorDHourlyMen: null,
+		indicatorEWomen: null,
+		indicatorEMen: null,
+		indicatorFAnnualThreshold1: null,
+		indicatorFAnnualWomen1: null,
+		indicatorFAnnualMen1: null,
+		indicatorFAnnualThreshold2: null,
+		indicatorFAnnualWomen2: null,
+		indicatorFAnnualMen2: null,
+		indicatorFAnnualThreshold3: null,
+		indicatorFAnnualWomen3: null,
+		indicatorFAnnualMen3: null,
+		indicatorFAnnualWomen4: null,
+		indicatorFAnnualMen4: null,
+		indicatorFHourlyThreshold1: null,
+		indicatorFHourlyWomen1: null,
+		indicatorFHourlyMen1: null,
+		indicatorFHourlyThreshold2: null,
+		indicatorFHourlyWomen2: null,
+		indicatorFHourlyMen2: null,
+		indicatorFHourlyThreshold3: null,
+		indicatorFHourlyWomen3: null,
+		indicatorFHourlyMen3: null,
+		indicatorFHourlyWomen4: null,
+		indicatorFHourlyMen4: null,
+		...overrides,
+	};
+}

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -21,6 +21,7 @@ const baseRow = {
 	secondDeclReferencePeriodEnd: null,
 	createdAt: new Date("2027-03-15T10:00:00Z"),
 	updatedAt: new Date("2027-03-15T12:00:00Z"),
+	cancelledAt: null as Date | null,
 	companyName: "ACME Corp",
 	workforce: 250,
 	nafCode: "62.02",
@@ -429,5 +430,53 @@ describe("assembleDeclaration", () => {
 
 		expect(result.Date_creation).toBeNull();
 		expect(result.Date_modification).toBeNull();
+	});
+
+	it("should expose Date_annulation as null for an active declaration", () => {
+		const result = assembleDeclaration(baseRow, [], []);
+
+		expect(result.Date_annulation).toBeNull();
+	});
+
+	it("should expose Date_annulation as ISO string for a cancelled declaration", () => {
+		const cancelledRow = {
+			...baseRow,
+			cancelledAt: new Date("2027-04-15T08:00:00Z"),
+		};
+		const result = assembleDeclaration(cancelledRow, [], []);
+
+		expect(result.Date_annulation).toBe("2027-04-15T08:00:00.000Z");
+	});
+
+	it("should preserve indicator data on a cancelled declaration", () => {
+		const cancelledRow = {
+			...baseRow,
+			cancelledAt: new Date("2027-04-15T08:00:00Z"),
+		};
+		const indicatorG: IndicatorGEntry[] = [
+			{
+				categoryName: "Cadres",
+				declarationType: "initial",
+				womenCount: 12,
+				menCount: 18,
+				annualBaseWomen: "52000",
+				annualBaseMen: "56000",
+				annualVariableWomen: null,
+				annualVariableMen: null,
+				hourlyBaseWomen: null,
+				hourlyBaseMen: null,
+				hourlyVariableWomen: null,
+				hourlyVariableMen: null,
+			},
+		];
+
+		const result = assembleDeclaration(cancelledRow, indicatorG, []);
+
+		expect(result.Date_annulation).toBe("2027-04-15T08:00:00.000Z");
+		expect(result.Indicateurs.A.Rem_globale_annuelle_moyenne_F).toBe("35000");
+		expect(result.Indicateurs.G).toHaveLength(1);
+		expect(result.Indicateurs.G?.[0]?.Effectif_F).toBe(12);
+		expect(result.SIREN).toBe("123456789");
+		expect(result.Effectif).toBe(250);
 	});
 });

--- a/packages/app/src/modules/export/__tests__/generateXlsx.test.ts
+++ b/packages/app/src/modules/export/__tests__/generateXlsx.test.ts
@@ -18,6 +18,7 @@ function makeRow(overrides: Partial<ExportRow> = {}): ExportRow {
 		compliancePath: null,
 		createdAt: "2027-03-15T10:00:00.000Z",
 		updatedAt: "2027-03-15T10:00:00.000Z",
+		cancelledAt: null,
 		totalWomen: 120,
 		totalMen: 130,
 		remunerationScore: 5,

--- a/packages/app/src/modules/export/__tests__/queries.test.ts
+++ b/packages/app/src/modules/export/__tests__/queries.test.ts
@@ -1,0 +1,101 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockWhere = vi.fn();
+const mockInnerJoin2 = vi.fn(() => ({ where: mockWhere }));
+const mockInnerJoin1 = vi.fn(() => ({ innerJoin: mockInnerJoin2 }));
+const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin1 }));
+const mockSelect = vi.fn<(fields: Record<string, unknown>) => unknown>(() => ({
+	from: mockFrom,
+}));
+
+vi.mock("~/server/db", () => ({
+	db: { select: (fields: Record<string, unknown>) => mockSelect(fields) },
+}));
+
+function compileWhere(): { sql: string; params: unknown[] } {
+	const condition = mockWhere.mock.calls[0]?.[0] as SQL | undefined;
+	if (!condition) {
+		throw new Error("where() was not called with a condition");
+	}
+	const dialect = new PgDialect({ casing: "snake_case" });
+	const built = dialect.sqlToQuery(condition);
+	return { sql: built.sql, params: built.params };
+}
+
+describe("fetchSubmittedDeclarations — composite temporal filter", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockResolvedValue([]);
+	});
+
+	it("should select cancelledAt alongside the existing columns", async () => {
+		const { fetchSubmittedDeclarations } = await import("../queries");
+		await fetchSubmittedDeclarations("2025-04-01", "2025-05-01");
+
+		const fields = mockSelect.mock.calls[0]?.[0];
+		expect(fields).toBeDefined();
+		expect(fields).toHaveProperty("cancelledAt");
+	});
+
+	it("should compose an OR with two AND branches: cancelled_at-window OR (submitted + updated_at-window + cancelled_at IS NULL)", async () => {
+		const { fetchSubmittedDeclarations } = await import("../queries");
+		await fetchSubmittedDeclarations("2025-04-01", "2025-05-01");
+
+		const { sql, params } = compileWhere();
+
+		expect(sql).toMatch(/\bor\b/i);
+		expect(sql).toContain('"cancelled_at" >=');
+		expect(sql).toContain('"cancelled_at" <');
+		expect(sql).toContain('"status" =');
+		expect(sql).toContain('"updated_at" >=');
+		expect(sql).toContain('"updated_at" <');
+		expect(sql).toContain('"cancelled_at" is null');
+		expect(params).toContain("submitted");
+		const dateBegin = new Date("2025-04-01T00:00:00Z").toISOString();
+		const dateEnd = new Date("2025-05-01T00:00:00Z").toISOString();
+		const dateLikeParams = params.filter(
+			(p) => p instanceof Date || typeof p === "string",
+		);
+		const beginCount = dateLikeParams.filter(
+			(p) => (p instanceof Date ? p.toISOString() : p) === dateBegin,
+		).length;
+		const endCount = dateLikeParams.filter(
+			(p) => (p instanceof Date ? p.toISOString() : p) === dateEnd,
+		).length;
+		expect(beginCount).toBe(2);
+		expect(endCount).toBe(2);
+	});
+
+	it("should not gate the cancelled-window arm on status='submitted'", async () => {
+		// Annulation tardive d'une déclaration soumise hors fenêtre :
+		// le filtre composite doit la capter sans exiger status='submitted'
+		// dans la même conjonction. Le statut n'apparaît que dans l'arm 2.
+		const { fetchSubmittedDeclarations } = await import("../queries");
+		await fetchSubmittedDeclarations("2025-04-01", "2025-05-01");
+
+		const { sql, params } = compileWhere();
+
+		expect(params.filter((p) => p === "submitted")).toHaveLength(1);
+		const orIndex = sql.toLowerCase().indexOf(" or ");
+		expect(orIndex).toBeGreaterThan(0);
+		const beforeOr = sql.slice(0, orIndex).toLowerCase();
+		expect(beforeOr).toContain('"cancelled_at" >=');
+		expect(beforeOr).not.toContain('"status"');
+	});
+
+	it("should keep cancelled_at IS NULL on the active-submission arm to avoid double-counting", async () => {
+		// Soumission ET annulation toutes deux dans la fenêtre :
+		// la déclaration doit être captée une seule fois. L'arm 2 exclut donc
+		// les annulations (cancelled_at IS NULL) que l'arm 1 capture déjà.
+		const { fetchSubmittedDeclarations } = await import("../queries");
+		await fetchSubmittedDeclarations("2025-04-01", "2025-05-01");
+
+		const { sql } = compileWhere();
+		const orIndex = sql.toLowerCase().indexOf(" or ");
+		const afterOr = sql.slice(orIndex).toLowerCase();
+		expect(afterOr).toContain('"cancelled_at" is null');
+		expect(afterOr).toContain('"status"');
+	});
+});

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNotNull, or } from "drizzle-orm";
 
 import type { DB } from "~/server/db";
 import { companies, declarations, users } from "~/server/db/schema";
@@ -36,6 +36,7 @@ export async function buildExportRows(
 			secondDeclReferencePeriodEnd: declarations.secondDeclReferencePeriodEnd,
 			createdAt: declarations.createdAt,
 			updatedAt: declarations.updatedAt,
+			cancelledAt: declarations.cancelledAt,
 			declarationId: declarations.id,
 			companyName: companies.name,
 			workforce: companies.workforce,
@@ -52,7 +53,13 @@ export async function buildExportRows(
 		.innerJoin(companies, eq(declarations.siren, companies.siren))
 		.innerJoin(users, eq(declarations.declarantId, users.id))
 		.where(
-			and(eq(declarations.status, "submitted"), eq(declarations.year, year)),
+			and(
+				eq(declarations.year, year),
+				or(
+					eq(declarations.status, "submitted"),
+					isNotNull(declarations.cancelledAt),
+				),
+			),
 		);
 
 	const declarationIds = rows.map((r) => r.declarationId);
@@ -78,6 +85,7 @@ export async function buildExportRows(
 			compliancePath: row.compliancePath,
 			createdAt: row.createdAt?.toISOString() ?? null,
 			updatedAt: row.updatedAt?.toISOString() ?? null,
+			cancelledAt: row.cancelledAt?.toISOString() ?? null,
 			totalWomen: row.totalWomen,
 			totalMen: row.totalMen,
 			remunerationScore: row.remunerationScore,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -266,6 +266,7 @@ export function assembleDeclaration(
 		Parcours_conformite: row.compliancePath,
 		Date_creation: row.createdAt?.toISOString() ?? null,
 		Date_modification: row.updatedAt?.toISOString() ?? null,
+		Date_annulation: row.cancelledAt?.toISOString() ?? null,
 		Effectif_F_rem_annuelle_globale: row.totalWomen,
 		Effectif_H_rem_annuelle_globale: row.totalMen,
 		Indicateurs: {

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -212,6 +212,13 @@ const declarationSchema = {
 		},
 		Date_creation: { type: ["string", "null"], format: "date-time" },
 		Date_modification: { type: ["string", "null"], format: "date-time" },
+		Date_annulation: {
+			type: ["string", "null"],
+			format: "date-time",
+			description:
+				"Date d'annulation administrative de la déclaration. `null` si la déclaration est active. Une déclaration annulée conserve l'intégralité de ses données pour audit.",
+			example: "2025-04-01T10:30:00.000Z",
+		},
 		Effectif_F_rem_annuelle_globale: {
 			type: ["integer", "null"],
 			description:
@@ -379,9 +386,10 @@ export const openApiSpec = {
 		"/api/v1/export/declarations": {
 			get: {
 				operationId: "getDeclarations",
-				summary: "Lister les déclarations par date de soumission",
+				summary:
+					"Lister les déclarations par date de soumission ou d'annulation",
 				description:
-					"Retourne les déclarations soumises dont la date de mise à jour (`Date_modification`) est comprise dans l'intervalle [`date_begin`, `date_end`[. Inclut les indicateurs A–G, la seconde déclaration et les avis CSE. Les libellés des champs reprennent ceux du fichier GIP MDS.",
+					"Retourne les déclarations dont la date de mise à jour (`Date_modification`, pour les déclarations actives soumises) ou la date d'annulation (`Date_annulation`, pour les déclarations annulées) est comprise dans l'intervalle [`date_begin`, `date_end`[. Inclut les indicateurs A–G, la seconde déclaration, les avis CSE et le champ `Date_annulation` (renseigné si la déclaration est annulée). Les libellés des champs reprennent ceux du fichier GIP MDS.",
 				parameters: [
 					{
 						name: "date_begin",

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, eq, gte, inArray, lt, or } from "drizzle-orm";
+import { and, eq, gte, inArray, isNull, lt, or } from "drizzle-orm";
 import type { DB } from "~/server/db";
 import { db } from "~/server/db";
 import {
@@ -107,6 +107,7 @@ export async function fetchSubmittedDeclarations(
 			secondDeclReferencePeriodEnd: declarations.secondDeclReferencePeriodEnd,
 			createdAt: declarations.createdAt,
 			updatedAt: declarations.updatedAt,
+			cancelledAt: declarations.cancelledAt,
 			declarationId: declarations.id,
 			companyName: companies.name,
 			workforce: companies.workforce,
@@ -119,10 +120,17 @@ export async function fetchSubmittedDeclarations(
 		.innerJoin(companies, eq(declarations.siren, companies.siren))
 		.innerJoin(users, eq(declarations.declarantId, users.id))
 		.where(
-			and(
-				eq(declarations.status, "submitted"),
-				gte(declarations.updatedAt, new Date(`${dateBegin}T00:00:00Z`)),
-				lt(declarations.updatedAt, new Date(`${dateEnd}T00:00:00Z`)),
+			or(
+				and(
+					gte(declarations.cancelledAt, new Date(`${dateBegin}T00:00:00Z`)),
+					lt(declarations.cancelledAt, new Date(`${dateEnd}T00:00:00Z`)),
+				),
+				and(
+					eq(declarations.status, "submitted"),
+					gte(declarations.updatedAt, new Date(`${dateBegin}T00:00:00Z`)),
+					lt(declarations.updatedAt, new Date(`${dateEnd}T00:00:00Z`)),
+					isNull(declarations.cancelledAt),
+				),
 			),
 		);
 }

--- a/packages/app/src/modules/export/shared/constants.ts
+++ b/packages/app/src/modules/export/shared/constants.ts
@@ -22,6 +22,7 @@ export const DECLARATION_COLUMNS: Array<{
 	{ key: "compliancePath", header: "Parcours_conformite" },
 	{ key: "createdAt", header: "Date_creation" },
 	{ key: "updatedAt", header: "Date_modification" },
+	{ key: "cancelledAt", header: "Date_annulation" },
 
 	// Employees
 	{ key: "totalWomen", header: "Total_femmes" },

--- a/packages/app/src/modules/export/types.ts
+++ b/packages/app/src/modules/export/types.ts
@@ -15,6 +15,7 @@ export type ExportRow = {
 	compliancePath: string | null;
 	createdAt: string | null;
 	updatedAt: string | null;
+	cancelledAt: string | null;
 
 	// Employees
 	totalWomen: number | null;


### PR DESCRIPTION
Closes #3417

## Summary

Étend la transmission API SUIT pour signaler les annulations administratives :

- **Filtre temporel composite** dans `fetchSubmittedDeclarations` :
  `cancelled_at IN [date_begin, date_end[ OR (status='submitted' AND updated_at IN window AND cancelled_at IS NULL)`
  → capte les annulations tardives (faites après la fenêtre de soumission initiale)
  → évite le double-comptage quand soumission et annulation tombent toutes deux dans la fenêtre.
- **`Date_annulation`** au top-level du payload `assembleDeclaration` (ISO string ou null). Données A–G + CSE + opinions préservées même pour une déclaration annulée.
- **OpenAPI** : champ `Date_annulation` documenté (date-time, nullable) ; description du endpoint mise à jour.
- **XLSX export annuel admin** : nouvelle colonne `Date_annulation` ; filtre étendu à `status='submitted' OR cancelled_at IS NOT NULL` (cohérence d'audit).

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm lint:check` + `pnpm format:check` verts
- [x] `pnpm test --run` — 1732 tests verts (10 nouveaux)
- [x] `assembleDeclaration` : 3 cas (active / annulée / annulée préserve indicateurs)
- [x] `buildExportRows` : 1 nouveau cas (annulée → ISO string)
- [x] `queries` (nouveau fichier) : 4 cas couvrant le filtre temporel composite (structure du `OR`, isolation des deux `AND`, anti-double-counting, sélection de `cancelledAt`)
- [x] Audit logging inchangé : la route `/api/v1/export/declarations` reste enveloppée dans `withAuditedRoute(EXPORT_API_DECLARATIONS)` — pas de nouveau wire-up.

## Dépendance

- Repose sur le schéma DB de #3420 (colonne `cancelled_at` + partial unique index + helper `isCancelled`).