### PR TITLE
feat(declaration): save on Précédent click for steps 2-5

### DIFF
--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -303,10 +303,10 @@ test.describe("Declaration workflow", () => {
 	});
 
 	test("previous button navigates back", async ({ page }) => {
-		await page.goto("/declaration-remuneration/etape/2");
+		await goToStep(page, 6);
 
 		await page.getByRole("link", { name: "Précédent" }).click();
-		await page.waitForURL("**/declaration-remuneration/etape/1");
+		await page.waitForURL("**/declaration-remuneration/etape/5");
 	});
 
 	test("previous button is present on step pages", async ({ page }) => {

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useRef } from "react";
 import { Controller } from "react-hook-form";
 
 import { useReadOnlyGuard } from "~/modules/auth";
@@ -69,36 +70,55 @@ export function Step1Opinions({
 		},
 	});
 
+	const NEXT_URL = "/avis-cse/etape/2";
+	const navTargetRef = useRef<"next" | "back">("next");
+
 	const mutation = api.cseOpinion.saveOpinions.useMutation({
-		onSuccess: () => router.push("/avis-cse/etape/2"),
+		onSuccess: () => {
+			if (navTargetRef.current === "back") {
+				router.back();
+			} else {
+				router.push(NEXT_URL);
+			}
+		},
 	});
 
-	const onSubmit = form.handleSubmit((data) => {
-		// Additional validation for conditional gap fields
-		const firstGapIncomplete =
-			data.firstDeclaration.gapConsulted === true &&
-			(!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
-		const secondGapIncomplete =
-			hasSecondDeclaration &&
-			data.secondDeclaration?.gapConsulted === true &&
-			(!data.secondDeclaration?.gapOpinion || !data.secondDeclaration?.gapDate);
+	function triggerSave(direction: "next" | "back") {
+		form.handleSubmit((data) => {
+			const firstGapIncomplete =
+				data.firstDeclaration.gapConsulted === true &&
+				(!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
+			const secondGapIncomplete =
+				hasSecondDeclaration &&
+				data.secondDeclaration?.gapConsulted === true &&
+				(!data.secondDeclaration?.gapOpinion ||
+					!data.secondDeclaration?.gapDate);
 
-		if (firstGapIncomplete) {
-			form.setError("firstDeclaration.gapOpinion", {
-				message: "Veuillez remplir tous les champs de consultation.",
-			});
-			return;
-		}
+			if (firstGapIncomplete) {
+				form.setError("firstDeclaration.gapOpinion", {
+					message: "Veuillez remplir tous les champs de consultation.",
+				});
+				return;
+			}
+			if (secondGapIncomplete) {
+				form.setError("secondDeclaration.gapOpinion", {
+					message: "Veuillez remplir tous les champs de consultation.",
+				});
+				return;
+			}
+			navTargetRef.current = direction;
+			mutation.mutate(data);
+		})();
+	}
 
-		if (secondGapIncomplete) {
-			form.setError("secondDeclaration.gapOpinion", {
-				message: "Veuillez remplir tous les champs de consultation.",
-			});
-			return;
-		}
+	const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		triggerSave("next");
+	};
 
-		mutation.mutate(data);
-	});
+	function onPrevious() {
+		triggerSave("back");
+	}
 
 	// Watch fields for controlled sub-components
 	const firstDeclOpinion = form.watch("firstDeclaration.accuracyOpinion");
@@ -242,10 +262,13 @@ export function Step1Opinions({
 			<div className={`fr-mt-4w ${formStyles.actions}`}>
 				<button
 					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
-					onClick={() => router.back()}
+					disabled={mutation.isPending}
+					onClick={onPrevious}
 					type="button"
 				>
-					Précédent
+					{mutation.isPending && navTargetRef.current === "back"
+						? "Enregistrement…"
+						: "Précédent"}
 				</button>
 				<span>
 					<button
@@ -254,7 +277,9 @@ export function Step1Opinions({
 						disabled={mutation.isPending || readOnlyGuard.isReadOnly}
 						type="submit"
 					>
-						{mutation.isPending ? "Enregistrement…" : "Suivant"}
+						{mutation.isPending && navTargetRef.current === "next"
+							? "Enregistrement…"
+							: "Suivant"}
 					</button>
 					{readOnlyGuard.tooltip}
 				</span>

--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
@@ -7,24 +7,20 @@ import styles from "./FormActions.module.scss";
 
 type FormActionsProps = {
 	previousHref?: string;
+	onPrevious?: () => void;
+	isPreviousPending?: boolean;
 	nextHref?: string;
 	nextLabel?: string;
 	isSubmitting?: boolean;
 	nextDisabled?: boolean;
 	className?: string;
-	/**
-	 * URL used by the "Suivant" button while admin impersonation is active.
-	 * - Provided (data already saved) → button is rendered as a Link so the admin
-	 *   can navigate without triggering the submit/save mutation.
-	 * - Omitted (data never saved) → button stays disabled, since navigating
-	 *   forward without any saved data would skip a step (issue #3230).
-	 * Ignored when `nextHref` is set (the button is already a Link).
-	 */
 	mimoquageNextHref?: string;
 };
 
 export function FormActions({
 	previousHref,
+	onPrevious,
+	isPreviousPending = false,
 	nextHref,
 	nextLabel = "Suivant",
 	isSubmitting = false,
@@ -34,9 +30,20 @@ export function FormActions({
 }: FormActionsProps) {
 	const { isReadOnly, buttonProps, tooltip } = useReadOnlyGuard();
 
+	const showPreviousAsButton = onPrevious !== undefined && !isReadOnly;
+
 	return (
 		<div className={`fr-mt-4w ${styles.actions} ${className ?? ""}`}>
-			{previousHref ? (
+			{showPreviousAsButton ? (
+				<button
+					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+					disabled={isPreviousPending || isSubmitting}
+					onClick={onPrevious}
+					type="button"
+				>
+					{isPreviousPending ? "Enregistrement…" : "Précédent"}
+				</button>
+			) : previousHref ? (
 				<Link
 					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
 					href={previousHref}
@@ -69,7 +76,9 @@ export function FormActions({
 					<button
 						{...buttonProps}
 						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-						disabled={isReadOnly || isSubmitting || nextDisabled}
+						disabled={
+							isReadOnly || isSubmitting || isPreviousPending || nextDisabled
+						}
 						type="submit"
 					>
 						{isSubmitting ? "Enregistrement…" : nextLabel}

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useSession } from "next-auth/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -107,6 +108,83 @@ describe("FormActions", () => {
 			render(<FormActions />);
 
 			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("onPrevious prop", () => {
+		it("renders a button for Précédent when onPrevious is provided", async () => {
+			const user = userEvent.setup();
+			const handlePrevious = vi.fn();
+			render(
+				<FormActions onPrevious={handlePrevious} previousHref="/step/1" />,
+			);
+
+			const btn = screen.getByRole("button", { name: /précédent/i });
+			expect(btn).toHaveAttribute("type", "button");
+			await user.click(btn);
+			expect(handlePrevious).toHaveBeenCalledTimes(1);
+		});
+
+		it("shows Enregistrement… on Précédent when isPreviousPending is true", () => {
+			render(
+				<FormActions
+					isPreviousPending
+					onPrevious={vi.fn()}
+					previousHref="/step/1"
+				/>,
+			);
+
+			expect(screen.getByText("Enregistrement…")).toBeInTheDocument();
+		});
+
+		it("disables Précédent and Suivant when isPreviousPending is true", () => {
+			render(
+				<FormActions
+					isPreviousPending
+					onPrevious={vi.fn()}
+					previousHref="/step/1"
+				/>,
+			);
+
+			expect(
+				screen.getByRole("button", { name: "Enregistrement…" }),
+			).toBeDisabled();
+			expect(screen.getByRole("button", { name: /suivant/i })).toBeDisabled();
+		});
+
+		it("disables Précédent and Suivant when isSubmitting is true", () => {
+			render(
+				<FormActions
+					isSubmitting
+					onPrevious={vi.fn()}
+					previousHref="/step/1"
+				/>,
+			);
+
+			expect(screen.getByRole("button", { name: /précédent/i })).toBeDisabled();
+		});
+
+		it("renders a Link for Précédent when admin is impersonating even if onPrevious is provided", () => {
+			mockedUseSession.mockReturnValue({
+				data: {
+					user: {
+						id: "admin-1",
+						impersonation: { siren: "123456789", name: "Acme" },
+					},
+					expires: "2099-01-01",
+				},
+				status: "authenticated",
+			} as unknown as ReturnType<typeof useSession>);
+
+			render(<FormActions onPrevious={vi.fn()} previousHref="/step/1" />);
+
+			const link = screen.getByRole("link", { name: /précédent/i });
+			expect(link).toHaveAttribute("href", "/step/1");
+			expect(
+				screen.queryByRole("button", { name: /précédent/i }),
+			).not.toBeInTheDocument();
+
+			mockedUseSession.mockReset();
 		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Controller } from "react-hook-form";
 import { useIsImpersonating } from "~/modules/auth";
 import { saveCompliancePathSchema } from "~/modules/declaration-remuneration/schemas";
@@ -77,10 +77,16 @@ export function CompliancePathChoice({
 	const hasInitialData = !!initialPath;
 	const saved = !hasDraft && hasInitialData;
 
+	const PREV_URL = "/declaration-remuneration/etape/6";
+	const navTargetRef = useRef<string | null>(null);
+
 	const mutation = api.declaration.saveCompliancePath.useMutation({
 		onSuccess: (_, { path }) => {
 			clearDraft();
-			if (path === "corrective_action") {
+			if (navTargetRef.current === PREV_URL) {
+				navTargetRef.current = null;
+				router.push(PREV_URL);
+			} else if (path === "corrective_action") {
 				router.push("/declaration-remuneration/parcours-conformite/etape/1");
 			} else if (path === "joint_evaluation") {
 				router.push(
@@ -94,8 +100,18 @@ export function CompliancePathChoice({
 
 	const onSubmit = form.handleSubmit((data) => {
 		if (!data.path) return;
+		navTargetRef.current = null;
 		mutation.mutate({ path: data.path });
 	});
+
+	function onPrevious() {
+		if (selectedPath) {
+			navTargetRef.current = PREV_URL;
+			mutation.mutate({ path: selectedPath });
+		} else {
+			router.push(PREV_URL);
+		}
+	}
 
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
@@ -193,13 +209,17 @@ export function CompliancePathChoice({
 			/>
 
 			<FormActions
-				isSubmitting={mutation.isPending}
+				isPreviousPending={
+					mutation.isPending && navTargetRef.current === PREV_URL
+				}
+				isSubmitting={mutation.isPending && navTargetRef.current !== PREV_URL}
 				mimoquageNextHref={
 					initialPath ? getCompliancePathHref(initialPath) : undefined
 				}
 				nextDisabled={!selectedPath}
 				nextLabel="Suivant"
-				previousHref="/declaration-remuneration/etape/6"
+				onPrevious={onPrevious}
+				previousHref={PREV_URL}
 			/>
 		</form>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
@@ -89,10 +89,14 @@ export function Step2PayGap({
 	const saved = !hasDraft && hasInitialData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
+	const NEXT_URL = "/declaration-remuneration/etape/3";
+	const PREV_URL = "/declaration-remuneration/etape/1";
+	const navTargetRef = useRef(NEXT_URL);
+
 	const mutation = api.declaration.updateStep2.useMutation({
 		onSuccess: () => {
 			clearDraft();
-			router.push("/declaration-remuneration/etape/3");
+			router.push(navTargetRef.current);
 		},
 	});
 
@@ -104,17 +108,29 @@ export function Step2PayGap({
 		form.setValue(fieldName, normalized);
 	}
 
-	const onSubmit = form.handleSubmit(() => {
-		const incomplete = rows.some((r) => !r.womenValue || !r.menValue);
-		if (incomplete) {
-			setValidationError(
-				"Veuillez renseigner toutes les données de rémunération avant de passer à l'étape suivante.",
-			);
-			return;
-		}
-		setValidationError(null);
-		mutation.mutate(form.getValues() as Step2Data);
-	});
+	function triggerSave(targetHref: string) {
+		form.handleSubmit(() => {
+			const incomplete = rows.some((r) => !r.womenValue || !r.menValue);
+			if (incomplete) {
+				setValidationError(
+					"Veuillez renseigner toutes les données de rémunération avant de passer à l'étape suivante.",
+				);
+				return;
+			}
+			setValidationError(null);
+			navTargetRef.current = targetHref;
+			mutation.mutate(form.getValues() as Step2Data);
+		})();
+	}
+
+	const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		triggerSave(NEXT_URL);
+	};
+
+	function onPrevious() {
+		triggerSave(PREV_URL);
+	}
 
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
@@ -226,11 +242,13 @@ export function Step2PayGap({
 
 			<FormActions
 				className="fr-mt-0"
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					hasSavedData ? "/declaration-remuneration/etape/3" : undefined
+				isPreviousPending={
+					mutation.isPending && navTargetRef.current === PREV_URL
 				}
-				previousHref="/declaration-remuneration/etape/1"
+				isSubmitting={mutation.isPending && navTargetRef.current === NEXT_URL}
+				mimoquageNextHref={hasSavedData ? NEXT_URL : undefined}
+				onPrevious={onPrevious}
+				previousHref={PREV_URL}
 			/>
 		</form>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import {
 	computeProportion,
@@ -106,10 +106,14 @@ export function Step3VariablePay({
 	const saved = !hasDraft && hasSavedData;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
+	const NEXT_URL = "/declaration-remuneration/etape/4";
+	const PREV_URL = "/declaration-remuneration/etape/2";
+	const navTargetRef = useRef(NEXT_URL);
+
 	const mutation = api.declaration.updateStep3.useMutation({
 		onSuccess: () => {
 			clearDraft();
-			router.push("/declaration-remuneration/etape/4");
+			router.push(navTargetRef.current);
 		},
 	});
 
@@ -144,18 +148,30 @@ export function Step3VariablePay({
 		form.setValue(field, value);
 	}
 
-	const onSubmit = form.handleSubmit(() => {
-		const incompleteRows = rows.some((r) => !r.womenValue || !r.menValue);
-		const incompleteBeneficiaries = !beneficiaryWomen || !beneficiaryMen;
-		if (incompleteRows || incompleteBeneficiaries) {
-			setValidationError(
-				"Veuillez renseigner toutes les données avant de passer à l'étape suivante.",
-			);
-			return;
-		}
-		setValidationError(null);
-		mutation.mutate(form.getValues() as Step3Data);
-	});
+	function triggerSave(targetHref: string) {
+		form.handleSubmit(() => {
+			const incompleteRows = rows.some((r) => !r.womenValue || !r.menValue);
+			const incompleteBeneficiaries = !beneficiaryWomen || !beneficiaryMen;
+			if (incompleteRows || incompleteBeneficiaries) {
+				setValidationError(
+					"Veuillez renseigner toutes les données avant de passer à l'étape suivante.",
+				);
+				return;
+			}
+			setValidationError(null);
+			navTargetRef.current = targetHref;
+			mutation.mutate(form.getValues() as Step3Data);
+		})();
+	}
+
+	const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		triggerSave(NEXT_URL);
+	};
+
+	function onPrevious() {
+		triggerSave(PREV_URL);
+	}
 
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
@@ -391,11 +407,13 @@ export function Step3VariablePay({
 
 			<FormActions
 				className="fr-mt-0"
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					hasSavedData ? "/declaration-remuneration/etape/4" : undefined
+				isPreviousPending={
+					mutation.isPending && navTargetRef.current === PREV_URL
 				}
-				previousHref="/declaration-remuneration/etape/2"
+				isSubmitting={mutation.isPending && navTargetRef.current === NEXT_URL}
+				mimoquageNextHref={hasSavedData ? NEXT_URL : undefined}
+				onPrevious={onPrevious}
+				previousHref={PREV_URL}
 			/>
 		</form>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -139,10 +139,14 @@ export function Step4QuartileDistribution({
 	const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>(emptyErrorMap);
 	const [showRecap, setShowRecap] = useState(false);
 
+	const NEXT_URL = "/declaration-remuneration/etape/5";
+	const PREV_URL = "/declaration-remuneration/etape/3";
+	const navTargetRef = useRef(NEXT_URL);
+
 	const mutation = api.declaration.updateStep4.useMutation({
 		onSuccess: () => {
 			clearDraft();
-			router.push("/declaration-remuneration/etape/5");
+			router.push(navTargetRef.current);
 		},
 	});
 
@@ -220,8 +224,7 @@ export function Step4QuartileDistribution({
 		requestAnimationFrame(() => alertRef.current?.focus());
 	}
 
-	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
-		event.preventDefault();
+	function triggerSave(targetHref: string) {
 		const values = form.getValues();
 		const errors = deriveErrors(values);
 		if (hasAnyError(errors)) {
@@ -232,7 +235,17 @@ export function Step4QuartileDistribution({
 		}
 		setFieldErrors(emptyErrorMap());
 		setShowRecap(false);
+		navTargetRef.current = targetHref;
 		mutation.mutate(normalizeForMutation(values));
+	}
+
+	function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+		event.preventDefault();
+		triggerSave(NEXT_URL);
+	}
+
+	function onPrevious() {
+		triggerSave(PREV_URL);
 	}
 
 	const annualMins = computeMinsForTable(annual);
@@ -387,11 +400,13 @@ export function Step4QuartileDistribution({
 
 			<FormActions
 				className="fr-mt-0"
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					hasSavedData ? "/declaration-remuneration/etape/5" : undefined
+				isPreviousPending={
+					mutation.isPending && navTargetRef.current === PREV_URL
 				}
-				previousHref="/declaration-remuneration/etape/3"
+				isSubmitting={mutation.isPending && navTargetRef.current === NEXT_URL}
+				mimoquageNextHref={hasSavedData ? NEXT_URL : undefined}
+				onPrevious={onPrevious}
+				previousHref={PREV_URL}
 			/>
 		</form>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { padDecimalToTwo } from "~/modules/domain";
@@ -92,10 +92,14 @@ export function Step5EmployeeCategories({
 			}
 		: undefined;
 
+	const NEXT_URL = "/declaration-remuneration/etape/6";
+	const PREV_URL = "/declaration-remuneration/etape/4";
+	const navTargetRef = useRef(NEXT_URL);
+
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => {
 			clearDraft();
-			router.push("/declaration-remuneration/etape/6");
+			router.push(navTargetRef.current);
 		},
 	});
 
@@ -107,22 +111,32 @@ export function Step5EmployeeCategories({
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
-			isSubmitting={mutation.isPending}
+			isPreviousPending={
+				mutation.isPending && navTargetRef.current === PREV_URL
+			}
+			isSubmitting={mutation.isPending && navTargetRef.current === NEXT_URL}
 			key={categoryFormKey}
 			maxMen={maxMen}
 			maxWomen={maxWomen}
-			mimoquageNextHref={
-				hasInitialData ? "/declaration-remuneration/etape/6" : undefined
-			}
-			onSubmit={(data) =>
+			mimoquageNextHref={hasInitialData ? NEXT_URL : undefined}
+			onPreviousSubmit={(data) => {
+				navTargetRef.current = PREV_URL;
 				mutation.mutate({
 					declarationType: "initial",
 					source: data.source,
 					categories: data.categories,
-				})
-			}
+				});
+			}}
+			onSubmit={(data) => {
+				navTargetRef.current = NEXT_URL;
+				mutation.mutate({
+					declarationType: "initial",
+					source: data.source,
+					categories: data.categories,
+				});
+			}}
 			onValuesChange={(values) => setField(values)}
-			previousHref="/declaration-remuneration/etape/4"
+			previousHref={PREV_URL}
 			referenceYear={declarationYear - 1}
 			savedOverride={!hasDraft && hasInitialData}
 			stepper={<StepIndicator currentStep={5} />}

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -210,7 +210,7 @@ describe("CompliancePathChoice", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("renders previous link pointing to step 6", () => {
+	it("renders previous button (not a link) that triggers save", () => {
 		render(
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
@@ -220,10 +220,9 @@ describe("CompliancePathChoice", () => {
 				email="test@example.fr"
 			/>,
 		);
-		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
-			"href",
-			"/declaration-remuneration/etape/6",
-		);
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		expect(prevButton).toBeInTheDocument();
+		expect(prevButton).toHaveAttribute("type", "button");
 	});
 
 	it("renders the email in the success banner", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Step2PayGap } from "../Step2PayGap";
 
 const mockMutate = vi.fn();
+let mockIsPending = false;
 
 vi.mock("~/trpc/react", () => ({
 	api: {
@@ -11,13 +12,20 @@ vi.mock("~/trpc/react", () => ({
 			updateStep2: {
 				useMutation: () => ({
 					mutate: mockMutate,
-					isPending: false,
+					get isPending() {
+						return mockIsPending;
+					},
 					error: null,
 				}),
 			},
 		},
 	},
 }));
+
+beforeEach(() => {
+	mockMutate.mockClear();
+	mockIsPending = false;
+});
 
 const emptyStep2Data = () => ({
 	indicatorAAnnualWomen: "",
@@ -185,7 +193,7 @@ describe("Step2PayGap", () => {
 		expect(screen.queryByText("élevé")).not.toBeInTheDocument();
 	});
 
-	it("renders previous link pointing to step 1", () => {
+	it("renders previous button (not a link) that triggers save", () => {
 		render(
 			<Step2PayGap
 				declarationSiren="123456789"
@@ -193,10 +201,9 @@ describe("Step2PayGap", () => {
 				initialData={emptyStep2Data()}
 			/>,
 		);
-		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
-			"href",
-			"/declaration-remuneration/etape/1",
-		);
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		expect(prevButton).toBeInTheDocument();
+		expect(prevButton).toHaveAttribute("type", "button");
 	});
 
 	it("uses gipPrefillData when no initialData", () => {
@@ -270,5 +277,98 @@ describe("Step2PayGap", () => {
 			),
 		).toBeInTheDocument();
 		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("clicking Précédent with valid data triggers the mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					indicatorAAnnualWomen: "100",
+					indicatorAAnnualMen: "200",
+					indicatorAHourlyWomen: "10",
+					indicatorAHourlyMen: "20",
+					indicatorCAnnualWomen: "100",
+					indicatorCAnnualMen: "200",
+					indicatorCHourlyWomen: "10",
+					indicatorCHourlyMen: "20",
+				}}
+			/>,
+		);
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(mockMutate).toHaveBeenCalled();
+	});
+
+	it("clicking Précédent with incomplete data shows validation error without mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
+		);
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(
+			screen.getByText(
+				/Veuillez renseigner toutes les données de rémunération/,
+			),
+		).toBeInTheDocument();
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("both Précédent and Suivant are disabled when mutation is pending", async () => {
+		mockMutate.mockImplementation(() => {
+			mockIsPending = true;
+		});
+		const user = userEvent.setup();
+		const { rerender } = render(
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					indicatorAAnnualWomen: "100",
+					indicatorAAnnualMen: "200",
+					indicatorAHourlyWomen: "10",
+					indicatorAHourlyMen: "20",
+					indicatorCAnnualWomen: "100",
+					indicatorCAnnualMen: "200",
+					indicatorCHourlyWomen: "10",
+					indicatorCHourlyMen: "20",
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /précédent/i }));
+
+		rerender(
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					indicatorAAnnualWomen: "100",
+					indicatorAAnnualMen: "200",
+					indicatorAHourlyWomen: "10",
+					indicatorAHourlyMen: "20",
+					indicatorCAnnualWomen: "100",
+					indicatorCAnnualMen: "200",
+					indicatorCHourlyWomen: "10",
+					indicatorCHourlyMen: "20",
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Enregistrement…")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Enregistrement…" }),
+		).toBeDisabled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Step3VariablePay } from "../Step3VariablePay";
 
 const mockMutate = vi.fn();
+let mockIsPending = false;
 
 vi.mock("~/trpc/react", () => ({
 	api: {
@@ -11,13 +12,20 @@ vi.mock("~/trpc/react", () => ({
 			updateStep3: {
 				useMutation: () => ({
 					mutate: mockMutate,
-					isPending: false,
+					get isPending() {
+						return mockIsPending;
+					},
 					error: null,
 				}),
 			},
 		},
 	},
 }));
+
+beforeEach(() => {
+	mockMutate.mockClear();
+	mockIsPending = false;
+});
 
 const emptyStep3Data = () => ({
 	indicatorBAnnualWomen: "",
@@ -222,7 +230,7 @@ describe("Step3VariablePay", () => {
 		expect(screen.getByText(/ne peut pas dépasser/i)).toBeInTheDocument();
 	});
 
-	it("renders previous link pointing to step 2", () => {
+	it("renders previous button (not a link) that triggers save", () => {
 		render(
 			<Step3VariablePay
 				declarationSiren="123456789"
@@ -230,10 +238,9 @@ describe("Step3VariablePay", () => {
 				initialData={emptyStep3Data()}
 			/>,
 		);
-		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
-			"href",
-			"/declaration-remuneration/etape/2",
-		);
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		expect(prevButton).toBeInTheDocument();
+		expect(prevButton).toHaveAttribute("type", "button");
 	});
 
 	it("uses gipPrefillData when no initialData", () => {
@@ -396,5 +403,102 @@ describe("Step3VariablePay", () => {
 		expect(benefWomenInput).toHaveValue("0");
 		const benefMenInput = screen.getByLabelText("Bénéficiaires hommes");
 		expect(benefMenInput).toHaveValue("0");
+	});
+
+	it("clicking Précédent with valid data triggers the mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					indicatorBAnnualWomen: "100",
+					indicatorBAnnualMen: "200",
+					indicatorBHourlyWomen: "10",
+					indicatorBHourlyMen: "20",
+					indicatorDAnnualWomen: "100",
+					indicatorDAnnualMen: "200",
+					indicatorDHourlyWomen: "10",
+					indicatorDHourlyMen: "20",
+					indicatorEWomen: "5",
+					indicatorEMen: "10",
+				}}
+			/>,
+		);
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(mockMutate).toHaveBeenCalled();
+	});
+
+	it("clicking Précédent with incomplete data shows validation error without mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(
+			screen.getByText(/Veuillez renseigner toutes les données/),
+		).toBeInTheDocument();
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("both Précédent and Suivant are disabled when mutation is pending", async () => {
+		mockMutate.mockImplementation(() => {
+			mockIsPending = true;
+		});
+		const user = userEvent.setup();
+		const { rerender } = render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					indicatorBAnnualWomen: "100",
+					indicatorBAnnualMen: "200",
+					indicatorBHourlyWomen: "10",
+					indicatorBHourlyMen: "20",
+					indicatorDAnnualWomen: "100",
+					indicatorDAnnualMen: "200",
+					indicatorDHourlyWomen: "10",
+					indicatorDHourlyMen: "20",
+					indicatorEWomen: "5",
+					indicatorEMen: "10",
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /précédent/i }));
+
+		rerender(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					indicatorBAnnualWomen: "100",
+					indicatorBAnnualMen: "200",
+					indicatorBHourlyWomen: "10",
+					indicatorBHourlyMen: "20",
+					indicatorDAnnualWomen: "100",
+					indicatorDAnnualMen: "200",
+					indicatorDHourlyWomen: "10",
+					indicatorDHourlyMen: "20",
+					indicatorEWomen: "5",
+					indicatorEMen: "10",
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Enregistrement…")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Enregistrement…" }),
+		).toBeDisabled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Step4QuartileDistribution } from "../Step4QuartileDistribution";
 
 const mockMutate = vi.fn();
+let mockIsPending = false;
 
 vi.mock("~/trpc/react", () => ({
 	api: {
@@ -11,13 +12,20 @@ vi.mock("~/trpc/react", () => ({
 			updateStep4: {
 				useMutation: () => ({
 					mutate: mockMutate,
-					isPending: false,
+					get isPending() {
+						return mockIsPending;
+					},
 					error: null,
 				}),
 			},
 		},
 	},
 }));
+
+beforeEach(() => {
+	mockMutate.mockClear();
+	mockIsPending = false;
+});
 
 const emptyStep4Data = () => ({
 	annual: [
@@ -264,7 +272,7 @@ describe("Step4QuartileDistribution", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders previous link pointing to step 3", () => {
+	it("renders previous button (not a link) that triggers save", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
@@ -272,10 +280,9 @@ describe("Step4QuartileDistribution", () => {
 				initialData={emptyStep4Data()}
 			/>,
 		);
-		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
-			"href",
-			"/declaration-remuneration/etape/3",
-		);
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		expect(prevButton).toBeInTheDocument();
+		expect(prevButton).toHaveAttribute("type", "button");
 	});
 
 	it("uses gipPrefillData to pre-populate 3 thresholds and counts", () => {
@@ -446,5 +453,113 @@ describe("Step4QuartileDistribution", () => {
 			/>,
 		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
+	});
+
+	it("clicking Précédent with valid data triggers the mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					annual: [
+						{ threshold: "20000", women: 60, men: 30 },
+						{ threshold: "25000", women: 40, men: 30 },
+						{ threshold: "35000", women: 24, men: 31 },
+						{ threshold: undefined, women: 15, men: 26 },
+					],
+					hourly: [
+						{ threshold: "10", women: 20, men: 23 },
+						{ threshold: "12", women: 16, men: 18 },
+						{ threshold: "15", women: 15, men: 18 },
+						{ threshold: undefined, women: 4, men: 9 },
+					],
+				}}
+			/>,
+		);
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(mockMutate).toHaveBeenCalled();
+	});
+
+	it("clicking Précédent with validation errors shows recap without calling mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+
+		const seuil1 = screen.getAllByLabelText(
+			/Seuil maximum 1er quartile/i,
+		)[0] as HTMLInputElement;
+		await user.type(seuil1, "50000");
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(
+			screen.getByText(/Le formulaire contient des erreurs/),
+		).toBeInTheDocument();
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("both Précédent and Suivant are disabled when mutation is pending after Précédent click", async () => {
+		mockMutate.mockImplementation(() => {
+			mockIsPending = true;
+		});
+		const user = userEvent.setup();
+		const { rerender } = render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					annual: [
+						{ threshold: "20000", women: 60, men: 30 },
+						{ threshold: "25000", women: 40, men: 30 },
+						{ threshold: "35000", women: 24, men: 31 },
+						{ threshold: undefined, women: 15, men: 26 },
+					],
+					hourly: [
+						{ threshold: "10", women: 20, men: 23 },
+						{ threshold: "12", women: 16, men: 18 },
+						{ threshold: "15", women: 15, men: 18 },
+						{ threshold: undefined, women: 4, men: 9 },
+					],
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /précédent/i }));
+
+		rerender(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={{
+					annual: [
+						{ threshold: "20000", women: 60, men: 30 },
+						{ threshold: "25000", women: 40, men: 30 },
+						{ threshold: "35000", women: 24, men: 31 },
+						{ threshold: undefined, women: 15, men: 26 },
+					],
+					hourly: [
+						{ threshold: "10", women: 20, men: 23 },
+						{ threshold: "12", women: 16, men: 18 },
+						{ threshold: "15", women: 15, men: 18 },
+						{ threshold: undefined, women: 4, men: 9 },
+					],
+				}}
+			/>,
+		);
+
+		expect(screen.getByText("Enregistrement…")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Enregistrement…" }),
+		).toBeDisabled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -5,6 +5,7 @@ import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/typ
 import { Step5EmployeeCategories } from "../Step5EmployeeCategories";
 
 const mockMutate = vi.fn();
+let mockIsPending = false;
 
 vi.mock("~/trpc/react", () => ({
 	api: {
@@ -12,7 +13,9 @@ vi.mock("~/trpc/react", () => ({
 			updateEmployeeCategories: {
 				useMutation: () => ({
 					mutate: mockMutate,
-					isPending: false,
+					get isPending() {
+						return mockIsPending;
+					},
 					error: null,
 				}),
 			},
@@ -22,6 +25,7 @@ vi.mock("~/trpc/react", () => ({
 
 beforeEach(() => {
 	mockMutate.mockClear();
+	mockIsPending = false;
 	HTMLDialogElement.prototype.showModal = vi.fn();
 	HTMLDialogElement.prototype.close = vi.fn();
 });
@@ -382,7 +386,7 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows a friendly error when source is not selected", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationYear={2025} />);
+		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
 
 		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",
@@ -486,17 +490,16 @@ describe("Step5EmployeeCategories", () => {
 		expect(mockMutate).not.toHaveBeenCalled();
 	});
 
-	it("renders previous link pointing to step 4", () => {
+	it("renders previous button (not a link) that triggers save", () => {
 		render(
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
 			/>,
 		);
-		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
-			"href",
-			"/declaration-remuneration/etape/4",
-		);
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		expect(prevButton).toBeInTheDocument();
+		expect(prevButton).toHaveAttribute("type", "button");
 	});
 
 	it("renders accordion for definitions", () => {
@@ -509,5 +512,80 @@ describe("Step5EmployeeCategories", () => {
 		expect(
 			screen.getByText("Définitions et méthode de calcul"),
 		).toBeInTheDocument();
+	});
+
+	it("clicking Précédent with valid data triggers the mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+
+		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
+		await user.type(nameInput, "Cadres");
+
+		await user.selectOptions(
+			screen.getByLabelText(/Quelle est la source utilisée/),
+			"accord-entreprise",
+		);
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(mockMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ declarationType: "initial" }),
+		);
+	});
+
+	it("clicking Précédent with incomplete data blocks mutation", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		await user.click(prevButton);
+
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("both Précédent and Suivant are disabled when mutation is pending after Précédent click", async () => {
+		mockMutate.mockImplementation(() => {
+			mockIsPending = true;
+		});
+		const user = userEvent.setup();
+		const { rerender } = render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+
+		const nameInput = document.getElementById("cat-0-name") as HTMLElement;
+		await user.type(nameInput, "Cadres");
+
+		await user.selectOptions(
+			screen.getByLabelText(/Quelle est la source utilisée/),
+			"accord-entreprise",
+		);
+
+		await user.click(screen.getByRole("button", { name: /précédent/i }));
+
+		rerender(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+
+		expect(screen.getByText("Enregistrement…")).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Enregistrement…" }),
+		).toBeDisabled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -386,7 +386,12 @@ describe("Step5EmployeeCategories", () => {
 
 	it("shows a friendly error when source is not selected", async () => {
 		const user = userEvent.setup();
-		render(<Step5EmployeeCategories declarationSiren="123456789" declarationYear={2025} />);
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
 
 		const nameInput = screen.getByLabelText("Libellé", {
 			selector: "#cat-0-name",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -4,7 +4,10 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
-import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
+import type {
+	EmployeeCategoryRow,
+	EmployeeCategorySubmitData,
+} from "~/modules/declaration-remuneration/types";
 import { api } from "~/trpc/react";
 import { CategoryForm } from "../step5/CategoryForm";
 import { BASE_PATH } from "./constants";
@@ -77,12 +80,34 @@ export function SecondDeclarationStep2Form({
 		setField({ startDate, endDate });
 	}, [startDate, endDate, setField]);
 
+	const NEXT_URL = `${BASE_PATH}/etape/3`;
+	const PREV_URL = `${BASE_PATH}/etape/1`;
+	const navTargetRef = useRef(NEXT_URL);
+
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => {
 			clearDraft();
-			router.push(`${BASE_PATH}/etape/3`);
+			router.push(navTargetRef.current);
 		},
 	});
+
+	function triggerMutate(data: EmployeeCategorySubmitData, targetUrl: string) {
+		if (!startDate || !endDate) {
+			setPeriodError(
+				"La période de référence est obligatoire. Veuillez renseigner les dates de début et de fin.",
+			);
+			return;
+		}
+		setPeriodError("");
+		navTargetRef.current = targetUrl;
+		mutation.mutate({
+			declarationType: "correction",
+			source: data.source,
+			categories: data.categories,
+			referencePeriodStart: startDate,
+			referencePeriodEnd: endDate,
+		});
+	}
 
 	return (
 		<CategoryForm
@@ -92,27 +117,14 @@ export function SecondDeclarationStep2Form({
 			initialCategories={sourceData}
 			initialSource={initialSource}
 			instructionText="Modifiez les données de votre première déclaration avant de valider votre indicateur."
-			isSubmitting={mutation.isPending}
-			mimoquageNextHref={
-				hasSavedSecondDeclaration ? `${BASE_PATH}/etape/3` : undefined
+			isPreviousPending={
+				mutation.isPending && navTargetRef.current === PREV_URL
 			}
-			onSubmit={(data) => {
-				if (!startDate || !endDate) {
-					setPeriodError(
-						"La période de référence est obligatoire. Veuillez renseigner les dates de début et de fin.",
-					);
-					return;
-				}
-				setPeriodError("");
-				mutation.mutate({
-					declarationType: "correction",
-					source: data.source,
-					categories: data.categories,
-					referencePeriodStart: startDate,
-					referencePeriodEnd: endDate,
-				});
-			}}
-			previousHref={`${BASE_PATH}/etape/1`}
+			isSubmitting={mutation.isPending && navTargetRef.current === NEXT_URL}
+			mimoquageNextHref={hasSavedSecondDeclaration ? NEXT_URL : undefined}
+			onPreviousSubmit={(data) => triggerMutate(data, PREV_URL)}
+			onSubmit={(data) => triggerMutate(data, NEXT_URL)}
+			previousHref={PREV_URL}
 			readOnlyLabel
 			referencePeriodPicker={
 				<ReferencePeriodPicker

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -133,7 +133,7 @@ describe("SecondDeclarationStep2Form", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("renders previous link to step 1", () => {
+	it("renders previous button (not a link) that triggers save", () => {
 		render(
 			<SecondDeclarationStep2Form
 				declarationSiren="123456789"
@@ -141,10 +141,9 @@ describe("SecondDeclarationStep2Form", () => {
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
-			"href",
-			"/declaration-remuneration/parcours-conformite/etape/1",
-		);
+		const prevButton = screen.getByRole("button", { name: /précédent/i });
+		expect(prevButton).toBeInTheDocument();
+		expect(prevButton).toHaveAttribute("type", "button");
 	});
 
 	it("uses second declaration data when available", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -63,7 +63,10 @@ type Props = {
 	instructionText: string;
 	tooltipPrefix: string;
 	accordionId: string;
-	previousHref: string;
+	previousHref?: string;
+	onPrevious?: () => void;
+	isPreviousPending?: boolean;
+	onPreviousSubmit?: (data: EmployeeCategorySubmitData) => void;
 	initialCategories: EmployeeCategoryRow[];
 	initialSource?: string;
 	maxWomen?: number;
@@ -119,6 +122,9 @@ export function CategoryForm({
 	tooltipPrefix,
 	accordionId,
 	previousHref,
+	onPrevious,
+	isPreviousPending = false,
+	onPreviousSubmit,
 	initialCategories,
 	initialSource = "",
 	maxWomen,
@@ -255,65 +261,75 @@ export function CategoryForm({
 	const categories = form.watch("categories");
 	const sourceError = form.formState.errors.source?.message;
 
-	const handleFormSubmit = form.handleSubmit((data) => {
-		setWorkforceError("");
+	function runValidatedSubmit(
+		callback: (data: EmployeeCategorySubmitData) => void,
+	) {
+		return form.handleSubmit((data) => {
+			setWorkforceError("");
 
-		const emptyNames = data.categories.some((cat) => !cat.name.trim());
-		if (emptyNames) {
-			setWorkforceError(
-				"Le nom de chaque catégorie d'emplois est obligatoire.",
-			);
-			return;
-		}
-
-		const names = data.categories.map((cat) => cat.name.trim().toLowerCase());
-		const hasDuplicates = names.length !== new Set(names).size;
-		if (hasDuplicates) {
-			setWorkforceError(
-				"Les noms des catégories d'emplois doivent être uniques.",
-			);
-			return;
-		}
-
-		if (maxWomen !== undefined || maxMen !== undefined) {
-			const totalWomen = data.categories.reduce(
-				(sum, cat) =>
-					sum + (cat.womenCount ? Number.parseInt(cat.womenCount, 10) : 0),
-				0,
-			);
-			const totalMen = data.categories.reduce(
-				(sum, cat) =>
-					sum + (cat.menCount ? Number.parseInt(cat.menCount, 10) : 0),
-				0,
-			);
-
-			const errors: string[] = [];
-			if (maxWomen !== undefined && totalWomen !== maxWomen) {
-				errors.push(
-					`Le total des effectifs femmes (${totalWomen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxWomen}).`,
+			const emptyNames = data.categories.some((cat) => !cat.name.trim());
+			if (emptyNames) {
+				setWorkforceError(
+					"Le nom de chaque catégorie d'emplois est obligatoire.",
 				);
-			}
-			if (maxMen !== undefined && totalMen !== maxMen) {
-				errors.push(
-					`Le total des effectifs hommes (${totalMen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxMen}).`,
-				);
-			}
-			if (errors.length > 0) {
-				setWorkforceError(errors.join(" "));
 				return;
 			}
-		}
 
-		onSubmit(
-			toSubmitData(
-				data.categories.map((cat, i) => ({
-					id: i,
-					...cat,
-				})),
-				data.source,
-			),
-		);
-	});
+			const names = data.categories.map((cat) => cat.name.trim().toLowerCase());
+			const hasDuplicates = names.length !== new Set(names).size;
+			if (hasDuplicates) {
+				setWorkforceError(
+					"Les noms des catégories d'emplois doivent être uniques.",
+				);
+				return;
+			}
+
+			if (maxWomen !== undefined || maxMen !== undefined) {
+				const totalWomen = data.categories.reduce(
+					(sum, cat) =>
+						sum + (cat.womenCount ? Number.parseInt(cat.womenCount, 10) : 0),
+					0,
+				);
+				const totalMen = data.categories.reduce(
+					(sum, cat) =>
+						sum + (cat.menCount ? Number.parseInt(cat.menCount, 10) : 0),
+					0,
+				);
+
+				const errors: string[] = [];
+				if (maxWomen !== undefined && totalWomen !== maxWomen) {
+					errors.push(
+						`Le total des effectifs femmes (${totalWomen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxWomen}).`,
+					);
+				}
+				if (maxMen !== undefined && totalMen !== maxMen) {
+					errors.push(
+						`Le total des effectifs hommes (${totalMen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxMen}).`,
+					);
+				}
+				if (errors.length > 0) {
+					setWorkforceError(errors.join(" "));
+					return;
+				}
+			}
+
+			callback(
+				toSubmitData(
+					data.categories.map((cat, i) => ({
+						id: i,
+						...cat,
+					})),
+					data.source,
+				),
+			);
+		});
+	}
+
+	const handleFormSubmit = runValidatedSubmit(onSubmit);
+
+	const handlePreviousClick = onPreviousSubmit
+		? () => runValidatedSubmit(onPreviousSubmit)()
+		: onPrevious;
 
 	return (
 		<form className={stepStyles.form} onSubmit={handleFormSubmit}>
@@ -560,8 +576,10 @@ export function CategoryForm({
 			/>
 
 			<FormActions
+				isPreviousPending={isPreviousPending}
 				isSubmitting={isSubmitting}
 				mimoquageNextHref={mimoquageNextHref}
+				onPrevious={handlePreviousClick}
 				previousHref={previousHref}
 			/>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -173,7 +173,6 @@ export function CategoryForm({
 	const hasInitialData = initialCategories.length > 0;
 	const [savedInternal, setSaved] = useState(hasInitialData);
 	const saved = savedOverride !== undefined ? savedOverride : savedInternal;
-	const [workforceError, setWorkforceError] = useState("");
 	const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
 	const deleteDialogRef = useRef<HTMLDialogElement>(null);
 
@@ -265,22 +264,22 @@ export function CategoryForm({
 		callback: (data: EmployeeCategorySubmitData) => void,
 	) {
 		return form.handleSubmit((data) => {
-			setWorkforceError("");
+			form.clearErrors("root");
 
 			const emptyNames = data.categories.some((cat) => !cat.name.trim());
 			if (emptyNames) {
-				setWorkforceError(
-					"Le nom de chaque catégorie d'emplois est obligatoire.",
-				);
+				form.setError("root", {
+					message: "Le nom de chaque catégorie d'emplois est obligatoire.",
+				});
 				return;
 			}
 
 			const names = data.categories.map((cat) => cat.name.trim().toLowerCase());
 			const hasDuplicates = names.length !== new Set(names).size;
 			if (hasDuplicates) {
-				setWorkforceError(
-					"Les noms des catégories d'emplois doivent être uniques.",
-				);
+				form.setError("root", {
+					message: "Les noms des catégories d'emplois doivent être uniques.",
+				});
 				return;
 			}
 
@@ -296,19 +295,19 @@ export function CategoryForm({
 					0,
 				);
 
-				const errors: string[] = [];
+				const messages: string[] = [];
 				if (maxWomen !== undefined && totalWomen !== maxWomen) {
-					errors.push(
+					messages.push(
 						`Le total des effectifs femmes (${totalWomen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxWomen}).`,
 					);
 				}
 				if (maxMen !== undefined && totalMen !== maxMen) {
-					errors.push(
+					messages.push(
 						`Le total des effectifs hommes (${totalMen}) ne correspond pas à l'effectif déclaré à l'étape 1 (${maxMen}).`,
 					);
 				}
-				if (errors.length > 0) {
-					setWorkforceError(errors.join(" "));
+				if (messages.length > 0) {
+					form.setError("root", { message: messages.join(" ") });
 					return;
 				}
 			}
@@ -572,7 +571,7 @@ export function CategoryForm({
 
 			<FormErrors
 				mutationError={submitError}
-				validationError={workforceError}
+				validationError={form.formState.errors.root?.message}
 			/>
 
 			<FormActions


### PR DESCRIPTION
Closes #3435

## Changement

Le bouton Précédent des étapes 2, 3, 4 et 5 de la déclaration de rémunération déclenche désormais la même validation + mutation que le bouton Suivant, et navigue en arrière uniquement en cas de succès.

Avant ce correctif, le lien Précédent naviguait sans sauvegarder.

## Approche technique

- `FormActions` : ajout des props `onPrevious` et `isPreviousPending`. Quand `onPrevious` est fourni et que l'utilisateur n'est pas en mode lecture seule (impersonation), un `<button type="button">` remplace le `<Link>` ; en mode lecture seule, le lien reste inchangé.
- Étapes 2, 3, 4 : pattern `navTargetRef` + `triggerSave(targetHref)` — le ref mémorise la cible de navigation sans déclencher de re-render, la mutation est commune aux deux directions.
- Étape 5 : `CategoryForm` reçoit `onPreviousSubmit` ; la logique de validation est extraite dans `runValidatedSubmit(callback)` partagé entre les deux directions.
- L'état de chargement `Enregistrement…` apparaît sur le bouton qui a initié la mutation (Précédent ou Suivant), l'autre bouton est désactivé.

## Tests ajoutés

Tests Vitest couvrant : bouton Précédent (button vs link), déclenchement de la mutation sur données valides, erreur de validation sur données incomplètes, désactivation des deux boutons pendant le chargement, cas impersonation admin.