### PR TITLE
feat(export): add FR labels helper for declaration status history

### DIFF
--- a/packages/app/src/modules/export/index.ts
+++ b/packages/app/src/modules/export/index.ts
@@ -32,4 +32,10 @@ export {
 	EXPORT_VERSION,
 	INDICATOR_G_COLUMNS,
 } from "./shared/constants";
+export {
+	DECLARATION_EVENT_TYPE_LABELS,
+	type DeclarationEventType,
+	getStatusHistoryLabel,
+	PATH_CHOICE_VALUE_LABELS,
+} from "./shared/statusHistoryLabels";
 export type { ExportRow, IndicatorGRow } from "./types";

--- a/packages/app/src/modules/export/shared/__tests__/statusHistoryLabels.test.ts
+++ b/packages/app/src/modules/export/shared/__tests__/statusHistoryLabels.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+	DECLARATION_EVENT_TYPE_LABELS,
+	getStatusHistoryLabel,
+} from "../statusHistoryLabels";
+
+describe("getStatusHistoryLabel", () => {
+	it("returns the base label for submit", () => {
+		expect(getStatusHistoryLabel("submit", null)).toBe(
+			"Soumission de la déclaration",
+		);
+	});
+
+	it("returns combined label for path_choice with joint_evaluation", () => {
+		expect(getStatusHistoryLabel("path_choice", "joint_evaluation")).toBe(
+			"Choix du parcours — Évaluation conjointe",
+		);
+	});
+
+	it("returns combined label for path_choice with corrective_action", () => {
+		expect(getStatusHistoryLabel("path_choice", "corrective_action")).toBe(
+			"Choix du parcours — Actions correctives",
+		);
+	});
+
+	it("returns combined label for path_choice with justify", () => {
+		expect(getStatusHistoryLabel("path_choice", "justify")).toBe(
+			"Choix du parcours — Justification de l'écart",
+		);
+	});
+
+	it("returns base label for path_choice with null value", () => {
+		expect(getStatusHistoryLabel("path_choice", null)).toBe(
+			"Choix du parcours",
+		);
+	});
+
+	it("returns base label for path_choice with unknown string value", () => {
+		expect(getStatusHistoryLabel("path_choice", "unknown_string")).toBe(
+			"Choix du parcours",
+		);
+	});
+
+	it("returns the base label for cancel", () => {
+		expect(getStatusHistoryLabel("cancel", null)).toBe(
+			"Annulation de la déclaration",
+		);
+	});
+
+	it("returns a non-empty string for every key in DECLARATION_EVENT_TYPE_LABELS", () => {
+		for (const key of Object.keys(DECLARATION_EVENT_TYPE_LABELS) as Array<
+			keyof typeof DECLARATION_EVENT_TYPE_LABELS
+		>) {
+			const result = getStatusHistoryLabel(key, null);
+			expect(result.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/packages/app/src/modules/export/shared/statusHistoryLabels.ts
+++ b/packages/app/src/modules/export/shared/statusHistoryLabels.ts
@@ -1,0 +1,30 @@
+export const DECLARATION_EVENT_TYPE_LABELS = {
+	submit: "Soumission de la déclaration",
+	path_choice: "Choix du parcours",
+	second_declaration_submit: "Soumission de la seconde déclaration",
+	joint_evaluation_submit: "Dépôt du rapport d'évaluation conjointe",
+	cse_opinion_submit: "Dépôt d'un avis CSE",
+	cancel: "Annulation de la déclaration",
+	demarche_complete: "Démarche terminée",
+} as const;
+
+export const PATH_CHOICE_VALUE_LABELS = {
+	justify: "Justification de l'écart",
+	corrective_action: "Actions correctives",
+	joint_evaluation: "Évaluation conjointe",
+} as const;
+
+export type DeclarationEventType = keyof typeof DECLARATION_EVENT_TYPE_LABELS;
+
+export function getStatusHistoryLabel(
+	eventType: DeclarationEventType,
+	value: string | null,
+): string {
+	if (eventType === "path_choice") {
+		if (value !== null && value in PATH_CHOICE_VALUE_LABELS) {
+			return `Choix du parcours — ${PATH_CHOICE_VALUE_LABELS[value as keyof typeof PATH_CHOICE_VALUE_LABELS]}`;
+		}
+		return DECLARATION_EVENT_TYPE_LABELS.path_choice;
+	}
+	return DECLARATION_EVENT_TYPE_LABELS[eventType];
+}


### PR DESCRIPTION
Closes #3498

## Résumé

Première brique de l'epic #3472 : ajoute un helper isomorphe (sans dépendance DB / Drizzle / React) qui mappe une transition de statut brute (`eventType` + `value` optionnel) vers son libellé FR.

### Nouveaux exports depuis `~/modules/export`

- `DECLARATION_EVENT_TYPE_LABELS` — record des 7 valeurs de l'enum `declaration_event_type`
- `PATH_CHOICE_VALUE_LABELS` — record des 3 valeurs métier du `path_choice`
- `getStatusHistoryLabel(eventType, value)` — fonction pure retournant le libellé FR (avec combinaison `"Choix du parcours — <label>"` pour `path_choice`)
- `type DeclarationEventType` — dérivé de la constante (sans import `server/`)

## Test plan

- [x] 8 tests unitaires couvrant tous les `eventType`, les 3 valeurs `path_choice`, le fallback `null`, et la valeur inconnue
- [x] Couverture 100% statements / branches / functions / lines
- [x] Typecheck vert
- [x] Lint + format verts (Biome)

## Référence Figma

N/A