### PR TITLE
[T8] Test E2E cycle annulation + intégration export Date_annulation

### DIFF
--- a/packages/app/src/e2e/admin-stats-campagne.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-campagne.e2e.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 import {
 	deleteSeededCampaignDeclarations,
 	seedSubmittedDeclarationsForStats,
-} from "./helpers/db";
+} from "./helpers/db-campaign";
 
 // 9-digit SIRENs reserved for this test only — chosen outside any legitimate
 // range so we don't collide with real data.

--- a/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
+++ b/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
@@ -4,8 +4,10 @@ import { getCurrentYear } from "~/modules/domain";
 
 import {
 	deleteCampaignDeadlines,
-	resetDeclarationToDraft,
 	setCampaignDeadlines,
+} from "./helpers/db-campaign";
+import {
+	resetDeclarationToDraft,
 	setCompanyHasCse,
 	setDeclarationComplianceState,
 	setUserPhone,

--- a/packages/app/src/e2e/constants.ts
+++ b/packages/app/src/e2e/constants.ts
@@ -1,3 +1,4 @@
 import path from "node:path";
 
 export const AUTH_FILE = path.join(import.meta.dirname, ".auth/user.json");
+export const TEST_SIREN = "130025265";

--- a/packages/app/src/e2e/declaration-cancellation.e2e.ts
+++ b/packages/app/src/e2e/declaration-cancellation.e2e.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+import { TEST_SIREN } from "./constants";
+import {
+	cleanCurrentYearDeclarations,
+	ensureCurrentYearDeclaration,
+	getCurrentDbYear,
+	resetDeclarationToDraft,
+} from "./helpers/db";
+import { completeDeclaration } from "./helpers/declaration-flows";
+
+test.describe("Declaration cancellation — full cycle", () => {
+	test.describe.configure({ mode: "serial" });
+
+	let currentYear: number;
+
+	test.beforeAll(async () => {
+		currentYear = await getCurrentDbYear();
+		await cleanCurrentYearDeclarations();
+	});
+
+	test.afterAll(async () => {
+		await cleanCurrentYearDeclarations();
+		await ensureCurrentYearDeclaration();
+		await resetDeclarationToDraft();
+	});
+
+	test("submit → cancel → resubmit → cancel → resubmit, then verify admin list and cancelled badge", async ({
+		page,
+	}) => {
+		const adminListUrl = `/admin/declarations?query=${TEST_SIREN}&year=${currentYear}&sortBy=createdAt&sortOrder=desc`;
+
+		async function findFirstDeclarationLink() {
+			await page.goto(adminListUrl);
+			await page.waitForLoadState("networkidle");
+			return page.locator("table tbody tr").first().getByRole("link").first();
+		}
+
+		async function cancelCurrentDeclaration() {
+			await page
+				.getByRole("button", { name: "Annuler la déclaration" })
+				.click();
+			await page
+				.getByRole("button", { name: "Confirmer l'annulation" })
+				.click();
+			await expect(page.getByText(/Annulée le/)).toBeVisible({
+				timeout: 10_000,
+			});
+		}
+
+		// S1 — declarant submits first declaration
+		await completeDeclaration(page, { hasGap: false });
+
+		// Verify mon-espace shows "Effectué" (status=submitted → done)
+		await page.goto("/mon-espace");
+		await expect(page.getByText("Effectué").first()).toBeVisible();
+
+		// Admin navigates to first submission and cancels it
+		const firstLink = await findFirstDeclarationLink();
+		await firstLink.click();
+		await page.waitForLoadState("networkidle");
+		const cancelledUrl1 = page.url();
+		await cancelCurrentDeclaration();
+
+		// S5 — declarant espace shows "À compléter" after cancellation
+		await page.goto("/mon-espace");
+		await expect(page.getByText("À compléter").first()).toBeVisible();
+
+		// S2 — declarant re-submits (second declaration)
+		await completeDeclaration(page, { hasGap: false });
+		await page.goto("/mon-espace");
+		await expect(page.getByText("Effectué").first()).toBeVisible();
+
+		// S3 — admin cancels second declaration (cycle multi-annulations)
+		const secondLink = await findFirstDeclarationLink();
+		await secondLink.click();
+		await page.waitForLoadState("networkidle");
+		await cancelCurrentDeclaration();
+
+		await page.goto("/mon-espace");
+		await expect(page.getByText("À compléter").first()).toBeVisible();
+
+		// S3 — declarant re-submits a third time
+		await completeDeclaration(page, { hasGap: false });
+		await page.goto("/mon-espace");
+		await expect(page.getByText("Effectué").first()).toBeVisible();
+
+		// S8 — admin lists declarations for this SIREN/year: 3 rows (2 cancelled + 1 active)
+		await page.goto(adminListUrl);
+		await page.waitForLoadState("networkidle");
+		const rows = page.locator("table tbody tr");
+		await expect(rows.first()).toBeVisible();
+		expect(await rows.count()).toBe(3);
+
+		// S8 — admin opens a cancelled declaration and sees "Annulée" badge
+		await page.goto(cancelledUrl1);
+		await expect(page.getByText(/Annulée le/)).toBeVisible();
+	});
+});

--- a/packages/app/src/e2e/helpers/db-campaign.ts
+++ b/packages/app/src/e2e/helpers/db-campaign.ts
@@ -1,0 +1,249 @@
+import postgres from "postgres";
+import { TEST_SIREN } from "../constants";
+
+const DEFAULT_DB_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
+
+function createConnection() {
+	const url = process.env.DATABASE_URL ?? DEFAULT_DB_URL;
+	return postgres(url, { max: 1 });
+}
+
+const PREV_YEAR_DECL_ID_PREFIX = "e2e-prev-year-decl-";
+const PREV_YEAR_DECL_ID_SUFFIX = "-000000000000";
+const PREV_YEAR_JOB_CATEGORY_IDS = [
+	"e2e-jobcat-1111-0000-000000000000",
+	"e2e-jobcat-2222-0000-000000000000",
+	"e2e-jobcat-3333-0000-000000000000",
+] as const;
+
+function previousYearDeclId(yearsBack: number) {
+	return `${PREV_YEAR_DECL_ID_PREFIX}${String(yearsBack).padStart(4, "0")}${PREV_YEAR_DECL_ID_SUFFIX}`;
+}
+
+export async function insertPreviousYearDeclaration(yearsBack = 1) {
+	const sql = createConnection();
+	const yearResult = await sql`
+		SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int - ${yearsBack} AS target_year
+	`;
+	const targetYear = yearResult[0]?.target_year as number;
+	const declId = previousYearDeclId(yearsBack);
+
+	try {
+		const users = await sql`
+			SELECT user_id FROM app_user_company WHERE siren = ${TEST_SIREN} LIMIT 1
+		`;
+		const userId = users[0]?.user_id;
+		if (!userId) return;
+
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id, total_women, total_men, current_step, status, created_at, updated_at)
+			VALUES (${declId}, ${TEST_SIREN}, ${targetYear}, ${userId}, 150, 200, 6, 'submitted', NOW(), NOW())
+			ON CONFLICT DO NOTHING
+		`;
+
+		const categories = [
+			{
+				id: PREV_YEAR_JOB_CATEGORY_IDS[0],
+				index: 0,
+				name: "Cadres dirigeants",
+			},
+			{
+				id: PREV_YEAR_JOB_CATEGORY_IDS[1],
+				index: 1,
+				name: "Ingénieurs et cadres",
+			},
+			{
+				id: PREV_YEAR_JOB_CATEGORY_IDS[2],
+				index: 2,
+				name: "Techniciens",
+			},
+		];
+
+		for (const cat of categories) {
+			await sql`
+				INSERT INTO app_job_category (id, declaration_id, category_index, name, source)
+				VALUES (${cat.id}, ${declId}, ${cat.index}, ${cat.name}, 'accord-entreprise')
+				ON CONFLICT DO NOTHING
+			`;
+		}
+	} finally {
+		await sql.end();
+	}
+}
+
+export async function deletePreviousYearDeclaration(yearsBack = 1) {
+	const sql = createConnection();
+	const declId = previousYearDeclId(yearsBack);
+
+	try {
+		await sql`DELETE FROM app_employee_category WHERE job_category_id = ANY(${PREV_YEAR_JOB_CATEGORY_IDS})`;
+		await sql`DELETE FROM app_job_category WHERE declaration_id = ${declId}`;
+		await sql`DELETE FROM app_declaration WHERE id = ${declId}`;
+	} finally {
+		await sql.end();
+	}
+}
+
+type CampaignDeadlineDates = {
+	decl1ModificationDeadline: string;
+	decl1JustificationDeadline: string;
+	decl1JointEvaluationDeadline: string;
+	decl2ModificationDeadline: string;
+	decl2JustificationDeadline: string;
+	decl2JointEvaluationDeadline: string;
+};
+
+export async function setCampaignDeadlines(
+	year: number,
+	dates: CampaignDeadlineDates,
+) {
+	const sql = createConnection();
+	try {
+		await sql`
+			INSERT INTO app_campaign_deadline (
+				year,
+				decl1_modification_deadline,
+				decl1_justification_deadline,
+				decl1_joint_evaluation_deadline,
+				decl2_modification_deadline,
+				decl2_justification_deadline,
+				decl2_joint_evaluation_deadline
+			) VALUES (
+				${year},
+				${dates.decl1ModificationDeadline},
+				${dates.decl1JustificationDeadline},
+				${dates.decl1JointEvaluationDeadline},
+				${dates.decl2ModificationDeadline},
+				${dates.decl2JustificationDeadline},
+				${dates.decl2JointEvaluationDeadline}
+			)
+			ON CONFLICT (year) DO UPDATE SET
+				decl1_modification_deadline = EXCLUDED.decl1_modification_deadline,
+				decl1_justification_deadline = EXCLUDED.decl1_justification_deadline,
+				decl1_joint_evaluation_deadline = EXCLUDED.decl1_joint_evaluation_deadline,
+				decl2_modification_deadline = EXCLUDED.decl2_modification_deadline,
+				decl2_justification_deadline = EXCLUDED.decl2_justification_deadline,
+				decl2_joint_evaluation_deadline = EXCLUDED.decl2_joint_evaluation_deadline
+		`;
+	} finally {
+		await sql.end();
+	}
+}
+
+export async function deleteCampaignDeadlines(year: number) {
+	const sql = createConnection();
+	try {
+		await sql`DELETE FROM app_campaign_deadline WHERE year = ${year}`;
+	} finally {
+		await sql.end();
+	}
+}
+
+type ReferentSeed = {
+	id: string;
+	region: string;
+	county: string | null;
+	name: string;
+	type: "email" | "url";
+	value: string;
+	principal: boolean;
+	substituteName: string | null;
+	substituteEmail: string | null;
+};
+
+export async function seedReferents(rows: ReferentSeed[]) {
+	const sql = createConnection();
+	try {
+		for (const r of rows) {
+			await sql`
+				INSERT INTO app_referent (
+					id, region, county, name, type, value, principal,
+					substitute_name, substitute_email, created_at, updated_at
+				) VALUES (
+					${r.id}, ${r.region}, ${r.county}, ${r.name}, ${r.type},
+					${r.value}, ${r.principal},
+					${r.substituteName}, ${r.substituteEmail}, NOW(), NOW()
+				)
+				ON CONFLICT (id) DO UPDATE SET
+					region = EXCLUDED.region,
+					county = EXCLUDED.county,
+					name = EXCLUDED.name,
+					type = EXCLUDED.type,
+					value = EXCLUDED.value,
+					principal = EXCLUDED.principal,
+					substitute_name = EXCLUDED.substitute_name,
+					substitute_email = EXCLUDED.substitute_email
+			`;
+		}
+	} finally {
+		await sql.end();
+	}
+}
+
+export async function deleteReferents(ids: string[]) {
+	if (ids.length === 0) return;
+	const sql = createConnection();
+	try {
+		await sql`DELETE FROM app_referent WHERE id = ANY(${ids})`;
+	} finally {
+		await sql.end();
+	}
+}
+
+type SeededCampaignDeclaration = {
+	siren: string;
+	year: number;
+	submittedAt: string;
+	workforce: number;
+};
+
+export async function seedSubmittedDeclarationsForStats(
+	rows: SeededCampaignDeclaration[],
+) {
+	if (rows.length === 0) return;
+	const sql = createConnection();
+	try {
+		const users = await sql`
+			SELECT user_id FROM app_user_company WHERE siren = ${TEST_SIREN} LIMIT 1
+		`;
+		const declarantId = users[0]?.user_id as string | undefined;
+		if (!declarantId) {
+			throw new Error(
+				"seedSubmittedDeclarationsForStats: no declarant found for TEST_SIREN",
+			);
+		}
+		for (const row of rows) {
+			await sql`
+				INSERT INTO app_company (siren, name, workforce, created_at, updated_at)
+				VALUES (${row.siren}, ${`E2E Stats Co. ${row.siren}`}, ${row.workforce}, NOW(), NOW())
+				ON CONFLICT (siren) DO UPDATE SET workforce = EXCLUDED.workforce
+			`;
+			await sql`
+				INSERT INTO app_declaration (
+					id, siren, year, declarant_id, current_step, status,
+					submitted_at, created_at, updated_at
+				)
+				VALUES (
+					gen_random_uuid(), ${row.siren}, ${row.year}, ${declarantId}, 6,
+					'submitted', ${row.submittedAt}, NOW(), NOW()
+				)
+				ON CONFLICT (siren, year) WHERE cancelled_at IS NULL DO UPDATE SET
+					status = 'submitted',
+					submitted_at = EXCLUDED.submitted_at
+			`;
+		}
+	} finally {
+		await sql.end();
+	}
+}
+
+export async function deleteSeededCampaignDeclarations(sirens: string[]) {
+	if (sirens.length === 0) return;
+	const sql = createConnection();
+	try {
+		await sql`DELETE FROM app_declaration WHERE siren = ANY(${sirens})`;
+		await sql`DELETE FROM app_company WHERE siren = ANY(${sirens})`;
+	} finally {
+		await sql.end();
+	}
+}

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -1,19 +1,13 @@
 import postgres from "postgres";
+import { TEST_SIREN } from "../constants";
 
 const DEFAULT_DB_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
-const TEST_SIREN = "130025265";
 
 function createConnection() {
 	const url = process.env.DATABASE_URL ?? DEFAULT_DB_URL;
 	return postgres(url, { max: 1 });
 }
 
-/**
- * Ensure a draft declaration row exists for the test SIREN and the current
- * year. Used by tests that can't rely on `getOrCreate` to lazily insert
- * the row — e.g. the admin-impersonation scenario, where the insert branch
- * is blocked server-side.
- */
 export async function ensureCurrentYearDeclaration() {
 	const sql = createConnection();
 	try {
@@ -44,14 +38,9 @@ export async function ensureCurrentYearDeclaration() {
 	}
 }
 
-/**
- * Reset the test declaration to draft and clean all associated data
- * so a new full flow can be tested from scratch.
- */
 export async function resetDeclarationToDraft() {
 	const sql = createConnection();
 	try {
-		// Reset declaration status
 		await sql`
 			UPDATE app_declaration
 			SET status = 'draft', current_step = 1,
@@ -60,7 +49,6 @@ export async function resetDeclarationToDraft() {
 			WHERE siren = ${TEST_SIREN}
 		`;
 
-		// Clean correction employee categories to avoid stale second-declaration data
 		await sql`
 			DELETE FROM app_employee_category
 			WHERE declaration_type = 'correction'
@@ -75,7 +63,6 @@ export async function resetDeclarationToDraft() {
 	}
 }
 
-/** Toggle the hasCse flag on the test company. */
 export async function setCompanyHasCse(hasCse: boolean | null) {
 	const sql = createConnection();
 	try {
@@ -87,7 +74,6 @@ export async function setCompanyHasCse(hasCse: boolean | null) {
 	}
 }
 
-/** Set the compliance state on the test declaration. */
 export async function setDeclarationComplianceState(state: {
 	status?: string;
 	currentStep?: number;
@@ -113,7 +99,6 @@ export async function setDeclarationComplianceState(state: {
 	}
 }
 
-/** Insert a dummy joint evaluation file for the test declaration. */
 export async function insertJointEvaluationFile(year: number) {
 	const sql = createConnection();
 	try {
@@ -131,11 +116,6 @@ export async function insertJointEvaluationFile(year: number) {
 	}
 }
 
-/**
- * Return the id of the most-recent joint_evaluation file for the test SIREN.
- * Used by E2E tests that need the fileId of a just-uploaded real file to
- * exercise the download endpoint.
- */
 export async function getLatestJointEvaluationFileIdForTestSiren(): Promise<
 	string | null
 > {
@@ -156,7 +136,6 @@ export async function getLatestJointEvaluationFileIdForTestSiren(): Promise<
 	}
 }
 
-/** Remove dummy joint evaluation files for the test declaration. */
 export async function deleteJointEvaluationFiles() {
 	const sql = createConnection();
 	try {
@@ -172,7 +151,6 @@ export async function deleteJointEvaluationFiles() {
 	}
 }
 
-/** Insert a dummy CSE opinion for the test declaration. */
 export async function insertCseOpinion(year: number) {
 	const sql = createConnection();
 	try {
@@ -190,7 +168,6 @@ export async function insertCseOpinion(year: number) {
 	}
 }
 
-/** Remove dummy CSE opinions for the test declaration. */
 export async function deleteCseOpinions() {
 	const sql = createConnection();
 	try {
@@ -205,89 +182,6 @@ export async function deleteCseOpinions() {
 	}
 }
 
-const PREV_YEAR_DECL_ID_PREFIX = "e2e-prev-year-decl-";
-const PREV_YEAR_DECL_ID_SUFFIX = "-000000000000";
-const PREV_YEAR_JOB_CATEGORY_IDS = [
-	"e2e-jobcat-1111-0000-000000000000",
-	"e2e-jobcat-2222-0000-000000000000",
-	"e2e-jobcat-3333-0000-000000000000",
-] as const;
-
-function previousYearDeclId(yearsBack: number) {
-	return `${PREV_YEAR_DECL_ID_PREFIX}${String(yearsBack).padStart(4, "0")}${PREV_YEAR_DECL_ID_SUFFIX}`;
-}
-
-/**
- * Insert a submitted declaration `yearsBack` years before the current year with
- * job categories (indicator 7). Default `yearsBack = 1` matches the original
- * N-1 seed so existing callers are unaffected.
- */
-export async function insertPreviousYearDeclaration(yearsBack = 1) {
-	const sql = createConnection();
-	const yearResult = await sql`
-		SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int - ${yearsBack} AS target_year
-	`;
-	const targetYear = yearResult[0]?.target_year as number;
-	const declId = previousYearDeclId(yearsBack);
-
-	try {
-		const users = await sql`
-			SELECT user_id FROM app_user_company WHERE siren = ${TEST_SIREN} LIMIT 1
-		`;
-		const userId = users[0]?.user_id;
-		if (!userId) return;
-
-		await sql`
-			INSERT INTO app_declaration (id, siren, year, declarant_id, total_women, total_men, current_step, status, created_at, updated_at)
-			VALUES (${declId}, ${TEST_SIREN}, ${targetYear}, ${userId}, 150, 200, 6, 'submitted', NOW(), NOW())
-			ON CONFLICT DO NOTHING
-		`;
-
-		const categories = [
-			{
-				id: PREV_YEAR_JOB_CATEGORY_IDS[0],
-				index: 0,
-				name: "Cadres dirigeants",
-			},
-			{
-				id: PREV_YEAR_JOB_CATEGORY_IDS[1],
-				index: 1,
-				name: "Ingénieurs et cadres",
-			},
-			{
-				id: PREV_YEAR_JOB_CATEGORY_IDS[2],
-				index: 2,
-				name: "Techniciens",
-			},
-		];
-
-		for (const cat of categories) {
-			await sql`
-				INSERT INTO app_job_category (id, declaration_id, category_index, name, source)
-				VALUES (${cat.id}, ${declId}, ${cat.index}, ${cat.name}, 'accord-entreprise')
-				ON CONFLICT DO NOTHING
-			`;
-		}
-	} finally {
-		await sql.end();
-	}
-}
-
-/** Remove the seeded previous-year declaration at `yearsBack` and its job categories. */
-export async function deletePreviousYearDeclaration(yearsBack = 1) {
-	const sql = createConnection();
-	const declId = previousYearDeclId(yearsBack);
-
-	try {
-		await sql`DELETE FROM app_employee_category WHERE job_category_id = ANY(${PREV_YEAR_JOB_CATEGORY_IDS})`;
-		await sql`DELETE FROM app_job_category WHERE declaration_id = ${declId}`;
-		await sql`DELETE FROM app_declaration WHERE id = ${declId}`;
-	} finally {
-		await sql.end();
-	}
-}
-
-/** Delete all job categories and employee categories for the test SIREN's current year declaration. */
 export async function deleteCurrentYearCategories() {
 	const sql = createConnection();
 	try {
@@ -313,185 +207,58 @@ export async function deleteCurrentYearCategories() {
 	}
 }
 
-type CampaignDeadlineDates = {
-	decl1ModificationDeadline: string;
-	decl1JustificationDeadline: string;
-	decl1JointEvaluationDeadline: string;
-	decl2ModificationDeadline: string;
-	decl2JustificationDeadline: string;
-	decl2JointEvaluationDeadline: string;
-};
-
-/** Upsert campaign deadlines for a given year (YYYY-MM-DD strings). */
-export async function setCampaignDeadlines(
-	year: number,
-	dates: CampaignDeadlineDates,
-) {
+export async function getCurrentDbYear(): Promise<number> {
 	const sql = createConnection();
 	try {
+		const rows = await sql<[{ year: number }]>`
+			SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS year
+		`;
+		return rows[0]?.year ?? 2026;
+	} finally {
+		await sql.end();
+	}
+}
+
+export async function cleanCurrentYearDeclarations() {
+	const sql = createConnection();
+	try {
+		const rows = await sql<[{ year: number }]>`
+			SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS year
+		`;
+		const year = rows[0]?.year;
+		if (!year) return;
 		await sql`
-			INSERT INTO app_campaign_deadline (
-				year,
-				decl1_modification_deadline,
-				decl1_justification_deadline,
-				decl1_joint_evaluation_deadline,
-				decl2_modification_deadline,
-				decl2_justification_deadline,
-				decl2_joint_evaluation_deadline
-			) VALUES (
-				${year},
-				${dates.decl1ModificationDeadline},
-				${dates.decl1JustificationDeadline},
-				${dates.decl1JointEvaluationDeadline},
-				${dates.decl2ModificationDeadline},
-				${dates.decl2JustificationDeadline},
-				${dates.decl2JointEvaluationDeadline}
+			DELETE FROM app_employee_category
+			WHERE job_category_id IN (
+				SELECT jc.id FROM app_job_category jc
+				INNER JOIN app_declaration d ON d.id = jc.declaration_id
+				WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}
 			)
-			ON CONFLICT (year) DO UPDATE SET
-				decl1_modification_deadline = EXCLUDED.decl1_modification_deadline,
-				decl1_justification_deadline = EXCLUDED.decl1_justification_deadline,
-				decl1_joint_evaluation_deadline = EXCLUDED.decl1_joint_evaluation_deadline,
-				decl2_modification_deadline = EXCLUDED.decl2_modification_deadline,
-				decl2_justification_deadline = EXCLUDED.decl2_justification_deadline,
-				decl2_joint_evaluation_deadline = EXCLUDED.decl2_joint_evaluation_deadline
 		`;
-	} finally {
-		await sql.end();
-	}
-}
-
-/** Delete campaign deadlines for a given year (revert to defaults). */
-export async function deleteCampaignDeadlines(year: number) {
-	const sql = createConnection();
-	try {
-		await sql`DELETE FROM app_campaign_deadline WHERE year = ${year}`;
-	} finally {
-		await sql.end();
-	}
-}
-
-type ReferentSeed = {
-	id: string;
-	region: string;
-	county: string | null;
-	name: string;
-	type: "email" | "url";
-	value: string;
-	principal: boolean;
-	substituteName: string | null;
-	substituteEmail: string | null;
-};
-
-/** Insert or update a list of referents (used by public referents E2E tests). */
-export async function seedReferents(rows: ReferentSeed[]) {
-	const sql = createConnection();
-	try {
-		for (const r of rows) {
-			await sql`
-				INSERT INTO app_referent (
-					id, region, county, name, type, value, principal,
-					substitute_name, substitute_email, created_at, updated_at
-				) VALUES (
-					${r.id}, ${r.region}, ${r.county}, ${r.name}, ${r.type},
-					${r.value}, ${r.principal},
-					${r.substituteName}, ${r.substituteEmail}, NOW(), NOW()
-				)
-				ON CONFLICT (id) DO UPDATE SET
-					region = EXCLUDED.region,
-					county = EXCLUDED.county,
-					name = EXCLUDED.name,
-					type = EXCLUDED.type,
-					value = EXCLUDED.value,
-					principal = EXCLUDED.principal,
-					substitute_name = EXCLUDED.substitute_name,
-					substitute_email = EXCLUDED.substitute_email
-			`;
-		}
-	} finally {
-		await sql.end();
-	}
-}
-
-/** Remove referents by id (used by public referents E2E tests). */
-export async function deleteReferents(ids: string[]) {
-	if (ids.length === 0) return;
-	const sql = createConnection();
-	try {
-		await sql`DELETE FROM app_referent WHERE id = ANY(${ids})`;
-	} finally {
-		await sql.end();
-	}
-}
-
-type SeededCampaignDeclaration = {
-	/** Unique 9-digit SIREN. Must not collide with existing data. */
-	siren: string;
-	year: number;
-	/** Campaign-day the declaration was submitted (ISO string). */
-	submittedAt: string;
-	/** Workforce stored on the synthetic company. */
-	workforce: number;
-};
-
-/**
- * Insert synthetic submitted declarations for the campaign progression E2E
- * tests (K2). Each entry creates a company row if needed and a matching
- * declaration with the specified `submitted_at`. Uses the real E2E declarant
- * attached to TEST_SIREN to satisfy the FK on `declarant_id`.
- */
-export async function seedSubmittedDeclarationsForStats(
-	rows: SeededCampaignDeclaration[],
-) {
-	if (rows.length === 0) return;
-	const sql = createConnection();
-	try {
-		const users = await sql`
-			SELECT user_id FROM app_user_company WHERE siren = ${TEST_SIREN} LIMIT 1
+		await sql`
+			DELETE FROM app_job_category
+			WHERE declaration_id IN (
+				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+			)
 		`;
-		const declarantId = users[0]?.user_id as string | undefined;
-		if (!declarantId) {
-			throw new Error(
-				"seedSubmittedDeclarationsForStats: no declarant found for TEST_SIREN",
-			);
-		}
-		for (const row of rows) {
-			await sql`
-				INSERT INTO app_company (siren, name, workforce, created_at, updated_at)
-				VALUES (${row.siren}, ${`E2E Stats Co. ${row.siren}`}, ${row.workforce}, NOW(), NOW())
-				ON CONFLICT (siren) DO UPDATE SET workforce = EXCLUDED.workforce
-			`;
-			await sql`
-				INSERT INTO app_declaration (
-					id, siren, year, declarant_id, current_step, status,
-					submitted_at, created_at, updated_at
-				)
-				VALUES (
-					gen_random_uuid(), ${row.siren}, ${row.year}, ${declarantId}, 6,
-					'submitted', ${row.submittedAt}, NOW(), NOW()
-				)
-				ON CONFLICT (siren, year) WHERE cancelled_at IS NULL DO UPDATE SET
-					status = 'submitted',
-					submitted_at = EXCLUDED.submitted_at
-			`;
-		}
+		await sql`
+			DELETE FROM app_cse_opinion
+			WHERE declaration_id IN (
+				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+			)
+		`;
+		await sql`
+			DELETE FROM app_file
+			WHERE declaration_id IN (
+				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+			)
+		`;
+		await sql`DELETE FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}`;
 	} finally {
 		await sql.end();
 	}
 }
 
-/** Remove the synthetic company+declaration rows seeded for the stats E2E. */
-export async function deleteSeededCampaignDeclarations(sirens: string[]) {
-	if (sirens.length === 0) return;
-	const sql = createConnection();
-	try {
-		await sql`DELETE FROM app_declaration WHERE siren = ANY(${sirens})`;
-		await sql`DELETE FROM app_company WHERE siren = ANY(${sirens})`;
-	} finally {
-		await sql.end();
-	}
-}
-
-/** Clear or set the phone number for the test user (identified via user_company link to TEST_SIREN). */
 export async function setUserPhone(phone: string | null) {
 	const sql = createConnection();
 	try {

--- a/packages/app/src/e2e/previous-year-categories.e2e.ts
+++ b/packages/app/src/e2e/previous-year-categories.e2e.ts
@@ -1,8 +1,10 @@
 import { expect, type Page, test } from "@playwright/test";
 import {
-	deleteCurrentYearCategories,
 	deletePreviousYearDeclaration,
 	insertPreviousYearDeclaration,
+} from "./helpers/db-campaign";
+import {
+	deleteCurrentYearCategories,
 	resetDeclarationToDraft,
 } from "./helpers/db";
 

--- a/packages/app/src/e2e/public-referents.e2e.ts
+++ b/packages/app/src/e2e/public-referents.e2e.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { deleteReferents, seedReferents } from "./helpers/db";
+import { deleteReferents, seedReferents } from "./helpers/db-campaign";
 
 // Fixed UUIDs so detail-page URLs (`/referents/[id]`) pass the
 // `z.string().uuid()` check in `publicReferents.getById`.

--- a/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
@@ -1,0 +1,109 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+
+describe("GET /api/v1/export/declarations — Date_annulation integration", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN = "123456789";
+	const YEAR = 2025;
+	const USER_ID = "export-integration-test-user";
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await sql`DELETE FROM app_declaration WHERE siren = ${SIREN} AND year = ${YEAR}`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await sql`DELETE FROM app_declaration WHERE siren = ${SIREN} AND year = ${YEAR}`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+
+		await sql`
+			INSERT INTO app_user (id, email, first_name, last_name)
+			VALUES (${USER_ID}, 'dir.rh@example.fr', 'Dir', 'RH')
+			ON CONFLICT DO NOTHING
+		`;
+		await sql`
+			INSERT INTO app_company (siren, name, workforce)
+			VALUES (${SIREN}, 'Entreprise Test Export', 250)
+			ON CONFLICT DO NOTHING
+		`;
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id, status, cancelled_at, created_at, updated_at)
+			VALUES
+				('export-decl-cancelled-1', ${SIREN}, ${YEAR}, ${USER_ID}, 'submitted', '2025-04-15T12:00:00Z', '2025-03-01T00:00:00Z', '2025-03-01T00:00:00Z'),
+				('export-decl-cancelled-2', ${SIREN}, ${YEAR}, ${USER_ID}, 'submitted', '2025-04-20T12:00:00Z', '2025-03-15T00:00:00Z', '2025-03-15T00:00:00Z'),
+				('export-decl-active',      ${SIREN}, ${YEAR}, ${USER_ID}, 'submitted', NULL,                   '2025-05-01T00:00:00Z', '2025-05-01T00:00:00Z')
+		`;
+	});
+
+	function gatewayRequest(params: Record<string, string>): Request {
+		const searchParams = new URLSearchParams(params);
+		return new Request(
+			`http://localhost/api/v1/export/declarations?${searchParams}`,
+			{ headers: { "x-gateway-forwarded": "test-value" } },
+		);
+	}
+
+	it("returns a cancelled declaration with its Date_annulation as ISO string", async () => {
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const response = await GET(
+			gatewayRequest({ date_begin: "2025-04-15", date_end: "2025-04-16" }),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.Nombre).toBe(1);
+		const decl = body.Declarations[0];
+		expect(decl.SIREN).toBe(SIREN);
+		expect(decl.Date_annulation).toBe("2025-04-15T12:00:00.000Z");
+		expect(decl.Indicateurs).toBeDefined();
+	});
+
+	it("returns the active declaration with Date_annulation null", async () => {
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const response = await GET(
+			gatewayRequest({ date_begin: "2025-05-01", date_end: "2025-05-02" }),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.Nombre).toBe(1);
+		const decl = body.Declarations[0];
+		expect(decl.Date_annulation).toBeNull();
+		expect(decl.SIREN).toBe(SIREN);
+	});
+
+	it("returns all 3 declarations across a wide date window, with 2 cancelled and 1 active", async () => {
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const response = await GET(
+			gatewayRequest({ date_begin: "2025-04-15", date_end: "2025-05-02" }),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.Nombre).toBe(3);
+
+		const cancelled = body.Declarations.filter(
+			(d: { Date_annulation: string | null }) => d.Date_annulation !== null,
+		);
+		const active = body.Declarations.filter(
+			(d: { Date_annulation: string | null }) => d.Date_annulation === null,
+		);
+		expect(cancelled).toHaveLength(2);
+		expect(active).toHaveLength(1);
+
+		for (const decl of body.Declarations) {
+			expect(decl.Indicateurs).toBeDefined();
+			expect(decl.SIREN).toBe(SIREN);
+		}
+	});
+});


### PR DESCRIPTION
## Contexte

Sub-ticket #3418 de l'epic #3133 (annulation de déclarations).

## Changements

- **E2E Playwright** (`declaration-cancellation.e2e.ts`) : test unique « cycle complet » — submit → admin annule → re-soumission × 2, puis vérifie que la liste admin affiche 3 lignes et que la page détail de la déclaration annulée affiche le badge « Annulée le »
- **Test d'intégration Vitest** (`exportApi.integration.test.ts`) : vérifie que `GET /api/v1/export/declarations` retourne `Date_annulation` en ISO string pour les déclarations annulées et `null` pour les actives (via testcontainers + vraies migrations Drizzle)
- **Split `db.ts`** (564 → 274 lignes) : fonctions campagne extraites dans `db-campaign.ts` (249 lignes) pour respecter la limite structurelle de 400 lignes
- **`TEST_SIREN` centralisé** dans `constants.ts`, imports mis à jour dans 4 fichiers E2E existants

## Critères d'acceptation

- [x] Tests ajoutés
- [x] Typecheck vert
- [x] `db.ts` < 400 lignes, `db-campaign.ts` < 400 lignes
- [x] `TEST_SIREN` non-dupliqué (extrait dans `constants.ts`)

Closes #3418