### PR TITLE
fix(prod/pg): bump CNPG storage from 8Gi to 20Gi

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -84,6 +84,11 @@ nginx:
       cpu: 1
       memory: 2G
 
+pg:
+  cnpg-cluster:
+    storage:
+      size: 20Gi
+
 redis:
   sentinel:
     enabled: true


### PR DESCRIPTION
## Contexte

Le PVC du primaire CNPG `pg-1` (namespace `egapro`, cluster `ovh-prod`) avait atteint **91 %** (940 M libres sur 10 G).

La cause n'était pas une croissance de données (`base` = 944 M) mais l'accumulation de WAL local (`pg_wal` = **7.9 G**) **retenue par un slot de réplication orphelin** `_cnpg_pg_7`. Cette réplique pg-7 avait divergé de timeline (file-based replication coincée à LSN A7/0 alors que le primaire avait forké à A6/FF000000), bloquant le recyclage du WAL sur pg-1.

Les répliques pg-3 (sync) et le streaming primaire étaient sains tout du long ; le backup S3 et le `ContinuousArchiving` continuaient de fonctionner.

## Hotfix déjà appliqué côté cluster

- `kubectl patch cluster pg --type=merge -p '{"spec":{"storage":{"size":"20Gi"}}}'` → resize **online** via CSI Cinder (`resizeInUseVolumes: true`) ; les 3 PVCs sont passés à 20Gi **sans redémarrage des pods**
- `kubectl cnpg destroy pg 7` → slot `_cnpg_pg_7` droppé, instance recréée proprement en `pg-8` via `pg_basebackup`
- `CHECKPOINT` → WAL local recyclé

### État après hotfix

| Métrique | Avant | Après |
|---|---|---|
| `df -h /var/lib/postgresql/data` sur pg-1 | 8.9G/9.8G (91 %) | 1.6G/20G (8 %) |
| `pg_wal` sur pg-1 | 7.9 G | 593 M |
| Slots actifs | `_cnpg_pg_3` (0 B), `_cnpg_pg_7` (8032 MB, **inactif**) | `_cnpg_pg_3` (0 B), `_cnpg_pg_8` (0 B), tous actifs |
| Instances | pg-1, pg-3, pg-7 (file-based, diverged) | pg-1, pg-3, pg-8 — **3/3 streaming, sync** |
| PVCs | 10Gi / 10Gi / 8Gi | 20Gi / 20Gi / 20Gi |

## Cette PR

Aligne l'IaC sur l'état runtime pour que les **futures nouvelles instances naissent à 20Gi** et éviter le drift au prochain déploiement kontinuous (qui réécrirait sinon `storage.size: 8Gi` — sans effet sur les PVCs existants qui ne rétrécissent pas, mais problématique pour toute nouvelle instance créée par l'opérateur).

Override placé dans les values **prod** uniquement (dev/preprod gardent les défauts du chart).

## Test plan

- [x] Hotfix runtime appliqué et validé (voir tableau ci-dessus)
- [x] `kubectl cnpg status pg` : `Cluster in healthy state`, 3/3 ready, 0 lag
- [ ] Merge → déploiement kontinuous prod
- [ ] Vérifier qu'aucun `Cluster.spec.storage.size` ne revient à `8Gi` après le déploiement
- [ ] (Optionnel) Investiguer la cause de la divergence de timeline de pg-7 (il y a 78 jours) pour éviter une récidive

🤖 Generated with [Claude Code](https://claude.com/claude-code)