### PR TITLE
feat(schema): add draft/draftUpdatedAt columns to app_declaration

### DIFF
--- a/packages/app/drizzle/0036_pale_mikhail_rasputin.sql
+++ b/packages/app/drizzle/0036_pale_mikhail_rasputin.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "app_declaration" ADD COLUMN "draft" jsonb;--> statement-breakpoint
+ALTER TABLE "app_declaration" ADD COLUMN "draft_updated_at" timestamp with time zone;

--- a/packages/app/drizzle/meta/0036_snapshot.json
+++ b/packages/app/drizzle/meta/0036_snapshot.json
@@ -1,2490 +1,2402 @@
 {
-  "id": "94cda144-458a-4392-bb97-72c5ec8d9ce7",
-  "prevId": "b0a674aa-5ec7-4d36-88aa-de06f79e956f",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.app_admin_impersonation_event": {
-      "name": "app_admin_impersonation_event",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "admin_user_id": {
-          "name": "admin_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stopped_at": {
-          "name": "stopped_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "admin_impersonation_event_admin_started_idx": {
-          "name": "admin_impersonation_event_admin_started_idx",
-          "columns": [
-            {
-              "expression": "admin_user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "started_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
-          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "admin_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_admin_impersonation_event_siren_app_company_siren_fk": {
-          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_campaign_deadline": {
-      "name": "app_campaign_deadline",
-      "schema": "",
-      "columns": {
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "gip_publication_date": {
-          "name": "gip_publication_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "campaign_start_date": {
-          "name": "campaign_start_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decl1_modification_deadline": {
-          "name": "decl1_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_justification_deadline": {
-          "name": "decl1_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_joint_evaluation_deadline": {
-          "name": "decl1_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_modification_deadline": {
-          "name": "decl2_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_justification_deadline": {
-          "name": "decl2_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_joint_evaluation_deadline": {
-          "name": "decl2_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_company": {
-      "name": "app_company",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "address": {
-          "name": "address",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "naf_code": {
-          "name": "naf_code",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce": {
-          "name": "workforce",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "has_cse": {
-          "name": "has_cse",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion": {
-      "name": "app_cse_opinion",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "gap_consulted": {
-          "name": "gap_consulted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion": {
-          "name": "opinion",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion_date": {
-          "name": "opinion_date",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_declaration_idx": {
-          "name": "cse_opinion_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_decl_number_type_idx": {
-          "name": "cse_opinion_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration_status_history": {
-      "name": "app_declaration_status_history",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "event_type": {
-          "name": "event_type",
-          "type": "declaration_event_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "round": {
-          "name": "round",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "actor_user_id": {
-          "name": "actor_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "decl_status_history_declaration_idx": {
-          "name": "decl_status_history_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": false,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
-          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
-          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "actor_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration": {
-      "name": "app_declaration",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declarant_id": {
-          "name": "declarant_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "total_women": {
-          "name": "total_women",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total_men": {
-          "name": "total_men",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "remuneration_score": {
-          "name": "remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_remuneration_score": {
-          "name": "variable_remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "quartile_score": {
-          "name": "quartile_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "category_score": {
-          "name": "category_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "first_declaration_path_choice": {
-          "name": "first_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_declaration_path_choice": {
-          "name": "second_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_women": {
-          "name": "indicator_a_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_men": {
-          "name": "indicator_a_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_women": {
-          "name": "indicator_a_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_men": {
-          "name": "indicator_a_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_women": {
-          "name": "indicator_b_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_men": {
-          "name": "indicator_b_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_women": {
-          "name": "indicator_b_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_men": {
-          "name": "indicator_b_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_women": {
-          "name": "indicator_c_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_men": {
-          "name": "indicator_c_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_women": {
-          "name": "indicator_c_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_men": {
-          "name": "indicator_c_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_women": {
-          "name": "indicator_d_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_men": {
-          "name": "indicator_d_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_women": {
-          "name": "indicator_d_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_men": {
-          "name": "indicator_d_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_women": {
-          "name": "indicator_e_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_men": {
-          "name": "indicator_e_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold1": {
-          "name": "indicator_f_annual_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold2": {
-          "name": "indicator_f_annual_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold3": {
-          "name": "indicator_f_annual_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women1": {
-          "name": "indicator_f_annual_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women2": {
-          "name": "indicator_f_annual_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women3": {
-          "name": "indicator_f_annual_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women4": {
-          "name": "indicator_f_annual_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men1": {
-          "name": "indicator_f_annual_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men2": {
-          "name": "indicator_f_annual_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men3": {
-          "name": "indicator_f_annual_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men4": {
-          "name": "indicator_f_annual_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold1": {
-          "name": "indicator_f_hourly_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold2": {
-          "name": "indicator_f_hourly_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold3": {
-          "name": "indicator_f_hourly_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women1": {
-          "name": "indicator_f_hourly_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women2": {
-          "name": "indicator_f_hourly_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women3": {
-          "name": "indicator_f_hourly_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women4": {
-          "name": "indicator_f_hourly_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men1": {
-          "name": "indicator_f_hourly_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men2": {
-          "name": "indicator_f_hourly_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men3": {
-          "name": "indicator_f_hourly_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men4": {
-          "name": "indicator_f_hourly_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "declaration_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'draft'"
-        },
-        "second_declaration_step": {
-          "name": "second_declaration_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_start": {
-          "name": "second_decl_reference_period_start",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_end": {
-          "name": "second_decl_reference_period_end",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cse_required": {
-          "name": "cse_required",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "rules_version": {
-          "name": "rules_version",
-          "type": "varchar",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2027.1'"
-        },
-        "cancelled_at": {
-          "name": "cancelled_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft": {
-          "name": "draft",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft_updated_at": {
-          "name": "draft_updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "declarations_siren_year_active_unique": {
-          "name": "declarations_siren_year_active_unique",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "year",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "cancelled_at IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "declaration_declarant_idx": {
-          "name": "declaration_declarant_idx",
-          "columns": [
-            {
-              "expression": "declarant_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_siren_app_company_siren_fk": {
-          "name": "app_declaration_siren_app_company_siren_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_declaration_declarant_id_app_user_id_fk": {
-          "name": "app_declaration_declarant_id_app_user_id_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "declarant_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_employee_category": {
-      "name": "app_employee_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "job_category_id": {
-          "name": "job_category_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_type": {
-          "name": "declaration_type",
-          "type": "declaration_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "women_count": {
-          "name": "women_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count": {
-          "name": "men_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_women": {
-          "name": "annual_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_men": {
-          "name": "annual_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_women": {
-          "name": "annual_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_men": {
-          "name": "annual_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_women": {
-          "name": "hourly_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_men": {
-          "name": "hourly_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_women": {
-          "name": "hourly_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_men": {
-          "name": "hourly_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_employee_category_job_category_id_app_job_category_id_fk": {
-          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
-          "tableFrom": "app_employee_category",
-          "tableTo": "app_job_category",
-          "columnsFrom": [
-            "job_category_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "employee_category_job_type_idx": {
-          "name": "employee_category_job_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "job_category_id",
-            "declaration_type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_export": {
-      "name": "app_export",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "version": {
-          "name": "version",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'v1'"
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "s3_key": {
-          "name": "s3_key",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "row_count": {
-          "name": "row_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "export_year_version_idx": {
-          "name": "export_year_version_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "year",
-            "version"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_file": {
-      "name": "app_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_path": {
-          "name": "file_path",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "uploaded_at": {
-          "name": "uploaded_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "file_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "file_declaration_idx": {
-          "name": "file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "file_joint_eval_unique": {
-          "name": "file_joint_eval_unique",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"type\" = 'joint_evaluation'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_gip_mds_data": {
-      "name": "app_gip_mds_data",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "imported_at": {
-          "name": "imported_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_start": {
-          "name": "period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_end": {
-          "name": "period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce_ema": {
-          "name": "workforce_ema",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_global": {
-          "name": "men_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_global": {
-          "name": "women_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_hourly_global": {
-          "name": "men_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_hourly_global": {
-          "name": "women_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_variable": {
-          "name": "men_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_variable": {
-          "name": "women_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_women": {
-          "name": "global_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_men": {
-          "name": "global_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_women": {
-          "name": "global_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_men": {
-          "name": "global_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_women": {
-          "name": "variable_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_men": {
-          "name": "variable_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_women": {
-          "name": "variable_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_men": {
-          "name": "variable_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_women": {
-          "name": "global_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_men": {
-          "name": "global_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_women": {
-          "name": "global_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_men": {
-          "name": "global_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_women": {
-          "name": "variable_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_men": {
-          "name": "variable_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_women": {
-          "name": "variable_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_men": {
-          "name": "variable_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold1": {
-          "name": "annual_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold2": {
-          "name": "annual_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold3": {
-          "name": "annual_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold1": {
-          "name": "hourly_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold2": {
-          "name": "hourly_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold3": {
-          "name": "hourly_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_index": {
-          "name": "confidence_index",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_exotic_contracts": {
-          "name": "confidence_exotic_contracts",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_unit_measure": {
-          "name": "confidence_unit_measure",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_suspension_ratio": {
-          "name": "confidence_suspension_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_suspensions": {
-          "name": "confidence_long_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_end_suspensions": {
-          "name": "confidence_no_end_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_sick_leave_ratio": {
-          "name": "confidence_sick_leave_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_sick_leave": {
-          "name": "confidence_long_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_sick_leave": {
-          "name": "confidence_no_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota250": {
-          "name": "confidence_quota250",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota0": {
-          "name": "confidence_quota0",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_multi_year": {
-          "name": "confidence_multi_year",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_fp_ratio": {
-          "name": "confidence_fp_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_remuneration": {
-          "name": "confidence_extreme_remuneration",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_rate": {
-          "name": "confidence_extreme_rate",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "gip_mds_data_siren_idx": {
-          "name": "gip_mds_data_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_gip_mds_data_siren_app_company_siren_fk": {
-          "name": "app_gip_mds_data_siren_app_company_siren_fk",
-          "tableFrom": "app_gip_mds_data",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_gip_mds_data_siren_year_pk": {
-          "name": "app_gip_mds_data_siren_year_pk",
-          "columns": [
-            "siren",
-            "year"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_global_setting": {
-      "name": "app_global_setting",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "default": 1
-        },
-        "active_campaign_year": {
-          "name": "active_campaign_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_global_setting_updated_by_app_user_id_fk": {
-          "name": "app_global_setting_updated_by_app_user_id_fk",
-          "tableFrom": "app_global_setting",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "updated_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_job_category": {
-      "name": "app_job_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category_index": {
-          "name": "category_index",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source": {
-          "name": "source",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_job_category_declaration_id_app_declaration_id_fk": {
-          "name": "app_job_category_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_job_category",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "job_category_declaration_index_idx": {
-          "name": "job_category_declaration_index_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "category_index"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_referent": {
-      "name": "app_referent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "region": {
-          "name": "region",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county": {
-          "name": "county",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "referent_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "principal": {
-          "name": "principal",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "substitute_name": {
-          "name": "substitute_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "substitute_email": {
-          "name": "substitute_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "referent_region_idx": {
-          "name": "referent_region_idx",
-          "columns": [
-            {
-              "expression": "region",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user_company": {
-      "name": "app_user_company",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "user_company_user_id_idx": {
-          "name": "user_company_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_user_company_user_id_app_user_id_fk": {
-          "name": "app_user_company_user_id_app_user_id_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_user_company_siren_app_company_siren_fk": {
-          "name": "app_user_company_siren_app_company_siren_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_user_company_user_id_siren_pk": {
-          "name": "app_user_company_user_id_siren_pk",
-          "columns": [
-            "user_id",
-            "siren"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user": {
-      "name": "app_user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "first_name": {
-          "name": "first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_name": {
-          "name": "last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "phone": {
-          "name": "phone",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_admin": {
-          "name": "is_admin",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "audit.action_log": {
-      "name": "action_log",
-      "schema": "audit",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_email": {
-          "name": "user_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "action": {
-          "name": "action",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category": {
-          "name": "category",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_type": {
-          "name": "resource_type",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "resource_id": {
-          "name": "resource_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "varchar(45)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration_ms": {
-          "name": "duration_ms",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "action_log_created_at_idx": {
-          "name": "action_log_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_user_idx": {
-          "name": "action_log_user_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_siren_idx": {
-          "name": "action_log_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_action_idx": {
-          "name": "action_log_action_idx",
-          "columns": [
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_category_created_at_idx": {
-          "name": "action_log_category_created_at_idx",
-          "columns": [
-            {
-              "expression": "category",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.compliance_path": {
-      "name": "compliance_path",
-      "schema": "public",
-      "values": [
-        "justify",
-        "corrective_action",
-        "joint_evaluation"
-      ]
-    },
-    "public.declaration_event_type": {
-      "name": "declaration_event_type",
-      "schema": "public",
-      "values": [
-        "submit",
-        "path_choice",
-        "second_declaration_submit",
-        "joint_evaluation_submit",
-        "cse_opinion_submit",
-        "cancel",
-        "demarche_complete"
-      ]
-    },
-    "public.declaration_status": {
-      "name": "declaration_status",
-      "schema": "public",
-      "values": [
-        "draft",
-        "awaiting_compliance_path_choice",
-        "corrective_actions_chosen",
-        "joint_evaluation_chosen",
-        "awaiting_revision_choice",
-        "revised_joint_evaluation_chosen",
-        "awaiting_cse_opinion",
-        "demarche_completed"
-      ]
-    },
-    "public.declaration_type": {
-      "name": "declaration_type",
-      "schema": "public",
-      "values": [
-        "initial",
-        "correction"
-      ]
-    },
-    "public.file_type": {
-      "name": "file_type",
-      "schema": "public",
-      "values": [
-        "cse_opinion",
-        "joint_evaluation"
-      ]
-    },
-    "public.referent_type": {
-      "name": "referent_type",
-      "schema": "public",
-      "values": [
-        "email",
-        "url"
-      ]
-    }
-  },
-  "schemas": {
-    "audit": "audit"
-  },
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "94cda144-458a-4392-bb97-72c5ec8d9ce7",
+	"prevId": "b0a674aa-5ec7-4d36-88aa-de06f79e956f",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_status_history": {
+			"name": "app_declaration_status_history",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "declaration_event_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"round": {
+					"name": "round",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"decl_status_history_declaration_idx": {
+					"name": "decl_status_history_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_status_history_actor_user_id_app_user_id_fk": {
+					"name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_declaration_path_choice": {
+					"name": "first_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_path_choice": {
+					"name": "second_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_required": {
+					"name": "cse_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"rules_version": {
+					"name": "rules_version",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'2027.1'"
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declarations_siren_year_active_unique": {
+					"name": "declarations_siren_year_active_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "cancelled_at IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.compliance_path": {
+			"name": "compliance_path",
+			"schema": "public",
+			"values": ["justify", "corrective_action", "joint_evaluation"]
+		},
+		"public.declaration_event_type": {
+			"name": "declaration_event_type",
+			"schema": "public",
+			"values": [
+				"submit",
+				"path_choice",
+				"second_declaration_submit",
+				"joint_evaluation_submit",
+				"cse_opinion_submit",
+				"cancel",
+				"demarche_complete"
+			]
+		},
+		"public.declaration_status": {
+			"name": "declaration_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"awaiting_compliance_path_choice",
+				"corrective_actions_chosen",
+				"joint_evaluation_chosen",
+				"awaiting_revision_choice",
+				"revised_joint_evaluation_chosen",
+				"awaiting_cse_opinion",
+				"demarche_completed"
+			]
+		},
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/packages/app/drizzle/meta/0036_snapshot.json
+++ b/packages/app/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,2490 @@
+{
+  "id": "94cda144-458a-4392-bb97-72c5ec8d9ce7",
+  "prevId": "b0a674aa-5ec7-4d36-88aa-de06f79e956f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_admin_impersonation_event": {
+      "name": "app_admin_impersonation_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_impersonation_event_admin_started_idx": {
+          "name": "admin_impersonation_event_admin_started_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_admin_impersonation_event_siren_app_company_siren_fk": {
+          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_campaign_deadline": {
+      "name": "app_campaign_deadline",
+      "schema": "",
+      "columns": {
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gip_publication_date": {
+          "name": "gip_publication_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_start_date": {
+          "name": "campaign_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decl1_modification_deadline": {
+          "name": "decl1_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_justification_deadline": {
+          "name": "decl1_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_joint_evaluation_deadline": {
+          "name": "decl1_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_modification_deadline": {
+          "name": "decl2_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_justification_deadline": {
+          "name": "decl2_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_joint_evaluation_deadline": {
+          "name": "decl2_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_company": {
+      "name": "app_company",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naf_code": {
+          "name": "naf_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce": {
+          "name": "workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_cse": {
+          "name": "has_cse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion": {
+      "name": "app_cse_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gap_consulted": {
+          "name": "gap_consulted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_date": {
+          "name": "opinion_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_declaration_idx": {
+          "name": "cse_opinion_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_decl_number_type_idx": {
+          "name": "cse_opinion_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration_status_history": {
+      "name": "app_declaration_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "declaration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "decl_status_history_declaration_idx": {
+          "name": "decl_status_history_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
+          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration": {
+      "name": "app_declaration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_women": {
+          "name": "total_women",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_men": {
+          "name": "total_men",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remuneration_score": {
+          "name": "remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_remuneration_score": {
+          "name": "variable_remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quartile_score": {
+          "name": "quartile_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_score": {
+          "name": "category_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_declaration_path_choice": {
+          "name": "first_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_declaration_path_choice": {
+          "name": "second_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_women": {
+          "name": "indicator_a_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_men": {
+          "name": "indicator_a_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_women": {
+          "name": "indicator_a_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_men": {
+          "name": "indicator_a_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_women": {
+          "name": "indicator_b_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_men": {
+          "name": "indicator_b_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_women": {
+          "name": "indicator_b_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_men": {
+          "name": "indicator_b_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_women": {
+          "name": "indicator_c_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_men": {
+          "name": "indicator_c_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_women": {
+          "name": "indicator_c_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_men": {
+          "name": "indicator_c_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_women": {
+          "name": "indicator_d_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_men": {
+          "name": "indicator_d_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_women": {
+          "name": "indicator_d_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_men": {
+          "name": "indicator_d_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_women": {
+          "name": "indicator_e_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_men": {
+          "name": "indicator_e_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold1": {
+          "name": "indicator_f_annual_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold2": {
+          "name": "indicator_f_annual_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold3": {
+          "name": "indicator_f_annual_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women1": {
+          "name": "indicator_f_annual_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women2": {
+          "name": "indicator_f_annual_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women3": {
+          "name": "indicator_f_annual_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women4": {
+          "name": "indicator_f_annual_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men1": {
+          "name": "indicator_f_annual_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men2": {
+          "name": "indicator_f_annual_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men3": {
+          "name": "indicator_f_annual_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men4": {
+          "name": "indicator_f_annual_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold1": {
+          "name": "indicator_f_hourly_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold2": {
+          "name": "indicator_f_hourly_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold3": {
+          "name": "indicator_f_hourly_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women1": {
+          "name": "indicator_f_hourly_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women2": {
+          "name": "indicator_f_hourly_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women3": {
+          "name": "indicator_f_hourly_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women4": {
+          "name": "indicator_f_hourly_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men1": {
+          "name": "indicator_f_hourly_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men2": {
+          "name": "indicator_f_hourly_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men3": {
+          "name": "indicator_f_hourly_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men4": {
+          "name": "indicator_f_hourly_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "declaration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "second_declaration_step": {
+          "name": "second_declaration_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_start": {
+          "name": "second_decl_reference_period_start",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_end": {
+          "name": "second_decl_reference_period_end",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cse_required": {
+          "name": "cse_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_version": {
+          "name": "rules_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2027.1'"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_updated_at": {
+          "name": "draft_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "declarations_siren_year_active_unique": {
+          "name": "declarations_siren_year_active_unique",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "cancelled_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "declaration_declarant_idx": {
+          "name": "declaration_declarant_idx",
+          "columns": [
+            {
+              "expression": "declarant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_siren_app_company_siren_fk": {
+          "name": "app_declaration_siren_app_company_siren_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_declaration_declarant_id_app_user_id_fk": {
+          "name": "app_declaration_declarant_id_app_user_id_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_employee_category": {
+      "name": "app_employee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_category_id": {
+          "name": "job_category_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_type": {
+          "name": "declaration_type",
+          "type": "declaration_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "women_count": {
+          "name": "women_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count": {
+          "name": "men_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_women": {
+          "name": "annual_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_men": {
+          "name": "annual_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_women": {
+          "name": "annual_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_men": {
+          "name": "annual_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_women": {
+          "name": "hourly_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_men": {
+          "name": "hourly_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_women": {
+          "name": "hourly_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_men": {
+          "name": "hourly_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_employee_category_job_category_id_app_job_category_id_fk": {
+          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
+          "tableFrom": "app_employee_category",
+          "tableTo": "app_job_category",
+          "columnsFrom": [
+            "job_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employee_category_job_type_idx": {
+          "name": "employee_category_job_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_category_id",
+            "declaration_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_export": {
+      "name": "app_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "export_year_version_idx": {
+          "name": "export_year_version_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_file": {
+      "name": "app_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "file_declaration_idx": {
+          "name": "file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_joint_eval_unique": {
+          "name": "file_joint_eval_unique",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"type\" = 'joint_evaluation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_gip_mds_data": {
+      "name": "app_gip_mds_data",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_ema": {
+          "name": "workforce_ema",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_global": {
+          "name": "men_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_global": {
+          "name": "women_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_hourly_global": {
+          "name": "men_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_hourly_global": {
+          "name": "women_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_variable": {
+          "name": "men_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_variable": {
+          "name": "women_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_women": {
+          "name": "global_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_men": {
+          "name": "global_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_women": {
+          "name": "global_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_men": {
+          "name": "global_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_women": {
+          "name": "variable_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_men": {
+          "name": "variable_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_women": {
+          "name": "variable_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_men": {
+          "name": "variable_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_women": {
+          "name": "global_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_men": {
+          "name": "global_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_women": {
+          "name": "global_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_men": {
+          "name": "global_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_women": {
+          "name": "variable_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_men": {
+          "name": "variable_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_women": {
+          "name": "variable_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_men": {
+          "name": "variable_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold1": {
+          "name": "annual_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold2": {
+          "name": "annual_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold3": {
+          "name": "annual_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold1": {
+          "name": "hourly_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold2": {
+          "name": "hourly_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold3": {
+          "name": "hourly_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_index": {
+          "name": "confidence_index",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_exotic_contracts": {
+          "name": "confidence_exotic_contracts",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_unit_measure": {
+          "name": "confidence_unit_measure",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_suspension_ratio": {
+          "name": "confidence_suspension_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_suspensions": {
+          "name": "confidence_long_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_end_suspensions": {
+          "name": "confidence_no_end_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_sick_leave_ratio": {
+          "name": "confidence_sick_leave_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_sick_leave": {
+          "name": "confidence_long_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_sick_leave": {
+          "name": "confidence_no_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota250": {
+          "name": "confidence_quota250",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota0": {
+          "name": "confidence_quota0",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_multi_year": {
+          "name": "confidence_multi_year",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_fp_ratio": {
+          "name": "confidence_fp_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_remuneration": {
+          "name": "confidence_extreme_remuneration",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_rate": {
+          "name": "confidence_extreme_rate",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gip_mds_data_siren_idx": {
+          "name": "gip_mds_data_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_gip_mds_data_siren_app_company_siren_fk": {
+          "name": "app_gip_mds_data_siren_app_company_siren_fk",
+          "tableFrom": "app_gip_mds_data",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_gip_mds_data_siren_year_pk": {
+          "name": "app_gip_mds_data_siren_year_pk",
+          "columns": [
+            "siren",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_global_setting": {
+      "name": "app_global_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "active_campaign_year": {
+          "name": "active_campaign_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_global_setting_updated_by_app_user_id_fk": {
+          "name": "app_global_setting_updated_by_app_user_id_fk",
+          "tableFrom": "app_global_setting",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_job_category": {
+      "name": "app_job_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_index": {
+          "name": "category_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_job_category_declaration_id_app_declaration_id_fk": {
+          "name": "app_job_category_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_job_category",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_category_declaration_index_idx": {
+          "name": "job_category_declaration_index_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "category_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_referent": {
+      "name": "app_referent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "referent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "substitute_name": {
+          "name": "substitute_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "substitute_email": {
+          "name": "substitute_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "referent_region_idx": {
+          "name": "referent_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user_company": {
+      "name": "app_user_company",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_company_user_id_idx": {
+          "name": "user_company_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_company_user_id_app_user_id_fk": {
+          "name": "app_user_company_user_id_app_user_id_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_company_siren_app_company_siren_fk": {
+          "name": "app_user_company_siren_app_company_siren_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_user_company_user_id_siren_pk": {
+          "name": "app_user_company_user_id_siren_pk",
+          "columns": [
+            "user_id",
+            "siren"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user": {
+      "name": "app_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "audit.action_log": {
+      "name": "action_log",
+      "schema": "audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_log_created_at_idx": {
+          "name": "action_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_user_idx": {
+          "name": "action_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_siren_idx": {
+          "name": "action_log_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_action_idx": {
+          "name": "action_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_category_created_at_idx": {
+          "name": "action_log_category_created_at_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.compliance_path": {
+      "name": "compliance_path",
+      "schema": "public",
+      "values": [
+        "justify",
+        "corrective_action",
+        "joint_evaluation"
+      ]
+    },
+    "public.declaration_event_type": {
+      "name": "declaration_event_type",
+      "schema": "public",
+      "values": [
+        "submit",
+        "path_choice",
+        "second_declaration_submit",
+        "joint_evaluation_submit",
+        "cse_opinion_submit",
+        "cancel",
+        "demarche_complete"
+      ]
+    },
+    "public.declaration_status": {
+      "name": "declaration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "awaiting_compliance_path_choice",
+        "corrective_actions_chosen",
+        "joint_evaluation_chosen",
+        "awaiting_revision_choice",
+        "revised_joint_evaluation_chosen",
+        "awaiting_cse_opinion",
+        "demarche_completed"
+      ]
+    },
+    "public.declaration_type": {
+      "name": "declaration_type",
+      "schema": "public",
+      "values": [
+        "initial",
+        "correction"
+      ]
+    },
+    "public.file_type": {
+      "name": "file_type",
+      "schema": "public",
+      "values": [
+        "cse_opinion",
+        "joint_evaluation"
+      ]
+    },
+    "public.referent_type": {
+      "name": "referent_type",
+      "schema": "public",
+      "values": [
+        "email",
+        "url"
+      ]
+    }
+  },
+  "schemas": {
+    "audit": "audit"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,265 +1,265 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1771922842861,
-      "tag": "0000_fuzzy_romulus",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1771928448125,
-      "tag": "0001_worthless_dragon_lord",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1772154191182,
-      "tag": "0002_lean_khan",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1772215461501,
-      "tag": "0003_absurd_komodo",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1772223004236,
-      "tag": "0004_next_jack_murdock",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1772611200000,
-      "tag": "0005_standardize_snake_case",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1772703893318,
-      "tag": "0006_lovely_korath",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1773158962249,
-      "tag": "0007_gigantic_doctor_faustus",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1773328599101,
-      "tag": "0008_powerful_omega_flight",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1773331852632,
-      "tag": "0009_hot_vector",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1773504000000,
-      "tag": "0010_gip_mds_data",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1773936000000,
-      "tag": "0011_add_export_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1774022400000,
-      "tag": "0012_export_date_to_year",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1774108800000,
-      "tag": "0013_add_gip_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1774195200000,
-      "tag": "0014_drop_session_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1774281600000,
-      "tag": "0015_drop_account_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1774368000000,
-      "tag": "0016_link_cse_joint_eval_to_declaration",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1774874768051,
-      "tag": "0017_flatten-indicator-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1774945983953,
-      "tag": "0018_rare_next_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1775050635448,
-      "tag": "0019_declaration_siren_fk",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1775200000000,
-      "tag": "0020_clean-user-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1775400000000,
-      "tag": "0021_add-campaign-deadlines",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1775450000000,
-      "tag": "0022_merge_file_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1775500000000,
-      "tag": "0023_add_audit_action_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1775600000000,
-      "tag": "0024_add_admin_impersonation_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1775700000000,
-      "tag": "0025_add_user_is_admin",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1775800000000,
-      "tag": "0026_add_referents_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1775900000000,
-      "tag": "0027_add_global_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1776000000000,
-      "tag": "0028_add_cse_opinion_completed_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1776100000000,
-      "tag": "0029_add_declaration_submitted_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1777379362370,
-      "tag": "0030_drop_job_category_detail",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1777500000000,
-      "tag": "0031_drop_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1778071563871,
-      "tag": "0032_sparkling_monster_badoon",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1778489783883,
-      "tag": "0033_add_cancelled_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1778584824979,
-      "tag": "0034_tranquil_catseye",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1778682813792,
-      "tag": "0035_status_history",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1779263787038,
-      "tag": "0036_pale_mikhail_rasputin",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1771922842861,
+			"tag": "0000_fuzzy_romulus",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1771928448125,
+			"tag": "0001_worthless_dragon_lord",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1772154191182,
+			"tag": "0002_lean_khan",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1772215461501,
+			"tag": "0003_absurd_komodo",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1772223004236,
+			"tag": "0004_next_jack_murdock",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1772611200000,
+			"tag": "0005_standardize_snake_case",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1772703893318,
+			"tag": "0006_lovely_korath",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1773158962249,
+			"tag": "0007_gigantic_doctor_faustus",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1773328599101,
+			"tag": "0008_powerful_omega_flight",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1773331852632,
+			"tag": "0009_hot_vector",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1773504000000,
+			"tag": "0010_gip_mds_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1773936000000,
+			"tag": "0011_add_export_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1774022400000,
+			"tag": "0012_export_date_to_year",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1774108800000,
+			"tag": "0013_add_gip_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1774195200000,
+			"tag": "0014_drop_session_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1774281600000,
+			"tag": "0015_drop_account_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1774368000000,
+			"tag": "0016_link_cse_joint_eval_to_declaration",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1774874768051,
+			"tag": "0017_flatten-indicator-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1774945983953,
+			"tag": "0018_rare_next_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1775050635448,
+			"tag": "0019_declaration_siren_fk",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1775200000000,
+			"tag": "0020_clean-user-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1775400000000,
+			"tag": "0021_add-campaign-deadlines",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1775450000000,
+			"tag": "0022_merge_file_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1775500000000,
+			"tag": "0023_add_audit_action_log",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1775600000000,
+			"tag": "0024_add_admin_impersonation_events",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1775700000000,
+			"tag": "0025_add_user_is_admin",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1775800000000,
+			"tag": "0026_add_referents_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1775900000000,
+			"tag": "0027_add_global_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1776000000000,
+			"tag": "0028_add_cse_opinion_completed_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1776100000000,
+			"tag": "0029_add_declaration_submitted_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1777379362370,
+			"tag": "0030_drop_job_category_detail",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1777500000000,
+			"tag": "0031_drop_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1778071563871,
+			"tag": "0032_sparkling_monster_badoon",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1778489783883,
+			"tag": "0033_add_cancelled_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1778584824979,
+			"tag": "0034_tranquil_catseye",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1778682813792,
+			"tag": "0035_status_history",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779263787038,
+			"tag": "0036_pale_mikhail_rasputin",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,258 +1,265 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1771922842861,
-			"tag": "0000_fuzzy_romulus",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1771928448125,
-			"tag": "0001_worthless_dragon_lord",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1772154191182,
-			"tag": "0002_lean_khan",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1772215461501,
-			"tag": "0003_absurd_komodo",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1772223004236,
-			"tag": "0004_next_jack_murdock",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1772611200000,
-			"tag": "0005_standardize_snake_case",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1772703893318,
-			"tag": "0006_lovely_korath",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1773158962249,
-			"tag": "0007_gigantic_doctor_faustus",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1773328599101,
-			"tag": "0008_powerful_omega_flight",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1773331852632,
-			"tag": "0009_hot_vector",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1773504000000,
-			"tag": "0010_gip_mds_data",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1773936000000,
-			"tag": "0011_add_export_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1774022400000,
-			"tag": "0012_export_date_to_year",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1774108800000,
-			"tag": "0013_add_gip_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1774195200000,
-			"tag": "0014_drop_session_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1774281600000,
-			"tag": "0015_drop_account_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1774368000000,
-			"tag": "0016_link_cse_joint_eval_to_declaration",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1774874768051,
-			"tag": "0017_flatten-indicator-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1774945983953,
-			"tag": "0018_rare_next_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1775050635448,
-			"tag": "0019_declaration_siren_fk",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1775200000000,
-			"tag": "0020_clean-user-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1775400000000,
-			"tag": "0021_add-campaign-deadlines",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1775450000000,
-			"tag": "0022_merge_file_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1775500000000,
-			"tag": "0023_add_audit_action_log",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1775600000000,
-			"tag": "0024_add_admin_impersonation_events",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1775700000000,
-			"tag": "0025_add_user_is_admin",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1775800000000,
-			"tag": "0026_add_referents_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1775900000000,
-			"tag": "0027_add_global_settings",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1776000000000,
-			"tag": "0028_add_cse_opinion_completed_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1776100000000,
-			"tag": "0029_add_declaration_submitted_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1777379362370,
-			"tag": "0030_drop_job_category_detail",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1777500000000,
-			"tag": "0031_drop_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1778071563871,
-			"tag": "0032_sparkling_monster_badoon",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1778489783883,
-			"tag": "0033_add_cancelled_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1778584824979,
-			"tag": "0034_tranquil_catseye",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1778682813792,
-			"tag": "0035_status_history",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1771922842861,
+      "tag": "0000_fuzzy_romulus",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771928448125,
+      "tag": "0001_worthless_dragon_lord",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772154191182,
+      "tag": "0002_lean_khan",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772215461501,
+      "tag": "0003_absurd_komodo",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772223004236,
+      "tag": "0004_next_jack_murdock",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772611200000,
+      "tag": "0005_standardize_snake_case",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1772703893318,
+      "tag": "0006_lovely_korath",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1773158962249,
+      "tag": "0007_gigantic_doctor_faustus",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1773328599101,
+      "tag": "0008_powerful_omega_flight",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1773331852632,
+      "tag": "0009_hot_vector",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1773504000000,
+      "tag": "0010_gip_mds_data",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1773936000000,
+      "tag": "0011_add_export_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1774022400000,
+      "tag": "0012_export_date_to_year",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1774108800000,
+      "tag": "0013_add_gip_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1774195200000,
+      "tag": "0014_drop_session_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1774281600000,
+      "tag": "0015_drop_account_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1774368000000,
+      "tag": "0016_link_cse_joint_eval_to_declaration",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1774874768051,
+      "tag": "0017_flatten-indicator-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1774945983953,
+      "tag": "0018_rare_next_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1775050635448,
+      "tag": "0019_declaration_siren_fk",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0020_clean-user-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1775400000000,
+      "tag": "0021_add-campaign-deadlines",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1775450000000,
+      "tag": "0022_merge_file_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1775500000000,
+      "tag": "0023_add_audit_action_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1775600000000,
+      "tag": "0024_add_admin_impersonation_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1775700000000,
+      "tag": "0025_add_user_is_admin",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1775800000000,
+      "tag": "0026_add_referents_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1775900000000,
+      "tag": "0027_add_global_settings",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0028_add_cse_opinion_completed_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1776100000000,
+      "tag": "0029_add_declaration_submitted_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1777379362370,
+      "tag": "0030_drop_job_category_detail",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1777500000000,
+      "tag": "0031_drop_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1778071563871,
+      "tag": "0032_sparkling_monster_badoon",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778489783883,
+      "tag": "0033_add_cancelled_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778584824979,
+      "tag": "0034_tranquil_catseye",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1778682813792,
+      "tag": "0035_status_history",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1779263787038,
+      "tag": "0036_pale_mikhail_rasputin",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -177,6 +177,8 @@ export const declarations = createTable(
 		cancelledAt: d.timestamp({ withTimezone: false, mode: "date" }),
 		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+		draft: d.jsonb(),
+		draftUpdatedAt: d.timestamp({ withTimezone: true }),
 	}),
 	(t) => [
 		uniqueIndex("declarations_siren_year_active_unique")


### PR DESCRIPTION
Closes #3504

## Résumé

Ajoute deux colonnes nullables sur la table `app_declaration` pour préparer la migration du brouillon de déclaration depuis le `localStorage` vers la DB (epic #3484) :

- `draft jsonb` — payload JSON du brouillon (slices `main`/`second`/`joint`/`compliance`/`cse`)
- `draft_updated_at timestamp with time zone` — timestamp de la dernière écriture du brouillon

Aucune contrainte additionnelle (pas de NOT NULL, pas de DEFAULT, pas d'index). Les déclarations existantes restent valides avec `draft = NULL`.

## Changements

- `packages/app/src/server/db/schema.ts` — 2 colonnes ajoutées sur la table `declarations`
- `packages/app/drizzle/0036_pale_mikhail_rasputin.sql` — migration générée par `pnpm db:generate`

## Test plan

- [x] Migration vérifiée : `ALTER TABLE app_declaration ADD COLUMN draft jsonb` + `ADD COLUMN draft_updated_at timestamp with time zone` (nullable, sans NOT NULL ni DEFAULT)
- [x] `pnpm db:migrate` passe sans erreur sur la base locale
- [x] Typecheck vert
- [x] Tests unitaires verts (1949/1949)
- [x] Lint et format verts