### PR TITLE
feat(export): expose Historique_statuts in SUIT declarations payload

### DIFF
--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -99,6 +99,12 @@ const nullIndicators = {
 	hourlyQuartile2ProportionMen: null,
 	hourlyQuartile3ProportionMen: null,
 	hourlyQuartile4ProportionMen: null,
+	statusHistoryArray: [] as Array<{
+		eventType: string;
+		value: string | null;
+		round: number | null;
+		createdAt: string;
+	}>,
 };
 
 describe("GET /api/v1/export/declarations", () => {
@@ -1057,6 +1063,84 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(decl.Date_avis_CSE).toBe("2027-10-01T13:00:00.000Z");
 		expect(decl.Date_fin_demarche).toBe("2027-10-15T14:00:00.000Z");
 		expect(decl.Seconde_declaration.Statut).toBe(true);
+	});
+
+	it("should include Historique_statuts with FR labels and Round on path_choice entries", async () => {
+		mockFetchSubmitted.mockResolvedValue([
+			{
+				declarationId: "decl-1",
+				siren: "123456789",
+				year: 2027,
+				status: "submitted",
+				firstDeclarationPathChoice: "corrective_action",
+				secondDeclarationPathChoice: null,
+				totalWomen: 100,
+				totalMen: 150,
+				submittedAt: new Date("2027-03-15T10:00:00Z"),
+				firstDeclarationPathChoiceAt: new Date("2027-04-01T10:00:00Z"),
+				secondDeclarationPathChoiceAt: null,
+				secondDeclarationSubmittedAt: null,
+				jointEvaluationSubmittedAt: null,
+				cseOpinionCompletedAt: null,
+				demarcheCompletedAt: null,
+				phase2Required: false,
+				phase2RevisionRequired: false,
+				cseRequired: false,
+				indicatorGRequired: false,
+				rulesVersion: "2027.1",
+				secondDeclReferencePeriodStart: null,
+				secondDeclReferencePeriodEnd: null,
+				createdAt: new Date("2027-03-15T10:00:00Z"),
+				updatedAt: new Date("2027-04-01T10:00:00Z"),
+				companyName: "ACME Corp",
+				workforce: 250,
+				nafCode: "62.02",
+				address: "1 rue test",
+				hasCse: false,
+				declarantFirstName: "Jean",
+				declarantLastName: "Dupont",
+				declarantEmail: "jean@acme.fr",
+				declarantPhone: "0612345678",
+				...nullIndicators,
+				statusHistoryArray: [
+					{
+						eventType: "submit",
+						value: null,
+						round: null,
+						createdAt: "2027-03-15T10:00:00.000Z",
+					},
+					{
+						eventType: "path_choice",
+						value: "corrective_action",
+						round: 1,
+						createdAt: "2027-04-01T10:00:00.000Z",
+					},
+				],
+			},
+		]);
+
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const request = gatewayForwardedRequest(
+			"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+		);
+		const response = await GET(request);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		const decl = body.Declarations[0];
+		expect(decl.Historique_statuts).toEqual([
+			{
+				Statut: "submit",
+				Libelle_statut: "Soumission de la déclaration",
+				Date: "2027-03-15T10:00:00.000Z",
+			},
+			{
+				Statut: "path_choice",
+				Libelle_statut: "Choix du parcours — Actions correctives",
+				Date: "2027-04-01T10:00:00.000Z",
+				Round: 1,
+			},
+		]);
 	});
 
 	it("should expose Seconde_declaration.Statut=false when secondDeclarationSubmittedAt is null", async () => {

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -120,6 +120,12 @@ const baseRow = {
 	hourlyQuartile3ProportionMen: "0.5410",
 	hourlyQuartile4ProportionWomen: "0.3509",
 	hourlyQuartile4ProportionMen: "0.6491",
+	statusHistoryArray: [] as Array<{
+		eventType: string;
+		value: string | null;
+		round: number | null;
+		createdAt: string;
+	}>,
 };
 
 describe("buildIndicators", () => {
@@ -524,5 +530,242 @@ describe("assembleDeclaration", () => {
 		expect(result.Indicateurs.G?.[0]?.Effectif_F).toBe(12);
 		expect(result.SIREN).toBe("123456789");
 		expect(result.Effectif).toBe(250);
+	});
+
+	it("should expose Historique_statuts as empty array when no history (S7)", () => {
+		const result = assembleDeclaration(baseRow, [], []);
+
+		expect(result.Historique_statuts).toEqual([]);
+	});
+
+	it("should expose Historique_statuts with FR labels for submit + demarche_complete (S1)", () => {
+		const row = {
+			...baseRow,
+			statusHistoryArray: [
+				{
+					eventType: "submit",
+					value: null,
+					round: null,
+					createdAt: "2027-03-15T10:00:00.123Z",
+				},
+				{
+					eventType: "demarche_complete",
+					value: null,
+					round: null,
+					createdAt: "2027-10-15T14:00:00.456Z",
+				},
+			],
+		};
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Historique_statuts).toEqual([
+			{
+				Statut: "submit",
+				Libelle_statut: "Soumission de la déclaration",
+				Date: "2027-03-15T10:00:00.123Z",
+			},
+			{
+				Statut: "demarche_complete",
+				Libelle_statut: "Démarche terminée",
+				Date: "2027-10-15T14:00:00.456Z",
+			},
+		]);
+	});
+
+	it("should expose Round and Libelle for path_choice corrective_action (S2)", () => {
+		const row = {
+			...baseRow,
+			statusHistoryArray: [
+				{
+					eventType: "path_choice",
+					value: "corrective_action",
+					round: 1,
+					createdAt: "2027-04-01T10:00:00.000Z",
+				},
+			],
+		};
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Historique_statuts).toEqual([
+			{
+				Statut: "path_choice",
+				Libelle_statut: "Choix du parcours — Actions correctives",
+				Date: "2027-04-01T10:00:00.000Z",
+				Round: 1,
+			},
+		]);
+	});
+
+	it("should expose all 5 lifecycle entries with FR labels (S3)", () => {
+		const row = {
+			...baseRow,
+			statusHistoryArray: [
+				{
+					eventType: "submit",
+					value: null,
+					round: null,
+					createdAt: "2027-03-15T10:00:00.000Z",
+				},
+				{
+					eventType: "path_choice",
+					value: "joint_evaluation",
+					round: 1,
+					createdAt: "2027-04-01T10:00:00.000Z",
+				},
+				{
+					eventType: "joint_evaluation_submit",
+					value: null,
+					round: null,
+					createdAt: "2027-09-01T12:00:00.000Z",
+				},
+				{
+					eventType: "cse_opinion_submit",
+					value: null,
+					round: null,
+					createdAt: "2027-10-01T13:00:00.000Z",
+				},
+				{
+					eventType: "demarche_complete",
+					value: null,
+					round: null,
+					createdAt: "2027-10-15T14:00:00.000Z",
+				},
+			],
+		};
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Historique_statuts).toHaveLength(5);
+		expect(result.Historique_statuts[0]?.Libelle_statut).toBe(
+			"Soumission de la déclaration",
+		);
+		expect(result.Historique_statuts[1]?.Libelle_statut).toBe(
+			"Choix du parcours — Évaluation conjointe",
+		);
+		expect(result.Historique_statuts[1]).toHaveProperty("Round", 1);
+		expect(result.Historique_statuts[2]?.Libelle_statut).toBe(
+			"Dépôt du rapport d'évaluation conjointe",
+		);
+		expect(result.Historique_statuts[3]?.Libelle_statut).toBe(
+			"Dépôt d'un avis CSE",
+		);
+		expect(result.Historique_statuts[4]?.Libelle_statut).toBe(
+			"Démarche terminée",
+		);
+	});
+
+	it("should expose two path_choice entries with their own Round (S4)", () => {
+		const row = {
+			...baseRow,
+			statusHistoryArray: [
+				{
+					eventType: "path_choice",
+					value: "justify",
+					round: 1,
+					createdAt: "2027-04-01T10:00:00.000Z",
+				},
+				{
+					eventType: "path_choice",
+					value: "corrective_action",
+					round: 2,
+					createdAt: "2027-08-01T10:00:00.000Z",
+				},
+			],
+		};
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Historique_statuts).toHaveLength(2);
+		expect(result.Historique_statuts[0]).toMatchObject({
+			Statut: "path_choice",
+			Libelle_statut: "Choix du parcours — Justification de l'écart",
+			Round: 1,
+		});
+		expect(result.Historique_statuts[1]).toMatchObject({
+			Statut: "path_choice",
+			Libelle_statut: "Choix du parcours — Actions correctives",
+			Round: 2,
+		});
+	});
+
+	it("should expose cancel entry with FR label while keeping Date_annulation (S5)", () => {
+		const row = {
+			...baseRow,
+			cancelledAt: new Date("2027-04-15T08:00:00Z"),
+			statusHistoryArray: [
+				{
+					eventType: "submit",
+					value: null,
+					round: null,
+					createdAt: "2027-03-15T10:00:00.000Z",
+				},
+				{
+					eventType: "cancel",
+					value: null,
+					round: null,
+					createdAt: "2027-04-15T08:00:00.000Z",
+				},
+			],
+		};
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Historique_statuts).toHaveLength(2);
+		expect(result.Historique_statuts[1]).toEqual({
+			Statut: "cancel",
+			Libelle_statut: "Annulation de la déclaration",
+			Date: "2027-04-15T08:00:00.000Z",
+		});
+		expect(result.Date_annulation).toBe("2027-04-15T08:00:00.000Z");
+	});
+
+	it("should preserve the order returned by the query without re-sorting", () => {
+		const row = {
+			...baseRow,
+			statusHistoryArray: [
+				{
+					eventType: "demarche_complete",
+					value: null,
+					round: null,
+					createdAt: "2027-10-15T14:00:00.000Z",
+				},
+				{
+					eventType: "submit",
+					value: null,
+					round: null,
+					createdAt: "2027-03-15T10:00:00.000Z",
+				},
+			],
+		};
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Historique_statuts.map((e) => e.Statut)).toEqual([
+			"demarche_complete",
+			"submit",
+		]);
+	});
+
+	it("should not add Round key when path_choice round is null", () => {
+		const row = {
+			...baseRow,
+			statusHistoryArray: [
+				{
+					eventType: "path_choice",
+					value: null,
+					round: null,
+					createdAt: "2027-04-01T10:00:00.000Z",
+				},
+			],
+		};
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Historique_statuts[0]).not.toHaveProperty("Round");
+		expect(result.Historique_statuts[0]?.Libelle_statut).toBe(
+			"Choix du parcours",
+		);
 	});
 });

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -33,6 +33,10 @@ import {
 	INDICATOR_F_HOURLY_THRESHOLD_LABELS,
 	INDICATOR_F_HOURLY_WOMEN_LABELS,
 } from "./shared/apiLabels";
+import {
+	type DeclarationEventType,
+	getStatusHistoryLabel,
+} from "./shared/statusHistoryLabels";
 
 const PHASE2_SIZE_MIN = 100;
 
@@ -325,6 +329,19 @@ export function assembleDeclaration(
 		Date_avis_CSE: row.cseOpinionCompletedAt?.toISOString() ?? null,
 		Date_fin_demarche: row.demarcheCompletedAt?.toISOString() ?? null,
 		Date_annulation: row.cancelledAt?.toISOString() ?? null,
+		Historique_statuts: row.statusHistoryArray.map((entry) => {
+			const base = {
+				Statut: entry.eventType,
+				Libelle_statut: getStatusHistoryLabel(
+					entry.eventType as DeclarationEventType,
+					entry.value,
+				),
+				Date: entry.createdAt,
+			};
+			return entry.eventType === "path_choice" && entry.round !== null
+				? { ...base, Round: entry.round }
+				: base;
+		}),
 		Effectif_F_rem_annuelle_globale: row.totalWomen,
 		Effectif_H_rem_annuelle_globale: row.totalMen,
 		Indicateurs: {

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -22,6 +22,13 @@ import type { IndicatorGRow } from "./types";
 const toDate = (value: unknown): Date | null =>
 	value == null ? null : new Date(value as string | number | Date);
 
+export type RawHistoryEntry = {
+	eventType: string;
+	value: string | null;
+	round: number | null;
+	createdAt: string;
+};
+
 function latestEventAt(eventType: string) {
 	return sql<Date | null>`(
 		SELECT MAX(${declarationStatusHistory.createdAt})
@@ -41,6 +48,30 @@ function latestPathChoiceAt(round: 1 | 2) {
 	)`.mapWith(toDate);
 }
 
+function statusHistoryArray() {
+	return sql<RawHistoryEntry[]>`(
+		SELECT COALESCE(
+			json_agg(
+				json_build_object(
+					'eventType', ${declarationStatusHistory.eventType},
+					'value', ${declarationStatusHistory.value},
+					'round', ${declarationStatusHistory.round},
+					'createdAt', to_char(
+						${declarationStatusHistory.createdAt} AT TIME ZONE 'UTC',
+						'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+					)
+				)
+				ORDER BY ${declarationStatusHistory.createdAt} ASC
+			),
+			'[]'::json
+		)
+		FROM ${declarationStatusHistory}
+		WHERE ${declarationStatusHistory.declarationId} = ${declarations.id}
+	)`.mapWith((value: unknown) =>
+		Array.isArray(value) ? (value as RawHistoryEntry[]) : [],
+	);
+}
+
 export const statusHistoryProjection = {
 	submittedAt: latestEventAt("submit"),
 	firstDeclarationPathChoiceAt: latestPathChoiceAt(1),
@@ -49,6 +80,7 @@ export const statusHistoryProjection = {
 	jointEvaluationSubmittedAt: latestEventAt("joint_evaluation_submit"),
 	cseOpinionCompletedAt: latestEventAt("cse_opinion_submit"),
 	demarcheCompletedAt: latestEventAt("demarche_complete"),
+	statusHistoryArray: statusHistoryArray(),
 };
 
 // ── Shared select columns for indicators A–F ───────────────────────


### PR DESCRIPTION
Closes #3499

## Summary

Adds a new `Historique_statuts` array field to each declaration in the SUIT `GET /api/v1/export/declarations` JSON response. The array is ordered ASC, exhaustive, and never null (empty array if no history). Each entry exposes:

- `Statut` — raw event type (e.g. `submit`, `path_choice`, `cancel`)
- `Libelle_statut` — French label from the helper added in #3498
- `Date` — ISO-8601 UTC string with millisecond precision
- `Round` — present **only** when `Statut === "path_choice"` and `round` is non-null (round 1 or 2)

Implementation:

- `queries.ts` — new `statusHistoryArray()` SQL projection using `json_agg(... ORDER BY created_at ASC)` with `COALESCE('[]')` for declarations without history. Added to `statusHistoryProjection`. Exports `RawHistoryEntry` type.
- `fetchDeclarations.ts` — new `Historique_statuts` field in `assembleDeclaration`, placed just before `Effectif_F_rem_annuelle_globale`. Uses `getStatusHistoryLabel` from #3498 for FR labels.

Strict retro-compat (S6): the existing scalar `Date_soumission`, `Date_parcours_apres_declaration_1/2`, `Date_seconde_declaration`, `Date_evaluation_conjointe`, `Date_avis_CSE`, `Date_fin_demarche`, `Date_annulation`, top-level `Statut`, and all other response fields are unchanged.

XLSX export (`buildExportRows.ts`) and OpenAPI spec are out of scope (deferred to other sub-tickets of #3472).

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test` green (1967 tests, including 7 new unit tests covering S1–S5, S7, and the no-round edge case)
- [x] `pnpm lint:check` + `pnpm format:check` green
- [x] `fetchDeclarations.ts` 100% line/statement/function coverage on the new mapping
- [x] Existing tests still green — no regression on the scalar `Date_*` fields (S6)