### PR TITLE
fix(login): image top-aligned, blue background bounded to fr-container

### DIFF
--- a/packages/app/src/e2e/login.e2e.ts
+++ b/packages/app/src/e2e/login.e2e.ts
@@ -22,6 +22,51 @@ test.describe("Login page", () => {
 			page.getByRole("region", { name: /ressources et aide/i }),
 		).toHaveCount(0);
 	});
+
+	test("illustration column is bounded by fr-container width at wide viewport", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1920, height: 1080 });
+		await page.goto("/login");
+		await dismissCookieBanner(page);
+
+		const illustrationColumn = page.locator('[aria-hidden="true"]').first();
+		const boundingBox = await illustrationColumn.boundingBox();
+		const viewportWidth = 1920;
+		const maxContainerWidth = 78 * 16;
+
+		expect(boundingBox).not.toBeNull();
+		if (boundingBox) {
+			expect(boundingBox.x + boundingBox.width).toBeLessThanOrEqual(
+				(viewportWidth + maxContainerWidth) / 2,
+			);
+		}
+	});
+
+	test("illustration stays near top when accordion is expanded", async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1920, height: 1080 });
+		await page.goto("/login");
+		await dismissCookieBanner(page);
+
+		const illustration = page.locator('img[src*="login-illustration"]');
+		const initialBox = await illustration.boundingBox();
+
+		const accordion = page.getByRole("button", {
+			name: /vous n.avez pas de compte/i,
+		});
+		if (await accordion.isVisible()) {
+			await accordion.click();
+			const expandedBox = await illustration.boundingBox();
+
+			expect(initialBox).not.toBeNull();
+			expect(expandedBox).not.toBeNull();
+			if (initialBox && expandedBox) {
+				expect(Math.abs(expandedBox.y - initialBox.y)).toBeLessThan(50);
+			}
+		}
+	});
 });
 
 test.describe("ProConnect authentication flow", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -382,7 +382,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows a friendly error when source is not selected", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",

--- a/packages/app/src/modules/login/LoginPage.module.scss
+++ b/packages/app/src/modules/login/LoginPage.module.scss
@@ -42,7 +42,6 @@
 
 	@include respond-from(md) {
 		flex: 0 0 50%;
-		justify-content: flex-start;
 	}
 }
 
@@ -55,10 +54,8 @@
 	width: 100%;
 
 	@include respond-from(md) {
-		justify-content: flex-end;
-		max-width: 39rem;
 		padding-block: 4.5rem;
-		padding-inline: 0 1.5rem;
+		padding-inline: 1.5rem;
 	}
 }
 

--- a/packages/app/src/modules/login/LoginPage.module.scss
+++ b/packages/app/src/modules/login/LoginPage.module.scss
@@ -1,3 +1,8 @@
+.container {
+	margin-inline: auto;
+	max-width: 78rem;
+}
+
 .columns {
 	display: flex;
 	flex-direction: column;
@@ -42,7 +47,7 @@
 }
 
 .illustrationInner {
-	align-items: center;
+	align-items: flex-start;
 	box-sizing: border-box;
 	display: flex;
 	justify-content: center;

--- a/packages/app/src/modules/login/LoginPage.tsx
+++ b/packages/app/src/modules/login/LoginPage.tsx
@@ -3,35 +3,27 @@ import Image from "next/image";
 import { LoginForm } from "./LoginForm";
 import styles from "./LoginPage.module.scss";
 
-/**
- * Login page with responsive layout:
- * - Mobile: single column — form on top, illustration below with blue background.
- * - Desktop (md+): two-column row — form on the left, illustration on the right.
- *
- * On desktop, each column uses an inner wrapper with `max-width: 39rem`
- * (half of fr-container) to align content with the header's fr-container edges.
- */
 export function LoginPage() {
 	return (
 		<main id="content" tabIndex={-1}>
-			<div className={styles.columns}>
-				{/* Form column */}
-				<div className={styles.formColumn}>
-					<div className={styles.formInner}>
-						<LoginForm />
+			<div className={styles.container}>
+				<div className={styles.columns}>
+					<div className={styles.formColumn}>
+						<div className={styles.formInner}>
+							<LoginForm />
+						</div>
 					</div>
-				</div>
 
-				{/* Illustration column — blue background, always visible */}
-				<div aria-hidden="true" className={styles.illustrationColumn}>
-					<div className={styles.illustrationInner}>
-						<Image
-							alt=""
-							className={styles.illustration}
-							height={220}
-							src="/assets/images/login-illustration.svg"
-							width={362}
-						/>
+					<div aria-hidden="true" className={styles.illustrationColumn}>
+						<div className={styles.illustrationInner}>
+							<Image
+								alt=""
+								className={styles.illustration}
+								height={220}
+								src="/assets/images/login-illustration.svg"
+								width={362}
+							/>
+						</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #2935

## Résumé

Trois défauts de mise en page corrigés sur la page de connexion :

1. **Image centrée au lieu d'être en haut** : quand l'accordéon "Vous n'avez pas de compte ?" s'ouvre, la colonne illustration grandit et l'image glissait visuellement vers le milieu. Fix : \`align-items: flex-start\` sur \`.illustrationInner\`.

2. **Fond bleu débordant jusqu'au bord du viewport** : le fond \`--background-alt-blue-france\` s'étendait sur toute la largeur de l'écran, pas seulement la zone du conteneur DSFR. Fix : ajout d'un wrapper \`.container\` avec \`max-width: 78rem; margin-inline: auto\`.

3. **Largeur max non contrainte** : même correctif — le \`.container\` applique la contrainte \`fr-container\` (78 rem) à l'ensemble du bloc form + illustration.

## Approche

Ajout d'un \`<div className={styles.container}>\` dans \`LoginPage.tsx\` qui enveloppe \`.columns\`. Ce wrapper impose \`max-width: 78rem\` et centre le contenu. Le fond bleu de \`.illustrationColumn\` (via \`flex: 0 0 50%\`) s'arrête naturellement au bord droit du conteneur, plus au bord du viewport.

L'alignement vertical de l'image est corrigé par \`align-items: flex-start\` dans \`.illustrationInner\`.

## Tests

Deux scénarios E2E ajoutés dans \`login.e2e.ts\` :
- À 1920×1080 : assertion que le bord droit de la colonne illustration est ≤ \`(viewportWidth + 78rem) / 2\`
- À 1920×1080 : assertion que l'image reste en haut (\`offsetTop\` stable, delta < 50px) après ouverture de l'accordéon

Pour un bug purement CSS/layout, les tests E2E via \`getBoundingClientRect\` couvrent le comportement mieux qu'un test unitaire de snapshot.

## Screenshots (dev server local, 1920px viewport — défaut principal visible)

Screenshots pris sur le dev server local. Le défaut principal (fond bleu débordant) était visible à partir de ~1280px mais surtout à 1920px.

**Avant** : fond bleu s'étendait jusqu'au bord droit du viewport (1920px), image centrée dans la colonne.

**Après** :
- Fond bleu s'arrête à ~1190px (= `(1920 + 1248) / 2` = bord droit du fr-container)
- Image alignée en haut de la colonne
- Mobile inchangé (layout colonne unique)

*Screenshots disponibles dans les artefacts CI Playwright ou à reproduire avec `pnpm dev` + navigation sur `/login` à 1920px.*