### PR TITLE
feat(declaration-draft): tRPC router declarationDraft (get/save/clear) + audit + expiration

### DIFF
--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -57,6 +57,11 @@ export const AUDIT_ACTIONS = {
 	// ── Admin stats reads ─────────────────────────────────
 	ADMIN_STATS_CAMPAIGN_PROGRESSION: "admin_stats.campaign_progression",
 
+	// ── Declaration draft ─────────────────────────────────
+	DRAFT_READ: "declaration_draft.read",
+	DRAFT_SAVE: "declaration_draft.save",
+	DRAFT_CLEAR: "declaration_draft.clear",
+
 	// ── Sensitive reads ────────────────────────────────────
 	ADMIN_FILE_DOWNLOAD: "admin.file_download",
 	PROFILE_READ: "profile.read",
@@ -129,6 +134,10 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION]: "read_sensitive",
+	[AUDIT_ACTIONS.DRAFT_READ]: "read_sensitive",
+	[AUDIT_ACTIONS.DRAFT_SAVE]: "mutation",
+	[AUDIT_ACTIONS.DRAFT_CLEAR]: "mutation",
+
 	[AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.PROFILE_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA]: "read_sensitive",

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/draftSchema.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/draftSchema.ts
@@ -11,8 +11,10 @@ export const draftPayloadSchema = z.object({
 		z.literal("second-2"),
 		z.literal("joint"),
 		z.literal("compliance"),
+		z.literal("opinions"),
+		z.literal("upload"),
 	]),
-	kind: z.enum(["main", "second", "joint", "compliance"]),
+	kind: z.enum(["main", "second", "joint", "compliance", "cse"]),
 	timestamp: z.number().int(),
 	fields: z.record(z.string(), z.unknown()),
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/schemas.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+import { sirenSchema } from "~/modules/admin";
+
+const yearSchema = z.number().int().gte(2000).lte(2100);
+const kindSchema = z.enum(["main", "second", "joint", "compliance", "cse"]);
+
+export const getDraftInput = z.object({
+	year: yearSchema,
+	siren: sirenSchema,
+});
+
+export const saveDraftInput = z.object({
+	year: yearSchema,
+	siren: sirenSchema,
+	slice: z.object({
+		kind: kindSchema,
+		step: z.string().min(1),
+		data: z.record(z.string(), z.unknown()),
+	}),
+});
+
+export const clearDraftInput = z.object({
+	year: yearSchema,
+	siren: sirenSchema,
+	kind: kindSchema.optional(),
+});
+
+export type GetDraftInput = z.infer<typeof getDraftInput>;
+export type SaveDraftInput = z.infer<typeof saveDraftInput>;
+export type ClearDraftInput = z.infer<typeof clearDraftInput>;

--- a/packages/app/src/server/api/root.ts
+++ b/packages/app/src/server/api/root.ts
@@ -6,6 +6,7 @@ import { adminStatsRouter } from "~/server/api/routers/adminStats";
 import { companyRouter } from "~/server/api/routers/company";
 import { cseOpinionRouter } from "~/server/api/routers/cseOpinion";
 import { declarationRouter } from "~/server/api/routers/declaration";
+import { declarationDraftRouter } from "~/server/api/routers/declarationDraft";
 import { gipMdsRouter } from "~/server/api/routers/gipMds";
 import { jointEvaluationRouter } from "~/server/api/routers/jointEvaluation";
 import { mailRouter } from "~/server/api/routers/mail";
@@ -27,6 +28,7 @@ export const appRouter = createTRPCRouter({
 	company: companyRouter,
 	cseOpinion: cseOpinionRouter,
 	declaration: declarationRouter,
+	declarationDraft: declarationDraftRouter,
 	gipMds: gipMdsRouter,
 	jointEvaluation: jointEvaluationRouter,
 	mail: mailRouter,

--- a/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
@@ -1,0 +1,429 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+vi.mock("~/server/db/schema", () => ({
+	declarations: {
+		siren: "siren",
+		year: "year",
+		draft: "draft",
+		draftUpdatedAt: "draftUpdatedAt",
+		cancelledAt: "cancelledAt",
+		declarantId: "declarantId",
+	},
+	userCompanies: {
+		siren: "siren",
+		userId: "userId",
+	},
+}));
+
+const mockLogAction = vi.fn();
+vi.mock("~/server/audit/log", () => ({
+	logAction: (...args: unknown[]) => mockLogAction(...args),
+}));
+
+const mockGetDefaultCampaignDeadlines = vi.fn();
+vi.mock("~/modules/domain", async (importOriginal) => {
+	const original = await importOriginal<typeof import("~/modules/domain")>();
+	return {
+		...original,
+		getDefaultCampaignDeadlines: (...args: unknown[]) =>
+			mockGetDefaultCampaignDeadlines(...args),
+	};
+});
+
+const SIREN = "123456789";
+const YEAR = 2024;
+const USER_SIRET = "12345678900015";
+const FORBIDDEN_MSG = "Accès refusé à ce SIREN.";
+
+type SelectResponse = unknown[];
+
+function createMockDb(responses: SelectResponse[] = []) {
+	let limitCallIndex = 0;
+
+	const mockLimit = vi.fn().mockImplementation(() => {
+		const result = responses[limitCallIndex] ?? [];
+		limitCallIndex++;
+		return Promise.resolve(result);
+	});
+
+	const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+	const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+	const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+
+	const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+	const mockSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+	const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
+
+	const mockValues = vi.fn().mockResolvedValue(undefined);
+	const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
+
+	return {
+		db: {
+			select: mockSelect,
+			update: mockUpdate,
+			insert: mockInsert,
+		} as unknown,
+		mocks: {
+			select: mockSelect,
+			update: mockUpdate,
+			insert: mockInsert,
+			set: mockSet,
+			values: mockValues,
+			updateWhere: mockUpdateWhere,
+		},
+	};
+}
+
+function createCaller(
+	mockDb: unknown,
+	siret: string | null = USER_SIRET,
+	impersonation: { siren: string; name: string } | null = null,
+) {
+	return import("~/server/api/routers/declarationDraft").then(
+		({ declarationDraftRouter }) =>
+			declarationDraftRouter.createCaller({
+				db: mockDb,
+				session: {
+					user: {
+						id: "user-1",
+						email: "user@example.com",
+						siret,
+						isAdmin: impersonation !== null,
+						impersonation,
+					},
+					expires: "",
+				},
+				headers: new Headers(),
+			} as never),
+	);
+}
+
+function futureDeadline() {
+	return {
+		decl1ModificationDeadline: new Date(Date.now() + 365 * 24 * 3600 * 1000),
+	};
+}
+
+function pastDeadline() {
+	return { decl1ModificationDeadline: new Date(Date.now() - 1000) };
+}
+
+describe("declarationDraftRouter", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		mockGetDefaultCampaignDeadlines.mockReturnValue(futureDeadline());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("get", () => {
+		it("returns null when no declaration row exists", async () => {
+			const { db } = createMockDb([[{ siren: SIREN }], []]);
+			const caller = await createCaller(db);
+
+			const result = await caller.get({ siren: SIREN, year: YEAR });
+
+			expect(result).toBeNull();
+		});
+
+		it("returns null when draft column is null", async () => {
+			const { db } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: null, draftUpdatedAt: new Date() }],
+			]);
+			const caller = await createCaller(db);
+
+			const result = await caller.get({ siren: SIREN, year: YEAR });
+
+			expect(result).toBeNull();
+		});
+
+		it("returns the draft when valid and not expired", async () => {
+			const draftData = { main: { step1: { workforce: 50 } } };
+			const { db } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: draftData, draftUpdatedAt: new Date() }],
+			]);
+			const caller = await createCaller(db);
+
+			const result = await caller.get({ siren: SIREN, year: YEAR });
+
+			expect(result).toEqual(draftData);
+		});
+
+		it("returns null when draft is older than 30 days (TTL expired)", async () => {
+			const draftData = { main: { step1: { workforce: 50 } } };
+			const thirtyOneDaysAgo = new Date(Date.now() - 31 * 24 * 3600 * 1000);
+			const { db } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: draftData, draftUpdatedAt: thirtyOneDaysAgo }],
+			]);
+			const caller = await createCaller(db);
+
+			const result = await caller.get({ siren: SIREN, year: YEAR });
+
+			expect(result).toBeNull();
+		});
+
+		it("returns null when decl1ModificationDeadline has passed", async () => {
+			mockGetDefaultCampaignDeadlines.mockReturnValue(pastDeadline());
+
+			const draftData = { main: { step1: { workforce: 50 } } };
+			const { db } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: draftData, draftUpdatedAt: new Date() }],
+			]);
+			const caller = await createCaller(db);
+
+			const result = await caller.get({ siren: SIREN, year: YEAR });
+
+			expect(result).toBeNull();
+		});
+
+		it("throws FORBIDDEN when user does not own the siren", async () => {
+			const { db } = createMockDb([[]]);
+			const caller = await createCaller(db);
+
+			await expect(caller.get({ siren: SIREN, year: YEAR })).rejects.toThrow(
+				FORBIDDEN_MSG,
+			);
+		});
+
+		it("returns null without DB call when admin is impersonating", async () => {
+			const { db, mocks } = createMockDb();
+			const impersonation = { siren: SIREN, name: "Acme" };
+			const caller = await createCaller(db, null, impersonation);
+
+			const result = await caller.get({ siren: SIREN, year: YEAR });
+
+			expect(result).toBeNull();
+			expect(mocks.select).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("save", () => {
+		it("inserts a new row when no declaration exists", async () => {
+			const { db, mocks } = createMockDb([[{ siren: SIREN }], []]);
+			const caller = await createCaller(db);
+
+			const result = await caller.save({
+				siren: SIREN,
+				year: YEAR,
+				slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.insert).toHaveBeenCalled();
+			expect(mocks.update).not.toHaveBeenCalled();
+		});
+
+		it("updates the existing row when a declaration exists", async () => {
+			const existingDraft = { main: { step1: { workforce: 40 } } };
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: existingDraft }],
+			]);
+			const caller = await createCaller(db);
+
+			const result = await caller.save({
+				siren: SIREN,
+				year: YEAR,
+				slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.update).toHaveBeenCalled();
+			expect(mocks.insert).not.toHaveBeenCalled();
+		});
+
+		it("merges new slice without overwriting existing slices", async () => {
+			const existingDraft = { main: { step1: { workforce: 50 } } };
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: existingDraft }],
+			]);
+			const caller = await createCaller(db);
+
+			await caller.save({
+				siren: SIREN,
+				year: YEAR,
+				slice: { kind: "second", step: "form", data: { foo: "bar" } },
+			});
+
+			expect(mocks.set).toHaveBeenCalledWith(
+				expect.objectContaining({
+					draft: {
+						main: { step1: { workforce: 50 } },
+						second: { form: { foo: "bar" } },
+					},
+				}),
+			);
+		});
+
+		it("throws FORBIDDEN when user does not own the siren", async () => {
+			const { db } = createMockDb([[]]);
+			const caller = await createCaller(db);
+
+			await expect(
+				caller.save({
+					siren: SIREN,
+					year: YEAR,
+					slice: { kind: "main", step: "step1", data: {} },
+				}),
+			).rejects.toThrow(FORBIDDEN_MSG);
+		});
+
+		it("returns ok without DB mutation when admin is impersonating", async () => {
+			const { db, mocks } = createMockDb();
+			const impersonation = { siren: SIREN, name: "Acme" };
+			const caller = await createCaller(db, null, impersonation);
+
+			const result = await caller.save({
+				siren: SIREN,
+				year: YEAR,
+				slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.update).not.toHaveBeenCalled();
+			expect(mocks.insert).not.toHaveBeenCalled();
+		});
+
+		it("emits DRAFT_SAVE audit log without slice data payload", async () => {
+			const { auditMiddleware } = await import("~/server/audit/trpcMiddleware");
+
+			const input = {
+				siren: SIREN,
+				year: YEAR,
+				slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+			};
+
+			await auditMiddleware({
+				ctx: {
+					session: {
+						user: { id: "user-1", email: "u@e.fr", siret: USER_SIRET },
+					},
+					headers: new Headers(),
+				},
+				path: "declarationDraft.save",
+				getRawInput: async () => input,
+				next: async () => ({ ok: true as const }),
+			} as never);
+
+			expect(mockLogAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "declaration_draft.save",
+					status: "success",
+				}),
+			);
+
+			const callArg = mockLogAction.mock.calls[0]?.[0] as Record<
+				string,
+				unknown
+			>;
+			const metadata = callArg?.["metadata"] as
+				| Record<string, unknown>
+				| undefined;
+			const slice = metadata?.["slice"] as Record<string, unknown> | undefined;
+			expect(slice).not.toHaveProperty("data");
+		});
+	});
+
+	describe("clear", () => {
+		it("sets draft and draftUpdatedAt to null when no kind is given", async () => {
+			const { db, mocks } = createMockDb([[{ siren: SIREN }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.clear({ siren: SIREN, year: YEAR });
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.set).toHaveBeenCalledWith(
+				expect.objectContaining({ draft: null, draftUpdatedAt: null }),
+			);
+		});
+
+		it("drops only the specified kind slice while preserving others", async () => {
+			const existingDraft = {
+				main: { step1: { workforce: 50 } },
+				cse: { opinions: { opinion: "favorable" } },
+			};
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: existingDraft }],
+			]);
+			const caller = await createCaller(db);
+
+			const result = await caller.clear({
+				siren: SIREN,
+				year: YEAR,
+				kind: "main",
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.set).toHaveBeenCalledWith(
+				expect.objectContaining({
+					draft: { cse: { opinions: { opinion: "favorable" } } },
+				}),
+			);
+		});
+
+		it("sets draft to null when clearing the last remaining slice", async () => {
+			const existingDraft = { main: { step1: { workforce: 50 } } };
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ draft: existingDraft }],
+			]);
+			const caller = await createCaller(db);
+
+			await caller.clear({ siren: SIREN, year: YEAR, kind: "main" });
+
+			expect(mocks.set).toHaveBeenCalledWith(
+				expect.objectContaining({ draft: null, draftUpdatedAt: null }),
+			);
+		});
+
+		it("returns ok early when partial clear finds no existing draft", async () => {
+			const { db, mocks } = createMockDb([[{ siren: SIREN }], []]);
+			const caller = await createCaller(db);
+
+			const result = await caller.clear({
+				siren: SIREN,
+				year: YEAR,
+				kind: "main",
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.update).not.toHaveBeenCalled();
+		});
+
+		it("throws FORBIDDEN when user does not own the siren", async () => {
+			const { db } = createMockDb([[]]);
+			const caller = await createCaller(db);
+
+			await expect(caller.clear({ siren: SIREN, year: YEAR })).rejects.toThrow(
+				FORBIDDEN_MSG,
+			);
+		});
+
+		it("returns ok without DB mutation when admin is impersonating", async () => {
+			const { db, mocks } = createMockDb();
+			const impersonation = { siren: SIREN, name: "Acme" };
+			const caller = await createCaller(db, null, impersonation);
+
+			const result = await caller.clear({ siren: SIREN, year: YEAR });
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.update).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
@@ -331,10 +331,8 @@ describe("declarationDraftRouter", () => {
 				string,
 				unknown
 			>;
-			const metadata = callArg?.["metadata"] as
-				| Record<string, unknown>
-				| undefined;
-			const slice = metadata?.["slice"] as Record<string, unknown> | undefined;
+			const metadata = callArg?.metadata as Record<string, unknown> | undefined;
+			const slice = metadata?.slice as Record<string, unknown> | undefined;
 			expect(slice).not.toHaveProperty("data");
 		});
 	});

--- a/packages/app/src/server/api/routers/declarationDraft.ts
+++ b/packages/app/src/server/api/routers/declarationDraft.ts
@@ -1,0 +1,190 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq, isNull } from "drizzle-orm";
+import type { Session } from "next-auth";
+
+import {
+	clearDraftInput,
+	getDraftInput,
+	saveDraftInput,
+} from "~/modules/declaration-remuneration/shared/draft/schemas";
+import { getDefaultCampaignDeadlines } from "~/modules/domain";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { isImpersonatingSiren } from "~/server/auth/companyAccess";
+import type { DB } from "~/server/db";
+import { declarations, userCompanies } from "~/server/db/schema";
+
+const DRAFT_TTL_MS = 30 * 24 * 3600 * 1000;
+
+type DraftBlob = Record<string, Record<string, unknown>>;
+
+async function assertOwnership(
+	db: DB,
+	session: Session,
+	siren: string,
+): Promise<void> {
+	if (isImpersonatingSiren(session, siren)) return;
+
+	const userId = session.user.id;
+	const rows = await db
+		.select({ siren: userCompanies.siren })
+		.from(userCompanies)
+		.where(
+			and(eq(userCompanies.userId, userId), eq(userCompanies.siren, siren)),
+		)
+		.limit(1);
+
+	if (!rows[0]) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Accès refusé à ce SIREN.",
+		});
+	}
+}
+
+function isDraftExpired(draftUpdatedAt: Date, year: number): boolean {
+	const now = Date.now();
+	if (now - draftUpdatedAt.getTime() > DRAFT_TTL_MS) return true;
+	const deadline = getDefaultCampaignDeadlines(year).decl1ModificationDeadline;
+	return now > deadline.getTime();
+}
+
+export const declarationDraftRouter = createTRPCRouter({
+	get: protectedProcedure.input(getDraftInput).query(async ({ ctx, input }) => {
+		const { siren, year } = input;
+
+		if (ctx.session.user.isAdmin && ctx.session.user.impersonation) {
+			return null;
+		}
+
+		await assertOwnership(ctx.db, ctx.session, siren);
+
+		const rows = await ctx.db
+			.select({
+				draft: declarations.draft,
+				draftUpdatedAt: declarations.draftUpdatedAt,
+			})
+			.from(declarations)
+			.where(
+				and(
+					eq(declarations.siren, siren),
+					eq(declarations.year, year),
+					isNull(declarations.cancelledAt),
+				),
+			)
+			.limit(1);
+
+		const row = rows[0];
+		if (!row || row.draft === null || row.draftUpdatedAt === null) return null;
+
+		if (isDraftExpired(row.draftUpdatedAt, year)) return null;
+
+		return row.draft as DraftBlob;
+	}),
+
+	save: protectedProcedure
+		.input(saveDraftInput)
+		.mutation(async ({ ctx, input }) => {
+			const { siren, year, slice } = input;
+
+			if (ctx.session.user.isAdmin && ctx.session.user.impersonation) {
+				return { ok: true as const };
+			}
+
+			await assertOwnership(ctx.db, ctx.session, siren);
+
+			const rows = await ctx.db
+				.select({ draft: declarations.draft })
+				.from(declarations)
+				.where(
+					and(
+						eq(declarations.siren, siren),
+						eq(declarations.year, year),
+						isNull(declarations.cancelledAt),
+					),
+				)
+				.limit(1);
+
+			const existing = rows[0];
+			const currentDraft = (existing?.draft ?? {}) as DraftBlob;
+			const kindData = (currentDraft[slice.kind] ?? {}) as Record<
+				string,
+				unknown
+			>;
+			const newDraft: DraftBlob = {
+				...currentDraft,
+				[slice.kind]: { ...kindData, [slice.step]: slice.data },
+			};
+			const now = new Date();
+
+			if (existing) {
+				await ctx.db
+					.update(declarations)
+					.set({ draft: newDraft, draftUpdatedAt: now })
+					.where(
+						and(
+							eq(declarations.siren, siren),
+							eq(declarations.year, year),
+							isNull(declarations.cancelledAt),
+						),
+					);
+			} else {
+				await ctx.db.insert(declarations).values({
+					siren,
+					year,
+					declarantId: ctx.session.user.id,
+					draft: newDraft,
+					draftUpdatedAt: now,
+				});
+			}
+
+			return { ok: true as const };
+		}),
+
+	clear: protectedProcedure
+		.input(clearDraftInput)
+		.mutation(async ({ ctx, input }) => {
+			const { siren, year, kind } = input;
+
+			if (ctx.session.user.isAdmin && ctx.session.user.impersonation) {
+				return { ok: true as const };
+			}
+
+			await assertOwnership(ctx.db, ctx.session, siren);
+
+			const where = and(
+				eq(declarations.siren, siren),
+				eq(declarations.year, year),
+				isNull(declarations.cancelledAt),
+			);
+
+			if (kind === undefined) {
+				await ctx.db
+					.update(declarations)
+					.set({ draft: null, draftUpdatedAt: null })
+					.where(where);
+			} else {
+				const rows = await ctx.db
+					.select({ draft: declarations.draft })
+					.from(declarations)
+					.where(where)
+					.limit(1);
+
+				const row = rows[0];
+				if (!row || row.draft === null) return { ok: true as const };
+
+				const current = row.draft as DraftBlob;
+				const { [kind]: _removed, ...remaining } = current;
+
+				const isEmpty = Object.keys(remaining).length === 0;
+				await ctx.db
+					.update(declarations)
+					.set({
+						draft: isEmpty ? null : remaining,
+						draftUpdatedAt: isEmpty ? null : new Date(),
+					})
+					.where(where);
+			}
+
+			return { ok: true as const };
+		}),
+});

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -66,6 +66,11 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	// ── gip mds ────────────────────────────────────────────
 	"gipMds.importFromUrl": AUDIT_ACTIONS.GIP_MDS_IMPORT,
 
+	// ── declaration draft ─────────────────────────────────
+	"declarationDraft.get": AUDIT_ACTIONS.DRAFT_READ,
+	"declarationDraft.save": AUDIT_ACTIONS.DRAFT_SAVE,
+	"declarationDraft.clear": AUDIT_ACTIONS.DRAFT_CLEAR,
+
 	// ── mail ──────────────────────────────────────────────
 	"mail.resendReceipt": AUDIT_ACTIONS.MAIL_RECEIPT_RESEND,
 };
@@ -230,4 +235,5 @@ const SENSITIVE_KEYS = new Set([
 	"accesskey",
 	"access_key",
 	"private_key",
+	"data",
 ]);


### PR DESCRIPTION
Closes #3505

## Résumé

Router tRPC `declarationDraft` exposant 3 `protectedProcedure` pour gérer le brouillon de déclaration côté serveur :
- **`get`** : retourne le draft avec expiration 30j (TTL) + deadline `decl1ModificationDeadline`
- **`save`** : merge last-write-wins par kind/step, INSERT si aucune ligne n'existe
- **`clear`** : reset total (draft=NULL) ou suppression partielle d'un slice par kind

Autres changements :
- Extension `draftSchema.ts` : kind `"cse"` + steps `"opinions"` / `"upload"`
- Schemas Zod input tRPC centralisés dans `shared/draft/schemas.ts`
- 3 nouvelles `AUDIT_ACTIONS` (`DRAFT_READ`, `DRAFT_SAVE`, `DRAFT_CLEAR`) + wire-up `PROCEDURE_TO_ACTION`
- Ajout de `"data"` dans `SENSITIVE_KEYS` du middleware pour exclure le payload de rémunération des logs d'audit
- Guard impersonation : les 3 procédures sont no-op (return null/{ ok: true }) quand `isAdmin + impersonation`

## Test plan

- [x] Typecheck vert
- [x] 1977 tests unitaires verts (238 fichiers)
- [x] Lint + format verts
- [x] 19 tests pour le router (ownership, TTL, deadline, merge, impersonation, audit log, clear partiel/total)
- [x] Audit DRAFT_SAVE vérifié : metadata sans le champ `data` brut
- [ ] CI GitHub Actions

## Notes

- Les schémas `schemas.ts` ne sont pas encore exportés depuis le barrel `declaration-remuneration/index.ts` (hors scope ticket — à ajouter dans le ticket du hook front #T3 qui importera ces schémas)
- Pattern impersonation intentionnellement no-op (return early) plutôt que FORBIDDEN — conforme au spec `#3505` (comportement localStorage)
- Pas de transaction sur le read-then-single-write dans `save`/`clear` — spec dit "last-write-wins, pas de lock optimiste"