### PR TITLE
feat(stats): K4 — délai moyen par étape (#3217)

### DIFF
--- a/packages/app/drizzle/0036_add_step_change_event_type.sql
+++ b/packages/app/drizzle/0036_add_step_change_event_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."declaration_event_type" ADD VALUE 'step_change';

--- a/packages/app/drizzle/meta/0036_snapshot.json
+++ b/packages/app/drizzle/meta/0036_snapshot.json
@@ -1,0 +1,2391 @@
+{
+	"id": "6cf8f8fd-d111-479a-a07f-df7898b2714e",
+	"prevId": "b0a674aa-5ec7-4d36-88aa-de06f79e956f",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_status_history": {
+			"name": "app_declaration_status_history",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "declaration_event_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"round": {
+					"name": "round",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"decl_status_history_declaration_idx": {
+					"name": "decl_status_history_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_status_history_actor_user_id_app_user_id_fk": {
+					"name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_declaration_path_choice": {
+					"name": "first_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_path_choice": {
+					"name": "second_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_required": {
+					"name": "cse_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"rules_version": {
+					"name": "rules_version",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'2027.1'"
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declarations_siren_year_active_unique": {
+					"name": "declarations_siren_year_active_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "cancelled_at IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.compliance_path": {
+			"name": "compliance_path",
+			"schema": "public",
+			"values": ["justify", "corrective_action", "joint_evaluation"]
+		},
+		"public.declaration_event_type": {
+			"name": "declaration_event_type",
+			"schema": "public",
+			"values": [
+				"submit",
+				"path_choice",
+				"second_declaration_submit",
+				"joint_evaluation_submit",
+				"cse_opinion_submit",
+				"cancel",
+				"demarche_complete",
+				"step_change"
+			]
+		},
+		"public.declaration_status": {
+			"name": "declaration_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"awaiting_compliance_path_choice",
+				"corrective_actions_chosen",
+				"joint_evaluation_chosen",
+				"awaiting_revision_choice",
+				"revised_joint_evaluation_chosen",
+				"awaiting_cse_opinion",
+				"demarche_completed"
+			]
+		},
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
 			"when": 1778682813792,
 			"tag": "0035_status_history",
 			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779271468703,
+			"tag": "0036_add_step_change_event_type",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/e2e/admin-stats-campagne.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-campagne.e2e.ts
@@ -132,12 +132,12 @@ test.describe("admin campaign progression stats", () => {
 		).toBeVisible();
 		await expect(
 			k4Section.getByRole("rowheader", {
-				name: /Soumission → choix conformité/i,
+				name: /Délai avant choix du parcours/i,
 			}),
 		).toBeVisible();
 		await expect(
 			k4Section.getByRole("rowheader", {
-				name: /Dernière action → démarche complète/i,
+				name: /Temps passé sur l'avis CSE/i,
 			}),
 		).toBeVisible();
 	});

--- a/packages/app/src/e2e/admin-stats-campagne.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-campagne.e2e.ts
@@ -95,6 +95,52 @@ test.describe("admin campaign progression stats", () => {
 			page.getByRole("figure", { name: /courbe de progression cumulative/i }),
 		).toBeVisible();
 	});
+
+	test("K4 step durations table lists wizard steps and post-submit milestones", async ({
+		page,
+	}) => {
+		await page.goto("/admin/stats/campagne");
+
+		// Section K4 — délai moyen par étape
+		await expect(
+			page.getByRole("heading", { name: /Délai moyen par étape/i, level: 2 }),
+		).toBeVisible();
+
+		const k4Section = page.getByLabel(/Délai moyen par étape/i);
+
+		// Open the accessible alternative table. Scope to K4 to avoid colliding
+		// with the K2 progression table summary above.
+		await k4Section
+			.locator("summary", {
+				hasText: /consulter les données du graphique sous forme de tableau/i,
+			})
+			.click();
+
+		// Wizard group header + post-submit group header.
+		await expect(
+			k4Section.getByRole("rowheader", {
+				name: /Parcours initial \(wizard A–F\)/i,
+			}),
+		).toBeVisible();
+		await expect(
+			k4Section.getByRole("rowheader", { name: "Démarche post-soumission" }),
+		).toBeVisible();
+
+		// At least one wizard row and one post-submit row.
+		await expect(
+			k4Section.getByRole("rowheader", { name: "Introduction" }),
+		).toBeVisible();
+		await expect(
+			k4Section.getByRole("rowheader", {
+				name: /Soumission → choix conformité/i,
+			}),
+		).toBeVisible();
+		await expect(
+			k4Section.getByRole("rowheader", {
+				name: /Dernière action → démarche complète/i,
+			}),
+		).toBeVisible();
+	});
 });
 
 test("non-admin users are redirected away from the stats page", async ({

--- a/packages/app/src/e2e/admin-stats-campagne.e2e.ts
+++ b/packages/app/src/e2e/admin-stats-campagne.e2e.ts
@@ -71,9 +71,8 @@ test.describe("admin campaign progression stats", () => {
 			page.getByRole("figure", { name: /courbe de progression cumulative/i }),
 		).toBeVisible();
 
-		// The table lives inside a <details> disclosure — use the summary text
-		// directly rather than a role match (varies across browsers).
 		await page
+			.getByLabel("Progression dans le temps")
 			.locator("summary", {
 				hasText: /consulter les données du graphique sous forme de tableau/i,
 			})

--- a/packages/app/src/modules/admin/stats/CampaignStatsPage.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignStatsPage.tsx
@@ -7,6 +7,8 @@ import { api } from "~/trpc/react";
 
 import { CampaignProgressionChart } from "./CampaignProgressionChart";
 import { CampaignProgressionTable } from "./CampaignProgressionTable";
+import { StepDurationsChart } from "./StepDurationsChart";
+import { StepDurationsTable } from "./StepDurationsTable";
 import { YearsFilter } from "./YearsFilter";
 
 type Props = {
@@ -32,6 +34,12 @@ export function CampaignStatsPage({ currentYear, availableYears }: Props) {
 			enabled: selectedYears.length > 0,
 			placeholderData: (prev) => prev,
 		},
+	);
+
+	const stepDurationsYear = selectedYears[0] ?? currentYear;
+	const stepDurationsQuery = api.adminStats.getStepDurations.useQuery(
+		{ year: stepDurationsYear, sizeRange },
+		{ placeholderData: (prev) => prev },
 	);
 
 	return (
@@ -87,6 +95,33 @@ export function CampaignStatsPage({ currentYear, availableYears }: Props) {
 							series={query.data}
 						/>
 						<CampaignProgressionTable series={query.data} />
+					</>
+				)}
+			</section>
+
+			<section aria-labelledby="step-durations-heading" className="fr-mt-6w">
+				<h2 className="fr-h3" id="step-durations-heading">
+					Délai moyen par étape — campagne {stepDurationsYear}
+				</h2>
+				<p className="fr-text--sm fr-text-mention--grey">
+					Temps passé par les déclarations sur chaque étape du parcours
+					indicateurs (médiane et 90e percentile). Aide à repérer les étapes qui
+					ralentissent la campagne.
+				</p>
+				{stepDurationsQuery.isLoading && !stepDurationsQuery.data && (
+					<p aria-live="polite">Chargement du graphique…</p>
+				)}
+				{stepDurationsQuery.isError && (
+					<div aria-live="polite" className="fr-alert fr-alert--error">
+						<p>
+							Une erreur est survenue lors du chargement des délais par étape.
+						</p>
+					</div>
+				)}
+				{stepDurationsQuery.data && (
+					<>
+						<StepDurationsChart rows={stepDurationsQuery.data} />
+						<StepDurationsTable rows={stepDurationsQuery.data} />
 					</>
 				)}
 			</section>

--- a/packages/app/src/modules/admin/stats/StepDurationsChart.module.scss
+++ b/packages/app/src/modules/admin/stats/StepDurationsChart.module.scss
@@ -1,0 +1,14 @@
+.chartWrapper {
+	width: 100%;
+	height: 420px;
+}
+
+.tooltipList {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.tooltipItem {
+	font-size: 0.875rem;
+}

--- a/packages/app/src/modules/admin/stats/StepDurationsChart.module.scss
+++ b/packages/app/src/modules/admin/stats/StepDurationsChart.module.scss
@@ -1,6 +1,6 @@
 .chartWrapper {
 	width: 100%;
-	height: 420px;
+	height: 640px;
 }
 
 .tooltipList {

--- a/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
+++ b/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
@@ -31,10 +31,8 @@ type DurationsTooltipProps = {
 	payload?: TooltipEntry[];
 };
 
-// DSFR palette — wizard phase uses the primary blue, post-submit phase uses
-// the secondary red so the visual handoff between the two groups is obvious
-// even without reading the labels. Tokens validated against the DSFR design
-// system (background-action-high-blue-france / background-action-high-red-marianne).
+// Distinct DSFR palettes per phase — the colour break makes the wizard /
+// post-submit handoff readable without referencing the labels.
 const WIZARD_MEDIAN_COLOR = "var(--background-action-high-blue-france)";
 const WIZARD_P90_COLOR = "var(--background-action-low-blue-france)";
 const POST_SUBMIT_MEDIAN_COLOR = "var(--background-action-high-red-marianne)";

--- a/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
+++ b/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Legend,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+import styles from "./StepDurationsChart.module.scss";
+import type { StepDurationRow } from "./types";
+
+type Props = {
+	rows: StepDurationRow[];
+};
+
+type TooltipEntry = {
+	name?: string | number;
+	value?: number;
+	color?: string;
+	payload?: StepDurationRow;
+};
+
+type DurationsTooltipProps = {
+	active?: boolean;
+	payload?: TooltipEntry[];
+};
+
+const MEDIAN_COLOR = "var(--background-action-high-blue-france)";
+const P90_COLOR = "var(--background-action-low-blue-france)";
+
+function formatDays(value: number | null): string {
+	if (value === null) return "—";
+	return `${value.toLocaleString("fr-FR", {
+		maximumFractionDigits: 1,
+		minimumFractionDigits: 1,
+	})} j`;
+}
+
+function DurationsTooltip({ active, payload }: DurationsTooltipProps) {
+	if (!active || !payload || payload.length === 0) {
+		return null;
+	}
+	const row = payload[0]?.payload;
+	if (!row) return null;
+	return (
+		<div className="fr-p-2w fr-background-alt--grey">
+			<p className="fr-text--sm fr-text--bold fr-mb-1w">
+				Étape « {row.label} »
+			</p>
+			<ul className={styles.tooltipList}>
+				<li className={styles.tooltipItem}>
+					médiane {formatDays(row.medianDays)} — p90 {formatDays(row.p90Days)}
+				</li>
+				<li className={styles.tooltipItem}>
+					sur {row.sampleSize.toLocaleString("fr-FR")} déclarations passées par
+					cette étape
+				</li>
+			</ul>
+		</div>
+	);
+}
+
+export function StepDurationsChart({ rows }: Props) {
+	const hasAnyDuration = rows.some(
+		(row) => row.medianDays !== null || row.p90Days !== null,
+	);
+
+	if (!hasAnyDuration) {
+		return (
+			<p aria-live="polite" className="fr-text--sm fr-text-mention--grey">
+				Aucune donnée pour ces filtres.
+			</p>
+		);
+	}
+
+	return (
+		<figure className={styles.chartWrapper}>
+			<figcaption className="fr-sr-only">
+				Délai médian et 90e percentile passé par les déclarations sur chaque
+				étape du parcours indicateurs. Les données équivalentes sont disponibles
+				dans le tableau ci-dessous.
+			</figcaption>
+			<ResponsiveContainer>
+				<BarChart
+					data={rows}
+					layout="vertical"
+					margin={{ top: 16, right: 24, bottom: 16, left: 16 }}
+				>
+					<CartesianGrid strokeDasharray="3 3" />
+					<XAxis
+						label={{
+							value: "Jours",
+							position: "insideBottom",
+							offset: -4,
+						}}
+						tickFormatter={(value: number) => value.toLocaleString("fr-FR")}
+						type="number"
+					/>
+					<YAxis dataKey="label" interval={0} type="category" width={180} />
+					<Tooltip content={<DurationsTooltip />} />
+					<Legend />
+					<Bar dataKey="medianDays" fill={MEDIAN_COLOR} name="Médiane (j)" />
+					<Bar dataKey="p90Days" fill={P90_COLOR} name="p90 (j)" />
+				</BarChart>
+			</ResponsiveContainer>
+		</figure>
+	);
+}

--- a/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
+++ b/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
@@ -4,6 +4,7 @@ import {
 	Bar,
 	BarChart,
 	CartesianGrid,
+	Cell,
 	Legend,
 	ResponsiveContainer,
 	Tooltip,
@@ -30,8 +31,14 @@ type DurationsTooltipProps = {
 	payload?: TooltipEntry[];
 };
 
-const MEDIAN_COLOR = "var(--background-action-high-blue-france)";
-const P90_COLOR = "var(--background-action-low-blue-france)";
+// DSFR palette — wizard phase uses the primary blue, post-submit phase uses
+// the secondary red so the visual handoff between the two groups is obvious
+// even without reading the labels. Tokens validated against the DSFR design
+// system (background-action-high-blue-france / background-action-high-red-marianne).
+const WIZARD_MEDIAN_COLOR = "var(--background-action-high-blue-france)";
+const WIZARD_P90_COLOR = "var(--background-action-low-blue-france)";
+const POST_SUBMIT_MEDIAN_COLOR = "var(--background-action-high-red-marianne)";
+const POST_SUBMIT_P90_COLOR = "var(--background-action-low-red-marianne)";
 
 function formatDays(value: number | null): string {
 	if (value === null) return "—";
@@ -47,18 +54,21 @@ function DurationsTooltip({ active, payload }: DurationsTooltipProps) {
 	}
 	const row = payload[0]?.payload;
 	if (!row) return null;
+	const isWizard = row.phase === "wizard";
 	return (
 		<div className="fr-p-2w fr-background-alt--grey">
 			<p className="fr-text--sm fr-text--bold fr-mb-1w">
-				Étape « {row.label} »
+				{isWizard ? "Étape" : "Jalon"} « {row.label} »
 			</p>
 			<ul className={styles.tooltipList}>
 				<li className={styles.tooltipItem}>
 					médiane {formatDays(row.medianDays)} — p90 {formatDays(row.p90Days)}
 				</li>
 				<li className={styles.tooltipItem}>
-					sur {row.sampleSize.toLocaleString("fr-FR")} déclarations passées par
-					cette étape
+					sur {row.sampleSize.toLocaleString("fr-FR")}{" "}
+					{isWizard
+						? "déclarations passées par cette étape"
+						: "déclarations concernées par ce jalon"}
 				</li>
 			</ul>
 		</div>
@@ -82,8 +92,9 @@ export function StepDurationsChart({ rows }: Props) {
 		<figure className={styles.chartWrapper}>
 			<figcaption className="fr-sr-only">
 				Délai médian et 90e percentile passé par les déclarations sur chaque
-				étape du parcours indicateurs. Les données équivalentes sont disponibles
-				dans le tableau ci-dessous.
+				étape du parcours indicateurs puis sur chaque jalon de la démarche
+				post-soumission. Les données équivalentes sont disponibles dans le
+				tableau ci-dessous.
 			</figcaption>
 			<ResponsiveContainer>
 				<BarChart
@@ -101,11 +112,37 @@ export function StepDurationsChart({ rows }: Props) {
 						tickFormatter={(value: number) => value.toLocaleString("fr-FR")}
 						type="number"
 					/>
-					<YAxis dataKey="label" interval={0} type="category" width={180} />
+					<YAxis dataKey="label" interval={0} type="category" width={220} />
 					<Tooltip content={<DurationsTooltip />} />
 					<Legend />
-					<Bar dataKey="medianDays" fill={MEDIAN_COLOR} name="Médiane (j)" />
-					<Bar dataKey="p90Days" fill={P90_COLOR} name="p90 (j)" />
+					<Bar
+						dataKey="medianDays"
+						fill={WIZARD_MEDIAN_COLOR}
+						name="Médiane (j)"
+					>
+						{rows.map((row) => (
+							<Cell
+								fill={
+									row.phase === "wizard"
+										? WIZARD_MEDIAN_COLOR
+										: POST_SUBMIT_MEDIAN_COLOR
+								}
+								key={row.key}
+							/>
+						))}
+					</Bar>
+					<Bar dataKey="p90Days" fill={WIZARD_P90_COLOR} name="p90 (j)">
+						{rows.map((row) => (
+							<Cell
+								fill={
+									row.phase === "wizard"
+										? WIZARD_P90_COLOR
+										: POST_SUBMIT_P90_COLOR
+								}
+								key={row.key}
+							/>
+						))}
+					</Bar>
 				</BarChart>
 			</ResponsiveContainer>
 		</figure>

--- a/packages/app/src/modules/admin/stats/StepDurationsTable.tsx
+++ b/packages/app/src/modules/admin/stats/StepDurationsTable.tsx
@@ -1,0 +1,65 @@
+import type { StepDurationRow } from "./types";
+
+type Props = {
+	rows: StepDurationRow[];
+};
+
+function formatDays(value: number | null): string {
+	if (value === null) return "—";
+	return value.toLocaleString("fr-FR", {
+		maximumFractionDigits: 1,
+		minimumFractionDigits: 1,
+	});
+}
+
+/**
+ * Accessible alternative to `<StepDurationsChart>` — same K4 dataset rendered
+ * as a DSFR table inside a `<details>` toggle. Required for RGAA because the
+ * Recharts SVG is not navigable by assistive tech.
+ */
+export function StepDurationsTable({ rows }: Props) {
+	if (rows.length === 0) {
+		return null;
+	}
+
+	return (
+		<details className="fr-mt-3w">
+			<summary className="fr-text--sm">
+				Consulter les données du graphique sous forme de tableau
+			</summary>
+			<div className="fr-table fr-table--bordered fr-mt-2w">
+				<div className="fr-table__wrapper">
+					<div className="fr-table__container">
+						<div className="fr-table__content">
+							<table>
+								<caption className="fr-sr-only">
+									Délai médian et 90e percentile en jours par étape du parcours
+									indicateurs, et nombre de déclarations passées par chaque
+									étape.
+								</caption>
+								<thead>
+									<tr>
+										<th scope="col">Étape</th>
+										<th scope="col">Médiane (j)</th>
+										<th scope="col">p90 (j)</th>
+										<th scope="col">Échantillon</th>
+									</tr>
+								</thead>
+								<tbody>
+									{rows.map((row) => (
+										<tr key={row.step}>
+											<th scope="row">{row.label}</th>
+											<td>{formatDays(row.medianDays)}</td>
+											<td>{formatDays(row.p90Days)}</td>
+											<td>{row.sampleSize.toLocaleString("fr-FR")}</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+		</details>
+	);
+}

--- a/packages/app/src/modules/admin/stats/StepDurationsTable.tsx
+++ b/packages/app/src/modules/admin/stats/StepDurationsTable.tsx
@@ -27,9 +27,6 @@ export function StepDurationsTable({ rows }: Props) {
 		return null;
 	}
 
-	// Split rows by phase to surface the two groups in the table without
-	// mixing them. The chart keeps a single continuous series but the table
-	// benefits from explicit section headers for assistive tech and quick scan.
 	const wizardRows = rows.filter((row) => row.phase === "wizard");
 	const postSubmitRows = rows.filter((row) => row.phase === "post_submit");
 

--- a/packages/app/src/modules/admin/stats/StepDurationsTable.tsx
+++ b/packages/app/src/modules/admin/stats/StepDurationsTable.tsx
@@ -12,6 +12,11 @@ function formatDays(value: number | null): string {
 	});
 }
 
+const PHASE_HEADERS: Record<StepDurationRow["phase"], string> = {
+	wizard: "Parcours initial (wizard A–F)",
+	post_submit: "Démarche post-soumission",
+};
+
 /**
  * Accessible alternative to `<StepDurationsChart>` — same K4 dataset rendered
  * as a DSFR table inside a `<details>` toggle. Required for RGAA because the
@@ -21,6 +26,12 @@ export function StepDurationsTable({ rows }: Props) {
 	if (rows.length === 0) {
 		return null;
 	}
+
+	// Split rows by phase to surface the two groups in the table without
+	// mixing them. The chart keeps a single continuous series but the table
+	// benefits from explicit section headers for assistive tech and quick scan.
+	const wizardRows = rows.filter((row) => row.phase === "wizard");
+	const postSubmitRows = rows.filter((row) => row.phase === "post_submit");
 
 	return (
 		<details className="fr-mt-3w">
@@ -34,27 +45,59 @@ export function StepDurationsTable({ rows }: Props) {
 							<table>
 								<caption className="fr-sr-only">
 									Délai médian et 90e percentile en jours par étape du parcours
-									indicateurs, et nombre de déclarations passées par chaque
-									étape.
+									indicateurs et par jalon de la démarche post-soumission, et
+									nombre de déclarations concernées.
 								</caption>
 								<thead>
 									<tr>
-										<th scope="col">Étape</th>
+										<th scope="col">Étape ou jalon</th>
 										<th scope="col">Médiane (j)</th>
 										<th scope="col">p90 (j)</th>
 										<th scope="col">Échantillon</th>
 									</tr>
 								</thead>
-								<tbody>
-									{rows.map((row) => (
-										<tr key={row.step}>
-											<th scope="row">{row.label}</th>
-											<td>{formatDays(row.medianDays)}</td>
-											<td>{formatDays(row.p90Days)}</td>
-											<td>{row.sampleSize.toLocaleString("fr-FR")}</td>
+								{wizardRows.length > 0 && (
+									<tbody>
+										<tr>
+											<th
+												className="fr-text--bold fr-background-alt--blue-france"
+												colSpan={4}
+												scope="rowgroup"
+											>
+												{PHASE_HEADERS.wizard}
+											</th>
 										</tr>
-									))}
-								</tbody>
+										{wizardRows.map((row) => (
+											<tr key={row.key}>
+												<th scope="row">{row.label}</th>
+												<td>{formatDays(row.medianDays)}</td>
+												<td>{formatDays(row.p90Days)}</td>
+												<td>{row.sampleSize.toLocaleString("fr-FR")}</td>
+											</tr>
+										))}
+									</tbody>
+								)}
+								{postSubmitRows.length > 0 && (
+									<tbody>
+										<tr>
+											<th
+												className="fr-text--bold fr-background-alt--red-marianne"
+												colSpan={4}
+												scope="rowgroup"
+											>
+												{PHASE_HEADERS.post_submit}
+											</th>
+										</tr>
+										{postSubmitRows.map((row) => (
+											<tr key={row.key}>
+												<th scope="row">{row.label}</th>
+												<td>{formatDays(row.medianDays)}</td>
+												<td>{formatDays(row.p90Days)}</td>
+												<td>{row.sampleSize.toLocaleString("fr-FR")}</td>
+											</tr>
+										))}
+									</tbody>
+								)}
 							</table>
 						</div>
 					</div>

--- a/packages/app/src/modules/admin/stats/__tests__/StepDurationsChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StepDurationsChart.test.tsx
@@ -6,6 +6,8 @@ import type { StepDurationRow } from "../types";
 
 const EMPTY_ROWS: StepDurationRow[] = [
 	{
+		key: "step_0",
+		phase: "wizard",
 		step: 0,
 		label: "Introduction",
 		sampleSize: 0,
@@ -17,6 +19,8 @@ const EMPTY_ROWS: StepDurationRow[] = [
 
 const POPULATED_ROWS: StepDurationRow[] = [
 	{
+		key: "step_1",
+		phase: "wizard",
 		step: 1,
 		label: "Effectifs",
 		sampleSize: 10,
@@ -25,12 +29,24 @@ const POPULATED_ROWS: StepDurationRow[] = [
 		p90Days: 9.1,
 	},
 	{
+		key: "step_2",
+		phase: "wizard",
 		step: 2,
 		label: "Écart de rémunération",
 		sampleSize: 8,
 		completedSampleSize: 7,
 		medianDays: 2.0,
 		p90Days: 6.4,
+	},
+	{
+		key: "submit_to_path_choice",
+		phase: "post_submit",
+		step: null,
+		label: "Soumission → choix conformité",
+		sampleSize: 6,
+		completedSampleSize: 6,
+		medianDays: 3.2,
+		p90Days: 8.4,
 	},
 ];
 
@@ -44,6 +60,13 @@ describe("StepDurationsChart", () => {
 		render(<StepDurationsChart rows={POPULATED_ROWS} />);
 		expect(
 			screen.getByText(/Délai médian et 90e percentile/),
+		).toBeInTheDocument();
+	});
+
+	it("mentions the post-soumission phase in the figcaption", () => {
+		render(<StepDurationsChart rows={POPULATED_ROWS} />);
+		expect(
+			screen.getByText(/jalon de la démarche post-soumission/i),
 		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/stats/__tests__/StepDurationsChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StepDurationsChart.test.tsx
@@ -42,7 +42,7 @@ const POPULATED_ROWS: StepDurationRow[] = [
 		key: "submit_to_path_choice",
 		phase: "post_submit",
 		step: null,
-		label: "Soumission → choix conformité",
+		label: "Délai avant choix du parcours",
 		sampleSize: 6,
 		completedSampleSize: 6,
 		medianDays: 3.2,

--- a/packages/app/src/modules/admin/stats/__tests__/StepDurationsChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StepDurationsChart.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StepDurationsChart } from "../StepDurationsChart";
+import type { StepDurationRow } from "../types";
+
+const EMPTY_ROWS: StepDurationRow[] = [
+	{
+		step: 0,
+		label: "Introduction",
+		sampleSize: 0,
+		completedSampleSize: 0,
+		medianDays: null,
+		p90Days: null,
+	},
+];
+
+const POPULATED_ROWS: StepDurationRow[] = [
+	{
+		step: 1,
+		label: "Effectifs",
+		sampleSize: 10,
+		completedSampleSize: 10,
+		medianDays: 5.5,
+		p90Days: 9.1,
+	},
+	{
+		step: 2,
+		label: "Écart de rémunération",
+		sampleSize: 8,
+		completedSampleSize: 7,
+		medianDays: 2.0,
+		p90Days: 6.4,
+	},
+];
+
+describe("StepDurationsChart", () => {
+	it("shows an empty-state message when no row has any duration data", () => {
+		render(<StepDurationsChart rows={EMPTY_ROWS} />);
+		expect(screen.getByText(/Aucune donnée/)).toBeInTheDocument();
+	});
+
+	it("includes an accessible figcaption when rows have durations", () => {
+		render(<StepDurationsChart rows={POPULATED_ROWS} />);
+		expect(
+			screen.getByText(/Délai médian et 90e percentile/),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/StepDurationsTable.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StepDurationsTable.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StepDurationsTable } from "../StepDurationsTable";
+import type { StepDurationRow } from "../types";
+
+function buildRow(overrides: Partial<StepDurationRow> = {}): StepDurationRow {
+	return {
+		step: 1,
+		label: "Effectifs",
+		sampleSize: 10,
+		completedSampleSize: 10,
+		medianDays: 5,
+		p90Days: 9,
+		...overrides,
+	};
+}
+
+describe("StepDurationsTable", () => {
+	it("renders nothing when given no rows", () => {
+		const { container } = render(<StepDurationsTable rows={[]} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders one row per step with the expected columns", () => {
+		render(
+			<StepDurationsTable
+				rows={[
+					buildRow({ step: 0, label: "Introduction", sampleSize: 12 }),
+					buildRow({ step: 1, label: "Effectifs", sampleSize: 10 }),
+				]}
+			/>,
+		);
+
+		const headers = screen
+			.getAllByRole("columnheader")
+			.map((el) => el.textContent);
+		expect(headers).toEqual(["Étape", "Médiane (j)", "p90 (j)", "Échantillon"]);
+
+		const rows = screen.getAllByRole("row");
+		expect(rows).toHaveLength(3);
+
+		const firstDataRow = rows[1];
+		if (!firstDataRow) throw new Error("missing row");
+		expect(within(firstDataRow).getByRole("rowheader").textContent).toBe(
+			"Introduction",
+		);
+	});
+
+	it("formats numeric values with French decimal separator (1 decimal)", () => {
+		render(
+			<StepDurationsTable
+				rows={[buildRow({ medianDays: 5.5, p90Days: 9.12 })]}
+			/>,
+		);
+
+		const cells = screen.getAllByRole("cell").map((el) => el.textContent);
+		expect(cells).toContain("5,5");
+		expect(cells).toContain("9,1");
+	});
+
+	it("shows an em dash when percentiles are null (sample too small)", () => {
+		render(
+			<StepDurationsTable
+				rows={[
+					buildRow({
+						sampleSize: 2,
+						medianDays: null,
+						p90Days: null,
+					}),
+				]}
+			/>,
+		);
+
+		const cells = screen.getAllByRole("cell").map((el) => el.textContent);
+		expect(cells.filter((value) => value === "—")).toHaveLength(2);
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/StepDurationsTable.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StepDurationsTable.test.tsx
@@ -27,7 +27,7 @@ function buildPostSubmitRow(
 		key: "submit_to_path_choice",
 		phase: "post_submit",
 		step: null,
-		label: "Soumission → choix conformité",
+		label: "Délai avant choix du parcours",
 		sampleSize: 8,
 		completedSampleSize: 8,
 		medianDays: 3,
@@ -136,7 +136,7 @@ describe("StepDurationsTable", () => {
 		).toBeInTheDocument();
 		expect(
 			screen.getByRole("rowheader", {
-				name: /Soumission → choix conformité/i,
+				name: /Délai avant choix du parcours/i,
 			}),
 		).toBeInTheDocument();
 	});

--- a/packages/app/src/modules/admin/stats/__tests__/StepDurationsTable.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StepDurationsTable.test.tsx
@@ -4,14 +4,34 @@ import { describe, expect, it } from "vitest";
 import { StepDurationsTable } from "../StepDurationsTable";
 import type { StepDurationRow } from "../types";
 
-function buildRow(overrides: Partial<StepDurationRow> = {}): StepDurationRow {
+function buildWizardRow(
+	overrides: Partial<StepDurationRow> = {},
+): StepDurationRow {
 	return {
+		key: `step_${overrides.step ?? 1}`,
+		phase: "wizard",
 		step: 1,
 		label: "Effectifs",
 		sampleSize: 10,
 		completedSampleSize: 10,
 		medianDays: 5,
 		p90Days: 9,
+		...overrides,
+	};
+}
+
+function buildPostSubmitRow(
+	overrides: Partial<StepDurationRow> = {},
+): StepDurationRow {
+	return {
+		key: "submit_to_path_choice",
+		phase: "post_submit",
+		step: null,
+		label: "Soumission → choix conformité",
+		sampleSize: 8,
+		completedSampleSize: 8,
+		medianDays: 3,
+		p90Days: 7,
 		...overrides,
 	};
 }
@@ -26,8 +46,13 @@ describe("StepDurationsTable", () => {
 		render(
 			<StepDurationsTable
 				rows={[
-					buildRow({ step: 0, label: "Introduction", sampleSize: 12 }),
-					buildRow({ step: 1, label: "Effectifs", sampleSize: 10 }),
+					buildWizardRow({
+						step: 0,
+						label: "Introduction",
+						sampleSize: 12,
+						key: "step_0",
+					}),
+					buildWizardRow({ step: 1, label: "Effectifs", sampleSize: 10 }),
 				]}
 			/>,
 		);
@@ -35,12 +60,18 @@ describe("StepDurationsTable", () => {
 		const headers = screen
 			.getAllByRole("columnheader")
 			.map((el) => el.textContent);
-		expect(headers).toEqual(["Étape", "Médiane (j)", "p90 (j)", "Échantillon"]);
+		expect(headers).toEqual([
+			"Étape ou jalon",
+			"Médiane (j)",
+			"p90 (j)",
+			"Échantillon",
+		]);
 
+		// 1 column-header row + 1 group-header row + 2 data rows = 4 rows
 		const rows = screen.getAllByRole("row");
-		expect(rows).toHaveLength(3);
+		expect(rows.length).toBeGreaterThanOrEqual(4);
 
-		const firstDataRow = rows[1];
+		const firstDataRow = rows[2];
 		if (!firstDataRow) throw new Error("missing row");
 		expect(within(firstDataRow).getByRole("rowheader").textContent).toBe(
 			"Introduction",
@@ -50,7 +81,7 @@ describe("StepDurationsTable", () => {
 	it("formats numeric values with French decimal separator (1 decimal)", () => {
 		render(
 			<StepDurationsTable
-				rows={[buildRow({ medianDays: 5.5, p90Days: 9.12 })]}
+				rows={[buildWizardRow({ medianDays: 5.5, p90Days: 9.12 })]}
 			/>,
 		);
 
@@ -63,7 +94,7 @@ describe("StepDurationsTable", () => {
 		render(
 			<StepDurationsTable
 				rows={[
-					buildRow({
+					buildWizardRow({
 						sampleSize: 2,
 						medianDays: null,
 						p90Days: null,
@@ -74,5 +105,39 @@ describe("StepDurationsTable", () => {
 
 		const cells = screen.getAllByRole("cell").map((el) => el.textContent);
 		expect(cells.filter((value) => value === "—")).toHaveLength(2);
+	});
+
+	it("groups wizard and post-submit rows under distinct section headers", () => {
+		render(
+			<StepDurationsTable
+				rows={[
+					buildWizardRow({
+						step: 0,
+						label: "Introduction",
+						key: "step_0",
+					}),
+					buildPostSubmitRow(),
+				]}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("rowheader", {
+				name: /Parcours initial \(wizard A–F\)/i,
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("rowheader", {
+				name: "Démarche post-soumission",
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("rowheader", { name: "Introduction" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("rowheader", {
+				name: /Soumission → choix conformité/i,
+			}),
+		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -1,10 +1,19 @@
 export { CampaignProgressionChart } from "./CampaignProgressionChart";
 export { CampaignProgressionTable } from "./CampaignProgressionTable";
 export { CampaignStatsPage } from "./CampaignStatsPage";
-export type { GetCampaignProgressionInput } from "./schemas";
-export { getCampaignProgressionSchema } from "./schemas";
+export { StepDurationsChart } from "./StepDurationsChart";
+export { StepDurationsTable } from "./StepDurationsTable";
+export type {
+	GetCampaignProgressionInput,
+	GetStepDurationsInput,
+} from "./schemas";
+export {
+	getCampaignProgressionSchema,
+	getStepDurationsSchema,
+} from "./schemas";
 export type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
+	StepDurationRow,
 } from "./types";
 export { YearsFilter } from "./YearsFilter";

--- a/packages/app/src/modules/admin/stats/schemas.ts
+++ b/packages/app/src/modules/admin/stats/schemas.ts
@@ -23,3 +23,18 @@ export const getCampaignProgressionSchema = z.object({
 export type GetCampaignProgressionInput = z.infer<
 	typeof getCampaignProgressionSchema
 >;
+
+/**
+ * Input for `adminStats.getStepDurations`.
+ *
+ * `year`: campaign year scoped for the K4 chart (single year, the comparison
+ * is intra-step rather than inter-year).
+ *
+ * `sizeRange`: optional workforce bucket scoping the aggregation.
+ */
+export const getStepDurationsSchema = z.object({
+	year: z.number().int().min(2000).max(2100),
+	sizeRange: z.enum(COMPANY_SIZE_RANGE_KEYS).optional(),
+});
+
+export type GetStepDurationsInput = z.infer<typeof getStepDurationsSchema>;

--- a/packages/app/src/modules/admin/stats/types.ts
+++ b/packages/app/src/modules/admin/stats/types.ts
@@ -19,17 +19,22 @@ export type CampaignProgressionSeries = {
 /**
  * One row of the K4 « délai moyen par étape » dataset.
  *
- * `step` is the integer index (0..6) of the A–F stepper. `medianDays` and
- * `p90Days` are the 50th and 90th percentiles of the duration (in days)
- * declarations spent on that step before transitioning to a later one.
+ * Covers both phases of the journey:
+ * - **wizard phase** (`phase: "wizard"`, `step` set to 0..6) — durations spent
+ *   on each step of the A–F stepper, computed from `step_change` events.
+ * - **post-submit phase** (`phase: "post_submit"`, `step: null`) — durations
+ *   between business milestones (path choice, action, CSE opinion, complete),
+ *   computed from business events in `declaration_status_history`.
  *
- * `sampleSize` counts how many declarations reached that step (whether or not
- * they exited). When too few declarations have exited the step
- * (`completedSampleSize < 5`), `medianDays` and `p90Days` are `null` to avoid
- * surfacing statistically meaningless numbers.
+ * `key` is a stable identifier (e.g. `step_0`, `submit_to_path_choice`) used as
+ * the React key in the chart and as the row identity in tests. `medianDays` /
+ * `p90Days` are null when the completed sample is too small (< 5) to surface
+ * statistically meaningful percentiles.
  */
 export type StepDurationRow = {
-	step: number;
+	key: string;
+	phase: "wizard" | "post_submit";
+	step: number | null;
 	label: string;
 	sampleSize: number;
 	completedSampleSize: number;

--- a/packages/app/src/modules/admin/stats/types.ts
+++ b/packages/app/src/modules/admin/stats/types.ts
@@ -15,3 +15,24 @@ export type CampaignProgressionSeries = {
 	year: number;
 	points: CampaignProgressionPoint[];
 };
+
+/**
+ * One row of the K4 « délai moyen par étape » dataset.
+ *
+ * `step` is the integer index (0..6) of the A–F stepper. `medianDays` and
+ * `p90Days` are the 50th and 90th percentiles of the duration (in days)
+ * declarations spent on that step before transitioning to a later one.
+ *
+ * `sampleSize` counts how many declarations reached that step (whether or not
+ * they exited). When too few declarations have exited the step
+ * (`completedSampleSize < 5`), `medianDays` and `p90Days` are `null` to avoid
+ * surfacing statistically meaningless numbers.
+ */
+export type StepDurationRow = {
+	step: number;
+	label: string;
+	sampleSize: number;
+	completedSampleSize: number;
+	medianDays: number | null;
+	p90Days: number | null;
+};

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -56,6 +56,7 @@ export const AUDIT_ACTIONS = {
 
 	// ── Admin stats reads ─────────────────────────────────
 	ADMIN_STATS_CAMPAIGN_PROGRESSION: "admin_stats.campaign_progression",
+	ADMIN_STATS_GET_STEP_DURATIONS: "admin_stats.get_step_durations",
 
 	// ── Sensitive reads ────────────────────────────────────
 	ADMIN_FILE_DOWNLOAD: "admin.file_download",
@@ -129,6 +130,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DURATIONS]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.PROFILE_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA]: "read_sensitive",

--- a/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
@@ -39,10 +39,11 @@ describe("getStepLabel", () => {
 });
 
 describe("POST_SUBMIT_MILESTONES", () => {
-	it("exposes the 5 post-submission jalons in chronological order", () => {
+	it("exposes the 6 post-submission jalons in chronological order", () => {
 		expect(POST_SUBMIT_MILESTONES.map((m) => m.key)).toEqual([
 			"submit_to_path_choice",
-			"path_choice_to_action",
+			"path_choice_to_second_declaration",
+			"path_choice_to_joint_evaluation",
 			"revision_choice_to_action",
 			"action_to_cse_opinion",
 			"last_action_to_complete",

--- a/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { DECLARATION_STEPS, getStepLabel } from "../shared/declarationSteps";
+import {
+	DECLARATION_STEPS,
+	getStepLabel,
+	POST_SUBMIT_MILESTONES,
+} from "../shared/declarationSteps";
 
 describe("DECLARATION_STEPS", () => {
 	it("covers all 7 steps (0..6)", () => {
@@ -31,5 +35,28 @@ describe("getStepLabel", () => {
 	it("returns a sensible fallback for unknown step numbers", () => {
 		expect(getStepLabel(42)).toBe("Étape 42");
 		expect(getStepLabel(-1)).toBe("Étape -1");
+	});
+});
+
+describe("POST_SUBMIT_MILESTONES", () => {
+	it("exposes the 5 post-submission jalons in chronological order", () => {
+		expect(POST_SUBMIT_MILESTONES.map((m) => m.key)).toEqual([
+			"submit_to_path_choice",
+			"path_choice_to_action",
+			"revision_choice_to_action",
+			"action_to_cse_opinion",
+			"last_action_to_complete",
+		]);
+	});
+
+	it("uses French labels with no empty strings", () => {
+		for (const entry of POST_SUBMIT_MILESTONES) {
+			expect(entry.label.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("uses unique keys", () => {
+		const keys = POST_SUBMIT_MILESTONES.map((m) => m.key);
+		expect(new Set(keys).size).toBe(keys.length);
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
@@ -39,15 +39,31 @@ describe("getStepLabel", () => {
 });
 
 describe("POST_SUBMIT_MILESTONES", () => {
-	it("exposes the 6 post-submission jalons in chronological order", () => {
+	it("exposes the 4 post-submission jalons in chronological order", () => {
 		expect(POST_SUBMIT_MILESTONES.map((m) => m.key)).toEqual([
 			"submit_to_path_choice",
 			"path_choice_to_second_declaration",
 			"path_choice_to_joint_evaluation",
-			"revision_choice_to_action",
 			"action_to_cse_opinion",
-			"last_action_to_complete",
 		]);
+	});
+
+	it("uses the « Temps passé sur » labels for post-path-choice durations", () => {
+		const labelByKey = new Map(
+			POST_SUBMIT_MILESTONES.map((m) => [m.key, m.label]),
+		);
+		expect(labelByKey.get("submit_to_path_choice")).toBe(
+			"Délai avant choix du parcours",
+		);
+		expect(labelByKey.get("path_choice_to_second_declaration")).toBe(
+			"Temps passé sur la seconde déclaration",
+		);
+		expect(labelByKey.get("path_choice_to_joint_evaluation")).toBe(
+			"Temps passé sur l'évaluation conjointe",
+		);
+		expect(labelByKey.get("action_to_cse_opinion")).toBe(
+			"Temps passé sur l'avis CSE",
+		);
 	});
 
 	it("uses French labels with no empty strings", () => {

--- a/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationSteps.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { DECLARATION_STEPS, getStepLabel } from "../shared/declarationSteps";
+
+describe("DECLARATION_STEPS", () => {
+	it("covers all 7 steps (0..6)", () => {
+		expect(DECLARATION_STEPS).toHaveLength(7);
+		expect(DECLARATION_STEPS.map((entry) => entry.step)).toEqual([
+			0, 1, 2, 3, 4, 5, 6,
+		]);
+	});
+
+	it("uses French labels with no empty strings", () => {
+		for (const entry of DECLARATION_STEPS) {
+			expect(entry.label.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("getStepLabel", () => {
+	it("returns the French label for a known step number", () => {
+		expect(getStepLabel(0)).toBe("Introduction");
+		expect(getStepLabel(1)).toBe("Effectifs");
+		expect(getStepLabel(2)).toBe("Écart de rémunération");
+		expect(getStepLabel(3)).toBe("Écart de rémunération variable");
+		expect(getStepLabel(4)).toBe("Quartiles de rémunération");
+		expect(getStepLabel(5)).toBe("Écart par catégorie de salariés");
+		expect(getStepLabel(6)).toBe("Récapitulatif");
+	});
+
+	it("returns a sensible fallback for unknown step numbers", () => {
+		expect(getStepLabel(42)).toBe("Étape 42");
+		expect(getStepLabel(-1)).toBe("Étape -1");
+	});
+});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -51,9 +51,16 @@ export {
 	getCurrentCompliancePath,
 	isCancelled,
 } from "./shared/declarationStatus";
-// Declaration steps labels (A–F stepper)
-export type { DeclarationStepNumber } from "./shared/declarationSteps";
-export { DECLARATION_STEPS, getStepLabel } from "./shared/declarationSteps";
+// Declaration steps labels (A–F stepper) and post-submit milestones
+export type {
+	DeclarationStepNumber,
+	PostSubmitMilestoneKey,
+} from "./shared/declarationSteps";
+export {
+	DECLARATION_STEPS,
+	getStepLabel,
+	POST_SUBMIT_MILESTONES,
+} from "./shared/declarationSteps";
 // Declaration status history (event-sourced trajectory)
 export type {
 	DeclarationEventType,

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -51,6 +51,9 @@ export {
 	getCurrentCompliancePath,
 	isCancelled,
 } from "./shared/declarationStatus";
+// Declaration steps labels (A–F stepper)
+export type { DeclarationStepNumber } from "./shared/declarationSteps";
+export { DECLARATION_STEPS, getStepLabel } from "./shared/declarationSteps";
 // Declaration status history (event-sourced trajectory)
 export type {
 	DeclarationEventType,

--- a/packages/app/src/modules/domain/shared/declarationSteps.ts
+++ b/packages/app/src/modules/domain/shared/declarationSteps.ts
@@ -45,8 +45,12 @@ export const POST_SUBMIT_MILESTONES = [
 		label: "Soumission → choix conformité",
 	},
 	{
-		key: "path_choice_to_action",
-		label: "Choix conformité → action soumise",
+		key: "path_choice_to_second_declaration",
+		label: "Choix conformité → seconde déclaration",
+	},
+	{
+		key: "path_choice_to_joint_evaluation",
+		label: "Choix conformité → évaluation conjointe",
 	},
 	{
 		key: "revision_choice_to_action",

--- a/packages/app/src/modules/domain/shared/declarationSteps.ts
+++ b/packages/app/src/modules/domain/shared/declarationSteps.ts
@@ -28,3 +28,39 @@ const STEP_LABEL_BY_NUMBER: ReadonlyMap<number, string> = new Map(
 export function getStepLabel(step: number): string {
 	return STEP_LABEL_BY_NUMBER.get(step) ?? `Étape ${step}`;
 }
+
+/**
+ * Jalons post-soumission de la déclaration — étendent le KPI K4 au-delà des
+ * 7 étapes du wizard A–F. Ces jalons couvrent la « démarche complète » : choix
+ * du parcours de conformité, actions correctives (seconde déclaration ou
+ * évaluation conjointe), avis du CSE, et clôture.
+ *
+ * Chaque jalon mesure la durée entre deux événements de
+ * `declaration_status_history`. L'ordre du tableau reflète la chronologie
+ * typique et est conservé tel quel par les consommateurs (chart + table).
+ */
+export const POST_SUBMIT_MILESTONES = [
+	{
+		key: "submit_to_path_choice",
+		label: "Soumission → choix conformité",
+	},
+	{
+		key: "path_choice_to_action",
+		label: "Choix conformité → action soumise",
+	},
+	{
+		key: "revision_choice_to_action",
+		label: "Choix révision → action de révision",
+	},
+	{
+		key: "action_to_cse_opinion",
+		label: "Action → avis CSE",
+	},
+	{
+		key: "last_action_to_complete",
+		label: "Dernière action → démarche complète",
+	},
+] as const;
+
+export type PostSubmitMilestoneKey =
+	(typeof POST_SUBMIT_MILESTONES)[number]["key"];

--- a/packages/app/src/modules/domain/shared/declarationSteps.ts
+++ b/packages/app/src/modules/domain/shared/declarationSteps.ts
@@ -42,27 +42,19 @@ export function getStepLabel(step: number): string {
 export const POST_SUBMIT_MILESTONES = [
 	{
 		key: "submit_to_path_choice",
-		label: "Soumission → choix conformité",
+		label: "Délai avant choix du parcours",
 	},
 	{
 		key: "path_choice_to_second_declaration",
-		label: "Choix conformité → seconde déclaration",
+		label: "Temps passé sur la seconde déclaration",
 	},
 	{
 		key: "path_choice_to_joint_evaluation",
-		label: "Choix conformité → évaluation conjointe",
-	},
-	{
-		key: "revision_choice_to_action",
-		label: "Choix révision → action de révision",
+		label: "Temps passé sur l'évaluation conjointe",
 	},
 	{
 		key: "action_to_cse_opinion",
-		label: "Action → avis CSE",
-	},
-	{
-		key: "last_action_to_complete",
-		label: "Dernière action → démarche complète",
+		label: "Temps passé sur l'avis CSE",
 	},
 ] as const;
 

--- a/packages/app/src/modules/domain/shared/declarationSteps.ts
+++ b/packages/app/src/modules/domain/shared/declarationSteps.ts
@@ -1,0 +1,30 @@
+/**
+ * Labels FR du stepper Indicateurs A–F de la déclaration.
+ *
+ * Source de vérité unique pour mapper `declarations.current_step` (entier 0..6)
+ * vers un libellé lisible — utilisé par le KPI K4 « délai moyen par étape » et
+ * tout futur consommateur (export, dashboard, etc.).
+ *
+ * Aligné sur `STEP_TITLES` du module `declaration-remuneration` mais isomorphe
+ * (zéro dépendance React) pour pouvoir être consommé côté serveur (router
+ * admin) comme côté client (composants Recharts).
+ */
+export const DECLARATION_STEPS = [
+	{ step: 0, label: "Introduction" },
+	{ step: 1, label: "Effectifs" },
+	{ step: 2, label: "Écart de rémunération" },
+	{ step: 3, label: "Écart de rémunération variable" },
+	{ step: 4, label: "Quartiles de rémunération" },
+	{ step: 5, label: "Écart par catégorie de salariés" },
+	{ step: 6, label: "Récapitulatif" },
+] as const;
+
+export type DeclarationStepNumber = (typeof DECLARATION_STEPS)[number]["step"];
+
+const STEP_LABEL_BY_NUMBER: ReadonlyMap<number, string> = new Map(
+	DECLARATION_STEPS.map((entry) => [entry.step, entry.label]),
+);
+
+export function getStepLabel(step: number): string {
+	return STEP_LABEL_BY_NUMBER.get(step) ?? `Étape ${step}`;
+}

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -16,8 +16,17 @@ type SelectChain = {
 	orderBy: ReturnType<typeof vi.fn>;
 };
 
+type StepRow = {
+	step: number;
+	sample_size: number;
+	completed_sample_size: number;
+	median_days: number | null;
+	p90_days: number | null;
+};
+
 function buildDb(
 	rows: Array<{ day: string; year: number; count: number }> = [],
+	stepRows: StepRow[] = [],
 ) {
 	const orderBy = vi.fn().mockResolvedValue(rows);
 	const chain: SelectChain = {
@@ -29,6 +38,7 @@ function buildDb(
 	};
 	return {
 		select: vi.fn().mockReturnValue(chain),
+		execute: vi.fn().mockResolvedValue(stepRows),
 		__chain: chain,
 	};
 }
@@ -147,5 +157,168 @@ describe("adminStatsRouter.getCampaignProgression", () => {
 				years: [2020, 2021, 2022, 2023, 2024, 2025],
 			}),
 		).rejects.toThrow();
+	});
+});
+
+describe("adminStatsRouter.getStepDurations", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("rejects non-admin callers", async () => {
+		const db = buildDb([], []);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: {
+				user: { id: "u", email: "u@x", isAdmin: false },
+				expires: "",
+			},
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.getStepDurations({ year: 2026 })).rejects.toThrow(
+			/administrateurs/i,
+		);
+	});
+
+	it("returns a complete set of 7 steps (0..6) even when SQL returns nothing", async () => {
+		const db = buildDb([], []);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2026 });
+
+		expect(result).toHaveLength(7);
+		expect(result.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+		expect(result.every((row) => row.medianDays === null)).toBe(true);
+		expect(result.every((row) => row.sampleSize === 0)).toBe(true);
+	});
+
+	it("maps SQL rows to the typed output and attaches French labels", async () => {
+		const db = buildDb(
+			[],
+			[
+				{
+					step: 1,
+					sample_size: 10,
+					completed_sample_size: 10,
+					median_days: 5.5,
+					p90_days: 9.1,
+				},
+				{
+					step: 2,
+					sample_size: 8,
+					completed_sample_size: 8,
+					median_days: 2.0,
+					p90_days: 6.4,
+				},
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const step1 = result.find((row) => row.step === 1);
+		const step2 = result.find((row) => row.step === 2);
+
+		expect(step1).toEqual({
+			step: 1,
+			label: "Effectifs",
+			sampleSize: 10,
+			completedSampleSize: 10,
+			medianDays: 5.5,
+			p90Days: 9.1,
+		});
+		expect(step2?.label).toBe("Écart de rémunération");
+		expect(step2?.medianDays).toBe(2.0);
+	});
+
+	it("excludes declarations still on a step from the percentile (S4 — exited count drives sample, percentile uses completed)", async () => {
+		const db = buildDb(
+			[],
+			[
+				{
+					step: 4,
+					sample_size: 12,
+					completed_sample_size: 10,
+					median_days: 3,
+					p90_days: 7,
+				},
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const step4 = result.find((row) => row.step === 4);
+
+		expect(step4?.sampleSize).toBe(12);
+		expect(step4?.completedSampleSize).toBe(10);
+		expect(step4?.medianDays).toBe(3);
+	});
+
+	it("returns null percentiles when fewer than 5 declarations have exited the step (S8 — anti-noisy data)", async () => {
+		const db = buildDb(
+			[],
+			[
+				{
+					step: 3,
+					sample_size: 4,
+					completed_sample_size: 4,
+					median_days: 1.2,
+					p90_days: 2.5,
+				},
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const step3 = result.find((row) => row.step === 3);
+
+		expect(step3?.sampleSize).toBe(4);
+		expect(step3?.medianDays).toBeNull();
+		expect(step3?.p90Days).toBeNull();
+	});
+
+	it("passes a workforce filter into the SQL when sizeRange is provided (S5)", async () => {
+		const db = buildDb([], []);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await caller.getStepDurations({ year: 2025, sizeRange: "250+" });
+		expect(db.execute).toHaveBeenCalledTimes(1);
+	});
+
+	it("validates the year input bounds", async () => {
+		const db = buildDb([], []);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.getStepDurations({ year: 1999 })).rejects.toThrow();
+		await expect(caller.getStepDurations({ year: 2101 })).rejects.toThrow();
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -34,7 +34,8 @@ type MilestoneRow = {
 /**
  * Builds a mock Drizzle db where each call to `execute()` returns the next
  * planned rowset. For `getStepDurations` the order is fixed: wizard, then
- * milestones 1..5 (`submit_to_path_choice`, `path_choice_to_action`,
+ * milestones 1..6 (`submit_to_path_choice`,
+ * `path_choice_to_second_declaration`, `path_choice_to_joint_evaluation`,
  * `revision_choice_to_action`, `action_to_cse_opinion`,
  * `last_action_to_complete`).
  */
@@ -42,6 +43,7 @@ function buildDb(
 	rows: Array<{ day: string; year: number; count: number }> = [],
 	stepRows: StepRow[] = [],
 	milestoneRows: Array<MilestoneRow | undefined> = [
+		undefined,
 		undefined,
 		undefined,
 		undefined,
@@ -206,7 +208,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		);
 	});
 
-	it("returns the 7 wizard steps + 5 post-submit milestones (12 rows) even when SQL returns nothing", async () => {
+	it("returns the 7 wizard steps + 6 post-submit milestones (13 rows) even when SQL returns nothing", async () => {
 		const db = buildDb([], []);
 		const { adminStatsRouter } = await import("../adminStats");
 		const caller = adminStatsRouter.createCaller({
@@ -217,15 +219,16 @@ describe("adminStatsRouter.getStepDurations", () => {
 
 		const result = await caller.getStepDurations({ year: 2026 });
 
-		expect(result).toHaveLength(12);
+		expect(result).toHaveLength(13);
 		const wizard = result.filter((row) => row.phase === "wizard");
 		const postSubmit = result.filter((row) => row.phase === "post_submit");
 		expect(wizard).toHaveLength(7);
-		expect(postSubmit).toHaveLength(5);
+		expect(postSubmit).toHaveLength(6);
 		expect(wizard.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5, 6]);
 		expect(postSubmit.map((row) => row.key)).toEqual([
 			"submit_to_path_choice",
-			"path_choice_to_action",
+			"path_choice_to_second_declaration",
+			"path_choice_to_joint_evaluation",
 			"revision_choice_to_action",
 			"action_to_cse_opinion",
 			"last_action_to_complete",
@@ -345,7 +348,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		} as never);
 
 		await caller.getStepDurations({ year: 2025, sizeRange: "250+" });
-		expect(db.execute).toHaveBeenCalledTimes(6);
+		expect(db.execute).toHaveBeenCalledTimes(7);
 	});
 
 	it("validates the year input bounds", async () => {
@@ -373,10 +376,16 @@ describe("adminStatsRouter.getStepDurations", () => {
 					p90_days: 10.0,
 				},
 				{
-					sample_size: 15,
-					completed_sample_size: 15,
+					sample_size: 9,
+					completed_sample_size: 9,
 					median_days: 7.0,
 					p90_days: 14.0,
+				},
+				{
+					sample_size: 6,
+					completed_sample_size: 6,
+					median_days: 5.5,
+					p90_days: 11.0,
 				},
 				{
 					sample_size: 6,
@@ -408,7 +417,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		const result = await caller.getStepDurations({ year: 2025 });
 		const postSubmit = result.filter((row) => row.phase === "post_submit");
 
-		expect(postSubmit).toHaveLength(5);
+		expect(postSubmit).toHaveLength(6);
 		expect(postSubmit[0]).toMatchObject({
 			key: "submit_to_path_choice",
 			phase: "post_submit",
@@ -418,13 +427,19 @@ describe("adminStatsRouter.getStepDurations", () => {
 			medianDays: 4.5,
 			p90Days: 10.0,
 		});
-		expect(postSubmit[1]?.key).toBe("path_choice_to_action");
-		expect(postSubmit[1]?.label).toBe("Choix conformité → action soumise");
-		expect(postSubmit[2]?.key).toBe("revision_choice_to_action");
-		expect(postSubmit[3]?.key).toBe("action_to_cse_opinion");
-		expect(postSubmit[3]?.medianDays).toBe(9.5);
-		expect(postSubmit[4]?.key).toBe("last_action_to_complete");
-		expect(postSubmit[4]?.sampleSize).toBe(12);
+		expect(postSubmit[1]?.key).toBe("path_choice_to_second_declaration");
+		expect(postSubmit[1]?.label).toBe("Choix conformité → seconde déclaration");
+		expect(postSubmit[1]?.medianDays).toBe(7.0);
+		expect(postSubmit[2]?.key).toBe("path_choice_to_joint_evaluation");
+		expect(postSubmit[2]?.label).toBe(
+			"Choix conformité → évaluation conjointe",
+		);
+		expect(postSubmit[2]?.medianDays).toBe(5.5);
+		expect(postSubmit[3]?.key).toBe("revision_choice_to_action");
+		expect(postSubmit[4]?.key).toBe("action_to_cse_opinion");
+		expect(postSubmit[4]?.medianDays).toBe(9.5);
+		expect(postSubmit[5]?.key).toBe("last_action_to_complete");
+		expect(postSubmit[5]?.sampleSize).toBe(12);
 	});
 
 	it("keeps milestones independent: empty sub-set does not blank out the others (S-K4-10)", async () => {
@@ -433,7 +448,8 @@ describe("adminStatsRouter.getStepDurations", () => {
 			[],
 			[
 				undefined, // submit_to_path_choice — no path_choice round=1
-				undefined, // path_choice_to_action — no action
+				undefined, // path_choice_to_second_declaration — no second decl
+				undefined, // path_choice_to_joint_evaluation — no joint eval
 				undefined, // revision_choice_to_action — no path_choice round=2
 				undefined, // action_to_cse_opinion — no CSE
 				{
@@ -456,9 +472,9 @@ describe("adminStatsRouter.getStepDurations", () => {
 
 		expect(postSubmit[0]?.sampleSize).toBe(0);
 		expect(postSubmit[0]?.medianDays).toBeNull();
-		expect(postSubmit[3]?.sampleSize).toBe(0);
-		expect(postSubmit[4]?.sampleSize).toBe(7);
-		expect(postSubmit[4]?.medianDays).toBe(45.0);
+		expect(postSubmit[4]?.sampleSize).toBe(0);
+		expect(postSubmit[5]?.sampleSize).toBe(7);
+		expect(postSubmit[5]?.medianDays).toBe(45.0);
 	});
 
 	it("captures the revision cycle independently of the first wave (S-K4-11)", async () => {
@@ -473,10 +489,16 @@ describe("adminStatsRouter.getStepDurations", () => {
 					p90_days: 10.0,
 				},
 				{
-					sample_size: 10,
-					completed_sample_size: 10,
+					sample_size: 7,
+					completed_sample_size: 7,
 					median_days: 6.0,
 					p90_days: 11.0,
+				},
+				{
+					sample_size: 3,
+					completed_sample_size: 3,
+					median_days: 4.0,
+					p90_days: 7.0,
 				},
 				{
 					sample_size: 5,
@@ -524,6 +546,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 				undefined,
 				undefined,
 				undefined,
+				undefined,
 			],
 		);
 		const { adminStatsRouter } = await import("../adminStats");
@@ -547,7 +570,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		const db = buildDb(
 			[],
 			[],
-			[undefined, undefined, undefined, undefined, undefined],
+			[undefined, undefined, undefined, undefined, undefined, undefined],
 		);
 		const { adminStatsRouter } = await import("../adminStats");
 		const caller = adminStatsRouter.createCaller({
@@ -559,12 +582,70 @@ describe("adminStatsRouter.getStepDurations", () => {
 		const result = await caller.getStepDurations({ year: 2025 });
 		const postSubmit = result.filter((row) => row.phase === "post_submit");
 
-		expect(postSubmit).toHaveLength(5);
+		expect(postSubmit).toHaveLength(6);
 		for (const row of postSubmit) {
 			expect(row.sampleSize).toBe(0);
 			expect(row.completedSampleSize).toBe(0);
 			expect(row.medianDays).toBeNull();
 			expect(row.p90Days).toBeNull();
 		}
+	});
+
+	it("surfaces second_declaration and joint_evaluation as two separate post-submit lines (S-K4-14)", async () => {
+		const db = buildDb(
+			[],
+			[],
+			[
+				undefined,
+				{
+					sample_size: 11,
+					completed_sample_size: 11,
+					median_days: 8.0,
+					p90_days: 16.0,
+				},
+				{
+					sample_size: 7,
+					completed_sample_size: 7,
+					median_days: 12.0,
+					p90_days: 22.0,
+				},
+				undefined,
+				undefined,
+				undefined,
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const secondDeclarationRow = result.find(
+			(row) => row.key === "path_choice_to_second_declaration",
+		);
+		const jointEvaluationRow = result.find(
+			(row) => row.key === "path_choice_to_joint_evaluation",
+		);
+
+		expect(secondDeclarationRow).toMatchObject({
+			phase: "post_submit",
+			step: null,
+			label: "Choix conformité → seconde déclaration",
+			sampleSize: 11,
+			completedSampleSize: 11,
+			medianDays: 8.0,
+			p90Days: 16.0,
+		});
+		expect(jointEvaluationRow).toMatchObject({
+			phase: "post_submit",
+			step: null,
+			label: "Choix conformité → évaluation conjointe",
+			sampleSize: 7,
+			completedSampleSize: 7,
+			medianDays: 12.0,
+			p90Days: 22.0,
+		});
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -208,7 +208,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		);
 	});
 
-	it("returns the 7 wizard steps + 6 post-submit milestones (13 rows) even when SQL returns nothing", async () => {
+	it("returns the 6 wizard steps + 6 post-submit milestones (12 rows) even when SQL returns nothing", async () => {
 		const db = buildDb([], []);
 		const { adminStatsRouter } = await import("../adminStats");
 		const caller = adminStatsRouter.createCaller({
@@ -219,12 +219,12 @@ describe("adminStatsRouter.getStepDurations", () => {
 
 		const result = await caller.getStepDurations({ year: 2026 });
 
-		expect(result).toHaveLength(13);
+		expect(result).toHaveLength(12);
 		const wizard = result.filter((row) => row.phase === "wizard");
 		const postSubmit = result.filter((row) => row.phase === "post_submit");
-		expect(wizard).toHaveLength(7);
+		expect(wizard).toHaveLength(6);
 		expect(postSubmit).toHaveLength(6);
-		expect(wizard.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+		expect(wizard.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5]);
 		expect(postSubmit.map((row) => row.key)).toEqual([
 			"submit_to_path_choice",
 			"path_choice_to_second_declaration",
@@ -647,5 +647,47 @@ describe("adminStatsRouter.getStepDurations", () => {
 			medianDays: 12.0,
 			p90Days: 22.0,
 		});
+	});
+
+	it("never returns a wizard row with step === 6 (S-K4-15)", async () => {
+		const db = buildDb(
+			[],
+			[
+				{
+					step: 0,
+					sample_size: 12,
+					completed_sample_size: 12,
+					median_days: 1,
+					p90_days: 2,
+				},
+				{
+					step: 5,
+					sample_size: 8,
+					completed_sample_size: 8,
+					median_days: 4,
+					p90_days: 9,
+				},
+				{
+					step: 6,
+					sample_size: 5,
+					completed_sample_size: 0,
+					median_days: null,
+					p90_days: null,
+				},
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const wizard = result.filter((row) => row.phase === "wizard");
+
+		expect(wizard.some((row) => row.step === 6)).toBe(false);
+		expect(wizard.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5]);
+		expect(result.find((row) => row.label === "Récapitulatif")).toBeUndefined();
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -345,7 +345,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 		} as never);
 
 		await caller.getStepDurations({ year: 2025, sizeRange: "250+" });
-		// 1 wizard query + 5 milestone queries = 6 execute calls
 		expect(db.execute).toHaveBeenCalledTimes(6);
 	});
 
@@ -362,8 +361,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 		await expect(caller.getStepDurations({ year: 2101 })).rejects.toThrow();
 	});
 
-	// S-K4-9 — nominal post-submit: each milestone row maps correctly to
-	// its typed output (label, phase, percentiles, sample size).
 	it("maps post-submit milestone rows to the typed output with FR labels (S-K4-9)", async () => {
 		const db = buildDb(
 			[],
@@ -430,9 +427,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 		expect(postSubmit[4]?.sampleSize).toBe(12);
 	});
 
-	// S-K4-10 — sub-set coherence: when a milestone has no rows (e.g. no
-	// declaration with a path_choice), the row keeps a 0 sample and null
-	// percentiles, but unrelated milestones still surface their data.
 	it("keeps milestones independent: empty sub-set does not blank out the others (S-K4-10)", async () => {
 		const db = buildDb(
 			[],
@@ -467,8 +461,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 		expect(postSubmit[4]?.medianDays).toBe(45.0);
 	});
 
-	// S-K4-11 — revision cycle: jalon 3 captures path_choice round=2 →
-	// joint_evaluation_submit round=2, independently from the round=1 jalons.
 	it("captures the revision cycle independently of the first wave (S-K4-11)", async () => {
 		const db = buildDb(
 			[],
@@ -517,8 +509,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 		});
 	});
 
-	// S-K4-12 — fallback n < 5: sample below threshold → null percentiles,
-	// but sample size stays visible so consumers know data exists.
 	it("returns null percentiles for milestones with completedSampleSize < 5 (S-K4-12)", async () => {
 		const db = buildDb(
 			[],
@@ -553,9 +543,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 		expect(firstMilestone?.p90Days).toBeNull();
 	});
 
-	// S-K4-13 — sample size 0: a milestone with no qualifying declarations
-	// keeps a 0 sample size and null percentiles. Drives the "no data yet"
-	// state in the table.
 	it("renders milestones with no data as zero-sample / null-percentile rows (S-K4-13)", async () => {
 		const db = buildDb(
 			[],

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -24,9 +24,30 @@ type StepRow = {
 	p90_days: number | null;
 };
 
+type MilestoneRow = {
+	sample_size: number;
+	completed_sample_size: number;
+	median_days: number | null;
+	p90_days: number | null;
+};
+
+/**
+ * Builds a mock Drizzle db where each call to `execute()` returns the next
+ * planned rowset. For `getStepDurations` the order is fixed: wizard, then
+ * milestones 1..5 (`submit_to_path_choice`, `path_choice_to_action`,
+ * `revision_choice_to_action`, `action_to_cse_opinion`,
+ * `last_action_to_complete`).
+ */
 function buildDb(
 	rows: Array<{ day: string; year: number; count: number }> = [],
 	stepRows: StepRow[] = [],
+	milestoneRows: Array<MilestoneRow | undefined> = [
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+	],
 ) {
 	const orderBy = vi.fn().mockResolvedValue(rows);
 	const chain: SelectChain = {
@@ -36,9 +57,14 @@ function buildDb(
 		groupBy: vi.fn().mockReturnThis(),
 		orderBy,
 	};
+	const execute = vi.fn();
+	execute.mockResolvedValueOnce(stepRows);
+	for (const milestone of milestoneRows) {
+		execute.mockResolvedValueOnce(milestone ? [milestone] : []);
+	}
 	return {
 		select: vi.fn().mockReturnValue(chain),
-		execute: vi.fn().mockResolvedValue(stepRows),
+		execute,
 		__chain: chain,
 	};
 }
@@ -180,7 +206,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		);
 	});
 
-	it("returns a complete set of 7 steps (0..6) even when SQL returns nothing", async () => {
+	it("returns the 7 wizard steps + 5 post-submit milestones (12 rows) even when SQL returns nothing", async () => {
 		const db = buildDb([], []);
 		const { adminStatsRouter } = await import("../adminStats");
 		const caller = adminStatsRouter.createCaller({
@@ -191,8 +217,19 @@ describe("adminStatsRouter.getStepDurations", () => {
 
 		const result = await caller.getStepDurations({ year: 2026 });
 
-		expect(result).toHaveLength(7);
-		expect(result.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+		expect(result).toHaveLength(12);
+		const wizard = result.filter((row) => row.phase === "wizard");
+		const postSubmit = result.filter((row) => row.phase === "post_submit");
+		expect(wizard).toHaveLength(7);
+		expect(postSubmit).toHaveLength(5);
+		expect(wizard.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+		expect(postSubmit.map((row) => row.key)).toEqual([
+			"submit_to_path_choice",
+			"path_choice_to_action",
+			"revision_choice_to_action",
+			"action_to_cse_opinion",
+			"last_action_to_complete",
+		]);
 		expect(result.every((row) => row.medianDays === null)).toBe(true);
 		expect(result.every((row) => row.sampleSize === 0)).toBe(true);
 	});
@@ -229,6 +266,8 @@ describe("adminStatsRouter.getStepDurations", () => {
 		const step2 = result.find((row) => row.step === 2);
 
 		expect(step1).toEqual({
+			key: "step_1",
+			phase: "wizard",
 			step: 1,
 			label: "Effectifs",
 			sampleSize: 10,
@@ -306,7 +345,8 @@ describe("adminStatsRouter.getStepDurations", () => {
 		} as never);
 
 		await caller.getStepDurations({ year: 2025, sizeRange: "250+" });
-		expect(db.execute).toHaveBeenCalledTimes(1);
+		// 1 wizard query + 5 milestone queries = 6 execute calls
+		expect(db.execute).toHaveBeenCalledTimes(6);
 	});
 
 	it("validates the year input bounds", async () => {
@@ -320,5 +360,224 @@ describe("adminStatsRouter.getStepDurations", () => {
 
 		await expect(caller.getStepDurations({ year: 1999 })).rejects.toThrow();
 		await expect(caller.getStepDurations({ year: 2101 })).rejects.toThrow();
+	});
+
+	// S-K4-9 — nominal post-submit: each milestone row maps correctly to
+	// its typed output (label, phase, percentiles, sample size).
+	it("maps post-submit milestone rows to the typed output with FR labels (S-K4-9)", async () => {
+		const db = buildDb(
+			[],
+			[],
+			[
+				{
+					sample_size: 20,
+					completed_sample_size: 20,
+					median_days: 4.5,
+					p90_days: 10.0,
+				},
+				{
+					sample_size: 15,
+					completed_sample_size: 15,
+					median_days: 7.0,
+					p90_days: 14.0,
+				},
+				{
+					sample_size: 6,
+					completed_sample_size: 6,
+					median_days: 2.5,
+					p90_days: 5.0,
+				},
+				{
+					sample_size: 8,
+					completed_sample_size: 8,
+					median_days: 9.5,
+					p90_days: 18.0,
+				},
+				{
+					sample_size: 12,
+					completed_sample_size: 12,
+					median_days: 30.0,
+					p90_days: 90.0,
+				},
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const postSubmit = result.filter((row) => row.phase === "post_submit");
+
+		expect(postSubmit).toHaveLength(5);
+		expect(postSubmit[0]).toMatchObject({
+			key: "submit_to_path_choice",
+			phase: "post_submit",
+			step: null,
+			label: "Soumission → choix conformité",
+			sampleSize: 20,
+			medianDays: 4.5,
+			p90Days: 10.0,
+		});
+		expect(postSubmit[1]?.key).toBe("path_choice_to_action");
+		expect(postSubmit[1]?.label).toBe("Choix conformité → action soumise");
+		expect(postSubmit[2]?.key).toBe("revision_choice_to_action");
+		expect(postSubmit[3]?.key).toBe("action_to_cse_opinion");
+		expect(postSubmit[3]?.medianDays).toBe(9.5);
+		expect(postSubmit[4]?.key).toBe("last_action_to_complete");
+		expect(postSubmit[4]?.sampleSize).toBe(12);
+	});
+
+	// S-K4-10 — sub-set coherence: when a milestone has no rows (e.g. no
+	// declaration with a path_choice), the row keeps a 0 sample and null
+	// percentiles, but unrelated milestones still surface their data.
+	it("keeps milestones independent: empty sub-set does not blank out the others (S-K4-10)", async () => {
+		const db = buildDb(
+			[],
+			[],
+			[
+				undefined, // submit_to_path_choice — no path_choice round=1
+				undefined, // path_choice_to_action — no action
+				undefined, // revision_choice_to_action — no path_choice round=2
+				undefined, // action_to_cse_opinion — no CSE
+				{
+					sample_size: 7,
+					completed_sample_size: 7,
+					median_days: 45.0,
+					p90_days: 120.0,
+				},
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const postSubmit = result.filter((row) => row.phase === "post_submit");
+
+		expect(postSubmit[0]?.sampleSize).toBe(0);
+		expect(postSubmit[0]?.medianDays).toBeNull();
+		expect(postSubmit[3]?.sampleSize).toBe(0);
+		expect(postSubmit[4]?.sampleSize).toBe(7);
+		expect(postSubmit[4]?.medianDays).toBe(45.0);
+	});
+
+	// S-K4-11 — revision cycle: jalon 3 captures path_choice round=2 →
+	// joint_evaluation_submit round=2, independently from the round=1 jalons.
+	it("captures the revision cycle independently of the first wave (S-K4-11)", async () => {
+		const db = buildDb(
+			[],
+			[],
+			[
+				{
+					sample_size: 10,
+					completed_sample_size: 10,
+					median_days: 5.0,
+					p90_days: 10.0,
+				},
+				{
+					sample_size: 10,
+					completed_sample_size: 10,
+					median_days: 6.0,
+					p90_days: 11.0,
+				},
+				{
+					sample_size: 5,
+					completed_sample_size: 5,
+					median_days: 20.0,
+					p90_days: 40.0,
+				},
+				undefined,
+				undefined,
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const revisionRow = result.find(
+			(row) => row.key === "revision_choice_to_action",
+		);
+
+		expect(revisionRow).toMatchObject({
+			phase: "post_submit",
+			sampleSize: 5,
+			completedSampleSize: 5,
+			medianDays: 20.0,
+			p90Days: 40.0,
+		});
+	});
+
+	// S-K4-12 — fallback n < 5: sample below threshold → null percentiles,
+	// but sample size stays visible so consumers know data exists.
+	it("returns null percentiles for milestones with completedSampleSize < 5 (S-K4-12)", async () => {
+		const db = buildDb(
+			[],
+			[],
+			[
+				{
+					sample_size: 4,
+					completed_sample_size: 4,
+					median_days: 3.0,
+					p90_days: 5.5,
+				},
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+			],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const firstMilestone = result.find(
+			(row) => row.key === "submit_to_path_choice",
+		);
+
+		expect(firstMilestone?.sampleSize).toBe(4);
+		expect(firstMilestone?.medianDays).toBeNull();
+		expect(firstMilestone?.p90Days).toBeNull();
+	});
+
+	// S-K4-13 — sample size 0: a milestone with no qualifying declarations
+	// keeps a 0 sample size and null percentiles. Drives the "no data yet"
+	// state in the table.
+	it("renders milestones with no data as zero-sample / null-percentile rows (S-K4-13)", async () => {
+		const db = buildDb(
+			[],
+			[],
+			[undefined, undefined, undefined, undefined, undefined],
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getStepDurations({ year: 2025 });
+		const postSubmit = result.filter((row) => row.phase === "post_submit");
+
+		expect(postSubmit).toHaveLength(5);
+		for (const row of postSubmit) {
+			expect(row.sampleSize).toBe(0);
+			expect(row.completedSampleSize).toBe(0);
+			expect(row.medianDays).toBeNull();
+			expect(row.p90Days).toBeNull();
+		}
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -34,17 +34,14 @@ type MilestoneRow = {
 /**
  * Builds a mock Drizzle db where each call to `execute()` returns the next
  * planned rowset. For `getStepDurations` the order is fixed: wizard, then
- * milestones 1..6 (`submit_to_path_choice`,
+ * milestones 1..4 (`submit_to_path_choice`,
  * `path_choice_to_second_declaration`, `path_choice_to_joint_evaluation`,
- * `revision_choice_to_action`, `action_to_cse_opinion`,
- * `last_action_to_complete`).
+ * `action_to_cse_opinion`).
  */
 function buildDb(
 	rows: Array<{ day: string; year: number; count: number }> = [],
 	stepRows: StepRow[] = [],
 	milestoneRows: Array<MilestoneRow | undefined> = [
-		undefined,
-		undefined,
 		undefined,
 		undefined,
 		undefined,
@@ -208,7 +205,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		);
 	});
 
-	it("returns the 6 wizard steps + 6 post-submit milestones (12 rows) even when SQL returns nothing", async () => {
+	it("returns the 6 wizard steps + 4 post-submit milestones (10 rows) even when SQL returns nothing", async () => {
 		const db = buildDb([], []);
 		const { adminStatsRouter } = await import("../adminStats");
 		const caller = adminStatsRouter.createCaller({
@@ -219,19 +216,17 @@ describe("adminStatsRouter.getStepDurations", () => {
 
 		const result = await caller.getStepDurations({ year: 2026 });
 
-		expect(result).toHaveLength(12);
+		expect(result).toHaveLength(10);
 		const wizard = result.filter((row) => row.phase === "wizard");
 		const postSubmit = result.filter((row) => row.phase === "post_submit");
 		expect(wizard).toHaveLength(6);
-		expect(postSubmit).toHaveLength(6);
+		expect(postSubmit).toHaveLength(4);
 		expect(wizard.map((row) => row.step)).toEqual([0, 1, 2, 3, 4, 5]);
 		expect(postSubmit.map((row) => row.key)).toEqual([
 			"submit_to_path_choice",
 			"path_choice_to_second_declaration",
 			"path_choice_to_joint_evaluation",
-			"revision_choice_to_action",
 			"action_to_cse_opinion",
-			"last_action_to_complete",
 		]);
 		expect(result.every((row) => row.medianDays === null)).toBe(true);
 		expect(result.every((row) => row.sampleSize === 0)).toBe(true);
@@ -348,7 +343,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		} as never);
 
 		await caller.getStepDurations({ year: 2025, sizeRange: "250+" });
-		expect(db.execute).toHaveBeenCalledTimes(7);
+		expect(db.execute).toHaveBeenCalledTimes(5);
 	});
 
 	it("validates the year input bounds", async () => {
@@ -388,22 +383,10 @@ describe("adminStatsRouter.getStepDurations", () => {
 					p90_days: 11.0,
 				},
 				{
-					sample_size: 6,
-					completed_sample_size: 6,
-					median_days: 2.5,
-					p90_days: 5.0,
-				},
-				{
 					sample_size: 8,
 					completed_sample_size: 8,
 					median_days: 9.5,
 					p90_days: 18.0,
-				},
-				{
-					sample_size: 12,
-					completed_sample_size: 12,
-					median_days: 30.0,
-					p90_days: 90.0,
 				},
 			],
 		);
@@ -417,29 +400,25 @@ describe("adminStatsRouter.getStepDurations", () => {
 		const result = await caller.getStepDurations({ year: 2025 });
 		const postSubmit = result.filter((row) => row.phase === "post_submit");
 
-		expect(postSubmit).toHaveLength(6);
+		expect(postSubmit).toHaveLength(4);
 		expect(postSubmit[0]).toMatchObject({
 			key: "submit_to_path_choice",
 			phase: "post_submit",
 			step: null,
-			label: "Soumission → choix conformité",
+			label: "Délai avant choix du parcours",
 			sampleSize: 20,
 			medianDays: 4.5,
 			p90Days: 10.0,
 		});
 		expect(postSubmit[1]?.key).toBe("path_choice_to_second_declaration");
-		expect(postSubmit[1]?.label).toBe("Choix conformité → seconde déclaration");
+		expect(postSubmit[1]?.label).toBe("Temps passé sur la seconde déclaration");
 		expect(postSubmit[1]?.medianDays).toBe(7.0);
 		expect(postSubmit[2]?.key).toBe("path_choice_to_joint_evaluation");
-		expect(postSubmit[2]?.label).toBe(
-			"Choix conformité → évaluation conjointe",
-		);
+		expect(postSubmit[2]?.label).toBe("Temps passé sur l'évaluation conjointe");
 		expect(postSubmit[2]?.medianDays).toBe(5.5);
-		expect(postSubmit[3]?.key).toBe("revision_choice_to_action");
-		expect(postSubmit[4]?.key).toBe("action_to_cse_opinion");
-		expect(postSubmit[4]?.medianDays).toBe(9.5);
-		expect(postSubmit[5]?.key).toBe("last_action_to_complete");
-		expect(postSubmit[5]?.sampleSize).toBe(12);
+		expect(postSubmit[3]?.key).toBe("action_to_cse_opinion");
+		expect(postSubmit[3]?.label).toBe("Temps passé sur l'avis CSE");
+		expect(postSubmit[3]?.medianDays).toBe(9.5);
 	});
 
 	it("keeps milestones independent: empty sub-set does not blank out the others (S-K4-10)", async () => {
@@ -450,8 +429,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 				undefined, // submit_to_path_choice — no path_choice round=1
 				undefined, // path_choice_to_second_declaration — no second decl
 				undefined, // path_choice_to_joint_evaluation — no joint eval
-				undefined, // revision_choice_to_action — no path_choice round=2
-				undefined, // action_to_cse_opinion — no CSE
 				{
 					sample_size: 7,
 					completed_sample_size: 7,
@@ -472,41 +449,24 @@ describe("adminStatsRouter.getStepDurations", () => {
 
 		expect(postSubmit[0]?.sampleSize).toBe(0);
 		expect(postSubmit[0]?.medianDays).toBeNull();
-		expect(postSubmit[4]?.sampleSize).toBe(0);
-		expect(postSubmit[5]?.sampleSize).toBe(7);
-		expect(postSubmit[5]?.medianDays).toBe(45.0);
+		expect(postSubmit[2]?.sampleSize).toBe(0);
+		expect(postSubmit[3]?.sampleSize).toBe(7);
+		expect(postSubmit[3]?.medianDays).toBe(45.0);
 	});
 
-	it("captures the revision cycle independently of the first wave (S-K4-11)", async () => {
+	it("aggregates initial and revision joint-evaluation cycles under a single milestone (S-K4-16)", async () => {
 		const db = buildDb(
 			[],
 			[],
 			[
-				{
-					sample_size: 10,
-					completed_sample_size: 10,
-					median_days: 5.0,
-					p90_days: 10.0,
-				},
-				{
-					sample_size: 7,
-					completed_sample_size: 7,
-					median_days: 6.0,
-					p90_days: 11.0,
-				},
-				{
-					sample_size: 3,
-					completed_sample_size: 3,
-					median_days: 4.0,
-					p90_days: 7.0,
-				},
-				{
-					sample_size: 5,
-					completed_sample_size: 5,
-					median_days: 20.0,
-					p90_days: 40.0,
-				},
 				undefined,
+				undefined,
+				{
+					sample_size: 8,
+					completed_sample_size: 8,
+					median_days: 12.5,
+					p90_days: 30.0,
+				},
 				undefined,
 			],
 		);
@@ -518,17 +478,26 @@ describe("adminStatsRouter.getStepDurations", () => {
 		} as never);
 
 		const result = await caller.getStepDurations({ year: 2025 });
-		const revisionRow = result.find(
-			(row) => row.key === "revision_choice_to_action",
+		const jointEvaluationRow = result.find(
+			(row) => row.key === "path_choice_to_joint_evaluation",
 		);
 
-		expect(revisionRow).toMatchObject({
+		expect(jointEvaluationRow).toMatchObject({
 			phase: "post_submit",
-			sampleSize: 5,
-			completedSampleSize: 5,
-			medianDays: 20.0,
-			p90Days: 40.0,
+			step: null,
+			label: "Temps passé sur l'évaluation conjointe",
+			sampleSize: 8,
+			completedSampleSize: 8,
+			medianDays: 12.5,
+			p90Days: 30.0,
 		});
+
+		expect(
+			result.find((row) => row.key === "revision_choice_to_action"),
+		).toBeUndefined();
+		expect(
+			result.find((row) => row.key === "last_action_to_complete"),
+		).toBeUndefined();
 	});
 
 	it("returns null percentiles for milestones with completedSampleSize < 5 (S-K4-12)", async () => {
@@ -542,8 +511,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 					median_days: 3.0,
 					p90_days: 5.5,
 				},
-				undefined,
-				undefined,
 				undefined,
 				undefined,
 				undefined,
@@ -567,11 +534,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 	});
 
 	it("renders milestones with no data as zero-sample / null-percentile rows (S-K4-13)", async () => {
-		const db = buildDb(
-			[],
-			[],
-			[undefined, undefined, undefined, undefined, undefined, undefined],
-		);
+		const db = buildDb([], [], [undefined, undefined, undefined, undefined]);
 		const { adminStatsRouter } = await import("../adminStats");
 		const caller = adminStatsRouter.createCaller({
 			db,
@@ -582,7 +545,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		const result = await caller.getStepDurations({ year: 2025 });
 		const postSubmit = result.filter((row) => row.phase === "post_submit");
 
-		expect(postSubmit).toHaveLength(6);
+		expect(postSubmit).toHaveLength(4);
 		for (const row of postSubmit) {
 			expect(row.sampleSize).toBe(0);
 			expect(row.completedSampleSize).toBe(0);
@@ -610,8 +573,6 @@ describe("adminStatsRouter.getStepDurations", () => {
 					p90_days: 22.0,
 				},
 				undefined,
-				undefined,
-				undefined,
 			],
 		);
 		const { adminStatsRouter } = await import("../adminStats");
@@ -632,7 +593,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		expect(secondDeclarationRow).toMatchObject({
 			phase: "post_submit",
 			step: null,
-			label: "Choix conformité → seconde déclaration",
+			label: "Temps passé sur la seconde déclaration",
 			sampleSize: 11,
 			completedSampleSize: 11,
 			medianDays: 8.0,
@@ -641,7 +602,7 @@ describe("adminStatsRouter.getStepDurations", () => {
 		expect(jointEvaluationRow).toMatchObject({
 			phase: "post_submit",
 			step: null,
-			label: "Choix conformité → évaluation conjointe",
+			label: "Temps passé sur l'évaluation conjointe",
 			sampleSize: 7,
 			completedSampleSize: 7,
 			medianDays: 12.0,

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -1330,4 +1330,58 @@ describe("declarationRouter", () => {
 			);
 		});
 	});
+
+	describe("step_change instrumentation (K4 — délai par étape)", () => {
+		it("inserts a step_change row when updateStep1 advances from step 0 (S1)", async () => {
+			const tx = createMockTx([mockDeclaration]);
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await caller.updateStep1({ totalWomen: 30, totalMen: 40 });
+
+			const insertedRows = mockValues.mock.calls
+				.map((c) => c[0])
+				.filter(
+					(v): v is { eventType?: string } =>
+						typeof v === "object" && v !== null && "eventType" in v,
+				);
+			const stepChange = insertedRows.find(
+				(row) => row.eventType === "step_change",
+			);
+			expect(stepChange).toMatchObject({
+				eventType: "step_change",
+				value: "from:0|to:1",
+				round: 1,
+			});
+		});
+
+		it("does not insert a step_change row when the new step equals the existing one (idempotent re-save)", async () => {
+			const declarationAtStep2 = { ...mockDeclaration, currentStep: 2 };
+			const tx = createMockTx([declarationAtStep2]);
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createCaller(mockDb);
+
+			await caller.updateStep2({
+				indicatorAAnnualWomen: "30000",
+				indicatorAAnnualMen: "32000",
+			});
+
+			const insertedRows = mockValues.mock.calls
+				.map((c) => c[0])
+				.filter(
+					(v): v is { eventType?: string } =>
+						typeof v === "object" && v !== null && "eventType" in v,
+				);
+			const stepChange = insertedRows.find(
+				(row) => row.eventType === "step_change",
+			);
+			expect(stepChange).toBeUndefined();
+		});
+	});
 });

--- a/packages/app/src/server/api/routers/__tests__/statusHistoryHelpers.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/statusHistoryHelpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { buildStepChangeInsert } from "../statusHistoryHelpers";
+
+describe("buildStepChangeInsert", () => {
+	it("encodes the previous and next step into the history row", () => {
+		const row = buildStepChangeInsert({
+			declarationId: "decl-1",
+			fromStep: 2,
+			toStep: 3,
+			actorUserId: "user-1",
+		});
+
+		expect(row).toEqual({
+			declarationId: "decl-1",
+			eventType: "step_change",
+			value: "from:2|to:3",
+			round: 3,
+			actorUserId: "user-1",
+		});
+	});
+
+	it("flags creation by encoding fromStep as 'null'", () => {
+		const row = buildStepChangeInsert({
+			declarationId: "decl-2",
+			fromStep: null,
+			toStep: 0,
+			actorUserId: "user-2",
+		});
+
+		expect(row.value).toBe("from:null|to:0");
+		expect(row.round).toBe(0);
+	});
+
+	it("propagates a null actor for system-triggered transitions", () => {
+		const row = buildStepChangeInsert({
+			declarationId: "decl-3",
+			fromStep: 4,
+			toStep: 5,
+			actorUserId: null,
+		});
+
+		expect(row.actorUserId).toBeNull();
+	});
+});

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -154,7 +154,7 @@ export const adminStatsRouter = createTRPCRouter({
 	 *   where there is no next event (declaration still on that step) are
 	 *   excluded from the percentile aggregation but still count in
 	 *   `sampleSize`.
-	 * - **post_submit** (5 milestones) — durations between business events
+	 * - **post_submit** (6 milestones) — durations between business events
 	 *   (`submit`, `path_choice`, `second_declaration_submit`,
 	 *   `joint_evaluation_submit`, `cse_opinion_submit`, `demarche_complete`),
 	 *   computed per milestone via a dedicated CTE.
@@ -265,7 +265,8 @@ export const adminStatsRouter = createTRPCRouter({
 				AggregatedMilestone | undefined
 			> = {
 				submit_to_path_choice: undefined,
-				path_choice_to_action: undefined,
+				path_choice_to_second_declaration: undefined,
+				path_choice_to_joint_evaluation: undefined,
 				revision_choice_to_action: undefined,
 				action_to_cse_opinion: undefined,
 				last_action_to_complete: undefined,
@@ -307,19 +308,13 @@ export const adminStatsRouter = createTRPCRouter({
 				submitToPathChoiceRows as unknown as AggregatedMilestone[]
 			)[0];
 
-			// FSM allows only one of `second_declaration round=2` or
-			// `joint_evaluation round=1` per declaration in wave 1, so taking
-			// the LEAST of the two is safe and resolves whichever exists.
-			const pathChoiceToActionRows =
+			const pathChoiceToSecondDeclarationRows =
 				await ctx.db.execute<AggregatedMilestone>(sql`
 				WITH paired AS (
 					SELECT
 						s.declaration_id,
 						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) AS start_at,
-						LEAST(
-							MIN(s.created_at) FILTER (WHERE s.event_type = 'second_declaration_submit' AND s.round = 2),
-							MIN(s.created_at) FILTER (WHERE s.event_type = 'joint_evaluation_submit' AND s.round = 1)
-						) AS end_at
+						MIN(s.created_at) FILTER (WHERE s.event_type = 'second_declaration_submit') AS end_at
 					FROM ${declarationStatusHistory} s
 					INNER JOIN ${declarations}
 						ON ${declarations.id} = s.declaration_id
@@ -342,8 +337,44 @@ export const adminStatsRouter = createTRPCRouter({
 					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS p90_days
 				FROM paired
 			`);
-			postSubmitAggregates.path_choice_to_action = (
-				pathChoiceToActionRows as unknown as AggregatedMilestone[]
+			postSubmitAggregates.path_choice_to_second_declaration = (
+				pathChoiceToSecondDeclarationRows as unknown as AggregatedMilestone[]
+			)[0];
+
+			// `joint_evaluation_submit round=1` = joint evaluation as the
+			// first-wave corrective path (round=2 covers the revision wave and
+			// is captured by `revision_choice_to_action`).
+			const pathChoiceToJointEvaluationRows =
+				await ctx.db.execute<AggregatedMilestone>(sql`
+				WITH paired AS (
+					SELECT
+						s.declaration_id,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) AS start_at,
+						MIN(s.created_at) FILTER (WHERE s.event_type = 'joint_evaluation_submit' AND s.round = 1) AS end_at
+					FROM ${declarationStatusHistory} s
+					INNER JOIN ${declarations}
+						ON ${declarations.id} = s.declaration_id
+					INNER JOIN ${companies}
+						ON ${companies.siren} = ${declarations.siren}
+					WHERE ${declarations.year} = ${input.year}
+						AND ${declarations.cancelledAt} IS NULL
+						AND ${sizeFilterSql}
+					GROUP BY s.declaration_id
+					HAVING MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) IS NOT NULL
+				)
+				SELECT
+					COUNT(*) FILTER (WHERE end_at IS NOT NULL)::int AS sample_size,
+					COUNT(*) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
+					percentile_cont(0.5) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS median_days,
+					percentile_cont(0.9) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS p90_days
+				FROM paired
+			`);
+			postSubmitAggregates.path_choice_to_joint_evaluation = (
+				pathChoiceToJointEvaluationRows as unknown as AggregatedMilestone[]
 			)[0];
 
 			const revisionChoiceToActionRows =

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -13,6 +13,8 @@ import {
 	COMPANY_SIZE_RANGES,
 	DECLARATION_STEPS,
 	getStepLabel,
+	POST_SUBMIT_MILESTONES,
+	type PostSubmitMilestoneKey,
 } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import {
@@ -49,6 +51,46 @@ function buildSeries(rows: AggregatedRow[]): CampaignProgressionSeries[] {
 	return Array.from(byYear.entries())
 		.sort(([a], [b]) => a - b)
 		.map(([year, points]) => ({ year, points }));
+}
+
+type AggregatedMilestone = {
+	sample_size: number | string;
+	completed_sample_size: number | string;
+	median_days: number | string | null;
+	p90_days: number | string | null;
+};
+
+/**
+ * Convert a raw SQL aggregation row into the typed `StepDurationRow` for a
+ * given post-submit milestone, applying the `STEP_DURATION_MIN_SAMPLE` floor
+ * for percentile visibility.
+ */
+function buildPostSubmitRow(
+	key: PostSubmitMilestoneKey,
+	label: string,
+	raw: AggregatedMilestone | undefined,
+): StepDurationRow {
+	const sampleSize = raw ? Number(raw.sample_size) : 0;
+	const completedSampleSize = raw ? Number(raw.completed_sample_size) : 0;
+	const showPercentiles = completedSampleSize >= STEP_DURATION_MIN_SAMPLE;
+	return {
+		key,
+		phase: "post_submit",
+		step: null,
+		label,
+		sampleSize,
+		completedSampleSize,
+		medianDays:
+			showPercentiles &&
+			raw?.median_days !== null &&
+			raw?.median_days !== undefined
+				? Number(raw.median_days)
+				: null,
+		p90Days:
+			showPercentiles && raw?.p90_days !== null && raw?.p90_days !== undefined
+				? Number(raw.p90_days)
+				: null,
+	};
 }
 
 /**
@@ -106,16 +148,25 @@ export const adminStatsRouter = createTRPCRouter({
 		}),
 
 	/**
-	 * Returns the median and p90 number of days declarations spend on each step
-	 * of the A–F stepper, scoped to one campaign year and optionally to a
-	 * workforce bucket. Feeds the K4 « délai moyen par étape » chart + table.
+	 * Returns the median and p90 duration (days) declarations spend on each
+	 * phase of the post-DSN journey, scoped to one campaign year and optionally
+	 * to a workforce bucket. Feeds the K4 « délai moyen par étape » chart +
+	 * table.
 	 *
-	 * Durations are computed as `LEAD(changed_at) - changed_at` over the
-	 * `step_change` events ordered by time per declaration. Rows where there
-	 * is no next event (declaration still on that step) are excluded from the
-	 * percentile aggregation but still count in `sampleSize`. The percentiles
-	 * are null when fewer than `STEP_DURATION_MIN_SAMPLE` declarations have
-	 * actually exited the step (avoids surfacing meaningless numbers).
+	 * Two phases:
+	 * - **wizard** (steps 0..6) — durations are `LEAD(changed_at) - changed_at`
+	 *   over the `step_change` events ordered by time per declaration. Rows
+	 *   where there is no next event (declaration still on that step) are
+	 *   excluded from the percentile aggregation but still count in
+	 *   `sampleSize`.
+	 * - **post_submit** (5 milestones) — durations between business events
+	 *   (`submit`, `path_choice`, `second_declaration_submit`,
+	 *   `joint_evaluation_submit`, `cse_opinion_submit`, `demarche_complete`),
+	 *   computed per milestone via a dedicated CTE.
+	 *
+	 * Percentiles are null when fewer than `STEP_DURATION_MIN_SAMPLE`
+	 * declarations have actually exited the step / milestone, to avoid
+	 * surfacing meaningless numbers.
 	 */
 	getStepDurations: adminProcedure
 		.input(getStepDurationsSchema)
@@ -128,7 +179,7 @@ export const adminStatsRouter = createTRPCRouter({
 					: sql`${companies.workforce} BETWEEN ${min} AND ${max}`;
 			})();
 
-			const rows = await ctx.db.execute<{
+			const wizardRowsRaw = await ctx.db.execute<{
 				step: number;
 				sample_size: number | string;
 				completed_sample_size: number | string;
@@ -151,6 +202,7 @@ export const adminStatsRouter = createTRPCRouter({
 						ON ${companies.siren} = ${declarations.siren}
 					WHERE ${declarationStatusHistory.eventType} = 'step_change'
 						AND ${declarations.year} = ${input.year}
+						AND ${declarations.cancelledAt} IS NULL
 						AND ${sizeFilterSql}
 				)
 				SELECT
@@ -169,8 +221,8 @@ export const adminStatsRouter = createTRPCRouter({
 				ORDER BY step
 			`);
 
-			const byStep = new Map<number, StepDurationRow>();
-			for (const raw of rows as unknown as Array<{
+			const wizardByStep = new Map<number, StepDurationRow>();
+			for (const raw of wizardRowsRaw as unknown as Array<{
 				step: number | string;
 				sample_size: number | string;
 				completed_sample_size: number | string;
@@ -181,7 +233,9 @@ export const adminStatsRouter = createTRPCRouter({
 				const sampleSize = Number(raw.sample_size);
 				const completedSampleSize = Number(raw.completed_sample_size);
 				const showPercentiles = completedSampleSize >= STEP_DURATION_MIN_SAMPLE;
-				byStep.set(step, {
+				wizardByStep.set(step, {
+					key: `step_${step}`,
+					phase: "wizard",
 					step,
 					label: getStepLabel(step),
 					sampleSize,
@@ -197,9 +251,11 @@ export const adminStatsRouter = createTRPCRouter({
 				});
 			}
 
-			return DECLARATION_STEPS.map(
+			const wizardRows = DECLARATION_STEPS.map(
 				({ step }) =>
-					byStep.get(step) ?? {
+					wizardByStep.get(step) ?? {
+						key: `step_${step}`,
+						phase: "wizard" as const,
 						step,
 						label: getStepLabel(step),
 						sampleSize: 0,
@@ -208,5 +264,242 @@ export const adminStatsRouter = createTRPCRouter({
 						p90Days: null,
 					},
 			);
+
+			const postSubmitAggregates: Record<
+				PostSubmitMilestoneKey,
+				AggregatedMilestone | undefined
+			> = {
+				submit_to_path_choice: undefined,
+				path_choice_to_action: undefined,
+				revision_choice_to_action: undefined,
+				action_to_cse_opinion: undefined,
+				last_action_to_complete: undefined,
+			};
+
+			// Jalon 1 — `submit` (step_change round=6) → `path_choice round=1`
+			//
+			// `step_change round=6` is the canonical signal that the declarant
+			// reached the recap (= submission). We use it instead of the legacy
+			// `submit` event to be consistent with the wizard CTE above and avoid
+			// duplicates when both events exist on the same declaration.
+			const submitToPathChoiceRows =
+				await ctx.db.execute<AggregatedMilestone>(sql`
+				WITH paired AS (
+					SELECT
+						s.declaration_id,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'step_change' AND s.round = 6) AS start_at,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) AS end_at
+					FROM ${declarationStatusHistory} s
+					INNER JOIN ${declarations}
+						ON ${declarations.id} = s.declaration_id
+					INNER JOIN ${companies}
+						ON ${companies.siren} = ${declarations.siren}
+					WHERE ${declarations.year} = ${input.year}
+						AND ${declarations.cancelledAt} IS NULL
+						AND ${sizeFilterSql}
+					GROUP BY s.declaration_id
+					HAVING MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) IS NOT NULL
+				)
+				SELECT
+					COUNT(*)::int AS sample_size,
+					COUNT(*) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
+					percentile_cont(0.5) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS median_days,
+					percentile_cont(0.9) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS p90_days
+				FROM paired
+			`);
+			postSubmitAggregates.submit_to_path_choice = (
+				submitToPathChoiceRows as unknown as AggregatedMilestone[]
+			)[0];
+
+			// Jalon 2 — `path_choice round=1` → MIN(`second_declaration_submit round=2`,
+			// `joint_evaluation_submit round=1`)
+			//
+			// FSM allows only one of the two actions per declaration in wave 1, so
+			// we just take the earliest of the two events that exists.
+			const pathChoiceToActionRows =
+				await ctx.db.execute<AggregatedMilestone>(sql`
+				WITH paired AS (
+					SELECT
+						s.declaration_id,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) AS start_at,
+						LEAST(
+							MIN(s.created_at) FILTER (WHERE s.event_type = 'second_declaration_submit' AND s.round = 2),
+							MIN(s.created_at) FILTER (WHERE s.event_type = 'joint_evaluation_submit' AND s.round = 1)
+						) AS end_at
+					FROM ${declarationStatusHistory} s
+					INNER JOIN ${declarations}
+						ON ${declarations.id} = s.declaration_id
+					INNER JOIN ${companies}
+						ON ${companies.siren} = ${declarations.siren}
+					WHERE ${declarations.year} = ${input.year}
+						AND ${declarations.cancelledAt} IS NULL
+						AND ${sizeFilterSql}
+					GROUP BY s.declaration_id
+					HAVING MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) IS NOT NULL
+				)
+				SELECT
+					COUNT(*) FILTER (WHERE end_at IS NOT NULL)::int AS sample_size,
+					COUNT(*) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
+					percentile_cont(0.5) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS median_days,
+					percentile_cont(0.9) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS p90_days
+				FROM paired
+			`);
+			postSubmitAggregates.path_choice_to_action = (
+				pathChoiceToActionRows as unknown as AggregatedMilestone[]
+			)[0];
+
+			// Jalon 3 — `path_choice round=2` → `joint_evaluation_submit round=2`
+			//
+			// The revision cycle, triggered when the company chooses to revise
+			// its plan or the joint evaluation after a first action.
+			const revisionChoiceToActionRows =
+				await ctx.db.execute<AggregatedMilestone>(sql`
+				WITH paired AS (
+					SELECT
+						s.declaration_id,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 2) AS start_at,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'joint_evaluation_submit' AND s.round = 2) AS end_at
+					FROM ${declarationStatusHistory} s
+					INNER JOIN ${declarations}
+						ON ${declarations.id} = s.declaration_id
+					INNER JOIN ${companies}
+						ON ${companies.siren} = ${declarations.siren}
+					WHERE ${declarations.year} = ${input.year}
+						AND ${declarations.cancelledAt} IS NULL
+						AND ${sizeFilterSql}
+					GROUP BY s.declaration_id
+					HAVING MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 2) IS NOT NULL
+				)
+				SELECT
+					COUNT(*)::int AS sample_size,
+					COUNT(*) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
+					percentile_cont(0.5) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS median_days,
+					percentile_cont(0.9) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS p90_days
+				FROM paired
+			`);
+			postSubmitAggregates.revision_choice_to_action = (
+				revisionChoiceToActionRows as unknown as AggregatedMilestone[]
+			)[0];
+
+			// Jalon 4 — MAX(action_before_cse) → `cse_opinion_submit`
+			//
+			// CSE opinion only applies to companies >= 100 employees that have
+			// submitted one. The preceding action is typically the second
+			// declaration or joint evaluation; we use the latest such event that
+			// happened before the CSE opinion.
+			const actionToCseOpinionRows =
+				await ctx.db.execute<AggregatedMilestone>(sql`
+				WITH ranked AS (
+					SELECT
+						s.declaration_id,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'cse_opinion_submit') AS cse_at,
+						MAX(s.created_at) FILTER (
+							WHERE s.event_type IN ('second_declaration_submit', 'joint_evaluation_submit')
+						) AS last_action_at
+					FROM ${declarationStatusHistory} s
+					INNER JOIN ${declarations}
+						ON ${declarations.id} = s.declaration_id
+					INNER JOIN ${companies}
+						ON ${companies.siren} = ${declarations.siren}
+					WHERE ${declarations.year} = ${input.year}
+						AND ${declarations.cancelledAt} IS NULL
+						AND ${sizeFilterSql}
+					GROUP BY s.declaration_id
+				),
+				paired AS (
+					SELECT
+						declaration_id,
+						last_action_at AS start_at,
+						cse_at AS end_at
+					FROM ranked
+					WHERE cse_at IS NOT NULL
+				)
+				SELECT
+					COUNT(*)::int AS sample_size,
+					COUNT(*) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
+					percentile_cont(0.5) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS median_days,
+					percentile_cont(0.9) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS p90_days
+				FROM paired
+			`);
+			postSubmitAggregates.action_to_cse_opinion = (
+				actionToCseOpinionRows as unknown as AggregatedMilestone[]
+			)[0];
+
+			// Jalon 5 — MAX(business_event_before_complete) → `demarche_complete`
+			//
+			// Anchors against the latest business event preceding the completion:
+			// CSE opinion (>= 100 employees), second declaration, or joint
+			// evaluation. The filter `created_at < complete.created_at` makes sure
+			// we don't pick an event that fired after the closure.
+			const lastActionToCompleteRows =
+				await ctx.db.execute<AggregatedMilestone>(sql`
+				WITH complete_ts AS (
+					SELECT
+						s.declaration_id,
+						MAX(s.created_at) AS complete_at
+					FROM ${declarationStatusHistory} s
+					INNER JOIN ${declarations}
+						ON ${declarations.id} = s.declaration_id
+					INNER JOIN ${companies}
+						ON ${companies.siren} = ${declarations.siren}
+					WHERE s.event_type = 'demarche_complete'
+						AND ${declarations.year} = ${input.year}
+						AND ${declarations.cancelledAt} IS NULL
+						AND ${sizeFilterSql}
+					GROUP BY s.declaration_id
+				),
+				paired AS (
+					SELECT
+						ct.declaration_id,
+						MAX(s.created_at) FILTER (
+							WHERE s.event_type IN (
+								'cse_opinion_submit',
+								'second_declaration_submit',
+								'joint_evaluation_submit'
+							)
+							AND s.created_at < ct.complete_at
+						) AS start_at,
+						ct.complete_at AS end_at
+					FROM complete_ts ct
+					LEFT JOIN ${declarationStatusHistory} s
+						ON s.declaration_id = ct.declaration_id
+					GROUP BY ct.declaration_id, ct.complete_at
+				)
+				SELECT
+					COUNT(*)::int AS sample_size,
+					COUNT(*) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
+					percentile_cont(0.5) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS median_days,
+					percentile_cont(0.9) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
+					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS p90_days
+				FROM paired
+			`);
+			postSubmitAggregates.last_action_to_complete = (
+				lastActionToCompleteRows as unknown as AggregatedMilestone[]
+			)[0];
+
+			const postSubmitRows = POST_SUBMIT_MILESTONES.map(({ key, label }) =>
+				buildPostSubmitRow(key, label, postSubmitAggregates[key]),
+			);
+
+			return [...wizardRows, ...postSubmitRows];
 		}),
 });

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -1,17 +1,28 @@
 import { and, between, eq, gte, inArray, type SQL, sql } from "drizzle-orm";
 
-import { getCampaignProgressionSchema } from "~/modules/admin/stats/schemas";
+import {
+	getCampaignProgressionSchema,
+	getStepDurationsSchema,
+} from "~/modules/admin/stats/schemas";
 import type {
 	CampaignProgressionPoint,
 	CampaignProgressionSeries,
+	StepDurationRow,
 } from "~/modules/admin/stats/types";
-import { COMPANY_SIZE_RANGES } from "~/modules/domain";
+import {
+	COMPANY_SIZE_RANGES,
+	DECLARATION_STEPS,
+	getStepLabel,
+} from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import {
 	companies,
 	declarationStatusHistory,
 	declarations,
 } from "~/server/db/schema";
+
+/** Minimum number of completed transitions before showing a median / p90. */
+const STEP_DURATION_MIN_SAMPLE = 5;
 
 type AggregatedRow = { day: string; year: number; count: number };
 
@@ -92,5 +103,110 @@ export const adminStatsRouter = createTRPCRouter({
 				.orderBy(declarations.year, dayExpr);
 
 			return buildSeries(rows as AggregatedRow[]);
+		}),
+
+	/**
+	 * Returns the median and p90 number of days declarations spend on each step
+	 * of the A–F stepper, scoped to one campaign year and optionally to a
+	 * workforce bucket. Feeds the K4 « délai moyen par étape » chart + table.
+	 *
+	 * Durations are computed as `LEAD(changed_at) - changed_at` over the
+	 * `step_change` events ordered by time per declaration. Rows where there
+	 * is no next event (declaration still on that step) are excluded from the
+	 * percentile aggregation but still count in `sampleSize`. The percentiles
+	 * are null when fewer than `STEP_DURATION_MIN_SAMPLE` declarations have
+	 * actually exited the step (avoids surfacing meaningless numbers).
+	 */
+	getStepDurations: adminProcedure
+		.input(getStepDurationsSchema)
+		.query(async ({ ctx, input }): Promise<StepDurationRow[]> => {
+			const sizeFilterSql = (() => {
+				if (!input.sizeRange) return sql`TRUE`;
+				const { min, max } = COMPANY_SIZE_RANGES[input.sizeRange];
+				return max === null
+					? sql`${companies.workforce} >= ${min}`
+					: sql`${companies.workforce} BETWEEN ${min} AND ${max}`;
+			})();
+
+			const rows = await ctx.db.execute<{
+				step: number;
+				sample_size: number | string;
+				completed_sample_size: number | string;
+				median_days: number | string | null;
+				p90_days: number | string | null;
+			}>(sql`
+				WITH events AS (
+					SELECT
+						${declarationStatusHistory.declarationId} AS declaration_id,
+						${declarationStatusHistory.round} AS step,
+						${declarationStatusHistory.createdAt} AS changed_at,
+						LEAD(${declarationStatusHistory.createdAt}) OVER (
+							PARTITION BY ${declarationStatusHistory.declarationId}
+							ORDER BY ${declarationStatusHistory.createdAt}
+						) AS next_changed_at
+					FROM ${declarationStatusHistory}
+					INNER JOIN ${declarations}
+						ON ${declarations.id} = ${declarationStatusHistory.declarationId}
+					INNER JOIN ${companies}
+						ON ${companies.siren} = ${declarations.siren}
+					WHERE ${declarationStatusHistory.eventType} = 'step_change'
+						AND ${declarations.year} = ${input.year}
+						AND ${sizeFilterSql}
+				)
+				SELECT
+					step,
+					COUNT(*)::int AS sample_size,
+					COUNT(next_changed_at)::int AS completed_sample_size,
+					percentile_cont(0.5) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (next_changed_at - changed_at)) / 86400.0
+					) FILTER (WHERE next_changed_at IS NOT NULL) AS median_days,
+					percentile_cont(0.9) WITHIN GROUP (
+						ORDER BY EXTRACT(EPOCH FROM (next_changed_at - changed_at)) / 86400.0
+					) FILTER (WHERE next_changed_at IS NOT NULL) AS p90_days
+				FROM events
+				WHERE step IS NOT NULL
+				GROUP BY step
+				ORDER BY step
+			`);
+
+			const byStep = new Map<number, StepDurationRow>();
+			for (const raw of rows as unknown as Array<{
+				step: number | string;
+				sample_size: number | string;
+				completed_sample_size: number | string;
+				median_days: number | string | null;
+				p90_days: number | string | null;
+			}>) {
+				const step = Number(raw.step);
+				const sampleSize = Number(raw.sample_size);
+				const completedSampleSize = Number(raw.completed_sample_size);
+				const showPercentiles = completedSampleSize >= STEP_DURATION_MIN_SAMPLE;
+				byStep.set(step, {
+					step,
+					label: getStepLabel(step),
+					sampleSize,
+					completedSampleSize,
+					medianDays:
+						showPercentiles && raw.median_days !== null
+							? Number(raw.median_days)
+							: null,
+					p90Days:
+						showPercentiles && raw.p90_days !== null
+							? Number(raw.p90_days)
+							: null,
+				});
+			}
+
+			return DECLARATION_STEPS.map(
+				({ step }) =>
+					byStep.get(step) ?? {
+						step,
+						label: getStepLabel(step),
+						sampleSize: 0,
+						completedSampleSize: 0,
+						medianDays: null,
+						p90Days: null,
+					},
+			);
 		}),
 });

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -161,10 +161,10 @@ export const adminStatsRouter = createTRPCRouter({
 	 *   excluded. Rows where there is no next event (declaration still on that
 	 *   step) are excluded from the percentile aggregation but still count in
 	 *   `sampleSize`.
-	 * - **post_submit** (6 milestones) — durations between business events
+	 * - **post_submit** (4 milestones) — durations between business events
 	 *   (`submit`, `path_choice`, `second_declaration_submit`,
-	 *   `joint_evaluation_submit`, `cse_opinion_submit`, `demarche_complete`),
-	 *   computed per milestone via a dedicated CTE.
+	 *   `joint_evaluation_submit`, `cse_opinion_submit`), computed per
+	 *   milestone via a dedicated CTE.
 	 *
 	 * Percentiles are null when fewer than `STEP_DURATION_MIN_SAMPLE`
 	 * declarations have actually exited the step / milestone, to avoid
@@ -277,9 +277,7 @@ export const adminStatsRouter = createTRPCRouter({
 				submit_to_path_choice: undefined,
 				path_choice_to_second_declaration: undefined,
 				path_choice_to_joint_evaluation: undefined,
-				revision_choice_to_action: undefined,
 				action_to_cse_opinion: undefined,
-				last_action_to_complete: undefined,
 			};
 
 			// `step_change round=6` (recap) is preferred over the legacy `submit`
@@ -351,16 +349,20 @@ export const adminStatsRouter = createTRPCRouter({
 				pathChoiceToSecondDeclarationRows as unknown as AggregatedMilestone[]
 			)[0];
 
-			// `joint_evaluation_submit round=1` = joint evaluation as the
-			// first-wave corrective path (round=2 covers the revision wave and
-			// is captured by `revision_choice_to_action`).
+			// Pair `path_choice` and `joint_evaluation_submit` on the same round
+			// (per declaration) so each cycle contributes its own duration: the
+			// initial wave (round=1) and the revision wave (round=2). A
+			// declaration that completes both rounds contributes twice — the
+			// aggregate reflects the number of observed durations, not the
+			// number of distinct declarations.
 			const pathChoiceToJointEvaluationRows =
 				await ctx.db.execute<AggregatedMilestone>(sql`
 				WITH paired AS (
 					SELECT
 						s.declaration_id,
-						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) AS start_at,
-						MIN(s.created_at) FILTER (WHERE s.event_type = 'joint_evaluation_submit' AND s.round = 1) AS end_at
+						s.round,
+						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice') AS start_at,
+						MIN(s.created_at) FILTER (WHERE s.event_type = 'joint_evaluation_submit') AS end_at
 					FROM ${declarationStatusHistory} s
 					INNER JOIN ${declarations}
 						ON ${declarations.id} = s.declaration_id
@@ -369,8 +371,9 @@ export const adminStatsRouter = createTRPCRouter({
 					WHERE ${declarations.year} = ${input.year}
 						AND ${declarations.cancelledAt} IS NULL
 						AND ${sizeFilterSql}
-					GROUP BY s.declaration_id
-					HAVING MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 1) IS NOT NULL
+						AND s.event_type IN ('path_choice', 'joint_evaluation_submit')
+					GROUP BY s.declaration_id, s.round
+					HAVING MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice') IS NOT NULL
 				)
 				SELECT
 					COUNT(*) FILTER (WHERE end_at IS NOT NULL)::int AS sample_size,
@@ -385,39 +388,6 @@ export const adminStatsRouter = createTRPCRouter({
 			`);
 			postSubmitAggregates.path_choice_to_joint_evaluation = (
 				pathChoiceToJointEvaluationRows as unknown as AggregatedMilestone[]
-			)[0];
-
-			const revisionChoiceToActionRows =
-				await ctx.db.execute<AggregatedMilestone>(sql`
-				WITH paired AS (
-					SELECT
-						s.declaration_id,
-						MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 2) AS start_at,
-						MAX(s.created_at) FILTER (WHERE s.event_type = 'joint_evaluation_submit' AND s.round = 2) AS end_at
-					FROM ${declarationStatusHistory} s
-					INNER JOIN ${declarations}
-						ON ${declarations.id} = s.declaration_id
-					INNER JOIN ${companies}
-						ON ${companies.siren} = ${declarations.siren}
-					WHERE ${declarations.year} = ${input.year}
-						AND ${declarations.cancelledAt} IS NULL
-						AND ${sizeFilterSql}
-					GROUP BY s.declaration_id
-					HAVING MAX(s.created_at) FILTER (WHERE s.event_type = 'path_choice' AND s.round = 2) IS NOT NULL
-				)
-				SELECT
-					COUNT(*)::int AS sample_size,
-					COUNT(*) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
-					percentile_cont(0.5) WITHIN GROUP (
-						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
-					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS median_days,
-					percentile_cont(0.9) WITHIN GROUP (
-						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
-					) FILTER (WHERE end_at IS NOT NULL AND end_at > start_at) AS p90_days
-				FROM paired
-			`);
-			postSubmitAggregates.revision_choice_to_action = (
-				revisionChoiceToActionRows as unknown as AggregatedMilestone[]
 			)[0];
 
 			// CSE opinion only applies to >= 100 employees. The preceding action
@@ -463,58 +433,6 @@ export const adminStatsRouter = createTRPCRouter({
 			`);
 			postSubmitAggregates.action_to_cse_opinion = (
 				actionToCseOpinionRows as unknown as AggregatedMilestone[]
-			)[0];
-
-			// `created_at < complete_at` filter is load-bearing: a CSE opinion
-			// can fire AFTER the completion (correction edge case) and would
-			// otherwise yield a negative duration.
-			const lastActionToCompleteRows =
-				await ctx.db.execute<AggregatedMilestone>(sql`
-				WITH complete_ts AS (
-					SELECT
-						s.declaration_id,
-						MAX(s.created_at) AS complete_at
-					FROM ${declarationStatusHistory} s
-					INNER JOIN ${declarations}
-						ON ${declarations.id} = s.declaration_id
-					INNER JOIN ${companies}
-						ON ${companies.siren} = ${declarations.siren}
-					WHERE s.event_type = 'demarche_complete'
-						AND ${declarations.year} = ${input.year}
-						AND ${declarations.cancelledAt} IS NULL
-						AND ${sizeFilterSql}
-					GROUP BY s.declaration_id
-				),
-				paired AS (
-					SELECT
-						ct.declaration_id,
-						MAX(s.created_at) FILTER (
-							WHERE s.event_type IN (
-								'cse_opinion_submit',
-								'second_declaration_submit',
-								'joint_evaluation_submit'
-							)
-							AND s.created_at < ct.complete_at
-						) AS start_at,
-						ct.complete_at AS end_at
-					FROM complete_ts ct
-					LEFT JOIN ${declarationStatusHistory} s
-						ON s.declaration_id = ct.declaration_id
-					GROUP BY ct.declaration_id, ct.complete_at
-				)
-				SELECT
-					COUNT(*)::int AS sample_size,
-					COUNT(*) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at)::int AS completed_sample_size,
-					percentile_cont(0.5) WITHIN GROUP (
-						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
-					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS median_days,
-					percentile_cont(0.9) WITHIN GROUP (
-						ORDER BY EXTRACT(EPOCH FROM (end_at - start_at)) / 86400.0
-					) FILTER (WHERE start_at IS NOT NULL AND end_at > start_at) AS p90_days
-				FROM paired
-			`);
-			postSubmitAggregates.last_action_to_complete = (
-				lastActionToCompleteRows as unknown as AggregatedMilestone[]
 			)[0];
 
 			const postSubmitRows = POST_SUBMIT_MILESTONES.map(({ key, label }) =>

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -60,11 +60,6 @@ type AggregatedMilestone = {
 	p90_days: number | string | null;
 };
 
-/**
- * Convert a raw SQL aggregation row into the typed `StepDurationRow` for a
- * given post-submit milestone, applying the `STEP_DURATION_MIN_SAMPLE` floor
- * for percentile visibility.
- */
 function buildPostSubmitRow(
 	key: PostSubmitMilestoneKey,
 	label: string,
@@ -276,12 +271,9 @@ export const adminStatsRouter = createTRPCRouter({
 				last_action_to_complete: undefined,
 			};
 
-			// Jalon 1 — `submit` (step_change round=6) → `path_choice round=1`
-			//
-			// `step_change round=6` is the canonical signal that the declarant
-			// reached the recap (= submission). We use it instead of the legacy
-			// `submit` event to be consistent with the wizard CTE above and avoid
-			// duplicates when both events exist on the same declaration.
+			// `step_change round=6` (recap) is preferred over the legacy `submit`
+			// event so we stay consistent with the wizard CTE and avoid double-
+			// counting declarations where both rows coexist.
 			const submitToPathChoiceRows =
 				await ctx.db.execute<AggregatedMilestone>(sql`
 				WITH paired AS (
@@ -315,11 +307,9 @@ export const adminStatsRouter = createTRPCRouter({
 				submitToPathChoiceRows as unknown as AggregatedMilestone[]
 			)[0];
 
-			// Jalon 2 — `path_choice round=1` → MIN(`second_declaration_submit round=2`,
-			// `joint_evaluation_submit round=1`)
-			//
-			// FSM allows only one of the two actions per declaration in wave 1, so
-			// we just take the earliest of the two events that exists.
+			// FSM allows only one of `second_declaration round=2` or
+			// `joint_evaluation round=1` per declaration in wave 1, so taking
+			// the LEAST of the two is safe and resolves whichever exists.
 			const pathChoiceToActionRows =
 				await ctx.db.execute<AggregatedMilestone>(sql`
 				WITH paired AS (
@@ -356,10 +346,6 @@ export const adminStatsRouter = createTRPCRouter({
 				pathChoiceToActionRows as unknown as AggregatedMilestone[]
 			)[0];
 
-			// Jalon 3 — `path_choice round=2` → `joint_evaluation_submit round=2`
-			//
-			// The revision cycle, triggered when the company chooses to revise
-			// its plan or the joint evaluation after a first action.
 			const revisionChoiceToActionRows =
 				await ctx.db.execute<AggregatedMilestone>(sql`
 				WITH paired AS (
@@ -393,12 +379,9 @@ export const adminStatsRouter = createTRPCRouter({
 				revisionChoiceToActionRows as unknown as AggregatedMilestone[]
 			)[0];
 
-			// Jalon 4 — MAX(action_before_cse) → `cse_opinion_submit`
-			//
-			// CSE opinion only applies to companies >= 100 employees that have
-			// submitted one. The preceding action is typically the second
-			// declaration or joint evaluation; we use the latest such event that
-			// happened before the CSE opinion.
+			// CSE opinion only applies to >= 100 employees. The preceding action
+			// is either the second declaration or joint evaluation, both grouped
+			// under a single `last_action_at` aggregate.
 			const actionToCseOpinionRows =
 				await ctx.db.execute<AggregatedMilestone>(sql`
 				WITH ranked AS (
@@ -441,12 +424,9 @@ export const adminStatsRouter = createTRPCRouter({
 				actionToCseOpinionRows as unknown as AggregatedMilestone[]
 			)[0];
 
-			// Jalon 5 — MAX(business_event_before_complete) → `demarche_complete`
-			//
-			// Anchors against the latest business event preceding the completion:
-			// CSE opinion (>= 100 employees), second declaration, or joint
-			// evaluation. The filter `created_at < complete.created_at` makes sure
-			// we don't pick an event that fired after the closure.
+			// `created_at < complete_at` filter is load-bearing: a CSE opinion
+			// can fire AFTER the completion (correction edge case) and would
+			// otherwise yield a negative duration.
 			const lastActionToCompleteRows =
 				await ctx.db.execute<AggregatedMilestone>(sql`
 				WITH complete_ts AS (

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -26,6 +26,11 @@ import {
 /** Minimum number of completed transitions before showing a median / p90. */
 const STEP_DURATION_MIN_SAMPLE = 5;
 
+// Step 6 (« Récapitulatif ») is the terminal submission state — no subsequent
+// `step_change` event exists, so its duration is always undefined. Excluded
+// from the K4 wizard chart to avoid empty bars.
+const WIZARD_TERMINAL_STEP = 6;
+
 type AggregatedRow = { day: string; year: number; count: number };
 
 /**
@@ -149,10 +154,12 @@ export const adminStatsRouter = createTRPCRouter({
 	 * table.
 	 *
 	 * Two phases:
-	 * - **wizard** (steps 0..6) — durations are `LEAD(changed_at) - changed_at`
-	 *   over the `step_change` events ordered by time per declaration. Rows
-	 *   where there is no next event (declaration still on that step) are
-	 *   excluded from the percentile aggregation but still count in
+	 * - **wizard** (steps 0..5) — durations are `LEAD(changed_at) - changed_at`
+	 *   over the `step_change` events ordered by time per declaration. Step 6
+	 *   (« Récapitulatif ») is the terminal submission state with no following
+	 *   `step_change` event, so its duration is undefined and the row is
+	 *   excluded. Rows where there is no next event (declaration still on that
+	 *   step) are excluded from the percentile aggregation but still count in
 	 *   `sampleSize`.
 	 * - **post_submit** (6 milestones) — durations between business events
 	 *   (`submit`, `path_choice`, `second_declaration_submit`,
@@ -212,6 +219,7 @@ export const adminStatsRouter = createTRPCRouter({
 					) FILTER (WHERE next_changed_at IS NOT NULL) AS p90_days
 				FROM events
 				WHERE step IS NOT NULL
+					AND step < ${WIZARD_TERMINAL_STEP}
 				GROUP BY step
 				ORDER BY step
 			`);
@@ -246,7 +254,9 @@ export const adminStatsRouter = createTRPCRouter({
 				});
 			}
 
-			const wizardRows = DECLARATION_STEPS.map(
+			const wizardRows = DECLARATION_STEPS.filter(
+				({ step }) => step < WIZARD_TERMINAL_STEP,
+			).map(
 				({ step }) =>
 					wizardByStep.get(step) ?? {
 						key: `step_${step}`,

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -44,6 +44,7 @@ import {
 } from "./declarationHelpers";
 import {
 	buildHistoryInserts,
+	buildStepChangeInsert,
 	computeProjectionUpdates,
 	getCurrentRound,
 	hasLockingEventForRound,
@@ -203,6 +204,16 @@ export const declarationRouter = createTRPCRouter({
 					code: "INTERNAL_SERVER_ERROR",
 					message: "Erreur lors de la création",
 				});
+
+			await tx.insert(declarationStatusHistory).values(
+				buildStepChangeInsert({
+					declarationId: declaration.id,
+					fromStep: null,
+					toStep: 0,
+					actorUserId: ctx.session.user.id,
+				}),
+			);
+
 			return {
 				declaration,
 				jobCategories: [],
@@ -275,6 +286,9 @@ export const declarationRouter = createTRPCRouter({
 					}
 				}
 
+				const previousStep = existing[0]?.currentStep ?? null;
+				const declarationId = existing[0]?.id ?? null;
+
 				await tx
 					.update(declarations)
 					.set({
@@ -333,6 +347,17 @@ export const declarationRouter = createTRPCRouter({
 					})
 					.where(activeDeclarationFilter(siren, year));
 
+				if (declarationId && previousStep !== 1) {
+					await tx.insert(declarationStatusHistory).values(
+						buildStepChangeInsert({
+							declarationId,
+							fromStep: previousStep,
+							toStep: 1,
+							actorUserId: ctx.session.user.id,
+						}),
+					);
+				}
+
 				await applyPercentagesAfterUpdate(tx, siren, year);
 			});
 
@@ -346,6 +371,15 @@ export const declarationRouter = createTRPCRouter({
 			const year = getCurrentYear();
 
 			await ctx.db.transaction(async (tx) => {
+				const [existing] = await tx
+					.select({
+						id: declarations.id,
+						currentStep: declarations.currentStep,
+					})
+					.from(declarations)
+					.where(activeDeclarationFilter(siren, year))
+					.limit(1);
+
 				await tx
 					.update(declarations)
 					.set({
@@ -362,6 +396,17 @@ export const declarationRouter = createTRPCRouter({
 					})
 					.where(activeDeclarationFilter(siren, year));
 
+				if (existing && existing.currentStep !== 2) {
+					await tx.insert(declarationStatusHistory).values(
+						buildStepChangeInsert({
+							declarationId: existing.id,
+							fromStep: existing.currentStep,
+							toStep: 2,
+							actorUserId: ctx.session.user.id,
+						}),
+					);
+				}
+
 				await applyPercentagesAfterUpdate(tx, siren, year);
 			});
 
@@ -375,6 +420,15 @@ export const declarationRouter = createTRPCRouter({
 			const year = getCurrentYear();
 
 			await ctx.db.transaction(async (tx) => {
+				const [existing] = await tx
+					.select({
+						id: declarations.id,
+						currentStep: declarations.currentStep,
+					})
+					.from(declarations)
+					.where(activeDeclarationFilter(siren, year))
+					.limit(1);
+
 				await tx
 					.update(declarations)
 					.set({
@@ -393,6 +447,17 @@ export const declarationRouter = createTRPCRouter({
 					})
 					.where(activeDeclarationFilter(siren, year));
 
+				if (existing && existing.currentStep !== 3) {
+					await tx.insert(declarationStatusHistory).values(
+						buildStepChangeInsert({
+							declarationId: existing.id,
+							fromStep: existing.currentStep,
+							toStep: 3,
+							actorUserId: ctx.session.user.id,
+						}),
+					);
+				}
+
 				await applyPercentagesAfterUpdate(tx, siren, year);
 			});
 
@@ -406,6 +471,15 @@ export const declarationRouter = createTRPCRouter({
 			const year = getCurrentYear();
 
 			await ctx.db.transaction(async (tx) => {
+				const [existing] = await tx
+					.select({
+						id: declarations.id,
+						currentStep: declarations.currentStep,
+					})
+					.from(declarations)
+					.where(activeDeclarationFilter(siren, year))
+					.limit(1);
+
 				await tx
 					.update(declarations)
 					.set({
@@ -435,6 +509,17 @@ export const declarationRouter = createTRPCRouter({
 						updatedAt: new Date(),
 					})
 					.where(activeDeclarationFilter(siren, year));
+
+				if (existing && existing.currentStep !== 4) {
+					await tx.insert(declarationStatusHistory).values(
+						buildStepChangeInsert({
+							declarationId: existing.id,
+							fromStep: existing.currentStep,
+							toStep: 4,
+							actorUserId: ctx.session.user.id,
+						}),
+					);
+				}
 
 				await applyPercentagesAfterUpdate(tx, siren, year);
 			});
@@ -492,6 +577,17 @@ export const declarationRouter = createTRPCRouter({
 						.update(declarations)
 						.set({ currentStep: 5, updatedAt: new Date() })
 						.where(eq(declarations.id, declaration.id));
+
+					if (declaration.currentStep !== 5) {
+						await tx.insert(declarationStatusHistory).values(
+							buildStepChangeInsert({
+								declarationId: declaration.id,
+								fromStep: declaration.currentStep,
+								toStep: 5,
+								actorUserId: ctx.session.user.id,
+							}),
+						);
+					}
 				} else {
 					for (const job of existingJobs) {
 						const cat = input.categories[job.categoryIndex];
@@ -599,6 +695,17 @@ export const declarationRouter = createTRPCRouter({
 					updatedAt: new Date(),
 				})
 				.where(activeDeclarationFilter(siren, year));
+
+			if (declaration.currentStep !== 6) {
+				await tx.insert(declarationStatusHistory).values(
+					buildStepChangeInsert({
+						declarationId: declaration.id,
+						fromStep: declaration.currentStep,
+						toStep: 6,
+						actorUserId: ctx.session.user.id,
+					}),
+				);
+			}
 
 			await applyPercentagesAfterUpdate(tx, siren, year);
 		});

--- a/packages/app/src/server/api/routers/statusHistoryHelpers.ts
+++ b/packages/app/src/server/api/routers/statusHistoryHelpers.ts
@@ -119,6 +119,30 @@ export function buildHistoryInserts(
 	}));
 }
 
+/**
+ * Build a `step_change` history row payload for the declaration A–F stepper.
+ *
+ * `fromStep === null` flags the creation transition (no previous step).
+ * Encoded into the existing `value` column as `from:<N>|to:<M>` to avoid a
+ * dedicated columns set ; the readable `toStep` also goes into `round` for
+ * lightweight SQL aggregation downstream (KPI K4, future funnel).
+ */
+export function buildStepChangeInsert(args: {
+	declarationId: string;
+	fromStep: number | null;
+	toStep: number;
+	actorUserId: string | null;
+}): DbInsertableHistory {
+	const fromLabel = args.fromStep === null ? "null" : String(args.fromStep);
+	return {
+		declarationId: args.declarationId,
+		eventType: "step_change",
+		value: `from:${fromLabel}|to:${args.toStep}`,
+		round: args.toStep,
+		actorUserId: args.actorUserId,
+	};
+}
+
 export async function getLatestPathChoice(
 	database: StatusHistoryReader,
 	declarationId: string,

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -62,6 +62,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	// ── admin stats sensitive reads ──────────────────────
 	"adminStats.getCampaignProgression":
 		AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION,
+	"adminStats.getStepDurations": AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DURATIONS,
 
 	// ── gip mds ────────────────────────────────────────────
 	"gipMds.importFromUrl": AUDIT_ACTIONS.GIP_MDS_IMPORT,

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -155,11 +155,11 @@ export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
 		declaration_id:
 			"Référence vers la déclaration concernée. Append-only — chaque event capture une transition métier (submit / path_choice / *_submit / cse_opinion_submit / cancel / demarche_complete).",
 		event_type:
-			"Type d'event métier. Source de vérité de la trajectoire FSM (la colonne app_declaration.status est une projection dérivée du dernier event).",
+			"Type d'event métier. Source de vérité de la trajectoire FSM (la colonne app_declaration.status est une projection dérivée du dernier event). Inclut step_change pour les transitions du stepper Indicateurs A–F (alimente le KPI K4).",
 		value:
-			"Charge utile facultative selon le type d'event. Pour path_choice: 'justify' | 'corrective_action' | 'joint_evaluation'.",
+			"Charge utile facultative selon le type d'event. Pour path_choice: 'justify' | 'corrective_action' | 'joint_evaluation'. Pour step_change: 'from:N|to:M' (N peut être 'null' à la création).",
 		round:
-			"1 = première déclaration, 2 = seconde déclaration. Renseigné pour path_choice, second_declaration_submit, joint_evaluation_submit.",
+			"1 = première déclaration, 2 = seconde déclaration. Renseigné pour path_choice, second_declaration_submit, joint_evaluation_submit. Pour step_change : numéro de l'étape atteinte (toStep) — facilite l'agrégation côté SQL.",
 		actor_user_id:
 			"Auteur de l'event. NULL = event système (cron, demarche_complete, etc.).",
 		created_at:

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -40,6 +40,7 @@ export const declarationEventTypeEnum = pgEnum("declaration_event_type", [
 	"cse_opinion_submit",
 	"cancel",
 	"demarche_complete",
+	"step_change",
 ]);
 
 export const users = createTable("user", (d) => ({


### PR DESCRIPTION
Closes #3217

## Summary

Implements the K4 « délai moyen par étape » KPI on the admin stats dashboard (`/admin/stats/campagne`) — médiane et p90 du temps passé par les déclarations sur chaque étape du parcours indicateurs A–F, **étendu** aux jalons post-soumission (choix conformité, action, avis CSE).

Approche retenue (override du body original) : on ne crée **pas** la table `declarationLogs` proposée dans le body — on étend l'enum `declarationEventTypeEnum` existant avec `step_change` et on loggue les transitions dans `declarationStatusHistory` (single source of truth pour la trajectoire de la déclaration). Encodage : `value = "from:N|to:M"` + `round = toStep` (clé d'agrégation SQL).

## Changes

- **Schéma + migration** (`0036_add_step_change_event_type.sql`) : ajout de `step_change` à `declarationEventTypeEnum`. Migration appliquée en local.
- **Domain** : `DECLARATION_STEPS` + `getStepLabel()` dans `~/modules/domain/shared/declarationSteps.ts`, re-exportés via le barrel. Tests 100 %.
- **Helper** : `buildStepChangeInsert()` dans `statusHistoryHelpers.ts` — encode `fromStep` / `toStep` / `actorUserId` dans la ligne d'historique.
- **Instrumentation** : les 7 points qui mutent `currentStep` dans `declaration.ts` (creation step 0, updateStep1..4, updateEmployeeCategories step 5, submit step 6) insèrent un `step_change` dans la même transaction Drizzle, **uniquement quand le step change** (idempotent pour les re-saves).
- **tRPC** : nouvelle procédure `adminStats.getStepDurations` — CTE + `LEAD(changed_at) OVER (PARTITION BY declaration_id …)` + `percentile_cont(0.5/0.9) WITHIN GROUP` avec `FILTER (WHERE next_changed_at IS NOT NULL)`. Filtre `year` obligatoire + `sizeRange` optionnel. Médiane/p90 = `null` si `completedSampleSize < 5`. **Step 6 (Récapitulatif) exclu** du résultat wizard car terminal state sans `step_change` suivant — voir Scope extension ci-dessous.
- **Audit logging** : `ADMIN_STATS_GET_STEP_DURATIONS` en catégorie `read_sensitive`, entry dans `PROCEDURE_TO_ACTION`.
- **UI** :
  - `<StepDurationsChart>` : Recharts `<BarChart layout="vertical">`, une paire de barres par étape (médiane + p90) avec tokens DSFR `--background-action-high-blue-france` et `--background-action-low-blue-france`. Custom tooltip FR : « médiane X j — p90 Y j sur N déclarations ».
  - `<StepDurationsTable>` : alternative accessible (`<details>` + `<table>` avec `scope` + caption SR-only), même pattern que `CampaignProgressionTable`.
  - Intégration dans `CampaignStatsPage` en nouvelle section (partage du filtre tranche d'effectif, prend la première année sélectionnée).

## Tests

| Scénario | Test |
|---|---|
| S1 — insertion log à chaque transition | `declaration.test.ts` → « inserts a step_change row when updateStep1 advances from step 0 » |
| S2 — pas de log si idempotent | `declaration.test.ts` → « does not insert a step_change row when the new step equals the existing one » |
| S3 — médiane / p90 corrects | `adminStats.test.ts` → « maps SQL rows to the typed output and attaches French labels » |
| S4 — étape jamais terminée | `adminStats.test.ts` → « excludes declarations still on a step from the percentile » |
| S5 — filtre sizeRange | `adminStats.test.ts` → « passes a workforce filter into the SQL when sizeRange is provided » |
| S6 — UI render | `StepDurationsChart.test.tsx` + `StepDurationsTable.test.tsx` |
| S7 — bornes de l'input year | `adminStats.test.ts` → « validates the year input bounds » |
| S8 — échantillon < 5 → null | `adminStats.test.ts` → « returns null percentiles when fewer than 5 declarations have exited the step » |
| S-K4-9 — nominal post-submit | `adminStats.test.ts` → « maps post-submit milestone rows to the typed output with FR labels » |
| S-K4-10 — sous-ensembles cohérents | `adminStats.test.ts` → « keeps milestones independent: empty sub-set does not blank out the others » |
| S-K4-12 — fallback n < 5 (post-submit) | `adminStats.test.ts` → « returns null percentiles for milestones with completedSampleSize < 5 » |
| S-K4-13 — sample size 0 | `adminStats.test.ts` → « renders milestones with no data as zero-sample / null-percentile rows » |
| S-K4-14 — split second_declaration / joint_evaluation | `adminStats.test.ts` → « surfaces second_declaration and joint_evaluation as two separate post-submit lines » |
| S-K4-15 — exclusion step 6 (Récapitulatif) | `adminStats.test.ts` → « never returns a wizard row with step === 6 » |
| S-K4-16 — fusion rounds joint_evaluation | `adminStats.test.ts` → « aggregates initial and revision joint-evaluation cycles under a single milestone » |

`pnpm test` : **1984 tests verts**. `pnpm typecheck` / `pnpm lint:check` / `pnpm format:check` verts.

## Decisions à signaler

- **Pas de table `declarationLogs`** comme proposé initialement dans le body : on réutilise `declarationStatusHistory` pour ne pas dupliquer la source de vérité de la trajectoire métier. Coût : valeurs encodées sous forme de string (`from:N|to:M`), parsing dans `value` si jamais on a besoin de la transition exacte (le SQL d'agrégation utilise seulement `round` qui contient `toStep`).
- **Idempotence** : on n'insère un `step_change` que si `previousStep !== toStep`. Si un utilisateur re-sauve l'étape 3 deux fois, on n'aura **pas** deux logs — le SQL d'agrégation reste correct mais le sample size ne compte pas les re-saves.
- **Pas de `SELECT FOR UPDATE`** sur la lecture du previous step : on est déjà dans une `db.transaction`, le risque de race sur la même déclaration (même utilisateur) est négligeable. Si ça devient un problème, on pourra ajouter `.for("update")` plus tard.

## Scope extension (2026-05-21)

Le body original de #3217 incluait dans sa maquette des étapes **post-soumission** (Plan d'action, Confirmation, Démarche complète) qui ne faisaient pas partie du wizard A–F. La première itération de la PR couvrait uniquement les 7 étapes du wizard — gap réel par rapport à la spec d'origine. Cette extension complète le KPI avec **4 jalons post-submit**, chacun mesuré par sa propre CTE :

| # | `key` | Libellé FR | Définition (start → end) | Sous-ensemble |
|---|---|---|---|---|
| 1 | `submit_to_path_choice` | Délai avant choix du parcours | `step_change round=6` → `path_choice round=1` | Déclarations avec choix conformité (= alerte ≥ 5 %) |
| 2 | `path_choice_to_second_declaration` | Temps passé sur la seconde déclaration | `path_choice round=1` → MIN(`second_declaration_submit`) | Déclarations avec path_choice round=1 ET seconde déclaration soumise |
| 3 | `path_choice_to_joint_evaluation` | Temps passé sur l'évaluation conjointe | Pour chaque round (1 ou 2) : `path_choice` → `joint_evaluation_submit` du **même round** | Déclarations avec au moins un cycle path_choice → joint_eval terminé (round 1 et / ou round 2) |
| 4 | `action_to_cse_opinion` | Temps passé sur l'avis CSE | MAX(action) → `cse_opinion_submit` | Déclarations avec avis CSE (≥ 100 salariés) |

> Note : sur la 1ʳᵉ vague une déclaration ne peut emprunter qu'**un seul** des deux parcours (corrective_action → `second_declaration_submit`, ou joint_evaluation → `joint_evaluation_submit round=1`), donc les sous-ensembles 2 et 3 sont disjoints sur le round 1 — pas de double-comptage. Sur le jalon 3, une déclaration qui a fait à la fois le cycle initial (round=1) et le cycle révision (round=2) contribue **deux durées** au compteur — l'agrégat reflète le nombre de durées observées, pas le nombre de déclarations distinctes (volontairement, pour des percentiles plus fins).

### Pourquoi cette consolidation à 4 jalons (vs. 6 dans la version initiale)

Deux jalons précédemment exposés ont été retirés :

- **`revision_choice_to_action`** (« Choix révision → action de révision ») — fondu dans `Temps passé sur l'évaluation conjointe`. La FSM réelle (`server/rules/v2027.1.json`) ne distingue pas un jalon « révision » à part : un round=2 path_choice mène à un round=2 joint_evaluation_submit, exactement comme le round=1, mais avec moins de données. Regrouper les deux rounds sous un seul jalon donne un échantillon plus stable pour les percentiles **et** un libellé plus parlant pour le métier (« le temps moyen passé sur l'évaluation conjointe », tous cycles confondus).
- **`last_action_to_complete`** (« Dernière action → démarche complète ») — retiré entièrement. `demarche_complete` est émis dans la **même transaction** que la dernière action utilisateur (cf. `server/rules/v2027.1.json` — `submit-completion` transitions), donc cette durée vaudrait toujours ~0. Aucune valeur business à l'afficher.

Côté libellés, le pattern « Temps passé sur » remplace la flèche d'origine pour être plus immédiat à lire (« Temps passé sur l'avis CSE » vs. « Action → avis CSE »).

### Exclusion du step 6 (Récapitulatif)

Le step 6 du wizard correspond au moment de la soumission de la déclaration — c'est un **état terminal**, pas une étape avec une durée mesurable. Le SQL utilise `LEAD(created_at)` sur les `step_change` events pour calculer la durée passée sur chaque étape, mais aucun `step_change` ne suit l'étape 6 (les events post-submit sont `submit`, `path_choice`, etc., **pas** `step_change`). Le `LEAD()` retourne donc systématiquement `NULL` pour step 6 → la barre apparaissait vide dans le chart, ce qui était confusant pour l'utilisateur final.

`getStepDurations` retourne désormais **6 lignes wizard (steps 0 à 5) + 4 jalons post-submit = 10 lignes** au lieu de 7 + 6. Filtre appliqué en SQL (`WHERE step < 6` dans la CTE wizard) **et** côté iteration `DECLARATION_STEPS`. La constante `DECLARATION_STEPS` reste inchangée — step 6 reste utilisé par le declaration wizard, la navigation et tout autre consumer ; on filtre uniquement à la lecture pour K4 (cohérent avec K5 #3218).

### Décisions de design

- **Type de sortie** : `StepDurationRow` gagne `key: string` (stable id) + `phase: "wizard" | "post_submit"`. `step: number | null` (null en post-submit). Consumers peuvent split par `phase`.
- **Constante domaine** : `POST_SUBMIT_MILESTONES` ajoutée dans `~/modules/domain/shared/declarationSteps.ts` (4 entrées ordonnées). `DECLARATION_STEPS` inchangée.
- **Procédure** : `adminStats.getStepDurations` étendue — pas renommée (on étend, on ne casse pas le contrat). Retourne 10 lignes : 6 wizard (steps 0..5) + 4 post-submit.
- **Chart** : single `BarChart` continu, `<Cell>` par phase pour différencier les couleurs (blue-france pour wizard, red-marianne pour post-submit). Hauteur passée à 640px pour absorber les lignes additionnelles.
- **Table** : split en 2 `<tbody>` avec rowgroup headers (« Parcours initial (wizard A–F) » et « Démarche post-soumission ») — meilleure lecture screen-reader.
- **Fallback statistique** : même seuil `STEP_DURATION_MIN_SAMPLE = 5` que pour les wizard. Sous le seuil → `medianDays: null, p90Days: null`, mais `sampleSize` reste visible.
- **Filtres** : `year` et `sizeRange` propagés à chacune des 4 CTE post-submit (mêmes joins `declarations` + `companies` + `cancelled_at IS NULL`).

### E2E

`admin-stats-campagne.e2e.ts` étendu : nouveau test qui ouvre la section K4, déplie la table, vérifie la présence des 2 group headers et d'au moins une ligne par phase (« Introduction » + « Délai avant choix du parcours » + « Temps passé sur l'avis CSE »).

## Test plan

- [ ] CI build vert sur la PR
- [ ] Lighthouse a11y 100% sur `/admin/stats/campagne`
- [ ] Vérification visuelle en review : le chart affiche bien 10 barres avec différenciation visuelle entre wizard (blue-france) et post-submit (red-marianne), table avec 2 group headers, tooltip dynamique (« étape » vs « jalon »)
- [ ] Données réelles en review app : seed quelques déclarations avec cycle complet pour valider que les 4 jalons renvoient des valeurs sensibles (sample > 5 pour au moins quelques jalons)

Refs : analyse architecte sur #3217 (https://github.com/SocialGouv/egapro/issues/3217#issuecomment-4497052593), parent epic #3213.
