### PR TITLE
T5 — Adapter les 9 consumers au hook async + E2E round-trip cache

### DIFF
--- a/packages/app/src/e2e/declarationDraft.e2e.ts
+++ b/packages/app/src/e2e/declarationDraft.e2e.ts
@@ -17,7 +17,14 @@ test.describe("Declaration draft round-trip", () => {
 				name: "Nombre de femmes",
 			});
 			await womenInput1.fill("75");
-			await page1.waitForTimeout(1200);
+
+			await page1.waitForResponse(
+				(r) =>
+					r.url().includes("declarationDraft.save") &&
+					r.request().method() === "POST" &&
+					r.status() === 200,
+				{ timeout: 10_000 },
+			);
 		} finally {
 			await ctx1.close();
 		}
@@ -31,7 +38,7 @@ test.describe("Declaration draft round-trip", () => {
 			const womenInput2 = page2.getByRole("textbox", {
 				name: "Nombre de femmes",
 			});
-			await expect(womenInput2).toHaveValue("75");
+			await expect(womenInput2).toHaveValue("75", { timeout: 10_000 });
 		} finally {
 			await ctx2.close();
 		}

--- a/packages/app/src/e2e/declarationDraft.e2e.ts
+++ b/packages/app/src/e2e/declarationDraft.e2e.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { AUTH_FILE } from "./helpers/login";
+
+test.describe("Declaration draft round-trip", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("S1 — restores workforce draft from a second browser context", async ({
+		browser,
+	}) => {
+		const ctx1 = await browser.newContext({ storageState: AUTH_FILE });
+		const page1 = await ctx1.newPage();
+		try {
+			await page1.goto("/declaration-remuneration/etape/1");
+			await page1.waitForURL("**/declaration-remuneration/etape/1");
+
+			const womenInput1 = page1.getByRole("textbox", {
+				name: "Nombre de femmes",
+			});
+			await womenInput1.fill("75");
+			await page1.waitForTimeout(1200);
+		} finally {
+			await ctx1.close();
+		}
+
+		const ctx2 = await browser.newContext({ storageState: AUTH_FILE });
+		const page2 = await ctx2.newPage();
+		try {
+			await page2.goto("/declaration-remuneration/etape/1");
+			await page2.waitForURL("**/declaration-remuneration/etape/1");
+
+			const womenInput2 = page2.getByRole("textbox", {
+				name: "Nombre de femmes",
+			});
+			await expect(womenInput2).toHaveValue("75");
+		} finally {
+			await ctx2.close();
+		}
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/DraftLoadingState.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/DraftLoadingState.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+export function DraftLoadingState() {
+	return (
+		<div aria-busy="true" aria-live="polite" className="fr-py-4w" role="status">
+			<p className="fr-mb-0 fr-text-mention--grey">
+				Chargement du brouillon en cours…
+			</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/DraftLoadingState.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/DraftLoadingState.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DraftLoadingState } from "../DraftLoadingState";
+
+describe("DraftLoadingState", () => {
+	it("renders an accessible loading status with French label", () => {
+		render(<DraftLoadingState />);
+		const status = screen.getByRole("status");
+		expect(status).toHaveAttribute("aria-live", "polite");
+		expect(status).toHaveAttribute("aria-busy", "true");
+		expect(status).toHaveTextContent(/Chargement du brouillon/i);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -278,6 +278,17 @@ describe("useDeclarationDraft", () => {
 		expect(clearMutateMock).not.toHaveBeenCalled();
 	});
 
+	it("reports isLoadingDraft=true while the session is loading", () => {
+		useSessionMock.mockReturnValue({
+			data: null,
+			status: "loading",
+			update: vi.fn(),
+		} as never);
+		queryState = { data: undefined, isLoading: false };
+		const { result } = renderDraftHook();
+		expect(result.current.isLoadingDraft).toBe(true);
+	});
+
 	it("is a no-op when the user is logged out", () => {
 		setSession({ userId: null });
 		queryState = { data: undefined, isLoading: true };

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDraftAutoSave.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDraftAutoSave.test.tsx
@@ -1,0 +1,67 @@
+import { renderHook } from "@testing-library/react";
+import type { FieldValues, UseFormReturn } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { useDraftAutoSave } from "../useDraftAutoSave";
+
+type TestValues = { name: string };
+
+function makeForm(): {
+	form: UseFormReturn<TestValues>;
+	emit: (values: TestValues) => void;
+	unsubscribe: ReturnType<typeof vi.fn>;
+} {
+	let watcher: ((values: TestValues) => void) | null = null;
+	const unsubscribe = vi.fn();
+	const watch = vi.fn((cb: (values: TestValues) => void) => {
+		watcher = cb;
+		return { unsubscribe };
+	});
+	return {
+		form: { watch } as unknown as UseFormReturn<TestValues>,
+		emit: (values) => watcher?.(values),
+		unsubscribe,
+	};
+}
+
+describe("useDraftAutoSave", () => {
+	it("does not subscribe while not ready", () => {
+		const { form } = makeForm();
+		const onChange = vi.fn();
+		renderHook(() => useDraftAutoSave(form, false, onChange));
+		expect((form.watch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+	});
+
+	it("subscribes and propagates values when ready", () => {
+		const { form, emit } = makeForm();
+		const onChange = vi.fn();
+		renderHook(() => useDraftAutoSave(form, true, onChange));
+		emit({ name: "alice" });
+		expect(onChange).toHaveBeenCalledWith({ name: "alice" });
+	});
+
+	it("unsubscribes on unmount", () => {
+		const { form, unsubscribe } = makeForm();
+		const { unmount } = renderHook(() => useDraftAutoSave(form, true, vi.fn()));
+		unmount();
+		expect(unsubscribe).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the latest onChange callback identity without re-subscribing", () => {
+		const { form, emit } = makeForm();
+		const first = vi.fn();
+		const second = vi.fn();
+		const { rerender } = renderHook(
+			({ onChange }: { onChange: (values: FieldValues) => void }) =>
+				useDraftAutoSave(form, true, onChange),
+			{ initialProps: { onChange: first } },
+		);
+		expect((form.watch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+
+		rerender({ onChange: second });
+		expect((form.watch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+
+		emit({ name: "bob" });
+		expect(first).not.toHaveBeenCalled();
+		expect(second).toHaveBeenCalledWith({ name: "bob" });
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDraftHydration.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDraftHydration.test.tsx
@@ -1,0 +1,56 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDraftHydration } from "../useDraftHydration";
+
+describe("useDraftHydration", () => {
+	it("does not call applyDraft while loading", () => {
+		const applyDraft = vi.fn();
+		const { result } = renderHook(() =>
+			useDraftHydration(true, { foo: "bar" }, applyDraft),
+		);
+		expect(result.current).toBe(false);
+		expect(applyDraft).not.toHaveBeenCalled();
+	});
+
+	it("calls applyDraft once when loading completes and returns true", () => {
+		const applyDraft = vi.fn();
+		const { result, rerender } = renderHook(
+			({ isLoading }) =>
+				useDraftHydration(isLoading, { foo: "bar" }, applyDraft),
+			{ initialProps: { isLoading: true } },
+		);
+		expect(result.current).toBe(false);
+
+		rerender({ isLoading: false });
+		expect(applyDraft).toHaveBeenCalledTimes(1);
+		expect(applyDraft).toHaveBeenCalledWith({ foo: "bar" });
+		expect(result.current).toBe(true);
+	});
+
+	it("does not re-apply draft when draft changes after hydration", () => {
+		const applyDraft = vi.fn();
+		const { rerender } = renderHook(
+			({ draft }) => useDraftHydration(false, draft, applyDraft),
+			{ initialProps: { draft: { foo: "a" } } },
+		);
+		expect(applyDraft).toHaveBeenCalledTimes(1);
+
+		rerender({ draft: { foo: "b" } });
+		expect(applyDraft).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses the latest applyDraft callback identity without re-firing", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		const { rerender } = renderHook(
+			({ apply }) => useDraftHydration(false, { foo: "x" }, apply),
+			{ initialProps: { apply: first } },
+		);
+		expect(first).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			rerender({ apply: second });
+		});
+		expect(second).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -59,6 +59,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 ): UseDeclarationDraftResult<T> {
 	const { siren, year, step, kind, dbValues } = options;
 	const session = useSession();
+	const isSessionLoading = session.status === "loading";
 	const userId = session.data?.user?.id ?? null;
 	const isImpersonating = Boolean(session.data?.user?.impersonation);
 	const isEnabled = userId !== null && !isImpersonating;
@@ -214,8 +215,16 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			setField,
 			clearDraft: clearDraftCallback,
 			hasDraft,
-			isLoadingDraft: isEnabled ? query.isLoading : false,
+			isLoadingDraft: isSessionLoading || (isEnabled && query.isLoading),
 		}),
-		[draft, setField, clearDraftCallback, hasDraft, query.isLoading, isEnabled],
+		[
+			draft,
+			setField,
+			clearDraftCallback,
+			hasDraft,
+			query.isLoading,
+			isEnabled,
+			isSessionLoading,
+		],
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDraftAutoSave.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDraftAutoSave.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { FieldValues, UseFormReturn } from "react-hook-form";
+
+export function useDraftAutoSave<TFieldValues extends FieldValues>(
+	form: UseFormReturn<TFieldValues>,
+	isReady: boolean,
+	onChange: (values: TFieldValues) => void,
+): void {
+	const onChangeRef = useRef(onChange);
+	onChangeRef.current = onChange;
+	useEffect(() => {
+		if (!isReady) return;
+		const sub = form.watch((values) =>
+			onChangeRef.current(values as TFieldValues),
+		);
+		return () => sub.unsubscribe();
+	}, [isReady, form]);
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDraftHydration.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDraftHydration.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export function useDraftHydration<T extends Record<string, unknown>>(
+	isLoadingDraft: boolean,
+	draft: Partial<T>,
+	applyDraft: (draft: Partial<T>) => void,
+): boolean {
+	const [hydrated, setHydrated] = useState(false);
+	const applyRef = useRef(applyDraft);
+	applyRef.current = applyDraft;
+
+	useEffect(() => {
+		if (isLoadingDraft || hydrated) return;
+		applyRef.current(draft);
+		setHydrated(true);
+	}, [isLoadingDraft, hydrated, draft]);
+
+	return hydrated;
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { Controller } from "react-hook-form";
 import { useIsImpersonating } from "~/modules/auth";
 import { saveCompliancePathSchema } from "~/modules/declaration-remuneration/schemas";
+import { DraftLoadingState } from "~/modules/declaration-remuneration/shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
+import { useDraftAutoSave } from "~/modules/declaration-remuneration/shared/draft/useDraftAutoSave";
+import { useDraftHydration } from "~/modules/declaration-remuneration/shared/draft/useDraftHydration";
 import type { CampaignDeadlines } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -48,30 +51,28 @@ export function CompliancePathChoice({
 
 	const dbValues = useMemo(() => ({ path: initialPath }), [initialPath]);
 
-	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
-		siren: declarationSiren,
-		year: declarationYear,
-		step: "compliance",
-		kind: "compliance",
-		dbValues,
-	});
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+		useDeclarationDraft({
+			siren: declarationSiren,
+			year: declarationYear,
+			step: "compliance",
+			kind: "compliance",
+			dbValues,
+		});
 
 	const form = useZodForm(saveCompliancePathSchema, {
 		defaultValues: { path: initialPath },
 	});
 
-	useEffect(() => {
-		if (draft.path !== undefined) {
-			form.setValue("path", draft.path as CompliancePathValue);
+	const draftHydrated = useDraftHydration(isLoadingDraft, draft, (d) => {
+		if (d.path !== undefined) {
+			form.setValue("path", d.path as CompliancePathValue);
 		}
-	}, [draft.path, form]);
+	});
 
-	useEffect(() => {
-		const sub = form.watch((values) =>
-			setField(values as { path: CompliancePathValue | undefined }),
-		);
-		return () => sub.unsubscribe();
-	}, [form, setField]);
+	useDraftAutoSave(form, draftHydrated, (values) =>
+		setField(values as { path: CompliancePathValue | undefined }),
+	);
 
 	const selectedPath = form.watch("path");
 	const hasInitialData = !!initialPath;
@@ -91,6 +92,8 @@ export function CompliancePathChoice({
 			}
 		},
 	});
+
+	if (!draftHydrated) return <DraftLoadingState />;
 
 	const onSubmit = form.handleSubmit((data) => {
 		if (!data.path) return;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -10,7 +10,9 @@ import { updateStep1Schema } from "../schemas";
 import common from "../shared/common.module.scss";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP1_CATEGORIES } from "../shared/devFillData";
+import { DraftLoadingState } from "../shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
+import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
@@ -49,13 +51,14 @@ export function Step1Workforce({
 		[initialData.totalWomen, initialData.totalMen],
 	);
 
-	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
-		siren: declarationSiren,
-		year: declarationYear,
-		step: 1,
-		kind: "main",
-		dbValues,
-	});
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+		useDeclarationDraft({
+			siren: declarationSiren,
+			year: declarationYear,
+			step: 1,
+			kind: "main",
+			dbValues,
+		});
 
 	const form = useZodForm(updateStep1Schema, {
 		defaultValues: dbValues,
@@ -65,14 +68,11 @@ export function Step1Workforce({
 	const totalMen = form.watch("totalMen");
 	const total = totalWomen + totalMen;
 
-	useEffect(() => {
-		if (typeof draft.totalWomen === "number") {
-			form.setValue("totalWomen", draft.totalWomen);
-		}
-		if (typeof draft.totalMen === "number") {
-			form.setValue("totalMen", draft.totalMen);
-		}
-	}, [draft.totalWomen, draft.totalMen, form]);
+	const draftHydrated = useDraftHydration(isLoadingDraft, draft, (d) => {
+		if (typeof d.totalWomen === "number")
+			form.setValue("totalWomen", d.totalWomen);
+		if (typeof d.totalMen === "number") form.setValue("totalMen", d.totalMen);
+	});
 
 	const saved = !hasDraft && hasInitialData;
 	const [validationError, setValidationError] = useState<string | null>(null);
@@ -108,6 +108,8 @@ export function Step1Workforce({
 		form.setValue("totalMen", value);
 		setField({ totalWomen, totalMen: value });
 	}
+
+	if (!draftHydrated) return <DraftLoadingState />;
 
 	const onSubmit = form.handleSubmit((data) => {
 		if (data.totalWomen + data.totalMen === 0) {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
@@ -11,7 +11,10 @@ import { updateStep2Schema } from "../schemas";
 import common from "../shared/common.module.scss";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP2_ROWS } from "../shared/devFillData";
+import { DraftLoadingState } from "../shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
+import { useDraftAutoSave } from "../shared/draft/useDraftAutoSave";
+import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
@@ -61,27 +64,27 @@ export function Step2PayGap({
 		[initialData],
 	);
 
-	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
-		siren: declarationSiren,
-		year: declarationYear,
-		step: 2,
-		kind: "main",
-		dbValues,
-	});
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+		useDeclarationDraft({
+			siren: declarationSiren,
+			year: declarationYear,
+			step: 2,
+			kind: "main",
+			dbValues,
+		});
 
 	const form = useZodForm(updateStep2Schema, { defaultValues });
 
-	useEffect(() => {
-		(Object.keys(draft) as Array<keyof Step2Data>).forEach((key) => {
-			const value = draft[key];
+	const draftHydrated = useDraftHydration(isLoadingDraft, draft, (d) => {
+		(Object.keys(d) as Array<keyof Step2Data>).forEach((key) => {
+			const value = d[key];
 			if (value !== undefined) form.setValue(key, value as string);
 		});
-	}, [draft, form]);
+	});
 
-	useEffect(() => {
-		const sub = form.watch((values) => setField(values as Step2Data));
-		return () => sub.unsubscribe();
-	}, [form, setField]);
+	useDraftAutoSave(form, draftHydrated, (values) =>
+		setField(values as Step2Data),
+	);
 
 	const formData = form.watch();
 	const rows = step2ToRows(formData as Step2Data);
@@ -95,6 +98,8 @@ export function Step2PayGap({
 			router.push("/declaration-remuneration/etape/3");
 		},
 	});
+
+	if (!draftHydrated) return <DraftLoadingState />;
 
 	function handleRowChange(index: number, field: PayGapField, value: string) {
 		const normalized = normalizeDecimalInput(value);

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import {
 	computeProportion,
@@ -18,7 +18,10 @@ import {
 	DEV_STEP3_BENEFICIARY_WOMEN,
 	DEV_STEP3_ROWS,
 } from "../shared/devFillData";
+import { DraftLoadingState } from "../shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
+import { useDraftAutoSave } from "../shared/draft/useDraftAutoSave";
+import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
@@ -73,27 +76,27 @@ export function Step3VariablePay({
 	const defaultValues = padStep3(rawDefaults);
 	const dbValues = useMemo(() => padStep3(initialData), [initialData]);
 
-	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
-		siren: declarationSiren,
-		year: declarationYear,
-		step: 3,
-		kind: "main",
-		dbValues,
-	});
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+		useDeclarationDraft({
+			siren: declarationSiren,
+			year: declarationYear,
+			step: 3,
+			kind: "main",
+			dbValues,
+		});
 
 	const form = useZodForm(updateStep3Schema, { defaultValues });
 
-	useEffect(() => {
-		(Object.keys(draft) as Array<keyof Step3Data>).forEach((key) => {
-			const value = draft[key];
+	const draftHydrated = useDraftHydration(isLoadingDraft, draft, (d) => {
+		(Object.keys(d) as Array<keyof Step3Data>).forEach((key) => {
+			const value = d[key];
 			if (value !== undefined) form.setValue(key, value as string);
 		});
-	}, [draft, form]);
+	});
 
-	useEffect(() => {
-		const sub = form.watch((values) => setField(values as Step3Data));
-		return () => sub.unsubscribe();
-	}, [form, setField]);
+	useDraftAutoSave(form, draftHydrated, (values) =>
+		setField(values as Step3Data),
+	);
 
 	const formData = form.watch();
 	const rows = step3ToRows(formData as Step3Data);
@@ -112,6 +115,8 @@ export function Step3VariablePay({
 			router.push("/declaration-remuneration/etape/4");
 		},
 	});
+
+	if (!draftHydrated) return <DraftLoadingState />;
 
 	function handleRowChange(index: number, field: PayGapField, value: string) {
 		const normalized = normalizeDecimalInput(value);

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
 import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared";
@@ -9,7 +9,10 @@ import { api } from "~/trpc/react";
 import { updateStep4Schema } from "../schemas";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP4_ANNUAL, DEV_STEP4_HOURLY } from "../shared/devFillData";
+import { DraftLoadingState } from "../shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
+import { useDraftAutoSave } from "../shared/draft/useDraftAutoSave";
+import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
@@ -101,13 +104,14 @@ export function Step4QuartileDistribution({
 		[hasSavedData, initialData],
 	);
 
-	const { draft, setField, clearDraft, hasDraft } = useDeclarationDraft({
-		siren: declarationSiren,
-		year: declarationYear,
-		step: 4,
-		kind: "main",
-		dbValues,
-	});
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+		useDeclarationDraft({
+			siren: declarationSiren,
+			year: declarationYear,
+			step: 4,
+			kind: "main",
+			dbValues,
+		});
 
 	const form = useZodForm(updateStep4Schema, {
 		defaultValues: {
@@ -116,20 +120,17 @@ export function Step4QuartileDistribution({
 		},
 	});
 
-	useEffect(() => {
-		if (draft.annual) form.setValue("annual", draft.annual);
-		if (draft.hourly) form.setValue("hourly", draft.hourly);
-	}, [draft.annual, draft.hourly, form]);
+	const draftHydrated = useDraftHydration(isLoadingDraft, draft, (d) => {
+		if (d.annual) form.setValue("annual", d.annual);
+		if (d.hourly) form.setValue("hourly", d.hourly);
+	});
 
-	useEffect(() => {
-		const sub = form.watch((values) =>
-			setField({
-				annual: values.annual as QuartileTuple,
-				hourly: values.hourly as QuartileTuple,
-			}),
-		);
-		return () => sub.unsubscribe();
-	}, [form, setField]);
+	useDraftAutoSave(form, draftHydrated, (values) =>
+		setField({
+			annual: values.annual as QuartileTuple,
+			hourly: values.hourly as QuartileTuple,
+		}),
+	);
 
 	const annual = form.watch("annual");
 	const hourly = form.watch("hourly");
@@ -145,6 +146,8 @@ export function Step4QuartileDistribution({
 			router.push("/declaration-remuneration/etape/5");
 		},
 	});
+
+	if (!draftHydrated) return <DraftLoadingState />;
 
 	function setQuartileField(
 		tableType: TableType,

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { padDecimalToTwo } from "~/modules/domain";
 import { api } from "~/trpc/react";
+import { DraftLoadingState } from "../shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
 import { StepIndicator } from "../shared/StepIndicator";
 import type { EmployeeCategoryRow } from "../types";
@@ -69,7 +70,7 @@ export function Step5EmployeeCategories({
 		[initialCategories, initialSource],
 	);
 
-	const { draft, setField, clearDraft, hasDraft } =
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
 		useDeclarationDraft<Step5FormValues>({
 			siren: declarationSiren,
 			year: declarationYear,
@@ -78,26 +79,23 @@ export function Step5EmployeeCategories({
 			dbValues,
 		});
 
-	const [draftLoaded, setDraftLoaded] = useState(false);
-
-	useEffect(() => {
-		if (hasDraft && !draftLoaded) setDraftLoaded(true);
-	}, [hasDraft, draftLoaded]);
-
-	const categoryFormKey = draftLoaded ? 1 : 0;
-	const categoryFormDefaultOverride = draftLoaded
-		? {
-				source: draft.source ?? initialSource ?? "",
-				categories: draft.categories ?? dbValues.categories,
-			}
-		: undefined;
-
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => {
 			clearDraft();
 			router.push("/declaration-remuneration/etape/6");
 		},
 	});
+
+	if (isLoadingDraft) {
+		return <DraftLoadingState />;
+	}
+
+	const categoryFormDefaultOverride = hasDraft
+		? {
+				source: draft.source ?? initialSource ?? "",
+				categories: draft.categories ?? dbValues.categories,
+			}
+		: undefined;
 
 	return (
 		<CategoryForm
@@ -108,7 +106,6 @@ export function Step5EmployeeCategories({
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
 			isSubmitting={mutation.isPending}
-			key={categoryFormKey}
 			maxMen={maxMen}
 			maxWomen={maxWomen}
 			mimoquageNextHref={

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
+import { CompliancePathChoice } from "../CompliancePathChoice";
+
+vi.mock(
+	"~/modules/declaration-remuneration/shared/draft/useDeclarationDraft",
+	() => ({
+		useDeclarationDraft: vi.fn(() => ({
+			draft: {},
+			setField: () => undefined,
+			clearDraft: () => undefined,
+			hasDraft: false,
+			isLoadingDraft: true,
+		})),
+	}),
+);
+
+import { JointEvaluationForm } from "../jointEvaluation/JointEvaluationForm";
+import { Step1Workforce } from "../Step1Workforce";
+import { Step2PayGap } from "../Step2PayGap";
+import { Step3VariablePay } from "../Step3VariablePay";
+import { Step4QuartileDistribution } from "../Step4QuartileDistribution";
+import { Step5EmployeeCategories } from "../Step5EmployeeCategories";
+import { SecondDeclarationStep1Info } from "../secondDeclaration/SecondDeclarationStep1Info";
+import { SecondDeclarationStep2Form } from "../secondDeclaration/SecondDeclarationStep2Form";
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			updateStep1: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+			updateStep2: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+			updateStep3: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+			updateStep4: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+			updateEmployeeCategories: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+			saveCompliancePath: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+			submitJointEvaluation: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+		},
+	},
+}));
+
+const loadingDraftResult = {
+	draft: {},
+	setField: () => undefined,
+	clearDraft: () => undefined,
+	hasDraft: false,
+	isLoadingDraft: true,
+};
+
+function mockLoadingDraft() {
+	vi.mocked(useDeclarationDraft).mockReturnValue(loadingDraftResult);
+}
+
+function expectLoadingState() {
+	const status = screen.getByRole("status");
+	expect(status).toHaveTextContent(/Chargement du brouillon/i);
+}
+
+const emptyStep1 = { totalWomen: 0, totalMen: 0 };
+const emptyStep2 = {
+	indicatorAAnnualWomen: "",
+	indicatorAAnnualMen: "",
+	indicatorAHourlyWomen: "",
+	indicatorAHourlyMen: "",
+	indicatorBAnnualWomen: "",
+	indicatorBAnnualMen: "",
+	indicatorBHourlyWomen: "",
+	indicatorBHourlyMen: "",
+	indicatorCAnnualWomen: "",
+	indicatorCAnnualMen: "",
+	indicatorCHourlyWomen: "",
+	indicatorCHourlyMen: "",
+	indicatorDAnnualWomen: "",
+	indicatorDAnnualMen: "",
+	indicatorDHourlyWomen: "",
+	indicatorDHourlyMen: "",
+};
+const emptyStep3 = {
+	...emptyStep2,
+	indicatorEWomen: "",
+	indicatorEMen: "",
+};
+const emptyQuartile = [
+	{ threshold: undefined, women: undefined, men: undefined },
+	{ threshold: undefined, women: undefined, men: undefined },
+	{ threshold: undefined, women: undefined, men: undefined },
+	{ threshold: undefined, women: undefined, men: undefined },
+];
+const emptyStep4 = {
+	annual: emptyQuartile,
+	hourly: emptyQuartile,
+};
+
+describe("DraftLoadingGate", () => {
+	it("Step1 renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1}
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("Step2 renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep2}
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("Step3 renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep3}
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("Step4 renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep4}
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("Step5 renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialCategories={[]}
+				initialSource={undefined}
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("CompliancePathChoice renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={{
+					gipPublicationDate: null,
+					campaignStartDate: null,
+					decl1ModificationDeadline: new Date("2026-03-01"),
+					decl2ModificationDeadline: new Date("2026-09-01"),
+					decl1JustificationDeadline: new Date("2026-03-01"),
+					decl1JointEvaluationDeadline: new Date("2026-05-01"),
+					decl2JustificationDeadline: new Date("2026-09-01"),
+					decl2JointEvaluationDeadline: new Date("2026-11-01"),
+				}}
+				currentYear={2026}
+				declarationSiren="123456789"
+				declarationYear={2026}
+				email="user@example.com"
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("SecondDeclarationStep1Info renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<SecondDeclarationStep1Info
+				declarationDate="01/01/2026"
+				declarationSiren="123456789"
+				declarationYear={2026}
+				modificationDeadline={new Date("2026-09-01")}
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("SecondDeclarationStep2Form renders loading skeleton while draft is loading", () => {
+		mockLoadingDraft();
+		render(
+			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialFirstDeclarationCategories={[]}
+			/>,
+		);
+		expectLoadingState();
+	});
+
+	it("JointEvaluationForm consumes the hook without crashing while draft is loading", () => {
+		mockLoadingDraft();
+		const { container } = render(
+			<JointEvaluationForm
+				declarationDate="01/01/2026"
+				declarationSiren="123456789"
+				declarationYear={2026}
+				hasCse={null}
+				jointEvaluationDeadline={new Date("2026-05-01")}
+			/>,
+		);
+		expect(container).toBeTruthy();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
+import { DraftLoadingState } from "~/modules/declaration-remuneration/shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
@@ -23,13 +24,17 @@ export function SecondDeclarationStep1Info({
 	declarationYear,
 	modificationDeadline,
 }: Props) {
-	const { hasDraft } = useDeclarationDraft({
+	const { hasDraft, isLoadingDraft } = useDeclarationDraft({
 		siren: declarationSiren,
 		year: declarationYear,
 		step: "second-1",
 		kind: "second",
 		dbValues: EMPTY_DB_VALUES,
 	});
+
+	if (isLoadingDraft) {
+		return <DraftLoadingState />;
+	}
 
 	const saved = !hasDraft;
 

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useIsImpersonating } from "~/modules/auth";
+import { DraftLoadingState } from "~/modules/declaration-remuneration/shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
+import { useDraftHydration } from "~/modules/declaration-remuneration/shared/draft/useDraftHydration";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { api } from "~/trpc/react";
 import { CategoryForm } from "../step5/CategoryForm";
@@ -52,7 +54,7 @@ export function SecondDeclarationStep2Form({
 		[initialStartDate, initialEndDate],
 	);
 
-	const { draft, setField, clearDraft } = useDeclarationDraft({
+	const { draft, setField, clearDraft, isLoadingDraft } = useDeclarationDraft({
 		siren: declarationSiren,
 		year: declarationYear,
 		step: "second-2",
@@ -60,22 +62,15 @@ export function SecondDeclarationStep2Form({
 		dbValues,
 	});
 
-	const didHydrate = useRef(false);
-	useEffect(() => {
-		if (didHydrate.current) return;
-		if (
-			typeof draft.startDate !== "string" &&
-			typeof draft.endDate !== "string"
-		)
-			return;
-		if (typeof draft.startDate === "string") setStartDate(draft.startDate);
-		if (typeof draft.endDate === "string") setEndDate(draft.endDate);
-		didHydrate.current = true;
-	}, [draft.startDate, draft.endDate]);
+	const draftHydrated = useDraftHydration(isLoadingDraft, draft, (d) => {
+		if (typeof d.startDate === "string") setStartDate(d.startDate);
+		if (typeof d.endDate === "string") setEndDate(d.endDate);
+	});
 
 	useEffect(() => {
+		if (!draftHydrated) return;
 		setField({ startDate, endDate });
-	}, [startDate, endDate, setField]);
+	}, [draftHydrated, startDate, endDate, setField]);
 
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => {
@@ -83,6 +78,8 @@ export function SecondDeclarationStep2Form({
 			router.push(`${BASE_PATH}/etape/3`);
 		},
 	});
+
+	if (!draftHydrated) return <DraftLoadingState />;
 
 	return (
 		<CategoryForm


### PR DESCRIPTION
Closes #3508

## Résumé

Adapte les 9 consumers du hook `useDeclarationDraft` (devenu async en T3 #3506) pour utiliser `isLoadingDraft` et éviter le flash UI vide pendant la résolution de la query tRPC.

## Changements

- **`useDraftHydration`** : hook qui applique le draft au form une seule fois quand `isLoadingDraft` devient `false`. Renvoie un flag `hydrated`.
- **`useDraftAutoSave`** : hook qui abonne `form.watch → setField` uniquement après l'hydratation (évite les sauvegardes de valeurs partielles pendant le chargement).
- **`DraftLoadingState`** : composant skeleton accessible (`role="status"` + `aria-busy="true"` + `aria-live="polite"`).
- Gate `if (!draftHydrated) return <DraftLoadingState />` appliqué dans :
  - `Step1Workforce`, `Step2PayGap`, `Step3VariablePay`, `Step4QuartileDistribution`, `Step5EmployeeCategories`
  - `CompliancePathChoice`
  - `SecondDeclarationStep1Info`, `SecondDeclarationStep2Form`
- `JointEvaluationForm` n'affiche pas le draft (uniquement `clearDraft` au submit) — pas de gate nécessaire.

## Tests

- 4 nouveaux fichiers de tests unitaires (DraftLoadingState, useDraftHydration, useDraftAutoSave, DraftLoadingGate).
- 1 nouveau test E2E `declarationDraft.e2e.ts` couvrant le scenario **S1** : un utilisateur reprend son brouillon depuis un second contexte navigateur (mêmes credentials).
- Tous les tests existants restent verts (414 tests dans le module declaration-remuneration, 2020 au total).

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (2020 / 2020)
- [x] `pnpm lint:check` vert
- [x] `pnpm format:check` vert
- [ ] CI verte sur la PR
- [ ] SonarCloud Quality Gate passed
- [ ] `pnpm test:e2e -- declarationDraft.e2e.ts` vert (vérifié en CI avec dev server)