### PR TITLE
feat(export): expose declaration id in SUIT API (#3478)

### DIFF
--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -284,6 +284,8 @@ describe("assembleDeclaration", () => {
 	it("should assemble a full declaration with French top-level keys", () => {
 		const result = assembleDeclaration(baseRow, [], []);
 
+		expect(result.id).toBe("decl-1");
+		expect(Object.keys(result)[0]).toBe("id");
 		expect(result.SIREN).toBe("123456789");
 		expect(result.Raison_sociale).toBe("ACME Corp");
 		expect(result.Effectif).toBe(250);

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -33,6 +33,17 @@ describe("openApiSpec", () => {
 		expect(dateEnd?.required).toBe(false);
 	});
 
+	it("should declare id as first property of declarationSchema with uuid format", () => {
+		const responseSchema =
+			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]
+				.content["application/json"].schema;
+		const declarationSchema = responseSchema.properties.Declarations.items;
+		expect(declarationSchema.properties.id).toBeDefined();
+		expect(declarationSchema.properties.id.type).toBe("string");
+		expect(declarationSchema.properties.id.format).toBe("uuid");
+		expect(Object.keys(declarationSchema.properties)[0]).toBe("id");
+	});
+
 	it("should define 200, 400, and 500 responses", () => {
 		const responses =
 			openApiSpec.paths["/api/v1/export/declarations"].get.responses;

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -295,6 +295,7 @@ export function assembleDeclaration(
 	const flags = deriveExportFlags(row, indicatorGEntries);
 
 	return {
+		id: row.declarationId,
 		SIREN: row.siren,
 		Raison_sociale: row.companyName,
 		Effectif: row.workforce,

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -169,6 +169,12 @@ const indicatorsSchema = {
 const declarationSchema = {
 	type: "object",
 	properties: {
+		id: {
+			type: "string",
+			format: "uuid",
+			description: "Identifiant interne de la déclaration (UUID)",
+			example: "11111111-2222-4333-8444-555555555555",
+		},
 		SIREN: {
 			type: "string",
 			description: "SIREN de l'entreprise (9 chiffres)",


### PR DESCRIPTION
Closes #3478

## Changes

Expose the declaration `id` (UUID) as the first property of each declaration object returned by `GET /api/v1/export/declarations`.

The field was already selected by the DB query (`declarationId` in `DeclarationRow`) — this change only projects it into the response payload.

## What changed

- `fetchDeclarations.ts`: added `id: row.declarationId` as first property in `assembleDeclaration`
- `openapi.ts`: added `id` field (type string, format uuid) as first property in `declarationSchema`
- Updated unit tests to assert `id` presence and position

## Non-breaking

Additive change: existing SUIT consumers continue working without modification.

## Test plan

- [x] `pnpm test` — unit tests assert `id` on assembled declarations and first key position
- [x] `pnpm typecheck` — green
- [x] `pnpm lint:check` — green
- [ ] `pnpm test:integration` — integration test asserts `id` is non-null UUID
- [ ] `GET /api/v1/openapi.json` — `declarationSchema.properties.id` present with `format: uuid`