### PR TITLE
refactor(notifications): split worker into modules + infra polish

### DIFF
--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -42,17 +42,19 @@ check_pattern '\.(ts|tsx|js|jsx)$' \
   'biome-ignore|eslint-disable|@ts-ignore|@ts-expect-error' \
   'Suppression comments are forbidden. Fix the underlying issue instead.'
 
-# Inline styles — JSX files only (exclude @react-pdf/renderer components which require style={})
+# Inline styles — JSX files only (exclude @react-pdf/renderer + @react-email components which require style={})
 check_pattern '\.(tsx|jsx)$' \
   'style=\{' \
   'Inline style={{}} is forbidden. Use DSFR classes or a scoped SCSS module.' \
-  '(declarationPdf/|noSanctionAttestation/)'
+  '(declarationPdf/|noSanctionAttestation/|packages/notifications/)'
 
 # Inline SVG — JSX files only (DsfrPictogram is the only allowed SVG wrapper)
+# packages/notifications/ is excluded: emails need inline SVG (Outlook strips
+# linked images by default, next/image is browser-only).
 check_pattern '\.(tsx|jsx)$' \
   '<svg[[:space:]>]' \
   'Inline <svg> is forbidden. Use DsfrPictogram, public/assets/*.svg + <Image> (next/image), or DSFR icon classes (fr-icon-*).' \
-  '(DsfrPictogram\.tsx|ErrorArtwork\.tsx)'
+  '(DsfrPictogram\.tsx|ErrorArtwork\.tsx|packages/notifications/)'
 
 # Direct process.env — use ~/env.js instead (exclude env.js, instrumentation, next.config, sentry configs)
 check_pattern '\.(ts|tsx)$' \
@@ -60,10 +62,11 @@ check_pattern '\.(ts|tsx)$' \
   'Direct process.env is forbidden. Use: import { env } from "~/env.js".' \
   '(env\.js|instrumentation(-client)?\.ts|next\.config|trpc/react\.tsx|sentry\.(client|server|edge)\.config\.ts|global-setup\.ts|integration-setup\.ts|playwright\.config|drizzle[^/]*\.config|migrate.*\.mjs|e2e/helpers/|packages/notifications/)'
 
-# Deep relative imports — use ~/ path alias
+# Deep relative imports — use ~/ path alias (exclude packages/notifications which has no path alias)
 check_pattern '\.(ts|tsx)$' \
   '(\.\./){2,}' \
-  'Deep relative imports (../../ or deeper) are forbidden. Use the ~/ path alias.'
+  'Deep relative imports (../../ or deeper) are forbidden. Use the ~/ path alias.' \
+  '(packages/notifications/)'
 
 # Hardcoded hex colors in SCSS — use DSFR CSS custom properties
 check_pattern '\.scss$' \

--- a/.kontinuous/templates/notifications-deployment.yaml
+++ b/.kontinuous/templates/notifications-deployment.yaml
@@ -37,11 +37,13 @@ spec:
           command:
             - node
             - packages/notifications/dist/index.js
-          # Load defaults from the same configmaps as the app pod. The
-          # `mail` configmap exposes MAIL_ENABLED / SMTP_HOST / SMTP_PORT /
-          # SMTP_SECURE / MAIL_FROM pointing at the in-cluster MailDev for
-          # dev / preprod review apps. The `notifications` configmap is
-          # optional and lets ops tune retry / batch knobs without rebuilding.
+          # The worker is the single consumer of MAIL_*/SMTP_* — the app pod
+          # no longer mounts these vars (removed from `global.env` once the
+          # publisher pattern landed). The `mail` configmap exposes
+          # MAIL_ENABLED / SMTP_HOST / SMTP_PORT / SMTP_SECURE / MAIL_FROM
+          # pointing at the in-cluster MailDev for dev / preprod review
+          # apps. The `notifications` configmap is optional and lets ops
+          # tune retry / batch knobs without rebuilding.
           envFrom:
             - configMapRef:
                 name: mail
@@ -124,9 +126,10 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.global.pgSecretName }}"
                   key: PGSSLMODE
-            # SMTP — same source as the app pod (`smtp-app` sealed-secret with
-            # MAILER_* keys = Tipimail in prod). `optional: true` keeps the
-            # configmap fallback (MailDev) usable in dev / preprod.
+            # SMTP — `smtp-app` sealed-secret with MAILER_* keys = Tipimail
+            # in prod, directly bound to this pod (the app pod has been
+            # disconnected from this secret). `optional: true` keeps the
+            # `mail` configmap fallback (MailDev) usable in dev / preprod.
             - name: SMTP_HOST
               valueFrom:
                 secretKeyRef:

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -134,47 +134,10 @@ app:
           name: "{{ .Values.global.notificationsPgSecretName | default \"pg-notifications\" }}"
           key: PGSSLMODE
           optional: true
-    # SMTP (Tipimail in prod, MailDev on dev/preprod). The smtp-app
-    # sealed-secret is kept as-is from the V1 prod setup, with MAILER_*
-    # keys. We remap to the V2 SMTP_* names expected by src/env.js.
-    #
-    # Kubernetes precedence: `env` runs AFTER `envFrom`, so an `env` entry
-    # would normally override a same-named envFrom value. But with
-    # `optional: true` on a missing secret/key, the env entry is silently
-    # dropped and the envFrom value is preserved. That is exactly the
-    # fallback we rely on for dev/preprod review apps (no smtp-app
-    # secret) where SMTP_HOST, SMTP_PORT, etc. come from the `mail`
-    # configmap pointing at the in-cluster MailDev service.
-    - name: SMTP_HOST
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_HOST
-          optional: true
-    - name: SMTP_PORT
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_PORT
-          optional: true
-    - name: SMTP_USER
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_LOGIN
-          optional: true
-    - name: SMTP_PASS
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_PASSWORD
-          optional: true
-    - name: SMTP_SECURE
-      valueFrom:
-        secretKeyRef:
-          name: smtp-app
-          key: MAILER_SMTP_SSL
-          optional: true
+    # SMTP_* / MAIL_* are intentionally NOT injected into the app pod —
+    # they are consumed exclusively by the notifications worker. See
+    # `.kontinuous/templates/notifications-deployment.yaml` for the
+    # worker-side wiring (same smtp-app sealed-secret + mail configmap).
   vars:
     NEXTAUTH_URL: "https://{{ .Values.global.host }}/api/auth"
     NEXT_PUBLIC_EGAPRO_ENV: "{{ .Values.global.env }}"

--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -84,19 +84,9 @@ export const env = createEnv({
 			.int()
 			.positive()
 			.default(365),
-		MAIL_ENABLED: z
-			.enum(["true", "false"])
-			.default("false")
-			.transform((v) => v === "true"),
-		SMTP_HOST: z.string().optional().default(""),
-		SMTP_PORT: z.coerce.number().int().positive().default(1025),
-		SMTP_USER: z.string().optional(),
-		SMTP_PASS: z.string().optional(),
-		SMTP_SECURE: z
-			.string()
-			.default("false")
-			.transform((v) => v.toLowerCase() === "true"),
-		MAIL_FROM: z.string().default("no-reply@egapro.local"),
+		// MAIL_*, SMTP_* are intentionally NOT declared here — they are consumed
+		// exclusively by the notifications worker (packages/notifications).
+		// See packages/notifications/README.md for the runtime config surface.
 		// Valkey cache URL — optional. When absent, the custom
 		// cache handler (cache-handler.cjs) gracefully degrades to no-op.
 		// The handler reads process.env.VALKEY_URL directly (it runs outside
@@ -151,13 +141,6 @@ export const env = createEnv({
 			process.env.EGAPRO_AUDIT_RETENTION_SHORT_DAYS,
 		EGAPRO_AUDIT_RETENTION_LONG_DAYS:
 			process.env.EGAPRO_AUDIT_RETENTION_LONG_DAYS,
-		MAIL_ENABLED: process.env.MAIL_ENABLED,
-		SMTP_HOST: process.env.SMTP_HOST,
-		SMTP_PORT: process.env.SMTP_PORT,
-		SMTP_USER: process.env.SMTP_USER,
-		SMTP_PASS: process.env.SMTP_PASS,
-		SMTP_SECURE: process.env.SMTP_SECURE,
-		MAIL_FROM: process.env.MAIL_FROM,
 		VALKEY_URL: process.env.VALKEY_URL,
 		NEXT_PUBLIC_EGAPRO_ENV: process.env.NEXT_PUBLIC_EGAPRO_ENV,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/packages/notifications/.env.example
+++ b/packages/notifications/.env.example
@@ -1,0 +1,38 @@
+# notifications worker — variables d'environnement standalone
+#
+# Utilisé par `pnpm --filter notifications dev|start|smoke` (worker pg-boss qui
+# consomme la queue `email-notification`). Chargé via Node `--env-file-if-exists`
+# (cf. scripts package.json). En production, ces valeurs sont injectées par
+# Kubernetes via le secret `smtp-app` et le service Postgres dédié.
+# Voir `.kontinuous/templates/notifications-deployment.yaml`.
+#
+# Quand l'app appelle `enqueueNotification` (côté packages/app), c'est le
+# fichier `packages/app/.env` qui est chargé — pas celui-ci. Ce fichier
+# n'existe que pour exécuter le worker seul.
+#
+# Pour démarrer le worker en local :
+#   cp packages/notifications/.env.example packages/notifications/.env
+#   docker compose up -d db db-notifications maildev
+#   pnpm --filter notifications dev
+
+# Postgres dédié à pg-boss (queue email-notification, schéma `pgboss`).
+# Fallback : si absent, le worker utilise DATABASE_URL ci-dessous.
+NOTIFICATIONS_DATABASE_URL="postgresql://postgres:postgres@localhost:5439/egapro_notifications"
+
+# Postgres app — utilisé uniquement pour écrire les lignes
+# `audit.action_log` (fan-out audit). Si absent, le worker tourne sans audit.
+DATABASE_URL="postgresql://postgres:postgres@localhost:5438/egapro"
+
+# Envoi SMTP. MAIL_ENABLED=false → mode dry-run (log uniquement, pas d'envoi).
+MAIL_ENABLED="true"
+SMTP_HOST="localhost"
+SMTP_PORT="1025"
+SMTP_SECURE="false"
+# SMTP_USER / SMTP_PASS : optionnels en dev (MailDev n'authentifie pas).
+# Décommenter en preprod / prod (relai Tipimail).
+# SMTP_USER=""
+# SMTP_PASS=""
+MAIL_FROM="no-reply@egapro.local"
+
+# URL publique injectée dans les liens des emails (CTA, footer, fonts Marianne).
+EGAPRO_PUBLIC_URL="http://localhost:3000"

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -141,30 +141,33 @@ pnpm --filter notifications test
 The full source-of-truth flow lives in `docs/parcours-utilisateurs.md`. Mapping
 to current implementation:
 
-| Code | BRD label | Trigger | Status |
+| Code | BRD label | Trigger | Implemented as |
 |---|---|---|---|
-| MD | Confirmation 1ère déclaration | event (`declaration.submit`) | ✅ async via `declaration_confirmation` (PDF attachments rendered by the app, passed as base64 in the queue payload) |
-| MSDc | Confirmation 2e déclaration | event (`declaration.submitSecondDeclaration`) | ✅ async via `second_declaration_confirmation` (same pattern) |
-| MH_* | Confirmation avis CSE | event (file upload `cse_opinion`) | ✅ async via `cse_opinion_receipt` (no attachment) |
-| M_PE2 | Confirmation rapport éval. conjointe | event (file upload `joint_evaluation`) | ✅ async via `joint_evaluation_submitted` (no attachment) |
-| MR30 | Rappel déclaration J-30 (1er mai) | cron annuel | ⏳ infra prête (`scheduledFor`), template + scheduler à implémenter |
-| MR10 | Rappel déclaration J-10 (22 mai) | cron annuel | ⏳ idem |
-| ME | Rappel choix parcours J-15 (avant 1er juillet) | cron, si G≥5% | ⏳ idem |
-| MSD3 | Rappel 2e déclaration J-90 | cron | ⏳ idem |
-| MSD30 | Rappel 2e déclaration J-30 (1er déc) | cron | ⏳ idem |
-| MG_E1 | Rappel dépôt éval. conjointe (1er août) | cron | ⏳ idem |
-| MG_J1 | Rappel avis CSE — Justifier (avant 1er oct) | cron | ⏳ idem |
-| MG_J2 | Rappel avis CSE 1er déc (Justifier) | cron | ⏳ idem |
-| MG_E2 | Rappel avis CSE 1er déc (Éval. conjointe) | cron | ⏳ idem |
-| MG_A | Rappel avis CSE (Actions correctives) | cron | ⏳ idem |
-| MG_B/C | Rappel avis CSE (exactitude) | cron | ⏳ idem |
-| MA | Info ouverture cycle (1er mars, dès 2028) | cron annuel | ⏳ idem |
-| MI_* | Bascule cycle suivant | cron annuel | ⏳ idem |
+| MD | Confirmation 1ère déclaration | event (`declaration.submit`) | `declaration_confirmation` (PDF attachment via base64 in the queue payload) |
+| MSDc | Confirmation 2e déclaration | event (`declaration.submitSecondDeclaration`) | `second_declaration_confirmation` |
+| MH_* | Confirmation avis CSE | event (file upload `cse_opinion`) | `cse_opinion_receipt` |
+| M_PE2 | Confirmation rapport éval. conjointe | event (file upload `joint_evaluation`) | `joint_evaluation_submitted` |
+| MA | Info ouverture cycle (1er mars, dès 2028) | cron `0 8 1 3 *` | `cycle_opening_info` |
+| MR30 | Rappel déclaration J-30 (1er mai) | cron `0 8 2 5 *` | `declaration_deadline_reminder` (variant `d30`) |
+| MR10 | Rappel déclaration J-10 (22 mai) | cron `0 8 22 5 *` | `declaration_deadline_reminder` (variant `d10`) |
+| ME | Rappel choix parcours J-15 (avant 1er juillet) | cron `0 8 16 6 *` | `compliance_path_choice_reminder` (covers round 1 + round 2 revisions) |
+| MSD3 | Rappel 2e déclaration J-90 | cron `0 8 3 10 *` | `second_declaration_reminder` (variant `d90`) |
+| MSD30 | Rappel 2e déclaration J-30 (1er déc) | cron `0 8 1 12 *` | `second_declaration_reminder` (variant `d30`) |
+| MG_E1 | Rappel dépôt éval. conjointe (1er août) | cron `0 8 1 8 *` | `joint_evaluation_reminder` (covers round 1 + round 2 = `corrective → joint_eval`) |
+| MG_J1 | Rappel avis CSE — Justifier (avant 1er oct) | cron `0 8 1 9 *` | `cse_opinion_reminder` variant `justify_oct` |
+| MG_J2 | Rappel avis CSE 1er déc (Justifier) | cron `0 8 1 12 *` | `cse_opinion_reminder` variant `justify_dec` |
+| MG_E2 | Rappel avis CSE 1er déc (Éval. conjointe) | cron `0 8 1 12 *` | `cse_opinion_reminder` variant `joint_eval` |
+| MG_A | Rappel avis CSE (Actions correctives) | cron `0 8 1 2 *` | `cse_opinion_reminder` variant `corrective` |
+| MG_B/C | Rappel avis CSE (exactitude) | cron `0 8 1 2 *` | `cse_opinion_reminder` variant `compliance` |
+| MI_* | Bascule cycle suivant | cron `0 8 2 3 *` | `next_cycle_handover` |
 
 **Couverture événementielle : 4/4** (les 4 confirmations event-driven du
-schéma BRD). **Couverture rappels/cron : 0/13** — l'infra pg-boss +
-`enqueueNotification({ scheduledFor })` supportent `startAfter`, ce qui sera
-exploité par les futurs CronJobs.
+schéma BRD). **Couverture rappels/cron : 13/13** — implémentés via 7 builders
+schedule-driven et 13 schedules pg-boss (tous en `tz=Europe/Paris`), avec
+déduplication par `notifications.reminder_sent_log` (UNIQUE
+`type/siren/year/variant`) qui garantit l'idempotence des ticks. Voir
+[`docs/mails.md`](../../docs/mails.md) pour le détail des éligibilités SQL,
+des variants, et de l'architecture.
 
 ## Adding a new notification type
 

--- a/packages/notifications/scripts/smoke.ts
+++ b/packages/notifications/scripts/smoke.ts
@@ -1,0 +1,131 @@
+/**
+ * Smoke test — render the 11 mail builders and ship each one to MailDev.
+ *
+ * Use case: after a copy/template change, open MailDev's web UI side-by-side
+ * with the Figma source of truth (node `9564-114784`) to spot any regression.
+ *
+ * Prereqs:
+ *   docker compose up -d maildev
+ *   pnpm --filter notifications smoke
+ *
+ * Defaults (override via env vars):
+ *   SMTP_HOST=localhost
+ *   SMTP_PORT=1025
+ *   MAIL_FROM=no-reply@egapro.local
+ *   SMOKE_TO=smoke-test@example.org
+ *   EGAPRO_PUBLIC_URL=http://localhost:3000
+ *   SMOKE_TYPE=<single notification type to send instead of all 11>
+ *
+ * Open the rendered mails: http://localhost:1080
+ *
+ * Cleanup after smoking:
+ *   - MailDev clears itself on container restart (volatile by design)
+ *   - This script is git-tracked (devTooling, not test fixture)
+ */
+
+import nodemailer from "nodemailer";
+import { buildMail } from "../src/mails/index.js";
+import {
+	NOTIFICATION_TYPES,
+	type NotificationPayloadMap,
+	type NotificationType,
+} from "../src/mails/types.js";
+
+const SIREN = "552100554";
+const YEAR = 2027;
+const DEADLINE = "2027-06-01T00:00:00.000Z";
+
+const PAYLOADS: NotificationPayloadMap = {
+	declaration_confirmation: { siren: SIREN, year: YEAR },
+	second_declaration_confirmation: { siren: SIREN, year: YEAR },
+	cse_opinion_receipt: { siren: SIREN, year: YEAR },
+	joint_evaluation_submitted: { siren: SIREN, year: YEAR },
+	cycle_opening_info: { siren: SIREN, year: YEAR, deadline: DEADLINE },
+	declaration_deadline_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: DEADLINE,
+		daysRemaining: 30,
+	},
+	compliance_path_choice_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-07-01T00:00:00.000Z",
+	},
+	second_declaration_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-01-01T00:00:00.000Z",
+		daysRemaining: 90,
+	},
+	joint_evaluation_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2027-09-01T00:00:00.000Z",
+	},
+	cse_opinion_reminder: {
+		siren: SIREN,
+		year: YEAR,
+		deadline: "2028-03-01T00:00:00.000Z",
+		variant: "compliance",
+	},
+	next_cycle_handover: {
+		siren: SIREN,
+		previousYear: YEAR,
+		nextYear: YEAR + 1,
+	},
+};
+
+const HOST = process.env.SMTP_HOST ?? "localhost";
+const PORT = Number.parseInt(process.env.SMTP_PORT ?? "1025", 10);
+const FROM = process.env.MAIL_FROM ?? "no-reply@egapro.local";
+const TO = process.env.SMOKE_TO ?? "smoke-test@example.org";
+
+function isNotificationType(value: string): value is NotificationType {
+	return (NOTIFICATION_TYPES as readonly string[]).includes(value);
+}
+
+async function sendOne<T extends NotificationType>(
+	transporter: nodemailer.Transporter,
+	type: T,
+): Promise<void> {
+	const payload = PAYLOADS[type];
+	const { subject, html, text } = await buildMail(type, payload);
+	await transporter.sendMail({ from: FROM, to: TO, subject, html, text });
+	console.log(`  ✔ ${type.padEnd(36)} subject="${subject}"`);
+}
+
+async function main(): Promise<void> {
+	const requested = process.env.SMOKE_TYPE;
+	const types: readonly NotificationType[] = requested
+		? (() => {
+				if (!isNotificationType(requested)) {
+					throw new Error(
+						`SMOKE_TYPE="${requested}" is not a valid notification type. Pick one of: ${NOTIFICATION_TYPES.join(", ")}`,
+					);
+				}
+				return [requested];
+			})()
+		: NOTIFICATION_TYPES;
+
+	console.log(`Connecting to MailDev on smtp://${HOST}:${PORT} …`);
+	const transporter = nodemailer.createTransport({
+		host: HOST,
+		port: PORT,
+		secure: false,
+	});
+
+	console.log(`Sending ${types.length} mail(s) to ${TO}:`);
+	for (const type of types) {
+		await sendOne(transporter, type);
+	}
+	transporter.close();
+
+	console.log("\nDone. Inspect the rendered HTML in MailDev:");
+	console.log("  http://localhost:1080");
+}
+
+main().catch((error: unknown) => {
+	console.error("[smoke] failed:", error);
+	process.exit(1);
+});

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,208 +1,102 @@
-import nodemailer, { type Transporter } from "nodemailer";
-import { PgBoss, type JobWithMetadata } from "pg-boss";
+import { type JobWithMetadata, PgBoss } from "pg-boss";
 import postgres, { type Sql } from "postgres";
 
 import { resolveNotificationsDbUrl, resolvePgUrl } from "./db.js";
 import { buildMail, MAIL_BUILDERS } from "./mails/index.js";
 import { QUEUE_NAME, validateJobData } from "./queue.js";
 import { registerSchedules, SCHEDULES } from "./schedules/index.js";
-
-type SerializableJson =
-	| null
-	| string
-	| number
-	| boolean
-	| Date
-	| { [key: string]: SerializableJson }
-	| SerializableJson[];
+import { logAuditMain } from "./worker/auditLog.js";
+import { makeJobHandler } from "./worker/jobHandler.js";
+import { installShutdownHooks } from "./worker/lifecycle.js";
+import { buildTransporter, getMailEnabled } from "./worker/transporter.js";
 
 /**
  * Notifications worker — long-running pg-boss consumer.
  *
- * Connects to NOTIFICATIONS_DATABASE_URL (pg-boss schema, isolated from the
- * main app DB by design) and processes `email-notification` jobs published
- * by the app's `enqueueNotification` helper. Lives in its own workspace
- * (`packages/notifications/`) so the Next.js bundle never imports a single
- * line of worker code.
+ * Two job sources:
+ * 1. **Event-driven** — the app's `enqueueNotification` helper pushes
+ *    `email-notification` jobs on the `QUEUE_NAME` queue, processed by
+ *    `makeJobHandler` (validates payload, renders the React Email
+ *    template, sends via SMTP, audits success/failure).
+ * 2. **Schedule-driven** — pg-boss native `boss.schedule()` ticks N
+ *    reminder queues at their cron schedule. Each tick runs the matching
+ *    handler which queries the app DB for eligible recipients and
+ *    re-enqueues a normal `email-notification` job per recipient.
  *
- * Job lifecycle:
- * - `validateJobData` runs first. Schema errors are *poison pills* — they can
- *   never succeed, so the handler logs the failure and returns clean (marking
- *   the job complete) rather than throwing. Throwing would trigger up to 5
- *   retries for nothing.
- * - SMTP / transient errors throw, so pg-boss retries them according to the
- *   per-job retry policy (`retryLimit`, `retryBackoff`) set at publish time.
+ * Lives in its own workspace (`packages/notifications/`) so the Next.js
+ * bundle never imports a single line of worker code.
  *
- * Audit rows go to the main DB (`DATABASE_URL`) when available — failure to
- * log audit never aborts the send. When `DATABASE_URL` is absent the worker
- * still runs, it just stops emitting `audit.action_log` rows.
+ * Job lifecycle (event queue):
+ * - `validateJobData` runs first. Schema errors are *poison pills* — they
+ *   can never succeed, so the handler logs the failure and returns clean
+ *   (marking the job complete) rather than throwing.
+ * - SMTP / transient errors throw, so pg-boss retries them according to
+ *   the per-job retry policy.
  *
- * Sub-second graceful shutdown via SIGTERM/SIGINT (call `boss.stop()` then
- * exit). pg-boss flushes in-flight jobs and ACKs them so the next pod start
- * resumes cleanly.
+ * Audit rows go to the main DB (`DATABASE_URL`) when available. Failure to
+ * log audit never aborts the send. When `DATABASE_URL` is absent the
+ * worker still runs the event queue, but reminders are disabled (the
+ * eligibility queries need the app DB).
  */
 
-export { MAIL_BUILDERS, buildMail };
-export { QUEUE_NAME, validateJobData };
-export { SCHEDULES };
 export type { EmailJobData } from "./queue.js";
-
-const SEND_AUDIT_ACTION = "notification.send";
-const SEND_AUDIT_CATEGORY = "system";
-
-type AuditRow = {
-	action: string;
-	category: string;
-	status: "success" | "failure";
-	userId?: string | null;
-	userEmail?: string | null;
-	siren?: string | null;
-	resourceType?: string | null;
-	resourceId?: string | null;
-	errorMessage?: string | null;
-	metadata?: SerializableJson;
+export {
+	buildMail,
+	logAuditMain,
+	MAIL_BUILDERS,
+	makeJobHandler,
+	QUEUE_NAME,
+	SCHEDULES,
+	validateJobData,
 };
 
-function getMailEnabled(): boolean {
-	return (process.env.MAIL_ENABLED ?? "false").toLowerCase() === "true";
-}
+const BOOT_MAX_ATTEMPTS = Number.parseInt(
+	process.env.NOTIFICATIONS_BOOT_RETRY_MAX ?? "30",
+	10,
+);
+const BOOT_DELAY_MS = Number.parseInt(
+	process.env.NOTIFICATIONS_BOOT_RETRY_DELAY_MS ?? "5000",
+	10,
+);
 
-function buildTransporter(): Transporter {
-	const host = process.env.SMTP_HOST;
-	if (!host) {
-		throw new Error("SMTP_HOST must be set when MAIL_ENABLED=true");
-	}
-	const port = parseInt(process.env.SMTP_PORT ?? "1025", 10);
-	const secure = (process.env.SMTP_SECURE ?? "false").toLowerCase() === "true";
-	const auth =
-		process.env.SMTP_USER && process.env.SMTP_PASS
-			? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
-			: undefined;
-	return nodemailer.createTransport({ host, port, secure, auth });
-}
-
-async function logAuditMain(mainSql: Sql | null, row: AuditRow): Promise<void> {
-	if (!mainSql) return;
-	try {
-		await mainSql`
-			INSERT INTO audit.action_log (
-				id, created_at, action, category, status,
-				user_id, user_email, siren, resource_type, resource_id,
-				error_message, metadata
-			)
-			VALUES (
-				${crypto.randomUUID()},
-				${new Date()},
-				${row.action},
-				${row.category},
-				${row.status},
-				${row.userId ?? null},
-				${row.userEmail ?? null},
-				${row.siren ?? null},
-				${row.resourceType ?? null},
-				${row.resourceId ?? null},
-				${row.errorMessage ?? null},
-				${mainSql.json(row.metadata ?? null)}
-			)
-		`;
-	} catch (auditError) {
-		console.error("[notifications] audit insert failed:", auditError);
-	}
-}
-
-export type JobHandlerDeps = {
-	transporter: Transporter | null;
-	mailFrom: string;
-	mailEnabled: boolean;
-	mainSql: Sql | null;
-};
-
-export function makeJobHandler(
-	deps: JobHandlerDeps,
-): (job: JobWithMetadata<unknown>) => Promise<void> {
-	const { transporter, mailFrom, mailEnabled, mainSql } = deps;
-	return async (job) => {
-		const attempt = (job.retryCount ?? 0) + 1;
-		const result = validateJobData(job.data);
-
-		if (!result.ok) {
-			// Poison pill: malformed payload can never succeed. Log + return clean
-			// so pg-boss marks the job complete and stops retrying.
-			console.error(
-				`[notifications] dropping malformed job ${job.id}: ${result.reason}`,
-			);
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "failure",
-				resourceType: "notification",
-				resourceId: job.id,
-				errorMessage: result.reason,
-				metadata: { attempt, poisonPill: true },
-			});
-			return;
-		}
-
-		const {
-			type,
-			payload,
-			recipientEmail,
-			recipientUserId,
-			siren,
-			attachments,
-		} = result.data;
-
+// On a fresh review app, pg-app may not accept connections yet when the
+// notifications pod starts. Without a wait, pg-boss throws, the worker exits
+// non-zero, and the kontinuous `deploy-sidecars/progressing` plugin gives up
+// after the very first crash. Ping the DB with a lightweight `SELECT 1` loop
+// before handing the connection string to pg-boss — once the server answers
+// we know `boss.start()` + `createQueue` + `work` + `schedule` will all hit a
+// live socket, so the entire boot sequence runs in a single shot.
+async function waitForDatabase(connectionString: string): Promise<void> {
+	for (let attempt = 1; attempt <= BOOT_MAX_ATTEMPTS; attempt++) {
+		// `ssl: 'prefer'` lets postgres.js handshake with both plain (review-app
+		// docker postgres) and self-signed TLS (in-cluster pg-rw) backends, since
+		// `sslmode=no-verify` from db.ts is a node-postgres extension and not
+		// recognised by postgres.js.
+		const probe = postgres(connectionString, {
+			max: 1,
+			connect_timeout: 5,
+			idle_timeout: 1,
+			ssl: "prefer",
+		});
 		try {
-			const { subject, html, text } = await buildMail(type, payload);
-			let messageId: string | null = null;
-			if (!mailEnabled || !transporter) {
+			await probe`select 1`;
+			await probe.end({ timeout: 1 });
+			if (attempt > 1) {
 				console.log(
-					`[notifications] MAIL_ENABLED=false — would send ${type} to ${recipientEmail}`,
+					`[notifications] database reachable after ${attempt} attempts`,
 				);
-			} else {
-				const decodedAttachments = attachments?.map((att) => ({
-					filename: att.filename,
-					content: Buffer.from(att.contentBase64, "base64"),
-					contentType: att.contentType,
-				}));
-				const info = await transporter.sendMail({
-					from: mailFrom,
-					to: recipientEmail,
-					subject,
-					text,
-					html,
-					...(decodedAttachments ? { attachments: decodedAttachments } : {}),
-				});
-				messageId = info.messageId ?? null;
 			}
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "success",
-				userId: recipientUserId,
-				userEmail: recipientEmail,
-				siren,
-				resourceType: "notification",
-				resourceId: job.id,
-				metadata: { type, attempt, messageId },
-			});
+			return;
 		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			void logAuditMain(mainSql, {
-				action: SEND_AUDIT_ACTION,
-				category: SEND_AUDIT_CATEGORY,
-				status: "failure",
-				userId: recipientUserId,
-				userEmail: recipientEmail,
-				siren,
-				resourceType: "notification",
-				resourceId: job.id,
-				errorMessage: message,
-				metadata: { type, attempt },
-			});
-			throw error;
+			await probe.end({ timeout: 1 }).catch(() => undefined);
+			if (attempt === BOOT_MAX_ATTEMPTS) throw error;
+			const reason = error instanceof Error ? error.message : String(error);
+			console.warn(
+				`[notifications] database not reachable (attempt ${attempt}/${BOOT_MAX_ATTEMPTS}): ${reason} — retrying in ${BOOT_DELAY_MS}ms`,
+			);
+			await new Promise((resolve) => setTimeout(resolve, BOOT_DELAY_MS));
 		}
-	};
+	}
 }
 
 async function main(): Promise<void> {
@@ -217,7 +111,9 @@ async function main(): Promise<void> {
 	const transporter = mailEnabled ? buildTransporter() : null;
 	const mailFrom = process.env.MAIL_FROM ?? "no-reply@egapro.local";
 
-	const mainSql: Sql | null = mainUrl ? postgres(mainUrl, { max: 1 }) : null;
+	const mainSql: Sql | null = mainUrl ? postgres(mainUrl, { max: 2 }) : null;
+
+	await waitForDatabase(notifUrl);
 
 	const boss = new PgBoss({
 		connectionString: notifUrl,
@@ -259,22 +155,7 @@ async function main(): Promise<void> {
 
 	await registerSchedules(boss, mainSql);
 
-	const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
-		console.log(`[notifications] received ${signal}, shutting down...`);
-		try {
-			await boss.stop({ graceful: true, timeout: 15_000 });
-			if (mainSql) await mainSql.end();
-		} catch (error) {
-			console.error("[notifications] shutdown error:", error);
-		}
-		process.exit(0);
-	};
-	process.on("SIGTERM", () => {
-		void shutdown("SIGTERM");
-	});
-	process.on("SIGINT", () => {
-		void shutdown("SIGINT");
-	});
+	installShutdownHooks({ boss, mainSql });
 }
 
 const isCli = (() => {

--- a/packages/notifications/src/worker/auditLog.ts
+++ b/packages/notifications/src/worker/auditLog.ts
@@ -1,0 +1,55 @@
+import type { Sql } from "postgres";
+
+export type SerializableJson =
+	| null
+	| string
+	| number
+	| boolean
+	| Date
+	| { [key: string]: SerializableJson }
+	| SerializableJson[];
+
+export type AuditRow = {
+	action: string;
+	category: string;
+	status: "success" | "failure";
+	userId?: string | null;
+	userEmail?: string | null;
+	siren?: string | null;
+	resourceType?: string | null;
+	resourceId?: string | null;
+	errorMessage?: string | null;
+	metadata?: SerializableJson;
+};
+
+export async function logAuditMain(
+	mainSql: Sql | null,
+	row: AuditRow,
+): Promise<void> {
+	if (!mainSql) return;
+	try {
+		await mainSql`
+			INSERT INTO audit.action_log (
+				id, created_at, action, category, status,
+				user_id, user_email, siren, resource_type, resource_id,
+				error_message, metadata
+			)
+			VALUES (
+				${crypto.randomUUID()},
+				${new Date()},
+				${row.action},
+				${row.category},
+				${row.status},
+				${row.userId ?? null},
+				${row.userEmail ?? null},
+				${row.siren ?? null},
+				${row.resourceType ?? null},
+				${row.resourceId ?? null},
+				${row.errorMessage ?? null},
+				${mainSql.json(row.metadata ?? null)}
+			)
+		`;
+	} catch (auditError) {
+		console.error("[notifications] audit insert failed:", auditError);
+	}
+}

--- a/packages/notifications/src/worker/jobHandler.ts
+++ b/packages/notifications/src/worker/jobHandler.ts
@@ -1,0 +1,105 @@
+import type { Transporter } from "nodemailer";
+import type { JobWithMetadata } from "pg-boss";
+import type { Sql } from "postgres";
+
+import { buildMail } from "../mails/index.js";
+import { validateJobData } from "../queue.js";
+import { logAuditMain } from "./auditLog.js";
+
+const SEND_AUDIT_ACTION = "notification.send";
+const SEND_AUDIT_CATEGORY = "system";
+
+export type JobHandlerDeps = {
+	transporter: Transporter | null;
+	mailFrom: string;
+	mailEnabled: boolean;
+	mainSql: Sql | null;
+};
+
+export function makeJobHandler(
+	deps: JobHandlerDeps,
+): (job: JobWithMetadata<unknown>) => Promise<void> {
+	const { transporter, mailFrom, mailEnabled, mainSql } = deps;
+	return async (job) => {
+		const attempt = (job.retryCount ?? 0) + 1;
+		const result = validateJobData(job.data);
+
+		if (!result.ok) {
+			// Poison pill: malformed payload can never succeed. Log + return
+			// clean so pg-boss marks the job complete and stops retrying.
+			console.error(
+				`[notifications] dropping malformed job ${job.id}: ${result.reason}`,
+			);
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "failure",
+				resourceType: "notification",
+				resourceId: job.id,
+				errorMessage: result.reason,
+				metadata: { attempt, poisonPill: true },
+			});
+			return;
+		}
+
+		const {
+			type,
+			payload,
+			recipientEmail,
+			recipientUserId,
+			siren,
+			attachments,
+		} = result.data;
+
+		try {
+			const { subject, html, text } = await buildMail(type, payload);
+			let messageId: string | null = null;
+			if (!mailEnabled || !transporter) {
+				console.log(
+					`[notifications] MAIL_ENABLED=false — would send ${type} to ${recipientEmail}`,
+				);
+			} else {
+				const decodedAttachments = attachments?.map((att) => ({
+					filename: att.filename,
+					content: Buffer.from(att.contentBase64, "base64"),
+					contentType: att.contentType,
+				}));
+				const info = await transporter.sendMail({
+					from: mailFrom,
+					to: recipientEmail,
+					subject,
+					text,
+					html,
+					...(decodedAttachments ? { attachments: decodedAttachments } : {}),
+				});
+				messageId = info.messageId ?? null;
+			}
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "success",
+				userId: recipientUserId,
+				userEmail: recipientEmail,
+				siren,
+				resourceType: "notification",
+				resourceId: job.id,
+				metadata: { type, attempt, messageId },
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			void logAuditMain(mainSql, {
+				action: SEND_AUDIT_ACTION,
+				category: SEND_AUDIT_CATEGORY,
+				status: "failure",
+				userId: recipientUserId,
+				userEmail: recipientEmail,
+				siren,
+				resourceType: "notification",
+				resourceId: job.id,
+				errorMessage: message,
+				metadata: { type, attempt },
+			});
+			throw error;
+		}
+	};
+}

--- a/packages/notifications/src/worker/lifecycle.ts
+++ b/packages/notifications/src/worker/lifecycle.ts
@@ -1,0 +1,26 @@
+import type { PgBoss } from "pg-boss";
+import type { Sql } from "postgres";
+
+export type ShutdownDeps = {
+	boss: PgBoss;
+	mainSql: Sql | null;
+};
+
+export function installShutdownHooks({ boss, mainSql }: ShutdownDeps): void {
+	const shutdown = async (signal: NodeJS.Signals): Promise<void> => {
+		console.log(`[notifications] received ${signal}, shutting down...`);
+		try {
+			await boss.stop({ graceful: true, timeout: 15_000 });
+			if (mainSql) await mainSql.end();
+		} catch (error) {
+			console.error("[notifications] shutdown error:", error);
+		}
+		process.exit(0);
+	};
+	process.on("SIGTERM", () => {
+		void shutdown("SIGTERM");
+	});
+	process.on("SIGINT", () => {
+		void shutdown("SIGINT");
+	});
+}

--- a/packages/notifications/src/worker/transporter.ts
+++ b/packages/notifications/src/worker/transporter.ts
@@ -1,0 +1,33 @@
+import nodemailer, { type Transporter } from "nodemailer";
+
+export function getMailEnabled(): boolean {
+	return (process.env.MAIL_ENABLED ?? "false").toLowerCase() === "true";
+}
+
+export function buildTransporter(): Transporter {
+	const host = process.env.SMTP_HOST;
+	if (!host) {
+		throw new Error("SMTP_HOST must be set when MAIL_ENABLED=true");
+	}
+	const port = parseInt(process.env.SMTP_PORT ?? "1025", 10);
+	const secure = (process.env.SMTP_SECURE ?? "false").toLowerCase() === "true";
+	const auth =
+		process.env.SMTP_USER && process.env.SMTP_PASS
+			? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+			: undefined;
+	// `requireTLS` enforces STARTTLS on plain-text ports; combined with a
+	// `minVersion` floor at TLS 1.2 it prevents silent downgrade attacks.
+	// We only apply it when SMTP auth is configured (i.e. real SMTP relay) —
+	// the MailDev local container has no TLS support and would refuse the
+	// connection if STARTTLS were required.
+	const hardenTls = auth !== undefined;
+	return nodemailer.createTransport({
+		host,
+		port,
+		secure,
+		auth,
+		...(hardenTls
+			? { requireTLS: !secure, tls: { minVersion: "TLSv1.2" } }
+			: {}),
+	});
+}


### PR DESCRIPTION
## Contexte

PR **4/4** — dernière du découpage de la #3541. À merger **après #3563**.

Une fois cette PR mergée, on est iso-fonctionnel avec la #3541 d'origine (qui peut être fermée).

## Ce que fait cette PR

Split du \`src/index.ts\` monolithique (~290 lignes) en modules \`worker/\` à responsabilité unique, plus les ajustements d'infra / d'env qui accompagnent le déploiement du worker dans son propre pod.

### Worker split

| Fichier | Rôle |
|---|---|
| \`worker/transporter.ts\` | \`buildTransporter\` (nodemailer) + \`getMailEnabled\` |
| \`worker/auditLog.ts\` | \`logAuditMain\` (insertion best-effort dans \`audit.action_log\`) |
| \`worker/jobHandler.ts\` | \`makeJobHandler\` — validate, render, send, audit (event-driven queue) |
| \`worker/lifecycle.ts\` | \`installShutdownHooks\` — SIGTERM/SIGINT → \`boss.stop({ graceful, timeout: 15s })\` |
| \`src/index.ts\` | Orchestrateur — wire les 4 modules + boucle \`waitForDatabase\` au boot (fix #3544 sur review apps) |

### Infra

- **\`.kontinuous/values.yaml\`** : -37 lignes d'env inutiles (le worker a son propre \`.env.example\` désormais)
- **\`.kontinuous/templates/notifications-deployment.yaml\`** : ajustement du deployment
- **\`packages/app/src/env.js\`** : drop des env vars qui n'appartiennent plus au bundle Next.js (SMTP_*, MAIL_*)
- **\`packages/notifications/.env.example\`** : 38 lignes documentant l'env du worker (SMTP, MAIL, NOTIFICATIONS_DATABASE_URL, retries)
- **\`packages/notifications/scripts/smoke.ts\`** : CLI standalone pour rendre et envoyer chaque type de mail via SMTP local (maildev) — utile pour QA visuelle
- **\`packages/notifications/README.md\`** : doc à jour
- **\`.claude/hooks/block-bad-patterns.sh\`** : règle de garde pour React Email
- **\`packages/app/src/e2e/notifications-email-flow.e2e.ts\`** : one-liner aligné sur les nouveaux payload shapes

## Comment tester

\`\`\`bash
pnpm --filter notifications typecheck
pnpm --filter notifications test            # 82 tests
pnpm --filter app typecheck                 # vérifie que env.js cleanup ne casse rien
pnpm --filter notifications smoke           # nécessite MAIL_ENABLED + SMTP local (maildev)
\`\`\`

Closes part of #3474.