### PR TITLE
[T3] UI back-office : bouton Annuler + modal DSFR + statut annulée

### DIFF
--- a/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
@@ -4,7 +4,9 @@ import Link from "next/link";
 
 import { api } from "~/trpc/react";
 
+import { CancelDeclarationButton } from "./CancelDeclarationButton";
 import {
+	CancelledBadge,
 	CompanySection,
 	CseOpinionsSection,
 	DeclarantSection,
@@ -53,6 +55,12 @@ export function AdminDeclarationDetailPage({ declarationId }: Props) {
 			<h1 className="fr-h3 fr-mt-2w">
 				{data.companyName} — {data.year}
 			</h1>
+			{data.cancelledAt && <CancelledBadge cancelledAt={data.cancelledAt} />}
+			<CancelDeclarationButton
+				cancelledAt={data.cancelledAt}
+				declarationId={data.id}
+				year={data.year}
+			/>
 			<DeclarationSummary declaration={data} />
 			<CompanySection declaration={data} />
 			<DeclarantSection declaration={data} />

--- a/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+
+import { getCurrentYear } from "~/modules/domain";
+import { useDsfrModal } from "~/modules/shared";
+import { api } from "~/trpc/react";
+
+import {
+	CANCEL_DECLARATION_BUTTON_LABEL,
+	CANCEL_DECLARATION_CONFIRM_LABEL,
+	CANCEL_DECLARATION_MODAL_BODY,
+	CANCEL_DECLARATION_MODAL_TITLE,
+} from "./shared/constants";
+
+const MODAL_ID = "cancel-declaration-modal";
+
+type Props = {
+	declarationId: string;
+	year: number;
+	cancelledAt: Date | null;
+};
+
+export function CancelDeclarationButton({
+	declarationId,
+	year,
+	cancelledAt,
+}: Props) {
+	if (cancelledAt !== null || year !== getCurrentYear()) {
+		return null;
+	}
+
+	return <CancelDeclarationButtonInner declarationId={declarationId} />;
+}
+
+function CancelDeclarationButtonInner({
+	declarationId,
+}: {
+	declarationId: string;
+}) {
+	const [error, setError] = useState<string | null>(null);
+	const { modalRef, open, close } = useDsfrModal();
+	const utils = api.useUtils();
+
+	const mutation = api.adminDeclarations.cancel.useMutation({
+		onSuccess: async () => {
+			close();
+			await utils.adminDeclarations.getById.invalidate({ id: declarationId });
+			await utils.adminDeclarations.search.invalidate();
+		},
+		onError: (err) => {
+			setError(err.message);
+		},
+	});
+
+	const handleConfirm = () => {
+		setError(null);
+		mutation.mutate({ id: declarationId });
+	};
+
+	const handleClose = () => {
+		setError(null);
+		close();
+	};
+
+	return (
+		<>
+			<button className="fr-btn fr-btn--secondary" onClick={open} type="button">
+				{CANCEL_DECLARATION_BUTTON_LABEL}
+			</button>
+			<dialog
+				aria-labelledby={`${MODAL_ID}-title`}
+				aria-modal="true"
+				className="fr-modal"
+				id={MODAL_ID}
+				ref={modalRef}
+			>
+				<div className="fr-container fr-container--fluid fr-container-md">
+					<div className="fr-grid-row fr-grid-row--center">
+						<div className="fr-col-12 fr-col-md-8 fr-col-lg-6">
+							<div className="fr-modal__body">
+								<div className="fr-modal__header">
+									<button
+										aria-controls={MODAL_ID}
+										className="fr-btn--close fr-btn"
+										onClick={handleClose}
+										title="Fermer"
+										type="button"
+									>
+										Fermer
+									</button>
+								</div>
+								<div className="fr-modal__content">
+									<h2 className="fr-modal__title" id={`${MODAL_ID}-title`}>
+										{CANCEL_DECLARATION_MODAL_TITLE}
+									</h2>
+									<p>{CANCEL_DECLARATION_MODAL_BODY}</p>
+									{error && (
+										<div
+											aria-live="polite"
+											className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
+											role="alert"
+										>
+											<p>{error}</p>
+										</div>
+									)}
+								</div>
+								<div className="fr-modal__footer">
+									<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+										<li>
+											<button
+												className="fr-btn fr-btn--primary"
+												disabled={mutation.isPending}
+												onClick={handleConfirm}
+												type="button"
+											>
+												{CANCEL_DECLARATION_CONFIRM_LABEL}
+											</button>
+										</li>
+										<li>
+											<button
+												className="fr-btn fr-btn--secondary"
+												onClick={handleClose}
+												type="button"
+											>
+												Annuler
+											</button>
+										</li>
+									</ul>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</dialog>
+		</>
+	);
+}

--- a/packages/app/src/modules/admin/declarations/DetailSections.tsx
+++ b/packages/app/src/modules/admin/declarations/DetailSections.tsx
@@ -6,11 +6,7 @@ import type { DeclarationDetail } from "./types";
 
 export function CancelledBadge({ cancelledAt }: { cancelledAt: Date }) {
 	return (
-		<div
-			aria-live="polite"
-			className="fr-alert fr-alert--warning fr-mb-3w"
-			role="alert"
-		>
+		<div className="fr-alert fr-alert--warning fr-mb-3w" role="alert">
 			<p>Annulée le {formatShortDate(cancelledAt)}</p>
 		</div>
 	);

--- a/packages/app/src/modules/admin/declarations/DetailSections.tsx
+++ b/packages/app/src/modules/admin/declarations/DetailSections.tsx
@@ -4,6 +4,18 @@ import { DsfrTable } from "~/modules/shared/DsfrTable";
 import { STATUS_LABELS } from "./shared/constants";
 import type { DeclarationDetail } from "./types";
 
+export function CancelledBadge({ cancelledAt }: { cancelledAt: Date }) {
+	return (
+		<div
+			aria-live="polite"
+			className="fr-alert fr-alert--warning fr-mb-3w"
+			role="alert"
+		>
+			<p>Annulée le {formatShortDate(cancelledAt)}</p>
+		</div>
+	);
+}
+
 export function DeclarationSummary({
 	declaration,
 }: {

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -20,6 +20,7 @@ vi.mock("~/trpc/react", () => ({
 						secondDeclarationStatus: null,
 						createdAt: new Date("2024-03-01T10:00:00Z"),
 						updatedAt: new Date("2024-06-15T10:00:00Z"),
+						cancelledAt: null,
 						companyName: "ACME Corp",
 						companyAddress: "123 Rue de Paris",
 						companyNafCode: "6201Z",

--- a/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockMutate, mockOpen, mockClose } = vi.hoisted(() => ({
+	mockMutate: vi.fn(),
+	mockOpen: vi.fn(),
+	mockClose: vi.fn(),
+}));
+
+vi.mock("~/modules/domain", () => ({
+	getCurrentYear: () => 2026,
+}));
+
+vi.mock("~/modules/shared", () => ({
+	useDsfrModal: () => ({
+		modalRef: { current: null },
+		open: mockOpen,
+		close: mockClose,
+	}),
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		adminDeclarations: {
+			cancel: {
+				useMutation: vi.fn().mockReturnValue({
+					mutate: mockMutate,
+					isPending: false,
+				}),
+			},
+		},
+		useUtils: vi.fn().mockReturnValue({
+			adminDeclarations: {
+				getById: { invalidate: vi.fn() },
+				search: { invalidate: vi.fn() },
+			},
+		}),
+	},
+}));
+
+import { CancelDeclarationButton } from "../CancelDeclarationButton";
+
+describe("CancelDeclarationButton", () => {
+	it("renders the button for a current year non-cancelled declaration", () => {
+		render(
+			<CancelDeclarationButton
+				cancelledAt={null}
+				declarationId="decl-1"
+				year={2026}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: "Annuler la déclaration" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders nothing for a past campaign year", () => {
+		render(
+			<CancelDeclarationButton
+				cancelledAt={null}
+				declarationId="decl-1"
+				year={2024}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: "Annuler la déclaration" }),
+		).toBeNull();
+	});
+
+	it("renders nothing for an already cancelled declaration", () => {
+		render(
+			<CancelDeclarationButton
+				cancelledAt={new Date("2026-03-01T10:00:00Z")}
+				declarationId="decl-1"
+				year={2026}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: "Annuler la déclaration" }),
+		).toBeNull();
+	});
+});

--- a/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
@@ -28,6 +28,7 @@ const declaration: DeclarationDetail = {
 	secondDeclarationStatus: null,
 	createdAt: new Date("2024-03-01T10:00:00Z"),
 	updatedAt: new Date("2024-06-15T10:00:00Z"),
+	cancelledAt: null,
 	companyName: "ACME Corp",
 	companyAddress: "123 Rue de Paris",
 	companyNafCode: "6201Z",

--- a/packages/app/src/modules/admin/declarations/index.ts
+++ b/packages/app/src/modules/admin/declarations/index.ts
@@ -1,5 +1,6 @@
 export { AdminDeclarationDetailPage } from "./AdminDeclarationDetailPage";
 export { AdminDeclarationsPage } from "./AdminDeclarationsPage";
+export { CancelDeclarationButton } from "./CancelDeclarationButton";
 export type {
 	SearchDeclarationsFormValues,
 	SearchDeclarationsInput,

--- a/packages/app/src/modules/admin/declarations/shared/constants.ts
+++ b/packages/app/src/modules/admin/declarations/shared/constants.ts
@@ -2,3 +2,9 @@ export const STATUS_LABELS: Record<string, string> = {
 	draft: "Brouillon",
 	submitted: "Transmise",
 };
+
+export const CANCEL_DECLARATION_BUTTON_LABEL = "Annuler la déclaration";
+export const CANCEL_DECLARATION_MODAL_TITLE = "Confirmer l'annulation";
+export const CANCEL_DECLARATION_MODAL_BODY =
+	"Cette action ne peut être annulée. La déclaration sera transmise à l'API SUIT comme annulée et l'entreprise pourra redéposer une nouvelle déclaration pour cette année.";
+export const CANCEL_DECLARATION_CONFIRM_LABEL = "Confirmer l'annulation";

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -141,6 +141,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 					secondDeclarationStatus: declarations.secondDeclarationStatus,
 					createdAt: declarations.createdAt,
 					updatedAt: declarations.updatedAt,
+					cancelledAt: declarations.cancelledAt,
 					companyName: companies.name,
 					companyAddress: companies.address,
 					companyNafCode: companies.nafCode,


### PR DESCRIPTION
Closes #3413

## Résumé

- Nouveau composant `CancelDeclarationButton` : bouton secondaire DSFR + modal de confirmation RGAA-conforme (`<dialog>`, `aria-modal`, `aria-labelledby`)
- Le bouton n'est rendu que pour les déclarations de la campagne en cours non encore annulées (`year === getCurrentYear() && cancelledAt === null`)
- Après confirmation : mutation `adminDeclarations.cancel`, invalidation du cache tRPC, badge "Annulée le ..." (`role="alert"`)
- `getById` étend son `select` pour retourner `cancelledAt`
- Wording centralisé dans `shared/constants.ts`

## Plan de test

- [ ] Déclaration campagne courante non annulée → bouton visible, modal s'ouvre
- [ ] Déclaration campagne passée → bouton absent
- [ ] Déclaration déjà annulée → bouton absent, badge "Annulée le ..." affiché
- [ ] Confirmation → mutation déclenchée, badge affiché, bouton disparaît
- [ ] Erreur tRPC → `<Alert>` dans la modal
- [ ] Tests RTL : 3 cas (visible / hidden campagne passée / hidden déjà annulée) — `pnpm test`