### PR TITLE
feat(forms): disable browser autofill on all forms (#3539)

### DIFF
--- a/packages/app/src/modules/admin/declarations/SearchForm.tsx
+++ b/packages/app/src/modules/admin/declarations/SearchForm.tsx
@@ -64,7 +64,11 @@ export function SearchForm() {
 	}, [reset, router]);
 
 	return (
-		<form className="fr-mb-4w" onSubmit={handleSubmit(onSubmit)}>
+		<form
+			autoComplete="off"
+			className="fr-mb-4w"
+			onSubmit={handleSubmit(onSubmit)}
+		>
 			<div className="fr-grid-row fr-grid-row--gutters">
 				<div className="fr-col-12 fr-col-md-4">
 					<div className="fr-input-group">

--- a/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
+++ b/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
@@ -60,7 +60,7 @@ export function ImpersonateForm() {
 
 	return (
 		<div className="fr-mt-4w">
-			<form noValidate onSubmit={onSearch}>
+			<form autoComplete="off" noValidate onSubmit={onSearch}>
 				<div
 					className={
 						sirenError

--- a/packages/app/src/modules/admin/referents/ReferentFormModal.tsx
+++ b/packages/app/src/modules/admin/referents/ReferentFormModal.tsx
@@ -129,7 +129,11 @@ export function ReferentFormModal({
 										? "Ajouter un référent"
 										: "Modifier le référent"}
 								</h2>
-								<form id={`${modalId}-form`} onSubmit={handleSubmit(doSubmit)}>
+								<form
+									autoComplete="off"
+									id={`${modalId}-form`}
+									onSubmit={handleSubmit(doSubmit)}
+								>
 									<ReferentFormFields
 										errors={errors}
 										modalId={modalId}

--- a/packages/app/src/modules/admin/settings/CampaignDeadlinesForm.tsx
+++ b/packages/app/src/modules/admin/settings/CampaignDeadlinesForm.tsx
@@ -131,7 +131,7 @@ export function CampaignDeadlinesForm({ initialYear, configuredYears }: Props) {
 				</select>
 			</div>
 
-			<form noValidate onSubmit={onSubmit}>
+			<form autoComplete="off" noValidate onSubmit={onSubmit}>
 				<input
 					type="hidden"
 					{...form.register("year", { valueAsNumber: true })}

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -114,7 +114,7 @@ export function Step1Opinions({
 	const secondDeclGapDate = form.watch("secondDeclaration.gapDate");
 
 	return (
-		<form onSubmit={onSubmit}>
+		<form autoComplete="off" onSubmit={onSubmit}>
 			{isJointEvaluation && (
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
 					<div className="fr-col">

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -109,7 +109,7 @@ export function Step2Upload({
 
 	return (
 		<>
-			<form onSubmit={formSubmit}>
+			<form autoComplete="off" onSubmit={formSubmit}>
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -46,6 +46,15 @@ beforeEach(() => {
 });
 
 describe("Step1Opinions", () => {
+	it("disables browser autofill on the form", () => {
+		const { container } = render(<Step1Opinions cseDeadline={cseDeadline} />);
+
+		expect(container.querySelector("form")).toHaveAttribute(
+			"autocomplete",
+			"off",
+		);
+	});
+
 	it("renders compliance path title when compliancePath is joint_evaluation", () => {
 		render(
 			<Step1Opinions

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -98,7 +98,11 @@ export function CompliancePathChoice({
 	});
 
 	return (
-		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
+		<form
+			autoComplete="off"
+			className={common.flexColumnGap2}
+			onSubmit={onSubmit}
+		>
 			<div className={common.flexBetween}>
 				<h1 className="fr-h4 fr-mb-0">
 					Déclaration des indicateurs de rémunération {currentYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -121,7 +121,11 @@ export function Step1Workforce({
 	});
 
 	return (
-		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
+		<form
+			autoComplete="off"
+			className={common.flexColumnGap2}
+			onSubmit={onSubmit}
+		>
 			<StepTitleRow
 				onDevFill={() => {
 					const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -117,7 +117,11 @@ export function Step2PayGap({
 	});
 
 	return (
-		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
+		<form
+			autoComplete="off"
+			className={common.flexColumnGap2}
+			onSubmit={onSubmit}
+		>
 			<StepTitleRow
 				onDevFill={() => {
 					DEV_STEP2_ROWS.forEach((row, i) => {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -158,7 +158,11 @@ export function Step3VariablePay({
 	});
 
 	return (
-		<form className={common.flexColumnGap2} onSubmit={onSubmit}>
+		<form
+			autoComplete="off"
+			className={common.flexColumnGap2}
+			onSubmit={onSubmit}
+		>
 			<StepTitleRow
 				onDevFill={() => {
 					DEV_STEP3_ROWS.forEach((row, i) => {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -242,7 +242,12 @@ export function Step4QuartileDistribution({
 	const showAlert = showRecap && recap.length > 0;
 
 	return (
-		<form className={stepStyles.formColumn} noValidate onSubmit={onSubmit}>
+		<form
+			autoComplete="off"
+			className={stepStyles.formColumn}
+			noValidate
+			onSubmit={onSubmit}
+		>
 			<StepTitleRow
 				onDevFill={() => {
 					form.setValue(

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -139,7 +139,11 @@ export function Step6Review({
 	}
 
 	return (
-		<form className={stepStyles.formColumn} onSubmit={handleSubmit}>
+		<form
+			autoComplete="off"
+			className={stepStyles.formColumn}
+			onSubmit={handleSubmit}
+		>
 			{/* Title + save status */}
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 				<div className="fr-col">

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -22,6 +22,20 @@ vi.mock("~/trpc/react", () => ({
 const emptyStep1Data = () => ({ totalWomen: 0, totalMen: 0 });
 
 describe("Step1Workforce", () => {
+	it("disables browser autofill on the form", () => {
+		const { container } = render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
+		);
+		expect(container.querySelector("form")).toHaveAttribute(
+			"autocomplete",
+			"off",
+		);
+	});
+
 	it("renders default state with zero totals", () => {
 		render(
 			<Step1Workforce

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -75,7 +75,11 @@ export function JointEvaluationForm({
 
 	return (
 		<>
-			<form className={common.flexColumnGap2} onSubmit={handleSubmit}>
+			<form
+				autoComplete="off"
+				className={common.flexColumnGap2}
+				onSubmit={handleSubmit}
+			>
 				<div className={common.flexBetween}>
 					<h1 className="fr-h4 fr-mb-0">
 						Parcours de mise en conformité pour l&apos;indicateur par catégorie

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -76,7 +76,11 @@ export function SecondDeclarationStep3Review({
 	}
 
 	return (
-		<form className={common.flexColumnGap2} onSubmit={handleSubmit}>
+		<form
+			autoComplete="off"
+			className={common.flexColumnGap2}
+			onSubmit={handleSubmit}
+		>
 			<div className={common.flexBetween}>
 				<h1 className="fr-h4 fr-mb-0">
 					Parcours de mise en conformité pour l&apos;indicateur par catégorie de

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -316,7 +316,11 @@ export function CategoryForm({
 	});
 
 	return (
-		<form className={stepStyles.form} onSubmit={handleFormSubmit}>
+		<form
+			autoComplete="off"
+			className={stepStyles.form}
+			onSubmit={handleFormSubmit}
+		>
 			<StepTitleRow
 				onDevFill={() => {
 					if (maxWomen == null || maxMen == null) return;

--- a/packages/app/src/modules/home/HomeSearch.tsx
+++ b/packages/app/src/modules/home/HomeSearch.tsx
@@ -48,6 +48,7 @@ export function HomeSearch() {
 						<form
 							action="/index-egapro/recherche"
 							aria-label="Rechercher une entreprise"
+							autoComplete="off"
 							method="GET"
 						>
 							<div className="fr-input-group">

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -101,7 +101,11 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 									.
 								</p>
 
-								<form id="company-edit-form" onSubmit={onSubmit}>
+								<form
+									autoComplete="off"
+									id="company-edit-form"
+									onSubmit={onSubmit}
+								>
 									<CompanyReadonlySection company={initialCompany} />
 									<Controller
 										control={form.control}

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -37,6 +37,15 @@ beforeEach(() => {
 // The <dialog> is closed (not open) in jsdom, so its content is hidden.
 // We use { hidden: true } for role queries to access hidden elements.
 describe("CompanyEditModal", () => {
+	it("disables browser autofill on the form", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		expect(container.querySelector("form")).toHaveAttribute(
+			"autocomplete",
+			"off",
+		);
+	});
+
 	it("renders the modal with company info", () => {
 		const { container } = render(<CompanyEditModal company={company} />);
 

--- a/packages/app/src/modules/profile/ProfileModal.tsx
+++ b/packages/app/src/modules/profile/ProfileModal.tsx
@@ -108,7 +108,7 @@ export function ProfileModal() {
 									de vérifier les données affichées et de compléter les
 									informations manquantes si nécessaire.
 								</p>
-								<form id="profile-form" onSubmit={onSubmit}>
+								<form autoComplete="off" id="profile-form" onSubmit={onSubmit}>
 									<div className="fr-grid-row fr-grid-row--gutters fr-mb-3w">
 										<div className="fr-col-12 fr-col-md-6">
 											<ReadonlyField

--- a/packages/app/src/modules/referents/shared/ReferentsSearchForm.tsx
+++ b/packages/app/src/modules/referents/shared/ReferentsSearchForm.tsx
@@ -125,7 +125,11 @@ export function ReferentsSearchForm({
 	);
 
 	return (
-		<form className="fr-mb-4w" onSubmit={handleSubmit(onSubmit)}>
+		<form
+			autoComplete="off"
+			className="fr-mb-4w"
+			onSubmit={handleSubmit(onSubmit)}
+		>
 			{wrapFieldsInFieldset ? (
 				<fieldset className="fr-fieldset">
 					<legend className="fr-fieldset__legend fr-sr-only">


### PR DESCRIPTION
## Contexte

Closes #3539

Demande préventive QA (aucun bug remonté) : désactiver l'autofill natif du navigateur (Chrome / Firefox / Safari) sur tous les formulaires de l'app, pour éviter que le navigateur ne pré-remplisse des champs métier (SIREN, effectifs, indicateurs, dates d'arrêt, opinions CSE…) avec des valeurs sauvegardées sur d'autres sites.

Approche retenue (validée dans l'analyse architecte) : `autoComplete="off"` au niveau `<form>`, un attribut par formulaire. Pas de wrapper, pas de modification de `useZodForm`, pas de gestion des password managers (hors scope).

## Changes

- **19 formulaires** modifiés (déclaration ×9, CSE opinion ×2, admin ×4, my-space / profile / home / referents ×4)
- **3 assertions unitaires** ajoutées sur des forms représentatifs (`Step1Workforce`, `CompanyEditModal`, `Step1Opinions`) — vérifient la présence de l'attribut `autocomplete="off"` dans le DOM rendu

## Quality gates

- `pnpm test` : 2088 tests verts (3 nouveaux ajoutés)
- `pnpm typecheck` : OK
- `pnpm lint:check` / `pnpm format:check` : OK
- `structural-auditor` : MINOR (aucune ERROR ; les WARNs concernent du legacy hors scope du ticket)
- `rgaa-auditor` : MINOR (cf. note ci-dessous)
- `security-auditor` : SECURE (aucun fichier `server/` / `routers/` / tRPC modifié)

## Note RGAA (à arbitrer côté revue humaine — non-bloquant)

L'audit RGAA signale un trade-off sur **`ProfileModal.tsx`** (formulaire d'édition du téléphone personnel de l'utilisateur connecté). RGAA 11.13 / WCAG 1.3.5 recommande `autocomplete=\"tel\"` sur un champ téléphone personnel — `autoComplete=\"off\"` au niveau du `<form>` peut écraser cette finalité dans certains navigateurs.

Options pour un éventuel suivi (hors scope direct du ticket) :
- ajouter `autoComplete=\"tel\"` directement sur l'input du `PhoneField` (les navigateurs conformes laissent l'attribut au niveau du champ l'emporter sur celui du form) ;
- ou retirer `autoComplete=\"off\"` uniquement sur le `ProfileModal` (qui ne contient que le téléphone perso).

À traiter dans une issue dédiée si l'équipe juge le compromis indésirable.

## Test plan

- [x] Tests unitaires verts (`pnpm test`)
- [x] Typecheck vert (`pnpm typecheck`)
- [x] Lint/format verts (`pnpm lint:check`, `pnpm format:check`)
- [ ] (revue humaine) Smoke manuel sur 2-3 forms représentatifs avec un profil navigateur ayant des données autofill enregistrées (email, adresse) — confirmer que les champs ne se pré-remplissent plus
- [ ] (revue humaine) Arbitrage sur la note RGAA `ProfileModal`