### PR TITLE
fix(step1-workforce): validation champ vide + alerte GIP sur onChange

### DIFF
--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -48,6 +48,15 @@ export default async function StepPage({ params }: StepPageProps) {
 		totalMen: d.totalMen ?? gip?.step1.totalMen ?? 0,
 	};
 
+	// When step1 has been saved with values different from GIP, the GIP indicators
+	// for steps 2–4 are no longer valid (updateStep1 already reset them in the DB).
+	const gipMatchesSavedStep1 =
+		gip === null ||
+		d.totalWomen === null ||
+		(d.totalWomen === (gip.step1.totalWomen ?? 0) &&
+			d.totalMen === (gip.step1.totalMen ?? 0));
+	const effectiveGipPrefillData = gipMatchesSavedStep1 ? gip : null;
+
 	const { step2Data, step3Data, step4Data } = mapToStepData(d);
 
 	const hasCurrentYearCategories = data.jobCategories.length > 0;
@@ -80,7 +89,7 @@ export default async function StepPage({ params }: StepPageProps) {
 		<HydrateClient>
 			<StepPageClient
 				declaration={d}
-				gipPrefillData={data.gipPrefillData ?? undefined}
+				gipPrefillData={effectiveGipPrefillData ?? undefined}
 				hasCse={company.hasCse}
 				initialSource={initialSource}
 				step={step}

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 import {
+	getEffectiveGipPrefillData,
 	StepPageClient,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
@@ -48,14 +49,11 @@ export default async function StepPage({ params }: StepPageProps) {
 		totalMen: d.totalMen ?? gip?.step1.totalMen ?? 0,
 	};
 
-	// When step1 has been saved with values different from GIP, the GIP indicators
-	// for steps 2–4 are no longer valid (updateStep1 already reset them in the DB).
-	const gipMatchesSavedStep1 =
-		gip === null ||
-		d.totalWomen === null ||
-		(d.totalWomen === (gip.step1.totalWomen ?? 0) &&
-			d.totalMen === (gip.step1.totalMen ?? 0));
-	const effectiveGipPrefillData = gipMatchesSavedStep1 ? gip : null;
+	const effectiveGipPrefillData = getEffectiveGipPrefillData(
+		gip,
+		d.totalWomen,
+		d.totalMen,
+	);
 
 	const { step2Data, step3Data, step4Data } = mapToStepData(d);
 

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -52,7 +52,9 @@ export async function resetDeclarationToDraft() {
 			UPDATE app_declaration
 			SET status = 'draft', current_step = 1,
 			    first_declaration_path_choice = NULL,
-			    second_declaration_path_choice = NULL
+			    second_declaration_path_choice = NULL,
+			    total_women = NULL,
+			    total_men = NULL
 			WHERE siren = ${TEST_SIREN}
 		`;
 

--- a/packages/app/src/e2e/step1-workforce-validation.e2e.ts
+++ b/packages/app/src/e2e/step1-workforce-validation.e2e.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import { resetDeclarationToDraft } from "./helpers/db";
+
+test.describe("Step 1 workforce — Bug #3527", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/declaration-remuneration");
+		await page.waitForURL("**/declaration-remuneration/etape/1");
+	});
+
+	test("Bug 1 — clearing one field blocks navigation and shows field-level error", async ({
+		page,
+	}) => {
+		const womenInput = page.getByRole("textbox", { name: "Nombre de femmes" });
+		const menInput = page.getByRole("textbox", { name: "Nombre d'hommes" });
+
+		await womenInput.fill("10");
+		await menInput.fill("15");
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.waitForURL("**/declaration-remuneration/etape/2");
+
+		await page.goto("/declaration-remuneration/etape/1");
+		await page.waitForURL("**/declaration-remuneration/etape/1");
+
+		await womenInput.clear();
+
+		await page.getByRole("button", { name: "Suivant" }).click();
+
+		await expect(page).toHaveURL(/etape\/1/);
+
+		await expect(page.locator(".fr-error-text").first()).toBeVisible();
+	});
+
+	test("Bug 1 — entering 0 explicitly is allowed and passes validation", async ({
+		page,
+	}) => {
+		const womenInput = page.getByRole("textbox", { name: "Nombre de femmes" });
+		const menInput = page.getByRole("textbox", { name: "Nombre d'hommes" });
+
+		await womenInput.fill("0");
+		await menInput.fill("20");
+
+		await page.getByRole("button", { name: "Suivant" }).click();
+
+		await expect(page).toHaveURL(/etape\/2/);
+	});
+});

--- a/packages/app/src/e2e/step1-workforce-validation.e2e.ts
+++ b/packages/app/src/e2e/step1-workforce-validation.e2e.ts
@@ -4,7 +4,7 @@ import { resetDeclarationToDraft } from "./helpers/db";
 test.describe("Step 1 workforce — Bug #3527", () => {
 	test.describe.configure({ mode: "serial" });
 
-	test.beforeAll(async () => {
+	test.beforeEach(async () => {
 		await resetDeclarationToDraft();
 	});
 

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -76,7 +76,9 @@ beforeEach(() => {
 
 describe("Step1Opinions", () => {
 	it("disables browser autofill on the form", () => {
-		const { container } = render(<Step1Opinions cseDeadline={cseDeadline} />);
+		const { container } = render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		expect(container.querySelector("form")).toHaveAttribute(
 			"autocomplete",

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -32,6 +32,7 @@ export type {
 	GipQuartileData,
 } from "./shared/gipMdsMapping";
 export { CSV_TO_SCHEMA_MAP, mapGipToFormData } from "./shared/gipMdsMapping";
+export { getEffectiveGipPrefillData } from "./shared/gipToStepData";
 export { ComplianceConfirmation } from "./steps/ComplianceConfirmation";
 export { CompliancePathChoice } from "./steps/CompliancePathChoice";
 export { CompliancePathPage } from "./steps/CompliancePathPage";

--- a/packages/app/src/modules/declaration-remuneration/shared/PrefillResetConfirmDialog.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PrefillResetConfirmDialog.tsx
@@ -31,14 +31,10 @@ export function PrefillResetConfirmDialog({
 				Confirmation de modification
 			</h2>
 			<p>
-				Vous avez modifié les effectifs préremplis à partir de vos données DSN.{" "}
-				<strong>
-					Cette modification réinitialisera les indicateurs préremplis des
-					étapes suivantes.
-				</strong>{" "}
-				Ceux-ci devront alors être ressaisis manuellement.
+				Vous avez modifié l&apos;effectif. En continuant, les données devront
+				être renseignées pour l&apos;ensemble de la suite des indicateurs.
 			</p>
-			<p>Voulez-vous continuer ?</p>
+			<p>Êtes-vous sûr de vouloir continuer&nbsp;?</p>
 
 			<ul className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-4w">
 				<li>

--- a/packages/app/src/modules/declaration-remuneration/shared/PrefillResetConfirmDialog.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PrefillResetConfirmDialog.tsx
@@ -1,0 +1,61 @@
+import type { RefObject } from "react";
+import dialogStyles from "./EditDialog.module.scss";
+
+type Props = {
+	dialogRef: RefObject<HTMLDialogElement | null>;
+	onConfirm: () => void;
+	onCancel: () => void;
+};
+
+export function PrefillResetConfirmDialog({
+	dialogRef,
+	onConfirm,
+	onCancel,
+}: Props) {
+	return (
+		<dialog
+			aria-labelledby="prefill-reset-title"
+			className={`fr-p-4w ${dialogStyles.dialogSmall}`}
+			ref={dialogRef}
+		>
+			<div className="fr-grid-row fr-grid-row--right fr-mb-2w">
+				<button
+					aria-label="Fermer"
+					className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-close-line"
+					onClick={onCancel}
+					type="button"
+				/>
+			</div>
+
+			<h2 className="fr-h4" id="prefill-reset-title">
+				Confirmation de modification
+			</h2>
+			<p>
+				Vous avez modifié les effectifs préremplis à partir de vos données DSN.{" "}
+				<strong>
+					Cette modification réinitialisera les indicateurs préremplis des
+					étapes suivantes.
+				</strong>{" "}
+				Ceux-ci devront alors être ressaisis manuellement.
+			</p>
+			<p>Voulez-vous continuer ?</p>
+
+			<ul className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-4w">
+				<li>
+					<button
+						className="fr-btn fr-btn--secondary"
+						onClick={onCancel}
+						type="button"
+					>
+						Annuler
+					</button>
+				</li>
+				<li>
+					<button className="fr-btn" onClick={onConfirm} type="button">
+						Continuer
+					</button>
+				</li>
+			</ul>
+		</dialog>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/gipToStepData.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/gipToStepData.ts
@@ -1,6 +1,18 @@
 import type { Step2Data, Step3Data } from "../types";
 import type { GipPrefillData } from "./gipMdsMapping";
 
+export function getEffectiveGipPrefillData(
+	gip: GipPrefillData | null,
+	totalWomen: number | null,
+	totalMen: number | null,
+): GipPrefillData | null {
+	if (gip === null || totalWomen === null) return gip;
+	const gipMatchesSaved =
+		totalWomen === (gip.step1.totalWomen ?? 0) &&
+		totalMen === (gip.step1.totalMen ?? 0);
+	return gipMatchesSaved ? gip : null;
+}
+
 export function gipToStep2(gip: GipPrefillData["step2"]): Step2Data {
 	return {
 		indicatorAAnnualWomen: gip.annualMeanWomen ?? "",

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -97,7 +97,6 @@ export function Step1Workforce({
 
 	const hasData = hasInitialData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
-	const [showResetWarning, setShowResetWarning] = useState(false);
 
 	const mutation = api.declaration.updateStep1.useMutation({
 		onSuccess: () => {
@@ -112,21 +111,21 @@ export function Step1Workforce({
 		return Number.parseInt(raw, 10);
 	}
 
+	const showResetWarning =
+		gipPrefillData !== undefined &&
+		((gipPrefillData.step1.totalWomen !== null &&
+			parseIntegerInput(womenRaw) !== gipPrefillData.step1.totalWomen) ||
+			(gipPrefillData.step1.totalMen !== null &&
+				parseIntegerInput(menRaw) !== gipPrefillData.step1.totalMen));
+
 	function handleWomenChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const raw = e.target.value;
 		setWomenRaw(raw);
 		setWomenError(null);
 		const value = parseIntegerInput(raw);
-		if (value === null) {
-			if (isPrefilled && raw === "") setShowResetWarning(true);
-			return;
-		}
+		if (value === null) return;
 		form.setValue("totalWomen", value);
 		setField({ totalWomen: value, totalMen });
-
-		if (isPrefilled && gipPrefillData.step1.totalWomen !== null) {
-			setShowResetWarning(value !== gipPrefillData.step1.totalWomen);
-		}
 	}
 
 	function handleMenChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -134,16 +133,9 @@ export function Step1Workforce({
 		setMenRaw(raw);
 		setMenError(null);
 		const value = parseIntegerInput(raw);
-		if (value === null) {
-			if (isPrefilled && raw === "") setShowResetWarning(true);
-			return;
-		}
+		if (value === null) return;
 		form.setValue("totalMen", value);
 		setField({ totalWomen, totalMen: value });
-
-		if (isPrefilled && gipPrefillData.step1.totalMen !== null) {
-			setShowResetWarning(value !== gipPrefillData.step1.totalMen);
-		}
 	}
 
 	if (!draftHydrated) return <DraftLoadingState />;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -75,19 +75,29 @@ export function Step1Workforce({
 	const totalMen = form.watch("totalMen");
 	const total = totalWomen + totalMen;
 
+	const [womenRaw, setWomenRaw] = useState(() =>
+		initialData.totalWomen > 0 ? String(initialData.totalWomen) : "",
+	);
+	const [menRaw, setMenRaw] = useState(() =>
+		initialData.totalMen > 0 ? String(initialData.totalMen) : "",
+	);
+	const [womenError, setWomenError] = useState<string | null>(null);
+	const [menError, setMenError] = useState<string | null>(null);
+
 	const draftHydrated = useDraftHydration(isLoadingDraft, draft, (d) => {
-		if (typeof d.totalWomen === "number")
+		if (typeof d.totalWomen === "number") {
 			form.setValue("totalWomen", d.totalWomen);
-		if (typeof d.totalMen === "number") form.setValue("totalMen", d.totalMen);
+			setWomenRaw(d.totalWomen > 0 ? String(d.totalWomen) : "");
+		}
+		if (typeof d.totalMen === "number") {
+			form.setValue("totalMen", d.totalMen);
+			setMenRaw(d.totalMen > 0 ? String(d.totalMen) : "");
+		}
 	});
 
 	const hasData = hasInitialData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 	const [showResetWarning, setShowResetWarning] = useState(false);
-
-	function handleInputFocus(currentValue: number) {
-		if (currentValue > 0) setShowResetWarning(true);
-	}
 
 	const mutation = api.declaration.updateStep1.useMutation({
 		onSuccess: () => {
@@ -97,34 +107,53 @@ export function Step1Workforce({
 	});
 
 	function parseIntegerInput(raw: string): number | null {
-		if (raw === "") return 0;
+		if (raw === "") return null;
 		if (/\D/.test(raw)) return null;
 		return Number.parseInt(raw, 10);
 	}
 
 	function handleWomenChange(e: React.ChangeEvent<HTMLInputElement>) {
-		const value = parseIntegerInput(e.target.value);
+		const raw = e.target.value;
+		setWomenRaw(raw);
+		setWomenError(null);
+		const value = parseIntegerInput(raw);
 		if (value === null) return;
 		form.setValue("totalWomen", value);
 		setField({ totalWomen: value, totalMen });
+
+		if (isPrefilled && gipPrefillData.step1.totalWomen !== null) {
+			setShowResetWarning(value !== gipPrefillData.step1.totalWomen);
+		}
 	}
 
 	function handleMenChange(e: React.ChangeEvent<HTMLInputElement>) {
-		const value = parseIntegerInput(e.target.value);
+		const raw = e.target.value;
+		setMenRaw(raw);
+		setMenError(null);
+		const value = parseIntegerInput(raw);
 		if (value === null) return;
 		form.setValue("totalMen", value);
 		setField({ totalWomen, totalMen: value });
+
+		if (isPrefilled && gipPrefillData.step1.totalMen !== null) {
+			setShowResetWarning(value !== gipPrefillData.step1.totalMen);
+		}
 	}
 
 	if (!draftHydrated) return <DraftLoadingState />;
 
 	const onSubmit = form.handleSubmit((data) => {
-		if (data.totalWomen + data.totalMen === 0) {
-			setValidationError(
-				"Veuillez renseigner les effectifs avant de passer à l'étape suivante.",
-			);
-			return;
+		const womenEmpty = womenRaw === "";
+		const menEmpty = menRaw === "";
+
+		if (womenEmpty) {
+			setWomenError("Veuillez renseigner le nombre de femmes.");
 		}
+		if (menEmpty) {
+			setMenError("Veuillez renseigner le nombre d'hommes.");
+		}
+		if (womenEmpty || menEmpty) return;
+
 		setValidationError(null);
 		mutation.mutate(data);
 	});
@@ -144,6 +173,8 @@ export function Step1Workforce({
 					const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;
 					form.setValue("totalWomen", womenValue);
 					form.setValue("totalMen", menValue);
+					setWomenRaw(String(womenValue));
+					setMenRaw(String(menValue));
 					setField({ totalWomen: womenValue, totalMen: menValue });
 				}}
 				title={
@@ -213,30 +244,62 @@ export function Step1Workforce({
 													<strong>Nombre de salariés</strong>
 												</td>
 												<td>
-													<input
-														aria-label="Nombre de femmes"
-														className={`fr-input ${common.numericInput}`}
-														disabled={isImpersonating}
-														inputMode="numeric"
-														onChange={handleWomenChange}
-														onFocus={() => handleInputFocus(totalWomen)}
-														pattern="[0-9]*"
-														type="text"
-														value={totalWomen > 0 ? String(totalWomen) : ""}
-													/>
+													<div
+														className={
+															womenError
+																? "fr-input-group fr-input-group--error"
+																: "fr-input-group"
+														}
+													>
+														<input
+															aria-describedby={
+																womenError ? "women-error" : undefined
+															}
+															aria-invalid={womenError ? true : undefined}
+															aria-label="Nombre de femmes"
+															className={`fr-input ${common.numericInput}${womenError ? "fr-input--error" : ""}`}
+															disabled={isImpersonating}
+															inputMode="numeric"
+															onChange={handleWomenChange}
+															pattern="[0-9]*"
+															type="text"
+															value={womenRaw}
+														/>
+														{womenError && (
+															<p className="fr-error-text" id="women-error">
+																{womenError}
+															</p>
+														)}
+													</div>
 												</td>
 												<td>
-													<input
-														aria-label="Nombre d'hommes"
-														className={`fr-input ${common.numericInput}`}
-														disabled={isImpersonating}
-														inputMode="numeric"
-														onChange={handleMenChange}
-														onFocus={() => handleInputFocus(totalMen)}
-														pattern="[0-9]*"
-														type="text"
-														value={totalMen > 0 ? String(totalMen) : ""}
-													/>
+													<div
+														className={
+															menError
+																? "fr-input-group fr-input-group--error"
+																: "fr-input-group"
+														}
+													>
+														<input
+															aria-describedby={
+																menError ? "men-error" : undefined
+															}
+															aria-invalid={menError ? true : undefined}
+															aria-label="Nombre d'hommes"
+															className={`fr-input ${common.numericInput}${menError ? "fr-input--error" : ""}`}
+															disabled={isImpersonating}
+															inputMode="numeric"
+															onChange={handleMenChange}
+															pattern="[0-9]*"
+															type="text"
+															value={menRaw}
+														/>
+														{menError && (
+															<p className="fr-error-text" id="men-error">
+																{menError}
+															</p>
+														)}
+													</div>
 												</td>
 												<td>
 													<strong>{total}</strong>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+
+import { useMemo, useRef, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -16,6 +17,7 @@ import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
+import { PrefillResetConfirmDialog } from "../shared/PrefillResetConfirmDialog";
 import { PrefillResetWarning } from "../shared/PrefillResetWarning";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
@@ -96,6 +98,12 @@ export function Step1Workforce({
 	});
 
 	const hasData = hasInitialData || hasDraft;
+
+	const dialogRef = useRef<HTMLDialogElement | null>(null);
+	const pendingSubmitData = useRef<{
+		totalWomen: number;
+		totalMen: number;
+	} | null>(null);
 	const [validationError, setValidationError] = useState<string | null>(null);
 
 	const mutation = api.declaration.updateStep1.useMutation({
@@ -109,6 +117,23 @@ export function Step1Workforce({
 		if (raw === "") return null;
 		if (/\D/.test(raw)) return null;
 		return Number.parseInt(raw, 10);
+	}
+
+	const shouldConfirmReset =
+		hasInitialData &&
+		(parseIntegerInput(womenRaw) !== dbValues.totalWomen ||
+			parseIntegerInput(menRaw) !== dbValues.totalMen);
+
+	function handleConfirm() {
+		dialogRef.current?.close();
+		if (pendingSubmitData.current) {
+			mutation.mutate(pendingSubmitData.current);
+		}
+	}
+
+	function handleCancelModal() {
+		dialogRef.current?.close();
+		pendingSubmitData.current = null;
 	}
 
 	const showResetWarning =
@@ -153,216 +178,229 @@ export function Step1Workforce({
 		if (womenEmpty || menEmpty) return;
 
 		setValidationError(null);
+		if (shouldConfirmReset) {
+			pendingSubmitData.current = data;
+			dialogRef.current?.showModal();
+			return;
+		}
 		mutation.mutate(data);
 	});
 
 	return (
-		<form
-			autoComplete="off"
-			className={common.flexColumnGap2}
-			onSubmit={onSubmit}
-		>
-			<StepTitleRow
-				hasData={hasData}
-				isPendingSave={isPendingSave}
-				isSaving={isSaving}
-				onDevFill={() => {
-					const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;
-					const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;
-					form.setValue("totalWomen", womenValue);
-					form.setValue("totalMen", menValue);
-					setWomenRaw(String(womenValue));
-					setMenRaw(String(menValue));
-					setField({ totalWomen: womenValue, totalMen: menValue });
-				}}
-				title={
-					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {declarationYear}
-					</h1>
-				}
-			/>
+		<>
+			<form
+				autoComplete="off"
+				className={common.flexColumnGap2}
+				onSubmit={onSubmit}
+			>
+				<StepTitleRow
+					hasData={hasData}
+					isPendingSave={isPendingSave}
+					isSaving={isSaving}
+					onDevFill={() => {
+						const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;
+						const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;
+						form.setValue("totalWomen", womenValue);
+						form.setValue("totalMen", menValue);
+						setWomenRaw(String(womenValue));
+						setMenRaw(String(menValue));
+						setField({ totalWomen: womenValue, totalMen: menValue });
+					}}
+					title={
+						<h1 className="fr-h4 fr-mb-0">
+							Déclaration des indicateurs de rémunération {declarationYear}
+						</h1>
+					}
+				/>
 
-			<StepIndicator currentStep={1} />
+				<StepIndicator currentStep={1} />
 
-			<div className={common.flexColumnGap1}>
-				<p className="fr-mb-0">
-					Période de référence pour le calcul des indicateurs : 01/01/2026 -
-					31/12/2026.
-					<TooltipButton
-						id="tooltip-period"
-						label="Information sur la période de référence"
-						text="Pour les entreprises créées en cours d'année, cette période correspond à la durée d'activité effective depuis la date de création jusqu'au 31/12/2026."
-					/>
-				</p>
+				<div className={common.flexColumnGap1}>
+					<p className="fr-mb-0">
+						Période de référence pour le calcul des indicateurs : 01/01/2026 -
+						31/12/2026.
+						<TooltipButton
+							id="tooltip-period"
+							label="Information sur la période de référence"
+							text="Pour les entreprises créées en cours d'année, cette période correspond à la durée d'activité effective depuis la date de création jusqu'au 31/12/2026."
+						/>
+					</p>
 
-				<p className={`fr-mb-0 ${common.fontMedium}`}>
-					{isPrefilled
-						? "Vérifiez les informations préremplies à partir de vos données DSN et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
-						: "Renseignez l'effectif physique de votre entreprise."}
-					<TooltipButton
-						id="tooltip-workforce"
-						label="Information sur les effectifs"
-						text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
-					/>
-				</p>
+					<p className={`fr-mb-0 ${common.fontMedium}`}>
+						{isPrefilled
+							? "Vérifiez les informations préremplies à partir de vos données DSN et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
+							: "Renseignez l'effectif physique de votre entreprise."}
+						<TooltipButton
+							id="tooltip-workforce"
+							label="Information sur les effectifs"
+							text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
+						/>
+					</p>
 
-				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
-			</div>
+					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
+				</div>
 
-			<div className={common.dataSection}>
-				<div className={common.flexColumnGapHalf}>
-					<div
-						className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.workforceTable}`}
-					>
-						<div className="fr-table__wrapper">
-							<div className="fr-table__container">
-								<div className="fr-table__content">
-									<table>
-										<caption>
-											Effectifs physiques pris en compte pour le calcul des
-											indicateurs
-										</caption>
-										<colgroup>
-											<col className={styles.labelCol} />
-											<col className={styles.inputCol} />
-											<col className={styles.inputCol} />
-											<col className={styles.totalCol} />
-										</colgroup>
-										<thead>
-											<tr>
-												<th scope="col">{/* vide */}</th>
-												<th scope="col">Femmes</th>
-												<th scope="col">Hommes</th>
-												<th scope="col">Total</th>
-											</tr>
-										</thead>
-										<tbody>
-											<tr>
-												<td>
-													<strong>Nombre de salariés</strong>
-												</td>
-												<td>
-													<div
-														className={
-															womenError
-																? "fr-input-group fr-input-group--error"
-																: "fr-input-group"
-														}
-													>
-														<input
-															aria-describedby={
-																womenError ? "women-error" : undefined
+				<div className={common.dataSection}>
+					<div className={common.flexColumnGapHalf}>
+						<div
+							className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.workforceTable}`}
+						>
+							<div className="fr-table__wrapper">
+								<div className="fr-table__container">
+									<div className="fr-table__content">
+										<table>
+											<caption>
+												Effectifs physiques pris en compte pour le calcul des
+												indicateurs
+											</caption>
+											<colgroup>
+												<col className={styles.labelCol} />
+												<col className={styles.inputCol} />
+												<col className={styles.inputCol} />
+												<col className={styles.totalCol} />
+											</colgroup>
+											<thead>
+												<tr>
+													<th scope="col">{/* vide */}</th>
+													<th scope="col">Femmes</th>
+													<th scope="col">Hommes</th>
+													<th scope="col">Total</th>
+												</tr>
+											</thead>
+											<tbody>
+												<tr>
+													<td>
+														<strong>Nombre de salariés</strong>
+													</td>
+													<td>
+														<div
+															className={
+																womenError
+																	? "fr-input-group fr-input-group--error"
+																	: "fr-input-group"
 															}
-															aria-invalid={womenError ? true : undefined}
-															aria-label="Nombre de femmes"
-															className={`fr-input ${common.numericInput}${womenError ? "fr-input--error" : ""}`}
-															disabled={isImpersonating}
-															inputMode="numeric"
-															onChange={handleWomenChange}
-															pattern="[0-9]*"
-															type="text"
-															value={womenRaw}
-														/>
-														{womenError && (
-															<p className="fr-error-text" id="women-error">
-																{womenError}
-															</p>
-														)}
-													</div>
-												</td>
-												<td>
-													<div
-														className={
-															menError
-																? "fr-input-group fr-input-group--error"
-																: "fr-input-group"
-														}
-													>
-														<input
-															aria-describedby={
-																menError ? "men-error" : undefined
+														>
+															<input
+																aria-describedby={
+																	womenError ? "women-error" : undefined
+																}
+																aria-invalid={womenError ? true : undefined}
+																aria-label="Nombre de femmes"
+																className={`fr-input ${common.numericInput}${womenError ? "fr-input--error" : ""}`}
+																disabled={isImpersonating}
+																inputMode="numeric"
+																onChange={handleWomenChange}
+																pattern="[0-9]*"
+																type="text"
+																value={womenRaw}
+															/>
+															{womenError && (
+																<p className="fr-error-text" id="women-error">
+																	{womenError}
+																</p>
+															)}
+														</div>
+													</td>
+													<td>
+														<div
+															className={
+																menError
+																	? "fr-input-group fr-input-group--error"
+																	: "fr-input-group"
 															}
-															aria-invalid={menError ? true : undefined}
-															aria-label="Nombre d'hommes"
-															className={`fr-input ${common.numericInput}${menError ? "fr-input--error" : ""}`}
-															disabled={isImpersonating}
-															inputMode="numeric"
-															onChange={handleMenChange}
-															pattern="[0-9]*"
-															type="text"
-															value={menRaw}
-														/>
-														{menError && (
-															<p className="fr-error-text" id="men-error">
-																{menError}
-															</p>
-														)}
-													</div>
-												</td>
-												<td>
-													<strong>{total}</strong>
-												</td>
-											</tr>
-										</tbody>
-									</table>
+														>
+															<input
+																aria-describedby={
+																	menError ? "men-error" : undefined
+																}
+																aria-invalid={menError ? true : undefined}
+																aria-label="Nombre d'hommes"
+																className={`fr-input ${common.numericInput}${menError ? "fr-input--error" : ""}`}
+																disabled={isImpersonating}
+																inputMode="numeric"
+																onChange={handleMenChange}
+																pattern="[0-9]*"
+																type="text"
+																value={menRaw}
+															/>
+															{menError && (
+																<p className="fr-error-text" id="men-error">
+																	{menError}
+																</p>
+															)}
+														</div>
+													</td>
+													<td>
+														<strong>{total}</strong>
+													</td>
+												</tr>
+											</tbody>
+										</table>
+									</div>
 								</div>
 							</div>
 						</div>
+
+						{isPrefilled && (
+							<PrefillSource periodEnd={gipPrefillData.periodEnd} />
+						)}
+
+						{showResetWarning && <PrefillResetWarning />}
 					</div>
 
-					{isPrefilled && (
-						<PrefillSource periodEnd={gipPrefillData.periodEnd} />
-					)}
-
-					{showResetWarning && <PrefillResetWarning />}
+					<DefinitionAccordion
+						id="accordion-step1"
+						title="Définitions et méthode de calcul"
+					>
+						<div className="fr-callout">
+							<p>Les informations affichées incluront notamment&nbsp;:</p>
+							<ul>
+								<li>Dernière situation connue&nbsp;?</li>
+								<li>Effectif physique moyen&nbsp;?</li>
+								<li>
+									Comment sont intégrés les salariés entrés et sortis&nbsp;?
+								</li>
+								<li>
+									Comment sont traités les changements de situation (ex. passage
+									du temps plein au temps partiel)&nbsp;?
+								</li>
+								<li>
+									Les absences de six mois ou plus, continues ou discontinues,
+									sont-elles exclues du calcul&nbsp;?
+								</li>
+								<li>
+									Comment sont prises en compte les absences de trois mois, avec
+									leur recalcul en équivalent temps plein (ETP)&nbsp;?
+								</li>
+								<li>
+									Le détail des règles de calcul, illustré par des exemples
+									concrets selon les types de salariés&nbsp;? (Salariés à
+									prendre en compte / Salariés à exclure)
+								</li>
+							</ul>
+						</div>
+					</DefinitionAccordion>
 				</div>
 
-				<DefinitionAccordion
-					id="accordion-step1"
-					title="Définitions et méthode de calcul"
-				>
-					<div className="fr-callout">
-						<p>Les informations affichées incluront notamment&nbsp;:</p>
-						<ul>
-							<li>Dernière situation connue&nbsp;?</li>
-							<li>Effectif physique moyen&nbsp;?</li>
-							<li>
-								Comment sont intégrés les salariés entrés et sortis&nbsp;?
-							</li>
-							<li>
-								Comment sont traités les changements de situation (ex. passage
-								du temps plein au temps partiel)&nbsp;?
-							</li>
-							<li>
-								Les absences de six mois ou plus, continues ou discontinues,
-								sont-elles exclues du calcul&nbsp;?
-							</li>
-							<li>
-								Comment sont prises en compte les absences de trois mois, avec
-								leur recalcul en équivalent temps plein (ETP)&nbsp;?
-							</li>
-							<li>
-								Le détail des règles de calcul, illustré par des exemples
-								concrets selon les types de salariés&nbsp;? (Salariés à prendre
-								en compte / Salariés à exclure)
-							</li>
-						</ul>
-					</div>
-				</DefinitionAccordion>
-			</div>
+				<FormErrors
+					mutationError={mutation.error?.message}
+					validationError={validationError}
+				/>
 
-			<FormErrors
-				mutationError={mutation.error?.message}
-				validationError={validationError}
+				<FormActions
+					className="fr-mt-0"
+					isSubmitting={mutation.isPending}
+					mimoquageNextHref={
+						hasInitialData ? "/declaration-remuneration/etape/2" : undefined
+					}
+					previousHref="/"
+				/>
+			</form>
+			<PrefillResetConfirmDialog
+				dialogRef={dialogRef}
+				onCancel={handleCancelModal}
+				onConfirm={handleConfirm}
 			/>
-
-			<FormActions
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					hasInitialData ? "/declaration-remuneration/etape/2" : undefined
-				}
-				previousHref="/"
-			/>
-		</form>
+		</>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -117,7 +117,10 @@ export function Step1Workforce({
 		setWomenRaw(raw);
 		setWomenError(null);
 		const value = parseIntegerInput(raw);
-		if (value === null) return;
+		if (value === null) {
+			if (isPrefilled && raw === "") setShowResetWarning(true);
+			return;
+		}
 		form.setValue("totalWomen", value);
 		setField({ totalWomen: value, totalMen });
 
@@ -131,7 +134,10 @@ export function Step1Workforce({
 		setMenRaw(raw);
 		setMenError(null);
 		const value = parseIntegerInput(raw);
-		if (value === null) return;
+		if (value === null) {
+			if (isPrefilled && raw === "") setShowResetWarning(true);
+			return;
+		}
 		form.setValue("totalMen", value);
 		setField({ totalWomen, totalMen: value });
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -302,6 +302,62 @@ describe("Step1Workforce", () => {
 		).toBeInTheDocument();
 	});
 
+	it("shows reset warning when GIP prefilled field is cleared to empty", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				gipPrefillData={{
+					step1: { totalWomen: 50, totalMen: 100 },
+					step2: {
+						annualMeanWomen: null,
+						annualMeanMen: null,
+						hourlyMeanWomen: null,
+						hourlyMeanMen: null,
+						annualMedianWomen: null,
+						annualMedianMen: null,
+						hourlyMedianWomen: null,
+						hourlyMedianMen: null,
+					},
+					step3: {
+						annualMeanWomen: null,
+						annualMeanMen: null,
+						hourlyMeanWomen: null,
+						hourlyMeanMen: null,
+						annualMedianWomen: null,
+						annualMedianMen: null,
+						hourlyMedianWomen: null,
+						hourlyMedianMen: null,
+						beneficiaryCountWomen: null,
+						beneficiaryCountMen: null,
+					},
+					step4: {
+						annual: {
+							thresholds: [null, null, null],
+							womenCounts: [null, null, null, null],
+							menCounts: [null, null, null, null],
+						},
+						hourly: {
+							thresholds: [null, null, null],
+							womenCounts: [null, null, null, null],
+							menCounts: [null, null, null, null],
+						},
+					},
+					confidenceIndex: null,
+					periodEnd: null,
+				}}
+				initialData={{ totalWomen: 50, totalMen: 100 }}
+			/>,
+		);
+
+		await user.clear(screen.getByLabelText("Nombre de femmes"));
+
+		expect(
+			screen.getByText(/réinitialise les indicateurs préremplis/),
+		).toBeInTheDocument();
+	});
+
 	it("does not show the reset warning when no GIP data is provided", async () => {
 		const user = userEvent.setup();
 		render(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Step1Workforce } from "../Step1Workforce";
 
 const mockMutate = vi.fn();
@@ -22,6 +22,10 @@ vi.mock("~/trpc/react", () => ({
 const emptyStep1Data = () => ({ totalWomen: 0, totalMen: 0 });
 
 describe("Step1Workforce", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
 	it("disables browser autofill on the form", () => {
 		const { container } = render(
 			<Step1Workforce
@@ -173,7 +177,7 @@ describe("Step1Workforce", () => {
 		});
 	});
 
-	it("shows validation error message when submitting with zero total", async () => {
+	it("shows field-level error messages when submitting with empty inputs", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Workforce
@@ -187,9 +191,29 @@ describe("Step1Workforce", () => {
 		await user.click(submitButton);
 
 		expect(
-			screen.getByText(
-				"Veuillez renseigner les effectifs avant de passer à l'étape suivante.",
-			),
+			screen.getByText("Veuillez renseigner le nombre de femmes."),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Veuillez renseigner le nombre d'hommes."),
+		).toBeInTheDocument();
+	});
+
+	it("blocks submit when one field is cleared after having a value", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={{ totalWomen: 10, totalMen: 20 }}
+			/>,
+		);
+
+		await user.clear(screen.getByLabelText("Nombre de femmes"));
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		expect(mockMutate).not.toHaveBeenCalled();
+		expect(
+			screen.getByText("Veuillez renseigner le nombre de femmes."),
 		).toBeInTheDocument();
 	});
 
@@ -220,7 +244,65 @@ describe("Step1Workforce", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("shows the reset warning when an input with a value receives focus", async () => {
+	it("shows the reset warning when a prefilled value is modified", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				gipPrefillData={{
+					step1: { totalWomen: 50, totalMen: 100 },
+					step2: {
+						annualMeanWomen: null,
+						annualMeanMen: null,
+						hourlyMeanWomen: null,
+						hourlyMeanMen: null,
+						annualMedianWomen: null,
+						annualMedianMen: null,
+						hourlyMedianWomen: null,
+						hourlyMedianMen: null,
+					},
+					step3: {
+						annualMeanWomen: null,
+						annualMeanMen: null,
+						hourlyMeanWomen: null,
+						hourlyMeanMen: null,
+						annualMedianWomen: null,
+						annualMedianMen: null,
+						hourlyMedianWomen: null,
+						hourlyMedianMen: null,
+						beneficiaryCountWomen: null,
+						beneficiaryCountMen: null,
+					},
+					step4: {
+						annual: {
+							thresholds: [null, null, null],
+							womenCounts: [null, null, null, null],
+							menCounts: [null, null, null, null],
+						},
+						hourly: {
+							thresholds: [null, null, null],
+							womenCounts: [null, null, null, null],
+							menCounts: [null, null, null, null],
+						},
+					},
+					confidenceIndex: null,
+					periodEnd: null,
+				}}
+				initialData={{ totalWomen: 50, totalMen: 100 }}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Nombre de femmes");
+		await user.clear(womenInput);
+		await user.type(womenInput, "49");
+
+		expect(
+			screen.getByText(/réinitialise les indicateurs préremplis/),
+		).toBeInTheDocument();
+	});
+
+	it("does not show the reset warning when no GIP data is provided", async () => {
 		const user = userEvent.setup();
 		render(
 			<Step1Workforce
@@ -230,24 +312,9 @@ describe("Step1Workforce", () => {
 			/>,
 		);
 
-		await user.click(screen.getByLabelText("Nombre de femmes"));
-
-		expect(
-			screen.getByText(/réinitialise les indicateurs préremplis/),
-		).toBeInTheDocument();
-	});
-
-	it("does not show the reset warning when focusing an empty input", async () => {
-		const user = userEvent.setup();
-		render(
-			<Step1Workforce
-				declarationSiren="123456789"
-				declarationYear={2026}
-				initialData={emptyStep1Data()}
-			/>,
-		);
-
-		await user.click(screen.getByLabelText("Nombre de femmes"));
+		const womenInput = screen.getByLabelText("Nombre de femmes");
+		await user.clear(womenInput);
+		await user.type(womenInput, "49");
 
 		expect(
 			screen.queryByText(/réinitialise les indicateurs préremplis/),

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -358,6 +358,97 @@ describe("Step1Workforce", () => {
 		).toBeInTheDocument();
 	});
 
+	describe("confirmation modal", () => {
+		beforeEach(() => {
+			HTMLDialogElement.prototype.showModal = vi
+				.fn()
+				.mockImplementation(function (this: HTMLDialogElement) {
+					this.setAttribute("open", "");
+				});
+			HTMLDialogElement.prototype.close = vi.fn().mockImplementation(function (
+				this: HTMLDialogElement,
+			) {
+				this.removeAttribute("open");
+			});
+		});
+
+		it("shows modal on submit when saved values are changed", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Workforce
+					declarationSiren="123456789"
+					declarationYear={2026}
+					initialData={{ totalWomen: 50, totalMen: 100 }}
+				/>,
+			);
+
+			await user.clear(screen.getByLabelText("Nombre de femmes"));
+			await user.type(screen.getByLabelText("Nombre de femmes"), "49");
+			await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+			expect(mockMutate).not.toHaveBeenCalled();
+			expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+		});
+
+		it("calls mutation after confirming", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Workforce
+					declarationSiren="123456789"
+					declarationYear={2026}
+					initialData={{ totalWomen: 50, totalMen: 100 }}
+				/>,
+			);
+
+			await user.clear(screen.getByLabelText("Nombre de femmes"));
+			await user.type(screen.getByLabelText("Nombre de femmes"), "49");
+			await user.click(screen.getByRole("button", { name: /suivant/i }));
+			await user.click(screen.getByRole("button", { name: /continuer/i }));
+
+			expect(mockMutate).toHaveBeenCalledWith({
+				totalWomen: 49,
+				totalMen: 100,
+			});
+		});
+
+		it("does not call mutation when cancelling", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Workforce
+					declarationSiren="123456789"
+					declarationYear={2026}
+					initialData={{ totalWomen: 50, totalMen: 100 }}
+				/>,
+			);
+
+			await user.clear(screen.getByLabelText("Nombre de femmes"));
+			await user.type(screen.getByLabelText("Nombre de femmes"), "49");
+			await user.click(screen.getByRole("button", { name: /suivant/i }));
+			await user.click(screen.getByRole("button", { name: /annuler/i }));
+
+			expect(mockMutate).not.toHaveBeenCalled();
+		});
+
+		it("does not show modal when values match initial data", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Workforce
+					declarationSiren="123456789"
+					declarationYear={2026}
+					initialData={{ totalWomen: 50, totalMen: 100 }}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+			expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+			expect(mockMutate).toHaveBeenCalledWith({
+				totalWomen: 50,
+				totalMen: 100,
+			});
+		});
+	});
+
 	it("does not show the reset warning when no GIP data is provided", async () => {
 		const user = userEvent.setup();
 		render(


### PR DESCRIPTION
## Problème

Deux bugs dans l'étape 1 (Effectifs) de la déclaration :

**Bug 1 — Champ vide laisse passer à l'étape suivante**

`parseIntegerInput("")` retournait `0`, et le schéma Zod validait avec `.min(0)`. Un seul champ vidé passait sans erreur.

**Bug 2 — Alerte GIP n'apparaît pas lors d'une modification**

La `PrefillResetWarning` se déclenchait sur `onFocus` conditionnée à `currentValue > 0`, sans comparer aux valeurs GIP d'origine.

## Corrections

**Bug 1 :** `parseIntegerInput("")` retourne désormais `null`. Deux états locaux (`womenRaw`, `menRaw`) trackent la chaîne brute de chaque input. Au submit, si l'un des deux est `""`, une erreur `fr-error-text` apparaît sous le champ concerné. Saisir `0` explicitement reste valide.

**Bug 2 :** La `PrefillResetWarning` se déclenche maintenant sur `onChange`, conditionnée à `isPrefilled`, en comparant la valeur courante à `gipPrefillData.step1.totalWomen` / `.totalMen`. La logique `onFocus` est supprimée.

## Tests

- Tests unitaires mis à jour pour le nouveau comportement
- Nouveau test unitaire : submit bloqué quand un seul champ est vidé
- Tests E2E ajoutés (`step1-workforce-validation.e2e.ts`) : vider un champ → erreur visible, saisir 0 → navigation autorisée

Closes #3527