### PR TITLE
T3 — Domain helpers display context + currentCompliancePath (#3446)

### DIFF
--- a/packages/app/src/modules/domain/__tests__/declarationDisplay.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationDisplay.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { getDeclarationDisplayContext } from "../shared/declarationDisplay";
+
+describe("getDeclarationDisplayContext", () => {
+	it("sets shouldShowGapJustification when firstDeclarationPathChoice is justify", () => {
+		const result = getDeclarationDisplayContext({
+			firstDeclarationPathChoice: "justify",
+			secondDeclarationPathChoice: null,
+			cseRequired: false,
+		});
+
+		expect(result).toEqual({
+			firstDeclarationPathChoice: "justify",
+			secondDeclarationPathChoice: null,
+			shouldShowGapJustification: true,
+			shouldShowCorrectiveActions: false,
+			shouldShowJointEvaluation: false,
+			shouldShowCseOpinion: false,
+		});
+	});
+
+	it("sets shouldShowCorrectiveActions and shouldShowJointEvaluation when both paths are set", () => {
+		const result = getDeclarationDisplayContext({
+			firstDeclarationPathChoice: "corrective_action",
+			secondDeclarationPathChoice: "joint_evaluation",
+			cseRequired: true,
+		});
+
+		expect(result).toEqual({
+			firstDeclarationPathChoice: "corrective_action",
+			secondDeclarationPathChoice: "joint_evaluation",
+			shouldShowGapJustification: false,
+			shouldShowCorrectiveActions: true,
+			shouldShowJointEvaluation: true,
+			shouldShowCseOpinion: true,
+		});
+	});
+
+	it("returns all booleans false when both pathChoices are null and cseRequired is false", () => {
+		const result = getDeclarationDisplayContext({
+			firstDeclarationPathChoice: null,
+			secondDeclarationPathChoice: null,
+			cseRequired: false,
+		});
+
+		expect(result).toEqual({
+			firstDeclarationPathChoice: null,
+			secondDeclarationPathChoice: null,
+			shouldShowGapJustification: false,
+			shouldShowCorrectiveActions: false,
+			shouldShowJointEvaluation: false,
+			shouldShowCseOpinion: false,
+		});
+	});
+
+	it("returns shouldShowCseOpinion true when both paths are null but cseRequired is true", () => {
+		const result = getDeclarationDisplayContext({
+			firstDeclarationPathChoice: null,
+			secondDeclarationPathChoice: null,
+			cseRequired: true,
+		});
+
+		expect(result.shouldShowCseOpinion).toBe(true);
+		expect(result.shouldShowGapJustification).toBe(false);
+		expect(result.shouldShowCorrectiveActions).toBe(false);
+		expect(result.shouldShowJointEvaluation).toBe(false);
+	});
+
+	it("sets shouldShowJointEvaluation and shouldShowCseOpinion together when path is joint_evaluation and cseRequired", () => {
+		const result = getDeclarationDisplayContext({
+			firstDeclarationPathChoice: "joint_evaluation",
+			secondDeclarationPathChoice: null,
+			cseRequired: true,
+		});
+
+		expect(result.shouldShowJointEvaluation).toBe(true);
+		expect(result.shouldShowCseOpinion).toBe(true);
+		expect(result.shouldShowGapJustification).toBe(false);
+		expect(result.shouldShowCorrectiveActions).toBe(false);
+	});
+
+	it("sets shouldShowGapJustification when justify is the second path choice", () => {
+		const result = getDeclarationDisplayContext({
+			firstDeclarationPathChoice: "corrective_action",
+			secondDeclarationPathChoice: "justify",
+			cseRequired: false,
+		});
+
+		expect(result.shouldShowGapJustification).toBe(true);
+		expect(result.shouldShowCorrectiveActions).toBe(true);
+		expect(result.shouldShowJointEvaluation).toBe(false);
+		expect(result.shouldShowCseOpinion).toBe(false);
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	computeDeclarationStatus,
+	getCurrentCompliancePath,
 	isCancelled,
 } from "../shared/declarationStatus";
 
@@ -103,5 +104,34 @@ describe("computeDeclarationStatus", () => {
 				cancelledAt: undefined,
 			}),
 		).toBe("done");
+	});
+});
+
+describe("getCurrentCompliancePath", () => {
+	it("returns firstDeclarationPathChoice when secondDeclarationPathChoice is null", () => {
+		expect(
+			getCurrentCompliancePath({
+				firstDeclarationPathChoice: "justify",
+				secondDeclarationPathChoice: null,
+			}),
+		).toBe("justify");
+	});
+
+	it("returns secondDeclarationPathChoice when it is set, ignoring first", () => {
+		expect(
+			getCurrentCompliancePath({
+				firstDeclarationPathChoice: "corrective_action",
+				secondDeclarationPathChoice: "joint_evaluation",
+			}),
+		).toBe("joint_evaluation");
+	});
+
+	it("returns null when both pathChoices are null", () => {
+		expect(
+			getCurrentCompliancePath({
+				firstDeclarationPathChoice: null,
+				secondDeclarationPathChoice: null,
+			}),
+		).toBeNull();
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -28,11 +28,15 @@ export {
 	QUARTILE_MIN_INCREMENT,
 	QUARTILE_THRESHOLD_COUNT,
 } from "./shared/constants";
+// Declaration display context
+export type { DeclarationDisplayContext } from "./shared/declarationDisplay";
+export { getDeclarationDisplayContext } from "./shared/declarationDisplay";
 // Declaration prerequisites
 export { hasRequiredDeclarationInfo } from "./shared/declarationPrerequisites";
 // Declaration status
 export {
 	computeDeclarationStatus,
+	getCurrentCompliancePath,
 	isCancelled,
 } from "./shared/declarationStatus";
 // Display formatting (%, €, units)

--- a/packages/app/src/modules/domain/shared/declarationDisplay.ts
+++ b/packages/app/src/modules/domain/shared/declarationDisplay.ts
@@ -1,0 +1,34 @@
+type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
+
+type DeclarationLike = {
+	firstDeclarationPathChoice: CompliancePath | null;
+	secondDeclarationPathChoice: CompliancePath | null;
+	cseRequired: boolean;
+};
+
+export type DeclarationDisplayContext = {
+	firstDeclarationPathChoice: CompliancePath | null;
+	secondDeclarationPathChoice: CompliancePath | null;
+	shouldShowGapJustification: boolean;
+	shouldShowCorrectiveActions: boolean;
+	shouldShowJointEvaluation: boolean;
+	shouldShowCseOpinion: boolean;
+};
+
+export function getDeclarationDisplayContext(
+	declaration: DeclarationLike,
+): DeclarationDisplayContext {
+	const paths = [
+		declaration.firstDeclarationPathChoice,
+		declaration.secondDeclarationPathChoice,
+	];
+
+	return {
+		firstDeclarationPathChoice: declaration.firstDeclarationPathChoice,
+		secondDeclarationPathChoice: declaration.secondDeclarationPathChoice,
+		shouldShowGapJustification: paths.includes("justify"),
+		shouldShowCorrectiveActions: paths.includes("corrective_action"),
+		shouldShowJointEvaluation: paths.includes("joint_evaluation"),
+		shouldShowCseOpinion: declaration.cseRequired,
+	};
+}

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -1,5 +1,17 @@
 import type { DeclarationStatus } from "../types";
 
+type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
+
+export function getCurrentCompliancePath(declaration: {
+	firstDeclarationPathChoice: CompliancePath | null;
+	secondDeclarationPathChoice: CompliancePath | null;
+}): CompliancePath | null {
+	return (
+		declaration.secondDeclarationPathChoice ??
+		declaration.firstDeclarationPathChoice
+	);
+}
+
 export function isCancelled(declaration: {
 	cancelledAt: Date | null;
 }): boolean {


### PR DESCRIPTION
## Summary
- `getDeclarationDisplayContext(declaration)` — boolean display flags (`shouldShowGapJustification`, `shouldShowCorrectiveActions`, `shouldShowJointEvaluation`, `shouldShowCseOpinion`) derived from path columns + `cseRequired`
- `getCurrentCompliancePath(declaration)` — `secondDeclarationPathChoice ?? firstDeclarationPathChoice` (explicit helper for T4/T5 consumers)
- 100% coverage on both helpers (13 tests total across 2 files)

**Legacy `DeclarationStatus` enum** (`to_complete | in_progress | done`): still used by `my-space/` consumers (`StatusBadge`, `declarationProcessState`, `buildDeclarationList`, etc.). Cleanup deferred to T5 as planned.

Closes #3446 — sub-task of epic #3144.

## Test plan
- [x] Typecheck PASS
- [x] Tests Vitest PASS (177 tests, 13 files)
- [x] Lint + format PASS