### PR TITLE
fix(journal): bump 0037 when timestamp to fix silent migration skip (#3557)

### DIFF
--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -264,7 +264,7 @@
 		{
 			"idx": 37,
 			"version": "7",
-			"when": 1779263787038,
+			"when": 1779271468704,
 			"tag": "0037_pale_mikhail_rasputin",
 			"breakpoints": true
 		}


### PR DESCRIPTION
Closes #3557

## Bug

La migration `0037_pale_mikhail_rasputin.sql` (qui ajoute `draft` jsonb + `draft_updated_at` timestamptz à `app_declaration`) est **silencieusement skippée** par le migrator Drizzle sur les DBs où `0036_add_step_change_event_type` a été appliquée avant que `0037` n'arrive dans le journal.

**Symptôme** : `Erreur 500` au chargement de `/declaration-remuneration` avec `column "draft" does not exist` dans les logs backend.

**Root cause** : dans `packages/app/drizzle/meta/_journal.json`, le `when` de l'entrée `idx: 37` (`1779263787038`) est plus ancien que celui de `idx: 36` (`1779271468703`). Le migrator Drizzle (`drizzle-orm/pg-core/dialect.js:56-71`) lit `lastDbMigration` une fois avant la boucle et compare ensuite chaque migration via `lastDbMigration.created_at < migration.folderMillis`. Pour `0037` : `1779271468703 < 1779263787038` est faux → skip silencieux, et `entrypoint.sh` log « Migrations completed » sans erreur.

C'est un piège classique de Drizzle quand deux PRs avec migrations sont développées en parallèle : le `when` provient de l'horloge locale au `pnpm db:generate`, et l'ordre de merge peut inverser la chronologie.

## Fix

Bump le `when` de `idx: 37` à `1779271468704` (= `1779271468703 + 1`). Le hash SQL est inchangé — la migration sera appliquée au prochain démarrage du pod.

## Risque prod

Preprod et prod n'ont **pas encore** été déployées avec `0037`. Sans ce fix, le merge `alpha → beta → master` reproduira le skip silencieux et un crash 500 surviendra sur `/declaration-remuneration` en production. Étape clé du parcours déclarant — impact business direct.

## Test plan

- [x] Reproduction confirmée sur la review app alpha (`column "draft" does not exist`)
- [x] Schéma de la DB locale après reset+migration : `draft` et `draft_updated_at` présentes
- [ ] Après merge, vérifier sur la review app alpha post-redéploiement que `\d app_declaration` liste les deux colonnes
- [ ] Avant merge `beta`/`master` : valider sur preprod que la migration a bien été appliquée

## Suite

Un garde-fou CI (`check-journal.mjs` asserte la monotonie du journal) est dans une PR follow-up — séparation pour permettre un merge rapide du fix prod-critique.
