### PR TITLE
fix(recherche-entreprise): fallback sur nom_complet si nom_raison_sociale est vide

### DIFF
--- a/packages/api/egapro/helpers.py
+++ b/packages/api/egapro/helpers.py
@@ -340,6 +340,19 @@ async def patch_from_recherche_entreprises(data):
                 entreprise.setdefault(key, value)
 
 
+async def fetch_raison_sociale_from_public_api(siren):
+    if not siren:
+        return None
+    url = "https://recherche-entreprises.api.gouv.fr/search"
+    params = {"q": siren, "per_page": 1}
+    headers = {"Referer": "egapro"}
+    data = await get(url, params=params, headers=headers)
+    if not data or not data.get("results"):
+        return None
+    item = data["results"][0] or {}
+    return item.get("nom_raison_sociale") or item.get("nom_complet") or None
+
+
 def compare_str(wanted: str, candidate: str):
     candidate = candidate.lower()
     if wanted == candidate:

--- a/packages/api/egapro/migrations/025_backfill_raison_sociale_from_nom_complet.py
+++ b/packages/api/egapro/migrations/025_backfill_raison_sociale_from_nom_complet.py
@@ -1,0 +1,115 @@
+import progressist
+
+from egapro import helpers
+
+
+async def main(db, logger):
+    decl_sirens = [
+        r["siren"]
+        for r in await db.declaration.fetch(
+            "SELECT DISTINCT siren FROM declaration "
+            "WHERE COALESCE(data->'entreprise'->>'raison_sociale', '') = ''"
+        )
+    ]
+    repeq_sirens = [
+        r["siren"]
+        for r in await db.representation_equilibree.fetch(
+            "SELECT DISTINCT siren FROM representation_equilibree "
+            "WHERE COALESCE(data->'entreprise'->>'raison_sociale', '') = ''"
+        )
+    ]
+    ues_records = await db.declaration.fetch(
+        "SELECT siren, year, owner, modified_at, data FROM declaration "
+        "WHERE jsonb_array_length(COALESCE(data->'entreprise'->'ues'->'entreprises', '[]'::jsonb)) > 0 "
+        "AND EXISTS ("
+        "  SELECT 1 FROM jsonb_array_elements(data->'entreprise'->'ues'->'entreprises') ue "
+        "  WHERE COALESCE(ue->>'raison_sociale', '') = ''"
+        ")"
+    )
+
+    ues_sirens = set()
+    for record in ues_records:
+        for ue in record.data.path("entreprise.ues.entreprises") or []:
+            if not ue.get("raison_sociale") and ue.get("siren"):
+                ues_sirens.add(ue["siren"])
+
+    siren_to_name = {}
+    all_sirens = sorted(set(decl_sirens) | set(repeq_sirens) | ues_sirens)
+    logger.info(
+        "Backfill: %d declarations, %d repeq, %d UES children, %d unique SIRENs",
+        len(decl_sirens),
+        len(repeq_sirens),
+        len(ues_sirens),
+        len(all_sirens),
+    )
+
+    bar = progressist.ProgressBar(prefix="Fetching…", total=len(all_sirens))
+    for siren in bar.iter(all_sirens):
+        try:
+            name = await helpers.fetch_raison_sociale_from_public_api(siren)
+        except Exception as exc:
+            logger.warning("Failed to fetch %s: %s", siren, exc)
+            continue
+        if name:
+            siren_to_name[siren] = name
+
+    logger.info("Fetched names for %d / %d SIRENs", len(siren_to_name), len(all_sirens))
+
+    updated_decl = 0
+    for siren in decl_sirens:
+        name = siren_to_name.get(siren)
+        if not name:
+            continue
+        res = await db.declaration.execute(
+            "UPDATE declaration "
+            "SET data = jsonb_set(data, '{entreprise,raison_sociale}', to_jsonb($2::text)) "
+            "WHERE siren=$1 AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''",
+            siren,
+            name,
+        )
+        if res:
+            updated_decl += int(res.split()[-1]) if res.split()[-1].isdigit() else 0
+
+    updated_repeq = 0
+    for siren in repeq_sirens:
+        name = siren_to_name.get(siren)
+        if not name:
+            continue
+        res = await db.representation_equilibree.execute(
+            "UPDATE representation_equilibree "
+            "SET data = jsonb_set(data, '{entreprise,raison_sociale}', to_jsonb($2::text)) "
+            "WHERE siren=$1 AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''",
+            siren,
+            name,
+        )
+        if res:
+            updated_repeq += int(res.split()[-1]) if res.split()[-1].isdigit() else 0
+
+    updated_ues_records = 0
+    for record in ues_records:
+        data = record.data.raw
+        entreprises = data["entreprise"]["ues"]["entreprises"]
+        changed = False
+        for ue in entreprises:
+            if ue.get("raison_sociale"):
+                continue
+            name = siren_to_name.get(ue.get("siren"))
+            if name:
+                ue["raison_sociale"] = name
+                changed = True
+        if changed:
+            await db.declaration.put(
+                record.data.siren,
+                record.data.year,
+                declarant=record["owner"],
+                data=data,
+                modified_at=record["modified_at"],
+            )
+            updated_ues_records += 1
+
+    logger.info(
+        "Backfill complete: %d declarations, %d repeq, %d UES records updated",
+        updated_decl,
+        updated_repeq,
+        updated_ues_records,
+    )

--- a/packages/api/egapro/migrations/025_backfill_raison_sociale_from_nom_complet.py
+++ b/packages/api/egapro/migrations/025_backfill_raison_sociale_from_nom_complet.py
@@ -8,23 +8,22 @@ async def main(db, logger):
         r["siren"]
         for r in await db.declaration.fetch(
             "SELECT DISTINCT siren FROM declaration "
-            "WHERE COALESCE(data->'entreprise'->>'raison_sociale', '') = ''"
+            "WHERE jsonb_typeof(data->'entreprise') = 'object' "
+            "AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''"
         )
     ]
     repeq_sirens = [
         r["siren"]
         for r in await db.representation_equilibree.fetch(
             "SELECT DISTINCT siren FROM representation_equilibree "
-            "WHERE COALESCE(data->'entreprise'->>'raison_sociale', '') = ''"
+            "WHERE jsonb_typeof(data->'entreprise') = 'object' "
+            "AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''"
         )
     ]
     ues_records = await db.declaration.fetch(
-        "SELECT siren, year, owner, modified_at, data FROM declaration "
-        "WHERE jsonb_array_length(COALESCE(data->'entreprise'->'ues'->'entreprises', '[]'::jsonb)) > 0 "
-        "AND EXISTS ("
-        "  SELECT 1 FROM jsonb_array_elements(data->'entreprise'->'ues'->'entreprises') ue "
-        "  WHERE COALESCE(ue->>'raison_sociale', '') = ''"
-        ")"
+        "SELECT siren, year, declarant, modified_at, data FROM declaration "
+        "WHERE jsonb_typeof(data->'entreprise'->'ues'->'entreprises') = 'array' "
+        "AND jsonb_array_length(data->'entreprise'->'ues'->'entreprises') > 0"
     )
 
     ues_sirens = set()
@@ -63,7 +62,9 @@ async def main(db, logger):
         res = await db.declaration.execute(
             "UPDATE declaration "
             "SET data = jsonb_set(data, '{entreprise,raison_sociale}', to_jsonb($2::text)) "
-            "WHERE siren=$1 AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''",
+            "WHERE siren=$1 "
+            "AND jsonb_typeof(data->'entreprise') = 'object' "
+            "AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''",
             siren,
             name,
         )
@@ -78,7 +79,9 @@ async def main(db, logger):
         res = await db.representation_equilibree.execute(
             "UPDATE representation_equilibree "
             "SET data = jsonb_set(data, '{entreprise,raison_sociale}', to_jsonb($2::text)) "
-            "WHERE siren=$1 AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''",
+            "WHERE siren=$1 "
+            "AND jsonb_typeof(data->'entreprise') = 'object' "
+            "AND COALESCE(data->'entreprise'->>'raison_sociale', '') = ''",
             siren,
             name,
         )
@@ -101,7 +104,7 @@ async def main(db, logger):
             await db.declaration.put(
                 record.data.siren,
                 record.data.year,
-                declarant=record["owner"],
+                declarant=record["declarant"],
                 data=data,
                 modified_at=record["modified_at"],
             )

--- a/packages/api/test/test_helpers.py
+++ b/packages/api/test/test_helpers.py
@@ -525,3 +525,76 @@ async def test_recherche_entreprise_with_date_radiation_current_year(monkeypatch
 )
 def test_code_insee_to_departement(code, expected):
     assert helpers.code_insee_to_departement(code) == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_raison_sociale_uses_nom_raison_sociale_when_present(monkeypatch):
+    async def mock_get(*args, **kwargs):
+        return {
+            "results": [
+                {"nom_raison_sociale": "RAISON SOCIALE SARL", "nom_complet": "Raison Sociale"}
+            ]
+        }
+
+    monkeypatch.setattr("egapro.helpers.get", mock_get)
+    assert (
+        await helpers.fetch_raison_sociale_from_public_api("384964508")
+        == "RAISON SOCIALE SARL"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_raison_sociale_falls_back_to_nom_complet(monkeypatch):
+    async def mock_get(*args, **kwargs):
+        return {"results": [{"nom_complet": "Nom Complet Only"}]}
+
+    monkeypatch.setattr("egapro.helpers.get", mock_get)
+    assert (
+        await helpers.fetch_raison_sociale_from_public_api("384964508")
+        == "Nom Complet Only"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_raison_sociale_falls_back_when_nom_raison_sociale_is_empty(
+    monkeypatch,
+):
+    async def mock_get(*args, **kwargs):
+        return {
+            "results": [
+                {"nom_raison_sociale": "", "nom_complet": "Nom Complet Fallback"}
+            ]
+        }
+
+    monkeypatch.setattr("egapro.helpers.get", mock_get)
+    assert (
+        await helpers.fetch_raison_sociale_from_public_api("384964508")
+        == "Nom Complet Fallback"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_raison_sociale_returns_none_when_both_missing(monkeypatch):
+    async def mock_get(*args, **kwargs):
+        return {"results": [{"siren": "384964508"}]}
+
+    monkeypatch.setattr("egapro.helpers.get", mock_get)
+    assert await helpers.fetch_raison_sociale_from_public_api("384964508") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_raison_sociale_returns_none_on_empty_results(monkeypatch):
+    async def mock_get(*args, **kwargs):
+        return {"results": []}
+
+    monkeypatch.setattr("egapro.helpers.get", mock_get)
+    assert await helpers.fetch_raison_sociale_from_public_api("384964508") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_raison_sociale_returns_none_on_api_failure(monkeypatch):
+    async def mock_get(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("egapro.helpers.get", mock_get)
+    assert await helpers.fetch_raison_sociale_from_public_api("384964508") is None

--- a/packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts
+++ b/packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts
@@ -255,7 +255,7 @@ export class RechercheEntrepriseService implements IEntrepriseService {
       etablissements: item.nombre_etablissements || 0,
       etatAdministratifUniteLegale: (item.etat_administratif || "A") as EtatAdministratif,
       label: item.nom_complet || "",
-      simpleLabel: item.nom_raison_sociale || "",
+      simpleLabel: item.nom_raison_sociale || item.nom_complet || "",
       highlightLabel: item.nom_complet || "",
       matching: item.matching_etablissements?.length || 0,
       siren: item.siren || "",

--- a/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
+++ b/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
@@ -1,0 +1,79 @@
+import { Siren } from "@common/core-domain/domain/valueObjects/Siren";
+
+import { RechercheEntrepriseService } from "../RechercheEntrepriseService";
+
+const TEST_SIREN = "384964508";
+
+function mockFetchOnce(body: unknown) {
+  global.fetch = jest.fn().mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as Response);
+}
+
+describe("RechercheEntrepriseService.siren mapping", () => {
+  const service = new RechercheEntrepriseService();
+  const siren = new Siren(TEST_SIREN);
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses nom_raison_sociale when present", async () => {
+    mockFetchOnce({
+      results: [
+        {
+          siren: TEST_SIREN,
+          nom_raison_sociale: "RAISON SOCIALE SARL",
+          nom_complet: "Raison Sociale SARL — Nom Complet",
+        },
+      ],
+    });
+
+    const entreprise = await service.siren(siren);
+    expect(entreprise.simpleLabel).toBe("RAISON SOCIALE SARL");
+  });
+
+  it("falls back to nom_complet when nom_raison_sociale is missing", async () => {
+    mockFetchOnce({
+      results: [
+        {
+          siren: TEST_SIREN,
+          nom_complet: "Nom Complet Only",
+        },
+      ],
+    });
+
+    const entreprise = await service.siren(siren);
+    expect(entreprise.simpleLabel).toBe("Nom Complet Only");
+  });
+
+  it("falls back to nom_complet when nom_raison_sociale is empty string", async () => {
+    mockFetchOnce({
+      results: [
+        {
+          siren: TEST_SIREN,
+          nom_raison_sociale: "",
+          nom_complet: "Nom Complet Fallback",
+        },
+      ],
+    });
+
+    const entreprise = await service.siren(siren);
+    expect(entreprise.simpleLabel).toBe("Nom Complet Fallback");
+  });
+
+  it("returns empty simpleLabel when both names are missing", async () => {
+    mockFetchOnce({
+      results: [
+        {
+          siren: TEST_SIREN,
+        },
+      ],
+    });
+
+    const entreprise = await service.siren(siren);
+    expect(entreprise.simpleLabel).toBe("");
+  });
+});

--- a/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
+++ b/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
@@ -1,79 +1,248 @@
+import {
+	EntrepriseServiceError,
+	EntrepriseServiceNotFoundError,
+} from "@api/core-domain/infra/services/IEntrepriseService";
 import { Siren } from "@common/core-domain/domain/valueObjects/Siren";
+import { Siret } from "@common/core-domain/domain/valueObjects/Siret";
+import { StatusCodes } from "http-status-codes";
 
 import { RechercheEntrepriseService } from "../RechercheEntrepriseService";
 
 const TEST_SIREN = "384964508";
+const TEST_SIRET = "42480547100044";
 
-function mockFetchOnce(body: unknown) {
-  global.fetch = jest.fn().mockResolvedValueOnce({
-    ok: true,
-    status: 200,
-    json: async () => body,
-  } as Response);
+function mockFetchOnce(body: unknown, init: Partial<Response> = {}) {
+	global.fetch = jest.fn().mockResolvedValueOnce({
+		ok: init.status ? init.status >= 200 && init.status < 300 : true,
+		status: init.status ?? 200,
+		json: async () => body,
+		...init,
+	} as Response);
 }
 
-describe("RechercheEntrepriseService.siren mapping", () => {
-  const service = new RechercheEntrepriseService();
-  const siren = new Siren(TEST_SIREN);
+function makeApiResult(overrides: Record<string, unknown> = {}) {
+	return {
+		siren: TEST_SIREN,
+		nom_raison_sociale: "ACME SARL",
+		nom_complet: "Acme SARL",
+		activite_principale: "62.02A",
+		caractere_employeur: "O",
+		nature_juridique: "5710",
+		date_creation: "2010-01-01",
+		etat_administratif: "A",
+		nombre_etablissements: 3,
+		matching_etablissements: [
+			{
+				siret: TEST_SIRET,
+				adresse: "1 rue test 75001 PARIS",
+				code_postal: "75001",
+				commune: "75101",
+				libelle_commune: "PARIS 1",
+				activite_principale: "62.02A",
+				est_siege: true,
+				etat_administratif: "A",
+			},
+		],
+		siege: {
+			siret: TEST_SIRET,
+			adresse: "1 rue test 75001 PARIS",
+			code_postal: "75001",
+			commune: "75101",
+			libelle_commune: "PARIS 1",
+			activite_principale: "62.02A",
+			est_siege: true,
+			etat_administratif: "A",
+		},
+		complements: { liste_idcc: ["1486"] },
+		...overrides,
+	};
+}
 
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+describe("RechercheEntrepriseService", () => {
+	const service = new RechercheEntrepriseService();
+	const siren = new Siren(TEST_SIREN);
 
-  it("uses nom_raison_sociale when present", async () => {
-    mockFetchOnce({
-      results: [
-        {
-          siren: TEST_SIREN,
-          nom_raison_sociale: "RAISON SOCIALE SARL",
-          nom_complet: "Raison Sociale SARL — Nom Complet",
-        },
-      ],
-    });
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
 
-    const entreprise = await service.siren(siren);
-    expect(entreprise.simpleLabel).toBe("RAISON SOCIALE SARL");
-  });
+	describe("siren mapping — nom_complet fallback (ticket #3442)", () => {
+		it("uses nom_raison_sociale when present", async () => {
+			mockFetchOnce({
+				results: [
+					{
+						siren: TEST_SIREN,
+						nom_raison_sociale: "RAISON SOCIALE SARL",
+						nom_complet: "x",
+					},
+				],
+			});
+			const entreprise = await service.siren(siren);
+			expect(entreprise.simpleLabel).toBe("RAISON SOCIALE SARL");
+		});
 
-  it("falls back to nom_complet when nom_raison_sociale is missing", async () => {
-    mockFetchOnce({
-      results: [
-        {
-          siren: TEST_SIREN,
-          nom_complet: "Nom Complet Only",
-        },
-      ],
-    });
+		it("falls back to nom_complet when nom_raison_sociale is missing", async () => {
+			mockFetchOnce({
+				results: [{ siren: TEST_SIREN, nom_complet: "Nom Complet Only" }],
+			});
+			const entreprise = await service.siren(siren);
+			expect(entreprise.simpleLabel).toBe("Nom Complet Only");
+		});
 
-    const entreprise = await service.siren(siren);
-    expect(entreprise.simpleLabel).toBe("Nom Complet Only");
-  });
+		it("falls back to nom_complet when nom_raison_sociale is empty string", async () => {
+			mockFetchOnce({
+				results: [
+					{
+						siren: TEST_SIREN,
+						nom_raison_sociale: "",
+						nom_complet: "Nom Complet Fallback",
+					},
+				],
+			});
+			const entreprise = await service.siren(siren);
+			expect(entreprise.simpleLabel).toBe("Nom Complet Fallback");
+		});
 
-  it("falls back to nom_complet when nom_raison_sociale is empty string", async () => {
-    mockFetchOnce({
-      results: [
-        {
-          siren: TEST_SIREN,
-          nom_raison_sociale: "",
-          nom_complet: "Nom Complet Fallback",
-        },
-      ],
-    });
+		it("returns empty simpleLabel when both names are missing", async () => {
+			mockFetchOnce({ results: [{ siren: TEST_SIREN }] });
+			const entreprise = await service.siren(siren);
+			expect(entreprise.simpleLabel).toBe("");
+		});
+	});
 
-    const entreprise = await service.siren(siren);
-    expect(entreprise.simpleLabel).toBe("Nom Complet Fallback");
-  });
+	describe("siren — error handling", () => {
+		it("injects a NON-DIFFUSIBLE placeholder when results is empty", async () => {
+			mockFetchOnce({ results: [] });
+			const entreprise = await service.siren(siren);
+			expect(entreprise.simpleLabel).toBe("[NON-DIFFUSIBLE]");
+			expect(entreprise.siren).toBe(TEST_SIREN);
+		});
 
-  it("returns empty simpleLabel when both names are missing", async () => {
-    mockFetchOnce({
-      results: [
-        {
-          siren: TEST_SIREN,
-        },
-      ],
-    });
+		it("throws EntrepriseServiceNotFoundError on 404", async () => {
+			mockFetchOnce({}, { status: StatusCodes.NOT_FOUND });
+			await expect(service.siren(siren)).rejects.toBeInstanceOf(
+				EntrepriseServiceNotFoundError,
+			);
+		});
 
-    const entreprise = await service.siren(siren);
-    expect(entreprise.simpleLabel).toBe("");
-  });
+		it("throws EntrepriseServiceError on 500", async () => {
+			mockFetchOnce({}, { status: StatusCodes.INTERNAL_SERVER_ERROR });
+			await expect(service.siren(siren)).rejects.toBeInstanceOf(
+				EntrepriseServiceError,
+			);
+		});
+	});
+
+	describe("search", () => {
+		it("maps API results into Entreprise[]", async () => {
+			mockFetchOnce({ results: [makeApiResult()] });
+			const result = await service.search({ query: "acme" });
+			expect(result).toHaveLength(1);
+			expect(result[0]?.siren).toBe(TEST_SIREN);
+			expect(result[0]?.label).toBe("Acme SARL");
+			expect(result[0]?.simpleLabel).toBe("ACME SARL");
+		});
+
+		it("injects a NON-DIFFUSIBLE placeholder for SIREN queries with empty results", async () => {
+			mockFetchOnce({ results: [] });
+			const result = await service.search({ query: TEST_SIREN });
+			expect(result).toHaveLength(1);
+			expect(result[0]?.simpleLabel).toBe("[NON-DIFFUSIBLE]");
+		});
+
+		it("filters by employer=true to keep only declared employers", async () => {
+			mockFetchOnce({
+				results: [
+					makeApiResult({ siren: "111111119", caractere_employeur: "O" }),
+					makeApiResult({ siren: "222222226", caractere_employeur: "N" }),
+				],
+			});
+			const result = await service.search({ query: "test", employer: true });
+			expect(result.map((r) => r.siren)).toEqual(["111111119"]);
+		});
+
+		it("filters by open=true to keep only active companies", async () => {
+			mockFetchOnce({
+				results: [
+					makeApiResult({ siren: "111111119", etat_administratif: "A" }),
+					makeApiResult({ siren: "222222226", etat_administratif: "C" }),
+				],
+			});
+			const result = await service.search({ query: "test", open: true });
+			expect(result.map((r) => r.siren)).toEqual(["111111119"]);
+		});
+
+		it("sorts by descending number of etablissements when ranked=true", async () => {
+			mockFetchOnce({
+				results: [
+					makeApiResult({ siren: "111111119", nombre_etablissements: 5 }),
+					makeApiResult({ siren: "222222226", nombre_etablissements: 20 }),
+				],
+			});
+			const result = await service.search({ query: "test", ranked: true });
+			expect(result.map((r) => r.siren)).toEqual(["222222226", "111111119"]);
+		});
+
+		it("throws EntrepriseServiceNotFoundError on 404", async () => {
+			mockFetchOnce({}, { status: StatusCodes.NOT_FOUND });
+			await expect(service.search({ query: "x" })).rejects.toBeInstanceOf(
+				EntrepriseServiceNotFoundError,
+			);
+		});
+
+		it("throws EntrepriseServiceError on 500", async () => {
+			mockFetchOnce({}, { status: StatusCodes.INTERNAL_SERVER_ERROR });
+			await expect(service.search({ query: "x" })).rejects.toBeInstanceOf(
+				EntrepriseServiceError,
+			);
+		});
+	});
+
+	describe("siret", () => {
+		const siret = new Siret(TEST_SIRET);
+
+		it("maps API result for a matching etablissement", async () => {
+			mockFetchOnce({ results: [makeApiResult()] });
+			const result = await service.siret(siret);
+			expect(result.siret).toBe(TEST_SIRET);
+			expect(result.siren).toBe(TEST_SIREN);
+			expect(result.etablissementSiege).toBe(true);
+		});
+
+		it("throws EntrepriseServiceNotFoundError when results is empty", async () => {
+			mockFetchOnce({ results: [] });
+			await expect(service.siret(siret)).rejects.toBeInstanceOf(
+				EntrepriseServiceNotFoundError,
+			);
+		});
+
+		it("throws EntrepriseServiceNotFoundError when no matching_etablissements", async () => {
+			mockFetchOnce({
+				results: [makeApiResult({ matching_etablissements: [] })],
+			});
+			await expect(service.siret(siret)).rejects.toBeInstanceOf(
+				EntrepriseServiceNotFoundError,
+			);
+		});
+
+		it("throws EntrepriseServiceNotFoundError when no matching etablissement for the SIRET", async () => {
+			mockFetchOnce({
+				results: [
+					makeApiResult({
+						matching_etablissements: [{ siret: "00000000000000" }],
+					}),
+				],
+			});
+			await expect(service.siret(siret)).rejects.toBeInstanceOf(
+				EntrepriseServiceNotFoundError,
+			);
+		});
+
+		it("throws EntrepriseServiceNotFoundError on 404", async () => {
+			mockFetchOnce({}, { status: StatusCodes.NOT_FOUND });
+			await expect(service.siret(siret)).rejects.toBeInstanceOf(
+				EntrepriseServiceNotFoundError,
+			);
+		});
+	});
 });


### PR DESCRIPTION
Closes #3442

## Contexte

Quand l'API `recherche-entreprises.api.gouv.fr` renvoie une unité légale dont `nom_raison_sociale` est absent ou vide, le `simpleLabel` exposé par `RechercheEntrepriseService.mapToEntreprise` était une chaîne vide. Or `simpleLabel` est utilisé comme **raison sociale** dans une douzaine d'écrans, et persisté en JSONB dans `declaration.data.entreprise.raison_sociale` (et idem pour `representation_equilibree`, UES enfants).

Le ticket demande de retomber sur `nom_complet` quand `nom_raison_sociale` est vide.

## Deux changements

### 1. Fix flux applicatif (TS) — `5e02e281`

[packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts:258](packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts#L258)

```diff
-      simpleLabel: item.nom_raison_sociale || "",
+      simpleLabel: item.nom_raison_sociale || item.nom_complet || "",
```

Pour les nouvelles soumissions. `highlightLabel` est déjà sur `nom_complet`. `mapToEtablissementFromUniteLegale` (ligne 313) utilise `nom_commercial` côté SIRET, hors périmètre.

### 2. Backfill des données existantes (API Python) — `db6e2db0`

Le fix TS ne corrige que le futur. Le mécanisme `helpers.patch_from_recherche_entreprises` (`views.py:194/219/305/551`) patche en mémoire à la lecture mais **ne met pas à jour la DB**, et surtout les **exports DGT** (`dgt.py:345/362`, `csv_representation.py:21`, `dgt_representation.py:55`, `exporter.py:67`) lisent `raison_sociale` directement depuis la donnée stockée → entreprises sans `nom_raison_sociale` ressortent avec `""` dans les fichiers transmis à la DGT.

Ajoute :
- `helpers.fetch_raison_sociale_from_public_api(siren)` qui interroge directement `recherche-entreprises.api.gouv.fr` (pas le proxy V1) pour appliquer le fallback sur les champs bruts.
- `packages/api/egapro/migrations/025_backfill_raison_sociale_from_nom_complet.py` qui parcourt :
  - `declaration` et `representation_equilibree` avec `raison_sociale` vide → `UPDATE ... jsonb_set`
  - UES enfants (`entreprise.ues.entreprises[]`) → modification Python puis `db.declaration.put(...)` (impossible en pur SQL pour les éléments d'array)

#### Exécution

```bash
egapro migrate 025_backfill_raison_sociale_from_nom_complet
```

**Étapes recommandées** :
1. Tester sur preprod avant prod.
2. Vérifier les logs (`X declarations, Y repeq, Z UES children, N unique SIRENs`).
3. Re-générer un export DGT pour confirmer que les `""` ont disparu.

L'API publique a un rate limit doux (~10 req/s) — pour 5k SIRENs, comptez ~10min. Si l'API échoue sur un SIREN, on logge un warning et on passe au suivant (idempotent : la migration ne touche que les rows toujours vides).

## Tests

### TS
Nouveau fichier `packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts` — 4 cas via `siren()` avec `fetch` mocké. Tous passent en local.

### Python
6 nouveaux tests dans `packages/api/test/test_helpers.py` pour `fetch_raison_sociale_from_public_api` (`nom_raison_sociale` présent / absent / empty string / les deux absents / API empty results / API failure). À valider en CI (env Docker pour les tests Python).

## Test plan

- [x] `pnpm lint` sur les fichiers TS modifiés
- [x] Tests TS Jest passent
- [ ] CI verte
- [ ] Vérification review app : déclaration avec un SIREN sans `nom_raison_sociale` → label visible
- [ ] Sur preprod : `egapro migrate 025_backfill_raison_sociale_from_nom_complet`, vérifier compteurs + sondage SQL avant/après
- [ ] Sur prod : idem après validation preprod

## Note de scope

Le titre du ticket mentionne "V1" — j'ai pris le parti que c'est un préfixe de priorisation et non une référence au code legacy Python `helpers.py:234` (qui passe par un proxy interne pré-mappant déjà `simpleLabel`). À confirmer en review.