### PR TITLE
[T2] Mutation tRPC adminDeclarations.cancel + audit log + garde campagne courante

### DIFF
--- a/packages/app/src/modules/admin/declarations/index.ts
+++ b/packages/app/src/modules/admin/declarations/index.ts
@@ -6,6 +6,7 @@ export type {
 	SearchDeclarationsOutput,
 } from "./schemas";
 export {
+	cancelDeclarationSchema,
 	getDeclarationByIdSchema,
 	searchDeclarationsFormSchema,
 	searchDeclarationsSchema,

--- a/packages/app/src/modules/admin/declarations/schemas.ts
+++ b/packages/app/src/modules/admin/declarations/schemas.ts
@@ -47,3 +47,7 @@ export type SearchDeclarationsFormValues = z.infer<
 export const getDeclarationByIdSchema = z.object({
 	id: z.string().uuid(),
 });
+
+export const cancelDeclarationSchema = z.object({
+	id: z.string().uuid(),
+});

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -48,6 +48,9 @@ export const AUDIT_ACTIONS = {
 	ADMIN_DECLARATIONS_SEARCH: "admin_declarations.search",
 	ADMIN_DECLARATION_GET_BY_ID: "admin_declarations.get_by_id",
 
+	// ── Admin declaration mutations ───────────────────────
+	ADMIN_DECLARATION_CANCEL: "admin_declaration.cancel",
+
 	// ── Admin settings mutations ──────────────────────────
 	ADMIN_SETTINGS_UPSERT_DEADLINES: "admin_settings.upsert_deadlines",
 
@@ -119,6 +122,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 
 	[AUDIT_ACTIONS.ADMIN_DECLARATIONS_SEARCH]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_DECLARATION_GET_BY_ID]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD]: "read_sensitive",

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.cancel.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.cancel.test.ts
@@ -1,0 +1,147 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+vi.mock("~/modules/domain", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/domain")>();
+	return {
+		...actual,
+		getCurrentYear: vi.fn().mockReturnValue(2026),
+	};
+});
+
+const DECL_ID_1 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+const DECL_ID_2 = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
+const DECL_ID_3 = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
+const DECL_ID_4 = "6ba7b813-9dad-11d1-80b4-00c04fd430c8";
+
+const adminSession = {
+	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	expires: "",
+};
+
+const userSession = {
+	user: { id: "user-1", email: "user@example.fr", isAdmin: false },
+	expires: "",
+};
+
+function buildDb(
+	declarationRow: {
+		id: string;
+		year: number;
+		cancelledAt: Date | null;
+	} | null,
+) {
+	const updateChain = {
+		set: vi.fn().mockReturnThis(),
+		where: vi.fn().mockResolvedValue(undefined),
+	};
+	return {
+		select: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					limit: vi
+						.fn()
+						.mockResolvedValue(declarationRow ? [declarationRow] : []),
+				}),
+			}),
+		}),
+		update: vi.fn().mockReturnValue(updateChain),
+		__updateChain: updateChain,
+	};
+}
+
+describe("adminDeclarationsRouter — cancel", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("cancels an active declaration in the current year", async () => {
+		const db = buildDb({ id: DECL_ID_1, year: 2026, cancelledAt: null });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.cancel({ id: DECL_ID_1 });
+
+		expect(result.id).toBe(DECL_ID_1);
+		expect(result.cancelledAt).toBeInstanceOf(Date);
+		expect(db.update).toHaveBeenCalled();
+		expect(db.__updateChain.set).toHaveBeenCalledWith(
+			expect.objectContaining({ cancelledAt: expect.any(Date) }),
+		);
+	});
+
+	it("rejects with BAD_REQUEST when the declaration belongs to a past campaign", async () => {
+		const db = buildDb({ id: DECL_ID_2, year: 2025, cancelledAt: null });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const error = await caller.cancel({ id: DECL_ID_2 }).catch((e) => e);
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe("BAD_REQUEST");
+		expect((error as TRPCError).message).toMatch(/campagne passée/);
+		expect(db.update).not.toHaveBeenCalled();
+	});
+
+	it("rejects with BAD_REQUEST when the declaration is already cancelled", async () => {
+		const db = buildDb({
+			id: DECL_ID_3,
+			year: 2026,
+			cancelledAt: new Date("2026-04-01"),
+		});
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const error = await caller.cancel({ id: DECL_ID_3 }).catch((e) => e);
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe("BAD_REQUEST");
+		expect((error as TRPCError).message).toMatch(/déjà annulée/);
+		expect(db.update).not.toHaveBeenCalled();
+	});
+
+	it("rejects with UNAUTHORIZED when the caller is not an admin", async () => {
+		const db = buildDb({ id: DECL_ID_4, year: 2026, cancelledAt: null });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: userSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.cancel({ id: DECL_ID_4 })).rejects.toThrow(
+			/administrateurs/i,
+		);
+		expect(db.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("adminDeclarationsRouter — cancel audit wiring", () => {
+	it("AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL is wired with category mutation", async () => {
+		const { AUDIT_ACTIONS, AUDIT_ACTION_CATEGORIES } = await import(
+			"~/modules/audit/shared/actionKeys"
+		);
+		expect(AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL).toBe(
+			"admin_declaration.cancel",
+		);
+		expect(
+			AUDIT_ACTION_CATEGORIES[AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL],
+		).toBe("mutation");
+	});
+});

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import {
 	and,
 	asc,
@@ -12,9 +13,11 @@ import {
 } from "drizzle-orm";
 
 import {
+	cancelDeclarationSchema,
 	getDeclarationByIdSchema,
 	searchDeclarationsSchema,
 } from "~/modules/admin/declarations/schemas";
+import { getCurrentYear } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import {
 	companies,
@@ -185,5 +188,46 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				files: declarationFiles,
 				cseOpinions: opinions,
 			};
+		}),
+
+	cancel: adminProcedure
+		.input(cancelDeclarationSchema)
+		.mutation(async ({ input, ctx }) => {
+			const rows = await ctx.db
+				.select({
+					id: declarations.id,
+					year: declarations.year,
+					cancelledAt: declarations.cancelledAt,
+				})
+				.from(declarations)
+				.where(eq(declarations.id, input.id))
+				.limit(1);
+
+			const declaration = rows[0];
+			if (!declaration) {
+				throw new TRPCError({ code: "NOT_FOUND" });
+			}
+
+			if (declaration.cancelledAt !== null) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "déclaration déjà annulée",
+				});
+			}
+
+			if (declaration.year !== getCurrentYear()) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "annulation impossible : campagne passée",
+				});
+			}
+
+			const cancelledAt = new Date();
+			await ctx.db
+				.update(declarations)
+				.set({ cancelledAt })
+				.where(eq(declarations.id, input.id));
+
+			return { id: input.id, cancelledAt };
 		}),
 });

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -48,6 +48,9 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"adminDeclarations.search": AUDIT_ACTIONS.ADMIN_DECLARATIONS_SEARCH,
 	"adminDeclarations.getById": AUDIT_ACTIONS.ADMIN_DECLARATION_GET_BY_ID,
 
+	// ── admin declaration mutations ───────────────────────
+	"adminDeclarations.cancel": AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL,
+
 	// ── public searches ────────────────────────────────────
 	"publicReferents.search": AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH,
 	"publicReferents.getById": AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW,


### PR DESCRIPTION
Closes #3412

## Changements

- `cancelDeclarationSchema` dans `modules/admin/declarations/schemas.ts` + export barrel
- Procedure `cancel` sur `adminDeclarationsRouter` (`adminProcedure`) :
  - `NOT_FOUND` si déclaration introuvable
  - `BAD_REQUEST` si `cancelledAt !== null` (idempotence)
  - `BAD_REQUEST` si `year !== getCurrentYear()` (campagne passée)
  - `db.update` → `cancelledAt = new Date()`, retourne `{ id, cancelledAt }`
- Audit log : constante `AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL`, category `mutation`, entrée `PROCEDURE_TO_ACTION`
- Tests unitaires : 5 cas (OK / campagne passée / déjà annulée / non-admin / wiring audit)

## Dépend de

- #3411 (colonne `cancelled_at` + `isCancelled` helper)