### PR TITLE
T6 — Brancher CSE Opinion (Step1/Step2) sur useDeclarationDraft

### DIFF
--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -41,6 +41,8 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 				}
 				hasSecondDeclaration={hasSecondDeclaration}
 				initialData={initialData}
+				siren={declarationData.declaration.siren}
+				year={declarationData.declaration.year}
 			/>
 		);
 	}
@@ -56,6 +58,7 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 				declarationYear={declarationData.declaration.year}
 				existingFiles={files}
 				hasSecondDeclaration={hasSecondDeclaration}
+				siren={declarationData.declaration.siren}
 			/>
 		);
 	}

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo } from "react";
 import { Controller } from "react-hook-form";
 
 import { useReadOnlyGuard } from "~/modules/auth";
+import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { getCurrentYear } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
@@ -19,6 +21,8 @@ import type { OpinionType } from "./types";
 
 type Props = {
 	cseDeadline: Date;
+	siren: string;
+	year: number;
 	initialData?: {
 		firstDeclAccuracyOpinion: OpinionType | null;
 		firstDeclAccuracyDate: string | null;
@@ -38,6 +42,8 @@ type Props = {
 
 export function Step1Opinions({
 	cseDeadline,
+	siren,
+	year,
 	initialData,
 	email,
 	firstDeclarationPathChoice,
@@ -46,6 +52,37 @@ export function Step1Opinions({
 	const isJointEvaluation = firstDeclarationPathChoice === "joint_evaluation";
 	const router = useRouter();
 	const readOnlyGuard = useReadOnlyGuard();
+
+	const dbValues = useMemo(
+		() => ({
+			firstDeclaration: {
+				accuracyOpinion: initialData?.firstDeclAccuracyOpinion ?? undefined,
+				accuracyDate: initialData?.firstDeclAccuracyDate ?? "",
+				gapConsulted: initialData?.firstDeclGapConsulted ?? undefined,
+				gapOpinion: initialData?.firstDeclGapOpinion ?? null,
+				gapDate: initialData?.firstDeclGapDate ?? null,
+			},
+			secondDeclaration: hasSecondDeclaration
+				? {
+						accuracyOpinion:
+							initialData?.secondDeclAccuracyOpinion ?? undefined,
+						accuracyDate: initialData?.secondDeclAccuracyDate ?? "",
+						gapConsulted: initialData?.secondDeclGapConsulted ?? undefined,
+						gapOpinion: initialData?.secondDeclGapOpinion ?? null,
+						gapDate: initialData?.secondDeclGapDate ?? null,
+					}
+				: undefined,
+		}),
+		[initialData, hasSecondDeclaration],
+	);
+
+	const { draft, setField, isLoadingDraft } = useDeclarationDraft({
+		siren,
+		year,
+		step: "opinions",
+		kind: "cse",
+		dbValues,
+	});
 
 	const form = useZodForm(saveOpinionsSchema, {
 		defaultValues: {
@@ -69,12 +106,54 @@ export function Step1Opinions({
 		},
 	});
 
+	useEffect(() => {
+		if (isLoadingDraft) return;
+		const fd = draft.firstDeclaration;
+		if (fd) {
+			if (fd.accuracyOpinion !== undefined)
+				form.setValue("firstDeclaration.accuracyOpinion", fd.accuracyOpinion);
+			if (fd.accuracyDate !== undefined)
+				form.setValue("firstDeclaration.accuracyDate", fd.accuracyDate);
+			if (fd.gapConsulted !== undefined)
+				form.setValue("firstDeclaration.gapConsulted", fd.gapConsulted);
+			if (fd.gapOpinion !== undefined)
+				form.setValue("firstDeclaration.gapOpinion", fd.gapOpinion);
+			if (fd.gapDate !== undefined)
+				form.setValue("firstDeclaration.gapDate", fd.gapDate);
+		}
+		if (hasSecondDeclaration) {
+			const sd = draft.secondDeclaration;
+			if (sd) {
+				if (sd.accuracyOpinion !== undefined)
+					form.setValue(
+						"secondDeclaration.accuracyOpinion",
+						sd.accuracyOpinion,
+					);
+				if (sd.accuracyDate !== undefined)
+					form.setValue("secondDeclaration.accuracyDate", sd.accuracyDate);
+				if (sd.gapConsulted !== undefined)
+					form.setValue("secondDeclaration.gapConsulted", sd.gapConsulted);
+				if (sd.gapOpinion !== undefined)
+					form.setValue("secondDeclaration.gapOpinion", sd.gapOpinion);
+				if (sd.gapDate !== undefined)
+					form.setValue("secondDeclaration.gapDate", sd.gapDate);
+			}
+		}
+	}, [isLoadingDraft, draft, form, hasSecondDeclaration]);
+
+	const triggerDraftSave = useCallback(() => {
+		const values = form.getValues();
+		setField({
+			firstDeclaration: values.firstDeclaration,
+			secondDeclaration: values.secondDeclaration,
+		});
+	}, [form, setField]);
+
 	const mutation = api.cseOpinion.saveOpinions.useMutation({
 		onSuccess: () => router.push("/avis-cse/etape/2"),
 	});
 
 	const onSubmit = form.handleSubmit((data) => {
-		// Additional validation for conditional gap fields
 		const firstGapIncomplete =
 			data.firstDeclaration.gapConsulted === true &&
 			(!data.firstDeclaration.gapOpinion || !data.firstDeclaration.gapDate);
@@ -100,7 +179,6 @@ export function Step1Opinions({
 		mutation.mutate(data);
 	});
 
-	// Watch fields for controlled sub-components
 	const firstDeclOpinion = form.watch("firstDeclaration.accuracyOpinion");
 	const firstDeclDate = form.watch("firstDeclaration.accuracyDate");
 	const firstDeclGapOpinion = form.watch("firstDeclaration.gapOpinion");
@@ -109,6 +187,10 @@ export function Step1Opinions({
 	const secondDeclDate = form.watch("secondDeclaration.accuracyDate");
 	const secondDeclGapOpinion = form.watch("secondDeclaration.gapOpinion");
 	const secondDeclGapDate = form.watch("secondDeclaration.gapDate");
+
+	if (isLoadingDraft) {
+		return <p>Chargement...</p>;
+	}
 
 	return (
 		<form onSubmit={onSubmit}>
@@ -155,12 +237,14 @@ export function Step1Opinions({
 				<AccuracyOpinionCard
 					date={firstDeclDate ?? ""}
 					id="first-decl-accuracy"
-					onDateChange={(v) =>
-						form.setValue("firstDeclaration.accuracyDate", v)
-					}
-					onOpinionChange={(v) =>
-						form.setValue("firstDeclaration.accuracyOpinion", v)
-					}
+					onDateChange={(v) => {
+						form.setValue("firstDeclaration.accuracyDate", v);
+						triggerDraftSave();
+					}}
+					onOpinionChange={(v) => {
+						form.setValue("firstDeclaration.accuracyOpinion", v);
+						triggerDraftSave();
+					}}
 					opinion={firstDeclOpinion ?? null}
 					title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
 				/>
@@ -173,11 +257,18 @@ export function Step1Opinions({
 							consulted={field.value ?? null}
 							date={firstDeclGapDate ?? ""}
 							id="first-decl-gap"
-							onConsultedChange={field.onChange}
-							onDateChange={(v) => form.setValue("firstDeclaration.gapDate", v)}
-							onOpinionChange={(v) =>
-								form.setValue("firstDeclaration.gapOpinion", v)
-							}
+							onConsultedChange={(v) => {
+								field.onChange(v);
+								triggerDraftSave();
+							}}
+							onDateChange={(v) => {
+								form.setValue("firstDeclaration.gapDate", v);
+								triggerDraftSave();
+							}}
+							onOpinionChange={(v) => {
+								form.setValue("firstDeclaration.gapOpinion", v);
+								triggerDraftSave();
+							}}
 							opinion={firstDeclGapOpinion ?? null}
 						/>
 					)}
@@ -192,12 +283,14 @@ export function Step1Opinions({
 						<AccuracyOpinionCard
 							date={secondDeclDate ?? ""}
 							id="second-decl-accuracy"
-							onDateChange={(v) =>
-								form.setValue("secondDeclaration.accuracyDate", v)
-							}
-							onOpinionChange={(v) =>
-								form.setValue("secondDeclaration.accuracyOpinion", v)
-							}
+							onDateChange={(v) => {
+								form.setValue("secondDeclaration.accuracyDate", v);
+								triggerDraftSave();
+							}}
+							onOpinionChange={(v) => {
+								form.setValue("secondDeclaration.accuracyOpinion", v);
+								triggerDraftSave();
+							}}
 							opinion={secondDeclOpinion ?? null}
 							title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
 						/>
@@ -210,13 +303,18 @@ export function Step1Opinions({
 									consulted={field.value ?? null}
 									date={secondDeclGapDate ?? ""}
 									id="second-decl-gap"
-									onConsultedChange={field.onChange}
-									onDateChange={(v) =>
-										form.setValue("secondDeclaration.gapDate", v)
-									}
-									onOpinionChange={(v) =>
-										form.setValue("secondDeclaration.gapOpinion", v)
-									}
+									onConsultedChange={(v) => {
+										field.onChange(v);
+										triggerDraftSave();
+									}}
+									onDateChange={(v) => {
+										form.setValue("secondDeclaration.gapDate", v);
+										triggerDraftSave();
+									}}
+									onOpinionChange={(v) => {
+										form.setValue("secondDeclaration.gapOpinion", v);
+										triggerDraftSave();
+									}}
 									opinion={secondDeclGapOpinion ?? null}
 								/>
 							)}

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -2,9 +2,10 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { useReadOnlyGuard } from "~/modules/auth";
+import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { FileUpload, getDsfrModal, useFileUploadForm } from "~/modules/shared";
 import { api } from "~/trpc/react";
@@ -17,12 +18,14 @@ import { MAX_CSE_FILES, type UploadedFile } from "./types";
 
 type Props = {
 	declarationYear: number;
+	siren: string;
 	hasSecondDeclaration?: boolean;
 	existingFiles?: UploadedFile[];
 };
 
 export function Step2Upload({
 	declarationYear,
+	siren,
 	hasSecondDeclaration = true,
 	existingFiles = [],
 }: Props) {
@@ -31,6 +34,15 @@ export function Step2Upload({
 	const [deletingFileId, setDeletingFileId] = useState<string | null>(null);
 	const [finalizeError, setFinalizeError] = useState<string | null>(null);
 	const readOnlyGuard = useReadOnlyGuard();
+
+	const emptyDbValues = useMemo(() => ({}), []);
+	useDeclarationDraft({
+		siren,
+		year: declarationYear,
+		step: "upload",
+		kind: "cse",
+		dbValues: emptyDbValues,
+	});
 
 	const refreshFileList = useCallback(() => {
 		void utils.cseOpinion.getFiles.invalidate();

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -3,6 +3,26 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Step1Opinions } from "../Step1Opinions";
 
+const { mockSetField, mockClearDraft, mockUseDeclarationDraft } = vi.hoisted(
+	() => {
+		const mockSetField = vi.fn();
+		const mockClearDraft = vi.fn();
+		const mockUseDeclarationDraft = vi.fn(() => ({
+			draft: {} as Record<string, unknown>,
+			setField: mockSetField,
+			clearDraft: mockClearDraft,
+			hasDraft: false,
+			isLoadingDraft: false,
+		}));
+		return { mockSetField, mockClearDraft, mockUseDeclarationDraft };
+	},
+);
+
+vi.mock(
+	"~/modules/declaration-remuneration/shared/draft/useDeclarationDraft",
+	() => ({ useDeclarationDraft: mockUseDeclarationDraft }),
+);
+
 const mockPush = vi.fn();
 const cseDeadline = new Date("2028-02-01T00:00:00");
 
@@ -43,6 +63,15 @@ vi.mock("~/trpc/react", () => ({
 beforeEach(() => {
 	mockPush.mockClear();
 	mockMutate.mockClear();
+	mockSetField.mockClear();
+	mockClearDraft.mockClear();
+	mockUseDeclarationDraft.mockReturnValue({
+		draft: {},
+		setField: mockSetField,
+		clearDraft: mockClearDraft,
+		hasDraft: false,
+		isLoadingDraft: false,
+	});
 });
 
 describe("Step1Opinions", () => {
@@ -51,6 +80,8 @@ describe("Step1Opinions", () => {
 			<Step1Opinions
 				cseDeadline={cseDeadline}
 				firstDeclarationPathChoice="joint_evaluation"
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
@@ -66,6 +97,8 @@ describe("Step1Opinions", () => {
 			<Step1Opinions
 				cseDeadline={cseDeadline}
 				firstDeclarationPathChoice="justify"
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
@@ -77,21 +110,30 @@ describe("Step1Opinions", () => {
 	});
 
 	it("renders h1 as CSE opinion title when no compliance path banner", () => {
-		render(<Step1Opinions cseDeadline={cseDeadline} />);
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		const heading = screen.getByRole("heading", { level: 1 });
 		expect(heading).toHaveTextContent("Transmettre l'avis ou les avis du CSE");
 	});
 
 	it("renders the stepper at step 1", () => {
-		render(<Step1Opinions cseDeadline={cseDeadline} />);
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		expect(screen.getByText(/Étape 1 sur 2/)).toBeInTheDocument();
 	});
 
 	it("renders both declaration sections when hasSecondDeclaration is true", () => {
 		render(
-			<Step1Opinions cseDeadline={cseDeadline} hasSecondDeclaration={true} />,
+			<Step1Opinions
+				cseDeadline={cseDeadline}
+				hasSecondDeclaration={true}
+				siren="123456789"
+				year={2026}
+			/>,
 		);
 
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
@@ -100,7 +142,12 @@ describe("Step1Opinions", () => {
 
 	it("hides second declaration section when hasSecondDeclaration is false", () => {
 		render(
-			<Step1Opinions cseDeadline={cseDeadline} hasSecondDeclaration={false} />,
+			<Step1Opinions
+				cseDeadline={cseDeadline}
+				hasSecondDeclaration={false}
+				siren="123456789"
+				year={2026}
+			/>,
 		);
 
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
@@ -112,6 +159,8 @@ describe("Step1Opinions", () => {
 			<Step1Opinions
 				cseDeadline={cseDeadline}
 				firstDeclarationPathChoice="joint_evaluation"
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
@@ -123,7 +172,9 @@ describe("Step1Opinions", () => {
 	});
 
 	it("does not render the submission banner for other paths", () => {
-		render(<Step1Opinions cseDeadline={cseDeadline} />);
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		expect(
 			screen.queryByText(
@@ -133,7 +184,9 @@ describe("Step1Opinions", () => {
 	});
 
 	it("renders previous and next buttons", () => {
-		render(<Step1Opinions cseDeadline={cseDeadline} />);
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		expect(
 			screen.getByRole("button", { name: /Précédent/ }),
@@ -143,7 +196,9 @@ describe("Step1Opinions", () => {
 
 	it("shows validation error when submitting empty form", async () => {
 		const user = userEvent.setup();
-		render(<Step1Opinions cseDeadline={cseDeadline} />);
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		await user.click(screen.getByRole("button", { name: /Suivant/ }));
 
@@ -171,6 +226,8 @@ describe("Step1Opinions", () => {
 					secondDeclGapOpinion: null,
 					secondDeclGapDate: null,
 				}}
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
@@ -213,6 +270,8 @@ describe("Step1Opinions", () => {
 					secondDeclGapOpinion: null,
 					secondDeclGapDate: null,
 				}}
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
@@ -247,16 +306,18 @@ describe("Step1Opinions", () => {
 					secondDeclGapOpinion: null,
 					secondDeclGapDate: null,
 				}}
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
 		// First declaration accuracy radios
 		const favorableRadios = screen.getAllByLabelText("Favorable");
-		expect(favorableRadios[0]).toBeChecked();
+		expect(favorableRadios[0]!).toBeChecked();
 
 		// Second declaration accuracy radios
 		const unfavorableRadios = screen.getAllByLabelText("Défavorable");
-		expect(unfavorableRadios[1]).toBeChecked();
+		expect(unfavorableRadios[1]!).toBeChecked();
 	});
 
 	it("displays email in submission banner for joint_evaluation path", () => {
@@ -265,6 +326,8 @@ describe("Step1Opinions", () => {
 				cseDeadline={cseDeadline}
 				email="test@example.fr"
 				firstDeclarationPathChoice="joint_evaluation"
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
@@ -276,9 +339,84 @@ describe("Step1Opinions", () => {
 			<Step1Opinions
 				cseDeadline={cseDeadline}
 				firstDeclarationPathChoice="joint_evaluation"
+				siren="123456789"
+				year={2026}
 			/>,
 		);
 
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
+	});
+
+	describe("draft integration", () => {
+		it("hydrates form from draft when available", () => {
+			mockUseDeclarationDraft.mockReturnValue({
+				draft: {
+					firstDeclaration: {
+						accuracyOpinion: "favorable",
+						accuracyDate: "",
+						gapConsulted: undefined,
+						gapOpinion: null,
+						gapDate: null,
+					},
+				},
+				setField: mockSetField,
+				clearDraft: mockClearDraft,
+				hasDraft: true,
+				isLoadingDraft: false,
+			});
+
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			const favorableRadios = screen.getAllByLabelText("Favorable");
+			expect(favorableRadios[0]!).toBeChecked();
+		});
+
+		it("shows loading state while draft is loading", () => {
+			mockUseDeclarationDraft.mockReturnValue({
+				draft: {},
+				setField: mockSetField,
+				clearDraft: mockClearDraft,
+				hasDraft: false,
+				isLoadingDraft: true,
+			});
+
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			expect(screen.getByText("Chargement...")).toBeInTheDocument();
+			expect(
+				screen.queryByText("Première déclaration"),
+			).not.toBeInTheDocument();
+		});
+
+		it("calls setField when a radio is changed", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getAllByLabelText("Favorable")[0]!);
+
+			expect(mockSetField).toHaveBeenCalled();
+			const callArg = mockSetField.mock.calls[
+				mockSetField.mock.calls.length - 1
+			]?.[0] as { firstDeclaration?: { accuracyOpinion?: string } } | undefined;
+			expect(callArg?.firstDeclaration?.accuracyOpinion).toBe("favorable");
+		});
 	});
 });

--- a/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
@@ -102,7 +102,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the page title", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		expect(
 			screen.getByText("Transmettre l'avis ou les avis du CSE"),
@@ -110,13 +110,13 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the stepper at step 2", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		expect(screen.getByText(/Étape 2 sur 2/)).toBeInTheDocument();
 	});
 
 	it("renders the file upload instructions", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		expect(
 			screen.getByText(/Veuillez importer l'ensemble des avis de votre CSE/),
@@ -125,7 +125,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the dropzone with select button", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		expect(
 			screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
@@ -134,7 +134,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders a hidden file input", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const fileInput = getFileInput();
 		expect(fileInput).toBeInTheDocument();
@@ -143,7 +143,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the opinion summary box", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		expect(screen.getByText("Avis CSE à transmettre :")).toBeInTheDocument();
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
@@ -151,7 +151,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders previous link and add file button", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const previousLink = screen.getByRole("link", { name: /Précédent/ });
 		expect(previousLink).toBeInTheDocument();
@@ -164,7 +164,7 @@ describe("Step2Upload", () => {
 
 	it("shows error when submitting without file", async () => {
 		const user = userEvent.setup();
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		await user.click(screen.getByRole("button", { name: /Soumettre/ }));
 
@@ -177,7 +177,7 @@ describe("Step2Upload", () => {
 
 	it("sets aria-invalid on file input when error occurs", async () => {
 		const user = userEvent.setup();
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const fileInput = getFileInput();
 		expect(fileInput).toHaveAttribute("aria-invalid", "false");
@@ -188,7 +188,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("shows error for non-PDF file", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const file = new File(["content"], "test.txt", { type: "text/plain" });
 		const fileInput = getFileInput();
@@ -203,7 +203,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("shows error for file exceeding 10 MB", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const largeContent = new ArrayBuffer(11 * 1024 * 1024);
 		const file = new File([largeContent], "large.pdf", {
@@ -219,7 +219,9 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the confirmation modal dialog", () => {
-		const { container } = render(<Step2Upload declarationYear={2025} />);
+		const { container } = render(
+			<Step2Upload declarationYear={2026} siren="123456789" />,
+		);
 
 		const dialog = container.querySelector("dialog");
 		expect(dialog).toBeInTheDocument();
@@ -227,7 +229,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("accepts PDF file and shows file card", () => {
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const file = new File(["content"], "avis-cse.pdf", {
 			type: "application/pdf",
@@ -245,7 +247,7 @@ describe("Step2Upload", () => {
 
 	it("removes file when delete button is clicked", async () => {
 		const user = userEvent.setup();
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const file = new File(["content"], "avis-cse.pdf", {
 			type: "application/pdf",
@@ -267,7 +269,8 @@ describe("Step2Upload", () => {
 	it("shows existing file cards when files are provided", () => {
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[
 					makeFile("avis-1.pdf", "file-1"),
 					makeFile("avis-2.pdf", "file-2"),
@@ -283,7 +286,8 @@ describe("Step2Upload", () => {
 	it("renders a view link for each existing file", () => {
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[
 					makeFile("avis-1.pdf", "file-1"),
 					makeFile("avis-2.pdf", "file-2"),
@@ -301,7 +305,8 @@ describe("Step2Upload", () => {
 	it("shows submit button when files exist but under limit", () => {
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
 			/>,
 		);
@@ -314,7 +319,8 @@ describe("Step2Upload", () => {
 	it("shows file count in hint text", () => {
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[
 					makeFile("avis-1.pdf", "file-1"),
 					makeFile("avis-2.pdf", "file-2"),
@@ -328,7 +334,8 @@ describe("Step2Upload", () => {
 	it("disables dropzone when max files reached", () => {
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[
 					makeFile("avis-1.pdf", "f1"),
 					makeFile("avis-2.pdf", "f2"),
@@ -355,7 +362,7 @@ describe("Step2Upload", () => {
 			fileName: "avis.pdf",
 		});
 
-		render(<Step2Upload declarationYear={2025} />);
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const file = new File(["content"], "avis.pdf", {
 			type: "application/pdf",
@@ -389,7 +396,8 @@ describe("Step2Upload", () => {
 		const user = userEvent.setup();
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
 			/>,
 		);
@@ -417,7 +425,8 @@ describe("Step2Upload", () => {
 
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
 			/>,
 		);
@@ -437,7 +446,8 @@ describe("Step2Upload", () => {
 	it("invalidates the file list and clears the deleting state on delete success", () => {
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
 			/>,
 		);
@@ -457,7 +467,8 @@ describe("Step2Upload", () => {
 	it("clears the deleting state when the delete mutation fails", () => {
 		render(
 			<Step2Upload
-				declarationYear={2025}
+				declarationYear={2026}
+				siren="123456789"
 				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
 			/>,
 		);


### PR DESCRIPTION
## Contexte

Ticket #3509 — partie de l'epic #3484.

Branche `Step1Opinions` et `Step2Upload` sur le hook `useDeclarationDraft` pour la persistance automatique des brouillons d'avis CSE.

## Changements

- **`Step1Opinions.tsx`** : intégration complète — `dbValues` mémorisés, `useDeclarationDraft` appelé avec `step: "opinions"`, `kind: "cse"`, hydratation du formulaire via `useEffect` gardé par `isLoadingDraft`, `triggerDraftSave` appelé sur chaque changement de champ, guard de chargement (`<p>Chargement...</p>`).
- **`Step2Upload.tsx`** : appel structurel du hook avec `step: "upload"`, `kind: "cse"`, `dbValues: {}` stable via `useMemo` (pas de `setField` nécessaire — pas de champs de formulaire au-delà de l'upload PDF).
- **`etape/[step]/page.tsx`** : passage des props `siren` et `year` aux deux composants.
- **`Step1Opinions.test.tsx`** : ajout de 3 tests draft (hydratation, état de chargement, `setField` sur changement), mise à jour de tous les renders avec `siren` et `year` requis, mock `useDeclarationDraft` via `vi.hoisted()`.
- **`Step2Upload.test.tsx`** : ajout de `siren` aux renders.

## Tests

- 92 tests cseOpinion passent
- 2005 tests total passent
- Typecheck, lint, format : verts

Closes #3509