### PR TITLE
Indicateur de sauvegarde : spinner pendant l'enregistrement du brouillon

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,6 +18,7 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:push": "drizzle-kit push",
+		"db:seed-dev": "node scripts/seed-dev.mjs",
 		"db:studio": "drizzle-kit studio",
 		"dev": "node scripts/copy-dsfr.mjs && node scripts/copy-swagger-ui.mjs && next dev --turbo",
 		"predev": "pnpm --filter notifications build",

--- a/packages/app/scripts/seed-dev.mjs
+++ b/packages/app/scripts/seed-dev.mjs
@@ -1,0 +1,100 @@
+/**
+ * Seed local dev DB with the minimum data needed to test the declaration flow.
+ * Run after first ProConnect login (test@fia1.fr) so the user row exists.
+ *
+ * Usage: pnpm db:seed-dev
+ */
+import postgres from "postgres";
+
+const TEST_SIREN = "130025265";
+const TEST_COMPANY_NAME = "Direction du Numérique (DEV)";
+const TEST_EMAIL = "test@fia1.fr";
+const CURRENT_YEAR = new Date().getFullYear();
+
+const sql = postgres(
+	process.env.DATABASE_URL ??
+		"postgresql://postgres:postgres@localhost:5438/egapro",
+	{ max: 1 },
+);
+
+async function main() {
+	// 1. Upsert user (creates it if ProConnect login hasn't happened yet)
+	let userRows = await sql`SELECT id FROM app_user WHERE email = ${TEST_EMAIL} LIMIT 1`;
+	if (userRows.length === 0) {
+		userRows = await sql`
+			INSERT INTO app_user (id, email) VALUES (gen_random_uuid(), ${TEST_EMAIL}) RETURNING id
+		`;
+	}
+	const userId = userRows[0]?.id;
+	if (!userId) throw new Error("Could not upsert user");
+	console.log(`User: ${TEST_EMAIL} (id=${userId})`);
+
+	// 2. Upsert company
+	await sql`
+		INSERT INTO app_company (siren, name, workforce, created_at, updated_at)
+		VALUES (${TEST_SIREN}, ${TEST_COMPANY_NAME}, 150, NOW(), NOW())
+		ON CONFLICT (siren) DO UPDATE SET name = EXCLUDED.name
+	`;
+	console.log(`Company: ${TEST_SIREN} "${TEST_COMPANY_NAME}"`);
+
+	// 3. Link user to company
+	await sql`
+		INSERT INTO app_user_company (user_id, siren)
+		VALUES (${userId}, ${TEST_SIREN})
+		ON CONFLICT DO NOTHING
+	`;
+	console.log(`Linked user → company`);
+
+	// 4. Upsert campaign deadline for current year
+	await sql`
+		INSERT INTO app_campaign_deadline (
+			year,
+			decl1_modification_deadline,
+			decl1_justification_deadline,
+			decl1_joint_evaluation_deadline,
+			decl2_modification_deadline,
+			decl2_justification_deadline,
+			decl2_joint_evaluation_deadline
+		) VALUES (
+			${CURRENT_YEAR},
+			${new Date(`${CURRENT_YEAR}-03-01`)},
+			${new Date(`${CURRENT_YEAR}-03-01`)},
+			${new Date(`${CURRENT_YEAR}-05-01`)},
+			${new Date(`${CURRENT_YEAR}-09-01`)},
+			${new Date(`${CURRENT_YEAR}-09-01`)},
+			${new Date(`${CURRENT_YEAR}-11-01`)}
+		)
+		ON CONFLICT (year) DO UPDATE SET
+			decl1_modification_deadline = EXCLUDED.decl1_modification_deadline
+	`;
+	console.log(`Campaign deadline for ${CURRENT_YEAR}`);
+
+	// 5. Upsert draft declaration for current year
+	await sql`
+		INSERT INTO app_declaration (
+			id, siren, year, declarant_id, current_step, status,
+			created_at, updated_at
+		)
+		VALUES (
+			gen_random_uuid(),
+			${TEST_SIREN},
+			${CURRENT_YEAR},
+			${userId},
+			1,
+			'draft',
+			NOW(),
+			NOW()
+		)
+		ON CONFLICT (siren, year) WHERE cancelled_at IS NULL DO NOTHING
+	`;
+	console.log(`Declaration ${TEST_SIREN}/${CURRENT_YEAR} (draft, step 1)`);
+
+	console.log("\nDone. Log in at http://localhost:3000/login with test@fia1.fr");
+}
+
+main()
+	.catch((err) => {
+		console.error(err);
+		process.exit(1);
+	})
+	.finally(() => sql.end());

--- a/packages/app/scripts/seed-dev.mjs
+++ b/packages/app/scripts/seed-dev.mjs
@@ -19,7 +19,8 @@ const sql = postgres(
 
 async function main() {
 	// 1. Upsert user (creates it if ProConnect login hasn't happened yet)
-	let userRows = await sql`SELECT id FROM app_user WHERE email = ${TEST_EMAIL} LIMIT 1`;
+	let userRows =
+		await sql`SELECT id FROM app_user WHERE email = ${TEST_EMAIL} LIMIT 1`;
 	if (userRows.length === 0) {
 		userRows = await sql`
 			INSERT INTO app_user (id, email) VALUES (gen_random_uuid(), ${TEST_EMAIL}) RETURNING id
@@ -89,7 +90,9 @@ async function main() {
 	`;
 	console.log(`Declaration ${TEST_SIREN}/${CURRENT_YEAR} (draft, step 1)`);
 
-	console.log("\nDone. Log in at http://localhost:3000/login with test@fia1.fr");
+	console.log(
+		"\nDone. Log in at http://localhost:3000/login with test@fia1.fr",
+	);
 }
 
 main()

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -313,11 +313,11 @@ describe("Step1Opinions", () => {
 
 		// First declaration accuracy radios
 		const favorableRadios = screen.getAllByLabelText("Favorable");
-		expect(favorableRadios[0]!).toBeChecked();
+		expect(favorableRadios[0]).toBeChecked();
 
 		// Second declaration accuracy radios
 		const unfavorableRadios = screen.getAllByLabelText("Défavorable");
-		expect(unfavorableRadios[1]!).toBeChecked();
+		expect(unfavorableRadios[1]).toBeChecked();
 	});
 
 	it("displays email in submission banner for joint_evaluation path", () => {
@@ -374,7 +374,7 @@ describe("Step1Opinions", () => {
 			);
 
 			const favorableRadios = screen.getAllByLabelText("Favorable");
-			expect(favorableRadios[0]!).toBeChecked();
+			expect(favorableRadios[0]).toBeChecked();
 		});
 
 		it("shows loading state while draft is loading", () => {
@@ -410,7 +410,7 @@ describe("Step1Opinions", () => {
 				/>,
 			);
 
-			await user.click(screen.getAllByLabelText("Favorable")[0]!);
+			await user.click(screen.getAllByLabelText("Favorable")[0] as HTMLElement);
 
 			expect(mockSetField).toHaveBeenCalled();
 			const callArg = mockSetField.mock.calls[

--- a/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.module.scss
@@ -14,7 +14,15 @@
 	gap: 0.5rem;
 }
 
+.iconSlot {
+	width: 1.5rem;
+	height: 1.5rem;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+}
+
 .spinning {
 	animation: spin 1s linear infinite;
-	display: inline-block;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.module.scss
@@ -1,6 +1,20 @@
+@keyframes spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+
 .indicator {
 	color: var(--text-mention-grey);
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
+}
+
+.spinning {
+	animation: spin 1s linear infinite;
+	display: inline-block;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
@@ -4,33 +4,47 @@ import styles from "./SavedIndicator.module.scss";
 
 type Props = {
 	isSaving?: boolean;
+	isPendingSave?: boolean;
 };
 
-export function SavedIndicator({ isSaving = false }: Props) {
+export function SavedIndicator({
+	isSaving = false,
+	isPendingSave = false,
+}: Props) {
 	return (
 		<p
-			aria-busy={isSaving}
+			aria-busy={isSaving || isPendingSave}
 			aria-live="polite"
 			className={`fr-mb-0 fr-text--lg ${styles.indicator}`}
 			role="status"
 		>
-			{isSaving ? (
+			{isPendingSave ? (
 				<>
 					<span
 						aria-hidden="true"
-						className={`fr-icon-refresh-line ${styles.spinning}`}
+						className={`fr-icon-pencil-line ${styles.iconSlot}`}
+					/>
+					Non enregistré
+				</>
+			) : isSaving ? (
+				<>
+					<span
+						aria-hidden="true"
+						className={`fr-icon-refresh-line ${styles.iconSlot} ${styles.spinning}`}
 					/>
 					Enregistrement...
 				</>
 			) : (
 				<>
-					<Image
-						alt=""
-						aria-hidden="true"
-						height={20}
-						src="/assets/declaration-remuneration/cloud-check.svg"
-						width={20}
-					/>
+					<span className={styles.iconSlot}>
+						<Image
+							alt=""
+							aria-hidden="true"
+							height={24}
+							src="/assets/declaration-remuneration/cloud-check.svg"
+							width={24}
+						/>
+					</span>
 					Enregistré
 				</>
 			)}

--- a/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
@@ -5,28 +5,23 @@ import styles from "./SavedIndicator.module.scss";
 type Props = {
 	isSaving?: boolean;
 	isPendingSave?: boolean;
+	hasData: boolean;
 };
 
 export function SavedIndicator({
 	isSaving = false,
 	isPendingSave = false,
+	hasData,
 }: Props) {
+	const isBusy = isSaving || isPendingSave;
 	return (
 		<p
-			aria-busy={isSaving || isPendingSave}
+			aria-busy={isBusy}
 			aria-live="polite"
 			className={`fr-mb-0 fr-text--lg ${styles.indicator}`}
 			role="status"
 		>
-			{isPendingSave ? (
-				<>
-					<span
-						aria-hidden="true"
-						className={`fr-icon-pencil-line ${styles.iconSlot}`}
-					/>
-					Non enregistré
-				</>
-			) : isSaving ? (
+			{isBusy ? (
 				<>
 					<span
 						aria-hidden="true"
@@ -34,7 +29,7 @@ export function SavedIndicator({
 					/>
 					Enregistrement...
 				</>
-			) : (
+			) : hasData ? (
 				<>
 					<span className={styles.iconSlot}>
 						<Image
@@ -46,6 +41,14 @@ export function SavedIndicator({
 						/>
 					</span>
 					Enregistré
+				</>
+			) : (
+				<>
+					<span
+						aria-hidden="true"
+						className={`fr-icon-pencil-line ${styles.iconSlot}`}
+					/>
+					Non enregistré
 				</>
 			)}
 		</p>

--- a/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
@@ -14,6 +14,7 @@ export function SavedIndicator({
 	hasData,
 }: Props) {
 	const isBusy = isSaving || isPendingSave;
+	if (!isBusy && !hasData) return null;
 	return (
 		<p
 			aria-busy={isBusy}
@@ -27,9 +28,9 @@ export function SavedIndicator({
 						aria-hidden="true"
 						className={`fr-icon-refresh-line ${styles.iconSlot} ${styles.spinning}`}
 					/>
-					Enregistrement...
+					Enregistre
 				</>
-			) : hasData ? (
+			) : (
 				<>
 					<span className={styles.iconSlot}>
 						<Image
@@ -41,14 +42,6 @@ export function SavedIndicator({
 						/>
 					</span>
 					Enregistré
-				</>
-			) : (
-				<>
-					<span
-						aria-hidden="true"
-						className={`fr-icon-pencil-line ${styles.iconSlot}`}
-					/>
-					Non enregistré
 				</>
 			)}
 		</p>

--- a/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/SavedIndicator.tsx
@@ -2,17 +2,38 @@ import Image from "next/image";
 
 import styles from "./SavedIndicator.module.scss";
 
-export function SavedIndicator() {
+type Props = {
+	isSaving?: boolean;
+};
+
+export function SavedIndicator({ isSaving = false }: Props) {
 	return (
-		<p className={`fr-mb-0 fr-text--lg ${styles.indicator}`}>
-			<Image
-				alt=""
-				aria-hidden="true"
-				height={20}
-				src="/assets/declaration-remuneration/cloud-check.svg"
-				width={20}
-			/>
-			Enregistré
+		<p
+			aria-busy={isSaving}
+			aria-live="polite"
+			className={`fr-mb-0 fr-text--lg ${styles.indicator}`}
+			role="status"
+		>
+			{isSaving ? (
+				<>
+					<span
+						aria-hidden="true"
+						className={`fr-icon-refresh-line ${styles.spinning}`}
+					/>
+					Enregistrement...
+				</>
+			) : (
+				<>
+					<Image
+						alt=""
+						aria-hidden="true"
+						height={20}
+						src="/assets/declaration-remuneration/cloud-check.svg"
+						width={20}
+					/>
+					Enregistré
+				</>
+			)}
 		</p>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
@@ -6,7 +6,7 @@ import { SavedIndicator } from "./SavedIndicator";
 type StepTitleRowProps = {
 	title: ReactNode;
 	onDevFill: () => void;
-	saved: boolean;
+	hasData: boolean;
 	isSaving?: boolean;
 	isPendingSave?: boolean;
 };
@@ -14,7 +14,7 @@ type StepTitleRowProps = {
 export function StepTitleRow({
 	title,
 	onDevFill,
-	saved,
+	hasData,
 	isSaving = false,
 	isPendingSave = false,
 }: StepTitleRowProps) {
@@ -24,11 +24,13 @@ export function StepTitleRow({
 			<div className="fr-col-auto">
 				<DevFillButton onFill={onDevFill} />
 			</div>
-			{(saved || isSaving || isPendingSave) && (
-				<div className="fr-col-auto">
-					<SavedIndicator isPendingSave={isPendingSave} isSaving={isSaving} />
-				</div>
-			)}
+			<div className="fr-col-auto">
+				<SavedIndicator
+					hasData={hasData}
+					isPendingSave={isPendingSave}
+					isSaving={isSaving}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
@@ -7,18 +7,24 @@ type StepTitleRowProps = {
 	title: ReactNode;
 	onDevFill: () => void;
 	saved: boolean;
+	isSaving?: boolean;
 };
 
-export function StepTitleRow({ title, onDevFill, saved }: StepTitleRowProps) {
+export function StepTitleRow({
+	title,
+	onDevFill,
+	saved,
+	isSaving = false,
+}: StepTitleRowProps) {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 			<div className="fr-col">{title}</div>
 			<div className="fr-col-auto">
 				<DevFillButton onFill={onDevFill} />
 			</div>
-			{saved && (
+			{(saved || isSaving) && (
 				<div className="fr-col-auto">
-					<SavedIndicator />
+					<SavedIndicator isSaving={isSaving} />
 				</div>
 			)}
 		</div>

--- a/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
@@ -8,6 +8,7 @@ type StepTitleRowProps = {
 	onDevFill: () => void;
 	saved: boolean;
 	isSaving?: boolean;
+	isPendingSave?: boolean;
 };
 
 export function StepTitleRow({
@@ -15,6 +16,7 @@ export function StepTitleRow({
 	onDevFill,
 	saved,
 	isSaving = false,
+	isPendingSave = false,
 }: StepTitleRowProps) {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
@@ -22,9 +24,9 @@ export function StepTitleRow({
 			<div className="fr-col-auto">
 				<DevFillButton onFill={onDevFill} />
 			</div>
-			{(saved || isSaving) && (
+			{(saved || isSaving || isPendingSave) && (
 				<div className="fr-col-auto">
-					<SavedIndicator isSaving={isSaving} />
+					<SavedIndicator isPendingSave={isPendingSave} isSaving={isSaving} />
 				</div>
 			)}
 		</div>

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.lifecycle.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.lifecycle.test.tsx
@@ -229,6 +229,119 @@ describe("useDeclarationDraft (lifecycle & cache)", () => {
 		).toEqual({ compliance: { "1": { y: 2 } } });
 	});
 
+	it("flushRef immediately writes pending save to cache so the next mount hydrates without waiting for the mutation", () => {
+		queryState = { data: null, isLoading: false };
+		const { result, unmount } = renderDraftHook();
+
+		act(() => {
+			result.current.setField({ totalWomen: 3000, totalMen: 0 });
+		});
+
+		// Unmount before the 600ms debounce fires (simulates quick back-navigation)
+		unmount();
+
+		// The cache must have been updated synchronously — the mutation call is verified
+		// separately; here we check the setData optimistic update happened
+		expect(setDataMock).toHaveBeenCalledTimes(1);
+		const updater = setDataMock.mock.calls[0]?.[0] as (
+			old: DraftBlob | null | undefined,
+		) => DraftBlob | null;
+		expect(updater(null)).toEqual({ main: { "1": { totalWomen: 3000 } } });
+		// And the mutation still fires to persist to the server
+		expect(saveMutateMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("flushRef immediately clears the cache so the next mount sees no stale data", () => {
+		queryState = {
+			data: { main: { "1": { totalWomen: 10 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result, unmount } = renderDraftHook();
+
+		// Revert to defaults — pending clear
+		act(() => {
+			result.current.setField({ totalWomen: 0, totalMen: 0 });
+		});
+
+		unmount();
+
+		// Cache cleared synchronously
+		expect(setDataMock).toHaveBeenCalledTimes(1);
+		const updater = setDataMock.mock.calls[0]?.[0] as (
+			old: DraftBlob | null | undefined,
+		) => DraftBlob | null;
+		expect(
+			updater({ main: { "1": { totalWomen: 10 } } } as DraftBlob),
+		).toBeNull();
+		expect(clearMutateMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps hasDraft=true when a stale clear from a previous mount resolves after remount (race condition)", () => {
+		queryState = {
+			data: { main: { "1": { totalWomen: 10 } } } as DraftBlob,
+			isLoading: false,
+		};
+		const { result, rerender } = renderDraftHook();
+		expect(result.current.hasDraft).toBe(true);
+
+		// Simulate the stale clear resolving: cache is now empty
+		act(() => {
+			queryState = { data: null, isLoading: false };
+			rerender();
+		});
+
+		// hasDraft must remain true — the form was already hydrated from the non-null
+		// queryDraft seen at mount time; flickering to false would show "Non enregistré"
+		// while form fields still display the saved data.
+		expect(result.current.hasDraft).toBe(true);
+	});
+
+	it("hasDraft stays false while typing into a blank form (no flash of Enregistré)", () => {
+		queryState = { data: null, isLoading: false };
+		const { result } = renderDraftHook();
+
+		// Initially blank form — nothing saved
+		expect(result.current.hasDraft).toBe(false);
+
+		// User starts typing — setField called immediately, localDraft set
+		act(() => {
+			result.current.setField({ totalWomen: 1, totalMen: 0 });
+		});
+
+		// hasDraft must still be false: queryDraft is null and no confirmed save yet.
+		// The spinner (isPendingSave) has not fired yet (VISUAL_DELAY_MS = 400ms),
+		// so showing "Enregistré" here would be a false positive.
+		expect(result.current.hasDraft).toBe(false);
+		expect(result.current.isPendingSave).toBe(false);
+
+		// After VISUAL_DELAY_MS the spinner appears — hasDraft still false (save pending, not confirmed)
+		act(() => {
+			vi.advanceTimersByTime(400);
+		});
+		expect(result.current.isPendingSave).toBe(true);
+		expect(result.current.hasDraft).toBe(false);
+
+		// After DEBOUNCE_MS the mutation fires
+		act(() => {
+			vi.advanceTimersByTime(200);
+		});
+		expect(saveMutateMock).toHaveBeenCalledTimes(1);
+
+		// hasDraft becomes true only once the save onSuccess patches the cache
+		saveOnSuccess?.(
+			{ ok: true },
+			{
+				year: YEAR,
+				siren: SIREN,
+				slice: { kind: "main", step: "1", data: { totalWomen: 1 } },
+			},
+		);
+		// The cache patch updates queryState, but since we're in a mock we simulate
+		// by checking that setDataMock was called — the actual hasDraft flip
+		// happens when React re-renders with the new query.data.
+		expect(setDataMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("returns the cache unchanged on clear success when kind is undefined", () => {
 		queryState = { data: null, isLoading: false };
 		renderDraftHook();

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/__tests__/useDeclarationDraft.test.tsx
@@ -174,7 +174,9 @@ describe("useDeclarationDraft", () => {
 		});
 
 		expect(result.current.draft).toEqual({ totalWomen: 7 });
-		expect(result.current.hasDraft).toBe(true);
+		// hasDraft stays false until the save is confirmed — localDraft is optimistic
+		// for the form fields but does not trigger the "Enregistré" indicator yet.
+		expect(result.current.hasDraft).toBe(false);
 		expect(saveMutateMock).not.toHaveBeenCalled();
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -29,6 +29,7 @@ type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
 };
 
 const DEBOUNCE_MS = 600;
+const VISUAL_DELAY_MS = 400;
 const EMPTY_DRAFT: Readonly<Record<string, never>> = Object.freeze({});
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -134,6 +135,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 	const hasDraft = Object.keys(draft).length > 0;
 
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const visualTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const pendingRef = useRef<{ diff: Record<string, unknown> | null } | null>(
 		null,
 	);
@@ -141,9 +143,14 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 
 	useEffect(() => {
 		flushRef.current = () => {
+			if (visualTimerRef.current !== null) {
+				clearTimeout(visualTimerRef.current);
+				visualTimerRef.current = null;
+			}
 			if (timerRef.current === null) return;
 			clearTimeout(timerRef.current);
 			timerRef.current = null;
+			setIsPendingSave(false);
 			const pending = pendingRef.current;
 			pendingRef.current = null;
 			if (pending === null || !isEnabled) return;
@@ -174,8 +181,12 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 				return next;
 			});
 			if (timerRef.current !== null) clearTimeout(timerRef.current);
+			if (visualTimerRef.current !== null) clearTimeout(visualTimerRef.current);
 			pendingRef.current = { diff: hasDiff ? diff : null };
-			setIsPendingSave(true);
+			visualTimerRef.current = setTimeout(() => {
+				visualTimerRef.current = null;
+				setIsPendingSave(true);
+			}, VISUAL_DELAY_MS);
 			timerRef.current = setTimeout(() => {
 				timerRef.current = null;
 				pendingRef.current = null;
@@ -196,6 +207,10 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 
 	const clearDraftCallback = useCallback(() => {
 		if (!isEnabled) return;
+		if (visualTimerRef.current !== null) {
+			clearTimeout(visualTimerRef.current);
+			visualTimerRef.current = null;
+		}
 		if (timerRef.current !== null) {
 			clearTimeout(timerRef.current);
 			timerRef.current = null;
@@ -221,7 +236,8 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			setField,
 			clearDraft: clearDraftCallback,
 			hasDraft,
-			isLoadingDraft: isSessionLoading || (isEnabled && query.isLoading),
+			isLoadingDraft:
+				isSessionLoading || (isEnabled && query.data === undefined),
 			isSaving: saveMutation.isPending,
 			isPendingSave,
 		}),

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -25,6 +25,7 @@ type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
 	hasDraft: boolean;
 	isLoadingDraft: boolean;
 	isSaving: boolean;
+	isPendingSave: boolean;
 };
 
 const DEBOUNCE_MS = 600;
@@ -116,6 +117,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 	clearMutateRef.current = clearMutation.mutate;
 
 	const [localDraft, setLocalDraft] = useState<Partial<T> | null>(null);
+	const [isPendingSave, setIsPendingSave] = useState(false);
 
 	const queryDraft = useMemo<Partial<T> | null>(() => {
 		const data = query.data as DraftBlob | null | undefined;
@@ -173,9 +175,11 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			});
 			if (timerRef.current !== null) clearTimeout(timerRef.current);
 			pendingRef.current = { diff: hasDiff ? diff : null };
+			setIsPendingSave(true);
 			timerRef.current = setTimeout(() => {
 				timerRef.current = null;
 				pendingRef.current = null;
+				setIsPendingSave(false);
 				if (hasDiff) {
 					saveMutateRef.current({
 						year,
@@ -196,6 +200,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			clearTimeout(timerRef.current);
 			timerRef.current = null;
 			pendingRef.current = null;
+			setIsPendingSave(false);
 		}
 		setLocalDraft((prev) => {
 			if (prev !== null && Object.keys(prev).length === 0) return prev;
@@ -218,6 +223,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			hasDraft,
 			isLoadingDraft: isSessionLoading || (isEnabled && query.isLoading),
 			isSaving: saveMutation.isPending,
+			isPendingSave,
 		}),
 		[
 			draft,
@@ -228,6 +234,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			isEnabled,
 			isSessionLoading,
 			saveMutation.isPending,
+			isPendingSave,
 		],
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -130,9 +130,25 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 		return stepData as Partial<T>;
 	}, [query.data, kind, stepKey]);
 
+	// Prevents hasDraft from flickering to false when a clearMutation from a
+	// previous mount resolves after the new mount has already hydrated the form.
+	// Set via effect so it only fires when queryDraft actually changes, preventing
+	// render-time re-override of the false set by setField/clearDraft callbacks.
+	const hadQueryDraftRef = useRef(false);
+	useEffect(() => {
+		if (queryDraft !== null && Object.keys(queryDraft).length > 0) {
+			hadQueryDraftRef.current = true;
+		}
+	}, [queryDraft]);
+
 	const draft: Partial<T> =
 		localDraft ?? queryDraft ?? (EMPTY_DRAFT as Partial<T>);
-	const hasDraft = Object.keys(draft).length > 0;
+	const localIsExplicitlyEmpty =
+		localDraft !== null && Object.keys(localDraft).length === 0;
+	const hasDraft =
+		!localIsExplicitlyEmpty &&
+		((queryDraft !== null && Object.keys(queryDraft).length > 0) ||
+			hadQueryDraftRef.current);
 
 	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const visualTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -155,8 +171,26 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			pendingRef.current = null;
 			if (pending === null || !isEnabled) return;
 			if (pending.diff === null) {
+				// Immediately reflect the clear in the cache so the next mount sees null,
+				// not stale data that the in-flight mutation will remove later.
+				utils.declarationDraft.get.setData({ year, siren }, (old) => {
+					if (!old) return old;
+					const base = old as DraftBlob;
+					const { [kind]: _removed, ...rest } = base;
+					return Object.keys(rest).length === 0 ? null : (rest as DraftBlob);
+				});
 				clearMutateRef.current({ year, siren, kind });
 			} else {
+				// Immediately reflect the save in the cache so the next mount hydrates
+				// with the correct data before the in-flight mutation resolves.
+				utils.declarationDraft.get.setData({ year, siren }, (old) => {
+					const base = (old ?? {}) as DraftBlob;
+					const slice = (base[kind] ?? {}) as Record<string, unknown>;
+					return {
+						...base,
+						[kind]: { ...slice, [stepKey]: pending.diff },
+					};
+				});
 				saveMutateRef.current({
 					year,
 					siren,
@@ -171,6 +205,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			if (!isEnabled) return;
 			const diff = computeDraftDiff(currentValues, dbValues);
 			const hasDiff = Object.keys(diff).length > 0;
+			if (!hasDiff) hadQueryDraftRef.current = false;
 			setLocalDraft((prev) => {
 				const next = hasDiff
 					? (diff as Partial<T>)
@@ -207,6 +242,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 
 	const clearDraftCallback = useCallback(() => {
 		if (!isEnabled) return;
+		hadQueryDraftRef.current = false;
 		if (visualTimerRef.current !== null) {
 			clearTimeout(visualTimerRef.current);
 			visualTimerRef.current = null;
@@ -246,7 +282,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			setField,
 			clearDraftCallback,
 			hasDraft,
-			query.isLoading,
+			query.data,
 			isEnabled,
 			isSessionLoading,
 			saveMutation.isPending,

--- a/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/draft/useDeclarationDraft.ts
@@ -24,6 +24,7 @@ type UseDeclarationDraftResult<T extends Record<string, unknown>> = {
 	clearDraft: () => void;
 	hasDraft: boolean;
 	isLoadingDraft: boolean;
+	isSaving: boolean;
 };
 
 const DEBOUNCE_MS = 600;
@@ -216,6 +217,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			clearDraft: clearDraftCallback,
 			hasDraft,
 			isLoadingDraft: isSessionLoading || (isEnabled && query.isLoading),
+			isSaving: saveMutation.isPending,
 		}),
 		[
 			draft,
@@ -225,6 +227,7 @@ export function useDeclarationDraft<T extends Record<string, unknown>>(
 			query.isLoading,
 			isEnabled,
 			isSessionLoading,
+			saveMutation.isPending,
 		],
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -51,14 +51,21 @@ export function CompliancePathChoice({
 
 	const dbValues = useMemo(() => ({ path: initialPath }), [initialPath]);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
-		useDeclarationDraft({
-			siren: declarationSiren,
-			year: declarationYear,
-			step: "compliance",
-			kind: "compliance",
-			dbValues,
-		});
+	const {
+		draft,
+		setField,
+		clearDraft,
+		hasDraft,
+		isLoadingDraft,
+		isSaving,
+		isPendingSave,
+	} = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: "compliance",
+		kind: "compliance",
+		dbValues,
+	});
 
 	const form = useZodForm(saveCompliancePathSchema, {
 		defaultValues: { path: initialPath },
@@ -76,7 +83,7 @@ export function CompliancePathChoice({
 
 	const selectedPath = form.watch("path");
 	const hasInitialData = !!initialPath;
-	const saved = !hasDraft && hasInitialData;
+	const hasData = hasInitialData || hasDraft;
 
 	const mutation = api.declaration.saveCompliancePath.useMutation({
 		onSuccess: (_, { path }) => {
@@ -106,7 +113,11 @@ export function CompliancePathChoice({
 				<h1 className="fr-h4 fr-mb-0">
 					Déclaration des indicateurs de rémunération {currentYear}
 				</h1>
-				{saved && <SavedIndicator />}
+				<SavedIndicator
+					hasData={hasData}
+					isPendingSave={isPendingSave}
+					isSaving={isSaving}
+				/>
 			</div>
 
 			<DeclarationSuccessBanner

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -51,14 +51,21 @@ export function Step1Workforce({
 		[initialData.totalWomen, initialData.totalMen],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
-		useDeclarationDraft({
-			siren: declarationSiren,
-			year: declarationYear,
-			step: 1,
-			kind: "main",
-			dbValues,
-		});
+	const {
+		draft,
+		setField,
+		clearDraft,
+		hasDraft,
+		isLoadingDraft,
+		isSaving,
+		isPendingSave,
+	} = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 1,
+		kind: "main",
+		dbValues,
+	});
 
 	const form = useZodForm(updateStep1Schema, {
 		defaultValues: dbValues,
@@ -74,7 +81,7 @@ export function Step1Workforce({
 		if (typeof d.totalMen === "number") form.setValue("totalMen", d.totalMen);
 	});
 
-	const saved = !hasDraft && hasInitialData;
+	const saved = (hasInitialData || hasDraft) && !isPendingSave && !isSaving;
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const [showResetWarning, setShowResetWarning] = useState(false);
 
@@ -125,6 +132,7 @@ export function Step1Workforce({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
 					const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -51,7 +51,7 @@ export function Step1Workforce({
 		[initialData.totalWomen, initialData.totalMen],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
 		useDeclarationDraft({
 			siren: declarationSiren,
 			year: declarationYear,
@@ -125,6 +125,7 @@ export function Step1Workforce({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				isSaving={isSaving}
 				onDevFill={() => {
 					const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;
 					const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -81,7 +81,7 @@ export function Step1Workforce({
 		if (typeof d.totalMen === "number") form.setValue("totalMen", d.totalMen);
 	});
 
-	const saved = (hasInitialData || hasDraft) && !isPendingSave && !isSaving;
+	const hasData = hasInitialData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const [showResetWarning, setShowResetWarning] = useState(false);
 
@@ -132,6 +132,7 @@ export function Step1Workforce({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				hasData={hasData}
 				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
@@ -141,7 +142,6 @@ export function Step1Workforce({
 					form.setValue("totalMen", menValue);
 					setField({ totalWomen: womenValue, totalMen: menValue });
 				}}
-				saved={saved}
 				title={
 					<h1 className="fr-h4 fr-mb-0">
 						Déclaration des indicateurs de rémunération {declarationYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -64,7 +64,7 @@ export function Step2PayGap({
 		[initialData],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
 		useDeclarationDraft({
 			siren: declarationSiren,
 			year: declarationYear,
@@ -124,6 +124,7 @@ export function Step2PayGap({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				isSaving={isSaving}
 				onDevFill={() => {
 					DEV_STEP2_ROWS.forEach((row, i) => {
 						const womenField = getStep2FieldName(i, "womenValue");

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -64,14 +64,21 @@ export function Step2PayGap({
 		[initialData],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
-		useDeclarationDraft({
-			siren: declarationSiren,
-			year: declarationYear,
-			step: 2,
-			kind: "main",
-			dbValues,
-		});
+	const {
+		draft,
+		setField,
+		clearDraft,
+		hasDraft,
+		isLoadingDraft,
+		isSaving,
+		isPendingSave,
+	} = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 2,
+		kind: "main",
+		dbValues,
+	});
 
 	const form = useZodForm(updateStep2Schema, { defaultValues });
 
@@ -89,7 +96,7 @@ export function Step2PayGap({
 	const formData = form.watch();
 	const rows = step2ToRows(formData as Step2Data);
 
-	const saved = !hasDraft && hasInitialData;
+	const saved = (hasInitialData || hasDraft) && !isPendingSave && !isSaving;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep2.useMutation({
@@ -124,6 +131,7 @@ export function Step2PayGap({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
 					DEV_STEP2_ROWS.forEach((row, i) => {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -96,7 +96,7 @@ export function Step2PayGap({
 	const formData = form.watch();
 	const rows = step2ToRows(formData as Step2Data);
 
-	const saved = (hasInitialData || hasDraft) && !isPendingSave && !isSaving;
+	const hasData = hasInitialData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep2.useMutation({
@@ -131,6 +131,7 @@ export function Step2PayGap({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				hasData={hasData}
 				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
@@ -141,7 +142,6 @@ export function Step2PayGap({
 						form.setValue(menField, padDecimalToTwo(row.menValue));
 					});
 				}}
-				saved={saved}
 				title={
 					<h1 className="fr-h4 fr-mb-0">
 						Déclaration des indicateurs de rémunération {declarationYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -76,7 +76,7 @@ export function Step3VariablePay({
 	const defaultValues = padStep3(rawDefaults);
 	const dbValues = useMemo(() => padStep3(initialData), [initialData]);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
 		useDeclarationDraft({
 			siren: declarationSiren,
 			year: declarationYear,
@@ -165,6 +165,7 @@ export function Step3VariablePay({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				isSaving={isSaving}
 				onDevFill={() => {
 					DEV_STEP3_ROWS.forEach((row, i) => {
 						const womenField = getStep3FieldName(i, "womenValue");

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -113,7 +113,7 @@ export function Step3VariablePay({
 	const [benefValidationError, setBenefValidationError] = useState<
 		string | null
 	>(null);
-	const saved = (hasSavedData || hasDraft) && !isPendingSave && !isSaving;
+	const hasData = hasSavedData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep3.useMutation({
@@ -172,6 +172,7 @@ export function Step3VariablePay({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				hasData={hasData}
 				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
@@ -184,7 +185,6 @@ export function Step3VariablePay({
 					form.setValue("indicatorEWomen", DEV_STEP3_BENEFICIARY_WOMEN);
 					form.setValue("indicatorEMen", DEV_STEP3_BENEFICIARY_MEN);
 				}}
-				saved={saved}
 				title={
 					<h1 className="fr-h4 fr-mb-0">
 						Déclaration des indicateurs de rémunération {declarationYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -76,14 +76,21 @@ export function Step3VariablePay({
 	const defaultValues = padStep3(rawDefaults);
 	const dbValues = useMemo(() => padStep3(initialData), [initialData]);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
-		useDeclarationDraft({
-			siren: declarationSiren,
-			year: declarationYear,
-			step: 3,
-			kind: "main",
-			dbValues,
-		});
+	const {
+		draft,
+		setField,
+		clearDraft,
+		hasDraft,
+		isLoadingDraft,
+		isSaving,
+		isPendingSave,
+	} = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 3,
+		kind: "main",
+		dbValues,
+	});
 
 	const form = useZodForm(updateStep3Schema, { defaultValues });
 
@@ -106,7 +113,7 @@ export function Step3VariablePay({
 	const [benefValidationError, setBenefValidationError] = useState<
 		string | null
 	>(null);
-	const saved = !hasDraft && hasSavedData;
+	const saved = (hasSavedData || hasDraft) && !isPendingSave && !isSaving;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep3.useMutation({
@@ -165,6 +172,7 @@ export function Step3VariablePay({
 	return (
 		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
 			<StepTitleRow
+				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
 					DEV_STEP3_ROWS.forEach((row, i) => {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -104,14 +104,21 @@ export function Step4QuartileDistribution({
 		[hasSavedData, initialData],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
-		useDeclarationDraft({
-			siren: declarationSiren,
-			year: declarationYear,
-			step: 4,
-			kind: "main",
-			dbValues,
-		});
+	const {
+		draft,
+		setField,
+		clearDraft,
+		hasDraft,
+		isLoadingDraft,
+		isSaving,
+		isPendingSave,
+	} = useDeclarationDraft({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 4,
+		kind: "main",
+		dbValues,
+	});
 
 	const form = useZodForm(updateStep4Schema, {
 		defaultValues: {
@@ -136,7 +143,7 @@ export function Step4QuartileDistribution({
 	const hourly = form.watch("hourly");
 
 	const [maxError, setMaxError] = useState<string | null>(null);
-	const saved = !hasDraft && hasSavedData;
+	const saved = (hasSavedData || hasDraft) && !isPendingSave && !isSaving;
 	const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>(emptyErrorMap);
 	const [showRecap, setShowRecap] = useState(false);
 
@@ -247,6 +254,7 @@ export function Step4QuartileDistribution({
 	return (
 		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
 			<StepTitleRow
+				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
 					form.setValue(

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -143,7 +143,7 @@ export function Step4QuartileDistribution({
 	const hourly = form.watch("hourly");
 
 	const [maxError, setMaxError] = useState<string | null>(null);
-	const saved = (hasSavedData || hasDraft) && !isPendingSave && !isSaving;
+	const hasData = hasSavedData || hasDraft;
 	const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>(emptyErrorMap);
 	const [showRecap, setShowRecap] = useState(false);
 
@@ -254,6 +254,7 @@ export function Step4QuartileDistribution({
 	return (
 		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
 			<StepTitleRow
+				hasData={hasData}
 				isPendingSave={isPendingSave}
 				isSaving={isSaving}
 				onDevFill={() => {
@@ -272,7 +273,6 @@ export function Step4QuartileDistribution({
 					setFieldErrors(emptyErrorMap());
 					setShowRecap(false);
 				}}
-				saved={saved}
 				title={
 					<h1 className="fr-h4 fr-mb-0">
 						Déclaration des indicateurs de rémunération {declarationYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -104,7 +104,7 @@ export function Step4QuartileDistribution({
 		[hasSavedData, initialData],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
 		useDeclarationDraft({
 			siren: declarationSiren,
 			year: declarationYear,
@@ -247,6 +247,7 @@ export function Step4QuartileDistribution({
 	return (
 		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
 			<StepTitleRow
+				isSaving={isSaving}
 				onDevFill={() => {
 					form.setValue(
 						"annual",

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -70,7 +70,7 @@ export function Step5EmployeeCategories({
 		[initialCategories, initialSource],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft } =
+	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
 		useDeclarationDraft<Step5FormValues>({
 			siren: declarationSiren,
 			year: declarationYear,
@@ -105,6 +105,7 @@ export function Step5EmployeeCategories({
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
+			isSavingOverride={isSaving}
 			isSubmitting={mutation.isPending}
 			maxMen={maxMen}
 			maxWomen={maxWomen}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -109,6 +109,7 @@ export function Step5EmployeeCategories({
 			accordionId="accordion-step5"
 			defaultValuesOverride={categoryFormDefaultOverride}
 			disabled={isImpersonating}
+			hasDataOverride={hasInitialData || hasDraft}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
@@ -130,9 +131,6 @@ export function Step5EmployeeCategories({
 			onValuesChange={(values) => setField(values)}
 			previousHref="/declaration-remuneration/etape/4"
 			referenceYear={declarationYear - 1}
-			savedOverride={
-				(hasInitialData || hasDraft) && !isPendingSave && !isSaving
-			}
 			stepper={<StepIndicator currentStep={5} />}
 			submitError={mutation.error?.message}
 			title={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -70,14 +70,21 @@ export function Step5EmployeeCategories({
 		[initialCategories, initialSource],
 	);
 
-	const { draft, setField, clearDraft, hasDraft, isLoadingDraft, isSaving } =
-		useDeclarationDraft<Step5FormValues>({
-			siren: declarationSiren,
-			year: declarationYear,
-			step: 5,
-			kind: "main",
-			dbValues,
-		});
+	const {
+		draft,
+		setField,
+		clearDraft,
+		hasDraft,
+		isLoadingDraft,
+		isSaving,
+		isPendingSave,
+	} = useDeclarationDraft<Step5FormValues>({
+		siren: declarationSiren,
+		year: declarationYear,
+		step: 5,
+		kind: "main",
+		dbValues,
+	});
 
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => {
@@ -105,6 +112,7 @@ export function Step5EmployeeCategories({
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
 			instructionText="Saisissez les données manquantes avant de valider votre indicateur."
+			isPendingSaveOverride={isPendingSave}
 			isSavingOverride={isSaving}
 			isSubmitting={mutation.isPending}
 			maxMen={maxMen}
@@ -122,7 +130,9 @@ export function Step5EmployeeCategories({
 			onValuesChange={(values) => setField(values)}
 			previousHref="/declaration-remuneration/etape/4"
 			referenceYear={declarationYear - 1}
-			savedOverride={!hasDraft && hasInitialData}
+			savedOverride={
+				(hasInitialData || hasDraft) && !isPendingSave && !isSaving
+			}
 			stepper={<StepIndicator currentStep={5} />}
 			submitError={mutation.error?.message}
 			title={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -145,7 +145,7 @@ export function Step6Review({
 					</h1>
 				</div>
 				<div className="fr-col-auto">
-					<SavedIndicator />
+					<SavedIndicator hasData={true} />
 				</div>
 			</div>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -12,6 +12,7 @@ vi.mock(
 			clearDraft: () => undefined,
 			hasDraft: false,
 			isLoadingDraft: true,
+			isSaving: false,
 		})),
 	}),
 );
@@ -59,6 +60,7 @@ const loadingDraftResult = {
 	clearDraft: () => undefined,
 	hasDraft: false,
 	isLoadingDraft: true,
+	isSaving: false,
 };
 
 function mockLoadingDraft() {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -13,6 +13,7 @@ vi.mock(
 			hasDraft: false,
 			isLoadingDraft: true,
 			isSaving: false,
+			isPendingSave: false,
 		})),
 	}),
 );
@@ -61,6 +62,7 @@ const loadingDraftResult = {
 	hasDraft: false,
 	isLoadingDraft: true,
 	isSaving: false,
+	isPendingSave: false,
 };
 
 function mockLoadingDraft() {

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -36,8 +36,6 @@ export function SecondDeclarationStep1Info({
 		return <DraftLoadingState />;
 	}
 
-	const saved = !hasDraft;
-
 	return (
 		<div className={common.flexColumnGap2}>
 			<div className={common.flexBetween}>
@@ -45,7 +43,7 @@ export function SecondDeclarationStep1Info({
 					Parcours de mise en conformité pour l&apos;indicateur par catégorie de
 					salariés
 				</h1>
-				{saved && <SavedIndicator />}
+				<SavedIndicator hasData={true} />
 			</div>
 
 			<SecondDeclarationStepIndicator currentStep={1} />

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -24,7 +24,7 @@ export function SecondDeclarationStep1Info({
 	declarationYear,
 	modificationDeadline,
 }: Props) {
-	const { hasDraft, isLoadingDraft } = useDeclarationDraft({
+	const { isLoadingDraft } = useDeclarationDraft({
 		siren: declarationSiren,
 		year: declarationYear,
 		step: "second-1",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -82,7 +82,7 @@ export function SecondDeclarationStep3Review({
 					Parcours de mise en conformité pour l&apos;indicateur par catégorie de
 					salariés
 				</h1>
-				<SavedIndicator />
+				<SavedIndicator hasData={true} />
 			</div>
 
 			<SecondDeclarationStepIndicator currentStep={3} />

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -77,6 +77,7 @@ type Props = {
 	disabled?: boolean;
 	mimoquageNextHref?: string;
 	savedOverride?: boolean;
+	isSavingOverride?: boolean;
 	onValuesChange?: (values: {
 		source: string;
 		categories: {
@@ -132,6 +133,7 @@ export function CategoryForm({
 	disabled = false,
 	mimoquageNextHref,
 	savedOverride,
+	isSavingOverride = false,
 	onValuesChange,
 	defaultValuesOverride,
 }: Props) {
@@ -318,6 +320,7 @@ export function CategoryForm({
 	return (
 		<form className={stepStyles.form} onSubmit={handleFormSubmit}>
 			<StepTitleRow
+				isSaving={isSavingOverride}
 				onDevFill={() => {
 					if (maxWomen == null || maxMen == null) return;
 					const devCats = createDevStep5Categories(nextId, maxWomen, maxMen);

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -76,7 +76,7 @@ type Props = {
 	descriptionText?: string;
 	disabled?: boolean;
 	mimoquageNextHref?: string;
-	savedOverride?: boolean;
+	hasDataOverride?: boolean;
 	isSavingOverride?: boolean;
 	isPendingSaveOverride?: boolean;
 	onValuesChange?: (values: {
@@ -133,7 +133,7 @@ export function CategoryForm({
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 	disabled = false,
 	mimoquageNextHref,
-	savedOverride,
+	hasDataOverride,
 	isSavingOverride = false,
 	isPendingSaveOverride = false,
 	onValuesChange,
@@ -169,8 +169,9 @@ export function CategoryForm({
 	});
 
 	const hasInitialData = initialCategories.length > 0;
-	const [savedInternal, setSaved] = useState(hasInitialData);
-	const saved = savedOverride !== undefined ? savedOverride : savedInternal;
+	const [hasDataInternal, setHasData] = useState(hasInitialData);
+	const hasData =
+		hasDataOverride !== undefined ? hasDataOverride : hasDataInternal;
 	const [workforceError, setWorkforceError] = useState("");
 	const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
 	const deleteDialogRef = useRef<HTMLDialogElement>(null);
@@ -190,14 +191,14 @@ export function CategoryForm({
 			const formField = field as Exclude<keyof EmployeeCategory, "id">;
 			if (raw === "") {
 				form.setValue(`categories.${index}.${formField}`, raw);
-				setSaved(false);
+				setHasData(false);
 				return;
 			}
 			if (isInteger && /\D/.test(raw)) return;
 			const n = isInteger ? Number.parseInt(raw, 10) : Number.parseFloat(raw);
 			if (Number.isNaN(n) || n < 0) return;
 			form.setValue(`categories.${index}.${formField}`, raw);
-			setSaved(false);
+			setHasData(false);
 		};
 	}
 
@@ -208,7 +209,7 @@ export function CategoryForm({
 				form.getValues(`categories.${index}.${formField}`),
 				(padded) => {
 					form.setValue(`categories.${index}.${formField}`, padded);
-					setSaved(false);
+					setHasData(false);
 				},
 			);
 		};
@@ -218,12 +219,12 @@ export function CategoryForm({
 		const empty = createEmptyCategory(nextId());
 		const formEntry = toFormValues([empty])[0];
 		if (formEntry) append(formEntry);
-		setSaved(false);
+		setHasData(false);
 	}
 
 	function handleImportCategories(imported: EmployeeCategory[]) {
 		form.setValue("categories", toFormValues(imported));
-		setSaved(false);
+		setHasData(false);
 	}
 
 	function askRemoveCategory(index: number) {
@@ -251,7 +252,7 @@ export function CategoryForm({
 	function confirmRemoveCategory() {
 		if (deleteIndex !== null) {
 			remove(deleteIndex);
-			setSaved(false);
+			setHasData(false);
 		}
 		closeDeleteDialog();
 	}
@@ -322,6 +323,7 @@ export function CategoryForm({
 	return (
 		<form className={stepStyles.form} onSubmit={handleFormSubmit}>
 			<StepTitleRow
+				hasData={hasData}
 				isPendingSave={isPendingSaveOverride}
 				isSaving={isSavingOverride}
 				onDevFill={() => {
@@ -329,9 +331,8 @@ export function CategoryForm({
 					const devCats = createDevStep5Categories(nextId, maxWomen, maxMen);
 					form.setValue("categories", toFormValues(devCats));
 					form.setValue("source", DEV_STEP5_SOURCE);
-					setSaved(false);
+					setHasData(false);
 				}}
-				saved={saved}
 				title={title}
 			/>
 
@@ -368,7 +369,7 @@ export function CategoryForm({
 								form.setValue("source", e.target.value, {
 									shouldValidate: true,
 								});
-								setSaved(false);
+								setHasData(false);
 							}}
 						>
 							<option disabled value="">
@@ -477,7 +478,7 @@ export function CategoryForm({
 														`categories.${index}.name`,
 														e.target.value,
 													);
-													setSaved(false);
+													setHasData(false);
 												}}
 												type="text"
 											/>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -78,6 +78,7 @@ type Props = {
 	mimoquageNextHref?: string;
 	savedOverride?: boolean;
 	isSavingOverride?: boolean;
+	isPendingSaveOverride?: boolean;
 	onValuesChange?: (values: {
 		source: string;
 		categories: {
@@ -134,6 +135,7 @@ export function CategoryForm({
 	mimoquageNextHref,
 	savedOverride,
 	isSavingOverride = false,
+	isPendingSaveOverride = false,
 	onValuesChange,
 	defaultValuesOverride,
 }: Props) {
@@ -320,6 +322,7 @@ export function CategoryForm({
 	return (
 		<form className={stepStyles.form} onSubmit={handleFormSubmit}>
 			<StepTitleRow
+				isPendingSave={isPendingSaveOverride}
 				isSaving={isSavingOverride}
 				onDevFill={() => {
 					if (maxWomen == null || maxMen == null) return;


### PR DESCRIPTION
## Contexte

Partie de l'epic #3484. Quand le brouillon se sauvegarde en base (debounce 600ms après qu'un champ est quitté), l'utilisateur n'avait aucun retour visuel immédiat.

## Changements

- `useDeclarationDraft` expose `isSaving: saveMutation.isPending`
- `SavedIndicator` : spinner `fr-icon-refresh-line` + "Enregistrement..." en cours de save → revient à nuage + "Enregistré" une fois terminé
- `role="status" aria-live="polite" aria-busy={isSaving}` pour l'accessibilité
- `StepTitleRow` affiche l'indicateur dès que `saved || isSaving`
- Steps 1–5 et `CategoryForm` propagent `isSaving`

Closes #3542