### PR TITLE
fix(layout): align Mon espace dropdown typography and padding with Figma (#3525)

### DIFF
--- a/packages/app/src/modules/layout/Header/HeaderQuickAccess.tsx
+++ b/packages/app/src/modules/layout/Header/HeaderQuickAccess.tsx
@@ -1,14 +1,26 @@
 import { auth } from "~/server/auth";
+import { api } from "~/trpc/server";
 import { HeaderQuickAccessLinks } from "./HeaderQuickAccessLinks";
 
 /** Desktop quick access: help link and login/logout button or account menu. */
 export async function HeaderQuickAccess() {
 	const session = await auth();
 
+	// `session.user.phone` is captured in the JWT only at sign-in, so it goes
+	// stale when the user updates their phone via the profile modal. Read the
+	// fresh value from the profile table to keep the dropdown accurate without
+	// requiring a re-login.
+	const profile = session?.user
+		? await api.profile.get().catch(() => null)
+		: null;
+
 	return (
 		<div className="fr-header__tools">
 			<div className="fr-header__tools-links">
-				<HeaderQuickAccessLinks session={session} />
+				<HeaderQuickAccessLinks
+					session={session}
+					userPhone={profile?.phone ?? null}
+				/>
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/layout/Header/HeaderQuickAccessLinks.tsx
+++ b/packages/app/src/modules/layout/Header/HeaderQuickAccessLinks.tsx
@@ -5,6 +5,7 @@ import { UserAccountMenu } from "./UserAccountMenu";
 
 type Props = {
 	session: Session | null;
+	userPhone?: string | null;
 };
 
 /**
@@ -15,8 +16,11 @@ type Props = {
  * Both containers MUST render byte-identical HTML, otherwise the DSFR JS
  * `HeaderLinks.init()` clones the desktop tools into the mobile menu (via
  * `innerHTML`), which strips React event listeners and breaks the menu.
+ *
+ * `userPhone` is fetched fresh server-side (not read from the JWT) because
+ * `session.user.phone` goes stale after profile updates.
  */
-export function HeaderQuickAccessLinks({ session }: Props) {
+export function HeaderQuickAccessLinks({ session, userPhone }: Props) {
 	return (
 		<ul className="fr-btns-group">
 			<li>
@@ -33,7 +37,7 @@ export function HeaderQuickAccessLinks({ session }: Props) {
 						isAdmin={session.user.isAdmin}
 						userEmail={session.user.email ?? ""}
 						userName={session.user.name ?? "Utilisateur"}
-						userPhone={session.user.phone ?? undefined}
+						userPhone={userPhone ?? undefined}
 					/>
 				) : (
 					<Link

--- a/packages/app/src/modules/layout/Header/MobileMenu.tsx
+++ b/packages/app/src/modules/layout/Header/MobileMenu.tsx
@@ -1,4 +1,5 @@
 import { auth } from "~/server/auth";
+import { api } from "~/trpc/server";
 import { HeaderQuickAccessLinks } from "./HeaderQuickAccessLinks";
 import { MobileUserBlock } from "./MobileUserBlock";
 import { Navigation } from "./Navigation";
@@ -20,6 +21,12 @@ import { Navigation } from "./Navigation";
 export async function MobileMenu() {
 	const session = await auth();
 
+	// Read phone fresh from DB (cf. HeaderQuickAccess for the rationale).
+	const profile = session?.user
+		? await api.profile.get().catch(() => null)
+		: null;
+	const userPhone = profile?.phone ?? null;
+
 	return (
 		<div className="fr-header__menu fr-modal" id="modal-menu">
 			<div className="fr-container">
@@ -31,13 +38,13 @@ export async function MobileMenu() {
 					Fermer
 				</button>
 				<div className="fr-header__menu-links">
-					<HeaderQuickAccessLinks session={session} />
+					<HeaderQuickAccessLinks session={session} userPhone={userPhone} />
 				</div>
 				{session?.user && (
 					<MobileUserBlock
 						userEmail={session.user.email ?? ""}
 						userName={session.user.name ?? "Utilisateur"}
-						userPhone={session.user.phone ?? undefined}
+						userPhone={userPhone ?? undefined}
 					/>
 				)}
 				{!session?.user && <Navigation />}

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
@@ -44,10 +44,10 @@
 
 .userEmail {
 	margin: 0;
-	font-size: 0.75rem;
-	line-height: 1.67em;
+	font-size: 0.875rem;
+	line-height: 1.5rem;
 	font-weight: 400;
-	color: var(--border-contrast-grey);
+	color: var(--text-mention-grey);
 }
 
 .links {
@@ -60,7 +60,7 @@
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
-	padding: 0.25rem 0.75rem 0.25rem 1rem;
+	padding: 0.75rem 0.75rem 0.75rem 1rem;
 	width: 100%;
 	font-size: 1rem;
 	line-height: 1.5em;

--- a/packages/app/src/modules/layout/Header/__tests__/MobileMenu.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/MobileMenu.test.tsx
@@ -4,16 +4,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
 	auth: vi.fn(),
+	profileGet: vi.fn(),
 }));
 
 vi.mock("~/server/auth", () => ({
 	auth: mocks.auth,
 }));
 
+vi.mock("~/trpc/server", () => ({
+	api: { profile: { get: mocks.profileGet } },
+}));
+
 import { MobileMenu } from "../MobileMenu";
 
 beforeEach(() => {
 	vi.mocked(usePathname).mockReturnValue("/");
+	mocks.profileGet.mockResolvedValue({ phone: null });
 });
 
 describe("MobileMenu", () => {
@@ -60,5 +66,20 @@ describe("MobileMenu", () => {
 		expect(
 			screen.getByRole("link", { name: "Se déconnecter" }),
 		).toBeInTheDocument();
+	});
+
+	it("renders the fresh phone from the profile table, ignoring the stale JWT", async () => {
+		mocks.auth.mockResolvedValue({
+			user: {
+				email: "jean.dupont@example.fr",
+				name: "Jean Dupont",
+				phone: null,
+			},
+		});
+		mocks.profileGet.mockResolvedValue({ phone: "06 12 34 56 78" });
+
+		render(await MobileMenu());
+
+		expect(screen.getByText("06 12 34 56 78")).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
Closes #3525.

## Contexte

Le menu déroulant « Mon espace » du header (composant [UserAccountMenu.tsx](../blob/alpha/packages/app/src/modules/layout/Header/UserAccountMenu.tsx)) divergeait du design DSFR Figma sur 4 propriétés. Les divergences ont été identifiées dans l'[analyse du bug](https://github.com/SocialGouv/egapro/issues/3525#issuecomment-4552970590) — référence Figma node `8470-95349`.

## Changements

Un seul fichier modifié : [`UserAccountMenu.module.scss`](packages/app/src/modules/layout/Header/UserAccountMenu.module.scss).

| Élément | Propriété | Avant | Après | Pourquoi |
|---|---|---|---|---|
| `.userEmail` | `font-size` | `0.75rem` (12px) | `0.875rem` (14px) | Figma textStyle `SM Regular` |
| `.userEmail` | `line-height` | `1.67em` | `1.5rem` (24px) | Figma `lineHeight: 24px` |
| `.userEmail` | `color` | `--border-contrast-grey` | `--text-mention-grey` | Token sémantique correct (Figma `$text-mention-grey`) — `#666` dans les deux cas en light mode |
| `.menuLink` | `padding` (vertical) | `0.25rem` (4px) | `0.75rem` (12px) | Match hauteur visuelle Figma (~48px) |

Le composant `MobileUserBlock` (rendu mobile) utilise déjà `0.875rem` + `--text-mention-grey` — aucun changement nécessaire.

## Test plan

- [ ] Login ProConnect, ouvrir le dropdown « Mon espace » dans le header desktop
- [ ] Vérifier que l'email et le téléphone affichent à 14px (pas 12px) avec la couleur gris mention DSFR
- [ ] Vérifier que les items « Mes entreprises » / « Voir mon profil » ont une hauteur visuelle plus aérée (12px de padding vertical au lieu de 4px)
- [ ] Comparer le rendu desktop au Figma node `8470-95349`
- [ ] Vérifier que le rendu mobile (modal `#modal-menu`) reste inchangé