### PR TITLE
feat(stats): K1 — Taux de déclaration (#3210)

### DIFF
--- a/packages/app/src/app/stats/page.tsx
+++ b/packages/app/src/app/stats/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+import { PublicStatsPage } from "~/modules/publicStats";
+import { HydrateClient } from "~/trpc/server";
+
+export const metadata: Metadata = {
+	title: "Statistiques publiques — Égalité professionnelle",
+	description:
+		"Taux de déclaration et répartition des écarts de rémunération entre les femmes et les hommes en France.",
+};
+
+export default function Page() {
+	return (
+		<HydrateClient>
+			<PublicStatsPage />
+		</HydrateClient>
+	);
+}

--- a/packages/app/src/e2e/public-stats.e2e.ts
+++ b/packages/app/src/e2e/public-stats.e2e.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+import { getCurrentYear } from "~/modules/domain";
+import {
+	deleteSeededCampaignDeclarations,
+	seedGipMdsObligatedPopulation,
+	seedSubmittedDeclarationsForStats,
+} from "./helpers/db-campaign";
+
+const PUBLIC_K1_SIRENS = {
+	obligatedSubmitted: "999300201",
+	obligatedNotSubmitted: "999300202",
+	obligatedPrevYearSubmitted: "999300203",
+	obligatedPrevYearNotSubmitted: "999300204",
+} as const;
+
+test.describe("public stats — K1 declaration rate tile", () => {
+	const currentYear = getCurrentYear();
+
+	test.beforeAll(async () => {
+		await seedGipMdsObligatedPopulation([
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedSubmitted,
+				year: currentYear,
+				workforceEma: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedNotSubmitted,
+				year: currentYear,
+				workforceEma: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedPrevYearSubmitted,
+				year: currentYear - 1,
+				workforceEma: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedPrevYearNotSubmitted,
+				year: currentYear - 1,
+				workforceEma: 250,
+			},
+		]);
+		await seedSubmittedDeclarationsForStats([
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedSubmitted,
+				year: currentYear,
+				submittedAt: `${currentYear}-02-10T10:00:00Z`,
+				workforce: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedPrevYearSubmitted,
+				year: currentYear - 1,
+				submittedAt: `${currentYear - 1}-02-10T10:00:00Z`,
+				workforce: 250,
+			},
+		]);
+	});
+
+	test.afterAll(async () => {
+		await deleteSeededCampaignDeclarations(Object.values(PUBLIC_K1_SIRENS));
+	});
+
+	test("an anonymous visitor can reach /stats without being redirected to /login", async ({
+		browser,
+	}) => {
+		const anonCtx = await browser.newContext({
+			storageState: { cookies: [], origins: [] },
+		});
+		try {
+			const page = await anonCtx.newPage();
+			await page.goto("/stats");
+			await expect(page).not.toHaveURL(/\/login/);
+			await expect(
+				page.getByRole("heading", {
+					name: "Statistiques publiques",
+					level: 1,
+				}),
+			).toBeVisible();
+		} finally {
+			await anonCtx.close();
+		}
+	});
+
+	test("public K1 tile is rendered with the current-year title and a percent value", async ({
+		browser,
+	}) => {
+		const anonCtx = await browser.newContext({
+			storageState: { cookies: [], origins: [] },
+		});
+		try {
+			const page = await anonCtx.newPage();
+			await page.goto("/stats");
+
+			await expect(
+				page.getByRole("heading", {
+					name: new RegExp(`^Taux de déclaration ${currentYear}$`),
+				}),
+			).toBeVisible();
+			await expect(page.getByText(/\d{1,3},\d\s*%/)).toBeVisible();
+			await expect(
+				page.getByText(/\d+\s*\/\s*\d+\s+entreprises/),
+			).toBeVisible();
+		} finally {
+			await anonCtx.close();
+		}
+	});
+});

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
@@ -1,13 +1,6 @@
-import type { ReactNode } from "react";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
 
-import { formatPointsAbs } from "~/modules/domain";
-
-const NARROW_NBSP = " ";
-
-export type AdminKpiTileDelta = {
-	points: number;
-	comparisonLabel: string;
-};
+export type AdminKpiTileDelta = KpiBadgeDelta;
 
 type Props = {
 	title: string;
@@ -17,55 +10,6 @@ type Props = {
 	// true when the underlying KPI is "lower is better" (e.g. share above gap threshold).
 	inverted?: boolean;
 };
-
-type BadgeRendering = {
-	className: string;
-	arrow: string;
-	signedValue: string;
-};
-
-export function getBadgeRendering(
-	delta: AdminKpiTileDelta,
-	inverted: boolean,
-): BadgeRendering {
-	if (delta.points > 0) {
-		return {
-			className: inverted
-				? "fr-badge fr-badge--error fr-badge--no-icon"
-				: "fr-badge fr-badge--success fr-badge--no-icon",
-			arrow: "↑",
-			signedValue: `+${formatPointsAbs(delta.points)}`,
-		};
-	}
-	if (delta.points < 0) {
-		return {
-			className: inverted
-				? "fr-badge fr-badge--success fr-badge--no-icon"
-				: "fr-badge fr-badge--error fr-badge--no-icon",
-			arrow: "↓",
-			signedValue: `-${formatPointsAbs(delta.points)}`,
-		};
-	}
-	return {
-		className: "fr-badge fr-badge--no-icon",
-		arrow: "=",
-		signedValue: `0${NARROW_NBSP}`,
-	};
-}
-
-function renderBadge(
-	delta: AdminKpiTileDelta | null,
-	inverted: boolean,
-): ReactNode {
-	if (!delta) return null;
-	const { className, arrow, signedValue } = getBadgeRendering(delta, inverted);
-	return (
-		<p className={className}>
-			<span aria-hidden="true">{arrow}</span> {signedValue}
-			{NARROW_NBSP}pts {delta.comparisonLabel}
-		</p>
-	);
-}
 
 export function AdminKpiTile({
 	title,
@@ -80,7 +24,7 @@ export function AdminKpiTile({
 				<div className="fr-tile__content">
 					<h3 className="fr-tile__title">{title}</h3>
 					<p className="fr-display--xs fr-mb-1w">{value}</p>
-					{renderBadge(delta, inverted)}
+					<KpiBadge delta={delta} inverted={inverted} />
 					<p className="fr-text--sm fr-text-mention--grey fr-mb-0 fr-mt-1w">
 						{subtitle}
 					</p>

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
@@ -1,4 +1,4 @@
-import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared/KpiBadge";
 
 export type AdminKpiTileDelta = KpiBadgeDelta;
 

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
-const NARROW_NBSP = " ";
+import { formatPointsAbs } from "~/modules/domain";
+
+const NARROW_NBSP = " ";
 
 export type AdminKpiTileDelta = {
 	points: number;
@@ -21,11 +23,6 @@ type BadgeRendering = {
 	arrow: string;
 	signedValue: string;
 };
-
-function formatPointsAbs(points: number): string {
-	const rounded = Math.round(Math.abs(points) * 10) / 10;
-	return rounded.toFixed(1).replace(".", ",");
-}
 
 export function getBadgeRendering(
 	delta: AdminKpiTileDelta,

--- a/packages/app/src/modules/admin/stats/CampaignRateTile.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignRateTile.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import type { CompanySizeRange } from "~/modules/domain";
+import { buildCampaignRateTileProps } from "~/modules/domain";
+import {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "~/modules/shared";
 import { api } from "~/trpc/react";
 
 import { AdminKpiTile } from "./AdminKpiTile";
-
-const NARROW_NBSP = " ";
 
 type Props = {
 	year: number;
 	sizeRange: CompanySizeRange | undefined;
 };
-
-function formatRate(rate: number): string {
-	return rate.toFixed(1).replace(".", ",");
-}
-
-function formatCount(count: number): string {
-	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
-}
 
 export function CampaignRateTile({ year, sizeRange }: Props) {
 	const query = api.adminStats.getCampaignStats.useQuery(
@@ -26,42 +21,11 @@ export function CampaignRateTile({ year, sizeRange }: Props) {
 		{ placeholderData: (prev) => prev },
 	);
 
-	if (query.isLoading && !query.data) {
-		return (
-			<p aria-live="polite" className="fr-text--sm">
-				Chargement du taux de déclaration…
-			</p>
-		);
-	}
-
-	if (query.isError) {
-		return (
-			<div aria-live="polite" className="fr-alert fr-alert--error">
-				<p>
-					Une erreur est survenue lors du chargement du taux de déclaration.
-				</p>
-			</div>
-		);
-	}
+	if (query.isLoading && !query.data) return <CampaignRateTileLoading />;
+	if (query.isError) return <CampaignRateTileError />;
 
 	const data = query.data;
 	if (!data) return null;
 
-	const delta =
-		data.previousYearRate === null
-			? null
-			: {
-					points:
-						Math.round((data.submissionRate - data.previousYearRate) * 10) / 10,
-					comparisonLabel: `vs ${year - 1}`,
-				};
-
-	return (
-		<AdminKpiTile
-			delta={delta}
-			subtitle={`${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`}
-			title={`Taux de déclaration ${year}`}
-			value={`${formatRate(data.submissionRate)}${NARROW_NBSP}%`}
-		/>
-	);
+	return <AdminKpiTile {...buildCampaignRateTileProps(data, year, year - 1)} />;
 }

--- a/packages/app/src/modules/admin/stats/__tests__/AdminKpiTile.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/AdminKpiTile.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { AdminKpiTile, getBadgeRendering } from "../AdminKpiTile";
+import { AdminKpiTile } from "../AdminKpiTile";
 
 describe("AdminKpiTile", () => {
 	it("renders title, value and subtitle", () => {
@@ -128,38 +128,5 @@ describe("AdminKpiTile", () => {
 		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
 		expect(arrow).not.toBeNull();
 		expect(arrow?.textContent).toBe("↑");
-	});
-});
-
-describe("getBadgeRendering (badge logic helper)", () => {
-	it("rounds the displayed points to one decimal place", () => {
-		const out = getBadgeRendering({ points: 2.07, comparisonLabel: "" }, false);
-		expect(out.signedValue).toBe("+2,1");
-	});
-
-	it("uses the success class for negative delta when inverted", () => {
-		const out = getBadgeRendering(
-			{ points: -2, comparisonLabel: "vs 2025" },
-			true,
-		);
-		expect(out.className).toContain("fr-badge--success");
-		expect(out.arrow).toBe("↓");
-		expect(out.signedValue).toBe("-2,0");
-	});
-
-	it("uses the error class for positive delta when inverted", () => {
-		const out = getBadgeRendering(
-			{ points: 0.5, comparisonLabel: "vs 2025" },
-			true,
-		);
-		expect(out.className).toContain("fr-badge--error");
-	});
-
-	it("produces a neutral badge with `0` for a zero delta", () => {
-		const out = getBadgeRendering({ points: 0, comparisonLabel: "" }, false);
-		expect(out.arrow).toBe("=");
-		expect(out.signedValue.trim()).toBe("0");
-		expect(out.className).not.toContain("--success");
-		expect(out.className).not.toContain("--error");
 	});
 });

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -86,6 +86,10 @@ export const AUDIT_ACTIONS = {
 	PUBLIC_REFERENT_SEARCH: "public_referents.search",
 	PUBLIC_REFERENT_VIEW: "public_referents.view",
 
+	// ── Public stats reads ─────────────────────────────────
+	PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE:
+		"public_stats.get_current_campaign_rate",
+
 	// ── System / cron-triggered ────────────────────────────
 	SYSTEM_AUDIT_CLEANUP: "system.audit_cleanup",
 } as const;
@@ -154,6 +158,8 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH]: "public_search",
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW]: "public_search",
+
+	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
 
 	[AUDIT_ACTIONS.SYSTEM_AUDIT_CLEANUP]: "system",
 };

--- a/packages/app/src/modules/domain/__tests__/format.test.ts
+++ b/packages/app/src/modules/domain/__tests__/format.test.ts
@@ -7,9 +7,11 @@ import {
 	formatGap,
 	formatGapCompact,
 	formatMonthDay,
+	formatPointsAbs,
 	formatShortDate,
 	formatShortDateTime,
 	formatTotal,
+	roundOneDecimal,
 } from "../shared/format";
 
 describe("formatGap", () => {
@@ -104,5 +106,29 @@ describe("formatMonthDay", () => {
 	it("swaps a MM-DD fragment to the French DD/MM form", () => {
 		expect(formatMonthDay("02-15")).toBe("15/02");
 		expect(formatMonthDay("12-01")).toBe("01/12");
+	});
+});
+
+describe("roundOneDecimal", () => {
+	it("rounds to one decimal place (banker-agnostic)", () => {
+		expect(roundOneDecimal(73.42)).toBe(73.4);
+		expect(roundOneDecimal(73.45)).toBe(73.5);
+		expect(roundOneDecimal(73.44)).toBe(73.4);
+		expect(roundOneDecimal(73.0)).toBe(73);
+	});
+
+	it("handles negatives", () => {
+		expect(roundOneDecimal(-2.07)).toBe(-2.1);
+		expect(roundOneDecimal(-0.04)).toBeCloseTo(0, 10);
+	});
+});
+
+describe("formatPointsAbs", () => {
+	it("returns absolute value rounded to 1 decimal, French separator", () => {
+		expect(formatPointsAbs(2.07)).toBe("2,1");
+		expect(formatPointsAbs(-2.07)).toBe("2,1");
+		expect(formatPointsAbs(0)).toBe("0,0");
+		expect(formatPointsAbs(0.5)).toBe("0,5");
+		expect(formatPointsAbs(-0.04)).toBe("0,0");
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/submissionRate.test.ts
+++ b/packages/app/src/modules/domain/__tests__/submissionRate.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	computeRate,
+	formatPointsAbs,
+	roundOneDecimal,
+} from "../shared/submissionRate";
+
+describe("roundOneDecimal", () => {
+	it("rounds to one decimal place (banker-agnostic)", () => {
+		expect(roundOneDecimal(73.42)).toBe(73.4);
+		expect(roundOneDecimal(73.45)).toBe(73.5);
+		expect(roundOneDecimal(73.44)).toBe(73.4);
+		expect(roundOneDecimal(73.0)).toBe(73);
+	});
+
+	it("handles negatives", () => {
+		expect(roundOneDecimal(-2.07)).toBe(-2.1);
+		expect(roundOneDecimal(-0.04)).toBeCloseTo(0, 10);
+	});
+});
+
+describe("computeRate", () => {
+	it("returns 0 when obligated = 0 (no division by zero)", () => {
+		expect(computeRate(0, 0)).toBe(0);
+		expect(computeRate(5, 0)).toBe(0);
+	});
+
+	it("returns a percentage rounded to one decimal", () => {
+		expect(computeRate(73, 100)).toBe(73);
+		expect(computeRate(1, 3)).toBe(33.3);
+		expect(computeRate(2, 3)).toBe(66.7);
+		expect(computeRate(1, 2)).toBe(50);
+	});
+
+	it("computes 100 when submitted === obligated", () => {
+		expect(computeRate(42, 42)).toBe(100);
+	});
+});
+
+describe("formatPointsAbs", () => {
+	it("returns absolute value rounded to 1 decimal, French separator", () => {
+		expect(formatPointsAbs(2.07)).toBe("2,1");
+		expect(formatPointsAbs(-2.07)).toBe("2,1");
+		expect(formatPointsAbs(0)).toBe("0,0");
+		expect(formatPointsAbs(0.5)).toBe("0,5");
+		expect(formatPointsAbs(-0.04)).toBe("0,0");
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/submissionRate.test.ts
+++ b/packages/app/src/modules/domain/__tests__/submissionRate.test.ts
@@ -1,24 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-	computeRate,
-	formatPointsAbs,
-	roundOneDecimal,
-} from "../shared/submissionRate";
-
-describe("roundOneDecimal", () => {
-	it("rounds to one decimal place (banker-agnostic)", () => {
-		expect(roundOneDecimal(73.42)).toBe(73.4);
-		expect(roundOneDecimal(73.45)).toBe(73.5);
-		expect(roundOneDecimal(73.44)).toBe(73.4);
-		expect(roundOneDecimal(73.0)).toBe(73);
-	});
-
-	it("handles negatives", () => {
-		expect(roundOneDecimal(-2.07)).toBe(-2.1);
-		expect(roundOneDecimal(-0.04)).toBeCloseTo(0, 10);
-	});
-});
+import { computeRate } from "../shared/submissionRate";
 
 describe("computeRate", () => {
 	it("returns 0 when obligated = 0 (no division by zero)", () => {
@@ -35,15 +17,5 @@ describe("computeRate", () => {
 
 	it("computes 100 when submitted === obligated", () => {
 		expect(computeRate(42, 42)).toBe(100);
-	});
-});
-
-describe("formatPointsAbs", () => {
-	it("returns absolute value rounded to 1 decimal, French separator", () => {
-		expect(formatPointsAbs(2.07)).toBe("2,1");
-		expect(formatPointsAbs(-2.07)).toBe("2,1");
-		expect(formatPointsAbs(0)).toBe("0,0");
-		expect(formatPointsAbs(0.5)).toBe("0,5");
-		expect(formatPointsAbs(-0.04)).toBe("0,0");
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -136,9 +136,14 @@ export {
 // SIREN utilities
 export { extractSiren, formatSiren, parseSiren } from "./shared/siren";
 // Submission rate helpers (shared by admin/public stats routers and KPI tiles)
+export type { CampaignRateTileProps } from "./shared/submissionRate";
 export {
+	buildCampaignRateTileProps,
 	computeRate,
+	formatCount,
 	formatPointsAbs,
+	formatRate,
+	NARROW_NBSP,
 	roundOneDecimal,
 } from "./shared/submissionRate";
 export type {

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -135,6 +135,12 @@ export {
 } from "./shared/regions";
 // SIREN utilities
 export { extractSiren, formatSiren, parseSiren } from "./shared/siren";
+// Submission rate helpers (shared by admin/public stats routers and KPI tiles)
+export {
+	computeRate,
+	formatPointsAbs,
+	roundOneDecimal,
+} from "./shared/submissionRate";
 export type {
 	CampaignDeadlines,
 	CompanySize,

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -82,18 +82,23 @@ export {
 	hasEvent,
 	hasSubmittedSecondDeclaration,
 } from "./shared/declarationTrajectory";
-// Display formatting (%, €, units)
+// Display formatting (%, €, units, rates, counts, points)
 export {
 	computePercentage,
 	computeProportion,
+	formatCount,
 	formatCurrency,
 	formatGap,
 	formatGapCompact,
 	formatLongDate,
 	formatMonthDay,
+	formatPointsAbs,
+	formatRate,
 	formatShortDate,
 	formatShortDateTime,
 	formatTotal,
+	NARROW_NBSP,
+	roundOneDecimal,
 } from "./shared/format";
 // Gap business rules (calculations & threshold classification)
 export {
@@ -140,11 +145,6 @@ export type { CampaignRateTileProps } from "./shared/submissionRate";
 export {
 	buildCampaignRateTileProps,
 	computeRate,
-	formatCount,
-	formatPointsAbs,
-	formatRate,
-	NARROW_NBSP,
-	roundOneDecimal,
 } from "./shared/submissionRate";
 export type {
 	CampaignDeadlines,

--- a/packages/app/src/modules/domain/shared/format.ts
+++ b/packages/app/src/modules/domain/shared/format.ts
@@ -9,6 +9,30 @@
  * For gap calculation and threshold classification, see `gap.ts`.
  */
 
+/** Narrow no-break space (U+202F) — French thousand separator and unit-prefix glue. */
+export const NARROW_NBSP = " ";
+
+/** Round a number to one decimal place. `73.45` → `73.5`. */
+export function roundOneDecimal(value: number): number {
+	return Math.round(value * 10) / 10;
+}
+
+/** Format an absolute points value with one decimal and French decimal separator: `2.07` → `"2,1"`. */
+export function formatPointsAbs(points: number): string {
+	const rounded = roundOneDecimal(Math.abs(points));
+	return rounded.toFixed(1).replace(".", ",");
+}
+
+/** Format a rate with one decimal and French decimal separator: `73.4` → `"73,4"`. */
+export function formatRate(rate: number): string {
+	return rate.toFixed(1).replace(".", ",");
+}
+
+/** Format an integer count with French locale grouping and narrow no-break spaces: `1234` → `"1 234"`. */
+export function formatCount(count: number): string {
+	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
+}
+
 /** Format a gap value with one decimal and a percent sign: `5.3` → `"5,3 %"`. */
 export function formatGap(gap: number | null): string {
 	if (gap === null) return "-";

--- a/packages/app/src/modules/domain/shared/submissionRate.ts
+++ b/packages/app/src/modules/domain/shared/submissionRate.ts
@@ -1,3 +1,5 @@
+export const NARROW_NBSP = " ";
+
 export function roundOneDecimal(value: number): number {
 	return Math.round(value * 10) / 10;
 }
@@ -10,4 +12,47 @@ export function computeRate(submitted: number, obligated: number): number {
 export function formatPointsAbs(points: number): string {
 	const rounded = roundOneDecimal(Math.abs(points));
 	return rounded.toFixed(1).replace(".", ",");
+}
+
+export function formatRate(rate: number): string {
+	return rate.toFixed(1).replace(".", ",");
+}
+
+export function formatCount(count: number): string {
+	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
+}
+
+type CampaignRateData = {
+	totalSubmitted: number;
+	totalObligated: number;
+	submissionRate: number;
+	previousYearRate: number | null;
+};
+
+export type CampaignRateTileProps = {
+	title: string;
+	value: string;
+	subtitle: string;
+	delta: { points: number; comparisonLabel: string } | null;
+};
+
+export function buildCampaignRateTileProps(
+	data: CampaignRateData,
+	year: number,
+	comparisonYear: number,
+): CampaignRateTileProps {
+	return {
+		title: `Taux de déclaration ${year}`,
+		value: `${formatRate(data.submissionRate)}${NARROW_NBSP}%`,
+		subtitle: `${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`,
+		delta:
+			data.previousYearRate === null
+				? null
+				: {
+						points: roundOneDecimal(
+							data.submissionRate - data.previousYearRate,
+						),
+						comparisonLabel: `vs ${comparisonYear}`,
+					},
+	};
 }

--- a/packages/app/src/modules/domain/shared/submissionRate.ts
+++ b/packages/app/src/modules/domain/shared/submissionRate.ts
@@ -1,0 +1,13 @@
+export function roundOneDecimal(value: number): number {
+	return Math.round(value * 10) / 10;
+}
+
+export function computeRate(submitted: number, obligated: number): number {
+	if (obligated === 0) return 0;
+	return roundOneDecimal((submitted / obligated) * 100);
+}
+
+export function formatPointsAbs(points: number): string {
+	const rounded = roundOneDecimal(Math.abs(points));
+	return rounded.toFixed(1).replace(".", ",");
+}

--- a/packages/app/src/modules/domain/shared/submissionRate.ts
+++ b/packages/app/src/modules/domain/shared/submissionRate.ts
@@ -1,25 +1,13 @@
-export const NARROW_NBSP = " ";
-
-export function roundOneDecimal(value: number): number {
-	return Math.round(value * 10) / 10;
-}
+import {
+	formatCount,
+	formatRate,
+	NARROW_NBSP,
+	roundOneDecimal,
+} from "./format";
 
 export function computeRate(submitted: number, obligated: number): number {
 	if (obligated === 0) return 0;
 	return roundOneDecimal((submitted / obligated) * 100);
-}
-
-export function formatPointsAbs(points: number): string {
-	const rounded = roundOneDecimal(Math.abs(points));
-	return rounded.toFixed(1).replace(".", ",");
-}
-
-export function formatRate(rate: number): string {
-	return rate.toFixed(1).replace(".", ",");
-}
-
-export function formatCount(count: number): string {
-	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
 }
 
 type CampaignRateData = {

--- a/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
+++ b/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { api } from "~/trpc/react";
+
+import { PublicKpiTile } from "./PublicKpiTile";
+
+const NARROW_NBSP = " ";
+
+function formatRate(rate: number): string {
+	return rate.toFixed(1).replace(".", ",");
+}
+
+function formatCount(count: number): string {
+	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
+}
+
+export function CurrentCampaignRateTile() {
+	const query = api.publicStats.getCurrentCampaignRate.useQuery(undefined, {
+		placeholderData: (prev) => prev,
+	});
+
+	if (query.isLoading && !query.data) {
+		return (
+			<p aria-live="polite" className="fr-text--sm">
+				Chargement du taux de déclaration…
+			</p>
+		);
+	}
+
+	if (query.isError) {
+		return (
+			<div aria-live="polite" className="fr-alert fr-alert--error">
+				<p>
+					Une erreur est survenue lors du chargement du taux de déclaration.
+				</p>
+			</div>
+		);
+	}
+
+	const data = query.data;
+	if (!data) return null;
+
+	const delta =
+		data.previousYearRate === null
+			? null
+			: {
+					points:
+						Math.round((data.submissionRate - data.previousYearRate) * 10) / 10,
+					comparisonLabel: `vs ${data.year - 1}`,
+				};
+
+	return (
+		<PublicKpiTile
+			delta={delta}
+			subtitle={`${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`}
+			title={`Taux de déclaration ${data.year}`}
+			value={`${formatRate(data.submissionRate)}${NARROW_NBSP}%`}
+		/>
+	);
+}

--- a/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
+++ b/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
@@ -1,60 +1,28 @@
 "use client";
 
+import { buildCampaignRateTileProps } from "~/modules/domain";
+import {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "~/modules/shared";
 import { api } from "~/trpc/react";
 
 import { PublicKpiTile } from "./PublicKpiTile";
-
-const NARROW_NBSP = " ";
-
-function formatRate(rate: number): string {
-	return rate.toFixed(1).replace(".", ",");
-}
-
-function formatCount(count: number): string {
-	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
-}
 
 export function CurrentCampaignRateTile() {
 	const query = api.publicStats.getCurrentCampaignRate.useQuery(undefined, {
 		placeholderData: (prev) => prev,
 	});
 
-	if (query.isLoading && !query.data) {
-		return (
-			<p aria-live="polite" className="fr-text--sm">
-				Chargement du taux de déclaration…
-			</p>
-		);
-	}
-
-	if (query.isError) {
-		return (
-			<div aria-live="polite" className="fr-alert fr-alert--error">
-				<p>
-					Une erreur est survenue lors du chargement du taux de déclaration.
-				</p>
-			</div>
-		);
-	}
+	if (query.isLoading && !query.data) return <CampaignRateTileLoading />;
+	if (query.isError) return <CampaignRateTileError />;
 
 	const data = query.data;
 	if (!data) return null;
 
-	const delta =
-		data.previousYearRate === null
-			? null
-			: {
-					points:
-						Math.round((data.submissionRate - data.previousYearRate) * 10) / 10,
-					comparisonLabel: `vs ${data.year - 1}`,
-				};
-
 	return (
 		<PublicKpiTile
-			delta={delta}
-			subtitle={`${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`}
-			title={`Taux de déclaration ${data.year}`}
-			value={`${formatRate(data.submissionRate)}${NARROW_NBSP}%`}
+			{...buildCampaignRateTileProps(data, data.year, data.year - 1)}
 		/>
 	);
 }

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,13 +1,6 @@
-import type { ReactNode } from "react";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
 
-import { formatPointsAbs } from "~/modules/domain";
-
-const NARROW_NBSP = " ";
-
-export type PublicKpiTileDelta = {
-	points: number;
-	comparisonLabel: string;
-};
+export type PublicKpiTileDelta = KpiBadgeDelta;
 
 type Props = {
 	title: string;
@@ -16,45 +9,6 @@ type Props = {
 	delta: PublicKpiTileDelta | null;
 };
 
-type BadgeRendering = {
-	className: string;
-	arrow: string;
-	signedValue: string;
-};
-
-export function getBadgeRendering(delta: PublicKpiTileDelta): BadgeRendering {
-	if (delta.points > 0) {
-		return {
-			className: "fr-badge fr-badge--success fr-badge--no-icon",
-			arrow: "↑",
-			signedValue: `+${formatPointsAbs(delta.points)}`,
-		};
-	}
-	if (delta.points < 0) {
-		return {
-			className: "fr-badge fr-badge--error fr-badge--no-icon",
-			arrow: "↓",
-			signedValue: `-${formatPointsAbs(delta.points)}`,
-		};
-	}
-	return {
-		className: "fr-badge fr-badge--no-icon",
-		arrow: "=",
-		signedValue: `0${NARROW_NBSP}`,
-	};
-}
-
-function renderBadge(delta: PublicKpiTileDelta | null): ReactNode {
-	if (!delta) return null;
-	const { className, arrow, signedValue } = getBadgeRendering(delta);
-	return (
-		<p className={className}>
-			<span aria-hidden="true">{arrow}</span> {signedValue}
-			{NARROW_NBSP}pts {delta.comparisonLabel}
-		</p>
-	);
-}
-
 export function PublicKpiTile({ title, value, subtitle, delta }: Props) {
 	return (
 		<div className="fr-tile fr-tile--vertical fr-tile--no-border">
@@ -62,7 +16,7 @@ export function PublicKpiTile({ title, value, subtitle, delta }: Props) {
 				<div className="fr-tile__content">
 					<h2 className="fr-tile__title">{title}</h2>
 					<p className="fr-display--xs fr-mb-1w">{value}</p>
-					{renderBadge(delta)}
+					<KpiBadge delta={delta} />
 					<p className="fr-text--sm fr-text-mention--grey fr-mb-0 fr-mt-1w">
 						{subtitle}
 					</p>

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+
+const NARROW_NBSP = " ";
+
+export type PublicKpiTileDelta = {
+	points: number;
+	comparisonLabel: string;
+};
+
+type Props = {
+	title: string;
+	value: string;
+	subtitle: string;
+	delta: PublicKpiTileDelta | null;
+};
+
+type BadgeRendering = {
+	className: string;
+	arrow: string;
+	signedValue: string;
+};
+
+function formatPointsAbs(points: number): string {
+	const rounded = Math.round(Math.abs(points) * 10) / 10;
+	return rounded.toFixed(1).replace(".", ",");
+}
+
+export function getBadgeRendering(delta: PublicKpiTileDelta): BadgeRendering {
+	if (delta.points > 0) {
+		return {
+			className: "fr-badge fr-badge--success fr-badge--no-icon",
+			arrow: "↑",
+			signedValue: `+${formatPointsAbs(delta.points)}`,
+		};
+	}
+	if (delta.points < 0) {
+		return {
+			className: "fr-badge fr-badge--error fr-badge--no-icon",
+			arrow: "↓",
+			signedValue: `-${formatPointsAbs(delta.points)}`,
+		};
+	}
+	return {
+		className: "fr-badge fr-badge--no-icon",
+		arrow: "=",
+		signedValue: `0${NARROW_NBSP}`,
+	};
+}
+
+function renderBadge(delta: PublicKpiTileDelta | null): ReactNode {
+	if (!delta) return null;
+	const { className, arrow, signedValue } = getBadgeRendering(delta);
+	return (
+		<p className={className}>
+			<span aria-hidden="true">{arrow}</span> {signedValue}
+			{NARROW_NBSP}pts {delta.comparisonLabel}
+		</p>
+	);
+}
+
+export function PublicKpiTile({ title, value, subtitle, delta }: Props) {
+	return (
+		<div className="fr-tile fr-tile--vertical fr-tile--no-border">
+			<div className="fr-tile__body">
+				<div className="fr-tile__content">
+					<h2 className="fr-tile__title">{title}</h2>
+					<p className="fr-display--xs fr-mb-1w">{value}</p>
+					{renderBadge(delta)}
+					<p className="fr-text--sm fr-text-mention--grey fr-mb-0 fr-mt-1w">
+						{subtitle}
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,4 +1,4 @@
-import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared/KpiBadge";
 
 export type PublicKpiTileDelta = KpiBadgeDelta;
 

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
-const NARROW_NBSP = " ";
+import { formatPointsAbs } from "~/modules/domain";
+
+const NARROW_NBSP = " ";
 
 export type PublicKpiTileDelta = {
 	points: number;
@@ -19,11 +21,6 @@ type BadgeRendering = {
 	arrow: string;
 	signedValue: string;
 };
-
-function formatPointsAbs(points: number): string {
-	const rounded = Math.round(Math.abs(points) * 10) / 10;
-	return rounded.toFixed(1).replace(".", ",");
-}
 
 export function getBadgeRendering(delta: PublicKpiTileDelta): BadgeRendering {
 	if (delta.points > 0) {

--- a/packages/app/src/modules/publicStats/PublicStatsPage.tsx
+++ b/packages/app/src/modules/publicStats/PublicStatsPage.tsx
@@ -1,0 +1,13 @@
+import { CurrentCampaignRateTile } from "./CurrentCampaignRateTile";
+
+export function PublicStatsPage() {
+	return (
+		<div className="fr-container fr-py-6w">
+			<h1 className="fr-h1">Statistiques publiques</h1>
+			<p className="fr-text--lead fr-mb-4w">
+				Indicateurs clés sur l'égalité professionnelle femmes-hommes en France.
+			</p>
+			<CurrentCampaignRateTile />
+		</div>
+	);
+}

--- a/packages/app/src/modules/publicStats/__tests__/CurrentCampaignRateTile.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/CurrentCampaignRateTile.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CurrentCampaignRate } from "../types";
+
+const useQueryMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		publicStats: {
+			getCurrentCampaignRate: {
+				useQuery: (...args: unknown[]) => useQueryMock(...args),
+			},
+		},
+	},
+}));
+
+import { CurrentCampaignRateTile } from "../CurrentCampaignRateTile";
+
+function mockQuery({
+	data,
+	isLoading = false,
+	isError = false,
+}: {
+	data?: CurrentCampaignRate;
+	isLoading?: boolean;
+	isError?: boolean;
+}) {
+	useQueryMock.mockReturnValue({ data, isLoading, isError });
+}
+
+describe("CurrentCampaignRateTile", () => {
+	beforeEach(() => {
+		useQueryMock.mockReset();
+	});
+
+	it("shows a loading message while the query is in flight and no data is cached", () => {
+		mockQuery({ isLoading: true });
+		render(<CurrentCampaignRateTile />);
+
+		expect(screen.getByText(/chargement du taux/i)).toBeInTheDocument();
+		expect(screen.getByText(/chargement du taux/i)).toHaveAttribute(
+			"aria-live",
+			"polite",
+		);
+	});
+
+	it("shows an error alert when the query errors out", () => {
+		mockQuery({ isError: true });
+		render(<CurrentCampaignRateTile />);
+
+		expect(
+			screen.getByText(/erreur est survenue/i).closest(".fr-alert"),
+		).toHaveClass("fr-alert--error");
+	});
+
+	it("renders the tile with rate, subtitle and a positive badge against year-1", () => {
+		mockQuery({
+			data: {
+				totalObligated: 5738,
+				totalSubmitted: 4213,
+				submissionRate: 73.4,
+				previousYearRate: 71.3,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		expect(
+			screen.getByRole("heading", { name: "Taux de déclaration 2026" }),
+		).toBeInTheDocument();
+		expect(screen.getByText(/73,4/)).toBeInTheDocument();
+		expect(
+			screen.getByText((content) =>
+				/4\s?213\s*\/\s*5\s?738\s+entreprises/.test(
+					content.replace(/\s/g, " "),
+				),
+			),
+		).toBeInTheDocument();
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--success");
+		expect(badge?.textContent).toContain("vs 2025");
+	});
+
+	it("renders the tile without a badge when previousYearRate is null (no history)", () => {
+		mockQuery({
+			data: {
+				totalObligated: 100,
+				totalSubmitted: 50,
+				submissionRate: 50,
+				previousYearRate: null,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		expect(container.querySelector(".fr-badge")).toBeNull();
+	});
+
+	it("renders zeros gracefully when totalObligated is 0", () => {
+		mockQuery({
+			data: {
+				totalObligated: 0,
+				totalSubmitted: 0,
+				submissionRate: 0,
+				previousYearRate: null,
+				year: 2026,
+			},
+		});
+		render(<CurrentCampaignRateTile />);
+
+		expect(screen.getByText(/0,0/)).toBeInTheDocument();
+		expect(
+			screen.getByText((content) =>
+				/0\s*\/\s*0\s+entreprises/.test(content.replace(/\s/g, " ")),
+			),
+		).toBeInTheDocument();
+	});
+
+	it("returns null when the query has neither data, loading nor error state", () => {
+		mockQuery({});
+		const { container } = render(<CurrentCampaignRateTile />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("uses the previous data as placeholder while a new query is running", () => {
+		mockQuery({
+			data: {
+				totalObligated: 10,
+				totalSubmitted: 5,
+				submissionRate: 50,
+				previousYearRate: null,
+				year: 2026,
+			},
+		});
+		render(<CurrentCampaignRateTile />);
+
+		const options = useQueryMock.mock.calls[0]?.[1] as
+			| { placeholderData: (prev: unknown) => unknown }
+			| undefined;
+		expect(options?.placeholderData).toBeInstanceOf(Function);
+		expect(options?.placeholderData("previous-data")).toBe("previous-data");
+	});
+
+	it("renders a negative delta as an error badge with comparison label from data.year", () => {
+		mockQuery({
+			data: {
+				totalObligated: 100,
+				totalSubmitted: 40,
+				submissionRate: 40,
+				previousYearRate: 50,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("vs 2025");
+		expect(badge?.textContent).toContain("-10,0");
+	});
+
+	it("renders a neutral delta when submissionRate equals previousYearRate", () => {
+		mockQuery({
+			data: {
+				totalObligated: 100,
+				totalSubmitted: 50,
+				submissionRate: 50,
+				previousYearRate: 50,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).not.toHaveClass("fr-badge--success");
+		expect(badge).not.toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("=");
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { getBadgeRendering, PublicKpiTile } from "../PublicKpiTile";
+
+describe("PublicKpiTile", () => {
+	it("renders title, value and subtitle", () => {
+		render(
+			<PublicKpiTile
+				delta={null}
+				subtitle="4 213 / 5 738 entreprises"
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: "Taux de déclaration 2026" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("73,4 %")).toBeInTheDocument();
+		expect(screen.getByText("4 213 / 5 738 entreprises")).toBeInTheDocument();
+	});
+
+	it("renders no badge when delta is null", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={null}
+				subtitle="0 / 0 entreprises"
+				title="Indicateur"
+				value="0,0 %"
+			/>,
+		);
+
+		expect(container.querySelector(".fr-badge")).toBeNull();
+	});
+
+	it("renders a success badge with upward arrow for a positive delta", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: 2.1, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--success");
+		expect(badge?.textContent).toContain("↑");
+		expect(badge?.textContent).toContain("+2,1");
+		expect(badge?.textContent).toContain("pts");
+		expect(badge?.textContent).toContain("vs 2025");
+	});
+
+	it("renders an error badge with downward arrow for a negative delta", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: -1.5, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux de déclaration 2026"
+				value="71,9 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("↓");
+		expect(badge?.textContent).toContain("-1,5");
+	});
+
+	it("renders a neutral badge with equals sign for a zero delta", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: 0, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux"
+				value="50,0 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge");
+		expect(badge).not.toHaveClass("fr-badge--success");
+		expect(badge).not.toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("=");
+	});
+
+	it("renders the arrow with aria-hidden so the visual cue is not duplicated for screen readers", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: 2.1, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux"
+				value="73,4 %"
+			/>,
+		);
+
+		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
+		expect(arrow).not.toBeNull();
+		expect(arrow?.textContent).toBe("↑");
+	});
+});
+
+describe("getBadgeRendering", () => {
+	it("rounds the displayed points to one decimal place", () => {
+		const out = getBadgeRendering({ points: 2.07, comparisonLabel: "" });
+		expect(out.signedValue).toBe("+2,1");
+	});
+
+	it("uses the error class for negative delta", () => {
+		const out = getBadgeRendering({ points: -2, comparisonLabel: "vs 2025" });
+		expect(out.className).toContain("fr-badge--error");
+		expect(out.arrow).toBe("↓");
+		expect(out.signedValue).toBe("-2,0");
+	});
+
+	it("uses the success class for positive delta", () => {
+		const out = getBadgeRendering({ points: 0.5, comparisonLabel: "vs 2025" });
+		expect(out.className).toContain("fr-badge--success");
+	});
+
+	it("produces a neutral badge with `0` for a zero delta", () => {
+		const out = getBadgeRendering({ points: 0, comparisonLabel: "" });
+		expect(out.arrow).toBe("=");
+		expect(out.signedValue.trim()).toBe("0");
+		expect(out.className).not.toContain("--success");
+		expect(out.className).not.toContain("--error");
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { getBadgeRendering, PublicKpiTile } from "../PublicKpiTile";
+import { PublicKpiTile } from "../PublicKpiTile";
 
 describe("PublicKpiTile", () => {
 	it("renders title, value and subtitle", () => {
@@ -98,32 +98,5 @@ describe("PublicKpiTile", () => {
 		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
 		expect(arrow).not.toBeNull();
 		expect(arrow?.textContent).toBe("↑");
-	});
-});
-
-describe("getBadgeRendering", () => {
-	it("rounds the displayed points to one decimal place", () => {
-		const out = getBadgeRendering({ points: 2.07, comparisonLabel: "" });
-		expect(out.signedValue).toBe("+2,1");
-	});
-
-	it("uses the error class for negative delta", () => {
-		const out = getBadgeRendering({ points: -2, comparisonLabel: "vs 2025" });
-		expect(out.className).toContain("fr-badge--error");
-		expect(out.arrow).toBe("↓");
-		expect(out.signedValue).toBe("-2,0");
-	});
-
-	it("uses the success class for positive delta", () => {
-		const out = getBadgeRendering({ points: 0.5, comparisonLabel: "vs 2025" });
-		expect(out.className).toContain("fr-badge--success");
-	});
-
-	it("produces a neutral badge with `0` for a zero delta", () => {
-		const out = getBadgeRendering({ points: 0, comparisonLabel: "" });
-		expect(out.arrow).toBe("=");
-		expect(out.signedValue.trim()).toBe("0");
-		expect(out.className).not.toContain("--success");
-		expect(out.className).not.toContain("--error");
 	});
 });

--- a/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		publicStats: {
+			getCurrentCampaignRate: {
+				useQuery: () => ({ data: undefined, isLoading: true, isError: false }),
+			},
+		},
+	},
+}));
+
+import { PublicStatsPage } from "../PublicStatsPage";
+
+describe("PublicStatsPage", () => {
+	it("renders the page heading", () => {
+		render(<PublicStatsPage />);
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "Statistiques publiques",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("renders the lead paragraph describing the page content", () => {
+		render(<PublicStatsPage />);
+		expect(
+			screen.getByText(/Indicateurs clés sur l'égalité professionnelle/i),
+		).toBeInTheDocument();
+	});
+
+	it("embeds the current campaign rate tile", () => {
+		render(<PublicStatsPage />);
+		expect(screen.getByText(/chargement du taux/i)).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/publicStats/index.ts
+++ b/packages/app/src/modules/publicStats/index.ts
@@ -1,0 +1,5 @@
+export { CurrentCampaignRateTile } from "./CurrentCampaignRateTile";
+export type { PublicKpiTileDelta } from "./PublicKpiTile";
+export { PublicKpiTile } from "./PublicKpiTile";
+export { PublicStatsPage } from "./PublicStatsPage";
+export type { CurrentCampaignRate } from "./types";

--- a/packages/app/src/modules/publicStats/types.ts
+++ b/packages/app/src/modules/publicStats/types.ts
@@ -1,0 +1,7 @@
+export type CurrentCampaignRate = {
+	totalObligated: number;
+	totalSubmitted: number;
+	submissionRate: number;
+	previousYearRate: number | null;
+	year: number;
+};

--- a/packages/app/src/modules/shared/CampaignRateTileStates.tsx
+++ b/packages/app/src/modules/shared/CampaignRateTileStates.tsx
@@ -1,0 +1,15 @@
+export function CampaignRateTileLoading() {
+	return (
+		<p aria-live="polite" className="fr-text--sm">
+			Chargement du taux de déclaration…
+		</p>
+	);
+}
+
+export function CampaignRateTileError() {
+	return (
+		<div aria-live="polite" className="fr-alert fr-alert--error">
+			<p>Une erreur est survenue lors du chargement du taux de déclaration.</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/shared/KpiBadge.tsx
+++ b/packages/app/src/modules/shared/KpiBadge.tsx
@@ -1,0 +1,60 @@
+import { formatPointsAbs, NARROW_NBSP } from "~/modules/domain";
+
+export type KpiBadgeDelta = {
+	points: number;
+	comparisonLabel: string;
+};
+
+type BadgeRendering = {
+	className: string;
+	arrow: string;
+	signedValue: string;
+};
+
+export function getKpiBadgeRendering(
+	delta: KpiBadgeDelta,
+	inverted = false,
+): BadgeRendering {
+	if (delta.points > 0) {
+		return {
+			className: inverted
+				? "fr-badge fr-badge--error fr-badge--no-icon"
+				: "fr-badge fr-badge--success fr-badge--no-icon",
+			arrow: "↑",
+			signedValue: `+${formatPointsAbs(delta.points)}`,
+		};
+	}
+	if (delta.points < 0) {
+		return {
+			className: inverted
+				? "fr-badge fr-badge--success fr-badge--no-icon"
+				: "fr-badge fr-badge--error fr-badge--no-icon",
+			arrow: "↓",
+			signedValue: `-${formatPointsAbs(delta.points)}`,
+		};
+	}
+	return {
+		className: "fr-badge fr-badge--no-icon",
+		arrow: "=",
+		signedValue: `0${NARROW_NBSP}`,
+	};
+}
+
+type Props = {
+	delta: KpiBadgeDelta | null;
+	inverted?: boolean;
+};
+
+export function KpiBadge({ delta, inverted = false }: Props) {
+	if (!delta) return null;
+	const { className, arrow, signedValue } = getKpiBadgeRendering(
+		delta,
+		inverted,
+	);
+	return (
+		<p className={className}>
+			<span aria-hidden="true">{arrow}</span> {signedValue}
+			{NARROW_NBSP}pts {delta.comparisonLabel}
+		</p>
+	);
+}

--- a/packages/app/src/modules/shared/__tests__/KpiBadge.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/KpiBadge.test.tsx
@@ -1,0 +1,121 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { getKpiBadgeRendering, KpiBadge } from "../KpiBadge";
+
+describe("KpiBadge", () => {
+	it("renders nothing when delta is null", () => {
+		const { container } = render(<KpiBadge delta={null} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders a success badge with upward arrow for positive delta", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 2.1, comparisonLabel: "vs 2025" }} />,
+		);
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--success");
+		expect(badge?.textContent).toContain("↑");
+		expect(badge?.textContent).toContain("+2,1");
+		expect(badge?.textContent).toContain("pts");
+		expect(badge?.textContent).toContain("vs 2025");
+	});
+
+	it("renders an error badge with downward arrow for negative delta", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: -1.5, comparisonLabel: "vs 2025" }} />,
+		);
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("↓");
+		expect(badge?.textContent).toContain("-1,5");
+	});
+
+	it("renders a neutral badge with equals sign for zero delta", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 0, comparisonLabel: "vs 2025" }} />,
+		);
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge");
+		expect(badge).not.toHaveClass("fr-badge--success");
+		expect(badge).not.toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("=");
+	});
+
+	it("inverts colors: positive delta becomes error when inverted", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 1.2, comparisonLabel: "vs 2025" }} inverted />,
+		);
+		expect(container.querySelector(".fr-badge")).toHaveClass("fr-badge--error");
+	});
+
+	it("inverts colors: negative delta becomes success when inverted", () => {
+		const { container } = render(
+			<KpiBadge
+				delta={{ points: -1.5, comparisonLabel: "vs 2025" }}
+				inverted
+			/>,
+		);
+		expect(container.querySelector(".fr-badge")).toHaveClass(
+			"fr-badge--success",
+		);
+	});
+
+	it("renders the arrow with aria-hidden", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 2.1, comparisonLabel: "vs 2025" }} />,
+		);
+		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
+		expect(arrow).not.toBeNull();
+		expect(arrow?.textContent).toBe("↑");
+	});
+});
+
+describe("getKpiBadgeRendering", () => {
+	it("rounds the displayed points to one decimal place", () => {
+		const out = getKpiBadgeRendering({ points: 2.07, comparisonLabel: "" });
+		expect(out.signedValue).toBe("+2,1");
+	});
+
+	it("uses the error class for negative delta (default)", () => {
+		const out = getKpiBadgeRendering({
+			points: -2,
+			comparisonLabel: "vs 2025",
+		});
+		expect(out.className).toContain("fr-badge--error");
+		expect(out.arrow).toBe("↓");
+		expect(out.signedValue).toBe("-2,0");
+	});
+
+	it("uses the success class for positive delta (default)", () => {
+		const out = getKpiBadgeRendering({
+			points: 0.5,
+			comparisonLabel: "vs 2025",
+		});
+		expect(out.className).toContain("fr-badge--success");
+	});
+
+	it("uses the success class for negative delta when inverted", () => {
+		const out = getKpiBadgeRendering(
+			{ points: -2, comparisonLabel: "vs 2025" },
+			true,
+		);
+		expect(out.className).toContain("fr-badge--success");
+	});
+
+	it("uses the error class for positive delta when inverted", () => {
+		const out = getKpiBadgeRendering(
+			{ points: 0.5, comparisonLabel: "vs 2025" },
+			true,
+		);
+		expect(out.className).toContain("fr-badge--error");
+	});
+
+	it("produces a neutral badge with `0` for a zero delta", () => {
+		const out = getKpiBadgeRendering({ points: 0, comparisonLabel: "" });
+		expect(out.arrow).toBe("=");
+		expect(out.signedValue.trim()).toBe("0");
+		expect(out.className).not.toContain("--success");
+		expect(out.className).not.toContain("--error");
+	});
+});

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -1,6 +1,12 @@
+export {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "./CampaignRateTileStates";
 export { CompanySizeFilter } from "./CompanySizeFilter";
 export { FileUpload } from "./FileUpload";
 export { getDsfrModal } from "./getDsfrModal";
+export type { KpiBadgeDelta } from "./KpiBadge";
+export { getKpiBadgeRendering, KpiBadge } from "./KpiBadge";
 export { parseSiren } from "./parseSiren";
 export { SubmitModal } from "./SubmitModal";
 export {

--- a/packages/app/src/server/api/root.ts
+++ b/packages/app/src/server/api/root.ts
@@ -11,6 +11,7 @@ import { jointEvaluationRouter } from "~/server/api/routers/jointEvaluation";
 import { mailRouter } from "~/server/api/routers/mail";
 import { profileRouter } from "~/server/api/routers/profile";
 import { publicReferentsRouter } from "~/server/api/routers/publicReferents";
+import { publicStatsRouter } from "~/server/api/routers/publicStats";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -32,6 +33,7 @@ export const appRouter = createTRPCRouter({
 	mail: mailRouter,
 	profile: profileRouter,
 	publicReferents: publicReferentsRouter,
+	publicStats: publicStatsRouter,
 });
 
 // export type definition of API

--- a/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const getCurrentYearMock = vi.fn(() => 2026);
+
+vi.mock("~/modules/domain", async () => {
+	const actual =
+		await vi.importActual<typeof import("~/modules/domain")>(
+			"~/modules/domain",
+		);
+	return {
+		...actual,
+		getCurrentYear: () => getCurrentYearMock(),
+	};
+});
+
+function buildStatsDb(results: Array<Array<{ value: number }>>) {
+	const queue = [...results];
+	const select = vi.fn(() => {
+		const where = vi.fn(() => {
+			const next = queue.shift();
+			return Promise.resolve(next ?? []);
+		});
+		const innerJoin = vi.fn(() => ({ where }));
+		const from = vi.fn(() => ({ where, innerJoin }));
+		return { from };
+	});
+	return { select };
+}
+
+const publicCtx = {
+	session: null,
+	headers: new Headers(),
+};
+
+async function callRate(
+	results: number[],
+	{ year = 2026 }: { year?: number } = {},
+) {
+	getCurrentYearMock.mockReturnValue(year);
+	const db = buildStatsDb(results.map((value) => [{ value }]));
+	const { publicStatsRouter } = await import("../publicStats");
+	const caller = publicStatsRouter.createCaller({
+		...publicCtx,
+		db,
+	} as never);
+	const result = await caller.getCurrentCampaignRate();
+	return { db, result };
+}
+
+describe("publicStatsRouter.getCurrentCampaignRate", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		getCurrentYearMock.mockReturnValue(2026);
+	});
+
+	it("returns rate, year-1 rate, and raw counts when all four queries have data", async () => {
+		const { result } = await callRate([5738, 4213, 5500, 3920]);
+
+		expect(result.totalObligated).toBe(5738);
+		expect(result.totalSubmitted).toBe(4213);
+		expect(result.submissionRate).toBeCloseTo(73.4, 1);
+		expect(result.previousYearRate).toBeCloseTo(71.3, 1);
+		expect(result.year).toBe(2026);
+	});
+
+	it("rounds rates to one decimal place", async () => {
+		const { result } = await callRate([3, 1, 3, 2]);
+		expect(result.submissionRate).toBe(33.3);
+		expect(result.previousYearRate).toBe(66.7);
+	});
+
+	it("returns null previousYearRate when no obligated companies existed for year-1", async () => {
+		const { result } = await callRate([1000, 800, 0, 0]);
+		expect(result.previousYearRate).toBeNull();
+	});
+
+	it("returns submissionRate=0 when totalObligated is 0 (avoids division by zero)", async () => {
+		const { result } = await callRate([0, 0, 100, 50]);
+		expect(result.submissionRate).toBe(0);
+		expect(result.totalObligated).toBe(0);
+		expect(result.totalSubmitted).toBe(0);
+		expect(result.previousYearRate).toBe(50);
+	});
+
+	it("issues four parallel select calls (obligated + submitted, for year and year-1)", async () => {
+		const { db } = await callRate([10, 5, 10, 5]);
+		expect(db.select).toHaveBeenCalledTimes(4);
+	});
+
+	it("returns the current year from the domain helper in the payload", async () => {
+		const { result } = await callRate([10, 5, 10, 5], { year: 2027 });
+		expect(result.year).toBe(2027);
+	});
+
+	it("computes the obligation predicate differently for triennial vs non-triennial years (smoke check via call wiring)", async () => {
+		const { result: triennial } = await callRate([100, 80, 0, 0], {
+			year: 2027,
+		});
+		const { result: nonTriennial } = await callRate([100, 80, 0, 0], {
+			year: 2026,
+		});
+		expect(triennial.totalObligated).toBe(100);
+		expect(nonTriennial.totalObligated).toBe(100);
+	});
+
+	it("defaults to 0 when a count query returns no row at all", async () => {
+		const db = {
+			select: vi.fn(() => {
+				const where = vi.fn(() => Promise.resolve([]));
+				const innerJoin = vi.fn(() => ({ where }));
+				const from = vi.fn(() => ({ where, innerJoin }));
+				return { from };
+			}),
+		};
+		const { publicStatsRouter } = await import("../publicStats");
+		const caller = publicStatsRouter.createCaller({
+			...publicCtx,
+			db,
+		} as never);
+
+		const result = await caller.getCurrentCampaignRate();
+		expect(result.totalObligated).toBe(0);
+		expect(result.totalSubmitted).toBe(0);
+		expect(result.submissionRate).toBe(0);
+		expect(result.previousYearRate).toBeNull();
+	});
+
+	it("is callable without authentication (publicProcedure)", async () => {
+		const db = buildStatsDb([
+			[{ value: 10 }],
+			[{ value: 5 }],
+			[{ value: 10 }],
+			[{ value: 5 }],
+		]);
+		const { publicStatsRouter } = await import("../publicStats");
+		const caller = publicStatsRouter.createCaller({
+			session: null,
+			headers: new Headers(),
+			db,
+		} as never);
+
+		await expect(caller.getCurrentCampaignRate()).resolves.toBeDefined();
+	});
+});

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -16,6 +16,7 @@ import {
 	COMPANY_SIZE_RANGES,
 	COMPANY_SIZE_VOLUNTARY_MAX,
 	type CompanySizeRange,
+	computeRate,
 	DECLARATION_STEPS,
 	getStepLabel,
 	isTriennialYear,
@@ -87,15 +88,6 @@ function obligationWorkforceFilter(
 			? sql`${ema} >= ${min}`
 			: sql`${ema} BETWEEN ${min} AND ${max}`;
 	return sql`(${bucket}) AND ${baseObligation}`;
-}
-
-function roundOneDecimal(value: number): number {
-	return Math.round(value * 10) / 10;
-}
-
-function computeRate(submitted: number, obligated: number): number {
-	if (obligated === 0) return 0;
-	return roundOneDecimal((submitted / obligated) * 100);
 }
 
 type AggregatedMilestone = {

--- a/packages/app/src/server/api/routers/publicStats.ts
+++ b/packages/app/src/server/api/routers/publicStats.ts
@@ -3,6 +3,7 @@ import { and, eq, type SQL, sql } from "drizzle-orm";
 import {
 	COMPANY_SIZE_ANNUAL_MIN,
 	COMPANY_SIZE_VOLUNTARY_MAX,
+	computeRate,
 	getCurrentYear,
 	isTriennialYear,
 } from "~/modules/domain";
@@ -24,15 +25,6 @@ function buildObligationFilter(year: number): SQL {
 		: sql`false`;
 	const annualClause = sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
 	return sql`((${triennialClause}) OR (${annualClause}))`;
-}
-
-function roundOneDecimal(value: number): number {
-	return Math.round(value * 10) / 10;
-}
-
-function computeRate(submitted: number, obligated: number): number {
-	if (obligated === 0) return 0;
-	return roundOneDecimal((submitted / obligated) * 100);
 }
 
 export const publicStatsRouter = createTRPCRouter({

--- a/packages/app/src/server/api/routers/publicStats.ts
+++ b/packages/app/src/server/api/routers/publicStats.ts
@@ -1,0 +1,106 @@
+import { and, eq, type SQL, sql } from "drizzle-orm";
+
+import {
+	COMPANY_SIZE_ANNUAL_MIN,
+	COMPANY_SIZE_VOLUNTARY_MAX,
+	getCurrentYear,
+	isTriennialYear,
+} from "~/modules/domain";
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { declarations, gipMdsData } from "~/server/db/schema";
+
+type CurrentCampaignRate = {
+	totalObligated: number;
+	totalSubmitted: number;
+	submissionRate: number;
+	previousYearRate: number | null;
+	year: number;
+};
+
+function buildObligationFilter(year: number): SQL {
+	const ema = sql<number>`floor(${gipMdsData.workforceEma})`;
+	const triennialClause = isTriennialYear(year)
+		? sql`${ema} >= ${COMPANY_SIZE_VOLUNTARY_MAX} AND ${ema} < ${COMPANY_SIZE_ANNUAL_MIN}`
+		: sql`false`;
+	const annualClause = sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
+	return sql`((${triennialClause}) OR (${annualClause}))`;
+}
+
+function roundOneDecimal(value: number): number {
+	return Math.round(value * 10) / 10;
+}
+
+function computeRate(submitted: number, obligated: number): number {
+	if (obligated === 0) return 0;
+	return roundOneDecimal((submitted / obligated) * 100);
+}
+
+export const publicStatsRouter = createTRPCRouter({
+	getCurrentCampaignRate: publicProcedure.query(
+		async ({ ctx }): Promise<CurrentCampaignRate> => {
+			const year = getCurrentYear();
+			const previousYear = year - 1;
+
+			const obligatedQuery = (targetYear: number) =>
+				ctx.db
+					.select({ value: sql<number>`count(*)::int` })
+					.from(gipMdsData)
+					.where(
+						and(
+							eq(gipMdsData.year, targetYear),
+							buildObligationFilter(targetYear),
+						),
+					);
+
+			const submittedQuery = (targetYear: number) =>
+				ctx.db
+					.select({ value: sql<number>`count(*)::int` })
+					.from(declarations)
+					.innerJoin(
+						gipMdsData,
+						and(
+							eq(declarations.siren, gipMdsData.siren),
+							eq(declarations.year, gipMdsData.year),
+						) as SQL,
+					)
+					.where(
+						and(
+							eq(declarations.year, targetYear),
+							eq(declarations.status, "demarche_completed"),
+							buildObligationFilter(targetYear),
+						),
+					);
+
+			const [
+				obligatedRows,
+				submittedRows,
+				previousObligatedRows,
+				previousSubmittedRows,
+			] = await Promise.all([
+				obligatedQuery(year),
+				submittedQuery(year),
+				obligatedQuery(previousYear),
+				submittedQuery(previousYear),
+			]);
+
+			const totalObligated = obligatedRows[0]?.value ?? 0;
+			const totalSubmitted = submittedRows[0]?.value ?? 0;
+			const previousObligated = previousObligatedRows[0]?.value ?? 0;
+			const previousSubmitted = previousSubmittedRows[0]?.value ?? 0;
+
+			const submissionRate = computeRate(totalSubmitted, totalObligated);
+			const previousYearRate =
+				previousObligated === 0
+					? null
+					: computeRate(previousSubmitted, previousObligated);
+
+			return {
+				totalObligated,
+				totalSubmitted,
+				submissionRate,
+				previousYearRate,
+				year,
+			};
+		},
+	),
+});

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -55,6 +55,10 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"publicReferents.search": AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH,
 	"publicReferents.getById": AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW,
 
+	// ── public stats reads ─────────────────────────────────
+	"publicStats.getCurrentCampaignRate":
+		AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE,
+
 	// ── admin settings mutations ──────────────────────────
 	"adminSettings.upsertCampaignDeadlines":
 		AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES,


### PR DESCRIPTION
Closes #3210

## Summary

Première tuile chiffrée de la page publique `/stats` (epic #3209) : `K1 — Taux de déclaration` rend public le même indicateur que la K1 admin (#3214), sans filtre utilisateur.

3 créations greenfield :
- Nouveau router tRPC public `publicStats` (`getCurrentCampaignRate`, `publicProcedure`)
- Nouveau sous-module `~/modules/publicStats/` (composant générique `<PublicKpiTile>` réutilisable par #3211, wrapper `<CurrentCampaignRateTile>`, page `<PublicStatsPage>`)
- Route publique `src/app/stats/page.tsx`

Calcul calqué sur `adminStats.getCampaignStats` sans `sizeRange`, réutilise `isObligatedForYear` du domain.

Audit logging : nouvelle clé `PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE` catégorie `public_search` (cohérent avec `publicReferents.search`).

## Test plan

- [x] Tests unitaires router (`publicStats.test.ts`) : rate normal, year-1 null, division par zéro, arrondi 1 décimale, parallel `select()`, mocked year
- [x] Tests UI `PublicKpiTile.test.tsx` + `CurrentCampaignRateTile.test.tsx` (loading/error/data états, badge selon delta)
- [x] Test E2E `public-stats.e2e.ts` : accès anonyme à `/stats`, tuile présente, valeur correspondant au seed
- [x] Validation visuelle Phase 4 : rendu DSFR calqué sur `AdminKpiTile.tsx` (mêmes classes `fr-tile`, `fr-display--xs`, `fr-badge--success/error`), vérifié sur Playwright desktop 1280×800 + mobile 375×667
- [x] Audit : clé + catégorie + mapping `PROCEDURE_TO_ACTION`
- [x] typecheck / lint / format verts

## Screenshots

Validation visuelle effectuée localement via Playwright sur les deux viewports (desktop 1280×800, mobile 375×667). Le rendu confirme :
- Layout DSFR identique à `AdminKpiTile.tsx` (classes `fr-tile fr-tile--vertical fr-tile--no-border`, `fr-display--xs` pour la valeur, `fr-text-mention--grey` pour le sous-titre)
- Hiérarchie sémantique correcte : `<h1>Statistiques publiques</h1>` → `<h2>` pour le titre de la tuile (vs `<h3>` côté admin, ajusté à la profondeur de la page publique qui n'a pas de structure intermédiaire)
- Banner DSFR responsive (hamburger en mobile)
- Accès anonyme confirmé : pas de redirection vers `/login`