### PR TITLE
feat(declarationHistory): mapping événement d'historique → libellé + lien (#3599)

### DIFF
--- a/packages/app/src/modules/declarationHistory/__tests__/eventDisplay.test.ts
+++ b/packages/app/src/modules/declarationHistory/__tests__/eventDisplay.test.ts
@@ -4,7 +4,7 @@ import {
 	type DeclarationEventType,
 	getHistoryEventDisplay,
 	type HistoryEvent,
-} from "../eventDisplay";
+} from "../index";
 
 function buildEvent(
 	eventType: DeclarationEventType,
@@ -126,6 +126,8 @@ describe("getHistoryEventDisplay", () => {
 			value: null,
 			round: null,
 		};
-		expect(() => getHistoryEventDisplay(unknownEvent)).toThrow("Unknown event type");
+		expect(() => getHistoryEventDisplay(unknownEvent)).toThrow(
+			"Unknown event type",
+		);
 	});
 });

--- a/packages/app/src/modules/declarationHistory/__tests__/eventDisplay.test.ts
+++ b/packages/app/src/modules/declarationHistory/__tests__/eventDisplay.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	type DeclarationEventType,
+	getHistoryEventDisplay,
+	type HistoryEvent,
+} from "../eventDisplay";
+
+function buildEvent(
+	eventType: DeclarationEventType,
+	round: number | null = null,
+): HistoryEvent {
+	return { eventType, value: null, round };
+}
+
+describe("getHistoryEventDisplay", () => {
+	it("submit: returns non-empty label and recap page link", () => {
+		const result = getHistoryEventDisplay(buildEvent("submit"));
+		expect(result.label).toBe("Soumission de la déclaration");
+		expect(result.pageLabel).toBe("Récapitulatif de votre déclaration");
+		expect(result.pageHref).toBe("/declaration-remuneration/recapitulatif");
+	});
+
+	it("path_choice: returns non-empty label and compliance path link", () => {
+		const result = getHistoryEventDisplay(buildEvent("path_choice"));
+		expect(result.label).toBe("Choix du parcours de mise en conformité");
+		expect(result.pageLabel).toBe("Parcours de mise en conformité");
+		expect(result.pageHref).toBe(
+			"/declaration-remuneration/parcours-conformite",
+		);
+	});
+
+	it("second_declaration_submit: returns non-empty label and compliance path link", () => {
+		const result = getHistoryEventDisplay(
+			buildEvent("second_declaration_submit"),
+		);
+		expect(result.label).toBe("Soumission de la seconde déclaration");
+		expect(result.pageLabel).toBe("Parcours de mise en conformité");
+		expect(result.pageHref).toBe(
+			"/declaration-remuneration/parcours-conformite",
+		);
+	});
+
+	it("joint_evaluation_submit: returns non-empty label and joint evaluation link", () => {
+		const result = getHistoryEventDisplay(
+			buildEvent("joint_evaluation_submit"),
+		);
+		expect(result.label).toBe("Dépôt de l'évaluation conjointe");
+		expect(result.pageLabel).toBe("Évaluation conjointe");
+		expect(result.pageHref).toBe(
+			"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
+		);
+	});
+
+	it("cse_opinion_submit: returns non-empty label and CSE opinion link", () => {
+		const result = getHistoryEventDisplay(buildEvent("cse_opinion_submit"));
+		expect(result.label).toBe("Dépôt de l'avis CSE");
+		expect(result.pageLabel).toBe("Avis CSE");
+		expect(result.pageHref).toBe("/avis-cse");
+	});
+
+	it("cancel: returns non-empty label and no page link", () => {
+		const result = getHistoryEventDisplay(buildEvent("cancel"));
+		expect(result.label).toBe("Annulation de la déclaration");
+		expect(result.pageLabel).toBeNull();
+		expect(result.pageHref).toBeNull();
+	});
+
+	it("demarche_complete: returns non-empty label and no page link", () => {
+		const result = getHistoryEventDisplay(buildEvent("demarche_complete"));
+		expect(result.label).toBe("Démarche finalisée");
+		expect(result.pageLabel).toBeNull();
+		expect(result.pageHref).toBeNull();
+	});
+
+	it("step_change with round=5: maps via STEP_TITLES and builds etape href", () => {
+		const result = getHistoryEventDisplay(buildEvent("step_change", 5));
+		expect(result.label).toBe("Modification de la page");
+		expect(result.pageLabel).toBe(
+			"Écart de rémunération par catégories de salariés (salaire de base et primes)",
+		);
+		expect(result.pageHref).toBe("/declaration-remuneration/etape/5");
+	});
+
+	it("step_change with round=0: maps to Introduction step", () => {
+		const result = getHistoryEventDisplay(buildEvent("step_change", 0));
+		expect(result.label).toBe("Modification de la page");
+		expect(result.pageLabel).toBe("Introduction");
+		expect(result.pageHref).toBe("/declaration-remuneration/etape/0");
+	});
+
+	it("step_change with null round: returns null page link", () => {
+		const result = getHistoryEventDisplay(buildEvent("step_change", null));
+		expect(result.label).toBe("Modification de la page");
+		expect(result.pageLabel).toBeNull();
+		expect(result.pageHref).toBeNull();
+	});
+
+	it("step_change with out-of-bounds round: returns null page link", () => {
+		const result = getHistoryEventDisplay(buildEvent("step_change", 999));
+		expect(result.label).toBe("Modification de la page");
+		expect(result.pageLabel).toBeNull();
+		expect(result.pageHref).toBeNull();
+	});
+
+	it("all event types return a non-empty French label", () => {
+		const eventTypes: DeclarationEventType[] = [
+			"submit",
+			"path_choice",
+			"second_declaration_submit",
+			"joint_evaluation_submit",
+			"cse_opinion_submit",
+			"cancel",
+			"demarche_complete",
+			"step_change",
+		];
+		for (const eventType of eventTypes) {
+			const result = getHistoryEventDisplay(buildEvent(eventType));
+			expect(result.label.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("throws for unknown event type at runtime (exhaustive guard)", () => {
+		const unknownEvent = {
+			eventType: "unknown_type" as unknown as DeclarationEventType,
+			value: null,
+			round: null,
+		};
+		expect(() => getHistoryEventDisplay(unknownEvent)).toThrow("Unknown event type");
+	});
+});

--- a/packages/app/src/modules/declarationHistory/eventDisplay.ts
+++ b/packages/app/src/modules/declarationHistory/eventDisplay.ts
@@ -1,0 +1,93 @@
+import { STEP_TITLES } from "~/modules/declaration-remuneration";
+import type { DeclarationEventType as DomainEventType } from "~/modules/domain";
+
+export type DeclarationEventType = DomainEventType | "step_change";
+
+export type HistoryEvent = {
+	eventType: DeclarationEventType;
+	value: string | null;
+	round: number | null;
+};
+
+export type HistoryEventDisplay = {
+	label: string;
+	pageLabel: string | null;
+	pageHref: string | null;
+};
+
+export function getHistoryEventDisplay(
+	event: HistoryEvent,
+): HistoryEventDisplay {
+	switch (event.eventType) {
+		case "step_change": {
+			const round = event.round;
+			if (round === null) {
+				return {
+					label: "Modification de la page",
+					pageLabel: null,
+					pageHref: null,
+				};
+			}
+			const title = STEP_TITLES[round];
+			if (title === undefined) {
+				return {
+					label: "Modification de la page",
+					pageLabel: null,
+					pageHref: null,
+				};
+			}
+			return {
+				label: "Modification de la page",
+				pageLabel: title,
+				pageHref: `/declaration-remuneration/etape/${round}`,
+			};
+		}
+		case "submit":
+			return {
+				label: "Soumission de la déclaration",
+				pageLabel: "Récapitulatif de votre déclaration",
+				pageHref: "/declaration-remuneration/recapitulatif",
+			};
+		case "path_choice":
+			return {
+				label: "Choix du parcours de mise en conformité",
+				pageLabel: "Parcours de mise en conformité",
+				pageHref: "/declaration-remuneration/parcours-conformite",
+			};
+		case "second_declaration_submit":
+			return {
+				label: "Soumission de la seconde déclaration",
+				pageLabel: "Parcours de mise en conformité",
+				pageHref: "/declaration-remuneration/parcours-conformite",
+			};
+		case "joint_evaluation_submit":
+			return {
+				label: "Dépôt de l'évaluation conjointe",
+				pageLabel: "Évaluation conjointe",
+				pageHref:
+					"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
+			};
+		case "cse_opinion_submit":
+			return {
+				label: "Dépôt de l'avis CSE",
+				pageLabel: "Avis CSE",
+				pageHref: "/avis-cse",
+			};
+		case "cancel":
+			return {
+				label: "Annulation de la déclaration",
+				pageLabel: null,
+				pageHref: null,
+			};
+		case "demarche_complete":
+			return {
+				label: "Démarche finalisée",
+				pageLabel: null,
+				pageHref: null,
+			};
+		default: {
+			const _exhaustive: never = event.eventType;
+			throw new Error(`Unknown event type: ${String(_exhaustive)}`);
+		}
+	}
+}

--- a/packages/app/src/modules/declarationHistory/index.ts
+++ b/packages/app/src/modules/declarationHistory/index.ts
@@ -1,0 +1,6 @@
+export type {
+	DeclarationEventType,
+	HistoryEvent,
+	HistoryEventDisplay,
+} from "./eventDisplay";
+export { getHistoryEventDisplay } from "./eventDisplay";


### PR DESCRIPTION
Closes #3599

## Summary

- New module `~/modules/declarationHistory` with pure function `getHistoryEventDisplay`
- Maps all 8 `DeclarationEventType` values to French labels + optional page link
- Exhaustive `switch` with TypeScript `never` guard on default case
- `step_change` maps via `STEP_TITLES` from `~/modules/declaration-remuneration` (no label duplication)
- `DeclarationEventType` extends the domain type with `| "step_change"` (no list duplication)

## Test plan

- [x] 13 unit tests covering all 8 event types + edge cases (null round, out-of-bounds round, runtime unknown type guard)
- [x] 100% coverage (statements, branches, functions, lines)
- [x] Typecheck green
- [x] Lint + format green
- [x] No React/tRPC/DB dependencies (pure isomorphic function)