### PR TITLE
fix(declaration-remuneration): spacing between FormActions and content (#3535)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
@@ -35,7 +35,7 @@ export function FormActions({
 	const { isReadOnly, buttonProps, tooltip } = useReadOnlyGuard();
 
 	return (
-		<div className={`fr-mt-4w ${styles.actions} ${className ?? ""}`}>
+		<div className={`${styles.actions} ${className ?? ""}`}>
 			{previousHref ? (
 				<Link
 					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -281,7 +281,6 @@ export function Step1Workforce({
 			/>
 
 			<FormActions
-				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
 				mimoquageNextHref={
 					hasInitialData ? "/declaration-remuneration/etape/2" : undefined

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -225,7 +225,6 @@ export function Step2PayGap({
 			/>
 
 			<FormActions
-				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
 				mimoquageNextHref={
 					hasSavedData ? "/declaration-remuneration/etape/3" : undefined

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -390,7 +390,6 @@ export function Step3VariablePay({
 			/>
 
 			<FormActions
-				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
 				mimoquageNextHref={
 					hasSavedData ? "/declaration-remuneration/etape/4" : undefined

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -386,7 +386,6 @@ export function Step4QuartileDistribution({
 			/>
 
 			<FormActions
-				className="fr-mt-0"
 				isSubmitting={mutation.isPending}
 				mimoquageNextHref={
 					hasSavedData ? "/declaration-remuneration/etape/5" : undefined


### PR DESCRIPTION
Closes #3535

## Problème

Sur les écrans du parcours `declaration-remuneration`, la distance entre le dernier bloc de contenu et la barre Précédent/Suivant était de **64px** au lieu des **32px** définis dans Figma.

**Root cause** : `FormActions.tsx` appliquait `fr-mt-4w` (margin-top: 32px) alors que le parent `<form>` est en `display: flex; flex-direction: column; gap: 32px`. En flex container, les marges **s'ajoutent au gap** (pas de collapsing) → 32 + 32 = 64px.

Note : 4 fichiers tentaient un override avec `className="fr-mt-0"` qui était silencieusement inopérant car `.fr-mt-4w` est défini après `.fr-mt-0` dans `dsfr.css` à spécificité égale.

## Fix

1. `FormActions.tsx` — retrait de `fr-mt-4w` de la className. La marge est désormais entièrement gérée par le `gap: 32px` du parent flex.
2. `Step1Workforce`, `Step2PayGap`, `Step3VariablePay`, `Step4QuartileDistribution` — retrait de `className="fr-mt-0"` devenu inutile.

Les écrans CSE (`Step1Opinions`, `Step2Upload`) ne sont **pas** touchés : ils utilisent `fr-mt-4w` inline dans un `<form>` en `display: block` où le comportement est correct (32px sans flex-gap).

## Fichiers modifiés

- `packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx`
- `packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx`
- `packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx`
- `packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx`
- `packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx`

## Mesures DOM avant/après

**Avant** (avec `fr-mt-4w` + gap parent 32px) :
- Dernier bloc contenu : y_end = 846
- FormActions : y_start = 910
- Distance = **64px** ❌

**Après** (sans `fr-mt-4w`, gap parent 32px seulement) :
- Step1 : `e67` y_end=846, `e98` y_start=878 → distance = **32px** ✓
- Step6 : last section y_end=1222, FormActions y_start=1254 → distance = **32px** ✓
- CSE Step1 (non-régression) : `e62` y_end=1262, `e91` y_start=1294 → distance = **32px** ✓

## Review app

https://egapro-ticket-3535-corriger-l-espace-entre-bouton-de-1brxq7ia.ovh.fabrique.social.gouv.fr

## Plan de test

- [x] Distance 32px entre le dernier bloc et FormActions sur Step1 (mesuré DOM)
- [x] Distance 32px sur Step6Review (mesuré DOM)
- [x] Non-régression CSE : avis-cse/etape/1 reste à 32px (mesuré DOM, display: block)
- [x] Typecheck vert
- [x] Lint/format vert
- [x] 2085 tests unitaires verts
- [x] CI/SonarCloud verts