### PR TITLE
feat(admin): fluid layout with fixed-width sidemenu

### DIFF
--- a/packages/app/src/app/admin/layout.tsx
+++ b/packages/app/src/app/admin/layout.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { AdminNavigation } from "~/modules/admin";
+import { AdminShell } from "~/modules/admin";
 import { auth } from "~/server/auth";
 
 export default async function AdminLayout({
@@ -11,22 +11,8 @@ export default async function AdminLayout({
 }) {
 	const session = await auth();
 
-	if (!session?.user) {
-		redirect("/login");
-	}
+	if (!session?.user) redirect("/login");
+	if (!session.user.isAdmin) redirect("/mon-espace");
 
-	if (!session.user.isAdmin) {
-		redirect("/mon-espace");
-	}
-
-	return (
-		<div className="fr-container fr-py-6w">
-			<div className="fr-grid-row fr-grid-row--gutters">
-				<div className="fr-col-12 fr-col-md-4">
-					<AdminNavigation />
-				</div>
-				<div className="fr-col-12 fr-col-md-8">{children}</div>
-			</div>
-		</div>
-	);
+	return <AdminShell>{children}</AdminShell>;
 }

--- a/packages/app/src/e2e/admin.e2e.ts
+++ b/packages/app/src/e2e/admin.e2e.ts
@@ -53,3 +53,28 @@ test("admin user can access /admin/parametres and sees settings page", async ({
 		page.getByRole("heading", { name: "Année de campagne active", level: 2 }),
 	).not.toBeVisible();
 });
+
+test("admin layout uses fluid container with fixed-width sidemenu on desktop", async ({
+	page,
+}) => {
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await page.goto("/admin");
+	await expect(
+		page.getByRole("heading", { name: "Backoffice", level: 1 }),
+	).toBeVisible();
+
+	const nav = page.locator("nav.fr-sidemenu");
+	const navBox = await nav.boundingBox();
+	expect(navBox).not.toBeNull();
+	if (navBox) {
+		expect(navBox.width).toBeGreaterThanOrEqual(260);
+		expect(navBox.width).toBeLessThanOrEqual(300);
+	}
+
+	const heading = page.getByRole("heading", { name: "Backoffice", level: 1 });
+	const headingBox = await heading.boundingBox();
+	expect(headingBox).not.toBeNull();
+	if (headingBox) {
+		expect(headingBox.width).toBeGreaterThan(800);
+	}
+});

--- a/packages/app/src/modules/admin/AdminShell.module.scss
+++ b/packages/app/src/modules/admin/AdminShell.module.scss
@@ -1,0 +1,21 @@
+.shell {
+	display: flex;
+	gap: 1.5rem;
+
+	@include respond-to(sm) {
+		flex-direction: column;
+	}
+}
+
+.nav {
+	flex: 0 0 280px;
+
+	@include respond-to(sm) {
+		flex: 1 1 auto;
+	}
+}
+
+.content {
+	flex: 1;
+	min-width: 0;
+}

--- a/packages/app/src/modules/admin/AdminShell.tsx
+++ b/packages/app/src/modules/admin/AdminShell.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+import { AdminNavigation } from "./AdminNavigation";
+import styles from "./AdminShell.module.scss";
+
+type Props = { children: ReactNode };
+
+export function AdminShell({ children }: Props) {
+	return (
+		<div className="fr-container--fluid fr-py-6w">
+			<div className={styles.shell}>
+				<div className={styles.nav}>
+					<AdminNavigation />
+				</div>
+				<div className={styles.content}>{children}</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AdminShell } from "../AdminShell";
+
+vi.mock("../AdminNavigation", () => ({
+	AdminNavigation: () => <nav aria-label="Administration">nav</nav>,
+}));
+
+describe("AdminShell", () => {
+	it("renders the admin navigation", () => {
+		render(<AdminShell>content</AdminShell>);
+		expect(
+			screen.getByRole("navigation", { name: /administration/i }),
+		).toBeInTheDocument();
+	});
+
+	it("renders children inside the content area", () => {
+		render(
+			<AdminShell>
+				<p>test content</p>
+			</AdminShell>,
+		);
+		expect(screen.getByText("test content")).toBeInTheDocument();
+	});
+
+	it("wraps content in a fluid container", () => {
+		const { container } = render(<AdminShell>children</AdminShell>);
+		const wrapper = container.firstElementChild as HTMLElement;
+		expect(wrapper.classList.contains("fr-container--fluid")).toBe(true);
+	});
+});

--- a/packages/app/src/modules/admin/index.ts
+++ b/packages/app/src/modules/admin/index.ts
@@ -1,5 +1,6 @@
 export { AdminHomePage } from "./AdminHomePage";
 export { AdminNavigation } from "./AdminNavigation";
+export { AdminShell } from "./AdminShell";
 export {
 	AdminDeclarationDetailPage,
 	AdminDeclarationsPage,


### PR DESCRIPTION
Closes #3567

## Résumé

- Crée `AdminShell` (Server Component) dans `~/modules/admin/` avec son SCSS module : flex layout, nav fixée à 280px sur md+, stack vertical sur mobile via `@include respond-to(sm)`.
- Remplace le wrapper `fr-container` + grille `fr-col-md-4/8` dans `app/admin/layout.tsx` par `<AdminShell>`.
- Exporte `AdminShell` depuis le barrel `modules/admin/index.ts`.
- Ajoute un test E2E sur viewport 1280×800 vérifiant que la nav fait ~280px et que le contenu dépasse 800px de large.
- Ajoute 3 tests unitaires pour `AdminShell` (navigation rendue, children rendus, classe `fr-container--fluid`).

## Test plan

- [ ] `pnpm typecheck` vert
- [ ] `pnpm test` vert (271 fichiers, 2360 tests)
- [ ] `pnpm lint:check` + `pnpm format:check` verts
- [ ] Sur viewport ≥ 768px : sidemenu ~280px, contenu > 800px de large
- [ ] Sur mobile (< md) : sidemenu collapsible affiché au-dessus du contenu
- [ ] Pages publiques inchangées