### PR TITLE
T7 — Purge draft slice in-transaction on 5 submit mutations

### DIFF
--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
@@ -20,6 +20,7 @@ function createMockDbForFinalize(
 		status: "awaiting_cse_opinion",
 		rulesVersion: "2027.1",
 	},
+	txDraft: Record<string, unknown> | null = null,
 ) {
 	const declarationLookupRow = { id: "decl-1" };
 
@@ -34,6 +35,9 @@ function createMockDbForFinalize(
 		if (call === 1) return Promise.resolve([declarationLookupRow]);
 		if (call === 4) {
 			return Promise.resolve(declaration ? [declaration] : []);
+		}
+		if (call === 5 && txDraft !== null) {
+			return Promise.resolve([{ draft: txDraft }]);
 		}
 		return Promise.resolve([]);
 	});
@@ -176,5 +180,50 @@ describe("cseOpinionRouter.finalize", () => {
 
 		await expect(caller.finalize()).rejects.toThrow("Mode mimoquage");
 		expect(ctx.update).not.toHaveBeenCalled();
+	});
+
+	it("purges the cse draft slice and keeps other slices after finalize", async () => {
+		const txDraft = { cse: { step1: { foo: "bar" } }, main: { step1: {} } };
+		const ctx = createMockDbForFinalize(2, 1, undefined, txDraft);
+		const caller = await createCaller(ctx.db);
+
+		await caller.finalize();
+
+		const setCalls = ctx.updateSet.mock.calls.map(
+			(c) => c[0] as Record<string, unknown>,
+		);
+		const purgeCall = setCalls.find((c) => "draft" in c);
+		expect(purgeCall).toBeDefined();
+		expect(purgeCall?.draft).toEqual({ main: { step1: {} } });
+		expect(purgeCall?.draftUpdatedAt).toBeInstanceOf(Date);
+	});
+
+	it("sets draft to null when cse was the only slice after finalize", async () => {
+		const txDraft = { cse: { step1: { foo: "bar" } } };
+		const ctx = createMockDbForFinalize(2, 1, undefined, txDraft);
+		const caller = await createCaller(ctx.db);
+
+		await caller.finalize();
+
+		const setCalls = ctx.updateSet.mock.calls.map(
+			(c) => c[0] as Record<string, unknown>,
+		);
+		const purgeCall = setCalls.find((c) => "draft" in c);
+		expect(purgeCall).toBeDefined();
+		expect(purgeCall?.draft).toBeNull();
+		expect(purgeCall?.draftUpdatedAt).toBeNull();
+	});
+
+	it("does not call draft update when no draft exists in cse finalize", async () => {
+		const ctx = createMockDbForFinalize(2, 1, undefined, null);
+		const caller = await createCaller(ctx.db);
+
+		await caller.finalize();
+
+		const setCalls = ctx.updateSet.mock.calls.map(
+			(c) => c[0] as Record<string, unknown>,
+		);
+		const purgeCall = setCalls.find((c) => "draft" in c);
+		expect(purgeCall).toBeUndefined();
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -134,6 +134,8 @@ type DeclarationStateRow = {
 	indicatorFHourlyMen2?: number | null;
 	indicatorFHourlyMen3?: number | null;
 	indicatorFHourlyMen4?: number | null;
+	draft?: Record<string, unknown> | null;
+	draftUpdatedAt?: Date | null;
 };
 
 type CompanyRow = {
@@ -300,13 +302,14 @@ function createSubmitMockDb(
 function createOneRowSelectDb(
 	declaration: DeclarationStateRow,
 	correctionCategories: Array<Record<string, unknown>> = [],
+	txRows: unknown[] = [],
 ) {
 	const joinRows = correctionCategories.map((ec) => ({
 		employee_category: ec,
 	}));
 	const selectQueue = createSelectQueue([[declaration], joinRows]);
 
-	const m = createMutationTxMock();
+	const m = createMutationTxMock(txRows);
 
 	return {
 		db: {
@@ -326,13 +329,14 @@ function createSimpleSelectDb(
 	declaration: DeclarationStateRow,
 	historyForRound: unknown[] = [],
 	historyForLock: unknown[] = [],
+	txRows: unknown[] = [],
 ) {
 	const queue = createSelectQueue([
 		[declaration],
 		historyForRound,
 		historyForLock,
 	]);
-	const m = createMutationTxMock();
+	const m = createMutationTxMock(txRows);
 
 	return {
 		db: {
@@ -609,6 +613,61 @@ describe("declarationRouter", () => {
 				"SIRET manquant ou invalide dans la session",
 			);
 		});
+
+		it("purges the main draft slice and keeps other slices after submit", async () => {
+			const declaration = buildDeclaration({
+				status: "draft",
+				draft: { main: { step1: { foo: "bar" } }, cse: { step1: {} } },
+			});
+			const company = buildCompany();
+			const ctx = createSubmitMockDb(declaration, company, []);
+			const caller = await createCaller(ctx.db);
+
+			await caller.submit();
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toEqual({ cse: { step1: {} } });
+			expect(purgeCall?.draftUpdatedAt).toBeInstanceOf(Date);
+		});
+
+		it("sets draft to null when main was the only slice after submit", async () => {
+			const declaration = buildDeclaration({
+				status: "draft",
+				draft: { main: { step1: { foo: "bar" } } },
+			});
+			const company = buildCompany();
+			const ctx = createSubmitMockDb(declaration, company, []);
+			const caller = await createCaller(ctx.db);
+
+			await caller.submit();
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toBeNull();
+			expect(purgeCall?.draftUpdatedAt).toBeNull();
+		});
+
+		it("does not call draft update when draft is null after submit", async () => {
+			const declaration = buildDeclaration({ status: "draft", draft: null });
+			const company = buildCompany();
+			const ctx = createSubmitMockDb(declaration, company, []);
+			const caller = await createCaller(ctx.db);
+
+			await caller.submit();
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeUndefined();
+		});
 	});
 
 	describe("submitSecondDeclaration (rules engine)", () => {
@@ -690,6 +749,46 @@ describe("declarationRouter", () => {
 			const caller = await createCaller(mockDb);
 
 			await expect(caller.submitSecondDeclaration()).rejects.toThrow();
+		});
+
+		it("purges the second draft slice and keeps other slices after submitSecondDeclaration", async () => {
+			const declaration = buildDeclaration({
+				status: "corrective_actions_chosen",
+				cseRequired: false,
+				draft: { second: { step1: { foo: "bar" } }, main: { step1: {} } },
+			});
+			const ctx = createOneRowSelectDb(declaration, [], [declaration]);
+			const caller = await createCaller(ctx.db);
+
+			await caller.submitSecondDeclaration();
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toEqual({ main: { step1: {} } });
+			expect(purgeCall?.draftUpdatedAt).toBeInstanceOf(Date);
+		});
+
+		it("sets draft to null when second was the only slice after submitSecondDeclaration", async () => {
+			const declaration = buildDeclaration({
+				status: "corrective_actions_chosen",
+				cseRequired: false,
+				draft: { second: { step1: { foo: "bar" } } },
+			});
+			const ctx = createOneRowSelectDb(declaration, [], [declaration]);
+			const caller = await createCaller(ctx.db);
+
+			await caller.submitSecondDeclaration();
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toBeNull();
+			expect(purgeCall?.draftUpdatedAt).toBeNull();
 		});
 	});
 
@@ -857,6 +956,49 @@ describe("declarationRouter", () => {
 				caller.saveCompliancePath({ path: "invalid_path" as never }),
 			).rejects.toThrow();
 		});
+
+		it("purges the compliance draft slice and keeps other slices after saveCompliancePath", async () => {
+			const declaration = buildDeclaration({
+				status: "awaiting_compliance_path_choice",
+				cseRequired: true,
+				draft: {
+					compliance: { step1: { path: "justify" } },
+					main: { step1: {} },
+				},
+			});
+			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
+			const caller = await createCaller(ctx.db);
+
+			await caller.saveCompliancePath({ path: "justify" });
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toEqual({ main: { step1: {} } });
+			expect(purgeCall?.draftUpdatedAt).toBeInstanceOf(Date);
+		});
+
+		it("sets draft to null when compliance was the only slice after saveCompliancePath", async () => {
+			const declaration = buildDeclaration({
+				status: "awaiting_compliance_path_choice",
+				cseRequired: true,
+				draft: { compliance: { step1: { path: "justify" } } },
+			});
+			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
+			const caller = await createCaller(ctx.db);
+
+			await caller.saveCompliancePath({ path: "justify" });
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toBeNull();
+			expect(purgeCall?.draftUpdatedAt).toBeNull();
+		});
 	});
 
 	describe("submitJointEvaluation (rules engine)", () => {
@@ -918,6 +1060,51 @@ describe("declarationRouter", () => {
 			const caller = await createCaller(mockDb);
 
 			await expect(caller.submitJointEvaluation()).rejects.toThrow();
+		});
+
+		it("purges the joint draft slice and keeps other slices after submitJointEvaluation", async () => {
+			const declaration = buildDeclaration({
+				status: "joint_evaluation_chosen",
+				cseRequired: true,
+				firstDeclarationPathChoice: "joint_evaluation",
+				draft: {
+					joint: { step1: { foo: "bar" } },
+					cse: { step1: {} },
+				},
+			});
+			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
+			const caller = await createCaller(ctx.db);
+
+			await caller.submitJointEvaluation();
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toEqual({ cse: { step1: {} } });
+			expect(purgeCall?.draftUpdatedAt).toBeInstanceOf(Date);
+		});
+
+		it("sets draft to null when joint was the only slice after submitJointEvaluation", async () => {
+			const declaration = buildDeclaration({
+				status: "joint_evaluation_chosen",
+				cseRequired: true,
+				firstDeclarationPathChoice: "joint_evaluation",
+				draft: { joint: { step1: { foo: "bar" } } },
+			});
+			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
+			const caller = await createCaller(ctx.db);
+
+			await caller.submitJointEvaluation();
+
+			const setCalls = ctx.set.mock.calls.map(
+				(c) => c[0] as Record<string, unknown>,
+			);
+			const purgeCall = setCalls.find((c) => "draft" in c);
+			expect(purgeCall).toBeDefined();
+			expect(purgeCall?.draft).toBeNull();
+			expect(purgeCall?.draftUpdatedAt).toBeNull();
 		});
 	});
 

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -172,6 +172,25 @@ export const cseOpinionRouter = createTRPCRouter({
 				.update(declarations)
 				.set({ ...projection, updatedAt: new Date() })
 				.where(eq(declarations.id, ctx.declarationId));
+
+			const [declRow] = await tx
+				.select()
+				.from(declarations)
+				.where(eq(declarations.id, ctx.declarationId))
+				.limit(1);
+
+			if (declRow?.draft) {
+				const current = declRow.draft as Record<string, unknown>;
+				const { cse: _removed, ...remaining } = current;
+				const isEmpty = Object.keys(remaining).length === 0;
+				await tx
+					.update(declarations)
+					.set({
+						draft: isEmpty ? null : remaining,
+						draftUpdatedAt: isEmpty ? null : new Date(),
+					})
+					.where(eq(declarations.id, ctx.declarationId));
+			}
 		});
 
 		return { success: true };

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -41,6 +41,7 @@ import {
 	deleteJobAndEmployeeCategories,
 	fetchAllCategories,
 	fetchPreviousYearJobCategories,
+	purgeDraftSlice,
 } from "./declarationHelpers";
 import {
 	buildHistoryInserts,
@@ -601,6 +602,7 @@ export const declarationRouter = createTRPCRouter({
 				.where(activeDeclarationFilter(siren, year));
 
 			await applyPercentagesAfterUpdate(tx, siren, year);
+			await purgeDraftSlice(tx, siren, year, "main");
 		});
 
 		const email = ctx.session.user.email;
@@ -691,6 +693,7 @@ export const declarationRouter = createTRPCRouter({
 					.update(declarations)
 					.set({ ...projection, updatedAt: new Date() })
 					.where(activeDeclarationFilter(siren, year));
+				await purgeDraftSlice(tx, siren, year, "compliance");
 			});
 
 			return { success: true };
@@ -740,6 +743,7 @@ export const declarationRouter = createTRPCRouter({
 					updatedAt: new Date(),
 				})
 				.where(activeDeclarationFilter(siren, year));
+			await purgeDraftSlice(tx, siren, year, "second");
 		});
 
 		const email = ctx.session.user.email;
@@ -793,6 +797,7 @@ export const declarationRouter = createTRPCRouter({
 					.update(declarations)
 					.set({ ...projection, updatedAt: new Date() })
 					.where(activeDeclarationFilter(siren, year));
+				await purgeDraftSlice(tx, siren, year, "joint");
 			});
 
 			return { success: true };

--- a/packages/app/src/server/api/routers/declarationHelpers.ts
+++ b/packages/app/src/server/api/routers/declarationHelpers.ts
@@ -37,6 +37,8 @@ type PercentagesTx = {
 	};
 };
 
+type DraftPurgeTx = PercentagesTx;
+
 export async function applyPercentagesAfterUpdate(
 	tx: PercentagesTx,
 	siren: string,
@@ -346,4 +348,31 @@ export function mapToEmployeeCategoryRows(
 				hourlyVariableMen: emp?.hourlyVariableMen ?? null,
 			};
 		});
+}
+
+export async function purgeDraftSlice(
+	tx: DraftPurgeTx,
+	siren: string,
+	year: number,
+	kind: string,
+): Promise<void> {
+	const [row] = await tx
+		.select()
+		.from(declarations)
+		.where(activeDeclarationFilter(siren, year))
+		.limit(1);
+
+	if (!row?.draft) return;
+
+	const current = row.draft as Record<string, unknown>;
+	const { [kind]: _removed, ...remaining } = current;
+	const isEmpty = Object.keys(remaining).length === 0;
+
+	await tx
+		.update(declarations)
+		.set({
+			draft: isEmpty ? null : remaining,
+			draftUpdatedAt: isEmpty ? null : new Date(),
+		})
+		.where(activeDeclarationFilter(siren, year));
 }


### PR DESCRIPTION
Closes #3510

## Changements

Adds `purgeDraftSlice` helper in `declarationHelpers.ts` and wires it into the existing `db.transaction(...)` of the 5 submit mutations:

| Mutation | Kind purgé |
|---|---|
| `declaration.submit` | `"main"` |
| `declaration.submitSecondDeclaration` | `"second"` |
| `declaration.submitJointEvaluation` | `"joint"` |
| `declaration.saveCompliancePath` | `"compliance"` |
| `cseOpinion.finalize` | `"cse"` |

After a successful submit, the corresponding slice is removed from `draft` JSONB. If all slices are removed, `draft` and `draftUpdatedAt` are set to `NULL`. If the transaction rolls back (error), the draft remains intact.

## Tests

- 3 new tests per mutation in `declaration.test.ts` (purge with sibling slices, single-slice → NULL, no-op when draft is null)
- 3 new tests in `cseOpinion.finalize.test.ts` (same cases)
- All 1989 existing tests remain green