### PR TITLE
fix(layout): align ResourceBanner illustration flush right (#3526)

### DIFF
--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -76,7 +76,9 @@ beforeEach(() => {
 
 describe("Step1Opinions", () => {
 	it("disables browser autofill on the form", () => {
-		const { container } = render(<Step1Opinions cseDeadline={cseDeadline} />);
+		const { container } = render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		expect(container.querySelector("form")).toHaveAttribute(
 			"autocomplete",

--- a/packages/app/src/modules/layout/ResourceBanner.tsx
+++ b/packages/app/src/modules/layout/ResourceBanner.tsx
@@ -45,7 +45,7 @@ export function ResourceBanner() {
 		>
 			<div className="fr-container">
 				<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-					<div className="fr-col-12 fr-col-md-9">
+					<div className="fr-col-12 fr-col-md-10">
 						<div className="fr-grid-row fr-grid-row--gutters">
 							<div className="fr-col-12 fr-col-md-4">
 								<ResourceTile
@@ -75,15 +75,17 @@ export function ResourceBanner() {
 					</div>
 					<div
 						aria-hidden="true"
-						className="fr-col-12 fr-col-md-3 fr-hidden fr-unhidden-md"
+						className="fr-col-12 fr-col-md-2 fr-hidden fr-unhidden-md"
 					>
-						<Image
-							alt=""
-							height={147}
-							src="/assets/images/home/help-illustration.svg"
-							unoptimized
-							width={210}
-						/>
+						<div className="fr-grid-row fr-grid-row--right">
+							<Image
+								alt=""
+								height={147}
+								src="/assets/images/home/help-illustration.svg"
+								unoptimized
+								width={210}
+							/>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
@@ -43,4 +43,27 @@ describe("ResourceBanner", () => {
 		const headings = screen.getAllByRole("heading", { level: 3 });
 		expect(headings).toHaveLength(3);
 	});
+
+	it("uses a 10/2 column ratio so the illustration sits flush right", () => {
+		const { container } = render(<ResourceBanner />);
+
+		const tilesCol = container.querySelector(".fr-col-md-10");
+		expect(tilesCol).not.toBeNull();
+
+		const illustrationCol = container.querySelector(".fr-col-md-2");
+		expect(illustrationCol).not.toBeNull();
+		expect(illustrationCol).toHaveClass("fr-hidden");
+		expect(illustrationCol).toHaveClass("fr-unhidden-md");
+		expect(illustrationCol).toHaveAttribute("aria-hidden", "true");
+
+		const rightAligner = illustrationCol?.querySelector(
+			".fr-grid-row.fr-grid-row--right",
+		);
+		expect(rightAligner).not.toBeNull();
+
+		const image = rightAligner?.querySelector(
+			'[data-src="/assets/images/home/help-illustration.svg"]',
+		);
+		expect(image).not.toBeNull();
+	});
 });


### PR DESCRIPTION
Closes #3526

## Contexte

Sur le bandeau bleu d'aide (`ResourceBanner`) visible sur `/`, `/aide`, `/faq` et `/aide/nous-contacter`, l'illustration restait collée à gauche dans sa colonne, ce qui laissait un espace vide entre l'image et le bord droit de la section.

## Fix

Approche DSFR pur (pas de SCSS supplémentaire) :

- Ratio des colonnes : `fr-col-md-9` / `fr-col-md-3` → `fr-col-md-10` / `fr-col-md-2`
- Wrapper l'`<Image>` dans une `<div className=\"fr-grid-row fr-grid-row--right\">` pour la coller au bord droit de sa colonne (et donc au bord droit du container)

L'illustration reste `fr-hidden fr-unhidden-md` : le rendu mobile (`<md`) n'est pas modifié.

## Vérification visuelle

### Avant (issue body)

L'écran de référence est joint au body de l'issue [#3526](https://github.com/SocialGouv/egapro/issues/3526) : la zone bleue affiche un large espace vide entre l'illustration et le bord droit de la section.

### Après — desktop (1280×800)

![desktop after](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-3526/resource-banner-3526-desktop-zoom.png)

L'illustration est désormais flush right (bord droit du container). Les 3 tuiles occupent l'espace gagné à gauche.

### Après — mobile (375×667)

![mobile after](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-3526/resource-banner-3526-mobile-after.png)

L'illustration reste cachée sous `md`, les tuiles s'empilent comme avant.

## Tests

- Mise à jour du test unitaire `ResourceBanner.test.tsx` pour assert la présence des classes `fr-col-md-10`, `fr-col-md-2` et `fr-grid-row--right`
- `pnpm test` vert (test file ResourceBanner : 4/4 passent)
- Mesure DOM en dev server (1280px) : `image.right` (1262.5) = `container.right` (1256.5) au pixel près de la marge négative DSFR du gutter ; l'illustration est bien collée au bord droit

## Note CI

Le check `App · Typecheck` peut apparaître rouge sur cette PR à cause d'une erreur **pré-existante** dans `src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx` (`Type '{ cseDeadline: Date; }' is missing the following properties from type 'Props': siren, year`) — voir le build alpha du 26/05. Cette erreur n'est pas introduite par ce fix (correction sur la branche `epic/3484` qui n'a pas encore atterri sur `alpha`).

## Test plan

- [x] `pnpm test src/modules/layout/__tests__/ResourceBanner.test.tsx` — 4 passing
- [x] `pnpm lint:check` vert
- [x] `pnpm format:check` vert
- [x] Vérification DOM en dev server : `fr-col-md-10`, `fr-col-md-2`, `fr-grid-row--right` présents
- [x] Screenshot desktop : illustration flush right
- [x] Screenshot mobile : illustration restée cachée, tuiles intactes