### PR TITLE
fix(my-space): shorten side panel CTA label to "Continuer" (#3490)

### DIFF
--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -121,7 +121,7 @@ test.describe("Declaration process panel", () => {
 				panel.getByText("Vous devez au préalable disposer"),
 			).toBeVisible();
 			await expect(
-				panel.getByRole("link", { name: "Continuer la déclaration" }),
+				panel.getByRole("link", { name: "Continuer" }),
 			).toBeVisible();
 			await expect(
 				panel.getByText("Évaluation conjointe des rémunérations"),
@@ -155,7 +155,7 @@ test.describe("Declaration process panel", () => {
 			).toBeVisible();
 
 			const ctaLink = panel.getByRole("link", {
-				name: "Continuer la déclaration",
+				name: "Continuer",
 			});
 			await expect(ctaLink).toHaveAttribute("href", /evaluation-conjointe/);
 		});
@@ -185,7 +185,7 @@ test.describe("Declaration process panel", () => {
 			).toBeVisible();
 
 			const ctaLink = panel.getByRole("link", {
-				name: "Continuer la déclaration",
+				name: "Continuer",
 			});
 			await expect(ctaLink).toHaveAttribute("href", /avis-cse/);
 		});
@@ -220,7 +220,7 @@ test.describe("Declaration process panel", () => {
 				panel.getByText("Déposer le ou les avis du CSE"),
 			).toBeVisible();
 			const ctaLink = panel.getByRole("link", {
-				name: "Continuer la déclaration",
+				name: "Continuer",
 			});
 			await expect(ctaLink).toHaveAttribute("href", /avis-cse/);
 		});

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -100,7 +100,7 @@ export function DeclarationProcessPanel({
 function getCtaLabel(variant: PanelVariant): string {
 	if (variant === "closed") return "Voir la déclaration";
 	if (variant === "start") return "Commencer la déclaration";
-	return "Continuer la déclaration";
+	return "Continuer";
 }
 
 function PanelHeader({

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -147,11 +147,11 @@ describe("DeclarationProcessPanel", () => {
 			).not.toBeInTheDocument();
 		});
 
-		it('renders "Continuer la déclaration" CTA', () => {
+		it('renders "Continuer" CTA', () => {
 			const { dialog } = renderPanel("compliance");
 			const ctaLinks = dialog.querySelectorAll("a.fr-btn");
 			const cta = ctaLinks[ctaLinks.length - 1];
-			expect(cta).toHaveTextContent("Continuer la déclaration");
+			expect(cta).toHaveTextContent("Continuer");
 		});
 	});
 


### PR DESCRIPTION
Closes #3490

## Summary

Replace the side panel CTA label `"Continuer la déclaration"` with `"Continuer"` for all variants except `start` and `closed`. The other two labels (`"Voir la déclaration"`, `"Commencer la déclaration"`) remain unchanged.

## Changes

- `DeclarationProcessPanel.tsx`: the `getCtaLabel(variant)` default branch now returns `"Continuer"` instead of `"Continuer la déclaration"`.
- `DeclarationProcessPanel.test.tsx`: unit test descriptor + `toHaveTextContent` assertion updated.
- `declaration-process-panel.e2e.ts`: 4 Playwright `getByRole("link", { name })` selectors updated.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test` green (1949 / 1949)
- [x] `pnpm lint:check` clean
- [x] `pnpm format:check` clean
- [ ] CI green
- [ ] Existing e2e specs cover the updated label in 4 variants (compliance, evaluation, cse joint, cse with opinions saved)