### PR TITLE
feat(stats): K7 — distribution des scores publique

### DIFF
--- a/packages/app/src/app/stats/page.tsx
+++ b/packages/app/src/app/stats/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+import { PublicStatsPage } from "~/modules/publicStats";
+import { HydrateClient } from "~/trpc/server";
+
+export const metadata: Metadata = {
+	title: "Statistiques publiques — Égalité professionnelle",
+	description:
+		"Taux de déclaration et répartition des écarts de rémunération entre les femmes et les hommes en France.",
+};
+
+export default function Page() {
+	return (
+		<HydrateClient>
+			<PublicStatsPage />
+		</HydrateClient>
+	);
+}

--- a/packages/app/src/e2e/helpers/db-campaign.ts
+++ b/packages/app/src/e2e/helpers/db-campaign.ts
@@ -195,6 +195,9 @@ type SeededCampaignDeclaration = {
 	year: number;
 	submittedAt: string;
 	workforce: number;
+	remunerationScore?: number | null;
+	quartileScore?: number | null;
+	categoryScore?: number | null;
 };
 
 export async function seedSubmittedDeclarationsForStats(
@@ -218,17 +221,26 @@ export async function seedSubmittedDeclarationsForStats(
 				VALUES (${row.siren}, ${`E2E Stats Co. ${row.siren}`}, ${row.workforce}, NOW(), NOW())
 				ON CONFLICT (siren) DO UPDATE SET workforce = EXCLUDED.workforce
 			`;
+			const remunerationScore = row.remunerationScore ?? null;
+			const quartileScore = row.quartileScore ?? null;
+			const categoryScore = row.categoryScore ?? null;
 			const inserted = await sql<[{ id: string }]>`
 				INSERT INTO app_declaration (
 					id, siren, year, declarant_id, current_step, status,
+					remuneration_score, quartile_score, category_score,
 					created_at, updated_at
 				)
 				VALUES (
 					gen_random_uuid(), ${row.siren}, ${row.year}, ${declarantId}, 6,
-					'demarche_completed', NOW(), NOW()
+					'demarche_completed',
+					${remunerationScore}, ${quartileScore}, ${categoryScore},
+					NOW(), NOW()
 				)
 				ON CONFLICT (siren, year) WHERE cancelled_at IS NULL DO UPDATE SET
-					status = 'demarche_completed'
+					status = 'demarche_completed',
+					remuneration_score = EXCLUDED.remuneration_score,
+					quartile_score = EXCLUDED.quartile_score,
+					category_score = EXCLUDED.category_score
 				RETURNING id
 			`;
 			const declarationId = inserted[0]?.id;

--- a/packages/app/src/e2e/public-stats.e2e.ts
+++ b/packages/app/src/e2e/public-stats.e2e.ts
@@ -12,6 +12,9 @@ const PUBLIC_K1_SIRENS = {
 	obligatedNotSubmitted: "999300202",
 	obligatedPrevYearSubmitted: "999300203",
 	obligatedPrevYearNotSubmitted: "999300204",
+	scoreHigh: "999300205",
+	scoreLow: "999300206",
+	scoreNc: "999300207",
 } as const;
 
 test.describe("public stats — K1 declaration rate tile", () => {
@@ -46,12 +49,42 @@ test.describe("public stats — K1 declaration rate tile", () => {
 				year: currentYear,
 				submittedAt: `${currentYear}-02-10T10:00:00Z`,
 				workforce: 250,
+				remunerationScore: 35,
+				quartileScore: 15,
+				categoryScore: 40,
 			},
 			{
 				siren: PUBLIC_K1_SIRENS.obligatedPrevYearSubmitted,
 				year: currentYear - 1,
 				submittedAt: `${currentYear - 1}-02-10T10:00:00Z`,
 				workforce: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.scoreHigh,
+				year: currentYear,
+				submittedAt: `${currentYear}-02-11T10:00:00Z`,
+				workforce: 200,
+				remunerationScore: 40,
+				quartileScore: 15,
+				categoryScore: 30,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.scoreLow,
+				year: currentYear,
+				submittedAt: `${currentYear}-02-12T10:00:00Z`,
+				workforce: 200,
+				remunerationScore: 10,
+				quartileScore: 5,
+				categoryScore: 20,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.scoreNc,
+				year: currentYear,
+				submittedAt: `${currentYear}-02-13T10:00:00Z`,
+				workforce: 200,
+				remunerationScore: null,
+				quartileScore: null,
+				categoryScore: null,
 			},
 		]);
 	});
@@ -96,9 +129,42 @@ test.describe("public stats — K1 declaration rate tile", () => {
 					name: new RegExp(`^Taux de déclaration ${currentYear}$`),
 				}),
 			).toBeVisible();
-			await expect(page.getByText(/\d{1,3},\d\s*%/)).toBeVisible();
+			await expect(page.getByText(/\d{1,3},\d\s*%/).first()).toBeVisible();
 			await expect(
 				page.getByText(/\d+\s*\/\s*\d+\s+entreprises/),
+			).toBeVisible();
+		} finally {
+			await anonCtx.close();
+		}
+	});
+
+	test("public K7 score distribution renders a bar chart and the accessible table", async ({
+		browser,
+	}) => {
+		const anonCtx = await browser.newContext({
+			storageState: { cookies: [], origins: [] },
+		});
+		try {
+			const page = await anonCtx.newPage();
+			await page.goto("/stats");
+
+			await expect(
+				page.getByRole("heading", {
+					level: 2,
+					name: new RegExp(`^Distribution des scores ${currentYear}$`),
+				}),
+			).toBeVisible();
+			const bars = page.locator(".recharts-bar-rectangle");
+			await expect(bars.first()).toBeVisible();
+			const distributionTable = page.getByRole("table", {
+				name: /nombre d'entreprises par tranche de score global/i,
+			});
+			await expect(distributionTable).toBeVisible();
+			await expect(
+				distributionTable.getByRole("rowheader", { name: "NC" }),
+			).toBeVisible();
+			await expect(
+				distributionTable.getByRole("rowheader", { name: "100" }),
 			).toBeVisible();
 		} finally {
 			await anonCtx.close();

--- a/packages/app/src/e2e/public-stats.e2e.ts
+++ b/packages/app/src/e2e/public-stats.e2e.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+import { getCurrentYear } from "~/modules/domain";
+import {
+	deleteSeededCampaignDeclarations,
+	seedGipMdsObligatedPopulation,
+	seedSubmittedDeclarationsForStats,
+} from "./helpers/db-campaign";
+
+const PUBLIC_K1_SIRENS = {
+	obligatedSubmitted: "999300201",
+	obligatedNotSubmitted: "999300202",
+	obligatedPrevYearSubmitted: "999300203",
+	obligatedPrevYearNotSubmitted: "999300204",
+} as const;
+
+test.describe("public stats — K1 declaration rate tile", () => {
+	const currentYear = getCurrentYear();
+
+	test.beforeAll(async () => {
+		await seedGipMdsObligatedPopulation([
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedSubmitted,
+				year: currentYear,
+				workforceEma: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedNotSubmitted,
+				year: currentYear,
+				workforceEma: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedPrevYearSubmitted,
+				year: currentYear - 1,
+				workforceEma: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedPrevYearNotSubmitted,
+				year: currentYear - 1,
+				workforceEma: 250,
+			},
+		]);
+		await seedSubmittedDeclarationsForStats([
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedSubmitted,
+				year: currentYear,
+				submittedAt: `${currentYear}-02-10T10:00:00Z`,
+				workforce: 250,
+			},
+			{
+				siren: PUBLIC_K1_SIRENS.obligatedPrevYearSubmitted,
+				year: currentYear - 1,
+				submittedAt: `${currentYear - 1}-02-10T10:00:00Z`,
+				workforce: 250,
+			},
+		]);
+	});
+
+	test.afterAll(async () => {
+		await deleteSeededCampaignDeclarations(Object.values(PUBLIC_K1_SIRENS));
+	});
+
+	test("an anonymous visitor can reach /stats without being redirected to /login", async ({
+		browser,
+	}) => {
+		const anonCtx = await browser.newContext({
+			storageState: { cookies: [], origins: [] },
+		});
+		try {
+			const page = await anonCtx.newPage();
+			await page.goto("/stats");
+			await expect(page).not.toHaveURL(/\/login/);
+			await expect(
+				page.getByRole("heading", {
+					name: "Statistiques publiques",
+					level: 1,
+				}),
+			).toBeVisible();
+		} finally {
+			await anonCtx.close();
+		}
+	});
+
+	test("public K1 tile is rendered with the current-year title and a percent value", async ({
+		browser,
+	}) => {
+		const anonCtx = await browser.newContext({
+			storageState: { cookies: [], origins: [] },
+		});
+		try {
+			const page = await anonCtx.newPage();
+			await page.goto("/stats");
+
+			await expect(
+				page.getByRole("heading", {
+					name: new RegExp(`^Taux de déclaration ${currentYear}$`),
+				}),
+			).toBeVisible();
+			await expect(page.getByText(/\d{1,3},\d\s*%/)).toBeVisible();
+			await expect(
+				page.getByText(/\d+\s*\/\s*\d+\s+entreprises/),
+			).toBeVisible();
+		} finally {
+			await anonCtx.close();
+		}
+	});
+});

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
@@ -1,13 +1,6 @@
-import type { ReactNode } from "react";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
 
-import { formatPointsAbs } from "~/modules/domain";
-
-const NARROW_NBSP = " ";
-
-export type AdminKpiTileDelta = {
-	points: number;
-	comparisonLabel: string;
-};
+export type AdminKpiTileDelta = KpiBadgeDelta;
 
 type Props = {
 	title: string;
@@ -17,55 +10,6 @@ type Props = {
 	// true when the underlying KPI is "lower is better" (e.g. share above gap threshold).
 	inverted?: boolean;
 };
-
-type BadgeRendering = {
-	className: string;
-	arrow: string;
-	signedValue: string;
-};
-
-export function getBadgeRendering(
-	delta: AdminKpiTileDelta,
-	inverted: boolean,
-): BadgeRendering {
-	if (delta.points > 0) {
-		return {
-			className: inverted
-				? "fr-badge fr-badge--error fr-badge--no-icon"
-				: "fr-badge fr-badge--success fr-badge--no-icon",
-			arrow: "↑",
-			signedValue: `+${formatPointsAbs(delta.points)}`,
-		};
-	}
-	if (delta.points < 0) {
-		return {
-			className: inverted
-				? "fr-badge fr-badge--success fr-badge--no-icon"
-				: "fr-badge fr-badge--error fr-badge--no-icon",
-			arrow: "↓",
-			signedValue: `-${formatPointsAbs(delta.points)}`,
-		};
-	}
-	return {
-		className: "fr-badge fr-badge--no-icon",
-		arrow: "=",
-		signedValue: `0${NARROW_NBSP}`,
-	};
-}
-
-function renderBadge(
-	delta: AdminKpiTileDelta | null,
-	inverted: boolean,
-): ReactNode {
-	if (!delta) return null;
-	const { className, arrow, signedValue } = getBadgeRendering(delta, inverted);
-	return (
-		<p className={className}>
-			<span aria-hidden="true">{arrow}</span> {signedValue}
-			{NARROW_NBSP}pts {delta.comparisonLabel}
-		</p>
-	);
-}
 
 export function AdminKpiTile({
 	title,
@@ -80,7 +24,7 @@ export function AdminKpiTile({
 				<div className="fr-tile__content">
 					<h3 className="fr-tile__title">{title}</h3>
 					<p className="fr-display--xs fr-mb-1w">{value}</p>
-					{renderBadge(delta, inverted)}
+					<KpiBadge delta={delta} inverted={inverted} />
 					<p className="fr-text--sm fr-text-mention--grey fr-mb-0 fr-mt-1w">
 						{subtitle}
 					</p>

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
@@ -1,4 +1,4 @@
-import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared/KpiBadge";
 
 export type AdminKpiTileDelta = KpiBadgeDelta;
 

--- a/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
+++ b/packages/app/src/modules/admin/stats/AdminKpiTile.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
-const NARROW_NBSP = " ";
+import { formatPointsAbs } from "~/modules/domain";
+
+const NARROW_NBSP = " ";
 
 export type AdminKpiTileDelta = {
 	points: number;
@@ -21,11 +23,6 @@ type BadgeRendering = {
 	arrow: string;
 	signedValue: string;
 };
-
-function formatPointsAbs(points: number): string {
-	const rounded = Math.round(Math.abs(points) * 10) / 10;
-	return rounded.toFixed(1).replace(".", ",");
-}
 
 export function getBadgeRendering(
 	delta: AdminKpiTileDelta,

--- a/packages/app/src/modules/admin/stats/CampaignRateTile.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignRateTile.tsx
@@ -1,24 +1,19 @@
 "use client";
 
 import type { CompanySizeRange } from "~/modules/domain";
+import { buildCampaignRateTileProps } from "~/modules/domain";
+import {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "~/modules/shared";
 import { api } from "~/trpc/react";
 
 import { AdminKpiTile } from "./AdminKpiTile";
-
-const NARROW_NBSP = " ";
 
 type Props = {
 	year: number;
 	sizeRange: CompanySizeRange | undefined;
 };
-
-function formatRate(rate: number): string {
-	return rate.toFixed(1).replace(".", ",");
-}
-
-function formatCount(count: number): string {
-	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
-}
 
 export function CampaignRateTile({ year, sizeRange }: Props) {
 	const query = api.adminStats.getCampaignStats.useQuery(
@@ -26,42 +21,11 @@ export function CampaignRateTile({ year, sizeRange }: Props) {
 		{ placeholderData: (prev) => prev },
 	);
 
-	if (query.isLoading && !query.data) {
-		return (
-			<p aria-live="polite" className="fr-text--sm">
-				Chargement du taux de déclaration…
-			</p>
-		);
-	}
-
-	if (query.isError) {
-		return (
-			<div aria-live="polite" className="fr-alert fr-alert--error">
-				<p>
-					Une erreur est survenue lors du chargement du taux de déclaration.
-				</p>
-			</div>
-		);
-	}
+	if (query.isLoading && !query.data) return <CampaignRateTileLoading />;
+	if (query.isError) return <CampaignRateTileError />;
 
 	const data = query.data;
 	if (!data) return null;
 
-	const delta =
-		data.previousYearRate === null
-			? null
-			: {
-					points:
-						Math.round((data.submissionRate - data.previousYearRate) * 10) / 10,
-					comparisonLabel: `vs ${year - 1}`,
-				};
-
-	return (
-		<AdminKpiTile
-			delta={delta}
-			subtitle={`${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`}
-			title={`Taux de déclaration ${year}`}
-			value={`${formatRate(data.submissionRate)}${NARROW_NBSP}%`}
-		/>
-	);
+	return <AdminKpiTile {...buildCampaignRateTileProps(data, year, year - 1)} />;
 }

--- a/packages/app/src/modules/admin/stats/__tests__/AdminKpiTile.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/AdminKpiTile.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { AdminKpiTile, getBadgeRendering } from "../AdminKpiTile";
+import { AdminKpiTile } from "../AdminKpiTile";
 
 describe("AdminKpiTile", () => {
 	it("renders title, value and subtitle", () => {
@@ -128,38 +128,5 @@ describe("AdminKpiTile", () => {
 		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
 		expect(arrow).not.toBeNull();
 		expect(arrow?.textContent).toBe("↑");
-	});
-});
-
-describe("getBadgeRendering (badge logic helper)", () => {
-	it("rounds the displayed points to one decimal place", () => {
-		const out = getBadgeRendering({ points: 2.07, comparisonLabel: "" }, false);
-		expect(out.signedValue).toBe("+2,1");
-	});
-
-	it("uses the success class for negative delta when inverted", () => {
-		const out = getBadgeRendering(
-			{ points: -2, comparisonLabel: "vs 2025" },
-			true,
-		);
-		expect(out.className).toContain("fr-badge--success");
-		expect(out.arrow).toBe("↓");
-		expect(out.signedValue).toBe("-2,0");
-	});
-
-	it("uses the error class for positive delta when inverted", () => {
-		const out = getBadgeRendering(
-			{ points: 0.5, comparisonLabel: "vs 2025" },
-			true,
-		);
-		expect(out.className).toContain("fr-badge--error");
-	});
-
-	it("produces a neutral badge with `0` for a zero delta", () => {
-		const out = getBadgeRendering({ points: 0, comparisonLabel: "" }, false);
-		expect(out.arrow).toBe("=");
-		expect(out.signedValue.trim()).toBe("0");
-		expect(out.className).not.toContain("--success");
-		expect(out.className).not.toContain("--error");
 	});
 });

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -93,6 +93,10 @@ export const AUDIT_ACTIONS = {
 	PUBLIC_REFERENT_SEARCH: "public_referents.search",
 	PUBLIC_REFERENT_VIEW: "public_referents.view",
 
+	// ── Public stats reads ─────────────────────────────────
+	PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE:
+		"public_stats.get_current_campaign_rate",
+
 	// ── System / cron-triggered ────────────────────────────
 	SYSTEM_AUDIT_CLEANUP: "system.audit_cleanup",
 } as const;
@@ -166,6 +170,8 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH]: "public_search",
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW]: "public_search",
+
+	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
 
 	[AUDIT_ACTIONS.SYSTEM_AUDIT_CLEANUP]: "system",
 };

--- a/packages/app/src/modules/domain/__tests__/computeGlobalScore.test.ts
+++ b/packages/app/src/modules/domain/__tests__/computeGlobalScore.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { computeGlobalScore } from "../shared/computeGlobalScore";
+
+describe("computeGlobalScore", () => {
+	it("sums the three sub-scores when all are present", () => {
+		expect(
+			computeGlobalScore({
+				remunerationScore: 40,
+				quartileScore: 15,
+				categoryScore: 30,
+			}),
+		).toBe(85);
+	});
+
+	it("returns the maximum 100 when all sub-scores are at their max", () => {
+		expect(
+			computeGlobalScore({
+				remunerationScore: 40,
+				quartileScore: 15,
+				categoryScore: 45,
+			}),
+		).toBe(100);
+	});
+
+	it("returns 0 when all sub-scores are 0", () => {
+		expect(
+			computeGlobalScore({
+				remunerationScore: 0,
+				quartileScore: 0,
+				categoryScore: 0,
+			}),
+		).toBe(0);
+	});
+
+	it("returns null when remunerationScore is missing", () => {
+		expect(
+			computeGlobalScore({
+				remunerationScore: null,
+				quartileScore: 15,
+				categoryScore: 30,
+			}),
+		).toBeNull();
+	});
+
+	it("returns null when quartileScore is missing", () => {
+		expect(
+			computeGlobalScore({
+				remunerationScore: 40,
+				quartileScore: null,
+				categoryScore: 30,
+			}),
+		).toBeNull();
+	});
+
+	it("returns null when categoryScore is missing", () => {
+		expect(
+			computeGlobalScore({
+				remunerationScore: 40,
+				quartileScore: 15,
+				categoryScore: null,
+			}),
+		).toBeNull();
+	});
+
+	it("returns null when all sub-scores are missing", () => {
+		expect(
+			computeGlobalScore({
+				remunerationScore: null,
+				quartileScore: null,
+				categoryScore: null,
+			}),
+		).toBeNull();
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/scoreBracket.test.ts
+++ b/packages/app/src/modules/domain/__tests__/scoreBracket.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { getScoreBracket, SCORE_BRACKETS } from "../shared/scoreBracket";
+
+describe("SCORE_BRACKETS", () => {
+	it("declares the 8 brackets in canonical order with NC last", () => {
+		expect(SCORE_BRACKETS.map((b) => b.id)).toEqual([
+			"lt50",
+			"50-59",
+			"60-69",
+			"70-79",
+			"80-89",
+			"90-99",
+			"100",
+			"nc",
+		]);
+	});
+
+	it("exposes human-readable labels for each bracket", () => {
+		expect(SCORE_BRACKETS.map((b) => b.label)).toEqual([
+			"<50",
+			"50-59",
+			"60-69",
+			"70-79",
+			"80-89",
+			"90-99",
+			"100",
+			"NC",
+		]);
+	});
+
+	it("uses null min/max for the NC bracket", () => {
+		const nc = SCORE_BRACKETS.find((b) => b.id === "nc");
+		expect(nc?.min).toBeNull();
+		expect(nc?.max).toBeNull();
+	});
+});
+
+describe("getScoreBracket", () => {
+	it("returns 'nc' when score is null", () => {
+		expect(getScoreBracket(null)).toBe("nc");
+	});
+
+	it("returns 'nc' when score is NaN", () => {
+		expect(getScoreBracket(Number.NaN)).toBe("nc");
+	});
+
+	it("returns 'nc' when score is Infinity", () => {
+		expect(getScoreBracket(Number.POSITIVE_INFINITY)).toBe("nc");
+	});
+
+	it("returns 'lt50' for scores below 50 (including 0 and 49)", () => {
+		expect(getScoreBracket(0)).toBe("lt50");
+		expect(getScoreBracket(25)).toBe("lt50");
+		expect(getScoreBracket(49)).toBe("lt50");
+	});
+
+	it("returns '50-59' for scores in [50, 59]", () => {
+		expect(getScoreBracket(50)).toBe("50-59");
+		expect(getScoreBracket(55)).toBe("50-59");
+		expect(getScoreBracket(59)).toBe("50-59");
+	});
+
+	it("returns '60-69' for scores in [60, 69]", () => {
+		expect(getScoreBracket(60)).toBe("60-69");
+		expect(getScoreBracket(69)).toBe("60-69");
+	});
+
+	it("returns '70-79' for scores in [70, 79]", () => {
+		expect(getScoreBracket(70)).toBe("70-79");
+		expect(getScoreBracket(79)).toBe("70-79");
+	});
+
+	it("returns '80-89' for scores in [80, 89]", () => {
+		expect(getScoreBracket(80)).toBe("80-89");
+		expect(getScoreBracket(89)).toBe("80-89");
+	});
+
+	it("returns '90-99' for scores in [90, 99]", () => {
+		expect(getScoreBracket(90)).toBe("90-99");
+		expect(getScoreBracket(99)).toBe("90-99");
+	});
+
+	it("returns '100' for the perfect score", () => {
+		expect(getScoreBracket(100)).toBe("100");
+	});
+
+	it("returns '100' for scores above 100 (defensive)", () => {
+		expect(getScoreBracket(105)).toBe("100");
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/submissionRate.test.ts
+++ b/packages/app/src/modules/domain/__tests__/submissionRate.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	computeRate,
+	formatPointsAbs,
+	roundOneDecimal,
+} from "../shared/submissionRate";
+
+describe("roundOneDecimal", () => {
+	it("rounds to one decimal place (banker-agnostic)", () => {
+		expect(roundOneDecimal(73.42)).toBe(73.4);
+		expect(roundOneDecimal(73.45)).toBe(73.5);
+		expect(roundOneDecimal(73.44)).toBe(73.4);
+		expect(roundOneDecimal(73.0)).toBe(73);
+	});
+
+	it("handles negatives", () => {
+		expect(roundOneDecimal(-2.07)).toBe(-2.1);
+		expect(roundOneDecimal(-0.04)).toBeCloseTo(0, 10);
+	});
+});
+
+describe("computeRate", () => {
+	it("returns 0 when obligated = 0 (no division by zero)", () => {
+		expect(computeRate(0, 0)).toBe(0);
+		expect(computeRate(5, 0)).toBe(0);
+	});
+
+	it("returns a percentage rounded to one decimal", () => {
+		expect(computeRate(73, 100)).toBe(73);
+		expect(computeRate(1, 3)).toBe(33.3);
+		expect(computeRate(2, 3)).toBe(66.7);
+		expect(computeRate(1, 2)).toBe(50);
+	});
+
+	it("computes 100 when submitted === obligated", () => {
+		expect(computeRate(42, 42)).toBe(100);
+	});
+});
+
+describe("formatPointsAbs", () => {
+	it("returns absolute value rounded to 1 decimal, French separator", () => {
+		expect(formatPointsAbs(2.07)).toBe("2,1");
+		expect(formatPointsAbs(-2.07)).toBe("2,1");
+		expect(formatPointsAbs(0)).toBe("0,0");
+		expect(formatPointsAbs(0.5)).toBe("0,5");
+		expect(formatPointsAbs(-0.04)).toBe("0,0");
+	});
+});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -150,6 +150,12 @@ export {
 } from "./shared/regions";
 // SIREN utilities
 export { extractSiren, formatSiren, parseSiren } from "./shared/siren";
+// Submission rate helpers (shared by admin/public stats routers and KPI tiles)
+export {
+	computeRate,
+	formatPointsAbs,
+	roundOneDecimal,
+} from "./shared/submissionRate";
 export type {
 	CampaignDeadlines,
 	CompanySize,

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -18,6 +18,9 @@ export {
 	classifyCompanySize,
 	isCseRequired,
 } from "./shared/companySize";
+// Global score computation (sum of sub-scores from the EgaPro index)
+export type { GlobalScoreInputs } from "./shared/computeGlobalScore";
+export { computeGlobalScore } from "./shared/computeGlobalScore";
 // Constants
 export {
 	COMPANY_SIZE_ANNUAL_MIN,
@@ -148,6 +151,9 @@ export {
 	REGIONS,
 	REGIONS_TO_COUNTIES,
 } from "./shared/regions";
+// Score brackets for public stats distribution chart
+export type { ScoreBracket, ScoreBracketId } from "./shared/scoreBracket";
+export { getScoreBracket, SCORE_BRACKETS } from "./shared/scoreBracket";
 // SIREN utilities
 export { extractSiren, formatSiren, parseSiren } from "./shared/siren";
 // Submission rate helpers (shared by admin/public stats routers and KPI tiles)

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -151,9 +151,14 @@ export {
 // SIREN utilities
 export { extractSiren, formatSiren, parseSiren } from "./shared/siren";
 // Submission rate helpers (shared by admin/public stats routers and KPI tiles)
+export type { CampaignRateTileProps } from "./shared/submissionRate";
 export {
+	buildCampaignRateTileProps,
 	computeRate,
+	formatCount,
 	formatPointsAbs,
+	formatRate,
+	NARROW_NBSP,
 	roundOneDecimal,
 } from "./shared/submissionRate";
 export type {

--- a/packages/app/src/modules/domain/shared/computeGlobalScore.ts
+++ b/packages/app/src/modules/domain/shared/computeGlobalScore.ts
@@ -1,0 +1,17 @@
+export type GlobalScoreInputs = {
+	remunerationScore: number | null;
+	quartileScore: number | null;
+	categoryScore: number | null;
+};
+
+export function computeGlobalScore(inputs: GlobalScoreInputs): number | null {
+	const { remunerationScore, quartileScore, categoryScore } = inputs;
+	if (
+		remunerationScore === null ||
+		quartileScore === null ||
+		categoryScore === null
+	) {
+		return null;
+	}
+	return remunerationScore + quartileScore + categoryScore;
+}

--- a/packages/app/src/modules/domain/shared/scoreBracket.ts
+++ b/packages/app/src/modules/domain/shared/scoreBracket.ts
@@ -1,0 +1,38 @@
+export type ScoreBracketId =
+	| "lt50"
+	| "50-59"
+	| "60-69"
+	| "70-79"
+	| "80-89"
+	| "90-99"
+	| "100"
+	| "nc";
+
+export type ScoreBracket = {
+	id: ScoreBracketId;
+	label: string;
+	min: number | null;
+	max: number | null;
+};
+
+export const SCORE_BRACKETS: readonly ScoreBracket[] = [
+	{ id: "lt50", label: "<50", min: 0, max: 49 },
+	{ id: "50-59", label: "50-59", min: 50, max: 59 },
+	{ id: "60-69", label: "60-69", min: 60, max: 69 },
+	{ id: "70-79", label: "70-79", min: 70, max: 79 },
+	{ id: "80-89", label: "80-89", min: 80, max: 89 },
+	{ id: "90-99", label: "90-99", min: 90, max: 99 },
+	{ id: "100", label: "100", min: 100, max: 100 },
+	{ id: "nc", label: "NC", min: null, max: null },
+];
+
+export function getScoreBracket(score: number | null): ScoreBracketId {
+	if (score === null || !Number.isFinite(score)) return "nc";
+	if (score < 50) return "lt50";
+	if (score < 60) return "50-59";
+	if (score < 70) return "60-69";
+	if (score < 80) return "70-79";
+	if (score < 90) return "80-89";
+	if (score < 100) return "90-99";
+	return "100";
+}

--- a/packages/app/src/modules/domain/shared/submissionRate.ts
+++ b/packages/app/src/modules/domain/shared/submissionRate.ts
@@ -1,3 +1,5 @@
+export const NARROW_NBSP = " ";
+
 export function roundOneDecimal(value: number): number {
 	return Math.round(value * 10) / 10;
 }
@@ -10,4 +12,47 @@ export function computeRate(submitted: number, obligated: number): number {
 export function formatPointsAbs(points: number): string {
 	const rounded = roundOneDecimal(Math.abs(points));
 	return rounded.toFixed(1).replace(".", ",");
+}
+
+export function formatRate(rate: number): string {
+	return rate.toFixed(1).replace(".", ",");
+}
+
+export function formatCount(count: number): string {
+	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
+}
+
+type CampaignRateData = {
+	totalSubmitted: number;
+	totalObligated: number;
+	submissionRate: number;
+	previousYearRate: number | null;
+};
+
+export type CampaignRateTileProps = {
+	title: string;
+	value: string;
+	subtitle: string;
+	delta: { points: number; comparisonLabel: string } | null;
+};
+
+export function buildCampaignRateTileProps(
+	data: CampaignRateData,
+	year: number,
+	comparisonYear: number,
+): CampaignRateTileProps {
+	return {
+		title: `Taux de déclaration ${year}`,
+		value: `${formatRate(data.submissionRate)}${NARROW_NBSP}%`,
+		subtitle: `${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`,
+		delta:
+			data.previousYearRate === null
+				? null
+				: {
+						points: roundOneDecimal(
+							data.submissionRate - data.previousYearRate,
+						),
+						comparisonLabel: `vs ${comparisonYear}`,
+					},
+	};
 }

--- a/packages/app/src/modules/domain/shared/submissionRate.ts
+++ b/packages/app/src/modules/domain/shared/submissionRate.ts
@@ -1,0 +1,13 @@
+export function roundOneDecimal(value: number): number {
+	return Math.round(value * 10) / 10;
+}
+
+export function computeRate(submitted: number, obligated: number): number {
+	if (obligated === 0) return 0;
+	return roundOneDecimal((submitted / obligated) * 100);
+}
+
+export function formatPointsAbs(points: number): string {
+	const rounded = roundOneDecimal(Math.abs(points));
+	return rounded.toFixed(1).replace(".", ",");
+}

--- a/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
+++ b/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { api } from "~/trpc/react";
+
+import { PublicKpiTile } from "./PublicKpiTile";
+
+const NARROW_NBSP = " ";
+
+function formatRate(rate: number): string {
+	return rate.toFixed(1).replace(".", ",");
+}
+
+function formatCount(count: number): string {
+	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
+}
+
+export function CurrentCampaignRateTile() {
+	const query = api.publicStats.getCurrentCampaignRate.useQuery(undefined, {
+		placeholderData: (prev) => prev,
+	});
+
+	if (query.isLoading && !query.data) {
+		return (
+			<p aria-live="polite" className="fr-text--sm">
+				Chargement du taux de déclaration…
+			</p>
+		);
+	}
+
+	if (query.isError) {
+		return (
+			<div aria-live="polite" className="fr-alert fr-alert--error">
+				<p>
+					Une erreur est survenue lors du chargement du taux de déclaration.
+				</p>
+			</div>
+		);
+	}
+
+	const data = query.data;
+	if (!data) return null;
+
+	const delta =
+		data.previousYearRate === null
+			? null
+			: {
+					points:
+						Math.round((data.submissionRate - data.previousYearRate) * 10) / 10,
+					comparisonLabel: `vs ${data.year - 1}`,
+				};
+
+	return (
+		<PublicKpiTile
+			delta={delta}
+			subtitle={`${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`}
+			title={`Taux de déclaration ${data.year}`}
+			value={`${formatRate(data.submissionRate)}${NARROW_NBSP}%`}
+		/>
+	);
+}

--- a/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
+++ b/packages/app/src/modules/publicStats/CurrentCampaignRateTile.tsx
@@ -1,60 +1,28 @@
 "use client";
 
+import { buildCampaignRateTileProps } from "~/modules/domain";
+import {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "~/modules/shared";
 import { api } from "~/trpc/react";
 
 import { PublicKpiTile } from "./PublicKpiTile";
-
-const NARROW_NBSP = " ";
-
-function formatRate(rate: number): string {
-	return rate.toFixed(1).replace(".", ",");
-}
-
-function formatCount(count: number): string {
-	return count.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP);
-}
 
 export function CurrentCampaignRateTile() {
 	const query = api.publicStats.getCurrentCampaignRate.useQuery(undefined, {
 		placeholderData: (prev) => prev,
 	});
 
-	if (query.isLoading && !query.data) {
-		return (
-			<p aria-live="polite" className="fr-text--sm">
-				Chargement du taux de déclaration…
-			</p>
-		);
-	}
-
-	if (query.isError) {
-		return (
-			<div aria-live="polite" className="fr-alert fr-alert--error">
-				<p>
-					Une erreur est survenue lors du chargement du taux de déclaration.
-				</p>
-			</div>
-		);
-	}
+	if (query.isLoading && !query.data) return <CampaignRateTileLoading />;
+	if (query.isError) return <CampaignRateTileError />;
 
 	const data = query.data;
 	if (!data) return null;
 
-	const delta =
-		data.previousYearRate === null
-			? null
-			: {
-					points:
-						Math.round((data.submissionRate - data.previousYearRate) * 10) / 10,
-					comparisonLabel: `vs ${data.year - 1}`,
-				};
-
 	return (
 		<PublicKpiTile
-			delta={delta}
-			subtitle={`${formatCount(data.totalSubmitted)} / ${formatCount(data.totalObligated)} entreprises`}
-			title={`Taux de déclaration ${data.year}`}
-			value={`${formatRate(data.submissionRate)}${NARROW_NBSP}%`}
+			{...buildCampaignRateTileProps(data, data.year, data.year - 1)}
 		/>
 	);
 }

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,13 +1,6 @@
-import type { ReactNode } from "react";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
 
-import { formatPointsAbs } from "~/modules/domain";
-
-const NARROW_NBSP = " ";
-
-export type PublicKpiTileDelta = {
-	points: number;
-	comparisonLabel: string;
-};
+export type PublicKpiTileDelta = KpiBadgeDelta;
 
 type Props = {
 	title: string;
@@ -16,45 +9,6 @@ type Props = {
 	delta: PublicKpiTileDelta | null;
 };
 
-type BadgeRendering = {
-	className: string;
-	arrow: string;
-	signedValue: string;
-};
-
-export function getBadgeRendering(delta: PublicKpiTileDelta): BadgeRendering {
-	if (delta.points > 0) {
-		return {
-			className: "fr-badge fr-badge--success fr-badge--no-icon",
-			arrow: "↑",
-			signedValue: `+${formatPointsAbs(delta.points)}`,
-		};
-	}
-	if (delta.points < 0) {
-		return {
-			className: "fr-badge fr-badge--error fr-badge--no-icon",
-			arrow: "↓",
-			signedValue: `-${formatPointsAbs(delta.points)}`,
-		};
-	}
-	return {
-		className: "fr-badge fr-badge--no-icon",
-		arrow: "=",
-		signedValue: `0${NARROW_NBSP}`,
-	};
-}
-
-function renderBadge(delta: PublicKpiTileDelta | null): ReactNode {
-	if (!delta) return null;
-	const { className, arrow, signedValue } = getBadgeRendering(delta);
-	return (
-		<p className={className}>
-			<span aria-hidden="true">{arrow}</span> {signedValue}
-			{NARROW_NBSP}pts {delta.comparisonLabel}
-		</p>
-	);
-}
-
 export function PublicKpiTile({ title, value, subtitle, delta }: Props) {
 	return (
 		<div className="fr-tile fr-tile--vertical fr-tile--no-border">
@@ -62,7 +16,7 @@ export function PublicKpiTile({ title, value, subtitle, delta }: Props) {
 				<div className="fr-tile__content">
 					<h2 className="fr-tile__title">{title}</h2>
 					<p className="fr-display--xs fr-mb-1w">{value}</p>
-					{renderBadge(delta)}
+					<KpiBadge delta={delta} />
 					<p className="fr-text--sm fr-text-mention--grey fr-mb-0 fr-mt-1w">
 						{subtitle}
 					</p>

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+
+const NARROW_NBSP = " ";
+
+export type PublicKpiTileDelta = {
+	points: number;
+	comparisonLabel: string;
+};
+
+type Props = {
+	title: string;
+	value: string;
+	subtitle: string;
+	delta: PublicKpiTileDelta | null;
+};
+
+type BadgeRendering = {
+	className: string;
+	arrow: string;
+	signedValue: string;
+};
+
+function formatPointsAbs(points: number): string {
+	const rounded = Math.round(Math.abs(points) * 10) / 10;
+	return rounded.toFixed(1).replace(".", ",");
+}
+
+export function getBadgeRendering(delta: PublicKpiTileDelta): BadgeRendering {
+	if (delta.points > 0) {
+		return {
+			className: "fr-badge fr-badge--success fr-badge--no-icon",
+			arrow: "↑",
+			signedValue: `+${formatPointsAbs(delta.points)}`,
+		};
+	}
+	if (delta.points < 0) {
+		return {
+			className: "fr-badge fr-badge--error fr-badge--no-icon",
+			arrow: "↓",
+			signedValue: `-${formatPointsAbs(delta.points)}`,
+		};
+	}
+	return {
+		className: "fr-badge fr-badge--no-icon",
+		arrow: "=",
+		signedValue: `0${NARROW_NBSP}`,
+	};
+}
+
+function renderBadge(delta: PublicKpiTileDelta | null): ReactNode {
+	if (!delta) return null;
+	const { className, arrow, signedValue } = getBadgeRendering(delta);
+	return (
+		<p className={className}>
+			<span aria-hidden="true">{arrow}</span> {signedValue}
+			{NARROW_NBSP}pts {delta.comparisonLabel}
+		</p>
+	);
+}
+
+export function PublicKpiTile({ title, value, subtitle, delta }: Props) {
+	return (
+		<div className="fr-tile fr-tile--vertical fr-tile--no-border">
+			<div className="fr-tile__body">
+				<div className="fr-tile__content">
+					<h2 className="fr-tile__title">{title}</h2>
+					<p className="fr-display--xs fr-mb-1w">{value}</p>
+					{renderBadge(delta)}
+					<p className="fr-text--sm fr-text-mention--grey fr-mb-0 fr-mt-1w">
+						{subtitle}
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,4 +1,4 @@
-import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared";
+import { KpiBadge, type KpiBadgeDelta } from "~/modules/shared/KpiBadge";
 
 export type PublicKpiTileDelta = KpiBadgeDelta;
 

--- a/packages/app/src/modules/publicStats/PublicKpiTile.tsx
+++ b/packages/app/src/modules/publicStats/PublicKpiTile.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 
-const NARROW_NBSP = " ";
+import { formatPointsAbs } from "~/modules/domain";
+
+const NARROW_NBSP = " ";
 
 export type PublicKpiTileDelta = {
 	points: number;
@@ -19,11 +21,6 @@ type BadgeRendering = {
 	arrow: string;
 	signedValue: string;
 };
-
-function formatPointsAbs(points: number): string {
-	const rounded = Math.round(Math.abs(points) * 10) / 10;
-	return rounded.toFixed(1).replace(".", ",");
-}
 
 export function getBadgeRendering(delta: PublicKpiTileDelta): BadgeRendering {
 	if (delta.points > 0) {

--- a/packages/app/src/modules/publicStats/PublicStatsPage.tsx
+++ b/packages/app/src/modules/publicStats/PublicStatsPage.tsx
@@ -1,4 +1,5 @@
 import { CurrentCampaignRateTile } from "./CurrentCampaignRateTile";
+import { ScoreDistributionTile } from "./ScoreDistributionTile";
 
 export function PublicStatsPage() {
 	return (
@@ -8,6 +9,7 @@ export function PublicStatsPage() {
 				Indicateurs clés sur l'égalité professionnelle femmes-hommes en France.
 			</p>
 			<CurrentCampaignRateTile />
+			<ScoreDistributionTile />
 		</div>
 	);
 }

--- a/packages/app/src/modules/publicStats/PublicStatsPage.tsx
+++ b/packages/app/src/modules/publicStats/PublicStatsPage.tsx
@@ -1,0 +1,13 @@
+import { CurrentCampaignRateTile } from "./CurrentCampaignRateTile";
+
+export function PublicStatsPage() {
+	return (
+		<div className="fr-container fr-py-6w">
+			<h1 className="fr-h1">Statistiques publiques</h1>
+			<p className="fr-text--lead fr-mb-4w">
+				Indicateurs clés sur l'égalité professionnelle femmes-hommes en France.
+			</p>
+			<CurrentCampaignRateTile />
+		</div>
+	);
+}

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
@@ -1,0 +1,4 @@
+.chartWrapper {
+	width: 100%;
+	height: 320px;
+}

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+import {
+	formatCount,
+	formatRate,
+	NARROW_NBSP,
+	type ScoreBracketId,
+} from "~/modules/domain";
+
+import styles from "./ScoreDistributionChart.module.scss";
+
+export type ScoreDistributionBracket = {
+	id: ScoreBracketId;
+	label: string;
+	count: number;
+	percentage: number;
+};
+
+type Props = {
+	brackets: ScoreDistributionBracket[];
+};
+
+const BRACKET_COLOR: Record<ScoreBracketId, string> = {
+	lt50: "var(--background-action-high-error)",
+	"50-59": "var(--background-action-high-warning)",
+	"60-69": "var(--background-action-high-yellow-tournesol)",
+	"70-79": "var(--background-action-high-green-emeraude)",
+	"80-89": "var(--background-action-high-green-bourgeon)",
+	"90-99": "var(--background-action-high-green-tilleul-verveine)",
+	"100": "var(--background-action-high-success)",
+	nc: "var(--background-alt-grey)",
+};
+
+type TooltipPayloadEntry = {
+	payload?: ScoreDistributionBracket;
+};
+
+type ChartTooltipProps = {
+	active?: boolean;
+	payload?: TooltipPayloadEntry[];
+};
+
+export function formatYAxisTick(value: number): string {
+	return value.toLocaleString("fr-FR");
+}
+
+export function ChartTooltip({ active, payload }: ChartTooltipProps) {
+	if (!active || !payload || payload.length === 0) return null;
+	const datum = payload[0]?.payload;
+	if (!datum) return null;
+	const noun = datum.count > 1 ? "entreprises" : "entreprise";
+	return (
+		<div className="fr-p-2w fr-background-alt--grey">
+			<p className="fr-text--sm fr-mb-0">
+				<strong>
+					{formatCount(datum.count)} {noun}
+				</strong>{" "}
+				— tranche {datum.label} ({formatRate(datum.percentage)}
+				{NARROW_NBSP}% du total)
+			</p>
+		</div>
+	);
+}
+
+export function ScoreDistributionChart({ brackets }: Props) {
+	return (
+		<div aria-hidden="true" className={styles.chartWrapper} role="presentation">
+			<ResponsiveContainer>
+				<BarChart data={brackets} margin={{ top: 16, right: 16, bottom: 8 }}>
+					<CartesianGrid strokeDasharray="3 3" vertical={false} />
+					<XAxis dataKey="label" />
+					<YAxis tickFormatter={formatYAxisTick} />
+					<Tooltip content={<ChartTooltip />} cursor={false} />
+					<Bar dataKey="count" isAnimationActive={false}>
+						{brackets.map((bracket) => (
+							<Cell fill={BRACKET_COLOR[bracket.id]} key={bracket.id} />
+						))}
+					</Bar>
+				</BarChart>
+			</ResponsiveContainer>
+		</div>
+	);
+}

--- a/packages/app/src/modules/publicStats/ScoreDistributionStates.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionStates.tsx
@@ -1,0 +1,18 @@
+export function ScoreDistributionLoading() {
+	return (
+		<p aria-live="polite" className="fr-text--sm fr-mt-6w">
+			Chargement de la distribution des scores…
+		</p>
+	);
+}
+
+export function ScoreDistributionTileError() {
+	return (
+		<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-6w">
+			<p>
+				Une erreur est survenue lors du chargement de la distribution des
+				scores.
+			</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/publicStats/ScoreDistributionTable.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionTable.tsx
@@ -1,0 +1,46 @@
+import { formatCount, formatRate, NARROW_NBSP } from "~/modules/domain";
+
+import type { ScoreDistributionBracket } from "./ScoreDistributionChart";
+
+type Props = {
+	brackets: ScoreDistributionBracket[];
+	captionId: string;
+};
+
+export function ScoreDistributionTable({ brackets, captionId }: Props) {
+	return (
+		<div className="fr-table fr-table--bordered">
+			<div className="fr-table__wrapper">
+				<div className="fr-table__container">
+					<div className="fr-table__content">
+						<table aria-labelledby={captionId}>
+							<caption className="fr-sr-only" id={captionId}>
+								Nombre d'entreprises par tranche de score global, pour l'année
+								en cours.
+							</caption>
+							<thead>
+								<tr>
+									<th scope="col">Tranche de score</th>
+									<th scope="col">Nombre d'entreprises</th>
+									<th scope="col">Part du total</th>
+								</tr>
+							</thead>
+							<tbody>
+								{brackets.map((bracket) => (
+									<tr key={bracket.id}>
+										<th scope="row">{bracket.label}</th>
+										<td>{formatCount(bracket.count)}</td>
+										<td>
+											{formatRate(bracket.percentage)}
+											{NARROW_NBSP}%
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/publicStats/ScoreDistributionTile.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionTile.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useId } from "react";
+
+import { api } from "~/trpc/react";
+
+import { ScoreDistributionChart } from "./ScoreDistributionChart";
+import {
+	ScoreDistributionLoading,
+	ScoreDistributionTileError,
+} from "./ScoreDistributionStates";
+import { ScoreDistributionTable } from "./ScoreDistributionTable";
+
+export function ScoreDistributionTile() {
+	const query = api.publicStats.getScoreDistribution.useQuery(undefined, {
+		placeholderData: (prev) => prev,
+	});
+	const headingId = useId();
+	const tableCaptionId = useId();
+
+	if (query.isLoading && !query.data) return <ScoreDistributionLoading />;
+	if (query.isError) return <ScoreDistributionTileError />;
+
+	const data = query.data;
+	if (!data) return null;
+
+	return (
+		<section aria-labelledby={headingId} className="fr-mt-6w">
+			<h2 className="fr-h3" id={headingId}>
+				Distribution des scores {data.year}
+			</h2>
+			<p className="fr-text--sm fr-text-mention--grey fr-mb-3w">
+				Répartition des entreprises ayant déclaré leur index par tranche de
+				score global sur 100. La tranche « NC » regroupe les entreprises dont le
+				score n'est pas calculable.
+			</p>
+			<ScoreDistributionChart brackets={data.brackets} />
+			<ScoreDistributionTable
+				brackets={data.brackets}
+				captionId={tableCaptionId}
+			/>
+		</section>
+	);
+}

--- a/packages/app/src/modules/publicStats/__tests__/CurrentCampaignRateTile.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/CurrentCampaignRateTile.test.tsx
@@ -1,0 +1,181 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CurrentCampaignRate } from "../types";
+
+const useQueryMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		publicStats: {
+			getCurrentCampaignRate: {
+				useQuery: (...args: unknown[]) => useQueryMock(...args),
+			},
+		},
+	},
+}));
+
+import { CurrentCampaignRateTile } from "../CurrentCampaignRateTile";
+
+function mockQuery({
+	data,
+	isLoading = false,
+	isError = false,
+}: {
+	data?: CurrentCampaignRate;
+	isLoading?: boolean;
+	isError?: boolean;
+}) {
+	useQueryMock.mockReturnValue({ data, isLoading, isError });
+}
+
+describe("CurrentCampaignRateTile", () => {
+	beforeEach(() => {
+		useQueryMock.mockReset();
+	});
+
+	it("shows a loading message while the query is in flight and no data is cached", () => {
+		mockQuery({ isLoading: true });
+		render(<CurrentCampaignRateTile />);
+
+		expect(screen.getByText(/chargement du taux/i)).toBeInTheDocument();
+		expect(screen.getByText(/chargement du taux/i)).toHaveAttribute(
+			"aria-live",
+			"polite",
+		);
+	});
+
+	it("shows an error alert when the query errors out", () => {
+		mockQuery({ isError: true });
+		render(<CurrentCampaignRateTile />);
+
+		expect(
+			screen.getByText(/erreur est survenue/i).closest(".fr-alert"),
+		).toHaveClass("fr-alert--error");
+	});
+
+	it("renders the tile with rate, subtitle and a positive badge against year-1", () => {
+		mockQuery({
+			data: {
+				totalObligated: 5738,
+				totalSubmitted: 4213,
+				submissionRate: 73.4,
+				previousYearRate: 71.3,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		expect(
+			screen.getByRole("heading", { name: "Taux de déclaration 2026" }),
+		).toBeInTheDocument();
+		expect(screen.getByText(/73,4/)).toBeInTheDocument();
+		expect(
+			screen.getByText((content) =>
+				/4\s?213\s*\/\s*5\s?738\s+entreprises/.test(
+					content.replace(/\s/g, " "),
+				),
+			),
+		).toBeInTheDocument();
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--success");
+		expect(badge?.textContent).toContain("vs 2025");
+	});
+
+	it("renders the tile without a badge when previousYearRate is null (no history)", () => {
+		mockQuery({
+			data: {
+				totalObligated: 100,
+				totalSubmitted: 50,
+				submissionRate: 50,
+				previousYearRate: null,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		expect(container.querySelector(".fr-badge")).toBeNull();
+	});
+
+	it("renders zeros gracefully when totalObligated is 0", () => {
+		mockQuery({
+			data: {
+				totalObligated: 0,
+				totalSubmitted: 0,
+				submissionRate: 0,
+				previousYearRate: null,
+				year: 2026,
+			},
+		});
+		render(<CurrentCampaignRateTile />);
+
+		expect(screen.getByText(/0,0/)).toBeInTheDocument();
+		expect(
+			screen.getByText((content) =>
+				/0\s*\/\s*0\s+entreprises/.test(content.replace(/\s/g, " ")),
+			),
+		).toBeInTheDocument();
+	});
+
+	it("returns null when the query has neither data, loading nor error state", () => {
+		mockQuery({});
+		const { container } = render(<CurrentCampaignRateTile />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("uses the previous data as placeholder while a new query is running", () => {
+		mockQuery({
+			data: {
+				totalObligated: 10,
+				totalSubmitted: 5,
+				submissionRate: 50,
+				previousYearRate: null,
+				year: 2026,
+			},
+		});
+		render(<CurrentCampaignRateTile />);
+
+		const options = useQueryMock.mock.calls[0]?.[1] as
+			| { placeholderData: (prev: unknown) => unknown }
+			| undefined;
+		expect(options?.placeholderData).toBeInstanceOf(Function);
+		expect(options?.placeholderData("previous-data")).toBe("previous-data");
+	});
+
+	it("renders a negative delta as an error badge with comparison label from data.year", () => {
+		mockQuery({
+			data: {
+				totalObligated: 100,
+				totalSubmitted: 40,
+				submissionRate: 40,
+				previousYearRate: 50,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("vs 2025");
+		expect(badge?.textContent).toContain("-10,0");
+	});
+
+	it("renders a neutral delta when submissionRate equals previousYearRate", () => {
+		mockQuery({
+			data: {
+				totalObligated: 100,
+				totalSubmitted: 50,
+				submissionRate: 50,
+				previousYearRate: 50,
+				year: 2026,
+			},
+		});
+		const { container } = render(<CurrentCampaignRateTile />);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).not.toHaveClass("fr-badge--success");
+		expect(badge).not.toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("=");
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { getBadgeRendering, PublicKpiTile } from "../PublicKpiTile";
+
+describe("PublicKpiTile", () => {
+	it("renders title, value and subtitle", () => {
+		render(
+			<PublicKpiTile
+				delta={null}
+				subtitle="4 213 / 5 738 entreprises"
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: "Taux de déclaration 2026" }),
+		).toBeInTheDocument();
+		expect(screen.getByText("73,4 %")).toBeInTheDocument();
+		expect(screen.getByText("4 213 / 5 738 entreprises")).toBeInTheDocument();
+	});
+
+	it("renders no badge when delta is null", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={null}
+				subtitle="0 / 0 entreprises"
+				title="Indicateur"
+				value="0,0 %"
+			/>,
+		);
+
+		expect(container.querySelector(".fr-badge")).toBeNull();
+	});
+
+	it("renders a success badge with upward arrow for a positive delta", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: 2.1, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux de déclaration 2026"
+				value="73,4 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--success");
+		expect(badge?.textContent).toContain("↑");
+		expect(badge?.textContent).toContain("+2,1");
+		expect(badge?.textContent).toContain("pts");
+		expect(badge?.textContent).toContain("vs 2025");
+	});
+
+	it("renders an error badge with downward arrow for a negative delta", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: -1.5, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux de déclaration 2026"
+				value="71,9 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("↓");
+		expect(badge?.textContent).toContain("-1,5");
+	});
+
+	it("renders a neutral badge with equals sign for a zero delta", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: 0, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux"
+				value="50,0 %"
+			/>,
+		);
+
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge");
+		expect(badge).not.toHaveClass("fr-badge--success");
+		expect(badge).not.toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("=");
+	});
+
+	it("renders the arrow with aria-hidden so the visual cue is not duplicated for screen readers", () => {
+		const { container } = render(
+			<PublicKpiTile
+				delta={{ points: 2.1, comparisonLabel: "vs 2025" }}
+				subtitle="—"
+				title="Taux"
+				value="73,4 %"
+			/>,
+		);
+
+		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
+		expect(arrow).not.toBeNull();
+		expect(arrow?.textContent).toBe("↑");
+	});
+});
+
+describe("getBadgeRendering", () => {
+	it("rounds the displayed points to one decimal place", () => {
+		const out = getBadgeRendering({ points: 2.07, comparisonLabel: "" });
+		expect(out.signedValue).toBe("+2,1");
+	});
+
+	it("uses the error class for negative delta", () => {
+		const out = getBadgeRendering({ points: -2, comparisonLabel: "vs 2025" });
+		expect(out.className).toContain("fr-badge--error");
+		expect(out.arrow).toBe("↓");
+		expect(out.signedValue).toBe("-2,0");
+	});
+
+	it("uses the success class for positive delta", () => {
+		const out = getBadgeRendering({ points: 0.5, comparisonLabel: "vs 2025" });
+		expect(out.className).toContain("fr-badge--success");
+	});
+
+	it("produces a neutral badge with `0` for a zero delta", () => {
+		const out = getBadgeRendering({ points: 0, comparisonLabel: "" });
+		expect(out.arrow).toBe("=");
+		expect(out.signedValue.trim()).toBe("0");
+		expect(out.className).not.toContain("--success");
+		expect(out.className).not.toContain("--error");
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicKpiTile.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { getBadgeRendering, PublicKpiTile } from "../PublicKpiTile";
+import { PublicKpiTile } from "../PublicKpiTile";
 
 describe("PublicKpiTile", () => {
 	it("renders title, value and subtitle", () => {
@@ -98,32 +98,5 @@ describe("PublicKpiTile", () => {
 		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
 		expect(arrow).not.toBeNull();
 		expect(arrow?.textContent).toBe("↑");
-	});
-});
-
-describe("getBadgeRendering", () => {
-	it("rounds the displayed points to one decimal place", () => {
-		const out = getBadgeRendering({ points: 2.07, comparisonLabel: "" });
-		expect(out.signedValue).toBe("+2,1");
-	});
-
-	it("uses the error class for negative delta", () => {
-		const out = getBadgeRendering({ points: -2, comparisonLabel: "vs 2025" });
-		expect(out.className).toContain("fr-badge--error");
-		expect(out.arrow).toBe("↓");
-		expect(out.signedValue).toBe("-2,0");
-	});
-
-	it("uses the success class for positive delta", () => {
-		const out = getBadgeRendering({ points: 0.5, comparisonLabel: "vs 2025" });
-		expect(out.className).toContain("fr-badge--success");
-	});
-
-	it("produces a neutral badge with `0` for a zero delta", () => {
-		const out = getBadgeRendering({ points: 0, comparisonLabel: "" });
-		expect(out.arrow).toBe("=");
-		expect(out.signedValue.trim()).toBe("0");
-		expect(out.className).not.toContain("--success");
-		expect(out.className).not.toContain("--error");
 	});
 });

--- a/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
@@ -7,6 +7,9 @@ vi.mock("~/trpc/react", () => ({
 			getCurrentCampaignRate: {
 				useQuery: () => ({ data: undefined, isLoading: true, isError: false }),
 			},
+			getScoreDistribution: {
+				useQuery: () => ({ data: undefined, isLoading: true, isError: false }),
+			},
 		},
 	},
 }));
@@ -34,5 +37,12 @@ describe("PublicStatsPage", () => {
 	it("embeds the current campaign rate tile", () => {
 		render(<PublicStatsPage />);
 		expect(screen.getByText(/chargement du taux/i)).toBeInTheDocument();
+	});
+
+	it("embeds the score distribution tile", () => {
+		render(<PublicStatsPage />);
+		expect(
+			screen.getByText(/chargement de la distribution/i),
+		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		publicStats: {
+			getCurrentCampaignRate: {
+				useQuery: () => ({ data: undefined, isLoading: true, isError: false }),
+			},
+		},
+	},
+}));
+
+import { PublicStatsPage } from "../PublicStatsPage";
+
+describe("PublicStatsPage", () => {
+	it("renders the page heading", () => {
+		render(<PublicStatsPage />);
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "Statistiques publiques",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("renders the lead paragraph describing the page content", () => {
+		render(<PublicStatsPage />);
+		expect(
+			screen.getByText(/Indicateurs clés sur l'égalité professionnelle/i),
+		).toBeInTheDocument();
+	});
+
+	it("embeds the current campaign rate tile", () => {
+		render(<PublicStatsPage />);
+		expect(screen.getByText(/chargement du taux/i)).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ScoreDistributionBracket } from "../ScoreDistributionChart";
+
+type RechartsTooltipModule = typeof import("recharts");
+
+vi.mock("recharts", async () => {
+	const actual = await vi.importActual<RechartsTooltipModule>("recharts");
+	return {
+		...actual,
+		ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
+			React.createElement("div", { "data-testid": "responsive" }, children),
+	};
+});
+
+import {
+	ChartTooltip,
+	formatYAxisTick,
+	ScoreDistributionChart,
+} from "../ScoreDistributionChart";
+
+const baseBrackets: ScoreDistributionBracket[] = [
+	{ id: "lt50", label: "<50", count: 12, percentage: 1.5 },
+	{ id: "50-59", label: "50-59", count: 50, percentage: 6.3 },
+	{ id: "60-69", label: "60-69", count: 100, percentage: 12.5 },
+	{ id: "70-79", label: "70-79", count: 150, percentage: 18.8 },
+	{ id: "80-89", label: "80-89", count: 200, percentage: 25 },
+	{ id: "90-99", label: "90-99", count: 230, percentage: 28.8 },
+	{ id: "100", label: "100", count: 50, percentage: 6.3 },
+	{ id: "nc", label: "NC", count: 8, percentage: 1 },
+];
+
+describe("ScoreDistributionChart", () => {
+	it("renders a Recharts container with the bracket dataset", () => {
+		const { container } = render(
+			<ScoreDistributionChart brackets={baseBrackets} />,
+		);
+		expect(screen.getByTestId("responsive")).toBeInTheDocument();
+		expect(container.querySelector("[aria-hidden='true']")).toBeInTheDocument();
+	});
+
+	it("hides the chart from assistive tech (alternative table provides the data)", () => {
+		const { container } = render(
+			<ScoreDistributionChart brackets={baseBrackets} />,
+		);
+		const wrapper = container.querySelector("[aria-hidden='true']");
+		expect(wrapper).toHaveAttribute("role", "presentation");
+	});
+
+	it("renders even with an empty dataset (defensive)", () => {
+		const { container } = render(<ScoreDistributionChart brackets={[]} />);
+		expect(container.querySelector("[aria-hidden='true']")).toBeInTheDocument();
+	});
+});
+
+describe("ChartTooltip", () => {
+	it("returns null when inactive", () => {
+		const { container } = render(
+			<ChartTooltip active={false} payload={[{ payload: baseBrackets[0] }]} />,
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("returns null when payload is missing", () => {
+		const { container } = render(<ChartTooltip active={true} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("returns null when payload is empty", () => {
+		const { container } = render(<ChartTooltip active={true} payload={[]} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("returns null when the payload entry has no datum", () => {
+		const { container } = render(<ChartTooltip active={true} payload={[{}]} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders the plural noun and the verbatim tooltip format for multi-entry buckets", () => {
+		render(
+			<ChartTooltip
+				active={true}
+				payload={[
+					{
+						payload: {
+							id: "80-89",
+							label: "80-89",
+							count: 230,
+							percentage: 28.8,
+						},
+					},
+				]}
+			/>,
+		);
+		expect(screen.getByText(/230\s+entreprises/)).toBeInTheDocument();
+		expect(screen.getByText(/tranche 80-89/)).toBeInTheDocument();
+		expect(screen.getByText(/28,8/)).toBeInTheDocument();
+	});
+
+	it("uses the singular noun when the bucket contains exactly one company", () => {
+		render(
+			<ChartTooltip
+				active={true}
+				payload={[
+					{ payload: { id: "100", label: "100", count: 1, percentage: 0.5 } },
+				]}
+			/>,
+		);
+		expect(screen.getByText(/1\s+entreprise(?!s)/)).toBeInTheDocument();
+	});
+
+	it("renders '0 entreprise' (French convention: 0 takes the singular)", () => {
+		render(
+			<ChartTooltip
+				active={true}
+				payload={[
+					{ payload: { id: "nc", label: "NC", count: 0, percentage: 0 } },
+				]}
+			/>,
+		);
+		expect(screen.getByText(/0\s+entreprise(?!s)/)).toBeInTheDocument();
+	});
+});
+
+describe("formatYAxisTick", () => {
+	it("formats integers using the French locale (narrow-no-break-space thousands)", () => {
+		expect(formatYAxisTick(1234)).toMatch(/1.234/);
+	});
+
+	it("formats zero as '0'", () => {
+		expect(formatYAxisTick(0)).toBe("0");
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionStates.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionStates.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+	ScoreDistributionLoading,
+	ScoreDistributionTileError,
+} from "../ScoreDistributionStates";
+
+describe("ScoreDistributionLoading", () => {
+	it("renders a polite live region with a loading message", () => {
+		render(<ScoreDistributionLoading />);
+		const message = screen.getByText(/chargement de la distribution/i);
+		expect(message).toHaveAttribute("aria-live", "polite");
+	});
+});
+
+describe("ScoreDistributionTileError", () => {
+	it("renders a DSFR error alert with a polite live region", () => {
+		const { container } = render(<ScoreDistributionTileError />);
+		expect(
+			screen.getByText(/erreur est survenue lors du chargement/i),
+		).toBeInTheDocument();
+		const alert = container.querySelector(".fr-alert");
+		expect(alert).toHaveClass("fr-alert--error");
+		expect(alert).toHaveAttribute("aria-live", "polite");
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionTable.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionTable.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ScoreDistributionBracket } from "../ScoreDistributionChart";
+import { ScoreDistributionTable } from "../ScoreDistributionTable";
+
+const sample: ScoreDistributionBracket[] = [
+	{ id: "lt50", label: "<50", count: 12, percentage: 1.5 },
+	{ id: "80-89", label: "80-89", count: 1234, percentage: 56.3 },
+	{ id: "100", label: "100", count: 80, percentage: 7.7 },
+	{ id: "nc", label: "NC", count: 0, percentage: 0 },
+];
+
+describe("ScoreDistributionTable", () => {
+	it("renders one row per bracket with the three labelled columns", () => {
+		render(<ScoreDistributionTable brackets={sample} captionId="caption-1" />);
+
+		const table = screen.getByRole("table");
+		expect(within(table).getAllByRole("row")).toHaveLength(sample.length + 1);
+		expect(within(table).getByText("Tranche de score")).toBeInTheDocument();
+		expect(within(table).getByText("Nombre d'entreprises")).toBeInTheDocument();
+		expect(within(table).getByText("Part du total")).toBeInTheDocument();
+	});
+
+	it("formats counts using French locale (narrow no-break space for thousands)", () => {
+		render(<ScoreDistributionTable brackets={sample} captionId="c2" />);
+		const cells = screen.getAllByRole("cell");
+		const countCell = cells.find((cell) =>
+			/1.234/.test(cell.textContent ?? ""),
+		);
+		expect(countCell).toBeDefined();
+	});
+
+	it("formats percentages with one decimal and a percent sign", () => {
+		render(<ScoreDistributionTable brackets={sample} captionId="c3" />);
+		expect(screen.getByText(/56,3/)).toBeInTheDocument();
+		expect(screen.getByText(/7,7/)).toBeInTheDocument();
+	});
+
+	it("renders 0 / 0,0 % for empty brackets without breaking", () => {
+		render(<ScoreDistributionTable brackets={sample} captionId="c4" />);
+		const rows = screen.getAllByRole("row");
+		const ncRow = rows.find((row) => /NC/.test(row.textContent ?? ""));
+		expect(ncRow?.textContent).toMatch(/0,0/);
+	});
+
+	it("labels the table via aria-labelledby pointing at the caption id", () => {
+		render(<ScoreDistributionTable brackets={sample} captionId="my-cap" />);
+		const table = screen.getByRole("table");
+		expect(table).toHaveAttribute("aria-labelledby", "my-cap");
+	});
+
+	it("uses scope='row' on the leftmost cell for screen-reader navigation", () => {
+		render(<ScoreDistributionTable brackets={sample} captionId="c5" />);
+		const rowHeaders = screen.getAllByRole("rowheader");
+		expect(rowHeaders).toHaveLength(sample.length);
+	});
+
+	it("renders an empty table body when given an empty bracket list", () => {
+		render(<ScoreDistributionTable brackets={[]} captionId="c6" />);
+		expect(screen.queryAllByRole("rowheader")).toHaveLength(0);
+	});
+});

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionTile.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionTile.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useQueryMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		publicStats: {
+			getScoreDistribution: {
+				useQuery: (...args: unknown[]) => useQueryMock(...args),
+			},
+		},
+	},
+}));
+
+vi.mock("../ScoreDistributionChart", () => ({
+	ScoreDistributionChart: () =>
+		React.createElement("div", { "data-testid": "chart" }),
+}));
+
+vi.mock("../ScoreDistributionTable", () => ({
+	ScoreDistributionTable: ({ captionId }: { captionId: string }) =>
+		React.createElement("div", {
+			"data-captionid": captionId,
+			"data-testid": "table",
+		}),
+}));
+
+import { ScoreDistributionTile } from "../ScoreDistributionTile";
+
+const sampleData = {
+	brackets: [
+		{ id: "lt50" as const, label: "<50", count: 1, percentage: 5 },
+		{ id: "50-59" as const, label: "50-59", count: 2, percentage: 10 },
+		{ id: "60-69" as const, label: "60-69", count: 0, percentage: 0 },
+		{ id: "70-79" as const, label: "70-79", count: 0, percentage: 0 },
+		{ id: "80-89" as const, label: "80-89", count: 0, percentage: 0 },
+		{ id: "90-99" as const, label: "90-99", count: 0, percentage: 0 },
+		{ id: "100" as const, label: "100", count: 0, percentage: 0 },
+		{ id: "nc" as const, label: "NC", count: 17, percentage: 85 },
+	],
+	total: 20,
+	year: 2026,
+};
+
+describe("ScoreDistributionTile", () => {
+	beforeEach(() => {
+		useQueryMock.mockReset();
+	});
+
+	it("shows the loading message while the query has no cached data", () => {
+		useQueryMock.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			isError: false,
+		});
+		render(<ScoreDistributionTile />);
+		expect(
+			screen.getByText(/chargement de la distribution/i),
+		).toBeInTheDocument();
+	});
+
+	it("shows the error alert when the query errors out", () => {
+		useQueryMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		const { container } = render(<ScoreDistributionTile />);
+		expect(container.querySelector(".fr-alert--error")).toBeInTheDocument();
+	});
+
+	it("returns null when the query has neither data, loading nor error state", () => {
+		useQueryMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: false,
+		});
+		const { container } = render(<ScoreDistributionTile />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders the heading with the current year from the query payload", () => {
+		useQueryMock.mockReturnValue({
+			data: sampleData,
+			isLoading: false,
+			isError: false,
+		});
+		render(<ScoreDistributionTile />);
+		expect(
+			screen.getByRole("heading", {
+				level: 2,
+				name: /distribution des scores 2026/i,
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("renders both the chart and the accessible table when data is present", () => {
+		useQueryMock.mockReturnValue({
+			data: sampleData,
+			isLoading: false,
+			isError: false,
+		});
+		render(<ScoreDistributionTile />);
+		expect(screen.getByTestId("chart")).toBeInTheDocument();
+		expect(screen.getByTestId("table")).toBeInTheDocument();
+	});
+
+	it("renders a descriptive paragraph mentioning the NC bracket", () => {
+		useQueryMock.mockReturnValue({
+			data: sampleData,
+			isLoading: false,
+			isError: false,
+		});
+		render(<ScoreDistributionTile />);
+		expect(screen.getByText(/NC/)).toBeInTheDocument();
+		expect(
+			screen.getByText(/Répartition des entreprises ayant déclaré/i),
+		).toBeInTheDocument();
+	});
+
+	it("uses placeholderData (prev) to preserve the previous result during refetch", () => {
+		useQueryMock.mockReturnValue({
+			data: sampleData,
+			isLoading: false,
+			isError: false,
+		});
+		render(<ScoreDistributionTile />);
+		const options = useQueryMock.mock.calls[0]?.[1] as
+			| { placeholderData: (prev: unknown) => unknown }
+			| undefined;
+		expect(options?.placeholderData("prev-value")).toBe("prev-value");
+	});
+
+	it("links the section to its heading via aria-labelledby", () => {
+		useQueryMock.mockReturnValue({
+			data: sampleData,
+			isLoading: false,
+			isError: false,
+		});
+		const { container } = render(<ScoreDistributionTile />);
+		const section = container.querySelector("section");
+		const heading = container.querySelector("h2");
+		expect(section?.getAttribute("aria-labelledby")).toBe(heading?.id);
+	});
+
+	it("propagates the caption id to the alternative table component", () => {
+		useQueryMock.mockReturnValue({
+			data: sampleData,
+			isLoading: false,
+			isError: false,
+		});
+		render(<ScoreDistributionTile />);
+		const table = screen.getByTestId("table");
+		expect(table.getAttribute("data-captionid")).toMatch(/.+/);
+	});
+});

--- a/packages/app/src/modules/publicStats/index.ts
+++ b/packages/app/src/modules/publicStats/index.ts
@@ -1,0 +1,5 @@
+export { CurrentCampaignRateTile } from "./CurrentCampaignRateTile";
+export type { PublicKpiTileDelta } from "./PublicKpiTile";
+export { PublicKpiTile } from "./PublicKpiTile";
+export { PublicStatsPage } from "./PublicStatsPage";
+export type { CurrentCampaignRate } from "./types";

--- a/packages/app/src/modules/publicStats/index.ts
+++ b/packages/app/src/modules/publicStats/index.ts
@@ -2,4 +2,8 @@ export { CurrentCampaignRateTile } from "./CurrentCampaignRateTile";
 export type { PublicKpiTileDelta } from "./PublicKpiTile";
 export { PublicKpiTile } from "./PublicKpiTile";
 export { PublicStatsPage } from "./PublicStatsPage";
+export type { ScoreDistributionBracket } from "./ScoreDistributionChart";
+export { ScoreDistributionChart } from "./ScoreDistributionChart";
+export { ScoreDistributionTable } from "./ScoreDistributionTable";
+export { ScoreDistributionTile } from "./ScoreDistributionTile";
 export type { CurrentCampaignRate } from "./types";

--- a/packages/app/src/modules/publicStats/types.ts
+++ b/packages/app/src/modules/publicStats/types.ts
@@ -1,0 +1,7 @@
+export type CurrentCampaignRate = {
+	totalObligated: number;
+	totalSubmitted: number;
+	submissionRate: number;
+	previousYearRate: number | null;
+	year: number;
+};

--- a/packages/app/src/modules/shared/CampaignRateTileStates.tsx
+++ b/packages/app/src/modules/shared/CampaignRateTileStates.tsx
@@ -1,0 +1,15 @@
+export function CampaignRateTileLoading() {
+	return (
+		<p aria-live="polite" className="fr-text--sm">
+			Chargement du taux de déclaration…
+		</p>
+	);
+}
+
+export function CampaignRateTileError() {
+	return (
+		<div aria-live="polite" className="fr-alert fr-alert--error">
+			<p>Une erreur est survenue lors du chargement du taux de déclaration.</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/shared/KpiBadge.tsx
+++ b/packages/app/src/modules/shared/KpiBadge.tsx
@@ -1,0 +1,60 @@
+import { formatPointsAbs, NARROW_NBSP } from "~/modules/domain";
+
+export type KpiBadgeDelta = {
+	points: number;
+	comparisonLabel: string;
+};
+
+type BadgeRendering = {
+	className: string;
+	arrow: string;
+	signedValue: string;
+};
+
+export function getKpiBadgeRendering(
+	delta: KpiBadgeDelta,
+	inverted = false,
+): BadgeRendering {
+	if (delta.points > 0) {
+		return {
+			className: inverted
+				? "fr-badge fr-badge--error fr-badge--no-icon"
+				: "fr-badge fr-badge--success fr-badge--no-icon",
+			arrow: "↑",
+			signedValue: `+${formatPointsAbs(delta.points)}`,
+		};
+	}
+	if (delta.points < 0) {
+		return {
+			className: inverted
+				? "fr-badge fr-badge--success fr-badge--no-icon"
+				: "fr-badge fr-badge--error fr-badge--no-icon",
+			arrow: "↓",
+			signedValue: `-${formatPointsAbs(delta.points)}`,
+		};
+	}
+	return {
+		className: "fr-badge fr-badge--no-icon",
+		arrow: "=",
+		signedValue: `0${NARROW_NBSP}`,
+	};
+}
+
+type Props = {
+	delta: KpiBadgeDelta | null;
+	inverted?: boolean;
+};
+
+export function KpiBadge({ delta, inverted = false }: Props) {
+	if (!delta) return null;
+	const { className, arrow, signedValue } = getKpiBadgeRendering(
+		delta,
+		inverted,
+	);
+	return (
+		<p className={className}>
+			<span aria-hidden="true">{arrow}</span> {signedValue}
+			{NARROW_NBSP}pts {delta.comparisonLabel}
+		</p>
+	);
+}

--- a/packages/app/src/modules/shared/__tests__/KpiBadge.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/KpiBadge.test.tsx
@@ -1,0 +1,121 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { getKpiBadgeRendering, KpiBadge } from "../KpiBadge";
+
+describe("KpiBadge", () => {
+	it("renders nothing when delta is null", () => {
+		const { container } = render(<KpiBadge delta={null} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("renders a success badge with upward arrow for positive delta", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 2.1, comparisonLabel: "vs 2025" }} />,
+		);
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--success");
+		expect(badge?.textContent).toContain("↑");
+		expect(badge?.textContent).toContain("+2,1");
+		expect(badge?.textContent).toContain("pts");
+		expect(badge?.textContent).toContain("vs 2025");
+	});
+
+	it("renders an error badge with downward arrow for negative delta", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: -1.5, comparisonLabel: "vs 2025" }} />,
+		);
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("↓");
+		expect(badge?.textContent).toContain("-1,5");
+	});
+
+	it("renders a neutral badge with equals sign for zero delta", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 0, comparisonLabel: "vs 2025" }} />,
+		);
+		const badge = container.querySelector(".fr-badge");
+		expect(badge).toHaveClass("fr-badge");
+		expect(badge).not.toHaveClass("fr-badge--success");
+		expect(badge).not.toHaveClass("fr-badge--error");
+		expect(badge?.textContent).toContain("=");
+	});
+
+	it("inverts colors: positive delta becomes error when inverted", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 1.2, comparisonLabel: "vs 2025" }} inverted />,
+		);
+		expect(container.querySelector(".fr-badge")).toHaveClass("fr-badge--error");
+	});
+
+	it("inverts colors: negative delta becomes success when inverted", () => {
+		const { container } = render(
+			<KpiBadge
+				delta={{ points: -1.5, comparisonLabel: "vs 2025" }}
+				inverted
+			/>,
+		);
+		expect(container.querySelector(".fr-badge")).toHaveClass(
+			"fr-badge--success",
+		);
+	});
+
+	it("renders the arrow with aria-hidden", () => {
+		const { container } = render(
+			<KpiBadge delta={{ points: 2.1, comparisonLabel: "vs 2025" }} />,
+		);
+		const arrow = container.querySelector(".fr-badge [aria-hidden='true']");
+		expect(arrow).not.toBeNull();
+		expect(arrow?.textContent).toBe("↑");
+	});
+});
+
+describe("getKpiBadgeRendering", () => {
+	it("rounds the displayed points to one decimal place", () => {
+		const out = getKpiBadgeRendering({ points: 2.07, comparisonLabel: "" });
+		expect(out.signedValue).toBe("+2,1");
+	});
+
+	it("uses the error class for negative delta (default)", () => {
+		const out = getKpiBadgeRendering({
+			points: -2,
+			comparisonLabel: "vs 2025",
+		});
+		expect(out.className).toContain("fr-badge--error");
+		expect(out.arrow).toBe("↓");
+		expect(out.signedValue).toBe("-2,0");
+	});
+
+	it("uses the success class for positive delta (default)", () => {
+		const out = getKpiBadgeRendering({
+			points: 0.5,
+			comparisonLabel: "vs 2025",
+		});
+		expect(out.className).toContain("fr-badge--success");
+	});
+
+	it("uses the success class for negative delta when inverted", () => {
+		const out = getKpiBadgeRendering(
+			{ points: -2, comparisonLabel: "vs 2025" },
+			true,
+		);
+		expect(out.className).toContain("fr-badge--success");
+	});
+
+	it("uses the error class for positive delta when inverted", () => {
+		const out = getKpiBadgeRendering(
+			{ points: 0.5, comparisonLabel: "vs 2025" },
+			true,
+		);
+		expect(out.className).toContain("fr-badge--error");
+	});
+
+	it("produces a neutral badge with `0` for a zero delta", () => {
+		const out = getKpiBadgeRendering({ points: 0, comparisonLabel: "" });
+		expect(out.arrow).toBe("=");
+		expect(out.signedValue.trim()).toBe("0");
+		expect(out.className).not.toContain("--success");
+		expect(out.className).not.toContain("--error");
+	});
+});

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -1,6 +1,12 @@
+export {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "./CampaignRateTileStates";
 export { CompanySizeFilter } from "./CompanySizeFilter";
 export { FileUpload } from "./FileUpload";
 export { getDsfrModal } from "./getDsfrModal";
+export type { KpiBadgeDelta } from "./KpiBadge";
+export { getKpiBadgeRendering, KpiBadge } from "./KpiBadge";
 export { parseSiren } from "./parseSiren";
 export { SubmitModal } from "./SubmitModal";
 export {

--- a/packages/app/src/server/api/root.ts
+++ b/packages/app/src/server/api/root.ts
@@ -12,6 +12,7 @@ import { jointEvaluationRouter } from "~/server/api/routers/jointEvaluation";
 import { mailRouter } from "~/server/api/routers/mail";
 import { profileRouter } from "~/server/api/routers/profile";
 import { publicReferentsRouter } from "~/server/api/routers/publicReferents";
+import { publicStatsRouter } from "~/server/api/routers/publicStats";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -34,6 +35,7 @@ export const appRouter = createTRPCRouter({
 	mail: mailRouter,
 	profile: profileRouter,
 	publicReferents: publicReferentsRouter,
+	publicStats: publicStatsRouter,
 });
 
 // export type definition of API

--- a/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const getCurrentYearMock = vi.fn(() => 2026);
+
+vi.mock("~/modules/domain", async () => {
+	const actual =
+		await vi.importActual<typeof import("~/modules/domain")>(
+			"~/modules/domain",
+		);
+	return {
+		...actual,
+		getCurrentYear: () => getCurrentYearMock(),
+	};
+});
+
+function buildStatsDb(results: Array<Array<{ value: number }>>) {
+	const queue = [...results];
+	const select = vi.fn(() => {
+		const where = vi.fn(() => {
+			const next = queue.shift();
+			return Promise.resolve(next ?? []);
+		});
+		const innerJoin = vi.fn(() => ({ where }));
+		const from = vi.fn(() => ({ where, innerJoin }));
+		return { from };
+	});
+	return { select };
+}
+
+const publicCtx = {
+	session: null,
+	headers: new Headers(),
+};
+
+async function callRate(
+	results: number[],
+	{ year = 2026 }: { year?: number } = {},
+) {
+	getCurrentYearMock.mockReturnValue(year);
+	const db = buildStatsDb(results.map((value) => [{ value }]));
+	const { publicStatsRouter } = await import("../publicStats");
+	const caller = publicStatsRouter.createCaller({
+		...publicCtx,
+		db,
+	} as never);
+	const result = await caller.getCurrentCampaignRate();
+	return { db, result };
+}
+
+describe("publicStatsRouter.getCurrentCampaignRate", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		getCurrentYearMock.mockReturnValue(2026);
+	});
+
+	it("returns rate, year-1 rate, and raw counts when all four queries have data", async () => {
+		const { result } = await callRate([5738, 4213, 5500, 3920]);
+
+		expect(result.totalObligated).toBe(5738);
+		expect(result.totalSubmitted).toBe(4213);
+		expect(result.submissionRate).toBeCloseTo(73.4, 1);
+		expect(result.previousYearRate).toBeCloseTo(71.3, 1);
+		expect(result.year).toBe(2026);
+	});
+
+	it("rounds rates to one decimal place", async () => {
+		const { result } = await callRate([3, 1, 3, 2]);
+		expect(result.submissionRate).toBe(33.3);
+		expect(result.previousYearRate).toBe(66.7);
+	});
+
+	it("returns null previousYearRate when no obligated companies existed for year-1", async () => {
+		const { result } = await callRate([1000, 800, 0, 0]);
+		expect(result.previousYearRate).toBeNull();
+	});
+
+	it("returns submissionRate=0 when totalObligated is 0 (avoids division by zero)", async () => {
+		const { result } = await callRate([0, 0, 100, 50]);
+		expect(result.submissionRate).toBe(0);
+		expect(result.totalObligated).toBe(0);
+		expect(result.totalSubmitted).toBe(0);
+		expect(result.previousYearRate).toBe(50);
+	});
+
+	it("issues four parallel select calls (obligated + submitted, for year and year-1)", async () => {
+		const { db } = await callRate([10, 5, 10, 5]);
+		expect(db.select).toHaveBeenCalledTimes(4);
+	});
+
+	it("returns the current year from the domain helper in the payload", async () => {
+		const { result } = await callRate([10, 5, 10, 5], { year: 2027 });
+		expect(result.year).toBe(2027);
+	});
+
+	it("computes the obligation predicate differently for triennial vs non-triennial years (smoke check via call wiring)", async () => {
+		const { result: triennial } = await callRate([100, 80, 0, 0], {
+			year: 2027,
+		});
+		const { result: nonTriennial } = await callRate([100, 80, 0, 0], {
+			year: 2026,
+		});
+		expect(triennial.totalObligated).toBe(100);
+		expect(nonTriennial.totalObligated).toBe(100);
+	});
+
+	it("defaults to 0 when a count query returns no row at all", async () => {
+		const db = {
+			select: vi.fn(() => {
+				const where = vi.fn(() => Promise.resolve([]));
+				const innerJoin = vi.fn(() => ({ where }));
+				const from = vi.fn(() => ({ where, innerJoin }));
+				return { from };
+			}),
+		};
+		const { publicStatsRouter } = await import("../publicStats");
+		const caller = publicStatsRouter.createCaller({
+			...publicCtx,
+			db,
+		} as never);
+
+		const result = await caller.getCurrentCampaignRate();
+		expect(result.totalObligated).toBe(0);
+		expect(result.totalSubmitted).toBe(0);
+		expect(result.submissionRate).toBe(0);
+		expect(result.previousYearRate).toBeNull();
+	});
+
+	it("is callable without authentication (publicProcedure)", async () => {
+		const db = buildStatsDb([
+			[{ value: 10 }],
+			[{ value: 5 }],
+			[{ value: 10 }],
+			[{ value: 5 }],
+		]);
+		const { publicStatsRouter } = await import("../publicStats");
+		const caller = publicStatsRouter.createCaller({
+			session: null,
+			headers: new Headers(),
+			db,
+		} as never);
+
+		await expect(caller.getCurrentCampaignRate()).resolves.toBeDefined();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
@@ -35,6 +35,18 @@ function buildStatsDb(results: Array<Array<{ value: number }>>) {
 	return { select };
 }
 
+type DistributionRow = { bucket: string; count: number };
+
+function buildDistributionDb(rows: DistributionRow[]) {
+	const select = vi.fn(() => {
+		const groupBy = vi.fn(() => Promise.resolve(rows));
+		const where = vi.fn(() => ({ groupBy }));
+		const from = vi.fn(() => ({ where }));
+		return { from };
+	});
+	return { select };
+}
+
 const publicCtx = {
 	session: null,
 	headers: new Headers(),
@@ -142,11 +154,137 @@ describe("publicStatsRouter.getCurrentCampaignRate", () => {
 		]);
 		const { publicStatsRouter } = await import("../publicStats");
 		const caller = publicStatsRouter.createCaller({
+			...publicCtx,
+			db,
+		} as never);
+
+		await expect(caller.getCurrentCampaignRate()).resolves.toBeDefined();
+	});
+});
+
+async function callDistribution(
+	rows: DistributionRow[],
+	{ year = 2026 }: { year?: number } = {},
+) {
+	getCurrentYearMock.mockReturnValue(year);
+	const db = buildDistributionDb(rows);
+	const { publicStatsRouter } = await import("../publicStats");
+	const caller = publicStatsRouter.createCaller({
+		...publicCtx,
+		db,
+	} as never);
+	const result = await caller.getScoreDistribution();
+	return { db, result };
+}
+
+describe("publicStatsRouter.getScoreDistribution", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		getCurrentYearMock.mockReturnValue(2026);
+	});
+
+	it("returns the 8 canonical brackets in fixed order with NC last", async () => {
+		const { result } = await callDistribution([
+			{ bucket: "lt50", count: 12 },
+			{ bucket: "50-59", count: 25 },
+			{ bucket: "60-69", count: 48 },
+			{ bucket: "70-79", count: 110 },
+			{ bucket: "80-89", count: 230 },
+			{ bucket: "90-99", count: 320 },
+			{ bucket: "100", count: 80 },
+			{ bucket: "nc", count: 35 },
+		]);
+
+		expect(result.brackets.map((b) => b.id)).toEqual([
+			"lt50",
+			"50-59",
+			"60-69",
+			"70-79",
+			"80-89",
+			"90-99",
+			"100",
+			"nc",
+		]);
+	});
+
+	it("fills missing buckets with zero counts to guarantee 8 entries", async () => {
+		const { result } = await callDistribution([{ bucket: "80-89", count: 5 }]);
+
+		expect(result.brackets).toHaveLength(8);
+		expect(result.brackets.find((b) => b.id === "80-89")?.count).toBe(5);
+		expect(result.brackets.find((b) => b.id === "lt50")?.count).toBe(0);
+		expect(result.brackets.find((b) => b.id === "nc")?.count).toBe(0);
+		expect(result.total).toBe(5);
+	});
+
+	it("returns 8 brackets at count=0 / 0% when no declaration has been submitted", async () => {
+		const { result } = await callDistribution([]);
+
+		expect(result.brackets).toHaveLength(8);
+		expect(result.brackets.every((b) => b.count === 0)).toBe(true);
+		expect(result.brackets.every((b) => b.percentage === 0)).toBe(true);
+		expect(result.total).toBe(0);
+	});
+
+	it("computes percentages rounded to one decimal", async () => {
+		const { result } = await callDistribution([
+			{ bucket: "80-89", count: 1 },
+			{ bucket: "90-99", count: 2 },
+		]);
+
+		const bucket80 = result.brackets.find((b) => b.id === "80-89");
+		const bucket90 = result.brackets.find((b) => b.id === "90-99");
+		expect(bucket80?.percentage).toBeCloseTo(33.3, 1);
+		expect(bucket90?.percentage).toBeCloseTo(66.7, 1);
+	});
+
+	it("attaches the human-readable label to each bracket", async () => {
+		const { result } = await callDistribution([{ bucket: "lt50", count: 1 }]);
+
+		expect(result.brackets.find((b) => b.id === "lt50")?.label).toBe("<50");
+		expect(result.brackets.find((b) => b.id === "100")?.label).toBe("100");
+		expect(result.brackets.find((b) => b.id === "nc")?.label).toBe("NC");
+	});
+
+	it("returns the current year from the domain helper", async () => {
+		const { result } = await callDistribution([], { year: 2027 });
+		expect(result.year).toBe(2027);
+	});
+
+	it("computes a total equal to the sum of all bracket counts", async () => {
+		const { result } = await callDistribution([
+			{ bucket: "60-69", count: 3 },
+			{ bucket: "80-89", count: 7 },
+			{ bucket: "nc", count: 2 },
+		]);
+
+		expect(result.total).toBe(12);
+	});
+
+	it("counts NC declarations (null global score) in the dedicated bracket", async () => {
+		const { result } = await callDistribution([
+			{ bucket: "nc", count: 42 },
+			{ bucket: "100", count: 8 },
+		]);
+
+		expect(result.brackets.find((b) => b.id === "nc")?.count).toBe(42);
+		expect(result.brackets.find((b) => b.id === "100")?.count).toBe(8);
+	});
+
+	it("issues a single grouped select to the declarations table", async () => {
+		const { db } = await callDistribution([{ bucket: "100", count: 1 }]);
+		expect(db.select).toHaveBeenCalledTimes(1);
+	});
+
+	it("is callable without authentication (publicProcedure)", async () => {
+		const db = buildDistributionDb([{ bucket: "100", count: 1 }]);
+		const { publicStatsRouter } = await import("../publicStats");
+		const caller = publicStatsRouter.createCaller({
 			session: null,
 			headers: new Headers(),
 			db,
 		} as never);
 
-		await expect(caller.getCurrentCampaignRate()).resolves.toBeDefined();
+		await expect(caller.getScoreDistribution()).resolves.toBeDefined();
 	});
 });

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -21,6 +21,7 @@ import {
 	COMPANY_SIZE_RANGES,
 	COMPANY_SIZE_VOLUNTARY_MAX,
 	type CompanySizeRange,
+	computeRate,
 	DECLARATION_STEPS,
 	FUNNEL_COMPLIANCE_KEY_STEPS,
 	FUNNEL_CSE_KEY_STEPS,
@@ -97,15 +98,6 @@ function obligationWorkforceFilter(
 			? sql`${ema} >= ${min}`
 			: sql`${ema} BETWEEN ${min} AND ${max}`;
 	return sql`(${bucket}) AND ${baseObligation}`;
-}
-
-function roundOneDecimal(value: number): number {
-	return Math.round(value * 10) / 10;
-}
-
-function computeRate(submitted: number, obligated: number): number {
-	if (obligated === 0) return 0;
-	return roundOneDecimal((submitted / obligated) * 100);
 }
 
 type AggregatedMilestone = {

--- a/packages/app/src/server/api/routers/publicStats.ts
+++ b/packages/app/src/server/api/routers/publicStats.ts
@@ -3,6 +3,7 @@ import { and, eq, type SQL, sql } from "drizzle-orm";
 import {
 	COMPANY_SIZE_ANNUAL_MIN,
 	COMPANY_SIZE_VOLUNTARY_MAX,
+	computeRate,
 	getCurrentYear,
 	isTriennialYear,
 } from "~/modules/domain";
@@ -24,15 +25,6 @@ function buildObligationFilter(year: number): SQL {
 		: sql`false`;
 	const annualClause = sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
 	return sql`((${triennialClause}) OR (${annualClause}))`;
-}
-
-function roundOneDecimal(value: number): number {
-	return Math.round(value * 10) / 10;
-}
-
-function computeRate(submitted: number, obligated: number): number {
-	if (obligated === 0) return 0;
-	return roundOneDecimal((submitted / obligated) * 100);
 }
 
 export const publicStatsRouter = createTRPCRouter({

--- a/packages/app/src/server/api/routers/publicStats.ts
+++ b/packages/app/src/server/api/routers/publicStats.ts
@@ -1,0 +1,106 @@
+import { and, eq, type SQL, sql } from "drizzle-orm";
+
+import {
+	COMPANY_SIZE_ANNUAL_MIN,
+	COMPANY_SIZE_VOLUNTARY_MAX,
+	getCurrentYear,
+	isTriennialYear,
+} from "~/modules/domain";
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { declarations, gipMdsData } from "~/server/db/schema";
+
+type CurrentCampaignRate = {
+	totalObligated: number;
+	totalSubmitted: number;
+	submissionRate: number;
+	previousYearRate: number | null;
+	year: number;
+};
+
+function buildObligationFilter(year: number): SQL {
+	const ema = sql<number>`floor(${gipMdsData.workforceEma})`;
+	const triennialClause = isTriennialYear(year)
+		? sql`${ema} >= ${COMPANY_SIZE_VOLUNTARY_MAX} AND ${ema} < ${COMPANY_SIZE_ANNUAL_MIN}`
+		: sql`false`;
+	const annualClause = sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
+	return sql`((${triennialClause}) OR (${annualClause}))`;
+}
+
+function roundOneDecimal(value: number): number {
+	return Math.round(value * 10) / 10;
+}
+
+function computeRate(submitted: number, obligated: number): number {
+	if (obligated === 0) return 0;
+	return roundOneDecimal((submitted / obligated) * 100);
+}
+
+export const publicStatsRouter = createTRPCRouter({
+	getCurrentCampaignRate: publicProcedure.query(
+		async ({ ctx }): Promise<CurrentCampaignRate> => {
+			const year = getCurrentYear();
+			const previousYear = year - 1;
+
+			const obligatedQuery = (targetYear: number) =>
+				ctx.db
+					.select({ value: sql<number>`count(*)::int` })
+					.from(gipMdsData)
+					.where(
+						and(
+							eq(gipMdsData.year, targetYear),
+							buildObligationFilter(targetYear),
+						),
+					);
+
+			const submittedQuery = (targetYear: number) =>
+				ctx.db
+					.select({ value: sql<number>`count(*)::int` })
+					.from(declarations)
+					.innerJoin(
+						gipMdsData,
+						and(
+							eq(declarations.siren, gipMdsData.siren),
+							eq(declarations.year, gipMdsData.year),
+						) as SQL,
+					)
+					.where(
+						and(
+							eq(declarations.year, targetYear),
+							eq(declarations.status, "demarche_completed"),
+							buildObligationFilter(targetYear),
+						),
+					);
+
+			const [
+				obligatedRows,
+				submittedRows,
+				previousObligatedRows,
+				previousSubmittedRows,
+			] = await Promise.all([
+				obligatedQuery(year),
+				submittedQuery(year),
+				obligatedQuery(previousYear),
+				submittedQuery(previousYear),
+			]);
+
+			const totalObligated = obligatedRows[0]?.value ?? 0;
+			const totalSubmitted = submittedRows[0]?.value ?? 0;
+			const previousObligated = previousObligatedRows[0]?.value ?? 0;
+			const previousSubmitted = previousSubmittedRows[0]?.value ?? 0;
+
+			const submissionRate = computeRate(totalSubmitted, totalObligated);
+			const previousYearRate =
+				previousObligated === 0
+					? null
+					: computeRate(previousSubmitted, previousObligated);
+
+			return {
+				totalObligated,
+				totalSubmitted,
+				submissionRate,
+				previousYearRate,
+				year,
+			};
+		},
+	),
+});

--- a/packages/app/src/server/api/routers/publicStats.ts
+++ b/packages/app/src/server/api/routers/publicStats.ts
@@ -6,6 +6,9 @@ import {
 	computeRate,
 	getCurrentYear,
 	isTriennialYear,
+	roundOneDecimal,
+	SCORE_BRACKETS,
+	type ScoreBracketId,
 } from "~/modules/domain";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { declarations, gipMdsData } from "~/server/db/schema";
@@ -15,6 +18,19 @@ type CurrentCampaignRate = {
 	totalSubmitted: number;
 	submissionRate: number;
 	previousYearRate: number | null;
+	year: number;
+};
+
+type ScoreDistributionBracket = {
+	id: ScoreBracketId;
+	label: string;
+	count: number;
+	percentage: number;
+};
+
+type ScoreDistribution = {
+	brackets: ScoreDistributionBracket[];
+	total: number;
 	year: number;
 };
 
@@ -93,6 +109,64 @@ export const publicStatsRouter = createTRPCRouter({
 				previousYearRate,
 				year,
 			};
+		},
+	),
+
+	getScoreDistribution: publicProcedure.query(
+		async ({ ctx }): Promise<ScoreDistribution> => {
+			const year = getCurrentYear();
+
+			const globalScore = sql<
+				number | null
+			>`(${declarations.remunerationScore} + ${declarations.quartileScore} + ${declarations.categoryScore})`;
+
+			const bucketExpr = sql<ScoreBracketId>`CASE
+					WHEN ${globalScore} IS NULL THEN 'nc'
+					WHEN ${globalScore} < 50 THEN 'lt50'
+					WHEN ${globalScore} < 60 THEN '50-59'
+					WHEN ${globalScore} < 70 THEN '60-69'
+					WHEN ${globalScore} < 80 THEN '70-79'
+					WHEN ${globalScore} < 90 THEN '80-89'
+					WHEN ${globalScore} < 100 THEN '90-99'
+					ELSE '100'
+				END`;
+
+			const rows = await ctx.db
+				.select({
+					bucket: bucketExpr,
+					count: sql<number>`count(*)::int`,
+				})
+				.from(declarations)
+				.where(
+					and(
+						eq(declarations.year, year),
+						eq(declarations.status, "demarche_completed"),
+					),
+				)
+				.groupBy(bucketExpr);
+
+			const counts = new Map<ScoreBracketId, number>();
+			for (const row of rows) {
+				counts.set(row.bucket, row.count);
+			}
+
+			const total = Array.from(counts.values()).reduce((sum, c) => sum + c, 0);
+
+			const brackets: ScoreDistributionBracket[] = SCORE_BRACKETS.map(
+				(bracket) => {
+					const count = counts.get(bracket.id) ?? 0;
+					const percentage =
+						total === 0 ? 0 : roundOneDecimal((count / total) * 100);
+					return {
+						id: bracket.id,
+						label: bracket.label,
+						count,
+						percentage,
+					};
+				},
+			);
+
+			return { brackets, total, year };
 		},
 	),
 });

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -55,6 +55,10 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"publicReferents.search": AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH,
 	"publicReferents.getById": AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW,
 
+	// ── public stats reads ─────────────────────────────────
+	"publicStats.getCurrentCampaignRate":
+		AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE,
+
 	// ── admin settings mutations ──────────────────────────
 	"adminSettings.upsertCampaignDeadlines":
 		AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES,


### PR DESCRIPTION
Closes #3211

> [!WARNING]
> Cette PR est stackée sur **#3550** (#3210 — K1 public). Elle doit être mergée **après** #3550. Une fois #3550 squash-mergé dans `epic/3209`, rebaser cette branche sur `epic/3209` et retargeter la PR sur `epic/3209`.

## Résumé

Ajoute la procédure publique `publicStats.getScoreDistribution` et son
graphique en barres `<ScoreDistributionChart>` (Recharts), intégré sous la
tuile K1 de la page publique `/stats`.

Le **score global d'index** n'étant pas persisté en base, il est calculé à
la volée en SQL — somme des sous-scores `remunerationScore + quartileScore
+ categoryScore`, NULL si l'un des trois manque — puis bucketé via
`CASE WHEN` dans 8 tranches canoniques : `<50`, `50-59`, `60-69`, `70-79`,
`80-89`, `90-99`, `100`, `NC`. La réponse expose toujours les 8 entrées
dans l'ordre canonique (count=0 si tranche vide) pour que le composant
chart ait un dataset stable.

## Découpage

- **Domaine pur** (`~/modules/domain`) :
  - `SCORE_BRACKETS` + `getScoreBracket(score: number | null)` — constantes
    et fonction de classement
  - `computeGlobalScore({ remunerationScore, quartileScore, categoryScore })`
    — somme des sous-scores ou `null` si non-calculable
- **tRPC** : `publicStats.getScoreDistribution` (procédure publique, pas
  d'audit log — agrégats anonymes, pas de PII)
- **UI** (`~/modules/publicStats`) :
  - `<ScoreDistributionChart>` : BarChart Recharts coloré dégradé rouge →
    vert via tokens DSFR (`--background-action-high-*`), gris pour NC.
    `aria-hidden="true"` car les données sont aussi exposées dans une
    table DSFR visible juste en-dessous (alternative RGAA 1.6).
  - `<ScoreDistributionTable>` : table DSFR `fr-table--bordered` avec 3
    colonnes (Tranche / Nombre / Part du total)
  - `<ScoreDistributionTile>` : container avec query tRPC + état
    loading/error/empty + heading `<h2>` propre
  - Tooltip custom au format `{count} entreprises — tranche {label}
    ({pct} % du total)` avec espaces fines insécables

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (2 189 tests passent, 100 % de couverture sur les
  fichiers touchés)
- [x] `pnpm lint:check` + `pnpm format:check` verts
- [x] Test E2E Playwright étendu : seed de déclarations avec scores variés
  (incluant un NC), vérification de la présence d'au moins une `<rect>`
  SVG et des rowheaders NC + 100 dans la table alternative
- [x] Validation visuelle dev server : chart visible avec dégradé rouge →
  vert, table en-dessous, responsive mobile OK

## Notes

- Pas d'audit log : `getScoreDistribution` est une procédure publique non
  sensible qui ne renvoie que des compteurs agrégés (pas de SIREN, pas de
  nom d'entreprise). Conforme à `.claude/rules/audit-logging.md`.
- Le score global est dupliqué (formule JS dans `computeGlobalScore` +
  expression SQL dans le router) : option (C) recommandée par l'architect
  pour rester performant sur des volumes potentiellement à 100k+ lignes
  sans charger tout en mémoire.

## Captures d'écran

Captures attachées en commentaire ci-dessous (desktop 1280x800 + mobile
375x667).