### PR TITLE
feat(notifications): scheduled reminders (eligibility + schedules)

### DIFF
--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -42,17 +42,19 @@ check_pattern '\.(ts|tsx|js|jsx)$' \
   'biome-ignore|eslint-disable|@ts-ignore|@ts-expect-error' \
   'Suppression comments are forbidden. Fix the underlying issue instead.'
 
-# Inline styles — JSX files only (exclude @react-pdf/renderer components which require style={})
+# Inline styles — JSX files only (exclude @react-pdf/renderer + @react-email components which require style={})
 check_pattern '\.(tsx|jsx)$' \
   'style=\{' \
   'Inline style={{}} is forbidden. Use DSFR classes or a scoped SCSS module.' \
-  '(declarationPdf/|noSanctionAttestation/)'
+  '(declarationPdf/|noSanctionAttestation/|packages/notifications/)'
 
 # Inline SVG — JSX files only (DsfrPictogram is the only allowed SVG wrapper)
+# packages/notifications/ is excluded: emails need inline SVG (Outlook strips
+# linked images by default, next/image is browser-only).
 check_pattern '\.(tsx|jsx)$' \
   '<svg[[:space:]>]' \
   'Inline <svg> is forbidden. Use DsfrPictogram, public/assets/*.svg + <Image> (next/image), or DSFR icon classes (fr-icon-*).' \
-  '(DsfrPictogram\.tsx|ErrorArtwork\.tsx)'
+  '(DsfrPictogram\.tsx|ErrorArtwork\.tsx|packages/notifications/)'
 
 # Direct process.env — use ~/env.js instead (exclude env.js, instrumentation, next.config, sentry configs)
 check_pattern '\.(ts|tsx)$' \
@@ -60,10 +62,11 @@ check_pattern '\.(ts|tsx)$' \
   'Direct process.env is forbidden. Use: import { env } from "~/env.js".' \
   '(env\.js|instrumentation(-client)?\.ts|next\.config|trpc/react\.tsx|sentry\.(client|server|edge)\.config\.ts|global-setup\.ts|integration-setup\.ts|playwright\.config|drizzle[^/]*\.config|migrate.*\.mjs|e2e/helpers/|packages/notifications/)'
 
-# Deep relative imports — use ~/ path alias
+# Deep relative imports — use ~/ path alias (exclude packages/notifications which has no path alias)
 check_pattern '\.(ts|tsx)$' \
   '(\.\./){2,}' \
-  'Deep relative imports (../../ or deeper) are forbidden. Use the ~/ path alias.'
+  'Deep relative imports (../../ or deeper) are forbidden. Use the ~/ path alias.' \
+  '(packages/notifications/)'
 
 # Hardcoded hex colors in SCSS — use DSFR CSS custom properties
 check_pattern '\.scss$' \

--- a/.kontinuous/templates/notifications-deployment.yaml
+++ b/.kontinuous/templates/notifications-deployment.yaml
@@ -37,11 +37,13 @@ spec:
           command:
             - node
             - packages/notifications/dist/index.js
-          # Load defaults from the same configmaps as the app pod. The
-          # `mail` configmap exposes MAIL_ENABLED / SMTP_HOST / SMTP_PORT /
-          # SMTP_SECURE / MAIL_FROM pointing at the in-cluster MailDev for
-          # dev / preprod review apps. The `notifications` configmap is
-          # optional and lets ops tune retry / batch knobs without rebuilding.
+          # The worker is the single consumer of MAIL_*/SMTP_* — the app pod
+          # no longer mounts these vars (removed from `global.env` once the
+          # publisher pattern landed). The `mail` configmap exposes
+          # MAIL_ENABLED / SMTP_HOST / SMTP_PORT / SMTP_SECURE / MAIL_FROM
+          # pointing at the in-cluster MailDev for dev / preprod review
+          # apps. The `notifications` configmap is optional and lets ops
+          # tune retry / batch knobs without rebuilding.
           envFrom:
             - configMapRef:
                 name: mail
@@ -124,9 +126,10 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.global.pgSecretName }}"
                   key: PGSSLMODE
-            # SMTP — same source as the app pod (`smtp-app` sealed-secret with
-            # MAILER_* keys = Tipimail in prod). `optional: true` keeps the
-            # configmap fallback (MailDev) usable in dev / preprod.
+            # SMTP — `smtp-app` sealed-secret with MAILER_* keys = Tipimail
+            # in prod, directly bound to this pod (the app pod has been
+            # disconnected from this secret). `optional: true` keeps the
+            # `mail` configmap fallback (MailDev) usable in dev / preprod.
             - name: SMTP_HOST
               valueFrom:
                 secretKeyRef:

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -134,47 +134,10 @@ app:
           name: "{{ .Values.global.notificationsPgSecretName | default \"pg-notifications\" }}"
           key: PGSSLMODE
           optional: true
-    # SMTP (Tipimail in prod, MailDev on dev/preprod). The smtp-app
-    # sealed-secret is kept as-is from the V1 prod setup, with MAILER_*
-    # keys. We remap to the V2 SMTP_* names expected by src/env.js.
-    #
-    # Kubernetes precedence: `env` runs AFTER `envFrom`, so an `env` entry
-    # would normally override a same-named envFrom value. But with
-    # `optional: true` on a missing secret/key, the env entry is silently
-    # dropped and the envFrom value is preserved. That is exactly the
-    # fallback we rely on for dev/preprod review apps (no smtp-app
-    # secret) where SMTP_HOST, SMTP_PORT, etc. come from the `mail`
-    # configmap pointing at the in-cluster MailDev service.
-    - name: SMTP_HOST
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_HOST
-          optional: true
-    - name: SMTP_PORT
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_PORT
-          optional: true
-    - name: SMTP_USER
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_LOGIN
-          optional: true
-    - name: SMTP_PASS
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_PASSWORD
-          optional: true
-    - name: SMTP_SECURE
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_SSL
-          optional: true
+    # SMTP_* / MAIL_* are intentionally NOT injected into the app pod —
+    # they are consumed exclusively by the notifications worker. See
+    # `.kontinuous/templates/notifications-deployment.yaml` for the
+    # worker-side wiring (same smtp-app sealed-secret + mail configmap).
   vars:
     NEXTAUTH_URL: "https://{{ .Values.global.host }}/api/auth"
     NEXT_PUBLIC_EGAPRO_ENV: "{{ .Values.global.env }}"

--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -84,19 +84,9 @@ export const env = createEnv({
 			.int()
 			.positive()
 			.default(365),
-		MAIL_ENABLED: z
-			.enum(["true", "false"])
-			.default("false")
-			.transform((v) => v === "true"),
-		SMTP_HOST: z.string().optional().default(""),
-		SMTP_PORT: z.coerce.number().int().positive().default(1025),
-		SMTP_USER: z.string().optional(),
-		SMTP_PASS: z.string().optional(),
-		SMTP_SECURE: z
-			.string()
-			.default("false")
-			.transform((v) => v.toLowerCase() === "true"),
-		MAIL_FROM: z.string().default("no-reply@egapro.local"),
+		// MAIL_*, SMTP_* are intentionally NOT declared here — they are consumed
+		// exclusively by the notifications worker (packages/notifications).
+		// See packages/notifications/README.md for the runtime config surface.
 		// Valkey cache URL — optional. When absent, the custom
 		// cache handler (cache-handler.cjs) gracefully degrades to no-op.
 		// The handler reads process.env.VALKEY_URL directly (it runs outside
@@ -151,13 +141,6 @@ export const env = createEnv({
 			process.env.EGAPRO_AUDIT_RETENTION_SHORT_DAYS,
 		EGAPRO_AUDIT_RETENTION_LONG_DAYS:
 			process.env.EGAPRO_AUDIT_RETENTION_LONG_DAYS,
-		MAIL_ENABLED: process.env.MAIL_ENABLED,
-		SMTP_HOST: process.env.SMTP_HOST,
-		SMTP_PORT: process.env.SMTP_PORT,
-		SMTP_USER: process.env.SMTP_USER,
-		SMTP_PASS: process.env.SMTP_PASS,
-		SMTP_SECURE: process.env.SMTP_SECURE,
-		MAIL_FROM: process.env.MAIL_FROM,
 		VALKEY_URL: process.env.VALKEY_URL,
 		NEXT_PUBLIC_EGAPRO_ENV: process.env.NEXT_PUBLIC_EGAPRO_ENV,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/packages/notifications/.env.example
+++ b/packages/notifications/.env.example
@@ -1,0 +1,38 @@
+# notifications worker — variables d'environnement standalone
+#
+# Utilisé par `pnpm --filter notifications dev|start|smoke` (worker pg-boss qui
+# consomme la queue `email-notification`). Chargé via Node `--env-file-if-exists`
+# (cf. scripts package.json). En production, ces valeurs sont injectées par
+# Kubernetes via le secret `smtp-app` et le service Postgres dédié.
+# Voir `.kontinuous/templates/notifications-deployment.yaml`.
+#
+# Quand l'app appelle `enqueueNotification` (côté packages/app), c'est le
+# fichier `packages/app/.env` qui est chargé — pas celui-ci. Ce fichier
+# n'existe que pour exécuter le worker seul.
+#
+# Pour démarrer le worker en local :
+#   cp packages/notifications/.env.example packages/notifications/.env
+#   docker compose up -d db db-notifications maildev
+#   pnpm --filter notifications dev
+
+# Postgres dédié à pg-boss (queue email-notification, schéma `pgboss`).
+# Fallback : si absent, le worker utilise DATABASE_URL ci-dessous.
+NOTIFICATIONS_DATABASE_URL="postgresql://postgres:postgres@localhost:5439/egapro_notifications"
+
+# Postgres app — utilisé uniquement pour écrire les lignes
+# `audit.action_log` (fan-out audit). Si absent, le worker tourne sans audit.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5438/egapro"
+
+# Envoi SMTP. MAIL_ENABLED=false → mode dry-run (log uniquement, pas d'envoi).
+MAIL_ENABLED="true"
+SMTP_HOST="localhost"
+SMTP_PORT="1025"
+SMTP_SECURE="false"
+# SMTP_USER / SMTP_PASS : optionnels en dev (MailDev n'authentifie pas).
+# Décommenter en preprod / prod (relai Tipimail).
+# SMTP_USER=""
+# SMTP_PASS=""
+MAIL_FROM="no-reply@egapro.local"
+
+# URL publique injectée dans les liens des emails (CTA, footer, fonts Marianne).
+EGAPRO_PUBLIC_URL="http://localhost:3000"

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -141,30 +141,33 @@ pnpm --filter notifications test
 The full source-of-truth flow lives in `docs/parcours-utilisateurs.md`. Mapping
 to current implementation:
 
-| Code | BRD label | Trigger | Status |
+| Code | BRD label | Trigger | Implemented as |
 |---|---|---|---|
-| MD | Confirmation 1ère déclaration | event (`declaration.submit`) | ✅ async via `declaration_confirmation` (PDF attachments rendered by the app, passed as base64 in the queue payload) |
-| MSDc | Confirmation 2e déclaration | event (`declaration.submitSecondDeclaration`) | ✅ async via `second_declaration_confirmation` (same pattern) |
-| MH_* | Confirmation avis CSE | event (file upload `cse_opinion`) | ✅ async via `cse_opinion_receipt` (no attachment) |
-| M_PE2 | Confirmation rapport éval. conjointe | event (file upload `joint_evaluation`) | ✅ async via `joint_evaluation_submitted` (no attachment) |
-| MR30 | Rappel déclaration J-30 (1er mai) | cron annuel | ⏳ infra prête (`scheduledFor`), template + scheduler à implémenter |
-| MR10 | Rappel déclaration J-10 (22 mai) | cron annuel | ⏳ idem |
-| ME | Rappel choix parcours J-15 (avant 1er juillet) | cron, si G≥5% | ⏳ idem |
-| MSD3 | Rappel 2e déclaration J-90 | cron | ⏳ idem |
-| MSD30 | Rappel 2e déclaration J-30 (1er déc) | cron | ⏳ idem |
-| MG_E1 | Rappel dépôt éval. conjointe (1er août) | cron | ⏳ idem |
-| MG_J1 | Rappel avis CSE — Justifier (avant 1er oct) | cron | ⏳ idem |
-| MG_J2 | Rappel avis CSE 1er déc (Justifier) | cron | ⏳ idem |
-| MG_E2 | Rappel avis CSE 1er déc (Éval. conjointe) | cron | ⏳ idem |
-| MG_A | Rappel avis CSE (Actions correctives) | cron | ⏳ idem |
-| MG_B/C | Rappel avis CSE (exactitude) | cron | ⏳ idem |
-| MA | Info ouverture cycle (1er mars, dès 2028) | cron annuel | ⏳ idem |
-| MI_* | Bascule cycle suivant | cron annuel | ⏳ idem |
+| MD | Confirmation 1ère déclaration | event (`declaration.submit`) | `declaration_confirmation` (PDF attachment via base64 in the queue payload) |
+| MSDc | Confirmation 2e déclaration | event (`declaration.submitSecondDeclaration`) | `second_declaration_confirmation` |
+| MH_* | Confirmation avis CSE | event (file upload `cse_opinion`) | `cse_opinion_receipt` |
+| M_PE2 | Confirmation rapport éval. conjointe | event (file upload `joint_evaluation`) | `joint_evaluation_submitted` |
+| MA | Info ouverture cycle (1er mars, dès 2028) | cron `0 8 1 3 *` | `cycle_opening_info` |
+| MR30 | Rappel déclaration J-30 (1er mai) | cron `0 8 2 5 *` | `declaration_deadline_reminder` (variant `d30`) |
+| MR10 | Rappel déclaration J-10 (22 mai) | cron `0 8 22 5 *` | `declaration_deadline_reminder` (variant `d10`) |
+| ME | Rappel choix parcours J-15 (avant 1er juillet) | cron `0 8 16 6 *` | `compliance_path_choice_reminder` (covers round 1 + round 2 revisions) |
+| MSD3 | Rappel 2e déclaration J-90 | cron `0 8 3 10 *` | `second_declaration_reminder` (variant `d90`) |
+| MSD30 | Rappel 2e déclaration J-30 (1er déc) | cron `0 8 1 12 *` | `second_declaration_reminder` (variant `d30`) |
+| MG_E1 | Rappel dépôt éval. conjointe (1er août) | cron `0 8 1 8 *` | `joint_evaluation_reminder` (covers round 1 + round 2 = `corrective → joint_eval`) |
+| MG_J1 | Rappel avis CSE — Justifier (avant 1er oct) | cron `0 8 1 9 *` | `cse_opinion_reminder` variant `justify_oct` |
+| MG_J2 | Rappel avis CSE 1er déc (Justifier) | cron `0 8 1 12 *` | `cse_opinion_reminder` variant `justify_dec` |
+| MG_E2 | Rappel avis CSE 1er déc (Éval. conjointe) | cron `0 8 1 12 *` | `cse_opinion_reminder` variant `joint_eval` |
+| MG_A | Rappel avis CSE (Actions correctives) | cron `0 8 1 2 *` | `cse_opinion_reminder` variant `corrective` |
+| MG_B/C | Rappel avis CSE (exactitude) | cron `0 8 1 2 *` | `cse_opinion_reminder` variant `compliance` |
+| MI_* | Bascule cycle suivant | cron `0 8 2 3 *` | `next_cycle_handover` |
 
 **Couverture événementielle : 4/4** (les 4 confirmations event-driven du
-schéma BRD). **Couverture rappels/cron : 0/13** — l'infra pg-boss +
-`enqueueNotification({ scheduledFor })` supportent `startAfter`, ce qui sera
-exploité par les futurs CronJobs.
+schéma BRD). **Couverture rappels/cron : 13/13** — implémentés via 7 builders
+schedule-driven et 13 schedules pg-boss (tous en `tz=Europe/Paris`), avec
+déduplication par `notifications.reminder_sent_log` (UNIQUE
+`type/siren/year/variant`) qui garantit l'idempotence des ticks. Voir
+[`docs/mails.md`](../../docs/mails.md) pour le détail des éligibilités SQL,
+des variants, et de l'architecture.
 
 ## Adding a new notification type
 

--- a/packages/notifications/scripts/smoke.ts
+++ b/packages/notifications/scripts/smoke.ts
@@ -1,0 +1,131 @@
+/**
+ * Smoke test — render the 11 mail builders and ship each one to MailDev.
+ *
+ * Use case: after a copy/template change, open MailDev's web UI side-by-side
+ * with the Figma source of truth (node `9564-114784`) to spot any regression.
+ *
+ * Prereqs:
+ *   docker compose up -d maildev
+ *   pnpm --filter notifications smoke
+ *
+ * Defaults (override via env vars):
+ *   SMTP_HOST=localhost
+ *   SMTP_PORT=1025
+ *   MAIL_FROM=no-reply@egapro.local
+ *   SMOKE_TO=smoke-test@example.org
+ *   EGAPRO_PUBLIC_URL=http://localhost:3000
+ *   SMOKE_TYPE=<single notification type to send instead of all 11>
+ *
+ * Open the rendered mails: http://localhost:1080
+ *
+ * Cleanup after smoking:
+ *   - MailDev clears itself on container restart (volatile by design)
+ *   - This script is git-tracked (devTooling, not test fixture)
+ */
+
+import nodemailer from "nodemailer";
+import { buildMail } from "../src/mails/index.js";
+import {
+	NOTIFICATION_TYPES,
+	type NotificationPayloadMap,
+	type NotificationType,
+} from "../src/mails/types.js";
+
+const SIREN = "552100554";
+const YEAR = 2027;
+const DEADLINE = "2027-06-01T00:00:00.000Z";
+
+const PAYLOADS: NotificationPayloadMap = {
+	declaration_confirmation: { siren: SIREN, year: YEAR },
+	second_declaration_confirmation: { siren: SIREN, year: YEAR },
+	cse_opinion_receipt: { siren: SIREN, year: YEAR },
+	joint_evaluation_submitted: { siren: SIREN, year: YEAR },
+	cycle_opening_info: { siren: SIREN, year: YEAR, deadline: DEADLINE },
+	declaration_deadline_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: DEADLINE,
+		daysRemaining: 30,
+	},
+	compliance_path_choice_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-07-01T00:00:00.000Z",
+	},
+	second_declaration_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-01-01T00:00:00.000Z",
+		daysRemaining: 90,
+	},
+	joint_evaluation_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-09-01T00:00:00.000Z",
+	},
+	cse_opinion_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-03-01T00:00:00.000Z",
+		variant: "compliance",
+	},
+	next_cycle_handover: {
+		siren: SIREN,
+		previousYear: YEAR,
+		nextYear: YEAR + 1,
+	},
+};
+
+const HOST = process.env.SMTP_HOST ?? "localhost";
+const PORT = Number.parseInt(process.env.SMTP_PORT ?? "1025", 10);
+const FROM = process.env.MAIL_FROM ?? "no-reply@egapro.local";
+const TO = process.env.SMOKE_TO ?? "smoke-test@example.org";
+
+function isNotificationType(value: string): value is NotificationType {
+	return (NOTIFICATION_TYPES as readonly string[]).includes(value);
+}
+
+async function sendOne<T extends NotificationType>(
+	transporter: nodemailer.Transporter,
+	type: T,
+): Promise<void> {
+	const payload = PAYLOADS[type];
+	const { subject, html, text } = await buildMail(type, payload);
+	await transporter.sendMail({ from: FROM, to: TO, subject, html, text });
+	console.log(`  ✔ ${type.padEnd(36)} subject="${subject}"`);
+}
+
+async function main(): Promise<void> {
+	const requested = process.env.SMOKE_TYPE;
+	const types: readonly NotificationType[] = requested
+		? (() => {
+				if (!isNotificationType(requested)) {
+					throw new Error(
+						`SMOKE_TYPE="${requested}" is not a valid notification type. Pick one of: ${NOTIFICATION_TYPES.join(", ")}`,
+					);
+				}
+				return [requested];
+			})()
+		: NOTIFICATION_TYPES;
+
+	console.log(`Connecting to MailDev on smtp://${HOST}:${PORT} …`);
+	const transporter = nodemailer.createTransport({
+		host: HOST,
+		port: PORT,
+		secure: false,
+	});
+
+	console.log(`Sending ${types.length} mail(s) to ${TO}:`);
+	for (const type of types) {
+		await sendOne(transporter, type);
+	}
+	transporter.close();
+
+	console.log("\nDone. Inspect the rendered HTML in MailDev:");
+	console.log("  http://localhost:1080");
+}
+
+main().catch((error: unknown) => {
+	console.error("[smoke] failed:", error);
+	process.exit(1);
+});

--- a/packages/notifications/src/eligibility/client.ts
+++ b/packages/notifications/src/eligibility/client.ts
@@ -1,0 +1,26 @@
+import postgres, { type Sql } from "postgres";
+import { resolvePgUrl } from "../db.js";
+
+let cached: Sql | null = null;
+
+// Read-only access to the app DB. Used by schedule handlers to find
+// eligible recipients for time-driven reminders, and to record dedup rows
+// in the `notifications.reminder_sent_log` table.
+export function getAppDbSql(): Sql | null {
+	if (cached) return cached;
+	const url = resolvePgUrl(process.env.DATABASE_URL, "");
+	if (!url) return null;
+	cached = postgres(url, { max: 2 });
+	return cached;
+}
+
+export async function closeAppDbSql(): Promise<void> {
+	if (cached) {
+		await cached.end({ timeout: 5 });
+		cached = null;
+	}
+}
+
+export function __resetAppDbSqlForTests(): void {
+	cached = null;
+}

--- a/packages/notifications/src/eligibility/dedup.ts
+++ b/packages/notifications/src/eligibility/dedup.ts
@@ -1,0 +1,74 @@
+import type { Sql } from "postgres";
+
+// Idempotence guard for cron-triggered reminders.
+//
+// Each schedule tick scans the app DB and enqueues a job for every eligible
+// recipient. Without dedup, two ticks in the same cycle (worker restart,
+// clock skew, duplicate cron firing) would re-send the same reminder.
+//
+// `(type, siren, year, variant)` is the natural identity of a reminder.
+// `variant` is the empty string `""` for types that don't carry one — keeps
+// the UNIQUE constraint simple (no NULL handling).
+
+let migrated = false;
+
+export async function ensureDedupTable(sql: Sql): Promise<void> {
+	if (migrated) return;
+	await sql.unsafe(`
+		CREATE SCHEMA IF NOT EXISTS notifications;
+		CREATE TABLE IF NOT EXISTS notifications.reminder_sent_log (
+			type text NOT NULL,
+			siren text NOT NULL,
+			year integer NOT NULL,
+			variant text NOT NULL DEFAULT '',
+			sent_at timestamptz NOT NULL DEFAULT now(),
+			UNIQUE (type, siren, year, variant)
+		);
+		CREATE INDEX IF NOT EXISTS reminder_sent_log_lookup_idx
+			ON notifications.reminder_sent_log (type, year);
+	`);
+	migrated = true;
+}
+
+export async function wasSent(
+	sql: Sql,
+	params: {
+		type: string;
+		siren: string;
+		year: number;
+		variant?: string;
+	},
+): Promise<boolean> {
+	const variant = params.variant ?? "";
+	const rows = await sql<{ count: number }[]>`
+		SELECT 1 AS count
+		FROM notifications.reminder_sent_log
+		WHERE type = ${params.type}
+			AND siren = ${params.siren}
+			AND year = ${params.year}
+			AND variant = ${variant}
+		LIMIT 1
+	`;
+	return rows.length > 0;
+}
+
+export async function markSent(
+	sql: Sql,
+	params: {
+		type: string;
+		siren: string;
+		year: number;
+		variant?: string;
+	},
+): Promise<void> {
+	const variant = params.variant ?? "";
+	await sql`
+		INSERT INTO notifications.reminder_sent_log (type, siren, year, variant)
+		VALUES (${params.type}, ${params.siren}, ${params.year}, ${variant})
+		ON CONFLICT (type, siren, year, variant) DO NOTHING
+	`;
+}
+
+export function __resetDedupForTests(): void {
+	migrated = false;
+}

--- a/packages/notifications/src/eligibility/index.ts
+++ b/packages/notifications/src/eligibility/index.ts
@@ -1,0 +1,21 @@
+export {
+	__resetAppDbSqlForTests,
+	closeAppDbSql,
+	getAppDbSql,
+} from "./client.js";
+export {
+	__resetDedupForTests,
+	ensureDedupTable,
+	markSent,
+	wasSent,
+} from "./dedup.js";
+export {
+	findAwaitingComplianceChoice,
+	findCompletedPreviousCycle,
+	findCorrectiveSecondDeclarationPending,
+	findCseOpinionPending,
+	findDraftDeclarations,
+	findJointEvaluationPending,
+	findOpenCycleRecipients,
+	type ReminderRecipient,
+} from "./queries.js";

--- a/packages/notifications/src/eligibility/queries.ts
+++ b/packages/notifications/src/eligibility/queries.ts
@@ -1,0 +1,262 @@
+import type { Sql } from "postgres";
+import type { CseOpinionReminderVariant } from "../mails/types.js";
+
+// Eligibility queries against the app DB.
+//
+// Tables follow the Drizzle multi-project prefix `app_*`. All queries
+// return `(siren, year, email, userId)` so the caller knows where to send
+// the reminder. The recipient is always the most recent declarant for the
+// company (deterministic, single mail per company per reminder).
+
+export type ReminderRecipient = {
+	siren: string;
+	year: number;
+	email: string;
+	userId: string;
+};
+
+// 1. Cycle opening (1er mars Y, Y >= 2028): recipients with a completed
+// previous cycle. We notify the past declarant of cycle Y-1.
+export async function findOpenCycleRecipients(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	const previousYear = year - 1;
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			${year}::int AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		JOIN app_company c ON c.siren = d.siren
+		WHERE d.year = ${previousYear}
+			AND d.cancelled_at IS NULL
+			AND d.status IN ('demarche_completed', 'awaiting_cse_opinion')
+			AND c.workforce >= 50
+			AND u.email IS NOT NULL
+	`;
+}
+
+// 2. Declaration deadline reminder (J-30 / J-10 before 1er juin):
+// declarations still in draft for the current campaign year.
+export async function findDraftDeclarations(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		JOIN app_company c ON c.siren = d.siren
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND d.status = 'draft'
+			AND c.workforce >= 50
+			AND u.email IS NOT NULL
+	`;
+}
+
+// 3. Compliance path choice reminder (J-15 before 1er juillet):
+// declarations submitted with gap >= 5% awaiting the user's compliance
+// decision. Covers two rounds:
+//  - Round 1: status='awaiting_compliance_path_choice' + first choice NULL
+//  - Round 2: status='awaiting_revision_choice' (after second declaration
+//    with persistent gap) + second choice NULL. In round 2 the *first*
+//    choice is already set to 'corrective_action', so filtering on it
+//    would silently exclude every round-2 recipient.
+export async function findAwaitingComplianceChoice(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND u.email IS NOT NULL
+			AND (
+				(d.status = 'awaiting_compliance_path_choice' AND d.first_declaration_path_choice IS NULL)
+				OR
+				(d.status = 'awaiting_revision_choice' AND d.second_declaration_path_choice IS NULL)
+			)
+	`;
+}
+
+// 4. Second declaration reminder (J-90 / J-30 before 1er janvier N+1):
+// declarations on the corrective-actions track that have not yet submitted
+// their second declaration. `secondDeclarationStep` is null until the
+// second declaration is submitted (then set to 3, see declaration.ts).
+export async function findCorrectiveSecondDeclarationPending(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND d.first_declaration_path_choice = 'corrective_action'
+			AND d.status = 'corrective_actions_chosen'
+			AND d.second_declaration_step IS NULL
+			AND u.email IS NOT NULL
+	`;
+}
+
+// 5. Joint evaluation reminder (1er août): declarations on the
+// joint-evaluation track without an uploaded joint_evaluation file.
+// `secondDeclarationPathChoice` takes precedence over `first*` once the
+// user re-chose at Round 2 (corrective Round 1 → joint_evaluation Round 2).
+export async function findJointEvaluationPending(
+	sql: Sql,
+	year: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${year}
+			AND d.cancelled_at IS NULL
+			AND u.email IS NOT NULL
+			AND COALESCE(d.second_declaration_path_choice, d.first_declaration_path_choice) = 'joint_evaluation'
+			AND NOT EXISTS (
+				SELECT 1
+				FROM app_file f
+				WHERE f.declaration_id = d.id
+					AND f.type = 'joint_evaluation'
+			)
+	`;
+}
+
+// 6. CSE opinion reminder — one variant per flowchart branch.
+//
+// All variants share the base eligibility:
+//   - declaration is active (not cancelled),
+//   - company is CSE-required (`cse_required = true`),
+//   - no CSE opinion has been deposited yet (NOT EXISTS in app_cse_opinion).
+//
+// Per-variant filters (derived from `docs/parcours-utilisateurs.md`):
+//   - compliance (MG_B / MG_C): no Phase 2 path chosen — covers the
+//     "100-149 sans 7e" branch (C2) and the "150+ conforme G<5%" branch
+//     (4a). Both go straight from Phase 1 submission to CSE deposit.
+//   - justify_oct (MG_J1) + justify_dec (MG_J2): one of the two path
+//     choices is `justify`. Same SQL filter, different cron.
+//   - corrective (MG_A): first-round path is `corrective_action`, the
+//     second declaration has been submitted (status = 'awaiting_cse_opinion')
+//     — without this status filter we would also trigger MG_A for
+//     declarations that haven't completed their second declaration yet.
+//   - joint_eval (MG_E2): one of the path choices is `joint_evaluation`
+//     AND the joint-eval report has been uploaded (else the FSM is still
+//     awaiting the report, not the CSE opinion).
+export async function findCseOpinionPending(
+	sql: Sql,
+	year: number,
+	variant: CseOpinionReminderVariant,
+): Promise<ReminderRecipient[]> {
+	const baseConditions = sql`
+		d.year = ${year}
+		AND d.cancelled_at IS NULL
+		AND d.cse_required = true
+		AND u.email IS NOT NULL
+		AND NOT EXISTS (
+			SELECT 1 FROM app_cse_opinion o WHERE o.declaration_id = d.id
+		)
+	`;
+	const variantFilter = buildCseOpinionVariantFilter(sql, variant);
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE ${baseConditions} AND (${variantFilter})
+	`;
+}
+
+function buildCseOpinionVariantFilter(
+	sql: Sql,
+	variant: CseOpinionReminderVariant,
+) {
+	switch (variant) {
+		// MG_B / MG_C — entreprise sans parcours Phase 2 (100-149 sans 7e ind,
+		// ou 150+ conforme G < 5 %). Neither round has chosen a compliance path.
+		case "compliance":
+			return sql`
+				d.first_declaration_path_choice IS NULL
+				AND d.second_declaration_path_choice IS NULL
+			`;
+		// MG_J1 / MG_J2 — parcours Justifier (Round 1 ou Round 2). Same filter,
+		// cron picks the timing (1er sept = J-30 / 1er déc = relance).
+		case "justify_oct":
+		case "justify_dec":
+			return sql`
+				d.first_declaration_path_choice = 'justify'
+				OR d.second_declaration_path_choice = 'justify'
+			`;
+		// MG_A — Actions correctives, 2e déclaration soumise et écarts corrigés.
+		// The FSM transitions to 'awaiting_cse_opinion' once the second
+		// declaration lands and the gap is back below 5 %.
+		case "corrective":
+			return sql`
+				d.first_declaration_path_choice = 'corrective_action'
+				AND d.status = 'awaiting_cse_opinion'
+			`;
+		// MG_E2 — Évaluation conjointe, rapport déposé. Without the file
+		// check, the FSM is still waiting for the report (M_PE2 trigger),
+		// not the CSE opinion.
+		case "joint_eval":
+			return sql`
+				(
+					d.first_declaration_path_choice  = 'joint_evaluation'
+					OR d.second_declaration_path_choice = 'joint_evaluation'
+				)
+				AND EXISTS (
+					SELECT 1 FROM app_file f
+					WHERE f.declaration_id = d.id AND f.type = 'joint_evaluation'
+				)
+			`;
+	}
+}
+
+// 7. Next cycle handover (2 mars N+1): companies whose previous cycle is
+// closed (status = demarche_completed). The recipient is the declarant of
+// that cycle.
+export async function findCompletedPreviousCycle(
+	sql: Sql,
+	previousYear: number,
+): Promise<ReminderRecipient[]> {
+	return sql<ReminderRecipient[]>`
+		SELECT
+			d.siren AS siren,
+			d.year AS year,
+			u.email AS email,
+			d.declarant_id AS "userId"
+		FROM app_declaration d
+		JOIN app_user u ON u.id = d.declarant_id
+		WHERE d.year = ${previousYear}
+			AND d.cancelled_at IS NULL
+			AND d.status = 'demarche_completed'
+			AND u.email IS NOT NULL
+	`;
+}

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -5,6 +5,7 @@ import postgres, { type Sql } from "postgres";
 import { resolveNotificationsDbUrl, resolvePgUrl } from "./db.js";
 import { buildMail, MAIL_BUILDERS } from "./mails/index.js";
 import { QUEUE_NAME, validateJobData } from "./queue.js";
+import { registerSchedules, SCHEDULES } from "./schedules/index.js";
 
 type SerializableJson =
 	| null
@@ -43,6 +44,7 @@ type SerializableJson =
 
 export { MAIL_BUILDERS, buildMail };
 export { QUEUE_NAME, validateJobData };
+export { SCHEDULES };
 export type { EmailJobData } from "./queue.js";
 
 const SEND_AUDIT_ACTION = "notification.send";
@@ -254,6 +256,8 @@ async function main(): Promise<void> {
 			}
 		},
 	);
+
+	await registerSchedules(boss, mainSql);
 
 	const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
 		console.log(`[notifications] received ${signal}, shutting down...`);

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,208 +1,102 @@
-import nodemailer, { type Transporter } from "nodemailer";
-import { PgBoss, type JobWithMetadata } from "pg-boss";
+import { type JobWithMetadata, PgBoss } from "pg-boss";
 import postgres, { type Sql } from "postgres";
 
 import { resolveNotificationsDbUrl, resolvePgUrl } from "./db.js";
 import { buildMail, MAIL_BUILDERS } from "./mails/index.js";
 import { QUEUE_NAME, validateJobData } from "./queue.js";
 import { registerSchedules, SCHEDULES } from "./schedules/index.js";
-
-type SerializableJson =
-	| null
-	| string
-	| number
-	| boolean
-	| Date
-	| { [key: string]: SerializableJson }
-	| SerializableJson[];
+import { logAuditMain } from "./worker/auditLog.js";
+import { makeJobHandler } from "./worker/jobHandler.js";
+import { installShutdownHooks } from "./worker/lifecycle.js";
+import { buildTransporter, getMailEnabled } from "./worker/transporter.js";
 
 /**
  * Notifications worker — long-running pg-boss consumer.
  *
- * Connects to NOTIFICATIONS_DATABASE_URL (pg-boss schema, isolated from the
- * main app DB by design) and processes `email-notification` jobs published
- * by the app's `enqueueNotification` helper. Lives in its own workspace
- * (`packages/notifications/`) so the Next.js bundle never imports a single
- * line of worker code.
+ * Two job sources:
+ * 1. **Event-driven** — the app's `enqueueNotification` helper pushes
+ *    `email-notification` jobs on the `QUEUE_NAME` queue, processed by
+ *    `makeJobHandler` (validates payload, renders the React Email
+ *    template, sends via SMTP, audits success/failure).
+ * 2. **Schedule-driven** — pg-boss native `boss.schedule()` ticks N
+ *    reminder queues at their cron schedule. Each tick runs the matching
+ *    handler which queries the app DB for eligible recipients and
+ *    re-enqueues a normal `email-notification` job per recipient.
  *
- * Job lifecycle:
- * - `validateJobData` runs first. Schema errors are *poison pills* — they can
- *   never succeed, so the handler logs the failure and returns clean (marking
- *   the job complete) rather than throwing. Throwing would trigger up to 5
- *   retries for nothing.
- * - SMTP / transient errors throw, so pg-boss retries them according to the
- *   per-job retry policy (`retryLimit`, `retryBackoff`) set at publish time.
+ * Lives in its own workspace (`packages/notifications/`) so the Next.js
+ * bundle never imports a single line of worker code.
  *
- * Audit rows go to the main DB (`DATABASE_URL`) when available — failure to
- * log audit never aborts the send. When `DATABASE_URL` is absent the worker
- * still runs, it just stops emitting `audit.action_log` rows.
+ * Job lifecycle (event queue):
+ * - `validateJobData` runs first. Schema errors are *poison pills* — they
+ *   can never succeed, so the handler logs the failure and returns clean
+ *   (marking the job complete) rather than throwing.
+ * - SMTP / transient errors throw, so pg-boss retries them according to
+ *   the per-job retry policy.
  *
- * Sub-second graceful shutdown via SIGTERM/SIGINT (call `boss.stop()` then
- * exit). pg-boss flushes in-flight jobs and ACKs them so the next pod start
- * resumes cleanly.
+ * Audit rows go to the main DB (`DATABASE_URL`) when available. Failure to
+ * log audit never aborts the send. When `DATABASE_URL` is absent the
+ * worker still runs the event queue, but reminders are disabled (the
+ * eligibility queries need the app DB).
  */
 
-export { MAIL_BUILDERS, buildMail };
-export { QUEUE_NAME, validateJobData };
-export { SCHEDULES };
 export type { EmailJobData } from "./queue.js";
-
-const SEND_AUDIT_ACTION = "notification.send";
-const SEND_AUDIT_CATEGORY = "system";
-
-type AuditRow = {
-	action: string;
-	category: string;
-	status: "success" | "failure";
-	userId?: string | null;
-	userEmail?: string | null;
-	siren?: string | null;
-	resourceType?: string | null;
-	resourceId?: string | null;
-	errorMessage?: string | null;
-	metadata?: SerializableJson;
+export {
+	buildMail,
+	logAuditMain,
+	MAIL_BUILDERS,
+	makeJobHandler,
+	QUEUE_NAME,
+	SCHEDULES,
+	validateJobData,
 };
 
-function getMailEnabled(): boolean {
-	return (process.env.MAIL_ENABLED ?? "false").toLowerCase() === "true";
-}
+const BOOT_MAX_ATTEMPTS = Number.parseInt(
+	process.env.NOTIFICATIONS_BOOT_RETRY_MAX ?? "30",
+	10,
+);
+const BOOT_DELAY_MS = Number.parseInt(
+	process.env.NOTIFICATIONS_BOOT_RETRY_DELAY_MS ?? "5000",
+	10,
+);
 
-function buildTransporter(): Transporter {
-	const host = process.env.SMTP_HOST;
-	if (!host) {
-		throw new Error("SMTP_HOST must be set when MAIL_ENABLED=true");
-	}
-	const port = parseInt(process.env.SMTP_PORT ?? "1025", 10);
-	const secure = (process.env.SMTP_SECURE ?? "false").toLowerCase() === "true";
-	const auth =
-		process.env.SMTP_USER && process.env.SMTP_PASS
-			? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
-			: undefined;
-	return nodemailer.createTransport({ host, port, secure, auth });
-}
-
-async function logAuditMain(mainSql: Sql | null, row: AuditRow): Promise<void> {
-	if (!mainSql) return;
-	try {
-		await mainSql`
-			INSERT INTO audit.action_log (
-				id, created_at, action, category, status,
-				user_id, user_email, siren, resource_type, resource_id,
-				error_message, metadata
-			)
-			VALUES (
-				${crypto.randomUUID()},
-				${new Date()},
-				${row.action},
-				${row.category},
-				${row.status},
-				${row.userId ?? null},
-				${row.userEmail ?? null},
-				${row.siren ?? null},
-				${row.resourceType ?? null},
-				${row.resourceId ?? null},
-				${row.errorMessage ?? null},
-				${mainSql.json(row.metadata ?? null)}
-			)
-		`;
-	} catch (auditError) {
-		console.error("[notifications] audit insert failed:", auditError);
-	}
-}
-
-export type JobHandlerDeps = {
-	transporter: Transporter | null;
-	mailFrom: string;
-	mailEnabled: boolean;
-	mainSql: Sql | null;
-};
-
-export function makeJobHandler(
-	deps: JobHandlerDeps,
-): (job: JobWithMetadata<unknown>) => Promise<void> {
-	const { transporter, mailFrom, mailEnabled, mainSql } = deps;
-	return async (job) => {
-		const attempt = (job.retryCount ?? 0) + 1;
-		const result = validateJobData(job.data);
-
-		if (!result.ok) {
-			// Poison pill: malformed payload can never succeed. Log + return clean
-			// so pg-boss marks the job complete and stops retrying.
-			console.error(
-				`[notifications] dropping malformed job ${job.id}: ${result.reason}`,
-			);
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "failure",
-				resourceType: "notification",
-				resourceId: job.id,
-				errorMessage: result.reason,
-				metadata: { attempt, poisonPill: true },
-			});
-			return;
-		}
-
-		const {
-			type,
-			payload,
-			recipientEmail,
-			recipientUserId,
-			siren,
-			attachments,
-		} = result.data;
-
+// On a fresh review app, pg-app may not accept connections yet when the
+// notifications pod starts. Without a wait, pg-boss throws, the worker exits
+// non-zero, and the kontinuous `deploy-sidecars/progressing` plugin gives up
+// after the very first crash. Ping the DB with a lightweight `SELECT 1` loop
+// before handing the connection string to pg-boss — once the server answers
+// we know `boss.start()` + `createQueue` + `work` + `schedule` will all hit a
+// live socket, so the entire boot sequence runs in a single shot.
+async function waitForDatabase(connectionString: string): Promise<void> {
+	for (let attempt = 1; attempt <= BOOT_MAX_ATTEMPTS; attempt++) {
+		// `ssl: 'prefer'` lets postgres.js handshake with both plain (review-app
+		// docker postgres) and self-signed TLS (in-cluster pg-rw) backends, since
+		// `sslmode=no-verify` from db.ts is a node-postgres extension and not
+		// recognised by postgres.js.
+		const probe = postgres(connectionString, {
+			max: 1,
+			connect_timeout: 5,
+			idle_timeout: 1,
+			ssl: "prefer",
+		});
 		try {
-			const { subject, html, text } = await buildMail(type, payload);
-			let messageId: string | null = null;
-			if (!mailEnabled || !transporter) {
+			await probe`select 1`;
+			await probe.end({ timeout: 1 });
+			if (attempt > 1) {
 				console.log(
-					`[notifications] MAIL_ENABLED=false — would send ${type} to ${recipientEmail}`,
+					`[notifications] database reachable after ${attempt} attempts`,
 				);
-			} else {
-				const decodedAttachments = attachments?.map((att) => ({
-					filename: att.filename,
-					content: Buffer.from(att.contentBase64, "base64"),
-					contentType: att.contentType,
-				}));
-				const info = await transporter.sendMail({
-					from: mailFrom,
-					to: recipientEmail,
-					subject,
-					text,
-					html,
-					...(decodedAttachments ? { attachments: decodedAttachments } : {}),
-				});
-				messageId = info.messageId ?? null;
 			}
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "success",
-				userId: recipientUserId,
-				userEmail: recipientEmail,
-				siren,
-				resourceType: "notification",
-				resourceId: job.id,
-				metadata: { type, attempt, messageId },
-			});
+			return;
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "failure",
-				userId: recipientUserId,
-				userEmail: recipientEmail,
-				siren,
-				resourceType: "notification",
-				resourceId: job.id,
-				errorMessage: message,
-				metadata: { type, attempt },
-			});
-			throw error;
+			await probe.end({ timeout: 1 }).catch(() => undefined);
+			if (attempt === BOOT_MAX_ATTEMPTS) throw error;
+			const reason = error instanceof Error ? error.message : String(error);
+			console.warn(
+				`[notifications] database not reachable (attempt ${attempt}/${BOOT_MAX_ATTEMPTS}): ${reason} — retrying in ${BOOT_DELAY_MS}ms`,
+			);
+			await new Promise((resolve) => setTimeout(resolve, BOOT_DELAY_MS));
 		}
-	};
+	}
 }
 
 async function main(): Promise<void> {
@@ -217,7 +111,9 @@ async function main(): Promise<void> {
 	const transporter = mailEnabled ? buildTransporter() : null;
 	const mailFrom = process.env.MAIL_FROM ?? "no-reply@egapro.local";
 
-	const mainSql: Sql | null = mainUrl ? postgres(mainUrl, { max: 1 }) : null;
+	const mainSql: Sql | null = mainUrl ? postgres(mainUrl, { max: 2 }) : null;
+
+	await waitForDatabase(notifUrl);
 
 	const boss = new PgBoss({
 		connectionString: notifUrl,
@@ -259,22 +155,7 @@ async function main(): Promise<void> {
 
 	await registerSchedules(boss, mainSql);
 
-	const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
-		console.log(`[notifications] received ${signal}, shutting down...`);
-		try {
-			await boss.stop({ graceful: true, timeout: 15_000 });
-			if (mainSql) await mainSql.end();
-		} catch (error) {
-			console.error("[notifications] shutdown error:", error);
-		}
-		process.exit(0);
-	};
-	process.on("SIGTERM", () => {
-		void shutdown("SIGTERM");
-	});
-	process.on("SIGINT", () => {
-		void shutdown("SIGINT");
-	});
+	installShutdownHooks({ boss, mainSql });
 }
 
 const isCli = (() => {

--- a/packages/notifications/src/schedules/__tests__/dispatch.test.ts
+++ b/packages/notifications/src/schedules/__tests__/dispatch.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnqueue, mockMarkSent, mockWasSent } = vi.hoisted(() => ({
+	mockEnqueue: vi.fn(),
+	mockMarkSent: vi.fn(),
+	mockWasSent: vi.fn(),
+}));
+
+vi.mock("../../publisher.js", () => ({
+	enqueueNotification: mockEnqueue,
+}));
+
+vi.mock("../../eligibility/index.js", () => ({
+	markSent: mockMarkSent,
+	wasSent: mockWasSent,
+}));
+
+import { dispatchReminder } from "../dispatch.js";
+
+const recipient = (siren: string) => ({
+	siren,
+	year: 2027,
+	email: `user-${siren}@example.fr`,
+	userId: `user-${siren}`,
+});
+
+const fakeSql = {} as unknown as Parameters<typeof dispatchReminder>[0]["sql"];
+
+describe("dispatchReminder", () => {
+	beforeEach(() => {
+		mockEnqueue.mockReset();
+		mockMarkSent.mockReset();
+		mockWasSent.mockReset();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("enqueues a job for each new recipient and marks them sent", async () => {
+		mockWasSent.mockResolvedValue(false);
+		mockEnqueue.mockResolvedValue({ status: "enqueued", id: "job-1" });
+		mockMarkSent.mockResolvedValue(undefined);
+
+		const result = await dispatchReminder({
+			sql: fakeSql,
+			type: "cycle_opening_info",
+			recipients: [recipient("111111111"), recipient("222222222")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-06-01T00:00:00.000Z",
+			}),
+		});
+
+		expect(result).toEqual({
+			scheduled: 2,
+			skippedAlreadySent: 0,
+			enqueued: 2,
+			enqueueErrors: 0,
+		});
+		expect(mockEnqueue).toHaveBeenCalledTimes(2);
+		expect(mockMarkSent).toHaveBeenCalledTimes(2);
+	});
+
+	it("skips recipients already in the dedup table", async () => {
+		mockWasSent.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+		mockEnqueue.mockResolvedValue({ status: "enqueued", id: "job-2" });
+		mockMarkSent.mockResolvedValue(undefined);
+
+		const result = await dispatchReminder({
+			sql: fakeSql,
+			type: "joint_evaluation_reminder",
+			recipients: [recipient("111111111"), recipient("222222222")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-09-01T00:00:00.000Z",
+			}),
+		});
+
+		expect(result.skippedAlreadySent).toBe(1);
+		expect(result.enqueued).toBe(1);
+		expect(mockEnqueue).toHaveBeenCalledTimes(1);
+		expect(mockMarkSent).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not mark sent if enqueue fails (so the next tick retries)", async () => {
+		mockWasSent.mockResolvedValue(false);
+		mockEnqueue.mockResolvedValue({ status: "error", error: "boom" });
+		const errorSpy = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+
+		const result = await dispatchReminder({
+			sql: fakeSql,
+			type: "compliance_path_choice_reminder",
+			recipients: [recipient("111111111")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-07-01T00:00:00.000Z",
+			}),
+		});
+
+		expect(result.enqueueErrors).toBe(1);
+		expect(result.enqueued).toBe(0);
+		expect(mockMarkSent).not.toHaveBeenCalled();
+		errorSpy.mockRestore();
+	});
+
+	it("propagates the variant to dedup keys", async () => {
+		mockWasSent.mockResolvedValue(false);
+		mockEnqueue.mockResolvedValue({ status: "enqueued", id: "job-3" });
+		mockMarkSent.mockResolvedValue(undefined);
+
+		await dispatchReminder({
+			sql: fakeSql,
+			type: "cse_opinion_reminder",
+			variant: "justify_oct",
+			recipients: [recipient("111111111")],
+			payloadFor: ({ siren }) => ({
+				siren,
+				year: 2027,
+				deadline: "2027-10-01T00:00:00.000Z",
+				variant: "justify_oct",
+			}),
+		});
+
+		expect(mockWasSent).toHaveBeenCalledWith(
+			fakeSql,
+			expect.objectContaining({ variant: "justify_oct" }),
+		);
+		expect(mockMarkSent).toHaveBeenCalledWith(
+			fakeSql,
+			expect.objectContaining({ variant: "justify_oct" }),
+		);
+	});
+});

--- a/packages/notifications/src/schedules/__tests__/registerSchedules.test.ts
+++ b/packages/notifications/src/schedules/__tests__/registerSchedules.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerSchedules, SCHEDULES } from "../index.js";
+
+type BossStub = {
+	createQueue: ReturnType<typeof vi.fn>;
+	work: ReturnType<typeof vi.fn>;
+	schedule: ReturnType<typeof vi.fn>;
+};
+
+function buildBoss(): BossStub {
+	return {
+		createQueue: vi.fn().mockResolvedValue(undefined),
+		work: vi.fn().mockResolvedValue(undefined),
+		schedule: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+describe("SCHEDULES", () => {
+	it("declares the expected 13 schedules", () => {
+		expect(SCHEDULES.length).toBe(13);
+	});
+
+	it("uses unique queue names", () => {
+		const names = SCHEDULES.map((s) => s.name);
+		expect(new Set(names).size).toBe(names.length);
+	});
+
+	it("uses Europe/Paris timezone for every schedule", () => {
+		for (const schedule of SCHEDULES) {
+			expect(schedule.timeZone).toBe("Europe/Paris");
+		}
+	});
+
+	it("uses valid 5-field cron expressions", () => {
+		for (const schedule of SCHEDULES) {
+			const fields = schedule.cron.split(/\s+/);
+			expect(fields.length).toBe(5);
+			expect(schedule.cron).toMatch(/^[\d*,/-]+(\s+[\d*,/-]+){4}$/);
+		}
+	});
+
+	it("includes the four CSE opinion reminder variants", () => {
+		const names = SCHEDULES.map((s) => s.name);
+		expect(names).toContain("reminder-cse-opinion-compliance");
+		expect(names).toContain("reminder-cse-opinion-justify-oct");
+		expect(names).toContain("reminder-cse-opinion-justify-dec");
+		expect(names).toContain("reminder-cse-opinion-corrective");
+		expect(names).toContain("reminder-cse-opinion-joint-eval");
+	});
+});
+
+describe("registerSchedules", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	let logSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+		logSpy.mockRestore();
+	});
+
+	it("disables reminders and warns when DATABASE_URL is missing", async () => {
+		const boss = buildBoss();
+		await registerSchedules(
+			boss as unknown as Parameters<typeof registerSchedules>[0],
+			null,
+		);
+		expect(boss.createQueue).not.toHaveBeenCalled();
+		expect(boss.work).not.toHaveBeenCalled();
+		expect(boss.schedule).not.toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("reminders disabled"),
+		);
+	});
+
+	it("registers all schedules with timezone and cron", async () => {
+		const boss = buildBoss();
+		const fakeSql = {} as unknown as Parameters<typeof registerSchedules>[1];
+		await registerSchedules(
+			boss as unknown as Parameters<typeof registerSchedules>[0],
+			fakeSql,
+		);
+		expect(boss.createQueue).toHaveBeenCalledTimes(SCHEDULES.length);
+		expect(boss.work).toHaveBeenCalledTimes(SCHEDULES.length);
+		expect(boss.schedule).toHaveBeenCalledTimes(SCHEDULES.length);
+		for (const schedule of SCHEDULES) {
+			expect(boss.schedule).toHaveBeenCalledWith(
+				schedule.name,
+				schedule.cron,
+				{},
+				{ tz: "Europe/Paris" },
+			);
+		}
+	});
+});

--- a/packages/notifications/src/schedules/dates.ts
+++ b/packages/notifications/src/schedules/dates.ts
@@ -1,0 +1,36 @@
+// Date helpers for schedule handlers.
+//
+// Worker code lives outside `~/modules/domain`, so we can't import its
+// `getCurrentYear()` helper. Instead we extract the year via
+// `Intl.DateTimeFormat` to stay aware of `Europe/Paris` (avoids edge cases
+// when a tick lands at 23:00 UTC on Dec 31 — which would be Jan 1 in
+// Paris, hence year + 1).
+
+const YEAR_FORMATTER = new Intl.DateTimeFormat("fr-FR", {
+	year: "numeric",
+	timeZone: "Europe/Paris",
+});
+
+export function getCurrentYear(now: Date = new Date()): number {
+	return Number(YEAR_FORMATTER.format(now));
+}
+
+// Build an ISO 8601 date string at midnight Paris time (close enough for
+// display). Used as the `deadline` field in reminder payloads.
+export function toIsoDate(year: number, month: number, day: number): string {
+	const paddedMonth = String(month).padStart(2, "0");
+	const paddedDay = String(day).padStart(2, "0");
+	return `${year}-${paddedMonth}-${paddedDay}T00:00:00.000Z`;
+}
+
+// First-of-month deadline helpers — mapped 1:1 to the regulatory milestones
+// laid out in `docs/parcours-utilisateurs.md`. Centralised here so each
+// schedule handler stays declarative.
+export const DEADLINES = {
+	declarationModification: (year: number) => toIsoDate(year, 6, 1), // 1er juin
+	compliancePathChoice: (year: number) => toIsoDate(year, 7, 1), // 1er juillet
+	jointEvaluationReport: (year: number) => toIsoDate(year, 9, 1), // 1er septembre
+	secondDeclaration: (year: number) => toIsoDate(year + 1, 1, 1), // 1er janvier N+1
+	cseOpinionFinal: (year: number) => toIsoDate(year + 1, 3, 1), // 1er mars N+1
+	cseOpinionJustifyOct: (year: number) => toIsoDate(year, 10, 1), // 1er octobre
+} as const;

--- a/packages/notifications/src/schedules/definitions.ts
+++ b/packages/notifications/src/schedules/definitions.ts
@@ -1,0 +1,108 @@
+import type { Sql } from "postgres";
+import type { CseOpinionReminderVariant } from "../mails/types.js";
+import type { DispatchResult } from "./dispatch.js";
+import {
+	handleCompliancePathChoiceReminder,
+	handleCseOpinionReminder,
+	handleCycleOpeningInfo,
+	handleDeclarationDeadlineReminder,
+	handleJointEvaluationReminder,
+	handleNextCycleHandover,
+	handleSecondDeclarationReminder,
+} from "./handlers.js";
+
+export type ScheduleDefinition = {
+	name: string;
+	cron: string;
+	timeZone: string;
+	run: (sql: Sql) => Promise<DispatchResult>;
+};
+
+const TZ = "Europe/Paris";
+
+// Cron timing rationale (all in Europe/Paris, anchored to the V2 calendar
+// in `docs/parcours-utilisateurs.md`):
+//
+// - Phase 1 cycle (year N):
+//   - 1er mars → MA   (cycle opening info)
+//   - 2 mai    → MR30 (J-30 before declaration deadline 1er juin)
+//   - 22 mai   → MR10 (J-10 before declaration deadline 1er juin)
+//   - 16 juin  → ME   (J-15 before compliance path choice 1er juillet)
+//   - 1er août → MG_E1 (joint-eval report due 1er septembre)
+//   - 3 oct    → MSD3 (J-90 before second declaration 1er janvier N+1)
+//   - 1er sept → MG_J1 (J-30 before CSE Justify deadline 1er octobre)
+//   - 1er déc  → MSD30 (J-30 before second declaration 1er janvier N+1)
+//   - 1er déc  → MG_J2 / MG_E2 (CSE Justify late + CSE Joint-eval reminders)
+//
+// - Phase 1 wrap-up (year N+1):
+//   - 1er fév  → MG_B/C / MG_A (J-30 before CSE final 1er mars N+1)
+//   - 2 mars   → MI_* (next-cycle handover)
+
+const CSE_VARIANT_SCHEDULES: ReadonlyArray<{
+	suffix: string;
+	cron: string;
+	variant: CseOpinionReminderVariant;
+}> = [
+	{ suffix: "compliance", cron: "0 8 1 2 *", variant: "compliance" },
+	{ suffix: "justify-oct", cron: "0 8 1 9 *", variant: "justify_oct" },
+	{ suffix: "justify-dec", cron: "0 8 1 12 *", variant: "justify_dec" },
+	{ suffix: "corrective", cron: "0 8 1 2 *", variant: "corrective" },
+	{ suffix: "joint-eval", cron: "0 8 1 12 *", variant: "joint_eval" },
+];
+
+export const SCHEDULES: ScheduleDefinition[] = [
+	{
+		name: "reminder-cycle-opening-info",
+		cron: "0 8 1 3 *",
+		timeZone: TZ,
+		run: handleCycleOpeningInfo,
+	},
+	{
+		name: "reminder-declaration-deadline-30",
+		cron: "0 8 2 5 *",
+		timeZone: TZ,
+		run: (sql) => handleDeclarationDeadlineReminder(sql, 30),
+	},
+	{
+		name: "reminder-declaration-deadline-10",
+		cron: "0 8 22 5 *",
+		timeZone: TZ,
+		run: (sql) => handleDeclarationDeadlineReminder(sql, 10),
+	},
+	{
+		name: "reminder-compliance-path-choice",
+		cron: "0 8 16 6 *",
+		timeZone: TZ,
+		run: handleCompliancePathChoiceReminder,
+	},
+	{
+		name: "reminder-second-declaration-90",
+		cron: "0 8 3 10 *",
+		timeZone: TZ,
+		run: (sql) => handleSecondDeclarationReminder(sql, 90),
+	},
+	{
+		name: "reminder-second-declaration-30",
+		cron: "0 8 1 12 *",
+		timeZone: TZ,
+		run: (sql) => handleSecondDeclarationReminder(sql, 30),
+	},
+	{
+		name: "reminder-joint-evaluation",
+		cron: "0 8 1 8 *",
+		timeZone: TZ,
+		run: handleJointEvaluationReminder,
+	},
+	...CSE_VARIANT_SCHEDULES.map(({ suffix, cron, variant }) => ({
+		name: `reminder-cse-opinion-${suffix}`,
+		cron,
+		timeZone: TZ,
+		run: (sql: Sql) => handleCseOpinionReminder(sql, variant),
+	})),
+	{
+		name: "reminder-next-cycle-handover",
+		cron: "0 8 2 3 *",
+		timeZone: TZ,
+		run: handleNextCycleHandover,
+	},
+];

--- a/packages/notifications/src/schedules/dispatch.ts
+++ b/packages/notifications/src/schedules/dispatch.ts
@@ -1,0 +1,82 @@
+import type { Sql } from "postgres";
+import type { ReminderRecipient } from "../eligibility/index.js";
+import { markSent, wasSent } from "../eligibility/index.js";
+import type {
+	NotificationPayloadMap,
+	NotificationType,
+} from "../mails/types.js";
+import { enqueueNotification } from "../publisher.js";
+
+export type DispatchResult = {
+	scheduled: number;
+	skippedAlreadySent: number;
+	enqueued: number;
+	enqueueErrors: number;
+};
+
+// Shared dispatch loop for all reminder schedules.
+// Iterates over the recipients returned by an eligibility query, skips
+// the ones already sent (via the dedup table), enqueues a notification job
+// for the rest, and records each successful enqueue in the dedup table.
+//
+// Variant matters for `cse_opinion_reminder` (one entry per variant in the
+// dedup table — same recipient may receive several variants per year).
+export async function dispatchReminder<T extends NotificationType>(params: {
+	sql: Sql;
+	type: T;
+	recipients: ReminderRecipient[];
+	payloadFor: (recipient: ReminderRecipient) => NotificationPayloadMap[T];
+	variant?: string;
+	dedupYearFor?: (recipient: ReminderRecipient) => number;
+}): Promise<DispatchResult> {
+	const result: DispatchResult = {
+		scheduled: params.recipients.length,
+		skippedAlreadySent: 0,
+		enqueued: 0,
+		enqueueErrors: 0,
+	};
+
+	for (const recipient of params.recipients) {
+		const dedupYear = params.dedupYearFor
+			? params.dedupYearFor(recipient)
+			: recipient.year;
+		const already = await wasSent(params.sql, {
+			type: params.type,
+			siren: recipient.siren,
+			year: dedupYear,
+			variant: params.variant,
+		});
+		if (already) {
+			result.skippedAlreadySent += 1;
+			continue;
+		}
+		const payload = params.payloadFor(recipient);
+		const enqueueResult = await enqueueNotification({
+			type: params.type,
+			recipientEmail: recipient.email,
+			recipientUserId: recipient.userId,
+			siren: recipient.siren,
+			payload,
+		});
+		if (enqueueResult.status === "enqueued") {
+			result.enqueued += 1;
+			await markSent(params.sql, {
+				type: params.type,
+				siren: recipient.siren,
+				year: dedupYear,
+				variant: params.variant,
+			});
+		} else {
+			result.enqueueErrors += 1;
+			console.error(
+				`[schedules] enqueue failed for ${params.type} siren=${recipient.siren}: ${
+					enqueueResult.status === "error"
+						? enqueueResult.error
+						: enqueueResult.status
+				}`,
+			);
+		}
+	}
+
+	return result;
+}

--- a/packages/notifications/src/schedules/handlers.ts
+++ b/packages/notifications/src/schedules/handlers.ts
@@ -1,0 +1,151 @@
+import type { Sql } from "postgres";
+import {
+	ensureDedupTable,
+	findAwaitingComplianceChoice,
+	findCompletedPreviousCycle,
+	findCorrectiveSecondDeclarationPending,
+	findCseOpinionPending,
+	findDraftDeclarations,
+	findJointEvaluationPending,
+	findOpenCycleRecipients,
+} from "../eligibility/index.js";
+import type { CseOpinionReminderVariant } from "../mails/types.js";
+import { DEADLINES, getCurrentYear } from "./dates.js";
+import { type DispatchResult, dispatchReminder } from "./dispatch.js";
+
+// 2028 is the first cycle that can announce its opening: 2027 is the
+// kick-off of EgaPro V2 so there is no prior cohort to notify.
+const CYCLE_OPENING_INFO_MIN_YEAR = 2028;
+
+export async function handleCycleOpeningInfo(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	if (year < CYCLE_OPENING_INFO_MIN_YEAR) {
+		return {
+			scheduled: 0,
+			skippedAlreadySent: 0,
+			enqueued: 0,
+			enqueueErrors: 0,
+		};
+	}
+	const recipients = await findOpenCycleRecipients(sql, year);
+	const deadline = DEADLINES.declarationModification(year);
+	return dispatchReminder({
+		sql,
+		type: "cycle_opening_info",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline }),
+	});
+}
+
+export async function handleDeclarationDeadlineReminder(
+	sql: Sql,
+	daysRemaining: 30 | 10,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findDraftDeclarations(sql, year);
+	const deadline = DEADLINES.declarationModification(year);
+	return dispatchReminder({
+		sql,
+		type: "declaration_deadline_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline, daysRemaining }),
+		variant: `d${daysRemaining}`,
+	});
+}
+
+export async function handleCompliancePathChoiceReminder(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findAwaitingComplianceChoice(sql, year);
+	const deadline = DEADLINES.compliancePathChoice(year);
+	return dispatchReminder({
+		sql,
+		type: "compliance_path_choice_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline }),
+	});
+}
+
+export async function handleSecondDeclarationReminder(
+	sql: Sql,
+	daysRemaining: 90 | 30,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findCorrectiveSecondDeclarationPending(sql, year);
+	const deadline = DEADLINES.secondDeclaration(year);
+	return dispatchReminder({
+		sql,
+		type: "second_declaration_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline, daysRemaining }),
+		variant: `d${daysRemaining}`,
+	});
+}
+
+export async function handleJointEvaluationReminder(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findJointEvaluationPending(sql, year);
+	const deadline = DEADLINES.jointEvaluationReport(year);
+	return dispatchReminder({
+		sql,
+		type: "joint_evaluation_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline }),
+	});
+}
+
+function deadlineForCseVariant(
+	variant: CseOpinionReminderVariant,
+	year: number,
+): string {
+	switch (variant) {
+		case "justify_oct":
+		case "justify_dec":
+			return DEADLINES.cseOpinionJustifyOct(year);
+		default:
+			return DEADLINES.cseOpinionFinal(year);
+	}
+}
+
+export async function handleCseOpinionReminder(
+	sql: Sql,
+	variant: CseOpinionReminderVariant,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const year = getCurrentYear();
+	const recipients = await findCseOpinionPending(sql, year, variant);
+	const deadline = deadlineForCseVariant(variant, year);
+	return dispatchReminder({
+		sql,
+		type: "cse_opinion_reminder",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, year, deadline, variant }),
+		variant,
+	});
+}
+
+export async function handleNextCycleHandover(
+	sql: Sql,
+): Promise<DispatchResult> {
+	await ensureDedupTable(sql);
+	const nextYear = getCurrentYear();
+	const previousYear = nextYear - 1;
+	const recipients = await findCompletedPreviousCycle(sql, previousYear);
+	return dispatchReminder({
+		sql,
+		type: "next_cycle_handover",
+		recipients,
+		payloadFor: ({ siren }) => ({ siren, previousYear, nextYear }),
+		dedupYearFor: () => previousYear,
+	});
+}

--- a/packages/notifications/src/schedules/index.ts
+++ b/packages/notifications/src/schedules/index.ts
@@ -1,0 +1,50 @@
+import type { PgBoss } from "pg-boss";
+import type { Sql } from "postgres";
+import { SCHEDULES, type ScheduleDefinition } from "./definitions.js";
+
+export type { DispatchResult } from "./dispatch.js";
+export type { ScheduleDefinition };
+export { SCHEDULES };
+
+// pg-boss `schedule()` enqueues a job on the queue named `<schedule.name>`
+// on every cron tick (with a built-in lock so multiple worker replicas
+// don't double-fire). We attach a worker on the same queue that runs the
+// matching handler. Idempotence inside a tick is guarded by
+// `notifications.reminder_sent_log` — even if the cron fires twice the
+// recipient gets a single mail.
+export async function registerSchedules(
+	boss: PgBoss,
+	appSql: Sql | null,
+): Promise<void> {
+	if (!appSql) {
+		console.warn(
+			"[schedules] DATABASE_URL not configured — reminders disabled",
+		);
+		return;
+	}
+
+	for (const schedule of SCHEDULES) {
+		await boss.createQueue(schedule.name);
+		await boss.work<unknown>(schedule.name, { batchSize: 1 }, async () => {
+			const startedAt = Date.now();
+			try {
+				const result = await schedule.run(appSql);
+				console.log(
+					`[schedules] ${schedule.name} → enqueued=${result.enqueued}, skipped=${result.skippedAlreadySent}, scheduled=${result.scheduled}, errors=${result.enqueueErrors} (${Date.now() - startedAt}ms)`,
+				);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(`[schedules] ${schedule.name} failed: ${message}`);
+				throw error;
+			}
+		});
+		await boss.schedule(
+			schedule.name,
+			schedule.cron,
+			{},
+			{ tz: schedule.timeZone },
+		);
+	}
+
+	console.log(`[schedules] registered ${SCHEDULES.length} reminder schedules`);
+}

--- a/packages/notifications/src/worker/auditLog.ts
+++ b/packages/notifications/src/worker/auditLog.ts
@@ -1,0 +1,55 @@
+import type { Sql } from "postgres";
+
+export type SerializableJson =
+	| null
+	| string
+	| number
+	| boolean
+	| Date
+	| { [key: string]: SerializableJson }
+	| SerializableJson[];
+
+export type AuditRow = {
+	action: string;
+	category: string;
+	status: "success" | "failure";
+	userId?: string | null;
+	userEmail?: string | null;
+	siren?: string | null;
+	resourceType?: string | null;
+	resourceId?: string | null;
+	errorMessage?: string | null;
+	metadata?: SerializableJson;
+};
+
+export async function logAuditMain(
+	mainSql: Sql | null,
+	row: AuditRow,
+): Promise<void> {
+	if (!mainSql) return;
+	try {
+		await mainSql`
+			INSERT INTO audit.action_log (
+				id, created_at, action, category, status,
+				user_id, user_email, siren, resource_type, resource_id,
+				error_message, metadata
+			)
+			VALUES (
+				${crypto.randomUUID()},
+				${new Date()},
+				${row.action},
+				${row.category},
+				${row.status},
+				${row.userId ?? null},
+				${row.userEmail ?? null},
+				${row.siren ?? null},
+				${row.resourceType ?? null},
+				${row.resourceId ?? null},
+				${row.errorMessage ?? null},
+				${mainSql.json(row.metadata ?? null)}
+			)
+		`;
+	} catch (auditError) {
+		console.error("[notifications] audit insert failed:", auditError);
+	}
+}

--- a/packages/notifications/src/worker/jobHandler.ts
+++ b/packages/notifications/src/worker/jobHandler.ts
@@ -1,0 +1,105 @@
+import type { Transporter } from "nodemailer";
+import type { JobWithMetadata } from "pg-boss";
+import type { Sql } from "postgres";
+
+import { buildMail } from "../mails/index.js";
+import { validateJobData } from "../queue.js";
+import { logAuditMain } from "./auditLog.js";
+
+const SEND_AUDIT_ACTION = "notification.send";
+const SEND_AUDIT_CATEGORY = "system";
+
+export type JobHandlerDeps = {
+	transporter: Transporter | null;
+	mailFrom: string;
+	mailEnabled: boolean;
+	mainSql: Sql | null;
+};
+
+export function makeJobHandler(
+	deps: JobHandlerDeps,
+): (job: JobWithMetadata<unknown>) => Promise<void> {
+	const { transporter, mailFrom, mailEnabled, mainSql } = deps;
+	return async (job) => {
+		const attempt = (job.retryCount ?? 0) + 1;
+		const result = validateJobData(job.data);
+
+		if (!result.ok) {
+			// Poison pill: malformed payload can never succeed. Log + return
+			// clean so pg-boss marks the job complete and stops retrying.
+			console.error(
+				`[notifications] dropping malformed job ${job.id}: ${result.reason}`,
+			);
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "failure",
+				resourceType: "notification",
+				resourceId: job.id,
+				errorMessage: result.reason,
+				metadata: { attempt, poisonPill: true },
+			});
+			return;
+		}
+
+		const {
+			type,
+			payload,
+			recipientEmail,
+			recipientUserId,
+			siren,
+			attachments,
+		} = result.data;
+
+		try {
+			const { subject, html, text } = await buildMail(type, payload);
+			let messageId: string | null = null;
+			if (!mailEnabled || !transporter) {
+				console.log(
+					`[notifications] MAIL_ENABLED=false — would send ${type} to ${recipientEmail}`,
+				);
+			} else {
+				const decodedAttachments = attachments?.map((att) => ({
+					filename: att.filename,
+					content: Buffer.from(att.contentBase64, "base64"),
+					contentType: att.contentType,
+				}));
+				const info = await transporter.sendMail({
+					from: mailFrom,
+					to: recipientEmail,
+					subject,
+					text,
+					html,
+					...(decodedAttachments ? { attachments: decodedAttachments } : {}),
+				});
+				messageId = info.messageId ?? null;
+			}
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "success",
+				userId: recipientUserId,
+				userEmail: recipientEmail,
+				siren,
+				resourceType: "notification",
+				resourceId: job.id,
+				metadata: { type, attempt, messageId },
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "failure",
+				userId: recipientUserId,
+				userEmail: recipientEmail,
+				siren,
+				resourceType: "notification",
+				resourceId: job.id,
+				errorMessage: message,
+				metadata: { type, attempt },
+			});
+			throw error;
+		}
+	};
+}

--- a/packages/notifications/src/worker/lifecycle.ts
+++ b/packages/notifications/src/worker/lifecycle.ts
@@ -1,0 +1,26 @@
+import type { PgBoss } from "pg-boss";
+import type { Sql } from "postgres";
+
+export type ShutdownDeps = {
+	boss: PgBoss;
+	mainSql: Sql | null;
+};
+
+export function installShutdownHooks({ boss, mainSql }: ShutdownDeps): void {
+	const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+		console.log(`[notifications] received ${signal}, shutting down...`);
+		try {
+			await boss.stop({ graceful: true, timeout: 15_000 });
+			if (mainSql) await mainSql.end();
+		} catch (error) {
+			console.error("[notifications] shutdown error:", error);
+		}
+		process.exit(0);
+	};
+	process.on("SIGTERM", () => {
+		void shutdown("SIGTERM");
+	});
+	process.on("SIGINT", () => {
+		void shutdown("SIGINT");
+	});
+}

--- a/packages/notifications/src/worker/transporter.ts
+++ b/packages/notifications/src/worker/transporter.ts
@@ -1,0 +1,33 @@
+import nodemailer, { type Transporter } from "nodemailer";
+
+export function getMailEnabled(): boolean {
+	return (process.env.MAIL_ENABLED ?? "false").toLowerCase() === "true";
+}
+
+export function buildTransporter(): Transporter {
+	const host = process.env.SMTP_HOST;
+	if (!host) {
+		throw new Error("SMTP_HOST must be set when MAIL_ENABLED=true");
+	}
+	const port = parseInt(process.env.SMTP_PORT ?? "1025", 10);
+	const secure = (process.env.SMTP_SECURE ?? "false").toLowerCase() === "true";
+	const auth =
+		process.env.SMTP_USER && process.env.SMTP_PASS
+			? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+			: undefined;
+	// `requireTLS` enforces STARTTLS on plain-text ports; combined with a
+	// `minVersion` floor at TLS 1.2 it prevents silent downgrade attacks.
+	// We only apply it when SMTP auth is configured (i.e. real SMTP relay) —
+	// the MailDev local container has no TLS support and would refuse the
+	// connection if STARTTLS were required.
+	const hardenTls = auth !== undefined;
+	return nodemailer.createTransport({
+		host,
+		port,
+		secure,
+		auth,
+		...(hardenTls
+			? { requireTLS: !secure, tls: { minVersion: "TLSv1.2" } }
+			: {}),
+	});
+}


### PR DESCRIPTION
## Contexte

PR **3/4** du découpage de la #3541. À merger **après #3562**.

## Ce que fait cette PR

Câble la pipeline cron qui déclenche les 7 mails de rappel ajoutés dans #3562.

### Nouveaux modules

#### \`eligibility/\` — qui doit recevoir quoi
- \`client.ts\` — connexion read-only à l'app DB
- \`queries.ts\` — \`findRecipientsFor*\` par type de rappel (declaration deadline, CSE opinion, joint eval, etc.)
- \`dedup.ts\` — \`wasSent\` / \`markSent\` via \`audit.action_log\` pour ne jamais doubler un envoi
- \`index.ts\` — barrel

#### \`schedules/\` — cron
- \`definitions.ts\` — 1 entry par schedule (name, cron, mail type, variant éventuel)
- \`dates.ts\` — helpers (J-N, début/fin de cycle)
- \`handlers.ts\` — pour chaque schedule : appelle l'eligibility query, dispatch
- \`dispatch.ts\` — \`enqueueNotification\` via \`publisher.ts\` (déjà en place), gate par \`wasSent\`
- \`index.ts\` — \`registerSchedules(boss, mainSql)\` + \`SCHEDULES\` export
- Tests : \`dispatch.test.ts\` + \`registerSchedules.test.ts\`

### Wire-up

\`src/index.ts\` :
- Import \`registerSchedules\` + \`SCHEDULES\`
- \`await registerSchedules(boss, mainSql)\` juste après \`boss.work(...)\`
- Re-export \`SCHEDULES\` pour introspection

## Comment tester

\`\`\`bash
pnpm --filter notifications test
\`\`\`

82 tests (vs. 71 dans #3562).

Pour tester le runtime : démarrer le worker avec un \`DATABASE_URL\` pointant sur l'app DB seedée, attendre un tick (les schedules sont définis avec crons réalistes).

Closes part of #3474.