### PR TITLE
feat(notifications): add 6 new email types for scheduled reminders

### DIFF
--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -42,17 +42,19 @@ check_pattern '\.(ts|tsx|js|jsx)$' \
   'biome-ignore|eslint-disable|@ts-ignore|@ts-expect-error' \
   'Suppression comments are forbidden. Fix the underlying issue instead.'
 
-# Inline styles — JSX files only (exclude @react-pdf/renderer components which require style={})
+# Inline styles — JSX files only (exclude @react-pdf/renderer + @react-email components which require style={})
 check_pattern '\.(tsx|jsx)$' \
   'style=\{' \
   'Inline style={{}} is forbidden. Use DSFR classes or a scoped SCSS module.' \
-  '(declarationPdf/|noSanctionAttestation/)'
+  '(declarationPdf/|noSanctionAttestation/|packages/notifications/)'
 
 # Inline SVG — JSX files only (DsfrPictogram is the only allowed SVG wrapper)
+# packages/notifications/ is excluded: emails need inline SVG (Outlook strips
+# linked images by default, next/image is browser-only).
 check_pattern '\.(tsx|jsx)$' \
   '<svg[[:space:]>]' \
   'Inline <svg> is forbidden. Use DsfrPictogram, public/assets/*.svg + <Image> (next/image), or DSFR icon classes (fr-icon-*).' \
-  '(DsfrPictogram\.tsx|ErrorArtwork\.tsx)'
+  '(DsfrPictogram\.tsx|ErrorArtwork\.tsx|packages/notifications/)'
 
 # Direct process.env — use ~/env.js instead (exclude env.js, instrumentation, next.config, sentry configs)
 check_pattern '\.(ts|tsx)$' \
@@ -60,10 +62,11 @@ check_pattern '\.(ts|tsx)$' \
   'Direct process.env is forbidden. Use: import { env } from "~/env.js".' \
   '(env\.js|instrumentation(-client)?\.ts|next\.config|trpc/react\.tsx|sentry\.(client|server|edge)\.config\.ts|global-setup\.ts|integration-setup\.ts|playwright\.config|drizzle[^/]*\.config|migrate.*\.mjs|e2e/helpers/|packages/notifications/)'
 
-# Deep relative imports — use ~/ path alias
+# Deep relative imports — use ~/ path alias (exclude packages/notifications which has no path alias)
 check_pattern '\.(ts|tsx)$' \
   '(\.\./){2,}' \
-  'Deep relative imports (../../ or deeper) are forbidden. Use the ~/ path alias.'
+  'Deep relative imports (../../ or deeper) are forbidden. Use the ~/ path alias.' \
+  '(packages/notifications/)'
 
 # Hardcoded hex colors in SCSS — use DSFR CSS custom properties
 check_pattern '\.scss$' \

--- a/.kontinuous/templates/notifications-deployment.yaml
+++ b/.kontinuous/templates/notifications-deployment.yaml
@@ -37,11 +37,13 @@ spec:
           command:
             - node
             - packages/notifications/dist/index.js
-          # Load defaults from the same configmaps as the app pod. The
-          # `mail` configmap exposes MAIL_ENABLED / SMTP_HOST / SMTP_PORT /
-          # SMTP_SECURE / MAIL_FROM pointing at the in-cluster MailDev for
-          # dev / preprod review apps. The `notifications` configmap is
-          # optional and lets ops tune retry / batch knobs without rebuilding.
+          # The worker is the single consumer of MAIL_*/SMTP_* — the app pod
+          # no longer mounts these vars (removed from `global.env` once the
+          # publisher pattern landed). The `mail` configmap exposes
+          # MAIL_ENABLED / SMTP_HOST / SMTP_PORT / SMTP_SECURE / MAIL_FROM
+          # pointing at the in-cluster MailDev for dev / preprod review
+          # apps. The `notifications` configmap is optional and lets ops
+          # tune retry / batch knobs without rebuilding.
           envFrom:
             - configMapRef:
                 name: mail
@@ -124,9 +126,10 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.global.pgSecretName }}"
                   key: PGSSLMODE
-            # SMTP — same source as the app pod (`smtp-app` sealed-secret with
-            # MAILER_* keys = Tipimail in prod). `optional: true` keeps the
-            # configmap fallback (MailDev) usable in dev / preprod.
+            # SMTP — `smtp-app` sealed-secret with MAILER_* keys = Tipimail
+            # in prod, directly bound to this pod (the app pod has been
+            # disconnected from this secret). `optional: true` keeps the
+            # `mail` configmap fallback (MailDev) usable in dev / preprod.
             - name: SMTP_HOST
               valueFrom:
                 secretKeyRef:

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -134,47 +134,10 @@ app:
           name: "{{ .Values.global.notificationsPgSecretName | default \"pg-notifications\" }}"
           key: PGSSLMODE
           optional: true
-    # SMTP (Tipimail in prod, MailDev on dev/preprod). The smtp-app
-    # sealed-secret is kept as-is from the V1 prod setup, with MAILER_*
-    # keys. We remap to the V2 SMTP_* names expected by src/env.js.
-    #
-    # Kubernetes precedence: `env` runs AFTER `envFrom`, so an `env` entry
-    # would normally override a same-named envFrom value. But with
-    # `optional: true` on a missing secret/key, the env entry is silently
-    # dropped and the envFrom value is preserved. That is exactly the
-    # fallback we rely on for dev/preprod review apps (no smtp-app
-    # secret) where SMTP_HOST, SMTP_PORT, etc. come from the `mail`
-    # configmap pointing at the in-cluster MailDev service.
-    - name: SMTP_HOST
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_HOST
-          optional: true
-    - name: SMTP_PORT
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_PORT
-          optional: true
-    - name: SMTP_USER
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_LOGIN
-          optional: true
-    - name: SMTP_PASS
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_PASSWORD
-          optional: true
-    - name: SMTP_SECURE
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_SSL
-          optional: true
+    # SMTP_* / MAIL_* are intentionally NOT injected into the app pod —
+    # they are consumed exclusively by the notifications worker. See
+    # `.kontinuous/templates/notifications-deployment.yaml` for the
+    # worker-side wiring (same smtp-app sealed-secret + mail configmap).
   vars:
     NEXTAUTH_URL: "https://{{ .Values.global.host }}/api/auth"
     NEXT_PUBLIC_EGAPRO_ENV: "{{ .Values.global.env }}"

--- a/docs/mails.md
+++ b/docs/mails.md
@@ -1,0 +1,271 @@
+# Mails transactionnels EGAPRO V2
+
+Inventaire exhaustif des mails envoyés par la plateforme. Deux mécanismes :
+
+1. **Event-driven** (4 mails) — émis depuis une mutation tRPC ou un upload, via le wrapper [`enqueueReceipt`](../packages/app/src/modules/mail/enqueueReceipt.ts) côté `packages/app`.
+2. **Schedule-driven** (7 mails, 13 schedules cron pg-boss) — émis depuis le worker `packages/notifications` à intervalles réguliers (cron natif pg-boss avec `tz=Europe/Paris`). Le handler interroge l'app DB pour trouver les destinataires éligibles, déduplique via `notifications.reminder_sent_log`, puis enqueue un job sur la même queue `email-notification` que les mails event-driven.
+
+Tous les jobs transitent par le même pipeline **publisher → pg-boss → worker → SMTP**. La pile de rendu HTML est **React Email** (composants typés DSFR, inline CSS auto, fallback texte produit par `html-to-text`).
+
+> Pour la doc d'architecture (queue, fallback DB, retry policy), voir [`docs/architecture.md`](architecture.md). Pour le détail des parcours utilisateur qui déclenchent ces mails, voir [`docs/features.md`](features.md) et [`docs/parcours-utilisateurs.md`](parcours-utilisateurs.md).
+
+---
+
+## Vue d'ensemble — 11 types · 13 schedules
+
+Chaque ligne pointe vers la **fiche détaillée** correspondante : sujet exact, corps complet, requête SQL d'éligibilité (pour les schedule-driven), bouton CTA et référence au flowchart BRD.
+
+### Event-driven (déclenchement immédiat)
+
+| # | Type pg-boss | Fiche détaillée | BRD | Déclencheur |
+|---|---|---|---|---|
+| 1 | `declaration_confirmation` | [`mails/declaration-confirmation.md`](mails/declaration-confirmation.md) | MD | tRPC `declaration.submit` |
+| 2 | `second_declaration_confirmation` | [`mails/second-declaration-confirmation.md`](mails/second-declaration-confirmation.md) | MSDc | tRPC `declaration.submitSecondDeclaration` |
+| 3 | `cse_opinion_receipt` | [`mails/cse-opinion-receipt.md`](mails/cse-opinion-receipt.md) | MH_* | `POST /api/upload` (`flowType=cse_opinion`) |
+| 4 | `joint_evaluation_submitted` | [`mails/joint-evaluation-submitted.md`](mails/joint-evaluation-submitted.md) | M_PE2 | `POST /api/upload` (`flowType=joint_evaluation`) |
+
+### Schedule-driven (cron pg-boss, fuseau Europe/Paris)
+
+| # | Type pg-boss | Fiche détaillée | BRD | Cron | Variants |
+|---|---|---|---|---|---|
+| 5 | `cycle_opening_info` | [`mails/cycle-opening-info.md`](mails/cycle-opening-info.md) | MA | `0 8 1 3 *` | — |
+| 6 | `declaration_deadline_reminder` | [`mails/declaration-deadline-reminder.md`](mails/declaration-deadline-reminder.md) | MR30 / MR10 | `0 8 2 5 *` + `0 8 22 5 *` | `daysRemaining: 30 \| 10` |
+| 7 | `compliance_path_choice_reminder` | [`mails/compliance-path-choice-reminder.md`](mails/compliance-path-choice-reminder.md) | ME | `0 8 16 6 *` | — (couvre **Round 1 + Round 2** depuis le fix) |
+| 8 | `second_declaration_reminder` | [`mails/second-declaration-reminder.md`](mails/second-declaration-reminder.md) | MSD3 / MSD30 | `0 8 3 10 *` + `0 8 1 12 *` | `daysRemaining: 90 \| 30` |
+| 9 | `joint_evaluation_reminder` | [`mails/joint-evaluation-reminder.md`](mails/joint-evaluation-reminder.md) | MG_E1 | `0 8 1 8 *` | — (couvre **Round 1 + Round 2** depuis le fix) |
+| 10 | `cse_opinion_reminder` | [`mails/cse-opinion-reminder.md`](mails/cse-opinion-reminder.md) | MG_B/C/J1/J2/A/E2 | 5 schedules | `variant: compliance \| justify_oct \| justify_dec \| corrective \| joint_eval` |
+| 11 | `next_cycle_handover` | [`mails/next-cycle-handover.md`](mails/next-cycle-handover.md) | MI_* | `0 8 2 3 *` | — |
+
+**Destinataire** : tous les rappels sont envoyés au `declarations.declarantId → app_user.email` (le compte ProConnect qui a soumis la déclaration courante ou Y-1 selon le rappel). Pas de cc/bcc/groupé — un mail par déclaration, par variant.
+
+---
+
+## Architecture
+
+### Pipeline complet
+
+```text
+                                    ┌──────────────────────────────────┐
+                                    │  packages/notifications (worker) │
+                                    │  - pg-boss instance              │
+                                    │  - registerHandlers(11 types)    │
+                                    │  - registerSchedules(13 crons)   │
+                                    └──────┬──────────────────┬────────┘
+                                           │                  │
+                              ┌────────────┴───────┐  ┌───────┴────────────────────┐
+                              │ Handler (mail send)│  │ Schedule tick (cron pg-boss)│
+                              │ - validateJob      │  │ - query eligibility (app DB)│
+                              │ - buildMail (React │  │ - skip if already sent      │
+                              │   Email render)    │  │ - enqueueNotification       │
+                              │ - SMTP send        │  │ - mark reminder_sent_log    │
+                              │ - audit log        │  │                             │
+                              └─────────▲──────────┘  └───────┬─────────────────────┘
+                                        │                     │
+                                        │ event-driven        │ time-driven
+                                        │                     │
+                              ┌─────────┴────────┐    ┌───────┴──────────┐
+                              │ packages/app     │    │ pg-boss internal │
+                              │ enqueueReceipt() │    │ cron scheduler   │
+                              │ (tRPC mutations  │    │ (boss.schedule,  │
+                              │  + upload route) │    │  tz=Europe/Paris)│
+                              └──────────────────┘    └──────────────────┘
+```
+
+### Découplage `app` ↔ `notifications`
+
+| Sujet | Côté `packages/app` | Côté `packages/notifications` |
+|---|---|---|
+| Code mail (builders, template, schedules) | rien | tout |
+| Point d'entrée publish | `enqueueReceipt()` (3 kinds) + `enqueueNotification()` direct (1 cas) | `publisher.ts` |
+| Imports | `notifications/publisher` + `notifications/queue` (1 fichier) | — |
+| Env vars `SMTP_*` / `MAIL_*` | **non déclarées** dans `env.js` (retirées) | lues via `process.env` direct (`worker/transporter.ts`) |
+| Env var `DATABASE_URL` | lue (Drizzle + audit + NextAuth) | lue (audit + eligibility + dedup table) — dépendance assumée |
+| Asset Marianne (fonts woff2) | `public/dsfr/fonts/*` (copié par `scripts/copy-dsfr.mjs`) | référencés via `${EGAPRO_PUBLIC_URL}/dsfr/fonts/*` dans `EmailLayout.tsx` |
+
+### Structure du package `packages/notifications/src/`
+
+```text
+src/
+├── index.ts                # Worker entry — orchestrate pg-boss + register handlers + schedules
+├── publisher.ts            # enqueueNotification (consumed by packages/app)
+├── queue.ts                # QUEUE_NAME + EmailJobData + validateJobData (type-specific)
+├── db.ts                   # DB URL resolution (NOTIFICATIONS_* / fallback to DATABASE_URL)
+├── mails/
+│   ├── index.ts            # MAIL_BUILDERS registry (11 entries) + buildMail() async
+│   ├── types.ts            # NOTIFICATION_TYPES (11) + NotificationPayloadMap
+│   ├── builders/           # 11 React Email builders (one .tsx per notification type)
+│   ├── template/           # React Email components (EmailShell, EmailLayout, EmailHeader, InfoBar, EmailFooter, EmailButton, EmailCtaWithLink, …)
+│   │                       # + tokens.ts (DSFR colors/font/spacing/BRAND)
+│   │                       # + EmailLayout charge Marianne Regular/Medium/Bold via <Font>
+│   └── shared/             # formatters, urls (getPublicUrl, getConnectionUrl, getMySpaceUrl), escapeHtml, renderEmail
+├── eligibility/            # Read-only app DB queries powering the schedule handlers
+│   ├── client.ts           # postgres.js client → DATABASE_URL
+│   ├── queries.ts          # 7 SQL queries (findDraftDeclarations, findCseOpinionPending, …)
+│   └── dedup.ts            # ensureDedupTable / wasSent / markSent (notifications.reminder_sent_log)
+├── schedules/              # pg-boss cron schedules
+│   ├── index.ts            # registerSchedules(boss, sql) — 13 createQueue + work + schedule
+│   ├── definitions.ts      # SCHEDULES const (name, cron, tz, handler) — 13 entries
+│   ├── dates.ts            # getCurrentYear (Intl.DateTimeFormat) + DEADLINES helpers
+│   ├── handlers.ts         # 7 handlers — one per NotificationType
+│   └── dispatch.ts         # dispatchReminder() — eligibility loop + dedup + enqueue
+└── worker/                 # Sub-modules of the worker entry
+    ├── transporter.ts      # SMTP nodemailer (TLS 1.2 min when SMTP auth set)
+    ├── auditLog.ts         # logAuditMain (success/failure → audit.action_log)
+    ├── jobHandler.ts       # makeJobHandler() — pure factory
+    └── lifecycle.ts        # SIGTERM/SIGINT graceful shutdown
+```
+
+### Charte typographique (Marianne)
+
+`EmailLayout.tsx` déclare les **3 weights de Marianne** utilisés par les templates :
+
+- `Marianne-Regular.woff2` (400) — corps de texte, paragraphes
+- `Marianne-Medium.woff2` (500) — libellés de boutons CTA
+- `Marianne-Bold.woff2` (700) — titres, salutation « Bonjour », signature, valeurs de l'`InfoList`
+
+Source : `${EGAPRO_PUBLIC_URL}/dsfr/fonts/Marianne-*.woff2`. Les fichiers sont déployés par [`packages/app/scripts/copy-dsfr.mjs`](../packages/app/scripts/copy-dsfr.mjs) lors de chaque build/dev de l'app — pas de wiring K8s supplémentaire. Fallback : `Arial, Helvetica, sans-serif` quand le client mail bloque les webfonts (Outlook ≤ 2019).
+
+### Schéma DB ajouté
+
+Une migration idempotente s'applique au boot du worker (via `ensureDedupTable`) :
+
+```sql
+CREATE SCHEMA IF NOT EXISTS notifications;
+CREATE TABLE IF NOT EXISTS notifications.reminder_sent_log (
+    type     text NOT NULL,
+    siren    text NOT NULL,
+    year     integer NOT NULL,
+    variant  text NOT NULL DEFAULT '',
+    sent_at  timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (type, siren, year, variant)
+);
+CREATE INDEX IF NOT EXISTS reminder_sent_log_lookup_idx
+    ON notifications.reminder_sent_log (type, year);
+```
+
+L'`UNIQUE (type, siren, year, variant)` garantit l'idempotence des ticks — si un tick re-run (worker restart, clock skew, double cron), `wasSent()` renvoie `true` et l'enqueue est skip.
+
+---
+
+## Comportement transverse
+
+### Audit log
+
+Chaque publication enregistre une ligne dans `audit.action_log` :
+
+- `notification.enqueue` (catégorie `mutation`, rétention 365j) — au moment du push dans pg-boss, status `success` ou `failure` selon le retour du publisher (`enqueued` / `error` / `queue_unavailable`)
+- `notification.send` (catégorie `system`, rétention 365j) — au moment de l'envoi SMTP effectif côté worker, status `success` ou `failure`
+
+Voir [`packages/app/src/modules/audit/shared/actionKeys.ts`](../packages/app/src/modules/audit/shared/actionKeys.ts).
+
+### Retry policy
+
+Le publisher configure pg-boss avec :
+
+- `retryLimit` = `NOTIFICATIONS_RETRY_LIMIT` (défaut 5)
+- `retryBackoff` = `true` (backoff exponentiel)
+- `retryDelay` = `NOTIFICATIONS_RETRY_DELAY_SECONDS` (défaut 60)
+
+Les erreurs **transitoires** (SMTP timeout, réseau) sont retentées. Les erreurs **structurelles** (payload invalide) sont marquées comme "poison pill" par le worker et ne sont pas retentées — voir [`packages/notifications/src/worker/jobHandler.ts`](../packages/notifications/src/worker/jobHandler.ts).
+
+### Sécurité SMTP
+
+`worker/transporter.ts` impose `requireTLS: true` et `tls.minVersion: "TLSv1.2"` dès qu'un couple `SMTP_USER` / `SMTP_PASS` est configuré (prod / preprod). En dev local (MailDev sans auth), ces options sont skip pour rester compatibles avec le conteneur.
+
+### Dégradation gracieuse
+
+`enqueueNotification` ne throw jamais : si pg-boss est indisponible, retourne `{ status: "queue_unavailable" }`. La mutation tRPC appelante reste un succès (la déclaration est bien enregistrée). Le mail est perdu et tracé dans l'audit log avec status `failure` + `errorMessage: "queue_unavailable"`.
+
+Si `DATABASE_URL` est absent côté worker, `registerSchedules` warn et **les rappels sont désactivés** (les eligibility queries en ont besoin). Les mails event-driven continuent de fonctionner via la queue.
+
+### Environnements
+
+| Environnement | SMTP cible | Worker déployé | Schedules actifs |
+|---|---|---|---|
+| Local (`pnpm dev:app`) | MailDev (`docker compose`) | Non — à lancer manuellement (`pnpm --filter notifications dev`) ou via les E2E | Oui dès que le worker tourne |
+| Review app / dev | MailDev in-cluster | Oui | Oui |
+| Preprod | MailDev in-cluster | Oui | Oui |
+| Prod | Tipimail (secret `smtp-app`) | Oui | Oui (Europe/Paris) |
+
+---
+
+## Tester un mail localement
+
+### Aperçu visuel (sans envoi SMTP)
+
+Rendre les builders en HTML statique, lancer un static server qui sert aussi les fonts Marianne, puis screenshot via Playwright :
+
+```bash
+# 1. Build le package
+pnpm --filter notifications build
+
+# 2. Rendu HTML d'un sample (un script de prévisualisation)
+node -e "
+import('./packages/notifications/dist/mails/index.js').then(async (m) => {
+  const { html } = await m.buildMail('declaration_confirmation', { siren: '552100554', year: 2027 });
+  require('node:fs').writeFileSync('/tmp/preview.html', html);
+});
+"
+
+# 3. Servir les fonts à côté (pour que Marianne se charge)
+mkdir -p /tmp/preview/dsfr && ln -sfn $(pwd)/packages/app/public/dsfr/fonts /tmp/preview/dsfr/fonts
+mv /tmp/preview.html /tmp/preview/preview.html
+python3 -m http.server 8089 --directory /tmp/preview --bind 127.0.0.1
+
+# 4. EGAPRO_PUBLIC_URL=http://localhost:8089 pour que les URLs woff2 résolvent
+# 5. Ouvrir http://localhost:8089/preview.html dans un navigateur
+```
+
+### Déclencher un schedule hors timing cron
+
+Pour pousser manuellement un job de rappel (utile pour debug review app ou tests E2E) :
+
+```bash
+# Démarrer le worker localement
+NOTIFICATIONS_DATABASE_URL=postgres://… \
+DATABASE_URL=postgres://… \
+MAIL_ENABLED=true \
+SMTP_HOST=localhost SMTP_PORT=1025 \
+EGAPRO_PUBLIC_URL=http://localhost:3000 \
+pnpm --filter notifications dev
+```
+
+```ts
+// Depuis un script Node connecté au même pg-boss DB :
+import { PgBoss } from "pg-boss";
+const boss = new PgBoss({ connectionString: process.env.NOTIFICATIONS_DATABASE_URL });
+await boss.start();
+await boss.send("reminder-declaration-deadline-30", {});
+// Le worker exécute le handler → eligibility queries → enqueue des jobs notification
+```
+
+Le worker consomme le job comme s'il avait été émis par le cron. La dedup `reminder_sent_log` joue son rôle normal — purger la table si on souhaite re-tester sur les mêmes destinataires.
+
+---
+
+## Ajouter un nouveau type de mail
+
+### Mail event-driven (déclenché par une mutation / route)
+
+1. Ajouter le literal à `NOTIFICATION_TYPES` dans `packages/notifications/src/mails/types.ts`
+2. Déclarer la forme du payload dans `NotificationPayloadMap`
+3. Créer `packages/notifications/src/mails/builders/<name>.tsx` qui exporte `MailBuilder<"<type>">` (async, retourne `{ subject, html, text }`)
+4. Référencer le builder dans `MAIL_BUILDERS` (`packages/notifications/src/mails/index.ts`)
+5. Étendre `validatePayloadForType` dans `packages/notifications/src/queue.ts`
+6. Si rattaché à un parcours « accusé de réception », étendre `KIND_TO_TYPE` dans [`enqueueReceipt.ts`](../packages/app/src/modules/mail/enqueueReceipt.ts). Sinon appeler `enqueueNotification` directement depuis la mutation/route.
+7. Ajouter un cas dans `packages/notifications/src/mails/__tests__/builders.test.ts`
+8. Créer la fiche détaillée `docs/mails/<kebab-case>.md` (modèle : reprendre une fiche event-driven existante)
+9. Ajouter une ligne au tableau « Event-driven » ci-dessus
+
+### Mail schedule-driven (déclenché par un cron)
+
+1. Étapes 1 → 5 ci-dessus (le type + builder + validation existent comme pour un event-driven)
+2. Si une nouvelle query est nécessaire : créer une fonction dans `packages/notifications/src/eligibility/queries.ts` qui retourne `ReminderRecipient[]`
+3. Ajouter le handler dans `packages/notifications/src/schedules/handlers.ts` (`handleXxx(sql)` qui appelle `dispatchReminder`)
+4. Référencer le schedule dans `packages/notifications/src/schedules/definitions.ts` (`SCHEDULES` const) avec son cron et `Europe/Paris`
+5. Si variants → étendre `CSE_OPINION_REMINDER_VARIANTS` (ou ajouter une nouvelle union de literal types) et propager dans le builder + le handler
+6. Ajouter un cas dans `packages/notifications/src/schedules/__tests__/registerSchedules.test.ts`
+7. Créer la fiche détaillée `docs/mails/<kebab-case>.md` (modèle : reprendre une fiche schedule-driven existante)
+8. Ajouter une ligne au tableau « Schedule-driven » ci-dessus
+
+Le schéma DB n'a pas besoin d'évoluer — la table `notifications.reminder_sent_log` est polymorphe (`type`/`variant`).

--- a/docs/mails/compliance-path-choice-reminder.md
+++ b/docs/mails/compliance-path-choice-reminder.md
@@ -1,0 +1,70 @@
+# `compliance_path_choice_reminder` — ME · Rappel choix de parcours
+
+| | |
+|---|---|
+| **Type pg-boss** | `compliance_path_choice_reminder` |
+| **Schedule** | `0 8 16 6 *` (J-15 avant 1er juillet = 16 juin 08:00) |
+| **Builder** | [`mails/builders/compliancePathChoiceReminder.tsx`](../../packages/notifications/src/mails/builders/compliancePathChoiceReminder.tsx) |
+| **Handler éligibilité** | [`findAwaitingComplianceChoice`](../../packages/notifications/src/eligibility/queries.ts) |
+| **Deadline référence** | 1ᵉʳ juillet Y (`DEADLINES.compliancePathChoice`) |
+| **Pré-requis métier** | Entreprise 100+ avec écart G ≥ 5 % (FSM bascule auto en `awaiting_compliance_path_choice` quand le seuil est dépassé) |
+
+## Destinataire
+
+`declarations.declarantId → app_user.email` — celui qui a soumis la 1ère ou la 2e déclaration sans avoir encore choisi de parcours.
+
+## Éligibilité (SQL — couvre Round 1 ET Round 2)
+
+```sql
+SELECT d.siren, d.year, u.email, d.declarant_id
+FROM app_declaration d
+JOIN app_user u ON u.id = d.declarant_id
+WHERE d.year = {currentYear}
+  AND d.cancelled_at IS NULL
+  AND u.email IS NOT NULL
+  AND (
+      -- Round 1: first compliance path not yet chosen
+      (d.status = 'awaiting_compliance_path_choice' AND d.first_declaration_path_choice IS NULL)
+      OR
+      -- Round 2: revision required after second declaration with persistent gap
+      (d.status = 'awaiting_revision_choice'        AND d.second_declaration_path_choice IS NULL)
+  );
+```
+
+> **Note** : Le Round 2 est nécessaire pour les entreprises qui ont choisi "Actions correctives" en Round 1 et dont l'écart G reste ≥ 5 % après la seconde déclaration. Sans la branche `awaiting_revision_choice`, ces destinataires ne recevraient aucun rappel.
+
+## Sujet
+
+```
+Egapro - Rappel : choix de votre parcours de mise en conformité
+```
+
+## Pré-en-tête (preview)
+
+> Vous devez choisir un parcours de mise en conformité avant la date limite.
+
+## Corps
+
+> **Bonjour,**
+>
+> Votre déclaration des indicateurs fait apparaître un écart de rémunération supérieur ou égal à **5 %**. Vous n'avez pas encore choisi votre parcours de mise en conformité.
+>
+> Conformément à la réglementation, lorsque l'écart de rémunération constaté est supérieur ou égal à 5 %, votre entreprise doit choisir un parcours de mise en conformité pour réduire cet écart.
+>
+> Trois parcours sont disponibles : justification des écarts, actions correctives, ou évaluation conjointe avec votre CSE. Le détail et les conséquences de chaque option sont expliqués sur le portail Egapro.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin d'effectuer ce choix.
+>
+> La sélection doit intervenir au plus tard le `1ᵉʳ juillet {year}`.
+>
+> [**Choisir mon parcours**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Code BRD **ME** — Phase 2 (entrée), chemin 4b dans les flowcharts 2027/2028/2029/2030.

--- a/docs/mails/cse-opinion-receipt.md
+++ b/docs/mails/cse-opinion-receipt.md
@@ -1,0 +1,48 @@
+# `cse_opinion_receipt` — MH_* · Confirmation avis CSE
+
+| | |
+|---|---|
+| **Type pg-boss** | `cse_opinion_receipt` |
+| **Trigger** | Event-driven — route handler `POST /api/upload` avec `flowType === "cse_opinion"` ([`route.ts:242`](../../packages/app/src/app/api/upload/route.ts#L242)) |
+| **Builder** | [`mails/builders/cseOpinionReceipt.tsx`](../../packages/notifications/src/mails/builders/cseOpinionReceipt.tsx) |
+| **Pièce jointe** | — (le fichier PDF reste sur S3, non re-attaché) |
+| **Renvoi manuel** | tRPC `mail.resendReceipt` avec `kind: "cseOpinion"` |
+| **Pré-requis métier** | Entreprise ≥ 100 salariés avec CSE constitué |
+
+## Destinataire
+
+`session.user.email` — le compte ProConnect qui a téléversé l'avis.
+
+## Sujet
+
+```
+Egapro - Réception de l'avis du CSE
+```
+
+## Pré-en-tête (preview)
+
+> L'avis du CSE déposé pour votre déclaration des indicateurs a bien été pris en compte.
+
+## Corps
+
+> **Bonjour,**
+>
+> L'avis du CSE déposé pour votre déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes a bien été pris en compte.
+>
+> Conformément à la réglementation, les entreprises d'au moins 100 salariés sont tenues de consulter leur CSE sur les indicateurs publiés et de déposer cet avis sur la plateforme Egapro.
+>
+> Le document que vous avez transmis est conservé dans votre dossier et reste consultable depuis votre espace personnel.
+>
+> Vous pouvez à tout moment consulter votre dossier depuis le portail Egapro.
+>
+> [**Consulter mon dossier**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Code BRD **MH_B / MH_C / MH_J / MH_A / MH_E** (selon chemin) — voir [`parcours-utilisateurs.md`](../parcours-utilisateurs.md), Phase 2 (toutes branches CSE).

--- a/docs/mails/cse-opinion-reminder.md
+++ b/docs/mails/cse-opinion-reminder.md
@@ -1,0 +1,159 @@
+# `cse_opinion_reminder` — MG_B / MG_C / MG_J1 / MG_J2 / MG_A / MG_E2 · Rappels avis CSE
+
+| | |
+|---|---|
+| **Type pg-boss** | `cse_opinion_reminder` |
+| **Variants** | `compliance` · `justify_oct` · `justify_dec` · `corrective` · `joint_eval` |
+| **Schedules** | 5 schedules — un par variant (voir ci-dessous) |
+| **Builder** | [`mails/builders/cseOpinionReminder.tsx`](../../packages/notifications/src/mails/builders/cseOpinionReminder.tsx) |
+| **Handler éligibilité** | [`findCseOpinionPending`](../../packages/notifications/src/eligibility/queries.ts) |
+| **Pré-requis métier** | `cse_required = true` ET avis CSE pas encore déposé |
+
+## Tableau des variants
+
+| Variant | BRD | Cron | Deadline référence | Public cible |
+|---|---|---|---|---|
+| `compliance` | MG_B / MG_C | `0 8 1 2 *` (1ᵉʳ février N+1) | 1ᵉʳ mars N+1 | Toute déclaration avec CSE sans avis déposé (100-149, 150+ conforme) |
+| `justify_oct` | MG_J1 | `0 8 1 9 *` (1ᵉʳ septembre) | 1ᵉʳ octobre N | Parcours « Justifier » — relance J-30 |
+| `justify_dec` | MG_J2 | `0 8 1 12 *` (1ᵉʳ décembre) | 1ᵉʳ octobre N (dépassé) | Parcours « Justifier » — relance si avis non encore déposé |
+| `corrective` | MG_A | `0 8 1 2 *` (1ᵉʳ février N+1) | 1ᵉʳ mars N+1 | Parcours « Actions correctives » |
+| `joint_eval` | MG_E2 | `0 8 1 12 *` (1ᵉʳ décembre) | 1ᵉʳ mars N+1 | Parcours « Évaluation conjointe » |
+
+**Dédup** : `(type, siren, year, variant)` — chaque variant a sa propre clé, donc un destinataire peut recevoir plusieurs variants au cours d'un même cycle (ex : un parcours `justify` reçoit `justify_oct` puis `justify_dec` si l'avis tarde).
+
+## Destinataire
+
+`declarations.declarantId → app_user.email`.
+
+## Éligibilité (SQL)
+
+Filtres communs à tous les variants :
+
+```sql
+d.year = {currentYear}
+AND d.cancelled_at IS NULL
+AND d.cse_required = true
+AND u.email IS NOT NULL
+AND NOT EXISTS (SELECT 1 FROM app_cse_opinion o WHERE o.declaration_id = d.id)
+```
+
+**Filtre additionnel par variant** — les filtres sont **mutuellement exclusifs par construction** (chaque variant cible une branche distincte du flowchart, donc un destinataire ne reçoit qu'un mail par cycle même si deux variants tickent le même jour) :
+
+| Variant | Filtre SQL spécifique | Branche flowchart |
+|---|---|---|
+| `compliance` | `first_declaration_path_choice IS NULL AND second_declaration_path_choice IS NULL` | MG_B (100-149 sans 7e) + MG_C (150+ conforme G<5 %) — pas de parcours Phase 2 |
+| `justify_oct` / `justify_dec` | `first_declaration_path_choice = 'justify' OR second_declaration_path_choice = 'justify'` | MG_J1 + MG_J2 — parcours Justifier (R1 ou R2) |
+| `corrective` | `first_declaration_path_choice = 'corrective_action' AND status = 'awaiting_cse_opinion'` | MG_A — Actions correctives, 2e déclaration soumise + écarts corrigés (FSM transitionné vers `awaiting_cse_opinion`) |
+| `joint_eval` | `(first OR second path = 'joint_evaluation') AND EXISTS(app_file type='joint_evaluation')` | MG_E2 — rapport d'éval. conjointe déjà déposé (sinon le FSM attend encore le rapport, pas l'avis CSE) |
+
+> **Pourquoi pas de filtre paramétrique uniforme** : un filtre OR sur first/second path est trop permissif pour `compliance` (matcherait aussi les Phase 2). Un filtre simple `path = corrective_action` est trop permissif pour `corrective` (matcherait avant que la 2e décl ne soit soumise). Idem `joint_evaluation` doit checker l'existence du file. Le switch explicite par variant garantit la sémantique flowchart.
+
+## Sujets (par variant)
+
+| Variant | Sujet |
+|---|---|
+| `compliance` | `Egapro - Rappel : avis du CSE — exactitude des données` |
+| `justify_oct` | `Egapro - Rappel : avis du CSE — exactitude des données et justification des écarts (1er octobre)` |
+| `justify_dec` | `Egapro - Rappel : avis du CSE — avis du CSE non encore déposé (relance du 1er décembre)` |
+| `corrective` | `Egapro - Rappel : avis du CSE — actions correctives — exactitude des données des deux déclarations` |
+| `joint_eval` | `Egapro - Rappel : avis du CSE — évaluation conjointe (relance du 1er décembre)` |
+
+## Pré-en-tête (par variant)
+
+| Variant | Preview text |
+|---|---|
+| `compliance` | L'avis du CSE sur l'exactitude des données déclarées n'a pas encore été déposé. |
+| `justify_oct` | L'avis du CSE sur l'exactitude des données et la justification des écarts est attendu avant le 1er octobre. |
+| `justify_dec` | L'avis du CSE sur votre justification des écarts n'a pas encore été reçu. |
+| `corrective` | L'avis du CSE sur l'exactitude des données des deux déclarations n'a pas encore été déposé. |
+| `joint_eval` | L'avis du CSE sur le rapport d'évaluation conjointe n'a pas encore été déposé. |
+
+## Corps (par variant)
+
+Structure commune : §1 (statement) + §2 (cadre réglementaire) + §3 (scope/justification) + §4 (invitation portail) + §5 (deadline) + CTA `Déposer l'avis du CSE` + § DREETS + signature.
+
+### Variant `compliance`
+
+> **Bonjour,**
+>
+> L'avis de votre CSE sur l'exactitude des données déclarées n'a pas encore été déposé sur la plateforme Egapro.
+>
+> Conformément à la réglementation, les entreprises d'au moins 100 salariés doivent recueillir l'avis de leur CSE sur l'exactitude des indicateurs publiés.
+>
+> Cet avis doit confirmer l'exactitude des données figurant dans votre déclaration.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de déposer l'avis du CSE.
+>
+> Le dépôt doit intervenir au plus tard le `1ᵉʳ mars {year+1}`.
+
+### Variant `justify_oct`
+
+> **Bonjour,**
+>
+> L'avis de votre CSE sur l'exactitude des données et la justification des écarts constatés n'a pas encore été déposé sur la plateforme Egapro.
+>
+> Conformément à la réglementation, le CSE doit être consulté sur les justifications avancées pour les écarts de rémunération constatés.
+>
+> Le dépôt de cet avis doit intervenir avant le 1er octobre.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de déposer l'avis du CSE.
+>
+> Le dépôt doit intervenir au plus tard le `1ᵉʳ octobre {year}`.
+
+### Variant `justify_dec`
+
+> **Bonjour,**
+>
+> Nous n'avons pas encore reçu l'avis de votre CSE sur la justification des écarts de rémunération.
+>
+> Conformément à la réglementation, votre justification des écarts doit être validée par l'avis du CSE pour clôturer votre procédure de mise en conformité.
+>
+> Sans dépôt de cet avis, la procédure de mise en conformité ne pourra pas être clôturée pour cette campagne.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de déposer l'avis du CSE.
+>
+> Le dépôt doit intervenir au plus tard le `1ᵉʳ octobre {year}` *(dépassé — relance)*.
+
+### Variant `corrective`
+
+> **Bonjour,**
+>
+> L'avis de votre CSE sur l'exactitude des données de votre première déclaration et de votre seconde déclaration au titre des actions correctives n'a pas encore été déposé.
+>
+> Conformément à la réglementation, votre CSE doit être consulté sur l'exactitude des indicateurs publiés ainsi que sur les actions correctives mises en œuvre.
+>
+> L'avis doit également mentionner les justifications éventuelles des écarts persistants.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de déposer l'avis du CSE.
+>
+> Le dépôt doit intervenir au plus tard le `1ᵉʳ mars {year+1}`.
+
+### Variant `joint_eval`
+
+> **Bonjour,**
+>
+> L'avis de votre CSE sur le rapport d'évaluation conjointe déposé pour votre entreprise n'a pas encore été reçu.
+>
+> Conformément à la réglementation, le CSE doit statuer sur l'évaluation conjointe et confirmer l'exactitude des données associées.
+>
+> Sans dépôt de cet avis, votre démarche d'évaluation conjointe restera incomplète.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de déposer l'avis du CSE.
+>
+> Le dépôt doit intervenir au plus tard le `1ᵉʳ mars {year+1}`.
+
+## CTA commun + clôture
+
+Tous les variants partagent les mêmes 3 éléments de pied :
+
+> [**Déposer l'avis du CSE**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Codes BRD **MG_B / MG_C / MG_J1 / MG_J2 / MG_A / MG_E2** — Phase 2, toutes branches CSE.

--- a/docs/mails/cycle-opening-info.md
+++ b/docs/mails/cycle-opening-info.md
@@ -1,0 +1,68 @@
+# `cycle_opening_info` — MA · Info ouverture cycle
+
+| | |
+|---|---|
+| **Type pg-boss** | `cycle_opening_info` |
+| **Trigger** | Schedule cron `0 8 1 3 *` (Europe/Paris) — chaque 1er mars à 08:00 |
+| **Builder** | [`mails/builders/cycleOpeningInfo.tsx`](../../packages/notifications/src/mails/builders/cycleOpeningInfo.tsx) |
+| **Handler éligibilité** | [`findOpenCycleRecipients`](../../packages/notifications/src/eligibility/queries.ts) |
+| **Schedule** | [`reminder-cycle-opening-info`](../../packages/notifications/src/schedules/definitions.ts) |
+| **Pré-requis** | `year >= 2028` (pas envoyé en 2027 — première année V2, pas de cohorte précédente à notifier) |
+
+## Destinataire
+
+`declarations.declarantId → app_user.email` du **cycle Y-1** (le déclarant de l'année précédente).
+
+## Éligibilité (SQL)
+
+```sql
+SELECT d.siren, {year} AS year, u.email, d.declarant_id
+FROM app_declaration d
+JOIN app_user u ON u.id = d.declarant_id
+JOIN app_company c ON c.siren = d.siren
+WHERE d.year = {year - 1}
+  AND d.cancelled_at IS NULL
+  AND d.status IN ('demarche_completed', 'awaiting_cse_opinion')
+  AND c.workforce >= 50
+  AND u.email IS NOT NULL;
+```
+
+## Sujet
+
+```
+Egapro - Ouverture de la période de déclaration des indicateurs Egapro
+```
+
+## Pré-en-tête (preview)
+
+> La période de déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes est désormais ouverte.
+
+## Corps
+
+> **Bonjour,**
+>
+> La période de déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes est désormais ouverte.
+>
+> Conformément à la réglementation, votre entreprise se doit de déclarer les indicateurs relatifs aux écarts de rémunération.
+>
+> Votre déclaration est préremplie avec les données connues de l'administration pour les six premiers indicateurs de rémunération, issues de la DSN.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de vérifier ces informations, de les modifier si nécessaire, et de compléter le 7ᵉ indicateur pour les entreprises concernées.
+>
+> La déclaration est ouverte jusqu'au `1ᵉʳ juin {year}`. Nous vous remercions de bien vouloir la finaliser dans ce délai.
+>
+> [**Commencer ma déclaration**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence Figma
+
+Mock de référence pour les 11 builders : [`9564-114784`](https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=9564-114784).
+
+## Référence flowchart
+
+Code BRD **MA** — apparaît dans les flowcharts 2028, 2029, 2030 (pas 2027).

--- a/docs/mails/declaration-confirmation.md
+++ b/docs/mails/declaration-confirmation.md
@@ -1,0 +1,47 @@
+# `declaration_confirmation` — MD · Confirmation 1ère déclaration
+
+| | |
+|---|---|
+| **Type pg-boss** | `declaration_confirmation` |
+| **Trigger** | Event-driven — mutation tRPC `declaration.submit` ([`declaration.ts:608`](../../packages/app/src/server/api/routers/declaration.ts#L608)) |
+| **Builder** | [`mails/builders/declarationConfirmation.tsx`](../../packages/notifications/src/mails/builders/declarationConfirmation.tsx) |
+| **Pièce jointe** | PDF récapitulatif (généré par `buildDeclarationAttachments` côté app) |
+| **Renvoi manuel** | tRPC `mail.resendReceipt` avec `kind: "declaration"` |
+
+## Destinataire
+
+`session.user.email` — le compte ProConnect qui a déclenché `declaration.submit`.
+
+## Sujet
+
+```
+Egapro - Accusé de réception de votre déclaration des indicateurs
+```
+
+## Pré-en-tête (preview)
+
+> Votre déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes a bien été enregistrée.
+
+## Corps
+
+> **Bonjour,**
+>
+> Votre déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes a bien été enregistrée.
+>
+> Conformément à la réglementation, votre entreprise satisfait à l'obligation annuelle de déclaration des indicateurs relatifs aux écarts de rémunération.
+>
+> Le récapitulatif détaillé de votre déclaration est joint à cet e-mail au format PDF. Il reprend l'ensemble des indicateurs enregistrés ainsi que le niveau de résultat obtenu.
+>
+> Vous pouvez à tout moment consulter ou modifier votre déclaration depuis le portail Egapro.
+>
+> [**Consulter ma déclaration**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Code BRD **MD** sur les flowcharts 2027-2030 — voir [`parcours-utilisateurs.md`](../parcours-utilisateurs.md), section Phase 1 commune (50+).

--- a/docs/mails/declaration-deadline-reminder.md
+++ b/docs/mails/declaration-deadline-reminder.md
@@ -1,0 +1,66 @@
+# `declaration_deadline_reminder` — MR30 / MR10 · Rappel échéance 1ère déclaration
+
+| | |
+|---|---|
+| **Type pg-boss** | `declaration_deadline_reminder` |
+| **Variants** | `daysRemaining: 30` (MR30) · `daysRemaining: 10` (MR10) |
+| **Schedules** | `0 8 2 5 *` (J-30 = 2 mai 08:00) · `0 8 22 5 *` (J-10 = 22 mai 08:00) |
+| **Builder** | [`mails/builders/declarationDeadlineReminder.tsx`](../../packages/notifications/src/mails/builders/declarationDeadlineReminder.tsx) |
+| **Handler éligibilité** | [`findDraftDeclarations`](../../packages/notifications/src/eligibility/queries.ts) |
+| **Deadline référence** | 1ᵉʳ juin Y (`DEADLINES.declarationModification`) |
+
+## Destinataire
+
+`declarations.declarantId → app_user.email` — celui qui a démarré la déclaration mais ne l'a pas encore soumise.
+
+## Éligibilité (SQL)
+
+```sql
+SELECT d.siren, d.year, u.email, d.declarant_id
+FROM app_declaration d
+JOIN app_user u ON u.id = d.declarant_id
+JOIN app_company c ON c.siren = d.siren
+WHERE d.year = {currentYear}
+  AND d.cancelled_at IS NULL
+  AND d.status = 'draft'
+  AND c.workforce >= 50
+  AND u.email IS NOT NULL;
+```
+
+**Dédup** : `(type, siren, year, variant=d30|d10)` — un envoi par variant par déclarant et par cycle.
+
+## Sujet
+
+```
+Egapro - Rappel : votre déclaration des indicateurs est attendue dans {daysRemaining} jours
+```
+
+## Pré-en-tête (preview)
+
+> Il vous reste {daysRemaining} jours pour finaliser votre déclaration des indicateurs.
+
+## Corps
+
+> **Bonjour,**
+>
+> Votre déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes n'a pas encore été finalisée. Il vous reste {daysRemaining} jours pour la déposer.
+>
+> Conformément à la réglementation, votre entreprise est tenue de déclarer chaque année les indicateurs relatifs aux écarts de rémunération.
+>
+> Votre déclaration est préremplie avec les données connues de l'administration pour les six premiers indicateurs de rémunération, issues de la DSN.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de finaliser et publier votre déclaration.
+>
+> La déclaration est ouverte jusqu'au `1ᵉʳ juin {year}`. Au-delà de cette date, elle ne pourra plus être modifiée.
+>
+> [**Reprendre ma déclaration**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Codes BRD **MR30** + **MR10** — Phase 1 commune (50+), tronc commun.

--- a/docs/mails/joint-evaluation-reminder.md
+++ b/docs/mails/joint-evaluation-reminder.md
@@ -1,0 +1,68 @@
+# `joint_evaluation_reminder` — MG_E1 · Rappel dépôt rapport d'évaluation conjointe
+
+| | |
+|---|---|
+| **Type pg-boss** | `joint_evaluation_reminder` |
+| **Schedule** | `0 8 1 8 *` (1ᵉʳ août 08:00) |
+| **Builder** | [`mails/builders/jointEvaluationReminder.tsx`](../../packages/notifications/src/mails/builders/jointEvaluationReminder.tsx) |
+| **Handler éligibilité** | [`findJointEvaluationPending`](../../packages/notifications/src/eligibility/queries.ts) |
+| **Deadline référence** | 1ᵉʳ septembre Y (`DEADLINES.jointEvaluationReport`) |
+| **Pré-requis métier** | Parcours « Évaluation conjointe » (Round 1 ou Round 2 = `corrective → joint_eval`) |
+
+## Destinataire
+
+`declarations.declarantId → app_user.email` — celui qui a choisi le parcours d'évaluation conjointe (lors du round courant).
+
+## Éligibilité (SQL — couvre Round 1 et Round 2)
+
+```sql
+SELECT d.siren, d.year, u.email, d.declarant_id
+FROM app_declaration d
+JOIN app_user u ON u.id = d.declarant_id
+WHERE d.year = {currentYear}
+  AND d.cancelled_at IS NULL
+  AND u.email IS NOT NULL
+  AND COALESCE(d.second_declaration_path_choice, d.first_declaration_path_choice) = 'joint_evaluation'
+  AND NOT EXISTS (
+      SELECT 1 FROM app_file f
+      WHERE f.declaration_id = d.id AND f.type = 'joint_evaluation'
+  );
+```
+
+> **Note** : Le `COALESCE` priorise le choix Round 2 (s'il existe) sur le choix Round 1. Cas typique : Round 1 = `corrective_action` → Round 2 = `joint_evaluation`.
+
+## Sujet
+
+```
+Egapro - Rappel : dépôt du rapport d'évaluation conjointe
+```
+
+## Pré-en-tête (preview)
+
+> Le rapport d'évaluation conjointe avec votre CSE n'a pas encore été téléversé sur la plateforme.
+
+## Corps
+
+> **Bonjour,**
+>
+> Le rapport d'évaluation conjointe mené avec votre CSE n'a pas encore été téléversé sur la plateforme Egapro.
+>
+> Conformément à la réglementation, l'évaluation conjointe doit retracer les mesures correctives décidées en commun avec le CSE pour réduire les écarts de rémunération constatés.
+>
+> Le rapport doit lister précisément ces mesures correctives ainsi que leur calendrier de mise en œuvre.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de téléverser ce rapport.
+>
+> Le dépôt doit intervenir au plus tard le `1ᵉʳ septembre {year}`.
+>
+> [**Téléverser le rapport**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Code BRD **MG_E1** — Phase 2 chemin 4b-E (Évaluation conjointe).

--- a/docs/mails/joint-evaluation-submitted.md
+++ b/docs/mails/joint-evaluation-submitted.md
@@ -1,0 +1,48 @@
+# `joint_evaluation_submitted` — M_PE2 · Confirmation rapport d'évaluation conjointe
+
+| | |
+|---|---|
+| **Type pg-boss** | `joint_evaluation_submitted` |
+| **Trigger** | Event-driven — route handler `POST /api/upload` avec `flowType === "joint_evaluation"` ([`route.ts:256`](../../packages/app/src/app/api/upload/route.ts#L256)) |
+| **Builder** | [`mails/builders/jointEvaluationSubmitted.tsx`](../../packages/notifications/src/mails/builders/jointEvaluationSubmitted.tsx) |
+| **Pièce jointe** | — |
+| **Renvoi manuel** | Non — l'endpoint `mail.resendReceipt` ne couvre que les 3 kinds gérés par `enqueueReceipt`. À renvoyer manuellement via un nouvel upload si besoin. |
+| **Pré-requis métier** | Parcours « Évaluation conjointe » (`first_declaration_path_choice = 'joint_evaluation'`) ou parcours 2e round corrective → joint_evaluation |
+
+## Destinataire
+
+`session.user.email` — le compte ProConnect qui a téléversé le rapport.
+
+## Sujet
+
+```
+Egapro - Réception du rapport d'évaluation conjointe
+```
+
+## Pré-en-tête (preview)
+
+> Le rapport d'évaluation conjointe déposé pour votre entreprise a bien été pris en compte.
+
+## Corps
+
+> **Bonjour,**
+>
+> Le rapport d'évaluation conjointe déposé pour votre entreprise a bien été pris en compte.
+>
+> Conformément à la réglementation, l'évaluation conjointe menée avec le CSE permet de retracer les mesures correctives décidées en commun pour réduire les écarts de rémunération constatés.
+>
+> Prochaine étape : votre CSE doit désormais rendre son avis sur le rapport déposé. Cet avis devra être téléversé sur la plateforme avant la date limite affichée dans votre espace personnel.
+>
+> Vous pouvez à tout moment consulter la suite de votre parcours depuis le portail Egapro.
+>
+> [**Voir la suite du parcours**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Code BRD **M_PE2** — voir [`parcours-utilisateurs.md`](../parcours-utilisateurs.md), Phase 2 chemin 4b-E (Évaluation conjointe).

--- a/docs/mails/next-cycle-handover.md
+++ b/docs/mails/next-cycle-handover.md
@@ -1,0 +1,63 @@
+# `next_cycle_handover` — MI_* · Bascule cycle suivant
+
+| | |
+|---|---|
+| **Type pg-boss** | `next_cycle_handover` |
+| **Schedule** | `0 8 2 3 *` (2 mars N+1 à 08:00, lendemain de la deadline finale) |
+| **Builder** | [`mails/builders/nextCycleHandover.tsx`](../../packages/notifications/src/mails/builders/nextCycleHandover.tsx) |
+| **Handler éligibilité** | [`findCompletedPreviousCycle`](../../packages/notifications/src/eligibility/queries.ts) |
+| **Pré-requis métier** | Déclaration `status = 'demarche_completed'` du cycle Y-1 |
+
+## Destinataire
+
+`declarations.declarantId → app_user.email` du **cycle Y-1**.
+
+## Éligibilité (SQL)
+
+```sql
+SELECT d.siren, d.year, u.email, d.declarant_id
+FROM app_declaration d
+JOIN app_user u ON u.id = d.declarant_id
+WHERE d.year = {previousYear}
+  AND d.cancelled_at IS NULL
+  AND d.status = 'demarche_completed'
+  AND u.email IS NOT NULL;
+```
+
+**Dédup** : clé `(type, siren, year=previousYear)` — la clé porte sur l'année du cycle clôturé, pas sur l'année courante, ce qui évite tout doublon entre deux ticks proches.
+
+## Sujet
+
+```
+Egapro - Clôture de votre déclaration et ouverture du prochain cycle
+```
+
+## Pré-en-tête (preview)
+
+> Votre déclaration {previousYear} est clôturée. La prochaine campagne {nextYear} ouvrira le 1ᵉʳ mars {nextYear}.
+
+## Corps
+
+> **Bonjour,**
+>
+> Votre déclaration des indicateurs au titre de l'année {previousYear} est désormais clôturée.
+>
+> Conformément à la réglementation, votre entreprise est tenue de déclarer chaque année les indicateurs relatifs aux écarts de rémunération.
+>
+> La prochaine campagne, au titre de l'année {nextYear}, sera préremplie avec les données connues de l'administration pour les six premiers indicateurs de rémunération, issues de la DSN.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro dès l'ouverture de la nouvelle campagne pour vérifier ces informations, les modifier si nécessaire, et compléter le 7ᵉ indicateur pour les entreprises concernées.
+>
+> La prochaine campagne ouvrira le `1ᵉʳ mars {nextYear}`.
+>
+> [**Accéder à mon espace**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Code BRD **MI_*** (selon chemin : MI_50 / MI_B / MI_C / MI_J / MI_A / MI_E) — terminal de chaque flowchart annuel.

--- a/docs/mails/second-declaration-confirmation.md
+++ b/docs/mails/second-declaration-confirmation.md
@@ -1,0 +1,48 @@
+# `second_declaration_confirmation` — MSDc · Confirmation 2e déclaration
+
+| | |
+|---|---|
+| **Type pg-boss** | `second_declaration_confirmation` |
+| **Trigger** | Event-driven — mutation tRPC `declaration.submitSecondDeclaration` ([`declaration.ts:747`](../../packages/app/src/server/api/routers/declaration.ts#L747)) |
+| **Builder** | [`mails/builders/secondDeclarationConfirmation.tsx`](../../packages/notifications/src/mails/builders/secondDeclarationConfirmation.tsx) |
+| **Pièce jointe** | PDF récapitulatif de la correction (généré par `buildSecondDeclarationAttachments` côté app) |
+| **Renvoi manuel** | tRPC `mail.resendReceipt` avec `kind: "secondDeclaration"` |
+| **Pré-requis métier** | Parcours « Actions correctives » uniquement (`first_declaration_path_choice = 'corrective_action'`) |
+
+## Destinataire
+
+`session.user.email` — le compte ProConnect qui a déclenché la mutation.
+
+## Sujet
+
+```
+Egapro - Accusé de réception de votre seconde déclaration
+```
+
+## Pré-en-tête (preview)
+
+> Votre seconde déclaration au titre des actions correctives a bien été enregistrée.
+
+## Corps
+
+> **Bonjour,**
+>
+> Votre seconde déclaration au titre des actions correctives a bien été enregistrée.
+>
+> Conformément à la réglementation, dès lors que l'écart de rémunération constaté est supérieur ou égal à 5 %, votre entreprise doit déposer une seconde déclaration retraçant les actions correctives mises en œuvre.
+>
+> Le récapitulatif détaillé de votre seconde déclaration est joint à cet e-mail au format PDF.
+>
+> Vous pouvez à tout moment consulter votre déclaration depuis le portail Egapro.
+>
+> [**Consulter ma déclaration**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Code BRD **MSDc** — voir [`parcours-utilisateurs.md`](../parcours-utilisateurs.md), Phase 2 chemin 4b-A (Actions correctives).

--- a/docs/mails/second-declaration-reminder.md
+++ b/docs/mails/second-declaration-reminder.md
@@ -1,0 +1,67 @@
+# `second_declaration_reminder` — MSD3 / MSD30 · Rappel 2e déclaration
+
+| | |
+|---|---|
+| **Type pg-boss** | `second_declaration_reminder` |
+| **Variants** | `daysRemaining: 90` (MSD3) · `daysRemaining: 30` (MSD30) |
+| **Schedules** | `0 8 3 10 *` (J-90 = 3 octobre 08:00) · `0 8 1 12 *` (J-30 = 1ᵉʳ décembre 08:00) |
+| **Builder** | [`mails/builders/secondDeclarationReminder.tsx`](../../packages/notifications/src/mails/builders/secondDeclarationReminder.tsx) |
+| **Handler éligibilité** | [`findCorrectiveSecondDeclarationPending`](../../packages/notifications/src/eligibility/queries.ts) |
+| **Deadline référence** | 1ᵉʳ janvier N+1 (`DEADLINES.secondDeclaration`) |
+| **Pré-requis métier** | Parcours « Actions correctives » uniquement |
+
+## Destinataire
+
+`declarations.declarantId → app_user.email` — celui qui a choisi le parcours d'actions correctives.
+
+## Éligibilité (SQL)
+
+```sql
+SELECT d.siren, d.year, u.email, d.declarant_id
+FROM app_declaration d
+JOIN app_user u ON u.id = d.declarant_id
+WHERE d.year = {currentYear}
+  AND d.cancelled_at IS NULL
+  AND d.first_declaration_path_choice = 'corrective_action'
+  AND d.status = 'corrective_actions_chosen'
+  AND d.second_declaration_step IS NULL
+  AND u.email IS NOT NULL;
+```
+
+**Dédup** : `(type, siren, year, variant=d90|d30)`.
+
+## Sujet
+
+```
+Egapro - Rappel : votre seconde déclaration est attendue dans {daysRemaining} jours
+```
+
+## Pré-en-tête (preview)
+
+> Il vous reste {daysRemaining} jours pour déposer votre seconde déclaration au titre des actions correctives.
+
+## Corps
+
+> **Bonjour,**
+>
+> Votre seconde déclaration au titre des actions correctives n'a pas encore été déposée. Il vous reste {daysRemaining} jours pour la finaliser.
+>
+> Conformément à la réglementation, vous avez engagé un parcours d'actions correctives à la suite d'un écart de rémunération supérieur ou égal à 5 %.
+>
+> La seconde déclaration doit retracer les actions correctives mises en œuvre par votre entreprise et leur impact sur les écarts constatés.
+>
+> Nous vous invitons à vous rendre sur le portail Egapro afin de déposer votre seconde déclaration.
+>
+> Le dépôt doit intervenir au plus tard le `1ᵉʳ janvier {year+1}`. Sans dépôt avant cette date, votre déclaration sera marquée comme non conforme.
+>
+> [**Déposer ma seconde déclaration**] → `${EGAPRO_PUBLIC_URL}/connexion`
+> `${EGAPRO_PUBLIC_URL}/connexion` *(lien visible sous le bouton, en bleu souligné)*
+>
+> Pour tout renseignement, vous pouvez contacter votre référent égalité professionnelle femmes-hommes au sein de votre DREETS en répondant à ce message.
+>
+> Cordialement,
+> **Le ministère chargé du travail**
+
+## Référence flowchart
+
+Codes BRD **MSD3** + **MSD30** — Phase 2 chemin 4b-A (Actions correctives).

--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -84,19 +84,9 @@ export const env = createEnv({
 			.int()
 			.positive()
 			.default(365),
-		MAIL_ENABLED: z
-			.enum(["true", "false"])
-			.default("false")
-			.transform((v) => v === "true"),
-		SMTP_HOST: z.string().optional().default(""),
-		SMTP_PORT: z.coerce.number().int().positive().default(1025),
-		SMTP_USER: z.string().optional(),
-		SMTP_PASS: z.string().optional(),
-		SMTP_SECURE: z
-			.string()
-			.default("false")
-			.transform((v) => v.toLowerCase() === "true"),
-		MAIL_FROM: z.string().default("no-reply@egapro.local"),
+		// MAIL_*, SMTP_* are intentionally NOT declared here — they are consumed
+		// exclusively by the notifications worker (packages/notifications).
+		// See packages/notifications/README.md for the runtime config surface.
 		// Valkey cache URL — optional. When absent, the custom
 		// cache handler (cache-handler.cjs) gracefully degrades to no-op.
 		// The handler reads process.env.VALKEY_URL directly (it runs outside
@@ -151,13 +141,6 @@ export const env = createEnv({
 			process.env.EGAPRO_AUDIT_RETENTION_SHORT_DAYS,
 		EGAPRO_AUDIT_RETENTION_LONG_DAYS:
 			process.env.EGAPRO_AUDIT_RETENTION_LONG_DAYS,
-		MAIL_ENABLED: process.env.MAIL_ENABLED,
-		SMTP_HOST: process.env.SMTP_HOST,
-		SMTP_PORT: process.env.SMTP_PORT,
-		SMTP_USER: process.env.SMTP_USER,
-		SMTP_PASS: process.env.SMTP_PASS,
-		SMTP_SECURE: process.env.SMTP_SECURE,
-		MAIL_FROM: process.env.MAIL_FROM,
 		VALKEY_URL: process.env.VALKEY_URL,
 		NEXT_PUBLIC_EGAPRO_ENV: process.env.NEXT_PUBLIC_EGAPRO_ENV,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/packages/notifications/.env.example
+++ b/packages/notifications/.env.example
@@ -1,0 +1,38 @@
+# notifications worker — variables d'environnement standalone
+#
+# Utilisé par `pnpm --filter notifications dev|start|smoke` (worker pg-boss qui
+# consomme la queue `email-notification`). Chargé via Node `--env-file-if-exists`
+# (cf. scripts package.json). En production, ces valeurs sont injectées par
+# Kubernetes via le secret `smtp-app` et le service Postgres dédié.
+# Voir `.kontinuous/templates/notifications-deployment.yaml`.
+#
+# Quand l'app appelle `enqueueNotification` (côté packages/app), c'est le
+# fichier `packages/app/.env` qui est chargé — pas celui-ci. Ce fichier
+# n'existe que pour exécuter le worker seul.
+#
+# Pour démarrer le worker en local :
+#   cp packages/notifications/.env.example packages/notifications/.env
+#   docker compose up -d db db-notifications maildev
+#   pnpm --filter notifications dev
+
+# Postgres dédié à pg-boss (queue email-notification, schéma `pgboss`).
+# Fallback : si absent, le worker utilise DATABASE_URL ci-dessous.
+NOTIFICATIONS_DATABASE_URL="postgresql://postgres:postgres@localhost:5439/egapro_notifications"
+
+# Postgres app — utilisé uniquement pour écrire les lignes
+# `audit.action_log` (fan-out audit). Si absent, le worker tourne sans audit.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5438/egapro"
+
+# Envoi SMTP. MAIL_ENABLED=false → mode dry-run (log uniquement, pas d'envoi).
+MAIL_ENABLED="true"
+SMTP_HOST="localhost"
+SMTP_PORT="1025"
+SMTP_SECURE="false"
+# SMTP_USER / SMTP_PASS : optionnels en dev (MailDev n'authentifie pas).
+# Décommenter en preprod / prod (relai Tipimail).
+# SMTP_USER=""
+# SMTP_PASS=""
+MAIL_FROM="no-reply@egapro.local"
+
+# URL publique injectée dans les liens des emails (CTA, footer, fonts Marianne).
+EGAPRO_PUBLIC_URL="http://localhost:3000"

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -141,30 +141,33 @@ pnpm --filter notifications test
 The full source-of-truth flow lives in `docs/parcours-utilisateurs.md`. Mapping
 to current implementation:
 
-| Code | BRD label | Trigger | Status |
+| Code | BRD label | Trigger | Implemented as |
 |---|---|---|---|
-| MD | Confirmation 1ère déclaration | event (`declaration.submit`) | ✅ async via `declaration_confirmation` (PDF attachments rendered by the app, passed as base64 in the queue payload) |
-| MSDc | Confirmation 2e déclaration | event (`declaration.submitSecondDeclaration`) | ✅ async via `second_declaration_confirmation` (same pattern) |
-| MH_* | Confirmation avis CSE | event (file upload `cse_opinion`) | ✅ async via `cse_opinion_receipt` (no attachment) |
-| M_PE2 | Confirmation rapport éval. conjointe | event (file upload `joint_evaluation`) | ✅ async via `joint_evaluation_submitted` (no attachment) |
-| MR30 | Rappel déclaration J-30 (1er mai) | cron annuel | ⏳ infra prête (`scheduledFor`), template + scheduler à implémenter |
-| MR10 | Rappel déclaration J-10 (22 mai) | cron annuel | ⏳ idem |
-| ME | Rappel choix parcours J-15 (avant 1er juillet) | cron, si G≥5% | ⏳ idem |
-| MSD3 | Rappel 2e déclaration J-90 | cron | ⏳ idem |
-| MSD30 | Rappel 2e déclaration J-30 (1er déc) | cron | ⏳ idem |
-| MG_E1 | Rappel dépôt éval. conjointe (1er août) | cron | ⏳ idem |
-| MG_J1 | Rappel avis CSE — Justifier (avant 1er oct) | cron | ⏳ idem |
-| MG_J2 | Rappel avis CSE 1er déc (Justifier) | cron | ⏳ idem |
-| MG_E2 | Rappel avis CSE 1er déc (Éval. conjointe) | cron | ⏳ idem |
-| MG_A | Rappel avis CSE (Actions correctives) | cron | ⏳ idem |
-| MG_B/C | Rappel avis CSE (exactitude) | cron | ⏳ idem |
-| MA | Info ouverture cycle (1er mars, dès 2028) | cron annuel | ⏳ idem |
-| MI_* | Bascule cycle suivant | cron annuel | ⏳ idem |
+| MD | Confirmation 1ère déclaration | event (`declaration.submit`) | `declaration_confirmation` (PDF attachment via base64 in the queue payload) |
+| MSDc | Confirmation 2e déclaration | event (`declaration.submitSecondDeclaration`) | `second_declaration_confirmation` |
+| MH_* | Confirmation avis CSE | event (file upload `cse_opinion`) | `cse_opinion_receipt` |
+| M_PE2 | Confirmation rapport éval. conjointe | event (file upload `joint_evaluation`) | `joint_evaluation_submitted` |
+| MA | Info ouverture cycle (1er mars, dès 2028) | cron `0 8 1 3 *` | `cycle_opening_info` |
+| MR30 | Rappel déclaration J-30 (1er mai) | cron `0 8 2 5 *` | `declaration_deadline_reminder` (variant `d30`) |
+| MR10 | Rappel déclaration J-10 (22 mai) | cron `0 8 22 5 *` | `declaration_deadline_reminder` (variant `d10`) |
+| ME | Rappel choix parcours J-15 (avant 1er juillet) | cron `0 8 16 6 *` | `compliance_path_choice_reminder` (covers round 1 + round 2 revisions) |
+| MSD3 | Rappel 2e déclaration J-90 | cron `0 8 3 10 *` | `second_declaration_reminder` (variant `d90`) |
+| MSD30 | Rappel 2e déclaration J-30 (1er déc) | cron `0 8 1 12 *` | `second_declaration_reminder` (variant `d30`) |
+| MG_E1 | Rappel dépôt éval. conjointe (1er août) | cron `0 8 1 8 *` | `joint_evaluation_reminder` (covers round 1 + round 2 = `corrective → joint_eval`) |
+| MG_J1 | Rappel avis CSE — Justifier (avant 1er oct) | cron `0 8 1 9 *` | `cse_opinion_reminder` variant `justify_oct` |
+| MG_J2 | Rappel avis CSE 1er déc (Justifier) | cron `0 8 1 12 *` | `cse_opinion_reminder` variant `justify_dec` |
+| MG_E2 | Rappel avis CSE 1er déc (Éval. conjointe) | cron `0 8 1 12 *` | `cse_opinion_reminder` variant `joint_eval` |
+| MG_A | Rappel avis CSE (Actions correctives) | cron `0 8 1 2 *` | `cse_opinion_reminder` variant `corrective` |
+| MG_B/C | Rappel avis CSE (exactitude) | cron `0 8 1 2 *` | `cse_opinion_reminder` variant `compliance` |
+| MI_* | Bascule cycle suivant | cron `0 8 2 3 *` | `next_cycle_handover` |
 
 **Couverture événementielle : 4/4** (les 4 confirmations event-driven du
-schéma BRD). **Couverture rappels/cron : 0/13** — l'infra pg-boss +
-`enqueueNotification({ scheduledFor })` supportent `startAfter`, ce qui sera
-exploité par les futurs CronJobs.
+schéma BRD). **Couverture rappels/cron : 13/13** — implémentés via 7 builders
+schedule-driven et 13 schedules pg-boss (tous en `tz=Europe/Paris`), avec
+déduplication par `notifications.reminder_sent_log` (UNIQUE
+`type/siren/year/variant`) qui garantit l'idempotence des ticks. Voir
+[`docs/mails.md`](../../docs/mails.md) pour le détail des éligibilités SQL,
+des variants, et de l'architecture.
 
 ## Adding a new notification type
 

--- a/packages/notifications/scripts/smoke.ts
+++ b/packages/notifications/scripts/smoke.ts
@@ -1,0 +1,131 @@
+/**
+ * Smoke test — render the 11 mail builders and ship each one to MailDev.
+ *
+ * Use case: after a copy/template change, open MailDev's web UI side-by-side
+ * with the Figma source of truth (node `9564-114784`) to spot any regression.
+ *
+ * Prereqs:
+ *   docker compose up -d maildev
+ *   pnpm --filter notifications smoke
+ *
+ * Defaults (override via env vars):
+ *   SMTP_HOST=localhost
+ *   SMTP_PORT=1025
+ *   MAIL_FROM=no-reply@egapro.local
+ *   SMOKE_TO=smoke-test@example.org
+ *   EGAPRO_PUBLIC_URL=http://localhost:3000
+ *   SMOKE_TYPE=<single notification type to send instead of all 11>
+ *
+ * Open the rendered mails: http://localhost:1080
+ *
+ * Cleanup after smoking:
+ *   - MailDev clears itself on container restart (volatile by design)
+ *   - This script is git-tracked (devTooling, not test fixture)
+ */
+
+import nodemailer from "nodemailer";
+import { buildMail } from "../src/mails/index.js";
+import {
+	NOTIFICATION_TYPES,
+	type NotificationPayloadMap,
+	type NotificationType,
+} from "../src/mails/types.js";
+
+const SIREN = "552100554";
+const YEAR = 2027;
+const DEADLINE = "2027-06-01T00:00:00.000Z";
+
+const PAYLOADS: NotificationPayloadMap = {
+	declaration_confirmation: { siren: SIREN, year: YEAR },
+	second_declaration_confirmation: { siren: SIREN, year: YEAR },
+	cse_opinion_receipt: { siren: SIREN, year: YEAR },
+	joint_evaluation_submitted: { siren: SIREN, year: YEAR },
+	cycle_opening_info: { siren: SIREN, year: YEAR, deadline: DEADLINE },
+	declaration_deadline_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: DEADLINE,
+		daysRemaining: 30,
+	},
+	compliance_path_choice_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-07-01T00:00:00.000Z",
+	},
+	second_declaration_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-01-01T00:00:00.000Z",
+		daysRemaining: 90,
+	},
+	joint_evaluation_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-09-01T00:00:00.000Z",
+	},
+	cse_opinion_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-03-01T00:00:00.000Z",
+		variant: "compliance",
+	},
+	next_cycle_handover: {
+		siren: SIREN,
+		previousYear: YEAR,
+		nextYear: YEAR + 1,
+	},
+};
+
+const HOST = process.env.SMTP_HOST ?? "localhost";
+const PORT = Number.parseInt(process.env.SMTP_PORT ?? "1025", 10);
+const FROM = process.env.MAIL_FROM ?? "no-reply@egapro.local";
+const TO = process.env.SMOKE_TO ?? "smoke-test@example.org";
+
+function isNotificationType(value: string): value is NotificationType {
+	return (NOTIFICATION_TYPES as readonly string[]).includes(value);
+}
+
+async function sendOne<T extends NotificationType>(
+	transporter: nodemailer.Transporter,
+	type: T,
+): Promise<void> {
+	const payload = PAYLOADS[type];
+	const { subject, html, text } = await buildMail(type, payload);
+	await transporter.sendMail({ from: FROM, to: TO, subject, html, text });
+	console.log(`  ✔ ${type.padEnd(36)} subject="${subject}"`);
+}
+
+async function main(): Promise<void> {
+	const requested = process.env.SMOKE_TYPE;
+	const types: readonly NotificationType[] = requested
+		? (() => {
+				if (!isNotificationType(requested)) {
+					throw new Error(
+						`SMOKE_TYPE="${requested}" is not a valid notification type. Pick one of: ${NOTIFICATION_TYPES.join(", ")}`,
+					);
+				}
+				return [requested];
+			})()
+		: NOTIFICATION_TYPES;
+
+	console.log(`Connecting to MailDev on smtp://${HOST}:${PORT} …`);
+	const transporter = nodemailer.createTransport({
+		host: HOST,
+		port: PORT,
+		secure: false,
+	});
+
+	console.log(`Sending ${types.length} mail(s) to ${TO}:`);
+	for (const type of types) {
+		await sendOne(transporter, type);
+	}
+	transporter.close();
+
+	console.log("\nDone. Inspect the rendered HTML in MailDev:");
+	console.log("  http://localhost:1080");
+}
+
+main().catch((error: unknown) => {
+	console.error("[smoke] failed:", error);
+	process.exit(1);
+});

--- a/packages/notifications/src/__tests__/queue.test.ts
+++ b/packages/notifications/src/__tests__/queue.test.ts
@@ -51,8 +51,7 @@ describe("validateJobData", () => {
 	it("rejects a payload missing siren/year", () => {
 		const result = validateJobData({ ...VALID, payload: { foo: "bar" } });
 		expect(result.ok).toBe(false);
-		if (!result.ok)
-			expect(result.reason).toContain("payload is missing required fields");
+		if (!result.ok) expect(result.reason).toContain("siren");
 	});
 
 	it("accepts a well-formed attachments array", () => {

--- a/packages/notifications/src/eligibility/client.ts
+++ b/packages/notifications/src/eligibility/client.ts
@@ -1,0 +1,26 @@
+import postgres, { type Sql } from "postgres";
+import { resolvePgUrl } from "../db.js";
+
+let cached: Sql | null = null;
+
+// Read-only access to the app DB. Used by schedule handlers to find
+// eligible recipients for time-driven reminders, and to record dedup rows
+// in the `notifications.reminder_sent_log` table.
+export function getAppDbSql(): Sql | null {
+	if (cached) return cached;
+	const url = resolvePgUrl(process.env.DATABASE_URL, "");
+	if (!url) return null;
+	cached = postgres(url, { max: 2 });
+	return cached;
+}
+
+export async function closeAppDbSql(): Promise<void> {
+	if (cached) {
+		await cached.end({ timeout: 5 });
+		cached = null;
+	}
+}
+
+export function __resetAppDbSqlForTests(): void {
+	cached = null;
+}

--- a/packages/notifications/src/eligibility/dedup.ts
+++ b/packages/notifications/src/eligibility/dedup.ts
@@ -1,0 +1,74 @@
+import type { Sql } from "postgres";
+
+// Idempotence guard for cron-triggered reminders.
+//
+// Each schedule tick scans the app DB and enqueues a job for every eligible
+// recipient. Without dedup, two ticks in the same cycle (worker restart,
+// clock skew, duplicate cron firing) would re-send the same reminder.
+//
+// `(type, siren, year, variant)` is the natural identity of a reminder.
+// `variant` is the empty string `""` for types that don't carry one — keeps
+// the UNIQUE constraint simple (no NULL handling).
+
+let migrated = false;
+
+export async function ensureDedupTable(sql: Sql): Promise<void> {
+	if (migrated) return;
+	await sql.unsafe(`
+		CREATE SCHEMA IF NOT EXISTS notifications;
+		CREATE TABLE IF NOT EXISTS notifications.reminder_sent_log (
+			type text NOT NULL,
+			siren text NOT NULL,
+			year integer NOT NULL,
+			variant text NOT NULL DEFAULT '',
+			sent_at timestamptz NOT NULL DEFAULT now(),
+			UNIQUE (type, siren, year, variant)
+		);
+		CREATE INDEX IF NOT EXISTS reminder_sent_log_lookup_idx
+			ON notifications.reminder_sent_log (type, year);
+	`);
+	migrated = true;
+}
+
+export async function wasSent(
+	sql: Sql,
+	params: {
+		type: string;
+		siren: string;
+		year: number;
+		variant?: string;
+	},
+): Promise<boolean> {
+	const variant = params.variant ?? "";
+	const rows = await sql<{ count: number }[]>`
+		SELECT 1 AS count
+		FROM notifications.reminder_sent_log
+		WHERE type = ${params.type}
+			AND siren = ${params.siren}
+			AND year = ${params.year}
+			AND variant = ${variant}
+		LIMIT 1
+	`;
+	return rows.length > 0;
+}
+
+export async function markSent(
+	sql: Sql,
+	params: {
+		type: string;
+		siren: string;
+		year: number;
+		variant?: string;
+	},
+): Promise<void> {
+	const variant = params.variant ?? "";
+	await sql`
+		INSERT INTO notifications.reminder_sent_log (type, siren, year, variant)
+		VALUES (${params.type}, ${params.siren}, ${params.year}, ${variant})
+		ON CONFLICT (type, siren, year, variant) DO NOTHING
+	`;
+}
+
+export function __resetDedupForTests(): void {
+	migrated = false;
+}

--- a/packages/notifications/src/eligibility/index.ts
+++ b/packages/notifications/src/eligibility/index.ts
@@ -1,0 +1,21 @@
+export {
+	__resetAppDbSqlForTests,
+	closeAppDbSql,
+	getAppDbSql,
+} from "./client.js";
+export {
+	__resetDedupForTests,
+	ensureDedupTable,
+	markSent,
+	wasSent,
+} from "./dedup.js";
+export {
+	findAwaitingComplianceChoice,
+	findCompletedPreviousCycle,
+	findCorrectiveSecondDeclarationPending,
+	findCseOpinionPending,
+	findDraftDeclarations,
+	findJointEvaluationPending,
+	findOpenCycleRecipients,
+	type ReminderRecipient,
+} from "./queries.js";

--- a/packages/notifications/src/eligibility/queries.ts
+++ b/packages/notifications/src/eligibility/queries.ts
@@ -1,0 +1,262 @@
+import type { Sql } from "postgres";
+import type { CseOpinionReminderVariant } from "../mails/types.js";
+
+// Eligibility queries against the app DB.
+//
+// Tables follow the Drizzle multi-project prefix `app_*`. All queries
+// return `(siren, year, email, userId)` so the caller knows where to send
+// the reminder. The recipient is always the most recent declarant for the
+// company (deterministic, single mail per company per reminder).
+
+export type ReminderRecipient = {
+	siren: string;
+	year: number;
+	email: string;
+	userId: string;
+};
+
+// 1. Cycle opening (1er mars Y, Y >= 2028): recipients with a completed
+// previous cycle. We notify the past declarant of cycle Y-1.
+export async function findOpenCycleRecipients(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	const previousYear = year - 1;
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			${year}::int AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		JOIN app_company c ON c.siren = d.siren
+		WHERE d.year = ${previousYear}
+			AND d.cancelled_at IS NULL
+			AND d.status IN ('demarche_completed', 'awaiting_cse_opinion')
+			AND c.workforce >= 50
+			AND u.email IS NOT NULL
+	`;
+}
+
+// 2. Declaration deadline reminder (J-30 / J-10 before 1er juin):
+// declarations still in draft for the current campaign year.
+export async function findDraftDeclarations(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		JOIN app_company c ON c.siren = d.siren
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND d.status = 'draft'
+			AND c.workforce >= 50
+			AND u.email IS NOT NULL
+	`;
+}
+
+// 3. Compliance path choice reminder (J-15 before 1er juillet):
+// declarations submitted with gap >= 5% awaiting the user's compliance
+// decision. Covers two rounds:
+//  - Round 1: status='awaiting_compliance_path_choice' + first choice NULL
+//  - Round 2: status='awaiting_revision_choice' (after second declaration
+//    with persistent gap) + second choice NULL. In round 2 the *first*
+//    choice is already set to 'corrective_action', so filtering on it
+//    would silently exclude every round-2 recipient.
+export async function findAwaitingComplianceChoice(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND u.email IS NOT NULL
+			AND (
+				(d.status = 'awaiting_compliance_path_choice' AND d.first_declaration_path_choice IS NULL)
+				OR
+				(d.status = 'awaiting_revision_choice' AND d.second_declaration_path_choice IS NULL)
+			)
+	`;
+}
+
+// 4. Second declaration reminder (J-90 / J-30 before 1er janvier N+1):
+// declarations on the corrective-actions track that have not yet submitted
+// their second declaration. `secondDeclarationStep` is null until the
+// second declaration is submitted (then set to 3, see declaration.ts).
+export async function findCorrectiveSecondDeclarationPending(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND d.first_declaration_path_choice = 'corrective_action'
+			AND d.status = 'corrective_actions_chosen'
+			AND d.second_declaration_step IS NULL
+			AND u.email IS NOT NULL
+	`;
+}
+
+// 5. Joint evaluation reminder (1er août): declarations on the
+// joint-evaluation track without an uploaded joint_evaluation file.
+// `secondDeclarationPathChoice` takes precedence over `first*` once the
+// user re-chose at Round 2 (corrective Round 1 → joint_evaluation Round 2).
+export async function findJointEvaluationPending(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND u.email IS NOT NULL
+			AND COALESCE(d.second_declaration_path_choice, d.first_declaration_path_choice) = 'joint_evaluation'
+			AND NOT EXISTS (
+				SELECT 1
+				FROM app_file f
+				WHERE f.declaration_id = d.id
+					AND f.type = 'joint_evaluation'
+			)
+	`;
+}
+
+// 6. CSE opinion reminder — one variant per flowchart branch.
+//
+// All variants share the base eligibility:
+//   - declaration is active (not cancelled),
+//   - company is CSE-required (`cse_required = true`),
+//   - no CSE opinion has been deposited yet (NOT EXISTS in app_cse_opinion).
+//
+// Per-variant filters (derived from `docs/parcours-utilisateurs.md`):
+//   - compliance (MG_B / MG_C): no Phase 2 path chosen — covers the
+//     "100-149 sans 7e" branch (C2) and the "150+ conforme G<5%" branch
+//     (4a). Both go straight from Phase 1 submission to CSE deposit.
+//   - justify_oct (MG_J1) + justify_dec (MG_J2): one of the two path
+//     choices is `justify`. Same SQL filter, different cron.
+//   - corrective (MG_A): first-round path is `corrective_action`, the
+//     second declaration has been submitted (status = 'awaiting_cse_opinion')
+//     — without this status filter we would also trigger MG_A for
+//     declarations that haven't completed their second declaration yet.
+//   - joint_eval (MG_E2): one of the path choices is `joint_evaluation`
+//     AND the joint-eval report has been uploaded (else the FSM is still
+//     awaiting the report, not the CSE opinion).
+export async function findCseOpinionPending(
+	sql: Sql,
+	year: number,
+	variant: CseOpinionReminderVariant,
+): Promise<ReminderRecipient[]> {
+	const baseConditions = sql`
+		d.year = ${year}
+		AND d.cancelled_at IS NULL
+		AND d.cse_required = true
+		AND u.email IS NOT NULL
+		AND NOT EXISTS (
+			SELECT 1 FROM app_cse_opinion o WHERE o.declaration_id = d.id
+		)
+	`;
+	const variantFilter = buildCseOpinionVariantFilter(sql, variant);
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE ${baseConditions} AND (${variantFilter})
+	`;
+}
+
+function buildCseOpinionVariantFilter(
+	sql: Sql,
+	variant: CseOpinionReminderVariant,
+) {
+	switch (variant) {
+		// MG_B / MG_C — entreprise sans parcours Phase 2 (100-149 sans 7e ind,
+		// ou 150+ conforme G < 5 %). Neither round has chosen a compliance path.
+		case "compliance":
+			return sql`
+				d.first_declaration_path_choice IS NULL
+				AND d.second_declaration_path_choice IS NULL
+			`;
+		// MG_J1 / MG_J2 — parcours Justifier (Round 1 ou Round 2). Same filter,
+		// cron picks the timing (1er sept = J-30 / 1er déc = relance).
+		case "justify_oct":
+		case "justify_dec":
+			return sql`
+				d.first_declaration_path_choice = 'justify'
+				OR d.second_declaration_path_choice = 'justify'
+			`;
+		// MG_A — Actions correctives, 2e déclaration soumise et écarts corrigés.
+		// The FSM transitions to 'awaiting_cse_opinion' once the second
+		// declaration lands and the gap is back below 5 %.
+		case "corrective":
+			return sql`
+				d.first_declaration_path_choice = 'corrective_action'
+				AND d.status = 'awaiting_cse_opinion'
+			`;
+		// MG_E2 — Évaluation conjointe, rapport déposé. Without the file
+		// check, the FSM is still waiting for the report (M_PE2 trigger),
+		// not the CSE opinion.
+		case "joint_eval":
+			return sql`
+				(
+					d.first_declaration_path_choice  = 'joint_evaluation'
+					OR d.second_declaration_path_choice = 'joint_evaluation'
+				)
+				AND EXISTS (
+					SELECT 1 FROM app_file f
+					WHERE f.declaration_id = d.id AND f.type = 'joint_evaluation'
+				)
+			`;
+	}
+}
+
+// 7. Next cycle handover (2 mars N+1): companies whose previous cycle is
+// closed (status = demarche_completed). The recipient is the declarant of
+// that cycle.
+export async function findCompletedPreviousCycle(
+	sql: Sql,
+	previousYear: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${previousYear}
+			AND d.cancelled_at IS NULL
+			AND d.status = 'demarche_completed'
+			AND u.email IS NOT NULL
+	`;
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,206 +1,102 @@
-import nodemailer, { type Transporter } from "nodemailer";
-import { PgBoss, type JobWithMetadata } from "pg-boss";
+import { type JobWithMetadata, PgBoss } from "pg-boss";
 import postgres, { type Sql } from "postgres";
 
 import { resolveNotificationsDbUrl, resolvePgUrl } from "./db.js";
 import { buildMail, MAIL_BUILDERS } from "./mails/index.js";
 import { QUEUE_NAME, validateJobData } from "./queue.js";
-
-type SerializableJson =
-	| null
-	| string
-	| number
-	| boolean
-	| Date
-	| { [key: string]: SerializableJson }
-	| SerializableJson[];
+import { registerSchedules, SCHEDULES } from "./schedules/index.js";
+import { logAuditMain } from "./worker/auditLog.js";
+import { makeJobHandler } from "./worker/jobHandler.js";
+import { installShutdownHooks } from "./worker/lifecycle.js";
+import { buildTransporter, getMailEnabled } from "./worker/transporter.js";
 
 /**
  * Notifications worker — long-running pg-boss consumer.
  *
- * Connects to NOTIFICATIONS_DATABASE_URL (pg-boss schema, isolated from the
- * main app DB by design) and processes `email-notification` jobs published
- * by the app's `enqueueNotification` helper. Lives in its own workspace
- * (`packages/notifications/`) so the Next.js bundle never imports a single
- * line of worker code.
+ * Two job sources:
+ * 1. **Event-driven** — the app's `enqueueNotification` helper pushes
+ *    `email-notification` jobs on the `QUEUE_NAME` queue, processed by
+ *    `makeJobHandler` (validates payload, renders the React Email
+ *    template, sends via SMTP, audits success/failure).
+ * 2. **Schedule-driven** — pg-boss native `boss.schedule()` ticks N
+ *    reminder queues at their cron schedule. Each tick runs the matching
+ *    handler which queries the app DB for eligible recipients and
+ *    re-enqueues a normal `email-notification` job per recipient.
  *
- * Job lifecycle:
- * - `validateJobData` runs first. Schema errors are *poison pills* — they can
- *   never succeed, so the handler logs the failure and returns clean (marking
- *   the job complete) rather than throwing. Throwing would trigger up to 5
- *   retries for nothing.
- * - SMTP / transient errors throw, so pg-boss retries them according to the
- *   per-job retry policy (`retryLimit`, `retryBackoff`) set at publish time.
+ * Lives in its own workspace (`packages/notifications/`) so the Next.js
+ * bundle never imports a single line of worker code.
  *
- * Audit rows go to the main DB (`DATABASE_URL`) when available — failure to
- * log audit never aborts the send. When `DATABASE_URL` is absent the worker
- * still runs, it just stops emitting `audit.action_log` rows.
+ * Job lifecycle (event queue):
+ * - `validateJobData` runs first. Schema errors are *poison pills* — they
+ *   can never succeed, so the handler logs the failure and returns clean
+ *   (marking the job complete) rather than throwing.
+ * - SMTP / transient errors throw, so pg-boss retries them according to
+ *   the per-job retry policy.
  *
- * Sub-second graceful shutdown via SIGTERM/SIGINT (call `boss.stop()` then
- * exit). pg-boss flushes in-flight jobs and ACKs them so the next pod start
- * resumes cleanly.
+ * Audit rows go to the main DB (`DATABASE_URL`) when available. Failure to
+ * log audit never aborts the send. When `DATABASE_URL` is absent the
+ * worker still runs the event queue, but reminders are disabled (the
+ * eligibility queries need the app DB).
  */
 
-export { MAIL_BUILDERS, buildMail };
-export { QUEUE_NAME, validateJobData };
 export type { EmailJobData } from "./queue.js";
-
-const SEND_AUDIT_ACTION = "notification.send";
-const SEND_AUDIT_CATEGORY = "system";
-
-type AuditRow = {
-	action: string;
-	category: string;
-	status: "success" | "failure";
-	userId?: string | null;
-	userEmail?: string | null;
-	siren?: string | null;
-	resourceType?: string | null;
-	resourceId?: string | null;
-	errorMessage?: string | null;
-	metadata?: SerializableJson;
+export {
+	buildMail,
+	logAuditMain,
+	MAIL_BUILDERS,
+	makeJobHandler,
+	QUEUE_NAME,
+	SCHEDULES,
+	validateJobData,
 };
 
-function getMailEnabled(): boolean {
-	return (process.env.MAIL_ENABLED ?? "false").toLowerCase() === "true";
-}
+const BOOT_MAX_ATTEMPTS = Number.parseInt(
+	process.env.NOTIFICATIONS_BOOT_RETRY_MAX ?? "30",
+	10,
+);
+const BOOT_DELAY_MS = Number.parseInt(
+	process.env.NOTIFICATIONS_BOOT_RETRY_DELAY_MS ?? "5000",
+	10,
+);
 
-function buildTransporter(): Transporter {
-	const host = process.env.SMTP_HOST;
-	if (!host) {
-		throw new Error("SMTP_HOST must be set when MAIL_ENABLED=true");
-	}
-	const port = parseInt(process.env.SMTP_PORT ?? "1025", 10);
-	const secure = (process.env.SMTP_SECURE ?? "false").toLowerCase() === "true";
-	const auth =
-		process.env.SMTP_USER && process.env.SMTP_PASS
-			? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
-			: undefined;
-	return nodemailer.createTransport({ host, port, secure, auth });
-}
-
-async function logAuditMain(mainSql: Sql | null, row: AuditRow): Promise<void> {
-	if (!mainSql) return;
-	try {
-		await mainSql`
-			INSERT INTO audit.action_log (
-				id, created_at, action, category, status,
-				user_id, user_email, siren, resource_type, resource_id,
-				error_message, metadata
-			)
-			VALUES (
-				${crypto.randomUUID()},
-				${new Date()},
-				${row.action},
-				${row.category},
-				${row.status},
-				${row.userId ?? null},
-				${row.userEmail ?? null},
-				${row.siren ?? null},
-				${row.resourceType ?? null},
-				${row.resourceId ?? null},
-				${row.errorMessage ?? null},
-				${mainSql.json(row.metadata ?? null)}
-			)
-		`;
-	} catch (auditError) {
-		console.error("[notifications] audit insert failed:", auditError);
-	}
-}
-
-export type JobHandlerDeps = {
-	transporter: Transporter | null;
-	mailFrom: string;
-	mailEnabled: boolean;
-	mainSql: Sql | null;
-};
-
-export function makeJobHandler(
-	deps: JobHandlerDeps,
-): (job: JobWithMetadata<unknown>) => Promise<void> {
-	const { transporter, mailFrom, mailEnabled, mainSql } = deps;
-	return async (job) => {
-		const attempt = (job.retryCount ?? 0) + 1;
-		const result = validateJobData(job.data);
-
-		if (!result.ok) {
-			// Poison pill: malformed payload can never succeed. Log + return clean
-			// so pg-boss marks the job complete and stops retrying.
-			console.error(
-				`[notifications] dropping malformed job ${job.id}: ${result.reason}`,
-			);
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "failure",
-				resourceType: "notification",
-				resourceId: job.id,
-				errorMessage: result.reason,
-				metadata: { attempt, poisonPill: true },
-			});
-			return;
-		}
-
-		const {
-			type,
-			payload,
-			recipientEmail,
-			recipientUserId,
-			siren,
-			attachments,
-		} = result.data;
-
+// On a fresh review app, pg-app may not accept connections yet when the
+// notifications pod starts. Without a wait, pg-boss throws, the worker exits
+// non-zero, and the kontinuous `deploy-sidecars/progressing` plugin gives up
+// after the very first crash. Ping the DB with a lightweight `SELECT 1` loop
+// before handing the connection string to pg-boss — once the server answers
+// we know `boss.start()` + `createQueue` + `work` + `schedule` will all hit a
+// live socket, so the entire boot sequence runs in a single shot.
+async function waitForDatabase(connectionString: string): Promise<void> {
+	for (let attempt = 1; attempt <= BOOT_MAX_ATTEMPTS; attempt++) {
+		// `ssl: 'prefer'` lets postgres.js handshake with both plain (review-app
+		// docker postgres) and self-signed TLS (in-cluster pg-rw) backends, since
+		// `sslmode=no-verify` from db.ts is a node-postgres extension and not
+		// recognised by postgres.js.
+		const probe = postgres(connectionString, {
+			max: 1,
+			connect_timeout: 5,
+			idle_timeout: 1,
+			ssl: "prefer",
+		});
 		try {
-			const { subject, html, text } = await buildMail(type, payload);
-			let messageId: string | null = null;
-			if (!mailEnabled || !transporter) {
+			await probe`select 1`;
+			await probe.end({ timeout: 1 });
+			if (attempt > 1) {
 				console.log(
-					`[notifications] MAIL_ENABLED=false — would send ${type} to ${recipientEmail}`,
+					`[notifications] database reachable after ${attempt} attempts`,
 				);
-			} else {
-				const decodedAttachments = attachments?.map((att) => ({
-					filename: att.filename,
-					content: Buffer.from(att.contentBase64, "base64"),
-					contentType: att.contentType,
-				}));
-				const info = await transporter.sendMail({
-					from: mailFrom,
-					to: recipientEmail,
-					subject,
-					text,
-					html,
-					...(decodedAttachments ? { attachments: decodedAttachments } : {}),
-				});
-				messageId = info.messageId ?? null;
 			}
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "success",
-				userId: recipientUserId,
-				userEmail: recipientEmail,
-				siren,
-				resourceType: "notification",
-				resourceId: job.id,
-				metadata: { type, attempt, messageId },
-			});
+			return;
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "failure",
-				userId: recipientUserId,
-				userEmail: recipientEmail,
-				siren,
-				resourceType: "notification",
-				resourceId: job.id,
-				errorMessage: message,
-				metadata: { type, attempt },
-			});
-			throw error;
+			await probe.end({ timeout: 1 }).catch(() => undefined);
+			if (attempt === BOOT_MAX_ATTEMPTS) throw error;
+			const reason = error instanceof Error ? error.message : String(error);
+			console.warn(
+				`[notifications] database not reachable (attempt ${attempt}/${BOOT_MAX_ATTEMPTS}): ${reason} — retrying in ${BOOT_DELAY_MS}ms`,
+			);
+			await new Promise((resolve) => setTimeout(resolve, BOOT_DELAY_MS));
 		}
-	};
+	}
 }
 
 async function main(): Promise<void> {
@@ -215,7 +111,9 @@ async function main(): Promise<void> {
 	const transporter = mailEnabled ? buildTransporter() : null;
 	const mailFrom = process.env.MAIL_FROM ?? "no-reply@egapro.local";
 
-	const mainSql: Sql | null = mainUrl ? postgres(mainUrl, { max: 1 }) : null;
+	const mainSql: Sql | null = mainUrl ? postgres(mainUrl, { max: 2 }) : null;
+
+	await waitForDatabase(notifUrl);
 
 	const boss = new PgBoss({
 		connectionString: notifUrl,
@@ -255,22 +153,9 @@ async function main(): Promise<void> {
 		},
 	);
 
-	const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
-		console.log(`[notifications] received ${signal}, shutting down...`);
-		try {
-			await boss.stop({ graceful: true, timeout: 15_000 });
-			if (mainSql) await mainSql.end();
-		} catch (error) {
-			console.error("[notifications] shutdown error:", error);
-		}
-		process.exit(0);
-	};
-	process.on("SIGTERM", () => {
-		void shutdown("SIGTERM");
-	});
-	process.on("SIGINT", () => {
-		void shutdown("SIGINT");
-	});
+	await registerSchedules(boss, mainSql);
+
+	installShutdownHooks({ boss, mainSql });
 }
 
 const isCli = (() => {

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -11,12 +11,47 @@ import {
 
 const SIREN = "552100554";
 const YEAR = 2027;
+const DEADLINE = "2027-06-01T00:00:00.000Z";
 
 const PAYLOADS: NotificationPayloadMap = {
 	declaration_confirmation: { siren: SIREN, year: YEAR },
 	second_declaration_confirmation: { siren: SIREN, year: YEAR },
 	cse_opinion_receipt: { siren: SIREN, year: YEAR },
 	joint_evaluation_submitted: { siren: SIREN, year: YEAR },
+	cycle_opening_info: { siren: SIREN, year: YEAR, deadline: DEADLINE },
+	declaration_deadline_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: DEADLINE,
+		daysRemaining: 30,
+	},
+	compliance_path_choice_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-07-01T00:00:00.000Z",
+	},
+	second_declaration_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-01-01T00:00:00.000Z",
+		daysRemaining: 90,
+	},
+	joint_evaluation_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-09-01T00:00:00.000Z",
+	},
+	cse_opinion_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-03-01T00:00:00.000Z",
+		variant: "compliance",
+	},
+	next_cycle_handover: {
+		siren: SIREN,
+		previousYear: YEAR,
+		nextYear: YEAR + 1,
+	},
 };
 
 describe("mail registry", () => {
@@ -108,6 +143,95 @@ describe("per-type rendering details", () => {
 		expect(mail.subject).toContain("évaluation conjointe");
 		expect(mail.html.toLowerCase()).toContain("évaluation conjointe");
 		expect(mail.html).toContain("Prochaine étape");
+	});
+
+	it("cycle_opening_info announces the declaration period", async () => {
+		const mail = await buildMail("cycle_opening_info", {
+			siren: SIREN,
+			year: YEAR,
+			deadline: DEADLINE,
+		});
+		expect(mail.subject).toBe(
+			"Egapro - Ouverture de la période de déclaration des indicateurs Egapro",
+		);
+		expect(mail.html.toLowerCase()).toContain("1ᵉʳ juin");
+		expect(mail.html).toContain("/connexion");
+	});
+
+	it.each([
+		30, 10,
+	] as const)("declaration_deadline_reminder J-%i exposes the count", async (daysRemaining) => {
+		const mail = await buildMail("declaration_deadline_reminder", {
+			siren: SIREN,
+			year: YEAR,
+			deadline: DEADLINE,
+			daysRemaining,
+		});
+		expect(mail.subject).toContain(`${daysRemaining} jours`);
+		expect(mail.html).toContain(`${daysRemaining} jours`);
+	});
+
+	it("compliance_path_choice_reminder names the 5 % threshold", async () => {
+		const mail = await buildMail("compliance_path_choice_reminder", {
+			siren: SIREN,
+			year: YEAR,
+			deadline: "2027-07-01T00:00:00.000Z",
+		});
+		expect(mail.subject.toLowerCase()).toContain("parcours");
+		expect(mail.html).toContain("5 %");
+	});
+
+	it.each([
+		90, 30,
+	] as const)("second_declaration_reminder J-%i exposes the count", async (daysRemaining) => {
+		const mail = await buildMail("second_declaration_reminder", {
+			siren: SIREN,
+			year: YEAR,
+			deadline: "2028-01-01T00:00:00.000Z",
+			daysRemaining,
+		});
+		expect(mail.subject).toContain(`${daysRemaining} jours`);
+		expect(mail.html).toContain("actions correctives");
+	});
+
+	it("joint_evaluation_reminder references the report deadline", async () => {
+		const mail = await buildMail("joint_evaluation_reminder", {
+			siren: SIREN,
+			year: YEAR,
+			deadline: "2027-09-01T00:00:00.000Z",
+		});
+		expect(mail.subject.toLowerCase()).toContain("évaluation conjointe");
+		expect(mail.html).toContain("1ᵉʳ septembre");
+	});
+
+	it.each([
+		["compliance", "exactitude"],
+		["justify_oct", "1er octobre"],
+		["justify_dec", "justification"],
+		["corrective", "actions correctives"],
+		["joint_eval", "évaluation conjointe"],
+	] as const)("cse_opinion_reminder variant=%s shows %s context", async (variant, marker) => {
+		const mail = await buildMail("cse_opinion_reminder", {
+			siren: SIREN,
+			year: YEAR,
+			deadline: "2028-03-01T00:00:00.000Z",
+			variant,
+		});
+		expect(mail.subject).toContain("CSE");
+		expect(mail.html.toLowerCase()).toContain(marker.toLowerCase());
+	});
+
+	it("next_cycle_handover announces closure and next cycle", async () => {
+		const mail = await buildMail("next_cycle_handover", {
+			siren: SIREN,
+			previousYear: YEAR,
+			nextYear: YEAR + 1,
+		});
+		expect(mail.subject).toBe(
+			"Egapro - Clôture de votre déclaration et ouverture du prochain cycle",
+		);
+		expect(mail.html).toContain(String(YEAR));
+		expect(mail.html).toContain(String(YEAR + 1));
 	});
 });
 

--- a/packages/notifications/src/mails/builders/compliancePathChoiceReminder.tsx
+++ b/packages/notifications/src/mails/builders/compliancePathChoiceReminder.tsx
@@ -1,0 +1,59 @@
+import { formatFrenchDate } from "../shared/formatters.js";
+import { renderEmail } from "../shared/render.js";
+import { getConnectionUrl } from "../shared/urls.js";
+import {
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { MailBuilder } from "../types.js";
+
+export const buildCompliancePathChoiceReminderMail: MailBuilder<
+	"compliance_path_choice_reminder"
+> = async (payload) => {
+	const subject =
+		"Egapro - Rappel : choix de votre parcours de mise en conformité";
+	const formattedDeadline = formatFrenchDate(payload.deadline);
+	const previewText =
+		"Vous devez choisir un parcours de mise en conformité avant la date limite.";
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>
+				Votre déclaration des indicateurs fait apparaître un écart de
+				rémunération supérieur ou égal à 5 %. Vous n'avez pas encore choisi
+				votre parcours de mise en conformité.
+			</EmailParagraph>
+			<EmailParagraph>
+				Conformément à la réglementation, lorsque l'écart de rémunération
+				constaté est supérieur ou égal à 5 %, votre entreprise doit choisir un
+				parcours de mise en conformité pour réduire cet écart.
+			</EmailParagraph>
+			<EmailParagraph>
+				Trois parcours sont disponibles : justification des écarts, actions
+				correctives, ou évaluation conjointe avec votre CSE. Le détail et les
+				conséquences de chaque option sont expliqués sur le portail Egapro.
+			</EmailParagraph>
+			<EmailParagraph>
+				Nous vous invitons à vous rendre sur le portail Egapro afin d'effectuer
+				ce choix.
+			</EmailParagraph>
+			<EmailParagraph>
+				La sélection doit intervenir au plus tard le {formattedDeadline}.
+			</EmailParagraph>
+			<EmailCtaWithLink
+				href={getConnectionUrl()}
+				label="Choisir mon parcours"
+			/>
+			<EmailParagraph>
+				Pour tout renseignement, vous pouvez contacter votre référent égalité
+				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+				message.
+			</EmailParagraph>
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/builders/cseOpinionReminder.tsx
+++ b/packages/notifications/src/mails/builders/cseOpinionReminder.tsx
@@ -1,0 +1,116 @@
+import { formatFrenchDate } from "../shared/formatters.js";
+import { renderEmail } from "../shared/render.js";
+import { getConnectionUrl } from "../shared/urls.js";
+import {
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { CseOpinionReminderVariant, MailBuilder } from "../types.js";
+
+type VariantCopy = {
+	subjectSuffix: string;
+	previewText: string;
+	statementParagraph: string;
+	frameworkParagraph: string;
+	scopeParagraph: string;
+	ctaLabel: string;
+};
+
+const VARIANT_COPY: Record<CseOpinionReminderVariant, VariantCopy> = {
+	compliance: {
+		subjectSuffix: "exactitude des données",
+		previewText:
+			"L'avis du CSE sur l'exactitude des données déclarées n'a pas encore été déposé.",
+		statementParagraph:
+			"L'avis de votre CSE sur l'exactitude des données déclarées n'a pas encore été déposé sur la plateforme Egapro.",
+		frameworkParagraph:
+			"Conformément à la réglementation, les entreprises d'au moins 100 salariés doivent recueillir l'avis de leur CSE sur l'exactitude des indicateurs publiés.",
+		scopeParagraph:
+			"Cet avis doit confirmer l'exactitude des données figurant dans votre déclaration.",
+		ctaLabel: "Déposer l'avis du CSE",
+	},
+	justify_oct: {
+		subjectSuffix:
+			"exactitude des données et justification des écarts (1er octobre)",
+		previewText:
+			"L'avis du CSE sur l'exactitude des données et la justification des écarts est attendu avant le 1er octobre.",
+		statementParagraph:
+			"L'avis de votre CSE sur l'exactitude des données et la justification des écarts constatés n'a pas encore été déposé sur la plateforme Egapro.",
+		frameworkParagraph:
+			"Conformément à la réglementation, le CSE doit être consulté sur les justifications avancées pour les écarts de rémunération constatés.",
+		scopeParagraph:
+			"Le dépôt de cet avis doit intervenir avant le 1er octobre.",
+		ctaLabel: "Déposer l'avis du CSE",
+	},
+	justify_dec: {
+		subjectSuffix: "avis du CSE non encore déposé (relance du 1er décembre)",
+		previewText:
+			"L'avis du CSE sur votre justification des écarts n'a pas encore été reçu.",
+		statementParagraph:
+			"Nous n'avons pas encore reçu l'avis de votre CSE sur la justification des écarts de rémunération.",
+		frameworkParagraph:
+			"Conformément à la réglementation, votre justification des écarts doit être validée par l'avis du CSE pour clôturer votre procédure de mise en conformité.",
+		scopeParagraph:
+			"Sans dépôt de cet avis, la procédure de mise en conformité ne pourra pas être clôturée pour cette campagne.",
+		ctaLabel: "Déposer l'avis du CSE",
+	},
+	corrective: {
+		subjectSuffix:
+			"actions correctives — exactitude des données des deux déclarations",
+		previewText:
+			"L'avis du CSE sur l'exactitude des données des deux déclarations n'a pas encore été déposé.",
+		statementParagraph:
+			"L'avis de votre CSE sur l'exactitude des données de votre première déclaration et de votre seconde déclaration au titre des actions correctives n'a pas encore été déposé.",
+		frameworkParagraph:
+			"Conformément à la réglementation, votre CSE doit être consulté sur l'exactitude des indicateurs publiés ainsi que sur les actions correctives mises en œuvre.",
+		scopeParagraph:
+			"L'avis doit également mentionner les justifications éventuelles des écarts persistants.",
+		ctaLabel: "Déposer l'avis du CSE",
+	},
+	joint_eval: {
+		subjectSuffix: "évaluation conjointe (relance du 1er décembre)",
+		previewText:
+			"L'avis du CSE sur le rapport d'évaluation conjointe n'a pas encore été déposé.",
+		statementParagraph:
+			"L'avis de votre CSE sur le rapport d'évaluation conjointe déposé pour votre entreprise n'a pas encore été reçu.",
+		frameworkParagraph:
+			"Conformément à la réglementation, le CSE doit statuer sur l'évaluation conjointe et confirmer l'exactitude des données associées.",
+		scopeParagraph:
+			"Sans dépôt de cet avis, votre démarche d'évaluation conjointe restera incomplète.",
+		ctaLabel: "Déposer l'avis du CSE",
+	},
+};
+
+export const buildCseOpinionReminderMail: MailBuilder<
+	"cse_opinion_reminder"
+> = async (payload) => {
+	const copy = VARIANT_COPY[payload.variant];
+	const subject = `Egapro - Rappel : avis du CSE — ${copy.subjectSuffix}`;
+	const formattedDeadline = formatFrenchDate(payload.deadline);
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={copy.previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>{copy.statementParagraph}</EmailParagraph>
+			<EmailParagraph>{copy.frameworkParagraph}</EmailParagraph>
+			<EmailParagraph>{copy.scopeParagraph}</EmailParagraph>
+			<EmailParagraph>
+				Nous vous invitons à vous rendre sur le portail Egapro afin de déposer
+				l'avis du CSE.
+			</EmailParagraph>
+			<EmailParagraph>
+				Le dépôt doit intervenir au plus tard le {formattedDeadline}.
+			</EmailParagraph>
+			<EmailCtaWithLink href={getConnectionUrl()} label={copy.ctaLabel} />
+			<EmailParagraph>
+				Pour tout renseignement, vous pouvez contacter votre référent égalité
+				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+				message.
+			</EmailParagraph>
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/builders/cycleOpeningInfo.tsx
+++ b/packages/notifications/src/mails/builders/cycleOpeningInfo.tsx
@@ -1,0 +1,59 @@
+import { formatFrenchDate } from "../shared/formatters.js";
+import { renderEmail } from "../shared/render.js";
+import { getConnectionUrl } from "../shared/urls.js";
+import {
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { MailBuilder } from "../types.js";
+
+export const buildCycleOpeningInfoMail: MailBuilder<
+	"cycle_opening_info"
+> = async (payload) => {
+	const subject =
+		"Egapro - Ouverture de la période de déclaration des indicateurs Egapro";
+	const formattedDeadline = formatFrenchDate(payload.deadline);
+	const previewText =
+		"La période de déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes est désormais ouverte.";
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>
+				La période de déclaration des indicateurs relatifs à l'égalité
+				professionnelle entre les femmes et les hommes est désormais ouverte.
+			</EmailParagraph>
+			<EmailParagraph>
+				Conformément à la réglementation, votre entreprise se doit de déclarer
+				les indicateurs relatifs aux écarts de rémunération.
+			</EmailParagraph>
+			<EmailParagraph>
+				Votre déclaration est préremplie avec les données connues de
+				l'administration pour les six premiers indicateurs de rémunération,
+				issues de la DSN.
+			</EmailParagraph>
+			<EmailParagraph>
+				Nous vous invitons à vous rendre sur le portail Egapro afin de vérifier
+				ces informations, de les modifier si nécessaire, et de compléter le 7ᵉ
+				indicateur pour les entreprises concernées.
+			</EmailParagraph>
+			<EmailParagraph>
+				La déclaration est ouverte jusqu'au {formattedDeadline}. Nous vous
+				remercions de bien vouloir la finaliser dans ce délai.
+			</EmailParagraph>
+			<EmailCtaWithLink
+				href={getConnectionUrl()}
+				label="Commencer ma déclaration"
+			/>
+			<EmailParagraph>
+				Pour tout renseignement, vous pouvez contacter votre référent égalité
+				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+				message.
+			</EmailParagraph>
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/builders/declarationDeadlineReminder.tsx
+++ b/packages/notifications/src/mails/builders/declarationDeadlineReminder.tsx
@@ -1,0 +1,57 @@
+import { formatFrenchDate } from "../shared/formatters.js";
+import { renderEmail } from "../shared/render.js";
+import { getConnectionUrl } from "../shared/urls.js";
+import {
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { MailBuilder } from "../types.js";
+
+export const buildDeclarationDeadlineReminderMail: MailBuilder<
+	"declaration_deadline_reminder"
+> = async (payload) => {
+	const subject = `Egapro - Rappel : votre déclaration des indicateurs est attendue dans ${payload.daysRemaining} jours`;
+	const formattedDeadline = formatFrenchDate(payload.deadline);
+	const previewText = `Il vous reste ${payload.daysRemaining} jours pour finaliser votre déclaration des indicateurs.`;
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>
+				Votre déclaration des indicateurs relatifs à l'égalité professionnelle
+				entre les femmes et les hommes n'a pas encore été finalisée. Il vous
+				reste {payload.daysRemaining} jours pour la déposer.
+			</EmailParagraph>
+			<EmailParagraph>
+				Conformément à la réglementation, votre entreprise est tenue de déclarer
+				chaque année les indicateurs relatifs aux écarts de rémunération.
+			</EmailParagraph>
+			<EmailParagraph>
+				Votre déclaration est préremplie avec les données connues de
+				l'administration pour les six premiers indicateurs de rémunération,
+				issues de la DSN.
+			</EmailParagraph>
+			<EmailParagraph>
+				Nous vous invitons à vous rendre sur le portail Egapro afin de finaliser
+				et publier votre déclaration.
+			</EmailParagraph>
+			<EmailParagraph>
+				La déclaration est ouverte jusqu'au {formattedDeadline}. Au-delà de
+				cette date, elle ne pourra plus être modifiée.
+			</EmailParagraph>
+			<EmailCtaWithLink
+				href={getConnectionUrl()}
+				label="Reprendre ma déclaration"
+			/>
+			<EmailParagraph>
+				Pour tout renseignement, vous pouvez contacter votre référent égalité
+				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+				message.
+			</EmailParagraph>
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/builders/index.ts
+++ b/packages/notifications/src/mails/builders/index.ts
@@ -1,4 +1,11 @@
+export { buildCompliancePathChoiceReminderMail } from "./compliancePathChoiceReminder.js";
 export { buildCseOpinionReceiptMail } from "./cseOpinionReceipt.js";
+export { buildCseOpinionReminderMail } from "./cseOpinionReminder.js";
+export { buildCycleOpeningInfoMail } from "./cycleOpeningInfo.js";
 export { buildDeclarationConfirmationMail } from "./declarationConfirmation.js";
+export { buildDeclarationDeadlineReminderMail } from "./declarationDeadlineReminder.js";
+export { buildJointEvaluationReminderMail } from "./jointEvaluationReminder.js";
 export { buildJointEvaluationSubmittedMail } from "./jointEvaluationSubmitted.js";
+export { buildNextCycleHandoverMail } from "./nextCycleHandover.js";
 export { buildSecondDeclarationConfirmationMail } from "./secondDeclarationConfirmation.js";
+export { buildSecondDeclarationReminderMail } from "./secondDeclarationReminder.js";

--- a/packages/notifications/src/mails/builders/jointEvaluationReminder.tsx
+++ b/packages/notifications/src/mails/builders/jointEvaluationReminder.tsx
@@ -1,0 +1,56 @@
+import { formatFrenchDate } from "../shared/formatters.js";
+import { renderEmail } from "../shared/render.js";
+import { getConnectionUrl } from "../shared/urls.js";
+import {
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { MailBuilder } from "../types.js";
+
+export const buildJointEvaluationReminderMail: MailBuilder<
+	"joint_evaluation_reminder"
+> = async (payload) => {
+	const subject = "Egapro - Rappel : dépôt du rapport d'évaluation conjointe";
+	const formattedDeadline = formatFrenchDate(payload.deadline);
+	const previewText =
+		"Le rapport d'évaluation conjointe avec votre CSE n'a pas encore été téléversé sur la plateforme.";
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>
+				Le rapport d'évaluation conjointe mené avec votre CSE n'a pas encore été
+				téléversé sur la plateforme Egapro.
+			</EmailParagraph>
+			<EmailParagraph>
+				Conformément à la réglementation, l'évaluation conjointe doit retracer
+				les mesures correctives décidées en commun avec le CSE pour réduire les
+				écarts de rémunération constatés.
+			</EmailParagraph>
+			<EmailParagraph>
+				Le rapport doit lister précisément ces mesures correctives ainsi que
+				leur calendrier de mise en œuvre.
+			</EmailParagraph>
+			<EmailParagraph>
+				Nous vous invitons à vous rendre sur le portail Egapro afin de
+				téléverser ce rapport.
+			</EmailParagraph>
+			<EmailParagraph>
+				Le dépôt doit intervenir au plus tard le {formattedDeadline}.
+			</EmailParagraph>
+			<EmailCtaWithLink
+				href={getConnectionUrl()}
+				label="Téléverser le rapport"
+			/>
+			<EmailParagraph>
+				Pour tout renseignement, vous pouvez contacter votre référent égalité
+				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+				message.
+			</EmailParagraph>
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/builders/nextCycleHandover.tsx
+++ b/packages/notifications/src/mails/builders/nextCycleHandover.tsx
@@ -1,0 +1,56 @@
+import { renderEmail } from "../shared/render.js";
+import { getConnectionUrl } from "../shared/urls.js";
+import {
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { MailBuilder } from "../types.js";
+
+export const buildNextCycleHandoverMail: MailBuilder<
+	"next_cycle_handover"
+> = async (payload) => {
+	const subject =
+		"Egapro - Clôture de votre déclaration et ouverture du prochain cycle";
+	const previewText = `Votre déclaration ${payload.previousYear} est clôturée. La prochaine campagne ${payload.nextYear} ouvrira le 1ᵉʳ mars ${payload.nextYear}.`;
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>
+				Votre déclaration des indicateurs au titre de l'année{" "}
+				{payload.previousYear} est désormais clôturée.
+			</EmailParagraph>
+			<EmailParagraph>
+				Conformément à la réglementation, votre entreprise est tenue de déclarer
+				chaque année les indicateurs relatifs aux écarts de rémunération.
+			</EmailParagraph>
+			<EmailParagraph>
+				La prochaine campagne, au titre de l'année {payload.nextYear}, sera
+				préremplie avec les données connues de l'administration pour les six
+				premiers indicateurs de rémunération, issues de la DSN.
+			</EmailParagraph>
+			<EmailParagraph>
+				Nous vous invitons à vous rendre sur le portail Egapro dès l'ouverture
+				de la nouvelle campagne pour vérifier ces informations, les modifier si
+				nécessaire, et compléter le 7ᵉ indicateur pour les entreprises
+				concernées.
+			</EmailParagraph>
+			<EmailParagraph>
+				La prochaine campagne ouvrira le 1ᵉʳ mars {payload.nextYear}.
+			</EmailParagraph>
+			<EmailCtaWithLink
+				href={getConnectionUrl()}
+				label="Accéder à mon espace"
+			/>
+			<EmailParagraph>
+				Pour tout renseignement, vous pouvez contacter votre référent égalité
+				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+				message.
+			</EmailParagraph>
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/builders/secondDeclarationReminder.tsx
+++ b/packages/notifications/src/mails/builders/secondDeclarationReminder.tsx
@@ -1,0 +1,57 @@
+import { formatFrenchDate } from "../shared/formatters.js";
+import { renderEmail } from "../shared/render.js";
+import { getConnectionUrl } from "../shared/urls.js";
+import {
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { MailBuilder } from "../types.js";
+
+export const buildSecondDeclarationReminderMail: MailBuilder<
+	"second_declaration_reminder"
+> = async (payload) => {
+	const subject = `Egapro - Rappel : votre seconde déclaration est attendue dans ${payload.daysRemaining} jours`;
+	const formattedDeadline = formatFrenchDate(payload.deadline);
+	const previewText = `Il vous reste ${payload.daysRemaining} jours pour déposer votre seconde déclaration au titre des actions correctives.`;
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>
+				Votre seconde déclaration au titre des actions correctives n'a pas
+				encore été déposée. Il vous reste {payload.daysRemaining} jours pour la
+				finaliser.
+			</EmailParagraph>
+			<EmailParagraph>
+				Conformément à la réglementation, vous avez engagé un parcours d'actions
+				correctives à la suite d'un écart de rémunération supérieur ou égal à 5
+				%.
+			</EmailParagraph>
+			<EmailParagraph>
+				La seconde déclaration doit retracer les actions correctives mises en
+				œuvre par votre entreprise et leur impact sur les écarts constatés.
+			</EmailParagraph>
+			<EmailParagraph>
+				Nous vous invitons à vous rendre sur le portail Egapro afin de déposer
+				votre seconde déclaration.
+			</EmailParagraph>
+			<EmailParagraph>
+				Le dépôt doit intervenir au plus tard le {formattedDeadline}. Sans dépôt
+				avant cette date, votre déclaration sera marquée comme non conforme.
+			</EmailParagraph>
+			<EmailCtaWithLink
+				href={getConnectionUrl()}
+				label="Déposer ma seconde déclaration"
+			/>
+			<EmailParagraph>
+				Pour tout renseignement, vous pouvez contacter votre référent égalité
+				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+				message.
+			</EmailParagraph>
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/index.ts
+++ b/packages/notifications/src/mails/index.ts
@@ -1,8 +1,15 @@
 import {
+	buildCompliancePathChoiceReminderMail,
 	buildCseOpinionReceiptMail,
+	buildCseOpinionReminderMail,
+	buildCycleOpeningInfoMail,
 	buildDeclarationConfirmationMail,
+	buildDeclarationDeadlineReminderMail,
+	buildJointEvaluationReminderMail,
 	buildJointEvaluationSubmittedMail,
+	buildNextCycleHandoverMail,
 	buildSecondDeclarationConfirmationMail,
+	buildSecondDeclarationReminderMail,
 } from "./builders/index.js";
 import {
 	type MailBuilderRegistry,
@@ -17,6 +24,13 @@ export const MAIL_BUILDERS: MailBuilderRegistry = {
 	second_declaration_confirmation: buildSecondDeclarationConfirmationMail,
 	cse_opinion_receipt: buildCseOpinionReceiptMail,
 	joint_evaluation_submitted: buildJointEvaluationSubmittedMail,
+	cycle_opening_info: buildCycleOpeningInfoMail,
+	declaration_deadline_reminder: buildDeclarationDeadlineReminderMail,
+	compliance_path_choice_reminder: buildCompliancePathChoiceReminderMail,
+	second_declaration_reminder: buildSecondDeclarationReminderMail,
+	joint_evaluation_reminder: buildJointEvaluationReminderMail,
+	cse_opinion_reminder: buildCseOpinionReminderMail,
+	next_cycle_handover: buildNextCycleHandoverMail,
 };
 
 export function isNotificationType(value: unknown): value is NotificationType {

--- a/packages/notifications/src/mails/types.ts
+++ b/packages/notifications/src/mails/types.ts
@@ -1,8 +1,17 @@
 export const NOTIFICATION_TYPES = [
+	// Event-driven (4 — déclenchés par mutation tRPC / upload)
 	"declaration_confirmation",
 	"second_declaration_confirmation",
 	"cse_opinion_receipt",
 	"joint_evaluation_submitted",
+	// Schedule-driven (7 — déclenchés par pg-boss cron)
+	"cycle_opening_info",
+	"declaration_deadline_reminder",
+	"compliance_path_choice_reminder",
+	"second_declaration_reminder",
+	"joint_evaluation_reminder",
+	"cse_opinion_reminder",
+	"next_cycle_handover",
 ] as const;
 
 export type NotificationType = (typeof NOTIFICATION_TYPES)[number];
@@ -12,11 +21,51 @@ export type CompanyScopedPayload = {
 	year: number;
 };
 
+export type DeadlinePayload = CompanyScopedPayload & {
+	deadline: string;
+};
+
+export type DeclarationDeadlineReminderPayload = DeadlinePayload & {
+	daysRemaining: 30 | 10;
+};
+
+export type SecondDeclarationReminderPayload = DeadlinePayload & {
+	daysRemaining: 90 | 30;
+};
+
+export const CSE_OPINION_REMINDER_VARIANTS = [
+	"compliance",
+	"justify_oct",
+	"justify_dec",
+	"corrective",
+	"joint_eval",
+] as const;
+
+export type CseOpinionReminderVariant =
+	(typeof CSE_OPINION_REMINDER_VARIANTS)[number];
+
+export type CseOpinionReminderPayload = DeadlinePayload & {
+	variant: CseOpinionReminderVariant;
+};
+
+export type NextCycleHandoverPayload = {
+	siren: string;
+	previousYear: number;
+	nextYear: number;
+};
+
 export type NotificationPayloadMap = {
 	declaration_confirmation: CompanyScopedPayload;
 	second_declaration_confirmation: CompanyScopedPayload;
 	cse_opinion_receipt: CompanyScopedPayload;
 	joint_evaluation_submitted: CompanyScopedPayload;
+	cycle_opening_info: DeadlinePayload;
+	declaration_deadline_reminder: DeclarationDeadlineReminderPayload;
+	compliance_path_choice_reminder: DeadlinePayload;
+	second_declaration_reminder: SecondDeclarationReminderPayload;
+	joint_evaluation_reminder: DeadlinePayload;
+	cse_opinion_reminder: CseOpinionReminderPayload;
+	next_cycle_handover: NextCycleHandoverPayload;
 };
 
 export type RenderedMail = {

--- a/packages/notifications/src/queue.ts
+++ b/packages/notifications/src/queue.ts
@@ -1,7 +1,9 @@
 import { isNotificationType } from "./mails/index.js";
-import type {
-	NotificationPayloadMap,
-	NotificationType,
+import {
+	CSE_OPINION_REMINDER_VARIANTS,
+	type CseOpinionReminderVariant,
+	type NotificationPayloadMap,
+	type NotificationType,
 } from "./mails/types.js";
 
 export type { NotificationPayloadMap, NotificationType };
@@ -28,24 +30,94 @@ export type JobValidationSuccess = { ok: true; data: EmailJobData };
 export type JobValidationResult = JobValidationSuccess | JobValidationFailure;
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const VARIANT_SET = new Set<string>(CSE_OPINION_REMINDER_VARIANTS);
 
-function isCompanyScopedPayload(value: unknown): boolean {
-	if (typeof value !== "object" || value === null) return false;
-	const v = value as Record<string, unknown>;
-	return typeof v.siren === "string" && typeof v.year === "number";
+function isString(value: unknown): value is string {
+	return typeof value === "string";
+}
+
+function isPositiveInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isCompanyScoped(p: Record<string, unknown>): boolean {
+	return isString(p.siren) && isPositiveInteger(p.year);
+}
+
+function isDeadlinePayload(p: Record<string, unknown>): boolean {
+	return isCompanyScoped(p) && isString(p.deadline);
 }
 
 function isSerializedAttachment(value: unknown): value is SerializedAttachment {
 	if (typeof value !== "object" || value === null) return false;
 	const v = value as Record<string, unknown>;
 	return (
-		typeof v.filename === "string" &&
+		isString(v.filename) &&
 		v.filename.length > 0 &&
-		typeof v.contentBase64 === "string" &&
+		isString(v.contentBase64) &&
 		v.contentBase64.length > 0 &&
-		typeof v.contentType === "string" &&
+		isString(v.contentType) &&
 		v.contentType.length > 0
 	);
+}
+
+function validatePayloadForType(
+	type: NotificationType,
+	payload: unknown,
+): string | null {
+	if (typeof payload !== "object" || payload === null) {
+		return "payload must be an object";
+	}
+	const p = payload as Record<string, unknown>;
+
+	switch (type) {
+		case "declaration_confirmation":
+		case "second_declaration_confirmation":
+		case "cse_opinion_receipt":
+		case "joint_evaluation_submitted": {
+			return isCompanyScoped(p)
+				? null
+				: "payload requires { siren: string, year: number }";
+		}
+		case "cycle_opening_info":
+		case "compliance_path_choice_reminder":
+		case "joint_evaluation_reminder": {
+			return isDeadlinePayload(p)
+				? null
+				: "payload requires { siren, year, deadline }";
+		}
+		case "declaration_deadline_reminder": {
+			if (!isDeadlinePayload(p)) {
+				return "payload requires { siren, year, deadline }";
+			}
+			return p.daysRemaining === 30 || p.daysRemaining === 10
+				? null
+				: "payload.daysRemaining must be 30 or 10";
+		}
+		case "second_declaration_reminder": {
+			if (!isDeadlinePayload(p)) {
+				return "payload requires { siren, year, deadline }";
+			}
+			return p.daysRemaining === 90 || p.daysRemaining === 30
+				? null
+				: "payload.daysRemaining must be 90 or 30";
+		}
+		case "cse_opinion_reminder": {
+			if (!isDeadlinePayload(p)) {
+				return "payload requires { siren, year, deadline }";
+			}
+			return isString(p.variant) && VARIANT_SET.has(p.variant)
+				? null
+				: `payload.variant must be one of ${CSE_OPINION_REMINDER_VARIANTS.join(", ")}`;
+		}
+		case "next_cycle_handover": {
+			return isString(p.siren) &&
+				isPositiveInteger(p.previousYear) &&
+				isPositiveInteger(p.nextYear)
+				? null
+				: "payload requires { siren, previousYear, nextYear }";
+		}
+	}
 }
 
 export function validateJobData(raw: unknown): JobValidationResult {
@@ -54,26 +126,24 @@ export function validateJobData(raw: unknown): JobValidationResult {
 	}
 	const d = raw as Record<string, unknown>;
 
-	if (typeof d.type !== "string" || !isNotificationType(d.type)) {
+	if (!isString(d.type) || !isNotificationType(d.type)) {
 		return {
 			ok: false,
 			reason: `unknown notification type: ${String(d.type)}`,
 		};
 	}
-	if (
-		typeof d.recipientEmail !== "string" ||
-		!EMAIL_RE.test(d.recipientEmail)
-	) {
+	if (!isString(d.recipientEmail) || !EMAIL_RE.test(d.recipientEmail)) {
 		return { ok: false, reason: "recipientEmail is missing or invalid" };
 	}
-	if (d.recipientUserId !== null && typeof d.recipientUserId !== "string") {
+	if (d.recipientUserId !== null && !isString(d.recipientUserId)) {
 		return { ok: false, reason: "recipientUserId must be a string or null" };
 	}
-	if (d.siren !== null && typeof d.siren !== "string") {
+	if (d.siren !== null && !isString(d.siren)) {
 		return { ok: false, reason: "siren must be a string or null" };
 	}
-	if (!isCompanyScopedPayload(d.payload)) {
-		return { ok: false, reason: "payload is missing required fields" };
+	const payloadError = validatePayloadForType(d.type, d.payload);
+	if (payloadError) {
+		return { ok: false, reason: payloadError };
 	}
 	if (d.attachments !== undefined) {
 		if (!Array.isArray(d.attachments)) {
@@ -91,3 +161,5 @@ export function validateJobData(raw: unknown): JobValidationResult {
 	}
 	return { ok: true, data: d as unknown as EmailJobData };
 }
+
+export type { CseOpinionReminderVariant };

--- a/packages/notifications/src/schedules/__tests__/dispatch.test.ts
+++ b/packages/notifications/src/schedules/__tests__/dispatch.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnqueue, mockMarkSent, mockWasSent } = vi.hoisted(() => ({
+	mockEnqueue: vi.fn(),
+	mockMarkSent: vi.fn(),
+	mockWasSent: vi.fn(),
+}));
+
+vi.mock("../../publisher.js", () => ({
+	enqueueNotification: mockEnqueue,
+}));
+
+vi.mock("../../eligibility/index.js", () => ({
+	markSent: mockMarkSent,
+	wasSent: mockWasSent,
+}));
+
+import { dispatchReminder } from "../dispatch.js";
+
+const recipient = (siren: string) => ({
+	siren,
+	year: 2027,
+	email: `user-${siren}@example.fr`,
+	userId: `user-${siren}`,
+});
+
+const fakeSql = {} as unknown as Parameters<typeof dispatchReminder>[0]["sql"];
+
+describe("dispatchReminder", () => {
+	beforeEach(() => {
+		mockEnqueue.mockReset();
+		mockMarkSent.mockReset();
+		mockWasSent.mockReset();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("enqueues a job for each new recipient and marks them sent", async () => {
+		mockWasSent.mockResolvedValue(false);
+		mockEnqueue.mockResolvedValue({ status: "enqueued", id: "job-1" });
+		mockMarkSent.mockResolvedValue(undefined);
+
+		const result = await dispatchReminder({
+			sql: fakeSql,
+			type: "cycle_opening_info",
+			recipients: [recipient("111111111"), recipient("222222222")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-06-01T00:00:00.000Z",
+			}),
+		});
+
+		expect(result).toEqual({
+			scheduled: 2,
+			skippedAlreadySent: 0,
+			enqueued: 2,
+			enqueueErrors: 0,
+		});
+		expect(mockEnqueue).toHaveBeenCalledTimes(2);
+		expect(mockMarkSent).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips recipients already in the dedup table", async () => {
+		mockWasSent.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+		mockEnqueue.mockResolvedValue({ status: "enqueued", id: "job-2" });
+		mockMarkSent.mockResolvedValue(undefined);
+
+		const result = await dispatchReminder({
+			sql: fakeSql,
+			type: "joint_evaluation_reminder",
+			recipients: [recipient("111111111"), recipient("222222222")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-09-01T00:00:00.000Z",
+			}),
+		});
+
+		expect(result.skippedAlreadySent).toBe(1);
+		expect(result.enqueued).toBe(1);
+		expect(mockEnqueue).toHaveBeenCalledTimes(1);
+		expect(mockMarkSent).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not mark sent if enqueue fails (so the next tick retries)", async () => {
+		mockWasSent.mockResolvedValue(false);
+		mockEnqueue.mockResolvedValue({ status: "error", error: "boom" });
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+
+		const result = await dispatchReminder({
+			sql: fakeSql,
+			type: "compliance_path_choice_reminder",
+			recipients: [recipient("111111111")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-07-01T00:00:00.000Z",
+			}),
+		});
+
+		expect(result.enqueueErrors).toBe(1);
+		expect(result.enqueued).toBe(0);
+		expect(mockMarkSent).not.toHaveBeenCalled();
+		errorSpy.mockRestore();
+	});
+
+	it("propagates the variant to dedup keys", async () => {
+		mockWasSent.mockResolvedValue(false);
+		mockEnqueue.mockResolvedValue({ status: "enqueued", id: "job-3" });
+		mockMarkSent.mockResolvedValue(undefined);
+
+		await dispatchReminder({
+			sql: fakeSql,
+			type: "cse_opinion_reminder",
+			variant: "justify_oct",
+			recipients: [recipient("111111111")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-10-01T00:00:00.000Z",
+				variant: "justify_oct",
+			}),
+		});
+
+		expect(mockWasSent).toHaveBeenCalledWith(
+			fakeSql,
+			expect.objectContaining({ variant: "justify_oct" }),
+		);
+		expect(mockMarkSent).toHaveBeenCalledWith(
+			fakeSql,
+			expect.objectContaining({ variant: "justify_oct" }),
+		);
+	});
+});

--- a/packages/notifications/src/schedules/__tests__/registerSchedules.test.ts
+++ b/packages/notifications/src/schedules/__tests__/registerSchedules.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerSchedules, SCHEDULES } from "../index.js";
+
+type BossStub = {
+	createQueue: ReturnType<typeof vi.fn>;
+	work: ReturnType<typeof vi.fn>;
+	schedule: ReturnType<typeof vi.fn>;
+};
+
+function buildBoss(): BossStub {
+	return {
+		createQueue: vi.fn().mockResolvedValue(undefined),
+		work: vi.fn().mockResolvedValue(undefined),
+		schedule: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+describe("SCHEDULES", () => {
+	it("declares the expected 13 schedules", () => {
+		expect(SCHEDULES.length).toBe(13);
+	});
+
+	it("uses unique queue names", () => {
+		const names = SCHEDULES.map((s) => s.name);
+		expect(new Set(names).size).toBe(names.length);
+	});
+
+	it("uses Europe/Paris timezone for every schedule", () => {
+		for (const schedule of SCHEDULES) {
+			expect(schedule.timeZone).toBe("Europe/Paris");
+		}
+	});
+
+	it("uses valid 5-field cron expressions", () => {
+		for (const schedule of SCHEDULES) {
+			const fields = schedule.cron.split(/\s+/);
+			expect(fields.length).toBe(5);
+			expect(schedule.cron).toMatch(/^[\d*,/-]+(\s+[\d*,/-]+){4}$/);
+		}
+	});
+
+	it("includes the four CSE opinion reminder variants", () => {
+		const names = SCHEDULES.map((s) => s.name);
+		expect(names).toContain("reminder-cse-opinion-compliance");
+		expect(names).toContain("reminder-cse-opinion-justify-oct");
+		expect(names).toContain("reminder-cse-opinion-justify-dec");
+		expect(names).toContain("reminder-cse-opinion-corrective");
+		expect(names).toContain("reminder-cse-opinion-joint-eval");
+	});
+});
+
+describe("registerSchedules", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+		logSpy.mockRestore();
+	});
+
+	it("disables reminders and warns when DATABASE_URL is missing", async () => {
+		const boss = buildBoss();
+		await registerSchedules(
+			boss as unknown as Parameters<typeof registerSchedules>[0],
+			null,
+		);
+		expect(boss.createQueue).not.toHaveBeenCalled();
+		expect(boss.work).not.toHaveBeenCalled();
+		expect(boss.schedule).not.toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("reminders disabled"),
+		);
+	});
+
+	it("registers all schedules with timezone and cron", async () => {
+		const boss = buildBoss();
+		const fakeSql = {} as unknown as Parameters<typeof registerSchedules>[1];
+		await registerSchedules(
+			boss as unknown as Parameters<typeof registerSchedules>[0],
+			fakeSql,
+		);
+		expect(boss.createQueue).toHaveBeenCalledTimes(SCHEDULES.length);
+		expect(boss.work).toHaveBeenCalledTimes(SCHEDULES.length);
+		expect(boss.schedule).toHaveBeenCalledTimes(SCHEDULES.length);
+		for (const schedule of SCHEDULES) {
+			expect(boss.schedule).toHaveBeenCalledWith(
+				schedule.name,
+				schedule.cron,
+				{},
+				{ tz: "Europe/Paris" },
+			);
+		}
+	});
+});

--- a/packages/notifications/src/schedules/dates.ts
+++ b/packages/notifications/src/schedules/dates.ts
@@ -1,0 +1,36 @@
+// Date helpers for schedule handlers.
+//
+// Worker code lives outside `~/modules/domain`, so we can't import its
+// `getCurrentYear()` helper. Instead we extract the year via
+// `Intl.DateTimeFormat` to stay aware of `Europe/Paris` (avoids edge cases
+// when a tick lands at 23:00 UTC on Dec 31 — which would be Jan 1 in
+// Paris, hence year + 1).
+
+const YEAR_FORMATTER = new Intl.DateTimeFormat("fr-FR", {
+	year: "numeric",
+	timeZone: "Europe/Paris",
+});
+
+export function getCurrentYear(now: Date = new Date()): number {
+	return Number(YEAR_FORMATTER.format(now));
+}
+
+// Build an ISO 8601 date string at midnight Paris time (close enough for
+// display). Used as the `deadline` field in reminder payloads.
+export function toIsoDate(year: number, month: number, day: number): string {
+	const paddedMonth = String(month).padStart(2, "0");
+	const paddedDay = String(day).padStart(2, "0");
+	return `${year}-${paddedMonth}-${paddedDay}T00:00:00.000Z`;
+}
+
+// First-of-month deadline helpers — mapped 1:1 to the regulatory milestones
+// laid out in `docs/parcours-utilisateurs.md`. Centralised here so each
+// schedule handler stays declarative.
+export const DEADLINES = {
+	declarationModification: (year: number) => toIsoDate(year, 6, 1), // 1er juin
+	compliancePathChoice: (year: number) => toIsoDate(year, 7, 1), // 1er juillet
+	jointEvaluationReport: (year: number) => toIsoDate(year, 9, 1), // 1er septembre
+	secondDeclaration: (year: number) => toIsoDate(year + 1, 1, 1), // 1er janvier N+1
+	cseOpinionFinal: (year: number) => toIsoDate(year + 1, 3, 1), // 1er mars N+1
+	cseOpinionJustifyOct: (year: number) => toIsoDate(year, 10, 1), // 1er octobre
+} as const;

--- a/packages/notifications/src/schedules/definitions.ts
+++ b/packages/notifications/src/schedules/definitions.ts
@@ -1,0 +1,108 @@
+import type { Sql } from "postgres";
+import type { CseOpinionReminderVariant } from "../mails/types.js";
+import type { DispatchResult } from "./dispatch.js";
+import {
+	handleCompliancePathChoiceReminder,
+	handleCseOpinionReminder,
+	handleCycleOpeningInfo,
+	handleDeclarationDeadlineReminder,
+	handleJointEvaluationReminder,
+	handleNextCycleHandover,
+	handleSecondDeclarationReminder,
+} from "./handlers.js";
+
+export type ScheduleDefinition = {
+	name: string;
+	cron: string;
+	timeZone: string;
+	run: (sql: Sql) => Promise<DispatchResult>;
+};
+
+const TZ = "Europe/Paris";
+
+// Cron timing rationale (all in Europe/Paris, anchored to the V2 calendar
+// in `docs/parcours-utilisateurs.md`):
+//
+// - Phase 1 cycle (year N):
+//   - 1er mars → MA   (cycle opening info)
+//   - 2 mai    → MR30 (J-30 before declaration deadline 1er juin)
+//   - 22 mai   → MR10 (J-10 before declaration deadline 1er juin)
+//   - 16 juin  → ME   (J-15 before compliance path choice 1er juillet)
+//   - 1er août → MG_E1 (joint-eval report due 1er septembre)
+//   - 3 oct    → MSD3 (J-90 before second declaration 1er janvier N+1)
+//   - 1er sept → MG_J1 (J-30 before CSE Justify deadline 1er octobre)
+//   - 1er déc  → MSD30 (J-30 before second declaration 1er janvier N+1)
+//   - 1er déc  → MG_J2 / MG_E2 (CSE Justify late + CSE Joint-eval reminders)
+//
+// - Phase 1 wrap-up (year N+1):
+//   - 1er fév  → MG_B/C / MG_A (J-30 before CSE final 1er mars N+1)
+//   - 2 mars   → MI_* (next-cycle handover)
+
+const CSE_VARIANT_SCHEDULES: ReadonlyArray<{
+	suffix: string;
+	cron: string;
+	variant: CseOpinionReminderVariant;
+}> = [
+	{ suffix: "compliance", cron: "0 8 1 2 *", variant: "compliance" },
+	{ suffix: "justify-oct", cron: "0 8 1 9 *", variant: "justify_oct" },
+	{ suffix: "justify-dec", cron: "0 8 1 12 *", variant: "justify_dec" },
+	{ suffix: "corrective", cron: "0 8 1 2 *", variant: "corrective" },
+	{ suffix: "joint-eval", cron: "0 8 1 12 *", variant: "joint_eval" },
+];
+
+export const SCHEDULES: ScheduleDefinition[] = [
+	{
+		name: "reminder-cycle-opening-info",
+		cron: "0 8 1 3 *",
+		timeZone: TZ,
+		run: handleCycleOpeningInfo,
+	},
+	{
+		name: "reminder-declaration-deadline-30",
+		cron: "0 8 2 5 *",
+		timeZone: TZ,
+		run: (sql) => handleDeclarationDeadlineReminder(sql, 30),
+	},
+	{
+		name: "reminder-declaration-deadline-10",
+		cron: "0 8 22 5 *",
+		timeZone: TZ,
+		run: (sql) => handleDeclarationDeadlineReminder(sql, 10),
+	},
+	{
+		name: "reminder-compliance-path-choice",
+		cron: "0 8 16 6 *",
+		timeZone: TZ,
+		run: handleCompliancePathChoiceReminder,
+	},
+	{
+		name: "reminder-second-declaration-90",
+		cron: "0 8 3 10 *",
+		timeZone: TZ,
+		run: (sql) => handleSecondDeclarationReminder(sql, 90),
+	},
+	{
+		name: "reminder-second-declaration-30",
+		cron: "0 8 1 12 *",
+		timeZone: TZ,
+		run: (sql) => handleSecondDeclarationReminder(sql, 30),
+	},
+	{
+		name: "reminder-joint-evaluation",
+		cron: "0 8 1 8 *",
+		timeZone: TZ,
+		run: handleJointEvaluationReminder,
+	},
+	...CSE_VARIANT_SCHEDULES.map(({ suffix, cron, variant }) => ({
+		name: `reminder-cse-opinion-${suffix}`,
+		cron,
+		timeZone: TZ,
+		run: (sql: Sql) => handleCseOpinionReminder(sql, variant),
+	})),
+	{
+		name: "reminder-next-cycle-handover",
+		cron: "0 8 2 3 *",
+		timeZone: TZ,
+		run: handleNextCycleHandover,
+	},
+];

--- a/packages/notifications/src/schedules/dispatch.ts
+++ b/packages/notifications/src/schedules/dispatch.ts
@@ -1,0 +1,82 @@
+import type { Sql } from "postgres";
+import type { ReminderRecipient } from "../eligibility/index.js";
+import { markSent, wasSent } from "../eligibility/index.js";
+import type {
+	NotificationPayloadMap,
+	NotificationType,
+} from "../mails/types.js";
+import { enqueueNotification } from "../publisher.js";
+
+export type DispatchResult = {
+	scheduled: number;
+	skippedAlreadySent: number;
+	enqueued: number;
+	enqueueErrors: number;
+};
+
+// Shared dispatch loop for all reminder schedules.
+// Iterates over the recipients returned by an eligibility query, skips
+// the ones already sent (via the dedup table), enqueues a notification job
+// for the rest, and records each successful enqueue in the dedup table.
+//
+// Variant matters for `cse_opinion_reminder` (one entry per variant in the
+// dedup table — same recipient may receive several variants per year).
+export async function dispatchReminder<T extends NotificationType>(params: {
+	sql: Sql;
+	type: T;
+	recipients: ReminderRecipient[];
+	payloadFor: (recipient: ReminderRecipient) => NotificationPayloadMap[T];
+	variant?: string;
+	dedupYearFor?: (recipient: ReminderRecipient) => number;
+}): Promise<DispatchResult> {
+	const result: DispatchResult = {
+		scheduled: params.recipients.length,
+		skippedAlreadySent: 0,
+		enqueued: 0,
+		enqueueErrors: 0,
+	};
+
+	for (const recipient of params.recipients) {
+		const dedupYear = params.dedupYearFor
+			? params.dedupYearFor(recipient)
+			: recipient.year;
+		const already = await wasSent(params.sql, {
+			type: params.type,
+			siren: recipient.siren,
+			year: dedupYear,
+			variant: params.variant,
+		});
+		if (already) {
+			result.skippedAlreadySent += 1;
+			continue;
+		}
+		const payload = params.payloadFor(recipient);
+		const enqueueResult = await enqueueNotification({
+			type: params.type,
+			recipientEmail: recipient.email,
+			recipientUserId: recipient.userId,
+			siren: recipient.siren,
+			payload,
+		});
+		if (enqueueResult.status === "enqueued") {
+			result.enqueued += 1;
+			await markSent(params.sql, {
+				type: params.type,
+				siren: recipient.siren,
+				year: dedupYear,
+				variant: params.variant,
+			});
+		} else {
+			result.enqueueErrors += 1;
+			console.error(
+				`[schedules] enqueue failed for ${params.type} siren=${recipient.siren}: ${
+					enqueueResult.status === "error"
+						? enqueueResult.error
+						: enqueueResult.status
+				}`,
+			);
+		}
+	}
+
+	return result;
+}

--- a/packages/notifications/src/schedules/handlers.ts
+++ b/packages/notifications/src/schedules/handlers.ts
@@ -1,0 +1,151 @@
+import type { Sql } from "postgres";
+import {
+	ensureDedupTable,
+	findAwaitingComplianceChoice,
+	findCompletedPreviousCycle,
+	findCorrectiveSecondDeclarationPending,
+	findCseOpinionPending,
+	findDraftDeclarations,
+	findJointEvaluationPending,
+	findOpenCycleRecipients,
+} from "../eligibility/index.js";
+import type { CseOpinionReminderVariant } from "../mails/types.js";
+import { DEADLINES, getCurrentYear } from "./dates.js";
+import { type DispatchResult, dispatchReminder } from "./dispatch.js";
+
+// 2028 is the first cycle that can announce its opening: 2027 is the
+// kick-off of EgaPro V2 so there is no prior cohort to notify.
+const CYCLE_OPENING_INFO_MIN_YEAR = 2028;
+
+export async function handleCycleOpeningInfo(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	if (year < CYCLE_OPENING_INFO_MIN_YEAR) {
+		return {
+			scheduled: 0,
+			skippedAlreadySent: 0,
+			enqueued: 0,
+			enqueueErrors: 0,
+		};
+	}
+	const recipients = await findOpenCycleRecipients(sql, year);
+	const deadline = DEADLINES.declarationModification(year);
+	return dispatchReminder({
+		sql,
+		type: "cycle_opening_info",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline }),
+	});
+}
+
+export async function handleDeclarationDeadlineReminder(
+	sql: Sql,
+	daysRemaining: 30 | 10,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findDraftDeclarations(sql, year);
+	const deadline = DEADLINES.declarationModification(year);
+	return dispatchReminder({
+		sql,
+		type: "declaration_deadline_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline, daysRemaining }),
+		variant: `d${daysRemaining}`,
+	});
+}
+
+export async function handleCompliancePathChoiceReminder(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findAwaitingComplianceChoice(sql, year);
+	const deadline = DEADLINES.compliancePathChoice(year);
+	return dispatchReminder({
+		sql,
+		type: "compliance_path_choice_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline }),
+	});
+}
+
+export async function handleSecondDeclarationReminder(
+	sql: Sql,
+	daysRemaining: 90 | 30,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findCorrectiveSecondDeclarationPending(sql, year);
+	const deadline = DEADLINES.secondDeclaration(year);
+	return dispatchReminder({
+		sql,
+		type: "second_declaration_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline, daysRemaining }),
+		variant: `d${daysRemaining}`,
+	});
+}
+
+export async function handleJointEvaluationReminder(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findJointEvaluationPending(sql, year);
+	const deadline = DEADLINES.jointEvaluationReport(year);
+	return dispatchReminder({
+		sql,
+		type: "joint_evaluation_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline }),
+	});
+}
+
+function deadlineForCseVariant(
+	variant: CseOpinionReminderVariant,
+	year: number,
+): string {
+	switch (variant) {
+		case "justify_oct":
+		case "justify_dec":
+			return DEADLINES.cseOpinionJustifyOct(year);
+		default:
+			return DEADLINES.cseOpinionFinal(year);
+	}
+}
+
+export async function handleCseOpinionReminder(
+	sql: Sql,
+	variant: CseOpinionReminderVariant,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findCseOpinionPending(sql, year, variant);
+	const deadline = deadlineForCseVariant(variant, year);
+	return dispatchReminder({
+		sql,
+		type: "cse_opinion_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline, variant }),
+		variant,
+	});
+}
+
+export async function handleNextCycleHandover(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const nextYear = getCurrentYear();
+	const previousYear = nextYear - 1;
+	const recipients = await findCompletedPreviousCycle(sql, previousYear);
+	return dispatchReminder({
+		sql,
+		type: "next_cycle_handover",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, previousYear, nextYear }),
+		dedupYearFor: () => previousYear,
+	});
+}

--- a/packages/notifications/src/schedules/index.ts
+++ b/packages/notifications/src/schedules/index.ts
@@ -1,0 +1,50 @@
+import type { PgBoss } from "pg-boss";
+import type { Sql } from "postgres";
+import { SCHEDULES, type ScheduleDefinition } from "./definitions.js";
+
+export type { DispatchResult } from "./dispatch.js";
+export type { ScheduleDefinition };
+export { SCHEDULES };
+
+// pg-boss `schedule()` enqueues a job on the queue named `<schedule.name>`
+// on every cron tick (with a built-in lock so multiple worker replicas
+// don't double-fire). We attach a worker on the same queue that runs the
+// matching handler. Idempotence inside a tick is guarded by
+// `notifications.reminder_sent_log` — even if the cron fires twice the
+// recipient gets a single mail.
+export async function registerSchedules(
+	boss: PgBoss,
+	appSql: Sql | null,
+): Promise<void> {
+	if (!appSql) {
+		console.warn(
+			"[schedules] DATABASE_URL not configured — reminders disabled",
+		);
+		return;
+	}
+
+	for (const schedule of SCHEDULES) {
+		await boss.createQueue(schedule.name);
+		await boss.work<unknown>(schedule.name, { batchSize: 1 }, async () => {
+			const startedAt = Date.now();
+			try {
+				const result = await schedule.run(appSql);
+				console.log(
+					`[schedules] ${schedule.name} → enqueued=${result.enqueued}, skipped=${result.skippedAlreadySent}, scheduled=${result.scheduled}, errors=${result.enqueueErrors} (${Date.now() - startedAt}ms)`,
+				);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(`[schedules] ${schedule.name} failed: ${message}`);
+				throw error;
+			}
+		});
+		await boss.schedule(
+			schedule.name,
+			schedule.cron,
+			{},
+			{ tz: schedule.timeZone },
+		);
+	}
+
+	console.log(`[schedules] registered ${SCHEDULES.length} reminder schedules`);
+}

--- a/packages/notifications/src/worker/auditLog.ts
+++ b/packages/notifications/src/worker/auditLog.ts
@@ -1,0 +1,55 @@
+import type { Sql } from "postgres";
+
+export type SerializableJson =
+	| null
+	| string
+	| number
+	| boolean
+	| Date
+	| { [key: string]: SerializableJson }
+	| SerializableJson[];
+
+export type AuditRow = {
+	action: string;
+	category: string;
+	status: "success" | "failure";
+	userId?: string | null;
+	userEmail?: string | null;
+	siren?: string | null;
+	resourceType?: string | null;
+	resourceId?: string | null;
+	errorMessage?: string | null;
+	metadata?: SerializableJson;
+};
+
+export async function logAuditMain(
+	mainSql: Sql | null,
+	row: AuditRow,
+): Promise<void> {
+	if (!mainSql) return;
+	try {
+		await mainSql`
+			INSERT INTO audit.action_log (
+				id, created_at, action, category, status,
+				user_id, user_email, siren, resource_type, resource_id,
+				error_message, metadata
+			)
+			VALUES (
+				${crypto.randomUUID()},
+				${new Date()},
+				${row.action},
+				${row.category},
+				${row.status},
+				${row.userId ?? null},
+				${row.userEmail ?? null},
+				${row.siren ?? null},
+				${row.resourceType ?? null},
+				${row.resourceId ?? null},
+				${row.errorMessage ?? null},
+				${mainSql.json(row.metadata ?? null)}
+			)
+		`;
+	} catch (auditError) {
+		console.error("[notifications] audit insert failed:", auditError);
+	}
+}

--- a/packages/notifications/src/worker/jobHandler.ts
+++ b/packages/notifications/src/worker/jobHandler.ts
@@ -1,0 +1,105 @@
+import type { Transporter } from "nodemailer";
+import type { JobWithMetadata } from "pg-boss";
+import type { Sql } from "postgres";
+
+import { buildMail } from "../mails/index.js";
+import { validateJobData } from "../queue.js";
+import { logAuditMain } from "./auditLog.js";
+
+const SEND_AUDIT_ACTION = "notification.send";
+const SEND_AUDIT_CATEGORY = "system";
+
+export type JobHandlerDeps = {
+	transporter: Transporter | null;
+	mailFrom: string;
+	mailEnabled: boolean;
+	mainSql: Sql | null;
+};
+
+export function makeJobHandler(
+	deps: JobHandlerDeps,
+): (job: JobWithMetadata<unknown>) => Promise<void> {
+	const { transporter, mailFrom, mailEnabled, mainSql } = deps;
+	return async (job) => {
+		const attempt = (job.retryCount ?? 0) + 1;
+		const result = validateJobData(job.data);
+
+		if (!result.ok) {
+			// Poison pill: malformed payload can never succeed. Log + return
+			// clean so pg-boss marks the job complete and stops retrying.
+			console.error(
+				`[notifications] dropping malformed job ${job.id}: ${result.reason}`,
+			);
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "failure",
+				resourceType: "notification",
+				resourceId: job.id,
+				errorMessage: result.reason,
+				metadata: { attempt, poisonPill: true },
+			});
+			return;
+		}
+
+		const {
+			type,
+			payload,
+			recipientEmail,
+			recipientUserId,
+			siren,
+			attachments,
+		} = result.data;
+
+		try {
+			const { subject, html, text } = await buildMail(type, payload);
+			let messageId: string | null = null;
+			if (!mailEnabled || !transporter) {
+				console.log(
+					`[notifications] MAIL_ENABLED=false — would send ${type} to ${recipientEmail}`,
+				);
+			} else {
+				const decodedAttachments = attachments?.map((att) => ({
+					filename: att.filename,
+					content: Buffer.from(att.contentBase64, "base64"),
+					contentType: att.contentType,
+				}));
+				const info = await transporter.sendMail({
+					from: mailFrom,
+					to: recipientEmail,
+					subject,
+					text,
+					html,
+					...(decodedAttachments ? { attachments: decodedAttachments } : {}),
+				});
+				messageId = info.messageId ?? null;
+			}
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "success",
+				userId: recipientUserId,
+				userEmail: recipientEmail,
+				siren,
+				resourceType: "notification",
+				resourceId: job.id,
+				metadata: { type, attempt, messageId },
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "failure",
+				userId: recipientUserId,
+				userEmail: recipientEmail,
+				siren,
+				resourceType: "notification",
+				resourceId: job.id,
+				errorMessage: message,
+				metadata: { type, attempt },
+			});
+			throw error;
+		}
+	};
+}

--- a/packages/notifications/src/worker/lifecycle.ts
+++ b/packages/notifications/src/worker/lifecycle.ts
@@ -1,0 +1,26 @@
+import type { PgBoss } from "pg-boss";
+import type { Sql } from "postgres";
+
+export type ShutdownDeps = {
+	boss: PgBoss;
+	mainSql: Sql | null;
+};
+
+export function installShutdownHooks({ boss, mainSql }: ShutdownDeps): void {
+	const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+		console.log(`[notifications] received ${signal}, shutting down...`);
+		try {
+			await boss.stop({ graceful: true, timeout: 15_000 });
+			if (mainSql) await mainSql.end();
+		} catch (error) {
+			console.error("[notifications] shutdown error:", error);
+		}
+		process.exit(0);
+	};
+	process.on("SIGTERM", () => {
+		void shutdown("SIGTERM");
+	});
+	process.on("SIGINT", () => {
+		void shutdown("SIGINT");
+	});
+}

--- a/packages/notifications/src/worker/transporter.ts
+++ b/packages/notifications/src/worker/transporter.ts
@@ -1,0 +1,33 @@
+import nodemailer, { type Transporter } from "nodemailer";
+
+export function getMailEnabled(): boolean {
+	return (process.env.MAIL_ENABLED ?? "false").toLowerCase() === "true";
+}
+
+export function buildTransporter(): Transporter {
+	const host = process.env.SMTP_HOST;
+	if (!host) {
+		throw new Error("SMTP_HOST must be set when MAIL_ENABLED=true");
+	}
+	const port = parseInt(process.env.SMTP_PORT ?? "1025", 10);
+	const secure = (process.env.SMTP_SECURE ?? "false").toLowerCase() === "true";
+	const auth =
+		process.env.SMTP_USER && process.env.SMTP_PASS
+			? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+			: undefined;
+	// `requireTLS` enforces STARTTLS on plain-text ports; combined with a
+	// `minVersion` floor at TLS 1.2 it prevents silent downgrade attacks.
+	// We only apply it when SMTP auth is configured (i.e. real SMTP relay) —
+	// the MailDev local container has no TLS support and would refuse the
+	// connection if STARTTLS were required.
+	const hardenTls = auth !== undefined;
+	return nodemailer.createTransport({
+		host,
+		port,
+		secure,
+		auth,
+		...(hardenTls
+			? { requireTLS: !secure, tls: { minVersion: "TLSv1.2" } }
+			: {}),
+	});
+}


### PR DESCRIPTION
## Contexte

PR **2/4** du découpage de la #3541. À merger **après #3561** (refacto du template kit).

Une fois la #3561 mergée dans `alpha`, la base de cette PR sera retargettée automatiquement.

## Ce que fait cette PR

Ajoute les 6 nouveaux types d'email (qui seront déclenchés par les schedules dans la PR suivante).

### Nouveaux types

- \`cycle_opening_info\` — annonce ouverture campagne
- \`declaration_deadline_reminder\` — J-30 / J-10 avant date butoir
- \`compliance_path_choice_reminder\` — choix du parcours après écart >= 5%
- \`second_declaration_reminder\` — J-90 / J-30
- \`joint_evaluation_reminder\` — rappel évaluation conjointe
- \`cse_opinion_reminder\` — 5 variants (compliance, justify_oct, justify_dec, corrective, joint_eval)
- \`next_cycle_handover\` — clôture cycle + ouverture suivant

### Changements

- **\`mails/types.ts\`** : nouveaux \`DeadlinePayload\`, \`DeclarationDeadlineReminderPayload\`, \`SecondDeclarationReminderPayload\`, \`CseOpinionReminderPayload\`, \`NextCycleHandoverPayload\`, \`CSE_OPINION_REMINDER_VARIANTS\`
- **\`mails/index.ts\`** : registry passe de 4 à 11 entrées
- **\`queue.ts\`** : refacto de \`validateJobData\` pour valider chaque shape par type
- **\`mails/builders/*\`** : 7 nouveaux \`.tsx\` (cseOpinionReminder couvre 5 variants)
- **\`docs/mails.md\` + \`docs/mails/*.md\`** : 1 doc par email (déclencheur, destinataire, contenu)
- **Tests** : \`builders.test.ts\` étend la couverture aux 11 types + edge cases (XSS, daysRemaining unions, variants)

### Note

Les nouveaux builders sont **enregistrés** mais pas encore **invoqués** — la pipeline d'envoi reste limitée aux 4 mails event-driven jusqu'à ce que la PR suivante (eligibility + schedules) câble les crons.

## Comment tester

\`\`\`bash
pnpm --filter notifications test
\`\`\`

71 tests passent (vs. 51 dans #3561).

Closes part of #3474.