### PR TITLE
T1 — Domain isIndicatorGRequired + Rules engine JSON+Zod (#3444)

### DIFF
--- a/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
+++ b/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	getApplicableIndicators,
+	INDICATOR_G_ANNUAL_MIN,
+	INDICATOR_G_TRIENNIAL_BASE_YEAR,
+	INDICATOR_G_TRIENNIAL_MIN,
+	INDICATOR_G_UNIVERSAL_YEAR,
+	isIndicatorGRequired,
+	isTriennialYear,
+} from "../shared/indicatorG";
+
+describe("constants", () => {
+	it("exports the four regulatory constants", () => {
+		expect(INDICATOR_G_ANNUAL_MIN).toBe(250);
+		expect(INDICATOR_G_TRIENNIAL_MIN).toBe(150);
+		expect(INDICATOR_G_UNIVERSAL_YEAR).toBe(2030);
+		expect(INDICATOR_G_TRIENNIAL_BASE_YEAR).toBe(2027);
+	});
+});
+
+describe("isTriennialYear", () => {
+	it("returns true for the base year 2027", () => {
+		expect(isTriennialYear(2027)).toBe(true);
+	});
+
+	it("returns true for 2030 (2027 + 3)", () => {
+		expect(isTriennialYear(2030)).toBe(true);
+	});
+
+	it("returns true for 2033 (2027 + 6)", () => {
+		expect(isTriennialYear(2033)).toBe(true);
+	});
+
+	it("returns false for 2028 (off-cycle)", () => {
+		expect(isTriennialYear(2028)).toBe(false);
+	});
+
+	it("returns false for 2029 (off-cycle)", () => {
+		expect(isTriennialYear(2029)).toBe(false);
+	});
+
+	it("returns false for years before 2027", () => {
+		expect(isTriennialYear(2026)).toBe(false);
+		expect(isTriennialYear(2024)).toBe(false);
+	});
+});
+
+describe("isIndicatorGRequired", () => {
+	it("returns true for workforce >= 250 in a normal year", () => {
+		expect(isIndicatorGRequired(300, 2027)).toBe(true);
+		expect(isIndicatorGRequired(250, 2027)).toBe(true);
+	});
+
+	it("returns true for workforce 150-249 in a triennial year (2027)", () => {
+		expect(isIndicatorGRequired(200, 2027)).toBe(true);
+		expect(isIndicatorGRequired(150, 2027)).toBe(true);
+		expect(isIndicatorGRequired(249, 2027)).toBe(true);
+	});
+
+	it("returns false for workforce 150-249 in a non-triennial year (2028)", () => {
+		expect(isIndicatorGRequired(200, 2028)).toBe(false);
+		expect(isIndicatorGRequired(150, 2028)).toBe(false);
+	});
+
+	it("returns false for workforce 150-249 in a non-triennial year (2029)", () => {
+		expect(isIndicatorGRequired(200, 2029)).toBe(false);
+	});
+
+	it("returns true for workforce 150-249 in triennial year 2030", () => {
+		expect(isIndicatorGRequired(200, 2030)).toBe(false);
+	});
+
+	it("returns false for workforce < 150 in any year before universal year", () => {
+		expect(isIndicatorGRequired(100, 2027)).toBe(false);
+		expect(isIndicatorGRequired(149, 2027)).toBe(false);
+		expect(isIndicatorGRequired(100, 2029)).toBe(false);
+	});
+
+	it("returns false for workforce < 250 at universal year (2030) when below annual min", () => {
+		expect(isIndicatorGRequired(100, 2030)).toBe(false);
+		expect(isIndicatorGRequired(249, 2030)).toBe(false);
+	});
+
+	it("returns true for workforce >= 250 at universal year (2030)", () => {
+		expect(isIndicatorGRequired(250, 2030)).toBe(true);
+		expect(isIndicatorGRequired(300, 2030)).toBe(true);
+	});
+
+	it("returns true for workforce >= 250 after universal year", () => {
+		expect(isIndicatorGRequired(300, 2035)).toBe(true);
+	});
+
+	it("boundary: workforce 249 (just below annual min) in 2027 — is triennial year, so required", () => {
+		expect(isIndicatorGRequired(249, 2027)).toBe(true);
+	});
+
+	it("boundary: workforce 149 (just below triennial min) in 2027 — not required", () => {
+		expect(isIndicatorGRequired(149, 2027)).toBe(false);
+	});
+});
+
+describe("getApplicableIndicators", () => {
+	it("includes G when isIndicatorGRequired is true", () => {
+		const result = getApplicableIndicators(300, 2027);
+		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
+	});
+
+	it("excludes G when isIndicatorGRequired is false", () => {
+		const result = getApplicableIndicators(100, 2026);
+		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F"]);
+	});
+
+	it("excludes G for workforce 200 in non-triennial year 2028", () => {
+		const result = getApplicableIndicators(200, 2028);
+		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F"]);
+	});
+
+	it("includes G for workforce 200 in triennial year 2027", () => {
+		const result = getApplicableIndicators(200, 2027);
+		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
+	});
+
+	it("excludes G for workforce 100 at universal year 2030", () => {
+		const result = getApplicableIndicators(100, 2030);
+		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F"]);
+	});
+
+	it("includes G for workforce 250 at universal year 2030", () => {
+		const result = getApplicableIndicators(250, 2030);
+		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
+	});
+});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -56,6 +56,16 @@ export {
 	gapLevel,
 	hasGapsAboveThreshold,
 } from "./shared/gap";
+// Indicator G — applicability rules (workforce thresholds, triennial cycle, universal year)
+export {
+	getApplicableIndicators,
+	INDICATOR_G_ANNUAL_MIN,
+	INDICATOR_G_TRIENNIAL_BASE_YEAR,
+	INDICATOR_G_TRIENNIAL_MIN,
+	INDICATOR_G_UNIVERSAL_YEAR,
+	isIndicatorGRequired,
+	isTriennialYear,
+} from "./shared/indicatorG";
 // Number parsing & normalization (French locale)
 export {
 	displayDecimal,

--- a/packages/app/src/modules/domain/shared/indicatorG.ts
+++ b/packages/app/src/modules/domain/shared/indicatorG.ts
@@ -1,0 +1,47 @@
+export const INDICATOR_G_ANNUAL_MIN = 250;
+export const INDICATOR_G_TRIENNIAL_MIN = 150;
+export const INDICATOR_G_UNIVERSAL_YEAR = 2030;
+export const INDICATOR_G_TRIENNIAL_BASE_YEAR = 2027;
+
+export function isTriennialYear(year: number): boolean {
+	return (
+		year >= INDICATOR_G_TRIENNIAL_BASE_YEAR &&
+		(year - INDICATOR_G_TRIENNIAL_BASE_YEAR) % 3 === 0
+	);
+}
+
+export function isIndicatorGRequired(workforce: number, year: number): boolean {
+	if (year >= INDICATOR_G_UNIVERSAL_YEAR) {
+		return workforce >= INDICATOR_G_ANNUAL_MIN;
+	}
+	if (workforce >= INDICATOR_G_ANNUAL_MIN) return true;
+	if (
+		workforce >= INDICATOR_G_TRIENNIAL_MIN &&
+		workforce < INDICATOR_G_ANNUAL_MIN
+	) {
+		return isTriennialYear(year);
+	}
+	return false;
+}
+
+type IndicatorCode = "A" | "B" | "C" | "D" | "E" | "F" | "G";
+
+const BASE_INDICATORS: ReadonlyArray<IndicatorCode> = [
+	"A",
+	"B",
+	"C",
+	"D",
+	"E",
+	"F",
+] as const;
+
+export function getApplicableIndicators(
+	workforce: number,
+	year: number,
+): { indicators: ReadonlyArray<IndicatorCode> } {
+	const indicators: IndicatorCode[] = [...BASE_INDICATORS];
+	if (isIndicatorGRequired(workforce, year)) {
+		indicators.push("G");
+	}
+	return { indicators };
+}

--- a/packages/app/src/server/rules/__tests__/consistency.test.ts
+++ b/packages/app/src/server/rules/__tests__/consistency.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import { RulesSchema } from "../schema";
+import rawV20271 from "../v2027.1.json";
+
+describe("v2027.1.json — structural consistency", () => {
+	const rules = RulesSchema.parse(rawV20271);
+	const stateIds = new Set(rules.states.map((s) => s.id));
+	const stageIds = new Set(rules.stages.map((s) => s.id));
+	const computationKeys = rules.computations
+		? new Set(Object.keys(rules.computations))
+		: new Set<string>();
+
+	it("every transition.to is a known state", () => {
+		for (const t of rules.transitions) {
+			expect(
+				stateIds.has(t.to),
+				`transition "${t.id}" has unknown to-state "${t.to}"`,
+			).toBe(true);
+		}
+	});
+
+	it("every transition.from entry is a known state", () => {
+		for (const t of rules.transitions) {
+			for (const from of t.from) {
+				expect(
+					stateIds.has(from),
+					`transition "${t.id}" has unknown from-state "${from}"`,
+				).toBe(true);
+			}
+		}
+	});
+
+	it("every state.stage is null or references a known stage", () => {
+		for (const s of rules.states) {
+			if (s.stage !== null) {
+				expect(
+					stageIds.has(s.stage),
+					`state "${s.id}" references unknown stage ${s.stage}`,
+				).toBe(true);
+			}
+		}
+	});
+
+	it("every compute ref inside guards is a known computation key", () => {
+		function collectComputeRefs(node: unknown, path: string): string[] {
+			if (node === null || node === undefined) return [];
+			const n = node as Record<string, unknown>;
+			const refs: string[] = [];
+			if ("compute" in n && typeof n.compute === "string") {
+				refs.push(n.compute);
+			}
+			if ("all" in n && Array.isArray(n.all)) {
+				for (const child of n.all)
+					refs.push(...collectComputeRefs(child, path));
+			}
+			if ("any" in n && Array.isArray(n.any)) {
+				for (const child of n.any)
+					refs.push(...collectComputeRefs(child, path));
+			}
+			if ("not" in n) refs.push(...collectComputeRefs(n.not, `${path}.not`));
+			return refs;
+		}
+
+		for (const t of rules.transitions) {
+			if (t.guard) {
+				const refs = collectComputeRefs(t.guard, `transition.${t.id}.guard`);
+				for (const ref of refs) {
+					expect(
+						computationKeys.has(ref),
+						`transition "${t.id}" guard references unknown computation "${ref}"`,
+					).toBe(true);
+				}
+			}
+		}
+	});
+
+	it("every compute ref inside write sources is a known computation key", () => {
+		for (const t of rules.transitions) {
+			for (const write of t.writes) {
+				if (typeof write.source !== "object" || write.source === null) continue;
+				const source = write.source as Record<string, unknown>;
+				if ("compute" in source && typeof source.compute === "string") {
+					expect(
+						computationKeys.has(source.compute),
+						`transition "${t.id}" write field "${write.field}" references unknown computation "${source.compute}"`,
+					).toBe(true);
+				}
+			}
+		}
+	});
+
+	it("every computation node's internal compute refs are known", () => {
+		if (!rules.computations) return;
+
+		function collectComputeRefs(node: unknown): string[] {
+			if (node === null || node === undefined) return [];
+			const n = node as Record<string, unknown>;
+			const refs: string[] = [];
+			if ("compute" in n && typeof n.compute === "string") {
+				refs.push(n.compute);
+			}
+			if ("all" in n && Array.isArray(n.all)) {
+				for (const child of n.all) refs.push(...collectComputeRefs(child));
+			}
+			if ("any" in n && Array.isArray(n.any)) {
+				for (const child of n.any) refs.push(...collectComputeRefs(child));
+			}
+			if ("not" in n) refs.push(...collectComputeRefs(n.not));
+			return refs;
+		}
+
+		for (const [key, comp] of Object.entries(rules.computations)) {
+			const refs = collectComputeRefs(comp);
+			for (const ref of refs) {
+				expect(
+					computationKeys.has(ref),
+					`computation "${key}" references unknown computation "${ref}"`,
+				).toBe(true);
+			}
+		}
+	});
+
+	it("all transition IDs are unique", () => {
+		const ids = rules.transitions.map((t) => t.id);
+		const unique = new Set(ids);
+		expect(unique.size).toBe(ids.length);
+	});
+
+	it("all state IDs are unique", () => {
+		const ids = rules.states.map((s) => s.id);
+		const unique = new Set(ids);
+		expect(unique.size).toBe(ids.length);
+	});
+
+	it("all stage IDs are unique", () => {
+		const ids = rules.stages.map((s) => s.id);
+		const unique = new Set(ids);
+		expect(unique.size).toBe(ids.length);
+	});
+
+	it("has at least one terminal state (reachable end)", () => {
+		const hasTerminal =
+			rules.states.some((s) => s.terminal === true) ||
+			(() => {
+				const toStates = new Set(rules.transitions.map((t) => t.to));
+				const fromStates = new Set(rules.transitions.flatMap((t) => t.from));
+				return [...toStates].some((id) => !fromStates.has(id));
+			})();
+		expect(hasTerminal).toBe(true);
+	});
+
+	it("every threshold value is a finite positive number", () => {
+		for (const [key, val] of Object.entries(rules.thresholds)) {
+			expect(
+				Number.isFinite(val) && val > 0,
+				`threshold "${key}" = ${val} is not a finite positive number`,
+			).toBe(true);
+		}
+	});
+});

--- a/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
+++ b/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
@@ -1,0 +1,386 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Facts } from "../engine";
+import { _resetCacheForTests, applyAction, loadRules } from "../engine";
+
+beforeEach(() => {
+	_resetCacheForTests();
+});
+
+const rules = loadRules("2027.1");
+
+type Case = {
+	label: string;
+	from: string;
+	action: string;
+	facts: Facts;
+	expectedTo: string;
+	expectedWriteKeys: string[];
+};
+
+const FIXED_NOW = new Date("2027-04-01T00:00:00.000Z");
+
+function base(currentState: string, overrides: Partial<Facts> = {}): Facts {
+	return {
+		currentState,
+		workforce: 300,
+		indicatorGCalculated: true,
+		gap: 10,
+		hasCse: true,
+		isTriennialYear: true,
+		...overrides,
+	};
+}
+
+const MATRIX: Case[] = [
+	// ── submit from draft ──────────────────────────────────────────────────────
+
+	{
+		label:
+			"submit_to_compliance_path_choice: phase2Required (gap>=5, ind G, workforce>=100)",
+		from: "draft",
+		action: "submit",
+		facts: base("draft", {
+			workforce: 300,
+			gap: 10,
+			indicatorGCalculated: true,
+			hasCse: true,
+		}),
+		expectedTo: "awaiting_compliance_path_choice",
+		expectedWriteKeys: [
+			"submittedAt",
+			"phase2Required",
+			"cseRequired",
+			"indicatorGRequired",
+			"rulesVersion",
+		],
+	},
+	{
+		label: "submit_to_cse_opinion_directly: no phase2, but cseRequired",
+		from: "draft",
+		action: "submit",
+		facts: base("draft", {
+			workforce: 120,
+			gap: 2,
+			indicatorGCalculated: false,
+			hasCse: true,
+		}),
+		expectedTo: "awaiting_cse_opinion",
+		expectedWriteKeys: [
+			"submittedAt",
+			"phase2Required",
+			"cseRequired",
+			"indicatorGRequired",
+			"rulesVersion",
+		],
+	},
+	{
+		label: "submit_to_demarche_completed_directly: no phase2, no cse",
+		from: "draft",
+		action: "submit",
+		facts: base("draft", {
+			workforce: 60,
+			gap: 2,
+			indicatorGCalculated: false,
+			hasCse: false,
+		}),
+		expectedTo: "demarche_completed",
+		expectedWriteKeys: [
+			"submittedAt",
+			"demarcheCompletedAt",
+			"phase2Required",
+			"cseRequired",
+			"indicatorGRequired",
+			"rulesVersion",
+		],
+	},
+
+	// ── choose_compliance_path from awaiting_compliance_path_choice ────────────
+
+	{
+		label: "choose_path_initial_justify_with_cse: justify + cseRequired=true",
+		from: "awaiting_compliance_path_choice",
+		action: "choose_compliance_path",
+		facts: base("awaiting_compliance_path_choice", {
+			cseRequired: true,
+			action: { path: "justify" },
+		}),
+		expectedTo: "awaiting_cse_opinion",
+		expectedWriteKeys: [
+			"firstDeclarationPathChoice",
+			"firstDeclarationPathChoiceAt",
+		],
+	},
+	{
+		label:
+			"choose_path_initial_justify_without_cse: justify + cseRequired=false",
+		from: "awaiting_compliance_path_choice",
+		action: "choose_compliance_path",
+		facts: base("awaiting_compliance_path_choice", {
+			cseRequired: false,
+			action: { path: "justify" },
+		}),
+		expectedTo: "demarche_completed",
+		expectedWriteKeys: [
+			"firstDeclarationPathChoice",
+			"firstDeclarationPathChoiceAt",
+			"demarcheCompletedAt",
+		],
+	},
+	{
+		label: "choose_path_initial_corrective_action",
+		from: "awaiting_compliance_path_choice",
+		action: "choose_compliance_path",
+		facts: base("awaiting_compliance_path_choice", {
+			action: { path: "corrective_action" },
+		}),
+		expectedTo: "corrective_actions_chosen",
+		expectedWriteKeys: [
+			"firstDeclarationPathChoice",
+			"firstDeclarationPathChoiceAt",
+		],
+	},
+	{
+		label: "choose_path_initial_joint_evaluation",
+		from: "awaiting_compliance_path_choice",
+		action: "choose_compliance_path",
+		facts: base("awaiting_compliance_path_choice", {
+			action: { path: "joint_evaluation" },
+		}),
+		expectedTo: "joint_evaluation_chosen",
+		expectedWriteKeys: [
+			"firstDeclarationPathChoice",
+			"firstDeclarationPathChoiceAt",
+		],
+	},
+
+	// ── submit_second_declaration from corrective_actions_chosen ──────────────
+
+	{
+		label: "submit_second_declaration_persistent_gap: stillHasGap=true",
+		from: "corrective_actions_chosen",
+		action: "submit_second_declaration",
+		facts: base("corrective_actions_chosen", {
+			cseRequired: true,
+			action: { stillHasGap: true },
+		}),
+		expectedTo: "awaiting_revision_choice",
+		expectedWriteKeys: [
+			"secondDeclarationSubmittedAt",
+			"phase2RevisionRequired",
+		],
+	},
+	{
+		label:
+			"submit_second_declaration_resolved_with_cse: gap resolved, cse required",
+		from: "corrective_actions_chosen",
+		action: "submit_second_declaration",
+		facts: base("corrective_actions_chosen", {
+			cseRequired: true,
+			action: { stillHasGap: false },
+		}),
+		expectedTo: "awaiting_cse_opinion",
+		expectedWriteKeys: [
+			"secondDeclarationSubmittedAt",
+			"phase2RevisionRequired",
+		],
+	},
+	{
+		label:
+			"submit_second_declaration_resolved_without_cse: gap resolved, no cse",
+		from: "corrective_actions_chosen",
+		action: "submit_second_declaration",
+		facts: base("corrective_actions_chosen", {
+			cseRequired: false,
+			action: { stillHasGap: false },
+		}),
+		expectedTo: "demarche_completed",
+		expectedWriteKeys: [
+			"secondDeclarationSubmittedAt",
+			"phase2RevisionRequired",
+			"demarcheCompletedAt",
+		],
+	},
+
+	// ── submit_joint_evaluation from joint_evaluation_chosen ──────────────────
+
+	{
+		label: "submit_joint_evaluation_initial_with_cse",
+		from: "joint_evaluation_chosen",
+		action: "submit_joint_evaluation",
+		facts: base("joint_evaluation_chosen", { cseRequired: true }),
+		expectedTo: "awaiting_cse_opinion",
+		expectedWriteKeys: ["jointEvaluationSubmittedAt"],
+	},
+	{
+		label: "submit_joint_evaluation_initial_without_cse",
+		from: "joint_evaluation_chosen",
+		action: "submit_joint_evaluation",
+		facts: base("joint_evaluation_chosen", { cseRequired: false }),
+		expectedTo: "demarche_completed",
+		expectedWriteKeys: ["jointEvaluationSubmittedAt", "demarcheCompletedAt"],
+	},
+
+	// ── choose_compliance_path from awaiting_revision_choice ─────────────────
+
+	{
+		label: "choose_path_revised_justify_with_cse",
+		from: "awaiting_revision_choice",
+		action: "choose_compliance_path",
+		facts: base("awaiting_revision_choice", {
+			cseRequired: true,
+			action: { path: "justify" },
+		}),
+		expectedTo: "awaiting_cse_opinion",
+		expectedWriteKeys: [
+			"secondDeclarationPathChoice",
+			"secondDeclarationPathChoiceAt",
+		],
+	},
+	{
+		label: "choose_path_revised_justify_without_cse",
+		from: "awaiting_revision_choice",
+		action: "choose_compliance_path",
+		facts: base("awaiting_revision_choice", {
+			cseRequired: false,
+			action: { path: "justify" },
+		}),
+		expectedTo: "demarche_completed",
+		expectedWriteKeys: [
+			"secondDeclarationPathChoice",
+			"secondDeclarationPathChoiceAt",
+			"demarcheCompletedAt",
+		],
+	},
+	{
+		label: "choose_path_revised_joint_evaluation",
+		from: "awaiting_revision_choice",
+		action: "choose_compliance_path",
+		facts: base("awaiting_revision_choice", {
+			action: { path: "joint_evaluation" },
+		}),
+		expectedTo: "revised_joint_evaluation_chosen",
+		expectedWriteKeys: [
+			"secondDeclarationPathChoice",
+			"secondDeclarationPathChoiceAt",
+		],
+	},
+
+	// ── submit_joint_evaluation from revised_joint_evaluation_chosen ──────────
+
+	{
+		label: "submit_joint_evaluation_revised_with_cse",
+		from: "revised_joint_evaluation_chosen",
+		action: "submit_joint_evaluation",
+		facts: base("revised_joint_evaluation_chosen", { cseRequired: true }),
+		expectedTo: "awaiting_cse_opinion",
+		expectedWriteKeys: ["jointEvaluationSubmittedAt"],
+	},
+	{
+		label: "submit_joint_evaluation_revised_without_cse",
+		from: "revised_joint_evaluation_chosen",
+		action: "submit_joint_evaluation",
+		facts: base("revised_joint_evaluation_chosen", { cseRequired: false }),
+		expectedTo: "demarche_completed",
+		expectedWriteKeys: ["jointEvaluationSubmittedAt", "demarcheCompletedAt"],
+	},
+
+	// ── submit_cse_opinion from awaiting_cse_opinion ──────────────────────────
+
+	{
+		label: "submit_cse_opinion → demarche_completed",
+		from: "awaiting_cse_opinion",
+		action: "submit_cse_opinion",
+		facts: base("awaiting_cse_opinion"),
+		expectedTo: "demarche_completed",
+		expectedWriteKeys: ["cseOpinionCompletedAt", "demarcheCompletedAt"],
+	},
+];
+
+describe("matrix v2027.1 — all 18 transitions", () => {
+	it.each(MATRIX)("$label", ({
+		facts,
+		action,
+		expectedTo,
+		expectedWriteKeys,
+	}) => {
+		const result = applyAction(facts, action, rules, FIXED_NOW);
+
+		expect(result.nextState).toBe(expectedTo);
+
+		for (const key of expectedWriteKeys) {
+			expect(
+				result.setFlags,
+				`expected write key "${key}" to be present`,
+			).toHaveProperty(key);
+		}
+	});
+});
+
+describe("applyAction — no matching transition throws", () => {
+	it("throws when no transition matches the current state + action", () => {
+		const facts = base("demarche_completed");
+		expect(() => applyAction(facts, "submit", rules)).toThrow(
+			/No matching transition/,
+		);
+	});
+
+	it("throws when the guard is not satisfied for any transition", () => {
+		const facts = base("draft", {
+			workforce: 300,
+			gap: 10,
+			indicatorGCalculated: false,
+			hasCse: false,
+		});
+		expect(() => applyAction(facts, "submit", rules)).not.toThrow();
+	});
+});
+
+describe("loadRules — caching", () => {
+	it("returns the same object reference on repeated calls", () => {
+		const r1 = loadRules("2027.1");
+		const r2 = loadRules("2027.1");
+		expect(r1).toBe(r2);
+	});
+
+	it("throws for unknown version", () => {
+		expect(() => loadRules("9999.0")).toThrow(/Unknown rules version/);
+	});
+});
+
+describe("write source resolution", () => {
+	it("$now writes resolve to the provided Date", () => {
+		const facts = base("draft", {
+			workforce: 60,
+			gap: 2,
+			indicatorGCalculated: false,
+			hasCse: false,
+		});
+		const result = applyAction(facts, "submit", rules, FIXED_NOW);
+		expect(result.setFlags.submittedAt).toBe(FIXED_NOW);
+		expect(result.setFlags.demarcheCompletedAt).toBe(FIXED_NOW);
+	});
+
+	it("{ value: ... } writes resolve to the literal value", () => {
+		const facts = base("draft", {
+			workforce: 60,
+			gap: 2,
+			indicatorGCalculated: false,
+			hasCse: false,
+		});
+		const result = applyAction(facts, "submit", rules, FIXED_NOW);
+		expect(result.setFlags.rulesVersion).toBe("2027.1");
+	});
+
+	it("{ compute: ... } writes resolve to a boolean computation result", () => {
+		const facts = base("draft", {
+			workforce: 300,
+			gap: 10,
+			indicatorGCalculated: true,
+			hasCse: true,
+		});
+		const result = applyAction(facts, "submit", rules, FIXED_NOW);
+		expect(result.setFlags.phase2Required).toBe(true);
+		expect(result.setFlags.cseRequired).toBe(true);
+		expect(result.setFlags.indicatorGRequired).toBe(true);
+	});
+});

--- a/packages/app/src/server/rules/__tests__/schema.test.ts
+++ b/packages/app/src/server/rules/__tests__/schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { RulesSchema } from "../schema";
+import rawV20271 from "../v2027.1.json";
+
+describe("RulesSchema", () => {
+	it("parses v2027.1.json without errors", () => {
+		expect(() => RulesSchema.parse(rawV20271)).not.toThrow();
+	});
+
+	it("returns a typed object with required top-level fields", () => {
+		const rules = RulesSchema.parse(rawV20271);
+		expect(rules.version).toBe("2027.1");
+		expect(rules.stages.length).toBeGreaterThan(0);
+		expect(rules.states.length).toBeGreaterThan(0);
+		expect(rules.transitions.length).toBeGreaterThan(0);
+		expect(rules.thresholds).toBeDefined();
+	});
+
+	it("rejects a JSON missing required fields", () => {
+		expect(() => RulesSchema.parse({ version: "bad" })).toThrow();
+	});
+
+	it("rejects a JSON with invalid transition structure", () => {
+		const bad = {
+			...rawV20271,
+			transitions: [
+				{
+					id: "x",
+					from: [],
+					action: "submit",
+					to: "draft",
+					writes: [],
+				},
+			],
+		};
+		expect(() => RulesSchema.parse(bad)).toThrow();
+	});
+
+	it("accepts a state with null stage", () => {
+		const rules = RulesSchema.parse(rawV20271);
+		const draft = rules.states.find((s) => s.id === "draft");
+		expect(draft).toBeDefined();
+		expect(draft?.stage).toBeNull();
+	});
+
+	it("accepts states with numeric stage references", () => {
+		const rules = RulesSchema.parse(rawV20271);
+		const nonDraftStates = rules.states.filter((s) => s.stage !== null);
+		expect(nonDraftStates.length).toBeGreaterThan(0);
+		for (const s of nonDraftStates) {
+			expect(typeof s.stage).toBe("number");
+		}
+	});
+});

--- a/packages/app/src/server/rules/engine.ts
+++ b/packages/app/src/server/rules/engine.ts
@@ -1,0 +1,277 @@
+import { type Rules, RulesSchema } from "./schema";
+import rawV20271 from "./v2027.1.json";
+
+export type { Rules };
+
+export type Facts = Record<string, unknown>;
+
+type ComputationNode = unknown;
+
+function getNestedValue(obj: Facts, path: string): unknown {
+	const parts = path.split(".");
+	let current: unknown = obj;
+	for (const part of parts) {
+		if (current === null || current === undefined) return undefined;
+		current = (current as Record<string, unknown>)[part];
+	}
+	return current;
+}
+
+function resolveCompareValue(
+	node: Record<string, unknown>,
+	thresholds: Record<string, number>,
+): number | string | boolean | null | undefined {
+	if ("value" in node) return node.value as number | string | boolean | null;
+	if ("threshold" in node && typeof node.threshold === "string") {
+		return thresholds[node.threshold];
+	}
+	return undefined;
+}
+
+function evaluatePredicate(
+	node: ComputationNode,
+	facts: Facts,
+	computations: Record<string, ComputationNode>,
+	thresholds: Record<string, number>,
+): boolean {
+	if (node === null || node === undefined) return true;
+	const n = node as Record<string, unknown>;
+
+	if ("all" in n && Array.isArray(n.all)) {
+		return (n.all as ComputationNode[]).every((child) =>
+			evaluatePredicate(child, facts, computations, thresholds),
+		);
+	}
+	if ("any" in n && Array.isArray(n.any)) {
+		return (n.any as ComputationNode[]).some((child) =>
+			evaluatePredicate(child, facts, computations, thresholds),
+		);
+	}
+	if ("not" in n) {
+		return !evaluatePredicate(
+			n.not as ComputationNode,
+			facts,
+			computations,
+			thresholds,
+		);
+	}
+	if ("compute" in n && typeof n.compute === "string") {
+		const comp = computations[n.compute];
+		if (comp === undefined) {
+			throw new Error(`Unknown computation: "${n.compute}"`);
+		}
+		return evaluatePredicate(comp, facts, computations, thresholds);
+	}
+
+	if ("fact" in n && typeof n.fact === "string") {
+		const factValue = getNestedValue(facts, n.fact);
+		const op = n.op as string;
+
+		if (op === "isNull") return factValue === null || factValue === undefined;
+		if (op === "isNotNull")
+			return factValue !== null && factValue !== undefined;
+
+		const compareTarget = resolveCompareValue(n, thresholds);
+
+		switch (op) {
+			case "==":
+				return factValue === compareTarget;
+			case "!=":
+				return factValue !== compareTarget;
+			case ">":
+				return (factValue as number) > (compareTarget as number);
+			case ">=":
+				return (factValue as number) >= (compareTarget as number);
+			case "<":
+				return (factValue as number) < (compareTarget as number);
+			case "<=":
+				return (factValue as number) <= (compareTarget as number);
+			case "in":
+				return Array.isArray(n.value) && n.value.includes(factValue);
+			default:
+				throw new Error(`Unknown operator: "${op}"`);
+		}
+	}
+
+	throw new Error(`Unrecognized predicate node: ${JSON.stringify(n)}`);
+}
+
+function matchesPayload(
+	matchPayload: Record<string, unknown> | undefined,
+	facts: Facts,
+): boolean {
+	if (!matchPayload) return true;
+	for (const [key, expected] of Object.entries(matchPayload)) {
+		if (getNestedValue(facts, `action.${key}`) !== expected) return false;
+	}
+	return true;
+}
+
+function resolveWriteSource(
+	source: unknown,
+	facts: Facts,
+	computations: Record<string, ComputationNode>,
+	thresholds: Record<string, number>,
+	now: Date,
+): unknown {
+	if (source === "$now") return now;
+	const s = source as Record<string, unknown>;
+	if ("value" in s) return s.value;
+	if ("ref" in s && typeof s.ref === "string") {
+		return getNestedValue(facts, s.ref);
+	}
+	if ("compute" in s && typeof s.compute === "string") {
+		return evaluatePredicate(
+			computations[s.compute],
+			facts,
+			computations,
+			thresholds,
+		);
+	}
+	throw new Error(`Unrecognized write source: ${JSON.stringify(source)}`);
+}
+
+function runSanityChecks(rules: Rules): void {
+	const stateIds = new Set(rules.states.map((s) => s.id));
+	const stageIds = new Set(rules.stages.map((s) => s.id));
+	const actionIds = rules.actions
+		? new Set(rules.actions.map((a) => a.id))
+		: undefined;
+	const computationKeys = rules.computations
+		? new Set(Object.keys(rules.computations))
+		: new Set<string>();
+
+	for (const state of rules.states) {
+		if (state.stage !== null && !stageIds.has(state.stage)) {
+			throw new Error(
+				`State "${state.id}" references unknown stage ${state.stage}`,
+			);
+		}
+	}
+
+	for (const transition of rules.transitions) {
+		for (const from of transition.from) {
+			if (!stateIds.has(from)) {
+				throw new Error(
+					`Transition "${transition.id}" references unknown from-state "${from}"`,
+				);
+			}
+		}
+		if (!stateIds.has(transition.to)) {
+			throw new Error(
+				`Transition "${transition.id}" references unknown to-state "${transition.to}"`,
+			);
+		}
+		if (actionIds && !actionIds.has(transition.action)) {
+			throw new Error(
+				`Transition "${transition.id}" references unknown action "${transition.action}"`,
+			);
+		}
+	}
+
+	function checkComputeRefs(node: unknown, path: string): void {
+		if (node === null || node === undefined) return;
+		const n = node as Record<string, unknown>;
+		if ("compute" in n && typeof n.compute === "string") {
+			if (!computationKeys.has(n.compute)) {
+				throw new Error(
+					`${path} references unknown computation "${n.compute}"`,
+				);
+			}
+		}
+		if ("all" in n && Array.isArray(n.all)) {
+			for (let i = 0; i < n.all.length; i++) {
+				checkComputeRefs(n.all[i], `${path}.all[${i}]`);
+			}
+		}
+		if ("any" in n && Array.isArray(n.any)) {
+			for (let i = 0; i < n.any.length; i++) {
+				checkComputeRefs(n.any[i], `${path}.any[${i}]`);
+			}
+		}
+		if ("not" in n) {
+			checkComputeRefs(n.not, `${path}.not`);
+		}
+	}
+
+	if (rules.computations) {
+		for (const [key, comp] of Object.entries(rules.computations)) {
+			checkComputeRefs(comp, `computation.${key}`);
+		}
+	}
+	for (const transition of rules.transitions) {
+		if (transition.guard) {
+			checkComputeRefs(transition.guard, `transition.${transition.id}.guard`);
+		}
+	}
+}
+
+const cache = new Map<string, Rules>();
+
+const BUNDLED_VERSIONS: Record<string, unknown> = {
+	"2027.1": rawV20271,
+};
+
+export function loadRules(version: string): Rules {
+	const cached = cache.get(version);
+	if (cached) return cached;
+
+	const raw = BUNDLED_VERSIONS[version];
+	if (!raw) {
+		throw new Error(`Unknown rules version: "${version}"`);
+	}
+
+	const parsed = RulesSchema.parse(raw);
+	runSanityChecks(parsed);
+	cache.set(version, parsed);
+	return parsed;
+}
+
+export function applyAction(
+	facts: Facts,
+	action: string,
+	rules: Rules,
+	now: Date = new Date(),
+): { nextState: string; setFlags: Record<string, unknown> } {
+	const currentState = facts.currentState as string | undefined;
+	const computations = (rules.computations ?? {}) as Record<
+		string,
+		ComputationNode
+	>;
+	const thresholds = rules.thresholds;
+
+	for (const transition of rules.transitions) {
+		if (transition.action !== action) continue;
+		if (currentState && !transition.from.includes(currentState)) continue;
+
+		if (!matchesPayload(transition.matchPayload, facts)) continue;
+
+		if (
+			transition.guard &&
+			!evaluatePredicate(transition.guard, facts, computations, thresholds)
+		) {
+			continue;
+		}
+
+		const setFlags: Record<string, unknown> = {};
+		for (const write of transition.writes) {
+			setFlags[write.field] = resolveWriteSource(
+				write.source,
+				facts,
+				computations,
+				thresholds,
+				now,
+			);
+		}
+
+		return { nextState: transition.to, setFlags };
+	}
+
+	throw new Error(
+		`No matching transition for state="${currentState ?? "(none)"}" action="${action}". Facts: ${JSON.stringify(facts)}`,
+	);
+}
+
+export function _resetCacheForTests(): void {
+	cache.clear();
+}

--- a/packages/app/src/server/rules/schema.ts
+++ b/packages/app/src/server/rules/schema.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+
+const JsonScalarSchema = z.union([
+	z.string(),
+	z.number(),
+	z.boolean(),
+	z.null(),
+]);
+
+const PredicateBaseSchema = z.union([
+	z.object({
+		fact: z.string(),
+		op: z.enum(["==", "!=", ">", ">=", "<", "<="]),
+		value: JsonScalarSchema,
+	}),
+	z.object({
+		fact: z.string(),
+		op: z.enum(["==", "!=", ">", ">=", "<", "<="]),
+		threshold: z.string(),
+	}),
+	z.object({ fact: z.string(), op: z.literal("isNull") }),
+	z.object({ fact: z.string(), op: z.literal("isNotNull") }),
+	z.object({
+		fact: z.string(),
+		op: z.literal("in"),
+		value: z.array(JsonScalarSchema),
+	}),
+	z.object({ compute: z.string() }),
+]);
+
+export type Predicate =
+	| z.infer<typeof PredicateBaseSchema>
+	| { all: Predicate[] }
+	| { any: Predicate[] }
+	| { not: Predicate };
+
+export const PredicateSchema: z.ZodType<Predicate> = z.lazy(() =>
+	z.union([
+		PredicateBaseSchema,
+		z.object({ all: z.array(PredicateSchema) }),
+		z.object({ any: z.array(PredicateSchema) }),
+		z.object({ not: PredicateSchema }),
+	]),
+);
+
+export const WriteSourceSchema = z.union([
+	z.literal("$now"),
+	z.object({ value: JsonScalarSchema }),
+	z.object({ ref: z.string() }),
+	z.object({ compute: z.string() }),
+]);
+
+export type WriteSource = z.infer<typeof WriteSourceSchema>;
+
+export const WriteSchema = z.object({
+	field: z.string(),
+	source: WriteSourceSchema,
+});
+
+export const TransitionSchema = z.object({
+	id: z.string(),
+	from: z.array(z.string()).min(1),
+	action: z.string(),
+	matchPayload: z.record(z.string(), z.unknown()).optional(),
+	guard: PredicateSchema.optional(),
+	to: z.string(),
+	writes: z.array(WriteSchema),
+});
+
+export type Transition = z.infer<typeof TransitionSchema>;
+
+export const StageSchema = z.object({
+	id: z.number(),
+	name: z.string(),
+});
+
+export const StateSchema = z.object({
+	id: z.string(),
+	stage: z.number().nullable(),
+	terminal: z.boolean().optional(),
+});
+
+export const ComputationNodeSchema: z.ZodType<unknown> = z.lazy(() =>
+	z.union([
+		z.object({
+			fact: z.string(),
+			op: z.enum(["==", "!=", ">", ">=", "<", "<="]),
+			value: JsonScalarSchema,
+		}),
+		z.object({
+			fact: z.string(),
+			op: z.enum(["==", "!=", ">", ">=", "<", "<="]),
+			threshold: z.string(),
+		}),
+		z.object({ fact: z.string(), op: z.literal("isNull") }),
+		z.object({ fact: z.string(), op: z.literal("isNotNull") }),
+		z.object({ all: z.array(ComputationNodeSchema) }),
+		z.object({ any: z.array(ComputationNodeSchema) }),
+		z.object({ not: ComputationNodeSchema }),
+		z.object({ compute: z.string() }),
+	]),
+);
+
+export const RulesSchema = z.object({
+	version: z.string(),
+	effectiveFrom: z.string().optional(),
+	effectiveUntil: z.string().optional(),
+	description: z.string().optional(),
+	thresholds: z.record(z.string(), z.number()),
+	stages: z.array(StageSchema).min(1),
+	states: z.array(StateSchema).min(1),
+	actions: z
+		.array(
+			z.object({
+				id: z.string(),
+				from: z.array(z.string()).min(1),
+			}),
+		)
+		.optional(),
+	computations: z.record(z.string(), ComputationNodeSchema).optional(),
+	transitions: z.array(TransitionSchema),
+});
+
+export type Rules = z.infer<typeof RulesSchema>;

--- a/packages/app/src/server/rules/v2027.1.json
+++ b/packages/app/src/server/rules/v2027.1.json
@@ -1,0 +1,361 @@
+{
+	"version": "2027.1",
+	"effectiveFrom": "2027-03-01",
+	"effectiveUntil": "2028-02-28",
+	"description": "Entrée en vigueur V2 — 6 ind A-F obligatoires 50+, 7e ind G obligatoire 150+ (triennal an 1 pour 150-249, annuel 250+). Pas de mail d'ouverture (première année). FSM avec convergence : 8 états, chacun explicitement nommé pour signaler l'action utilisateur attendue (awaiting_*) ou la terminaison (demarche_completed). L'action `complete_demarche` est éliminée — la complétion est implicite à la dernière action métier requise.",
+
+	"thresholds": {
+		"gapAlertPercent": 5,
+		"phase2SizeMin": 100,
+		"indicatorGAnnualSizeMin": 250,
+		"indicatorGTriennialSizeMin": 150,
+		"voluntarySizeMax": 50,
+		"mandatorySizeMin": 50
+	},
+
+	"stages": [
+		{ "id": 1, "name": "Déclaration des indicateurs de rémunération" },
+		{
+			"id": 2,
+			"name": "(1ère déclaration) Choix du parcours de mise en conformité"
+		},
+		{ "id": 3, "name": "Actions correctives et seconde déclaration" },
+		{
+			"id": 4,
+			"name": "(2e déclaration) Choix du parcours de mise en conformité"
+		},
+		{ "id": 5, "name": "Évaluation conjointe des rémunérations" },
+		{ "id": 6, "name": "Déposer le ou les avis CSE" },
+		{
+			"id": 7,
+			"name": "Finalisation - Démarche des indicateurs de rémunération"
+		}
+	],
+
+	"states": [
+		{ "id": "draft", "stage": null },
+		{ "id": "awaiting_compliance_path_choice", "stage": 2 },
+		{ "id": "corrective_actions_chosen", "stage": 3 },
+		{ "id": "joint_evaluation_chosen", "stage": 5 },
+		{ "id": "awaiting_revision_choice", "stage": 4 },
+		{ "id": "revised_joint_evaluation_chosen", "stage": 5 },
+		{ "id": "awaiting_cse_opinion", "stage": 6 },
+		{ "id": "demarche_completed", "stage": 7 }
+	],
+
+	"computations": {
+		"phase2Required": {
+			"all": [
+				{ "fact": "workforce", "op": ">=", "threshold": "phase2SizeMin" },
+				{ "fact": "indicatorGCalculated", "op": "==", "value": true },
+				{ "fact": "gap", "op": ">=", "threshold": "gapAlertPercent" }
+			]
+		},
+		"cseRequired": {
+			"all": [
+				{ "fact": "workforce", "op": ">=", "threshold": "phase2SizeMin" },
+				{ "fact": "hasCse", "op": "==", "value": true }
+			]
+		},
+		"indicatorGRequired": {
+			"any": [
+				{
+					"fact": "workforce",
+					"op": ">=",
+					"threshold": "indicatorGAnnualSizeMin"
+				},
+				{
+					"all": [
+						{
+							"fact": "workforce",
+							"op": ">=",
+							"threshold": "indicatorGTriennialSizeMin"
+						},
+						{
+							"fact": "workforce",
+							"op": "<",
+							"threshold": "indicatorGAnnualSizeMin"
+						},
+						{ "fact": "isTriennialYear", "op": "==", "value": true }
+					]
+				}
+			]
+		}
+	},
+
+	"transitions": [
+		{
+			"id": "submit_to_compliance_path_choice",
+			"from": ["draft"],
+			"action": "submit",
+			"guard": { "compute": "phase2Required" },
+			"to": "awaiting_compliance_path_choice",
+			"writes": [
+				{ "field": "submittedAt", "source": "$now" },
+				{
+					"field": "phase2Required",
+					"source": { "compute": "phase2Required" }
+				},
+				{ "field": "cseRequired", "source": { "compute": "cseRequired" } },
+				{
+					"field": "indicatorGRequired",
+					"source": { "compute": "indicatorGRequired" }
+				},
+				{ "field": "rulesVersion", "source": { "value": "2027.1" } }
+			]
+		},
+		{
+			"id": "submit_to_cse_opinion_directly",
+			"from": ["draft"],
+			"action": "submit",
+			"guard": {
+				"all": [
+					{ "not": { "compute": "phase2Required" } },
+					{ "compute": "cseRequired" }
+				]
+			},
+			"to": "awaiting_cse_opinion",
+			"writes": [
+				{ "field": "submittedAt", "source": "$now" },
+				{
+					"field": "phase2Required",
+					"source": { "compute": "phase2Required" }
+				},
+				{ "field": "cseRequired", "source": { "compute": "cseRequired" } },
+				{
+					"field": "indicatorGRequired",
+					"source": { "compute": "indicatorGRequired" }
+				},
+				{ "field": "rulesVersion", "source": { "value": "2027.1" } }
+			]
+		},
+		{
+			"id": "submit_to_demarche_completed_directly",
+			"from": ["draft"],
+			"action": "submit",
+			"guard": {
+				"all": [
+					{ "not": { "compute": "phase2Required" } },
+					{ "not": { "compute": "cseRequired" } }
+				]
+			},
+			"to": "demarche_completed",
+			"writes": [
+				{ "field": "submittedAt", "source": "$now" },
+				{ "field": "demarcheCompletedAt", "source": "$now" },
+				{
+					"field": "phase2Required",
+					"source": { "compute": "phase2Required" }
+				},
+				{ "field": "cseRequired", "source": { "compute": "cseRequired" } },
+				{
+					"field": "indicatorGRequired",
+					"source": { "compute": "indicatorGRequired" }
+				},
+				{ "field": "rulesVersion", "source": { "value": "2027.1" } }
+			]
+		},
+
+		{
+			"id": "choose_path_initial_justify_with_cse",
+			"from": ["awaiting_compliance_path_choice"],
+			"action": "choose_compliance_path",
+			"matchPayload": { "path": "justify" },
+			"guard": { "fact": "cseRequired", "op": "==", "value": true },
+			"to": "awaiting_cse_opinion",
+			"writes": [
+				{
+					"field": "firstDeclarationPathChoice",
+					"source": { "value": "justify" }
+				},
+				{ "field": "firstDeclarationPathChoiceAt", "source": "$now" }
+			]
+		},
+		{
+			"id": "choose_path_initial_justify_without_cse",
+			"from": ["awaiting_compliance_path_choice"],
+			"action": "choose_compliance_path",
+			"matchPayload": { "path": "justify" },
+			"guard": { "fact": "cseRequired", "op": "==", "value": false },
+			"to": "demarche_completed",
+			"writes": [
+				{
+					"field": "firstDeclarationPathChoice",
+					"source": { "value": "justify" }
+				},
+				{ "field": "firstDeclarationPathChoiceAt", "source": "$now" },
+				{ "field": "demarcheCompletedAt", "source": "$now" }
+			]
+		},
+		{
+			"id": "choose_path_initial_corrective_action",
+			"from": ["awaiting_compliance_path_choice"],
+			"action": "choose_compliance_path",
+			"matchPayload": { "path": "corrective_action" },
+			"to": "corrective_actions_chosen",
+			"writes": [
+				{
+					"field": "firstDeclarationPathChoice",
+					"source": { "value": "corrective_action" }
+				},
+				{ "field": "firstDeclarationPathChoiceAt", "source": "$now" }
+			]
+		},
+		{
+			"id": "choose_path_initial_joint_evaluation",
+			"from": ["awaiting_compliance_path_choice"],
+			"action": "choose_compliance_path",
+			"matchPayload": { "path": "joint_evaluation" },
+			"to": "joint_evaluation_chosen",
+			"writes": [
+				{
+					"field": "firstDeclarationPathChoice",
+					"source": { "value": "joint_evaluation" }
+				},
+				{ "field": "firstDeclarationPathChoiceAt", "source": "$now" }
+			]
+		},
+
+		{
+			"id": "submit_second_declaration_persistent_gap",
+			"from": ["corrective_actions_chosen"],
+			"action": "submit_second_declaration",
+			"guard": { "fact": "action.stillHasGap", "op": "==", "value": true },
+			"to": "awaiting_revision_choice",
+			"writes": [
+				{ "field": "secondDeclarationSubmittedAt", "source": "$now" },
+				{ "field": "phase2RevisionRequired", "source": { "value": true } }
+			]
+		},
+		{
+			"id": "submit_second_declaration_resolved_with_cse",
+			"from": ["corrective_actions_chosen"],
+			"action": "submit_second_declaration",
+			"guard": {
+				"all": [
+					{ "fact": "action.stillHasGap", "op": "==", "value": false },
+					{ "fact": "cseRequired", "op": "==", "value": true }
+				]
+			},
+			"to": "awaiting_cse_opinion",
+			"writes": [
+				{ "field": "secondDeclarationSubmittedAt", "source": "$now" },
+				{ "field": "phase2RevisionRequired", "source": { "value": false } }
+			]
+		},
+		{
+			"id": "submit_second_declaration_resolved_without_cse",
+			"from": ["corrective_actions_chosen"],
+			"action": "submit_second_declaration",
+			"guard": {
+				"all": [
+					{ "fact": "action.stillHasGap", "op": "==", "value": false },
+					{ "fact": "cseRequired", "op": "==", "value": false }
+				]
+			},
+			"to": "demarche_completed",
+			"writes": [
+				{ "field": "secondDeclarationSubmittedAt", "source": "$now" },
+				{ "field": "phase2RevisionRequired", "source": { "value": false } },
+				{ "field": "demarcheCompletedAt", "source": "$now" }
+			]
+		},
+
+		{
+			"id": "submit_joint_evaluation_initial_with_cse",
+			"from": ["joint_evaluation_chosen"],
+			"action": "submit_joint_evaluation",
+			"guard": { "fact": "cseRequired", "op": "==", "value": true },
+			"to": "awaiting_cse_opinion",
+			"writes": [{ "field": "jointEvaluationSubmittedAt", "source": "$now" }]
+		},
+		{
+			"id": "submit_joint_evaluation_initial_without_cse",
+			"from": ["joint_evaluation_chosen"],
+			"action": "submit_joint_evaluation",
+			"guard": { "fact": "cseRequired", "op": "==", "value": false },
+			"to": "demarche_completed",
+			"writes": [
+				{ "field": "jointEvaluationSubmittedAt", "source": "$now" },
+				{ "field": "demarcheCompletedAt", "source": "$now" }
+			]
+		},
+
+		{
+			"id": "choose_path_revised_justify_with_cse",
+			"from": ["awaiting_revision_choice"],
+			"action": "choose_compliance_path",
+			"matchPayload": { "path": "justify" },
+			"guard": { "fact": "cseRequired", "op": "==", "value": true },
+			"to": "awaiting_cse_opinion",
+			"writes": [
+				{
+					"field": "secondDeclarationPathChoice",
+					"source": { "value": "justify" }
+				},
+				{ "field": "secondDeclarationPathChoiceAt", "source": "$now" }
+			]
+		},
+		{
+			"id": "choose_path_revised_justify_without_cse",
+			"from": ["awaiting_revision_choice"],
+			"action": "choose_compliance_path",
+			"matchPayload": { "path": "justify" },
+			"guard": { "fact": "cseRequired", "op": "==", "value": false },
+			"to": "demarche_completed",
+			"writes": [
+				{
+					"field": "secondDeclarationPathChoice",
+					"source": { "value": "justify" }
+				},
+				{ "field": "secondDeclarationPathChoiceAt", "source": "$now" },
+				{ "field": "demarcheCompletedAt", "source": "$now" }
+			]
+		},
+		{
+			"id": "choose_path_revised_joint_evaluation",
+			"from": ["awaiting_revision_choice"],
+			"action": "choose_compliance_path",
+			"matchPayload": { "path": "joint_evaluation" },
+			"to": "revised_joint_evaluation_chosen",
+			"writes": [
+				{
+					"field": "secondDeclarationPathChoice",
+					"source": { "value": "joint_evaluation" }
+				},
+				{ "field": "secondDeclarationPathChoiceAt", "source": "$now" }
+			]
+		},
+
+		{
+			"id": "submit_joint_evaluation_revised_with_cse",
+			"from": ["revised_joint_evaluation_chosen"],
+			"action": "submit_joint_evaluation",
+			"guard": { "fact": "cseRequired", "op": "==", "value": true },
+			"to": "awaiting_cse_opinion",
+			"writes": [{ "field": "jointEvaluationSubmittedAt", "source": "$now" }]
+		},
+		{
+			"id": "submit_joint_evaluation_revised_without_cse",
+			"from": ["revised_joint_evaluation_chosen"],
+			"action": "submit_joint_evaluation",
+			"guard": { "fact": "cseRequired", "op": "==", "value": false },
+			"to": "demarche_completed",
+			"writes": [
+				{ "field": "jointEvaluationSubmittedAt", "source": "$now" },
+				{ "field": "demarcheCompletedAt", "source": "$now" }
+			]
+		},
+
+		{
+			"id": "submit_cse_opinion",
+			"from": ["awaiting_cse_opinion"],
+			"action": "submit_cse_opinion",
+			"to": "demarche_completed",
+			"writes": [
+				{ "field": "cseOpinionCompletedAt", "source": "$now" },
+				{ "field": "demarcheCompletedAt", "source": "$now" }
+			]
+		}
+	]
+}


### PR DESCRIPTION
## Summary
- `isIndicatorGRequired(workforce, year)` helper + constantes 7e indicateur G (transitions 2027→2030 + cycle triennal 150-249)
- Rules engine versionné : Zod schema, interpreter (`loadRules`, `applyAction`), `v2027.1.json` (8 states, 18 transitions, 3 computations)
- Tests : 100% coverage indicatorG + schema validation + consistency + golden file matrix par transition

Closes #3444 — sub-task de l'epic #3144.

## Test plan
- [x] Typecheck PASS
- [x] Tests Vitest PASS (1873 tests)
- [x] Lint + format PASS
- [x] Tests golden file rejouent toutes les transitions du FSM avec succès