### PR TITLE
fix(api): cast status-history aggregations to Date in export query

### DIFF
--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -16,13 +16,19 @@ import {
 import type { CseRow, FileRow, IndicatorGEntry } from "./fetchDeclarations";
 import type { IndicatorGRow } from "./types";
 
+// postgres.js returns ISO strings (not Date) for raw `sql<>` aggregations like
+// MAX(timestamptz) — the column-type metadata is lost. mapWith bridges that
+// gap so callers can rely on a real Date | null.
+const toDate = (value: unknown): Date | null =>
+	value == null ? null : new Date(value as string | number | Date);
+
 function latestEventAt(eventType: string) {
 	return sql<Date | null>`(
 		SELECT MAX(${declarationStatusHistory.createdAt})
 		FROM ${declarationStatusHistory}
 		WHERE ${declarationStatusHistory.declarationId} = ${declarations.id}
 		AND ${declarationStatusHistory.eventType} = ${eventType}
-	)`;
+	)`.mapWith(toDate);
 }
 
 function latestPathChoiceAt(round: 1 | 2) {
@@ -32,7 +38,7 @@ function latestPathChoiceAt(round: 1 | 2) {
 		WHERE ${declarationStatusHistory.declarationId} = ${declarations.id}
 		AND ${declarationStatusHistory.eventType} = 'path_choice'
 		AND ${declarationStatusHistory.round} = ${round}
-	)`;
+	)`.mapWith(toDate);
 }
 
 export const statusHistoryProjection = {


### PR DESCRIPTION
## Summary

The `/api/v1/export/declarations` endpoint (SUIT API) returns **HTTP 500** whenever a declaration with a non-null `path_choice` event in its history lands in the requested date window. Same root cause affects the yearly XLSX export cron through the shared projection.

## Root cause

`statusHistoryProjection` (`packages/app/src/modules/export/queries.ts`) builds 7 timestamp fields as raw correlated subqueries:

```ts
function latestEventAt(eventType: string) {
  return sql<Date | null>`(
    SELECT MAX(${declarationStatusHistory.createdAt}) ...
  )`;
}
```

The `sql<Date | null>` annotation is **TypeScript only**. At runtime, postgres.js returns ISO **strings** for raw `sql<>` aggregations like `MAX(timestamptz)` because the column-type metadata is lost on the raw expression. The downstream code (`assembleDeclaration`, `buildExportRows`) then calls `.toISOString()` directly:

```ts
Date_parcours_apres_declaration_1:
  row.firstDeclarationPathChoiceAt?.toISOString() ?? null,
```

On a non-null string value, optional chaining doesn't short-circuit, so we end up calling `.toISOString` on a string → `TypeError: row.firstDeclarationPathChoiceAt?.toISOString is not a function`.

Confirmed via alpha pod logs:

```
[api/v1/export/declarations] e.firstDeclarationPathChoiceAt?.toISOString is not a function
```

Why it was missed until now: until #3457 (status state machine), no event types beyond `submit` were emitted into `declaration_status_history`. Once `path_choice` events started being written, any export window catching such a row crashes. The route handler's generic `catch` swallowed the message — surfacing only `"Erreur lors de la récupération des déclarations"`.

## Fix

Wrap each raw aggregation with `.mapWith(toDate)` so callers receive a real `Date | null`. Single source of truth at the projection layer covers both consumers (SUIT API + XLSX cron).

```ts
const toDate = (value: unknown): Date | null =>
  value == null ? null : new Date(value as string | number | Date);

function latestEventAt(eventType: string) {
  return sql<Date | null>`(...)`.mapWith(toDate);
}
```

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm vitest run src/modules/export/__tests__/` — 100 tests pass
- [x] `pnpm check` (biome) green
- [ ] Manual: hit `/api/v1/export/declarations?date_begin=2026-05-19` on review app after merge — should return 200 with the cancelled/submitted declarations including their `Date_parcours_apres_declaration_1` as ISO string
- [ ] Manual: confirm yearly XLSX cron still produces a valid file (no implicit date format break)

## Follow-up (out of scope)

- Improve the export route handler's `catch`: never lose the real message. Either pass `error.cause` to `console.error`, add a request-id in the JSON response, or both. Suggest a separate PR.
- The existing `exportApi.integration.test.ts` still uses the legacy `'submitted'` status which doesn't exist in the post-#3457 enum — it needs an update independently of this fix.