### PR TITLE
[T4] UI back-office : filtre Annulée + section déclarations sœurs

### DIFF
--- a/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
@@ -13,6 +13,7 @@ import {
 	DeclarationSummary,
 	FilesSection,
 } from "./DetailSections";
+import { SiblingDeclarationsSection } from "./SiblingDeclarationsSection";
 
 type Props = {
 	declarationId: string;
@@ -68,6 +69,7 @@ export function AdminDeclarationDetailPage({ declarationId }: Props) {
 				<CseOpinionsSection opinions={data.cseOpinions} />
 			)}
 			{data.files.length > 0 && <FilesSection files={data.files} />}
+			<SiblingDeclarationsSection siblings={data.siblings} />
 		</div>
 	);
 }

--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -78,7 +78,13 @@ export function DeclarationTable({
 								</Link>
 							</td>
 							<td>{row.year}</td>
-							<td>{STATUS_LABELS[row.status ?? ""] ?? row.status}</td>
+							<td>
+								{row.cancelledAt !== null ? (
+									<span className="fr-badge fr-badge--warning">Annulée</span>
+								) : (
+									(STATUS_LABELS[row.status ?? ""] ?? row.status)
+								)}
+							</td>
 							<td>{row.declarantEmail}</td>
 							<td>{formatShortDate(row.createdAt)}</td>
 						</tr>

--- a/packages/app/src/modules/admin/declarations/SearchForm.tsx
+++ b/packages/app/src/modules/admin/declarations/SearchForm.tsx
@@ -22,7 +22,11 @@ export function SearchForm() {
 				dateFrom: searchParams.get("dateFrom") ?? "",
 				dateTo: searchParams.get("dateTo") ?? "",
 				status:
-					(searchParams.get("status") as "" | "draft" | "submitted") ?? "",
+					(searchParams.get("status") as
+						| ""
+						| "draft"
+						| "submitted"
+						| "cancelled") ?? "",
 			},
 		},
 	);
@@ -136,6 +140,7 @@ export function SearchForm() {
 							<option value="">Tous</option>
 							<option value="draft">Brouillon</option>
 							<option value="submitted">Transmise</option>
+							<option value="cancelled">Annulée</option>
 						</select>
 					</div>
 				</div>

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { formatShortDateTime } from "~/modules/domain";
+import { STATUS_LABELS } from "./shared/constants";
+
+type Sibling = {
+	id: string;
+	cancelledAt: Date | null;
+	updatedAt: Date | null;
+	status: string;
+};
+
+type Props = {
+	siblings: Sibling[];
+};
+
+export function SiblingDeclarationsSection({ siblings }: Props) {
+	if (siblings.length === 0) {
+		return null;
+	}
+
+	return (
+		<section className="fr-mt-4w">
+			<h3 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h3>
+			<ul className="fr-raw-list">
+				{siblings.map((sibling) => (
+					<li className="fr-mb-1w" key={sibling.id}>
+						<Link
+							aria-label={`Voir la déclaration du ${formatShortDateTime(sibling.updatedAt)}`}
+							href={`/admin/declarations/${sibling.id}`}
+						>
+							{formatShortDateTime(sibling.updatedAt)}
+						</Link>
+						{" — "}
+						{sibling.cancelledAt !== null ? (
+							<span className="fr-badge fr-badge--warning">Annulée</span>
+						) : (
+							(STATUS_LABELS[sibling.status] ?? sibling.status)
+						)}
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -46,6 +46,7 @@ vi.mock("~/trpc/react", () => ({
 								opinionDate: "2024-03-15",
 							},
 						],
+						siblings: [],
 					},
 					isLoading: false,
 				}),

--- a/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
@@ -24,6 +24,7 @@ const baseRow: DeclarationSearchRow = {
 	siren: "123456789",
 	year: 2024,
 	status: "submitted",
+	cancelledAt: null,
 	remunerationScore: 85,
 	createdAt: new Date("2024-06-15T10:00:00Z"),
 	updatedAt: new Date("2024-06-15T10:00:00Z"),
@@ -89,5 +90,20 @@ describe("DeclarationTable", () => {
 		expect(
 			screen.getByRole("navigation", { name: "Pagination" }),
 		).toBeInTheDocument();
+	});
+
+	it("shows cancelled badge when cancelledAt is set", () => {
+		const cancelledRow = { ...baseRow, cancelledAt: new Date("2024-07-01") };
+		render(<DeclarationTable {...defaultProps} rows={[cancelledRow]} />);
+
+		expect(screen.getByText("Annulée")).toBeInTheDocument();
+		expect(screen.queryByText("Transmise")).not.toBeInTheDocument();
+	});
+
+	it("shows status label when cancelledAt is null", () => {
+		render(<DeclarationTable {...defaultProps} />);
+
+		expect(screen.getByText("Transmise")).toBeInTheDocument();
+		expect(screen.queryByText("Annulée")).not.toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
@@ -54,6 +54,7 @@ const declaration: DeclarationDetail = {
 			opinionDate: "2024-03-15",
 		},
 	],
+	siblings: [],
 };
 
 describe("DeclarationSummary", () => {

--- a/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SiblingDeclarationsSection } from "../SiblingDeclarationsSection";
+
+const SIBLING_ID_1 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+const SIBLING_ID_2 = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
+
+describe("SiblingDeclarationsSection", () => {
+	it("renders nothing when siblings array is empty", () => {
+		const { container } = render(<SiblingDeclarationsSection siblings={[]} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders section heading when siblings exist", () => {
+		render(
+			<SiblingDeclarationsSection
+				siblings={[
+					{
+						id: SIBLING_ID_1,
+						status: "submitted",
+						cancelledAt: null,
+						updatedAt: new Date("2026-03-10T12:00:00Z"),
+					},
+				]}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: "Autres déclarations pour ce SIREN / cette année",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("renders a link to each sibling detail page", () => {
+		render(
+			<SiblingDeclarationsSection
+				siblings={[
+					{
+						id: SIBLING_ID_1,
+						status: "submitted",
+						cancelledAt: null,
+						updatedAt: new Date("2026-03-10T12:00:00Z"),
+					},
+				]}
+			/>,
+		);
+
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("href", `/admin/declarations/${SIBLING_ID_1}`);
+	});
+
+	it("shows cancelled badge for cancelled siblings", () => {
+		render(
+			<SiblingDeclarationsSection
+				siblings={[
+					{
+						id: SIBLING_ID_1,
+						status: "cancelled",
+						cancelledAt: new Date("2026-04-01"),
+						updatedAt: new Date("2026-04-01T10:00:00Z"),
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("Annulée")).toBeInTheDocument();
+	});
+
+	it("shows status label for non-cancelled siblings", () => {
+		render(
+			<SiblingDeclarationsSection
+				siblings={[
+					{
+						id: SIBLING_ID_1,
+						status: "submitted",
+						cancelledAt: null,
+						updatedAt: new Date("2026-03-10T12:00:00Z"),
+					},
+				]}
+			/>,
+		);
+
+		const listitem = screen.getByRole("listitem");
+		expect(listitem).toHaveTextContent("Transmise");
+	});
+
+	it("renders multiple siblings", () => {
+		render(
+			<SiblingDeclarationsSection
+				siblings={[
+					{
+						id: SIBLING_ID_1,
+						status: "submitted",
+						cancelledAt: null,
+						updatedAt: new Date("2026-03-10T12:00:00Z"),
+					},
+					{
+						id: SIBLING_ID_2,
+						status: "cancelled",
+						cancelledAt: new Date("2026-04-01"),
+						updatedAt: new Date("2026-04-01T10:00:00Z"),
+					},
+				]}
+			/>,
+		);
+
+		const links = screen.getAllByRole("link");
+		expect(links).toHaveLength(2);
+		expect(links[0]).toHaveAttribute(
+			"href",
+			`/admin/declarations/${SIBLING_ID_1}`,
+		);
+		expect(links[1]).toHaveAttribute(
+			"href",
+			`/admin/declarations/${SIBLING_ID_2}`,
+		);
+	});
+});

--- a/packages/app/src/modules/admin/declarations/schemas.ts
+++ b/packages/app/src/modules/admin/declarations/schemas.ts
@@ -19,7 +19,7 @@ export const searchDeclarationsSchema = z.object({
 	year: z.coerce.number().int().min(2018).max(2100).optional(),
 	dateFrom: z.string().date().optional().or(z.literal("")),
 	dateTo: z.string().date().optional().or(z.literal("")),
-	status: z.enum(["draft", "submitted"]).optional(),
+	status: z.enum(["draft", "submitted", "cancelled"]).optional(),
 	page: z.coerce.number().int().min(1).default(1),
 	pageSize: z.coerce.number().int().min(10).max(100).default(DEFAULT_PAGE_SIZE),
 	sortBy: z.enum(SORT_COLUMNS).default("createdAt"),
@@ -37,7 +37,7 @@ export const searchDeclarationsFormSchema = z.object({
 	year: z.string().optional(),
 	dateFrom: z.string().optional(),
 	dateTo: z.string().optional(),
-	status: z.enum(["", "draft", "submitted"]).optional(),
+	status: z.enum(["", "draft", "submitted", "cancelled"]).optional(),
 });
 
 export type SearchDeclarationsFormValues = z.infer<

--- a/packages/app/src/modules/admin/declarations/shared/constants.ts
+++ b/packages/app/src/modules/admin/declarations/shared/constants.ts
@@ -1,6 +1,7 @@
 export const STATUS_LABELS: Record<string, string> = {
 	draft: "Brouillon",
 	submitted: "Transmise",
+	cancelled: "Annulée",
 };
 
 export const CANCEL_DECLARATION_BUTTON_LABEL = "Annuler la déclaration";

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const DECL_ID_1 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+const DECL_ID_2 = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
+const DECL_ID_3 = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
+
+const adminSession = {
+	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	expires: "",
+};
+
+const baseDeclaration = {
+	id: DECL_ID_1,
+	siren: "123456789",
+	year: 2026,
+	status: "submitted",
+	currentStep: 6,
+	totalWomen: 50,
+	totalMen: 50,
+	remunerationScore: 85,
+	compliancePath: null,
+	complianceCompletedAt: null,
+	secondDeclarationStatus: null,
+	createdAt: new Date("2026-03-01"),
+	updatedAt: new Date("2026-03-15"),
+	cancelledAt: null,
+	companyName: "ACME Corp",
+	companyAddress: "1 rue de Paris",
+	companyNafCode: "6201Z",
+	companyWorkforce: 200,
+	companyHasCse: true,
+	declarantEmail: "alice@example.fr",
+	declarantFirstName: "Alice",
+	declarantLastName: "Dupont",
+	declarantPhone: null,
+};
+
+function buildDb(options: {
+	declaration: typeof baseDeclaration | null;
+	siblings?: {
+		id: string;
+		status: string;
+		cancelledAt: Date | null;
+		updatedAt: Date;
+	}[];
+}) {
+	const { declaration, siblings = [] } = options;
+
+	let selectCallCount = 0;
+	return {
+		select: vi.fn().mockImplementation(() => {
+			selectCallCount++;
+			const callIndex = selectCallCount;
+			const chain = {
+				from: vi.fn().mockReturnThis(),
+				innerJoin: vi.fn().mockReturnThis(),
+				where: vi.fn().mockReturnThis(),
+				limit: vi.fn().mockImplementation(() => {
+					if (callIndex === 1)
+						return Promise.resolve(declaration ? [declaration] : []);
+					return chain;
+				}),
+				orderBy: vi.fn().mockResolvedValue(callIndex === 4 ? siblings : []),
+			};
+			if (callIndex === 2 || callIndex === 3) {
+				chain.where = vi.fn().mockResolvedValue([]);
+			}
+			return chain;
+		}),
+	};
+}
+
+describe("adminDeclarationsRouter — getById", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("returns null when declaration not found", async () => {
+		const db = buildDb({ declaration: null });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getById({ id: DECL_ID_3 });
+
+		expect(result).toBeNull();
+	});
+
+	it("includes empty siblings array when no sibling declarations exist", async () => {
+		const db = buildDb({ declaration: baseDeclaration, siblings: [] });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getById({ id: DECL_ID_1 });
+
+		expect(result).not.toBeNull();
+		expect(result?.siblings).toEqual([]);
+	});
+
+	it("includes siblings with correct status derivation for cancelled sibling", async () => {
+		const cancelledAt = new Date("2026-04-01");
+		const siblings = [
+			{
+				id: DECL_ID_2,
+				status: "draft",
+				cancelledAt,
+				updatedAt: new Date("2026-04-01"),
+			},
+		];
+		const db = buildDb({ declaration: baseDeclaration, siblings });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getById({ id: DECL_ID_1 });
+
+		expect(result?.siblings).toHaveLength(1);
+		expect(result?.siblings[0]?.id).toBe(DECL_ID_2);
+		expect(result?.siblings[0]?.status).toBe("cancelled");
+		expect(result?.siblings[0]?.cancelledAt).toEqual(cancelledAt);
+	});
+
+	it("includes siblings with original status for active sibling", async () => {
+		const siblings = [
+			{
+				id: DECL_ID_2,
+				status: "submitted",
+				cancelledAt: null,
+				updatedAt: new Date("2026-03-10"),
+			},
+		];
+		const db = buildDb({ declaration: baseDeclaration, siblings });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getById({ id: DECL_ID_1 });
+
+		expect(result?.siblings[0]?.status).toBe("submitted");
+		expect(result?.siblings[0]?.cancelledAt).toBeNull();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.search.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.search.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const DECL_ID_1 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+const DECL_ID_2 = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
+
+const adminSession = {
+	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	expires: "",
+};
+
+type Row = {
+	id: string;
+	siren: string;
+	year: number;
+	status: string;
+	cancelledAt: Date | null;
+	remunerationScore: number | null;
+	createdAt: Date;
+	updatedAt: Date;
+	companyName: string;
+	declarantEmail: string;
+	declarantFirstName: string | null;
+	declarantLastName: string | null;
+};
+
+function buildDb(rows: Row[]) {
+	const chain = {
+		from: vi.fn().mockReturnThis(),
+		innerJoin: vi.fn().mockReturnThis(),
+		where: vi.fn().mockReturnThis(),
+		orderBy: vi.fn().mockReturnThis(),
+		limit: vi.fn().mockReturnThis(),
+		offset: vi.fn().mockResolvedValue(rows),
+	};
+	const countChain = {
+		from: vi.fn().mockReturnThis(),
+		innerJoin: vi.fn().mockReturnThis(),
+		where: vi.fn().mockResolvedValue([{ total: rows.length }]),
+	};
+	return {
+		select: vi
+			.fn()
+			.mockImplementationOnce(() => chain)
+			.mockImplementationOnce(() => countChain),
+		__chain: chain,
+	};
+}
+
+const activeRow: Row = {
+	id: DECL_ID_1,
+	siren: "123456789",
+	year: 2026,
+	status: "submitted",
+	cancelledAt: null,
+	remunerationScore: 85,
+	createdAt: new Date("2026-03-01"),
+	updatedAt: new Date("2026-03-01"),
+	companyName: "ACME Corp",
+	declarantEmail: "alice@example.fr",
+	declarantFirstName: "Alice",
+	declarantLastName: "Dupont",
+};
+
+const cancelledRow: Row = {
+	...activeRow,
+	id: DECL_ID_2,
+	cancelledAt: new Date("2026-04-01"),
+};
+
+describe("adminDeclarationsRouter — search", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("returns only cancelled rows when status=cancelled", async () => {
+		const db = buildDb([cancelledRow]);
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.search({ status: "cancelled" });
+
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0]?.id).toBe(DECL_ID_2);
+	});
+
+	it("excludes cancelled rows by default (no status filter)", async () => {
+		const db = buildDb([activeRow]);
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.search({});
+
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0]?.id).toBe(DECL_ID_1);
+	});
+
+	it("excludes cancelled rows when filtering by submitted status", async () => {
+		const db = buildDb([activeRow]);
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.search({ status: "submitted" });
+
+		expect(result.rows).toHaveLength(1);
+		expect(result.rows[0]?.id).toBe(DECL_ID_1);
+	});
+
+	it("includes cancelledAt field in search results", async () => {
+		const db = buildDb([cancelledRow]);
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.search({ status: "cancelled" });
+
+		expect(result.rows[0]?.cancelledAt).toBeInstanceOf(Date);
+	});
+});

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -7,7 +7,10 @@ import {
 	eq,
 	gte,
 	ilike,
+	isNotNull,
+	isNull,
 	lt,
+	ne,
 	or,
 	type SQL,
 } from "drizzle-orm";
@@ -73,8 +76,13 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				);
 			}
 
-			if (input.status) {
+			if (input.status === "cancelled") {
+				filters.push(isNotNull(declarations.cancelledAt));
+			} else if (input.status) {
 				filters.push(eq(declarations.status, input.status));
+				filters.push(isNull(declarations.cancelledAt));
+			} else {
+				filters.push(isNull(declarations.cancelledAt));
 			}
 
 			const where = filters.length > 0 ? and(...filters) : undefined;
@@ -89,6 +97,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 						siren: declarations.siren,
 						year: declarations.year,
 						status: declarations.status,
+						cancelledAt: declarations.cancelledAt,
 						remunerationScore: declarations.remunerationScore,
 						createdAt: declarations.createdAt,
 						updatedAt: declarations.updatedAt,
@@ -163,7 +172,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				return null;
 			}
 
-			const [declarationFiles, opinions] = await Promise.all([
+			const [declarationFiles, opinions, siblingRows] = await Promise.all([
 				ctx.db
 					.select({
 						id: files.id,
@@ -182,12 +191,36 @@ export const adminDeclarationsRouter = createTRPCRouter({
 					})
 					.from(cseOpinions)
 					.where(eq(cseOpinions.declarationId, input.id)),
+				ctx.db
+					.select({
+						id: declarations.id,
+						status: declarations.status,
+						cancelledAt: declarations.cancelledAt,
+						updatedAt: declarations.updatedAt,
+					})
+					.from(declarations)
+					.where(
+						and(
+							eq(declarations.siren, declaration.siren),
+							eq(declarations.year, declaration.year),
+							ne(declarations.id, input.id),
+						),
+					)
+					.orderBy(desc(declarations.updatedAt)),
 			]);
+
+			const siblings = siblingRows.map((s) => ({
+				id: s.id,
+				cancelledAt: s.cancelledAt,
+				updatedAt: s.updatedAt,
+				status: s.cancelledAt !== null ? "cancelled" : (s.status ?? "draft"),
+			}));
 
 			return {
 				...declaration,
 				files: declarationFiles,
 				cseOpinions: opinions,
+				siblings,
 			};
 		}),
 


### PR DESCRIPTION
Closes #3414

## Résumé

- Filtre statut « Annulée » dans la liste back-office (les déclarations annulées sont masquées par défaut, visibles uniquement via le filtre explicite)
- Badge `fr-badge--warning` « Annulée » sur les rows annulées dans le tableau
- Section « Autres déclarations pour ce SIREN / cette année » sur le détail admin (déclarations sœurs triées par `updatedAt desc`, non rendue si `siblings: []`)
- Procédure `getById` étendue : retourne `siblings: { id, status, cancelledAt, updatedAt }[]`

## Tests

- `adminDeclarations.search.test.ts` : filtre annulées + exclusion par défaut
- `adminDeclarations.getById.test.ts` : siblings peuplés, vide, dérivation statut
- `SiblingDeclarationsSection.test.tsx` : rendu conditionnel, badge, lien, statut
- `DeclarationTable.test.tsx` : badge sur row annulée