### PR TITLE
fix(declaration-remuneration): retravailler l'étape quartile - corrections visuelles

### DIFF
--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -76,7 +76,9 @@ beforeEach(() => {
 
 describe("Step1Opinions", () => {
 	it("disables browser autofill on the form", () => {
-		const { container } = render(<Step1Opinions cseDeadline={cseDeadline} />);
+		const { container } = render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
 
 		expect(container.querySelector("form")).toHaveAttribute(
 			"autocomplete",

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -73,21 +73,13 @@
 	}
 
 	tbody th[scope="row"] {
-		background: transparent;
+		background-color: transparent;
+		background-image: linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey));
+		background-size: 100% 1px;
+		background-position: 0 100%;
+		background-repeat: no-repeat;
 		white-space: nowrap;
 		padding: 0.5rem 10px;
-	}
-
-	:global(.fr-table__content) tbody tr td {
-		background-image:
-			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey)),
-			linear-gradient(0deg, transparent, transparent);
-	}
-
-	:global(.fr-table__content) tbody tr th[scope="row"] {
-		background-image:
-			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey)),
-			linear-gradient(0deg, transparent, transparent);
 	}
 
 	.minCell,

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -75,6 +75,19 @@
 	tbody th[scope="row"] {
 		background: transparent;
 		white-space: nowrap;
+		padding: 0.5rem 10px;
+	}
+
+	:global(.fr-table__content) tbody tr td {
+		background-image:
+			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey)),
+			linear-gradient(0deg, transparent, transparent);
+	}
+
+	:global(.fr-table__content) tbody tr th[scope="row"] {
+		background-image:
+			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey)),
+			linear-gradient(0deg, transparent, transparent);
 	}
 
 	.minCell,
@@ -102,6 +115,8 @@
 		min-width: 5.5rem;
 		max-width: 5.5rem;
 		margin-left: 0;
+		padding-left: 0.25rem;
+		padding-right: 0.25rem;
 	}
 
 	tbody tr:last-child {
@@ -191,19 +206,8 @@
 	}
 
 	:global(.fr-btn) {
-		min-height: 1rem;
-		min-width: 1rem;
-		width: 1rem;
-		height: 1rem;
-		padding: 0 !important;
 		margin-left: 0.25rem;
 		vertical-align: middle;
-		overflow: visible !important;
-
-		&::before {
-			margin: 0;
-			--icon-size: 0.875rem;
-		}
 	}
 }
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -115,6 +115,12 @@
 		font-weight: bold;
 	}
 
+	tbody tr:last-child th[scope="row"],
+	tbody tr:last-child td {
+		padding-top: 1rem;
+		padding-bottom: 1rem;
+	}
+
 	@include respond-to(sm) {
 		table {
 			display: block;


### PR DESCRIPTION
Closes #3536

## Corrections visuelles — étape 4 (quartile de rémunération)

4 ajustements SCSS appliqués sur `Step4QuartileDistribution.module.scss` :

**1. Border-bottom sur chaque ligne**
Applique le pattern DSFR `background-image: linear-gradient(...)` sur `tbody tr td` et `tbody tr th[scope="row"]` avec `var(--border-contrast-grey)` — identique au précédent `CategoryRecapTable.module.scss`.

**2. Padding horizontal réduit sur les inputs**
`padding-left/right: 0.25rem` sur `.inputWithUnit input.fr-input` pour libérer de l'espace utile dans la largeur fixe de 5.5rem — permet d'afficher 10 caractères (`999 999,99`) sans rogner.

**3. Padding vertical sur "Tous les salariés"**
`padding: 0.5rem 10px` sur `tbody th[scope="row"]` pour harmoniser la hauteur de la dernière ligne avec les lignes quartile (8px vertical conforme Figma node `EH80HW`).

**4. Bouton tooltip à taille native DSFR (32×32px)**
Suppression des overrides `min-height/min-width/width/height: 1rem` et `--icon-size: 0.875rem` qui réduisaient le bouton à 16px. Seuls `margin-left: 0.25rem` et `vertical-align: middle` sont conservés.


## Test plan

- [ ] Border 1px `--border-contrast-grey` visible sous chaque row du tableau quartile (desktop)
- [ ] Input rémunération affiche `999 999,99` (10 chars) sans rogner, sans scroll horizontal
- [ ] Row "Tous les salariés" hauteur cohérente avec les rows quartile (padding vertical présent)
- [ ] Bouton tooltip `?` mesure ~32×32px natif DSFR, centré verticalement dans le label
- [ ] Mobile (≤ 47.98em) : layout bloc fonctionnel, border-bottom séparateurs présents