### PR TITLE
feat(declaration-draft): rewrite useDeclarationDraft on tRPC async debounced (#3506)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.lifecycle.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.lifecycle.test.tsx
@@ -1,0 +1,246 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
+
+vi.unmock(
+	"~/modules/declaration-remuneration/shared/draft/useDeclarationDraft",
+);
+
+import { useDeclarationDraft } from "../useDeclarationDraft";
+
+type DraftBlob = Record<string, Record<string, unknown>>;
+type StepValues = { totalWomen: number; totalMen: number };
+
+const useSessionMock = vi.mocked(useSession);
+
+const SIREN = "123456789";
+const YEAR = 2026;
+const USER_ID = "user-1";
+const DB_VALUES: StepValues = { totalWomen: 0, totalMen: 0 };
+
+let queryState: { data: DraftBlob | null | undefined; isLoading: boolean };
+let saveMutateMock: Mock;
+let clearMutateMock: Mock;
+let setDataMock: Mock;
+let saveOnSuccess: ((data: unknown, variables: unknown) => void) | undefined;
+let clearOnSuccess: ((data: unknown, variables: unknown) => void) | undefined;
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		useUtils: () => ({
+			declarationDraft: {
+				get: {
+					setData: (_input: unknown, updater: unknown) => setDataMock(updater),
+				},
+			},
+		}),
+		declarationDraft: {
+			get: { useQuery: () => queryState },
+			save: {
+				useMutation: (opts?: {
+					onSuccess?: (data: unknown, variables: unknown) => void;
+				}) => {
+					saveOnSuccess = opts?.onSuccess;
+					return { mutate: saveMutateMock };
+				},
+			},
+			clear: {
+				useMutation: (opts?: {
+					onSuccess?: (data: unknown, variables: unknown) => void;
+				}) => {
+					clearOnSuccess = opts?.onSuccess;
+					return { mutate: clearMutateMock };
+				},
+			},
+		},
+	},
+}));
+
+function setSession(
+	options: { userId?: string | null; impersonating?: boolean } = {},
+) {
+	const { userId = USER_ID, impersonating = false } = options;
+	useSessionMock.mockReturnValue({
+		data:
+			userId === null
+				? null
+				: ({
+						user: {
+							id: userId,
+							impersonation: impersonating
+								? { siren: "999999999", name: "X" }
+								: null,
+						},
+						expires: "",
+					} as never),
+		status: userId === null ? "unauthenticated" : "authenticated",
+		update: vi.fn(),
+	} as never);
+}
+
+function renderDraftHook() {
+	return renderHook(() =>
+		useDeclarationDraft<StepValues>({
+			siren: SIREN,
+			year: YEAR,
+			step: 1,
+			kind: "main",
+			dbValues: DB_VALUES,
+		}),
+	);
+}
+
+describe("useDeclarationDraft (lifecycle & cache)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		queryState = { data: undefined, isLoading: true };
+		saveMutateMock = vi.fn();
+		clearMutateMock = vi.fn();
+		setDataMock = vi.fn();
+		saveOnSuccess = undefined;
+		clearOnSuccess = undefined;
+		setSession();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		useSessionMock.mockReset();
+	});
+
+	it("flushes a pending debounced save when the component unmounts", () => {
+		queryState = { data: null, isLoading: false };
+		const { result, unmount } = renderDraftHook();
+
+		act(() => {
+			result.current.setField({ totalWomen: 4, totalMen: 0 });
+		});
+		expect(saveMutateMock).not.toHaveBeenCalled();
+
+		act(() => {
+			vi.advanceTimersByTime(300);
+		});
+
+		unmount();
+		expect(saveMutateMock).toHaveBeenCalledTimes(1);
+		expect(saveMutateMock).toHaveBeenCalledWith({
+			year: YEAR,
+			siren: SIREN,
+			slice: { kind: "main", step: "1", data: { totalWomen: 4 } },
+		});
+	});
+
+	it("flushes a pending clear on unmount when the diff went empty", () => {
+		queryState = {
+			data: { main: { "1": { totalWomen: 10 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result, unmount } = renderDraftHook();
+
+		act(() => {
+			result.current.setField({ totalWomen: 0, totalMen: 0 });
+		});
+		expect(clearMutateMock).not.toHaveBeenCalled();
+
+		unmount();
+		expect(clearMutateMock).toHaveBeenCalledTimes(1);
+		expect(saveMutateMock).not.toHaveBeenCalled();
+	});
+
+	it("skips the flush on unmount if the user is no longer enabled", () => {
+		setSession();
+		queryState = { data: null, isLoading: false };
+		const { result, rerender, unmount } = renderDraftHook();
+
+		act(() => {
+			result.current.setField({ totalWomen: 1, totalMen: 0 });
+		});
+
+		setSession({ impersonating: true });
+		rerender();
+
+		unmount();
+		expect(saveMutateMock).not.toHaveBeenCalled();
+		expect(clearMutateMock).not.toHaveBeenCalled();
+	});
+
+	it("does nothing on unmount when no debounced mutation is pending", () => {
+		queryState = { data: null, isLoading: false };
+		const { unmount } = renderDraftHook();
+		unmount();
+		expect(saveMutateMock).not.toHaveBeenCalled();
+		expect(clearMutateMock).not.toHaveBeenCalled();
+	});
+
+	it("patches the get cache on save success", () => {
+		queryState = { data: null, isLoading: false };
+		renderDraftHook();
+		expect(saveOnSuccess).toBeDefined();
+
+		saveOnSuccess?.(
+			{ ok: true },
+			{
+				year: YEAR,
+				siren: SIREN,
+				slice: { kind: "main", step: "1", data: { totalWomen: 7 } },
+			},
+		);
+		expect(setDataMock).toHaveBeenCalledTimes(1);
+		const updater = setDataMock.mock.calls[0]?.[0] as (
+			old: DraftBlob | null | undefined,
+		) => DraftBlob | null;
+		expect(updater(undefined)).toEqual({ main: { "1": { totalWomen: 7 } } });
+		expect(
+			updater({ main: { "1": { totalMen: 1 }, "2": { x: 9 } } } as DraftBlob),
+		).toEqual({
+			main: { "1": { totalWomen: 7 }, "2": { x: 9 } },
+		});
+		expect(updater({ compliance: { "1": { x: 1 } } } as DraftBlob)).toEqual({
+			compliance: { "1": { x: 1 } },
+			main: { "1": { totalWomen: 7 } },
+		});
+	});
+
+	it("patches the get cache on clear success (removes the kind slice)", () => {
+		queryState = { data: null, isLoading: false };
+		renderDraftHook();
+		expect(clearOnSuccess).toBeDefined();
+
+		clearOnSuccess?.({ ok: true }, { year: YEAR, siren: SIREN, kind: "main" });
+		expect(setDataMock).toHaveBeenCalledTimes(1);
+		const updater = setDataMock.mock.calls[0]?.[0] as (
+			old: DraftBlob | null | undefined,
+		) => DraftBlob | null;
+		expect(updater(undefined)).toBeUndefined();
+		expect(updater(null)).toBeNull();
+		expect(updater({ main: { "1": { x: 1 } } } as DraftBlob)).toBeNull();
+		expect(
+			updater({
+				main: { "1": { x: 1 } },
+				compliance: { "1": { y: 2 } },
+			} as DraftBlob),
+		).toEqual({ compliance: { "1": { y: 2 } } });
+	});
+
+	it("returns the cache unchanged on clear success when kind is undefined", () => {
+		queryState = { data: null, isLoading: false };
+		renderDraftHook();
+		expect(clearOnSuccess).toBeDefined();
+
+		clearOnSuccess?.(
+			{ ok: true },
+			{ year: YEAR, siren: SIREN, kind: undefined },
+		);
+		const updater = setDataMock.mock.calls[0]?.[0] as (
+			old: DraftBlob | null | undefined,
+		) => DraftBlob | null;
+		expect(updater({ main: { "1": { x: 1 } } } as DraftBlob)).toBeNull();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -1,34 +1,53 @@
 import { act, renderHook } from "@testing-library/react";
 import { useSession } from "next-auth/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
 
-import type { DraftPayload } from "../draftSchema";
+vi.unmock(
+	"~/modules/declaration-remuneration/shared/draft/useDeclarationDraft",
+);
+
 import { useDeclarationDraft } from "../useDeclarationDraft";
+
+type DraftBlob = Record<string, Record<string, unknown>>;
+type DraftKindLiteral = "main" | "second" | "joint" | "compliance" | "cse";
+type StepValues = { totalWomen: number; totalMen: number };
 
 const useSessionMock = vi.mocked(useSession);
 
 const SIREN = "123456789";
 const YEAR = 2026;
 const USER_ID = "user-1";
-const STORAGE_KEY = `egapro:declaration-draft:${USER_ID}:${SIREN}:${YEAR}`;
-
-const FIXED_NOW = new Date("2026-03-15T12:00:00Z").getTime();
-
-function buildPayload(overrides: Partial<DraftPayload> = {}): DraftPayload {
-	return {
-		siren: SIREN,
-		year: YEAR,
-		step: 1,
-		kind: "main",
-		timestamp: FIXED_NOW - 1000,
-		fields: { totalWomen: 10 },
-		...overrides,
-	};
-}
-
-type StepValues = { totalWomen: number; totalMen: number };
-
 const DB_VALUES: StepValues = { totalWomen: 0, totalMen: 0 };
+
+let queryState: { data: DraftBlob | null | undefined; isLoading: boolean };
+let saveMutateMock: Mock;
+let clearMutateMock: Mock;
+let setDataMock: Mock;
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		useUtils: () => ({
+			declarationDraft: {
+				get: {
+					setData: (_input: unknown, updater: unknown) => setDataMock(updater),
+				},
+			},
+		}),
+		declarationDraft: {
+			get: { useQuery: () => queryState },
+			save: { useMutation: () => ({ mutate: saveMutateMock }) },
+			clear: { useMutation: () => ({ mutate: clearMutateMock }) },
+		},
+	},
+}));
 
 function setSession(
 	options: { userId?: string | null; impersonating?: boolean } = {},
@@ -52,11 +71,32 @@ function setSession(
 	} as never);
 }
 
+function renderDraftHook(
+	overrides: Partial<{
+		kind: DraftKindLiteral;
+		step: number | "second-1";
+		dbValues: StepValues;
+	}> = {},
+) {
+	return renderHook(() =>
+		useDeclarationDraft<StepValues>({
+			siren: SIREN,
+			year: YEAR,
+			step: overrides.step ?? 1,
+			kind: overrides.kind ?? "main",
+			dbValues: overrides.dbValues ?? DB_VALUES,
+		}),
+	);
+}
+
 describe("useDeclarationDraft", () => {
 	beforeEach(() => {
-		window.localStorage.clear();
 		vi.useFakeTimers();
-		vi.setSystemTime(new Date(FIXED_NOW));
+		queryState = { data: undefined, isLoading: true };
+		saveMutateMock = vi.fn();
+		clearMutateMock = vi.fn();
+		setDataMock = vi.fn();
+		setSession();
 	});
 
 	afterEach(() => {
@@ -64,204 +104,215 @@ describe("useDeclarationDraft", () => {
 		useSessionMock.mockReset();
 	});
 
-	it("is a no-op when userId is null (logged out)", () => {
-		setSession({ userId: null });
-		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildPayload()));
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
+	it("returns an empty draft and loading=true while the query is pending", () => {
+		const { result } = renderDraftHook();
 		expect(result.current.draft).toEqual({});
 		expect(result.current.hasDraft).toBe(false);
-
-		act(() => {
-			result.current.setField({ totalWomen: 99, totalMen: 0 });
-		});
-		expect(window.localStorage.length).toBe(1);
-
-		act(() => {
-			result.current.clearDraft();
-		});
-		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+		expect(result.current.isLoadingDraft).toBe(true);
 	});
 
-	it("is a no-op when impersonating", () => {
-		setSession({ impersonating: true });
-		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(buildPayload()));
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
-		expect(result.current.draft).toEqual({});
-		expect(result.current.hasDraft).toBe(false);
-
-		act(() => {
-			result.current.setField({ totalWomen: 99, totalMen: 0 });
-			result.current.clearDraft();
-		});
-		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
-	});
-
-	it("hydrates draft when payload step matches the current step", () => {
-		setSession();
-		window.localStorage.setItem(
-			STORAGE_KEY,
-			JSON.stringify(buildPayload({ fields: { totalWomen: 10, totalMen: 5 } })),
-		);
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
+	it("hydrates draft from the query slice when data resolves", () => {
+		queryState = {
+			data: { main: { "1": { totalWomen: 10, totalMen: 5 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result } = renderDraftHook();
 		expect(result.current.draft).toEqual({ totalWomen: 10, totalMen: 5 });
 		expect(result.current.hasDraft).toBe(true);
+		expect(result.current.isLoadingDraft).toBe(false);
 	});
 
-	it("does not hydrate when payload step does not match — and does not purge", () => {
-		setSession();
-		const payload = buildPayload({ step: 2 });
-		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
-		expect(result.current.draft).toEqual({});
-		expect(result.current.hasDraft).toBe(false);
-		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
-	});
-
-	it("does not hydrate from a different SIREN's draft (key isolation)", () => {
-		setSession();
-		const otherSiren = "987654321";
-		const otherKey = `egapro:declaration-draft:${USER_ID}:${otherSiren}:${YEAR}`;
-		window.localStorage.setItem(
-			otherKey,
-			JSON.stringify(buildPayload({ siren: otherSiren })),
-		);
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
-		expect(result.current.draft).toEqual({});
-		expect(result.current.hasDraft).toBe(false);
-		expect(window.localStorage.getItem(otherKey)).not.toBeNull();
-	});
-
-	it("does not hydrate from a different year's draft (key isolation)", () => {
-		setSession();
-		const otherYear = 2025;
-		const otherKey = `egapro:declaration-draft:${USER_ID}:${SIREN}:${otherYear}`;
-		window.localStorage.setItem(
-			otherKey,
-			JSON.stringify(buildPayload({ year: otherYear })),
-		);
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
+	it("returns an empty draft when the query data has no slice for this kind", () => {
+		queryState = {
+			data: { compliance: { "1": { foo: 1 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result } = renderDraftHook();
 		expect(result.current.draft).toEqual({});
 		expect(result.current.hasDraft).toBe(false);
 	});
 
-	it("clears the draft when setField makes values match dbValues", () => {
-		setSession();
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
+	it("returns an empty draft when the kind slice exists but the step is missing", () => {
+		queryState = {
+			data: { main: { "2": { totalWomen: 3 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result } = renderDraftHook({ step: 1 });
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("debounces save calls (multiple setField in <600ms → 1 mutation)", () => {
+		queryState = { data: null, isLoading: false };
+		const { result } = renderDraftHook();
+
+		act(() => {
+			result.current.setField({ totalWomen: 1, totalMen: 0 });
+			result.current.setField({ totalWomen: 2, totalMen: 0 });
+			result.current.setField({ totalWomen: 3, totalMen: 0 });
+		});
+		expect(saveMutateMock).not.toHaveBeenCalled();
+
+		act(() => {
+			vi.advanceTimersByTime(600);
+		});
+
+		expect(saveMutateMock).toHaveBeenCalledTimes(1);
+		expect(saveMutateMock).toHaveBeenCalledWith({
+			year: YEAR,
+			siren: SIREN,
+			slice: { kind: "main", step: "1", data: { totalWomen: 3 } },
+		});
+	});
+
+	it("updates the local draft immediately on setField (optimistic)", () => {
+		queryState = { data: null, isLoading: false };
+		const { result } = renderDraftHook();
+
+		act(() => {
+			result.current.setField({ totalWomen: 7, totalMen: 0 });
+		});
+
+		expect(result.current.draft).toEqual({ totalWomen: 7 });
+		expect(result.current.hasDraft).toBe(true);
+		expect(saveMutateMock).not.toHaveBeenCalled();
+	});
+
+	it("clearDraft triggers the clear mutation immediately (not debounced)", () => {
+		queryState = {
+			data: { main: { "1": { totalWomen: 10 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result } = renderDraftHook();
+		expect(result.current.hasDraft).toBe(true);
+
+		act(() => {
+			result.current.clearDraft();
+		});
+
+		expect(clearMutateMock).toHaveBeenCalledTimes(1);
+		expect(clearMutateMock).toHaveBeenCalledWith({
+			year: YEAR,
+			siren: SIREN,
+			kind: "main",
+		});
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+	});
+
+	it("clearDraft cancels any pending debounced save", () => {
+		queryState = { data: null, isLoading: false };
+		const { result } = renderDraftHook();
 
 		act(() => {
 			result.current.setField({ totalWomen: 5, totalMen: 0 });
 		});
-		expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
-		expect(result.current.hasDraft).toBe(true);
+		act(() => {
+			result.current.clearDraft();
+		});
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(saveMutateMock).not.toHaveBeenCalled();
+		expect(clearMutateMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("setField with values equal to dbValues triggers a clear (no save)", () => {
+		queryState = {
+			data: { main: { "1": { totalWomen: 5 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result } = renderDraftHook();
 
 		act(() => {
 			result.current.setField({ totalWomen: 0, totalMen: 0 });
 		});
-		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+		expect(result.current.draft).toEqual({});
 		expect(result.current.hasDraft).toBe(false);
-	});
 
-	it("writes the diff under the (user, siren, year)-scoped key", () => {
-		setSession();
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
 		act(() => {
-			result.current.setField({ totalWomen: 5, totalMen: 0 });
+			vi.advanceTimersByTime(600);
 		});
-		const stored = JSON.parse(
-			window.localStorage.getItem(STORAGE_KEY) ?? "{}",
-		) as DraftPayload;
-		expect(stored.fields).toEqual({ totalWomen: 5 });
-		expect(stored.siren).toBe(SIREN);
-		expect(stored.year).toBe(YEAR);
-		expect(stored.step).toBe(1);
-		expect(stored.kind).toBe("main");
-		expect(stored.timestamp).toBe(FIXED_NOW);
+		expect(saveMutateMock).not.toHaveBeenCalled();
+		expect(clearMutateMock).toHaveBeenCalledTimes(1);
+		expect(clearMutateMock).toHaveBeenCalledWith({
+			year: YEAR,
+			siren: SIREN,
+			kind: "main",
+		});
 	});
 
-	it("clearDraft removes the key and resets hasDraft", () => {
-		setSession();
-		window.localStorage.setItem(
-			STORAGE_KEY,
-			JSON.stringify(buildPayload({ fields: { totalWomen: 10 } })),
-		);
-		const { result } = renderHook(() =>
-			useDeclarationDraft<StepValues>({
-				siren: SIREN,
-				year: YEAR,
-				step: 1,
-				kind: "main",
-				dbValues: DB_VALUES,
-			}),
-		);
+	it("hasDraft becomes true once the query resolves with a non-empty slice", () => {
+		queryState = { data: undefined, isLoading: true };
+		const { rerender, result } = renderDraftHook();
+		expect(result.current.hasDraft).toBe(false);
+
+		queryState = {
+			data: { main: { "1": { totalWomen: 10 } } } as DraftBlob,
+			isLoading: false,
+		};
+		rerender();
 		expect(result.current.hasDraft).toBe(true);
+		expect(result.current.draft).toEqual({ totalWomen: 10 });
+	});
+
+	it("disables the query and is a no-op when impersonating", () => {
+		setSession({ impersonating: true });
+		queryState = { data: undefined, isLoading: true };
+		const { result } = renderDraftHook();
+
+		expect(result.current.isLoadingDraft).toBe(false);
+		expect(result.current.draft).toEqual({});
+		expect(result.current.hasDraft).toBe(false);
+
 		act(() => {
+			result.current.setField({ totalWomen: 99, totalMen: 0 });
 			result.current.clearDraft();
 		});
-		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
-		expect(result.current.hasDraft).toBe(false);
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(saveMutateMock).not.toHaveBeenCalled();
+		expect(clearMutateMock).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op when the user is logged out", () => {
+		setSession({ userId: null });
+		queryState = { data: undefined, isLoading: true };
+		const { result } = renderDraftHook();
+
+		expect(result.current.isLoadingDraft).toBe(false);
+		expect(result.current.draft).toEqual({});
+
+		act(() => {
+			result.current.setField({ totalWomen: 1, totalMen: 0 });
+			result.current.clearDraft();
+		});
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(saveMutateMock).not.toHaveBeenCalled();
+		expect(clearMutateMock).not.toHaveBeenCalled();
+	});
+
+	it("honors a custom step in the save payload", () => {
+		queryState = { data: null, isLoading: false };
+		const { result } = renderDraftHook({ step: "second-1" });
+
+		act(() => {
+			result.current.setField({ totalWomen: 1, totalMen: 0 });
+		});
+		act(() => {
+			vi.advanceTimersByTime(600);
+		});
+
+		expect(saveMutateMock).toHaveBeenCalledWith({
+			year: YEAR,
+			siren: SIREN,
+			slice: { kind: "main", step: "second-1", data: { totalWomen: 1 } },
+		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -313,6 +313,30 @@ describe("useDeclarationDraft", () => {
 		expect(result.current.draft).toBe(draftAfterFirst);
 	});
 
+	it("keeps a stable draft reference for nested values with identical contents", () => {
+		queryState = { data: null, isLoading: false };
+		const tupleDb = { rows: [{ a: 0, b: 0 }] };
+		const { result } = renderHook(() =>
+			useDeclarationDraft<typeof tupleDb>({
+				siren: SIREN,
+				year: YEAR,
+				step: 4,
+				kind: "main",
+				dbValues: tupleDb,
+			}),
+		);
+
+		act(() => {
+			result.current.setField({ rows: [{ a: 1, b: 2 }] });
+		});
+		const draftAfterFirst = result.current.draft;
+
+		act(() => {
+			result.current.setField({ rows: [{ a: 1, b: 2 }] });
+		});
+		expect(result.current.draft).toBe(draftAfterFirst);
+	});
+
 	it("honors a custom step in the save payload", () => {
 		queryState = { data: null, isLoading: false };
 		const { result } = renderDraftHook({ step: "second-1" });

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -298,6 +298,21 @@ describe("useDeclarationDraft", () => {
 		expect(clearMutateMock).not.toHaveBeenCalled();
 	});
 
+	it("keeps a stable draft reference when setField is called with the same values", () => {
+		queryState = { data: null, isLoading: false };
+		const { result } = renderDraftHook();
+
+		act(() => {
+			result.current.setField({ totalWomen: 5, totalMen: 0 });
+		});
+		const draftAfterFirst = result.current.draft;
+
+		act(() => {
+			result.current.setField({ totalWomen: 5, totalMen: 0 });
+		});
+		expect(result.current.draft).toBe(draftAfterFirst);
+	});
+
 	it("honors a custom step in the save payload", () => {
 		queryState = { data: null, isLoading: false };
 		const { result } = renderDraftHook({ step: "second-1" });

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -1,11 +1,14 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { api } from "~/trpc/react";
 
 import { computeDraftDiff } from "./computeDraftDiff";
 import type { DraftKind, DraftStep } from "./draftSchema";
-import { clearDraft, readDraft, writeDraft } from "./draftStorage";
+
+type DraftBlob = Record<string, Record<string, unknown>>;
 
 type UseDeclarationDraftOptions<T extends Record<string, unknown>> = {
 	siren: string;
@@ -20,7 +23,10 @@ type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
 	setField: (currentValues: T) => void;
 	clearDraft: () => void;
 	hasDraft: boolean;
+	isLoadingDraft: boolean;
 };
+
+const DEBOUNCE_MS = 600;
 
 export function useDeclarationDraft<T extends Record<string, unknown>>(
 	options: UseDeclarationDraftOptions<T>,
@@ -31,48 +37,133 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 	const isImpersonating = Boolean(session.data?.user?.impersonation);
 	const isEnabled = userId !== null && !isImpersonating;
 
-	const [draft, setDraft] = useState<Partial<T>>({});
-	const [hasDraft, setHasDraft] = useState(false);
+	const utils = api.useUtils();
+	const query = api.declarationDraft.get.useQuery(
+		{ year, siren },
+		{ staleTime: Infinity, enabled: isEnabled },
+	);
+
+	const stepKey = String(step);
+
+	const { mutate: saveMutate } = api.declarationDraft.save.useMutation({
+		onSuccess: (_data, variables) => {
+			utils.declarationDraft.get.setData(
+				{ year: variables.year, siren: variables.siren },
+				(old) => {
+					const base = (old ?? {}) as DraftBlob;
+					const slice = (base[variables.slice.kind] ?? {}) as Record<
+						string,
+						unknown
+					>;
+					return {
+						...base,
+						[variables.slice.kind]: {
+							...slice,
+							[variables.slice.step]: variables.slice.data,
+						},
+					};
+				},
+			);
+		},
+	});
+
+	const { mutate: clearMutate } = api.declarationDraft.clear.useMutation({
+		onSuccess: (_data, variables) => {
+			utils.declarationDraft.get.setData(
+				{ year: variables.year, siren: variables.siren },
+				(old) => {
+					if (!old) return old;
+					const base = old as DraftBlob;
+					if (variables.kind === undefined) return null;
+					const { [variables.kind]: _removed, ...rest } = base;
+					return Object.keys(rest).length === 0 ? null : (rest as DraftBlob);
+				},
+			);
+		},
+	});
+
+	const [localDraft, setLocalDraft] = useState<Partial<T> | null>(null);
+
+	const queryDraft = useMemo<Partial<T> | null>(() => {
+		const data = query.data as DraftBlob | null | undefined;
+		if (!data) return null;
+		const slice = data[kind];
+		if (!slice) return null;
+		const stepData = slice[stepKey];
+		if (!stepData) return null;
+		return stepData as Partial<T>;
+	}, [query.data, kind, stepKey]);
+
+	const draft: Partial<T> = localDraft ?? queryDraft ?? {};
+	const hasDraft = Object.keys(draft).length > 0;
+
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const pendingRef = useRef<{ diff: Record<string, unknown> | null } | null>(
+		null,
+	);
+	const flushRef = useRef<(() => void) | null>(null);
 
 	useEffect(() => {
-		if (!isEnabled || userId === null) return;
-		const payload = readDraft(userId, siren, year);
-		if (payload === null) return;
-		if (payload.step !== step) {
-			return;
-		}
-		const fields = payload.fields as Partial<T>;
-		setDraft(fields);
-		setHasDraft(Object.keys(fields).length > 0);
-	}, [isEnabled, userId, siren, year, step]);
+		flushRef.current = () => {
+			if (timerRef.current === null) return;
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+			const pending = pendingRef.current;
+			pendingRef.current = null;
+			if (pending === null || !isEnabled) return;
+			if (pending.diff === null) {
+				clearMutate({ year, siren, kind });
+			} else {
+				saveMutate({
+					year,
+					siren,
+					slice: { kind, step: stepKey, data: pending.diff },
+				});
+			}
+		};
+	});
 
 	const setField = useCallback(
 		(currentValues: T) => {
-			if (!isEnabled || userId === null) return;
+			if (!isEnabled) return;
 			const diff = computeDraftDiff(currentValues, dbValues);
-			if (Object.keys(diff).length === 0) {
-				clearDraft(userId, siren, year);
-				setHasDraft(false);
-				return;
-			}
-			writeDraft(userId, siren, year, {
-				siren,
-				year,
-				step,
-				kind,
-				timestamp: Date.now(),
-				fields: diff,
-			});
-			setHasDraft(true);
+			const hasDiff = Object.keys(diff).length > 0;
+			setLocalDraft(hasDiff ? (diff as Partial<T>) : ({} as Partial<T>));
+			if (timerRef.current !== null) clearTimeout(timerRef.current);
+			pendingRef.current = { diff: hasDiff ? diff : null };
+			timerRef.current = setTimeout(() => {
+				timerRef.current = null;
+				pendingRef.current = null;
+				if (hasDiff) {
+					saveMutate({
+						year,
+						siren,
+						slice: { kind, step: stepKey, data: diff },
+					});
+				} else {
+					clearMutate({ year, siren, kind });
+				}
+			}, DEBOUNCE_MS);
 		},
-		[isEnabled, userId, siren, year, step, kind, dbValues],
+		[isEnabled, siren, year, kind, stepKey, dbValues, saveMutate, clearMutate],
 	);
 
 	const clearDraftCallback = useCallback(() => {
-		if (!isEnabled || userId === null) return;
-		clearDraft(userId, siren, year);
-		setHasDraft(false);
-	}, [isEnabled, userId, siren, year]);
+		if (!isEnabled) return;
+		if (timerRef.current !== null) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+			pendingRef.current = null;
+		}
+		setLocalDraft({} as Partial<T>);
+		clearMutate({ year, siren, kind });
+	}, [isEnabled, siren, year, kind, clearMutate]);
+
+	useEffect(() => {
+		return () => {
+			flushRef.current?.();
+		};
+	}, []);
 
 	return useMemo(
 		() => ({
@@ -80,7 +171,8 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			setField,
 			clearDraft: clearDraftCallback,
 			hasDraft,
+			isLoadingDraft: isEnabled ? query.isLoading : false,
 		}),
-		[draft, setField, clearDraftCallback, hasDraft],
+		[draft, setField, clearDraftCallback, hasDraft, query.isLoading, isEnabled],
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -27,6 +27,20 @@ type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
 };
 
 const DEBOUNCE_MS = 600;
+const EMPTY_DRAFT: Readonly<Record<string, never>> = Object.freeze({});
+
+function shallowEqualRecord(
+	a: Record<string, unknown>,
+	b: Record<string, unknown>,
+): boolean {
+	const keysA = Object.keys(a);
+	const keysB = Object.keys(b);
+	if (keysA.length !== keysB.length) return false;
+	for (const key of keysA) {
+		if (!Object.is(a[key], b[key])) return false;
+	}
+	return true;
+}
 
 export function useDeclarationDraft<T extends Record<string, unknown>>(
 	options: UseDeclarationDraftOptions<T>,
@@ -45,7 +59,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 
 	const stepKey = String(step);
 
-	const { mutate: saveMutate } = api.declarationDraft.save.useMutation({
+	const saveMutation = api.declarationDraft.save.useMutation({
 		onSuccess: (_data, variables) => {
 			utils.declarationDraft.get.setData(
 				{ year: variables.year, siren: variables.siren },
@@ -67,7 +81,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 		},
 	});
 
-	const { mutate: clearMutate } = api.declarationDraft.clear.useMutation({
+	const clearMutation = api.declarationDraft.clear.useMutation({
 		onSuccess: (_data, variables) => {
 			utils.declarationDraft.get.setData(
 				{ year: variables.year, siren: variables.siren },
@@ -82,6 +96,11 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 		},
 	});
 
+	const saveMutateRef = useRef(saveMutation.mutate);
+	const clearMutateRef = useRef(clearMutation.mutate);
+	saveMutateRef.current = saveMutation.mutate;
+	clearMutateRef.current = clearMutation.mutate;
+
 	const [localDraft, setLocalDraft] = useState<Partial<T> | null>(null);
 
 	const queryDraft = useMemo<Partial<T> | null>(() => {
@@ -94,7 +113,8 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 		return stepData as Partial<T>;
 	}, [query.data, kind, stepKey]);
 
-	const draft: Partial<T> = localDraft ?? queryDraft ?? {};
+	const draft: Partial<T> =
+		localDraft ?? queryDraft ?? (EMPTY_DRAFT as Partial<T>);
 	const hasDraft = Object.keys(draft).length > 0;
 
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -112,9 +132,9 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			pendingRef.current = null;
 			if (pending === null || !isEnabled) return;
 			if (pending.diff === null) {
-				clearMutate({ year, siren, kind });
+				clearMutateRef.current({ year, siren, kind });
 			} else {
-				saveMutate({
+				saveMutateRef.current({
 					year,
 					siren,
 					slice: { kind, step: stepKey, data: pending.diff },
@@ -128,24 +148,38 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			if (!isEnabled) return;
 			const diff = computeDraftDiff(currentValues, dbValues);
 			const hasDiff = Object.keys(diff).length > 0;
-			setLocalDraft(hasDiff ? (diff as Partial<T>) : ({} as Partial<T>));
+			setLocalDraft((prev) => {
+				const next = hasDiff
+					? (diff as Partial<T>)
+					: (EMPTY_DRAFT as Partial<T>);
+				if (
+					prev !== null &&
+					shallowEqualRecord(
+						prev as Record<string, unknown>,
+						next as Record<string, unknown>,
+					)
+				) {
+					return prev;
+				}
+				return next;
+			});
 			if (timerRef.current !== null) clearTimeout(timerRef.current);
 			pendingRef.current = { diff: hasDiff ? diff : null };
 			timerRef.current = setTimeout(() => {
 				timerRef.current = null;
 				pendingRef.current = null;
 				if (hasDiff) {
-					saveMutate({
+					saveMutateRef.current({
 						year,
 						siren,
 						slice: { kind, step: stepKey, data: diff },
 					});
 				} else {
-					clearMutate({ year, siren, kind });
+					clearMutateRef.current({ year, siren, kind });
 				}
 			}, DEBOUNCE_MS);
 		},
-		[isEnabled, siren, year, kind, stepKey, dbValues, saveMutate, clearMutate],
+		[isEnabled, siren, year, kind, stepKey, dbValues],
 	);
 
 	const clearDraftCallback = useCallback(() => {
@@ -155,9 +189,12 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			timerRef.current = null;
 			pendingRef.current = null;
 		}
-		setLocalDraft({} as Partial<T>);
-		clearMutate({ year, siren, kind });
-	}, [isEnabled, siren, year, kind, clearMutate]);
+		setLocalDraft((prev) => {
+			if (prev !== null && Object.keys(prev).length === 0) return prev;
+			return EMPTY_DRAFT as Partial<T>;
+		});
+		clearMutateRef.current({ year, siren, kind });
+	}, [isEnabled, siren, year, kind]);
 
 	useEffect(() => {
 		return () => {

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -29,15 +29,27 @@ type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
 const DEBOUNCE_MS = 600;
 const EMPTY_DRAFT: Readonly<Record<string, never>> = Object.freeze({});
 
-function shallowEqualRecord(
-	a: Record<string, unknown>,
-	b: Record<string, unknown>,
-): boolean {
-	const keysA = Object.keys(a);
-	const keysB = Object.keys(b);
+function deepEqual(a: unknown, b: unknown): boolean {
+	if (Object.is(a, b)) return true;
+	if (a === null || b === null) return false;
+	if (typeof a !== "object" || typeof b !== "object") return false;
+	const aIsArray = Array.isArray(a);
+	const bIsArray = Array.isArray(b);
+	if (aIsArray !== bIsArray) return false;
+	if (aIsArray && bIsArray) {
+		if (a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i++) {
+			if (!deepEqual(a[i], b[i])) return false;
+		}
+		return true;
+	}
+	const aObj = a as Record<string, unknown>;
+	const bObj = b as Record<string, unknown>;
+	const keysA = Object.keys(aObj);
+	const keysB = Object.keys(bObj);
 	if (keysA.length !== keysB.length) return false;
 	for (const key of keysA) {
-		if (!Object.is(a[key], b[key])) return false;
+		if (!deepEqual(aObj[key], bObj[key])) return false;
 	}
 	return true;
 }
@@ -152,13 +164,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 				const next = hasDiff
 					? (diff as Partial<T>)
 					: (EMPTY_DRAFT as Partial<T>);
-				if (
-					prev !== null &&
-					shallowEqualRecord(
-						prev as Record<string, unknown>,
-						next as Record<string, unknown>,
-					)
-				) {
+				if (prev !== null && deepEqual(prev, next)) {
 					return prev;
 				}
 				return next;

--- a/packages/app/src/test/setup.ts
+++ b/packages/app/src/test/setup.ts
@@ -131,3 +131,16 @@ vi.mock("~/trpc/server", () => ({
 	HydrateClient: ({ children }: { children: React.ReactNode }) =>
 		React.createElement(React.Fragment, null, children),
 }));
+
+vi.mock(
+	"~/modules/declaration-remuneration/shared/draft/useDeclarationDraft",
+	() => ({
+		useDeclarationDraft: () => ({
+			draft: {},
+			setField: () => undefined,
+			clearDraft: () => undefined,
+			hasDraft: false,
+			isLoadingDraft: false,
+		}),
+	}),
+);


### PR DESCRIPTION
Closes #3506

## Summary

T3 of epic #3484. Rewrite the `useDeclarationDraft` hook so it consumes the tRPC `declarationDraft` router (created in #3505, #3515) instead of synchronous `localStorage`.

The hook's **public input shape and return contract** are preserved — none of the 9 consumers compile-break. The single addition is the new `isLoadingDraft` flag (to be wired in T5).

## Implementation notes

- **Read** : `api.declarationDraft.get.useQuery({ year, siren })` with `staleTime: Infinity` (cache only mutates through this hook). Slice = `data?.[kind]?.[step]`.
- **Write** : `setField(currentValues)` computes the diff vs `dbValues` (legacy `computeDraftDiff`), updates a local optimistic state immediately, then schedules a debounced (600 ms) `save` mutation. An empty diff triggers a `clear` instead.
- **clearDraft** : non-debounced `clear({ year, siren, kind })`, cancels any pending save.
- **Impersonation / logged out** : `useQuery({enabled: false})`, all setters become no-ops. `isLoadingDraft` returns `false` immediately.
- **Unmount flush** : a `flushRef` runs the pending mutation on unmount so the last keystroke is never lost.
- **Cache** : `onSuccess` patches `utils.declarationDraft.get.setData` instead of invalidating the query — avoids a round-trip given `staleTime: Infinity`.

## Test plan

- [x] Unit : 20 tests across two files (`useDeclarationDraft.test.tsx` + `useDeclarationDraft.lifecycle.test.tsx`), 100% coverage on the hook itself
- [x] Typecheck / lint / format vert
- [x] Suite globale (1988 tests) toujours verte — un mock no-op global du hook a été ajouté à `src/test/setup.ts` pour que les 16+ tests de consumers continuent à passer sans modification (les tests réels du hook l'opt-out via `vi.unmock`)
- [x] Aucun consumer (composant) modifié — T5 ajoutera l'usage de `isLoadingDraft` pour gater le `form.reset(defaultValues)`

## Out of scope

- Adaptation des consumers (T5)
- Suppression de l'ancien `draftStorage.ts` (cleanup ticket à venir — non listé dans les fichiers impactés de #3506)