### PR TITLE
feat(declaration): getStatusHistory tRPC query — lecture auditée #3598

### DIFF
--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -68,6 +68,7 @@ export const AUDIT_ACTIONS = {
 	DRAFT_CLEAR: "declaration_draft.clear",
 
 	// ── Sensitive reads ────────────────────────────────────
+	DECLARATION_HISTORY_READ: "declaration_history.read",
 	ADMIN_FILE_DOWNLOAD: "admin.file_download",
 	PROFILE_READ: "profile.read",
 	DECLARATION_READ_GIP_DATA: "declaration.read_gip_data",
@@ -151,6 +152,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.DRAFT_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_SAVE]: "mutation",
 	[AUDIT_ACTIONS.DRAFT_CLEAR]: "mutation",
+	[AUDIT_ACTIONS.DECLARATION_HISTORY_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.PROFILE_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA]: "read_sensitive",

--- a/packages/app/src/modules/declaration/index.ts
+++ b/packages/app/src/modules/declaration/index.ts
@@ -1,5 +1,6 @@
 export type { SaveCompliancePathInput } from "./schemas";
 export {
+	declarationHistoryInputSchema,
 	saveCompliancePathInputSchema,
 	saveCompliancePathSchema,
 	submitDeclarationSchema,

--- a/packages/app/src/modules/declaration/schemas.ts
+++ b/packages/app/src/modules/declaration/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { COMPLIANCE_PATHS } from "~/modules/declaration-remuneration/steps/compliancePath/constants";
+import { sirenInputSchema } from "~/modules/my-space/schemas";
 
 export const submitDeclarationSchema = z.object({}).optional();
 
@@ -14,3 +15,10 @@ export type SaveCompliancePathInput = z.infer<typeof saveCompliancePathSchema>;
 export const submitSecondDeclarationSchema = z.object({}).optional();
 
 export const submitJointEvaluationSchema = z.object({}).optional();
+
+export const declarationHistoryInputSchema = z.object({
+	siren: sirenInputSchema.shape.siren,
+	year: z.number().int(),
+	limit: z.number().int().min(1).max(50).default(10),
+	offset: z.number().int().min(0).default(0),
+});

--- a/packages/app/src/modules/declaration/schemas.ts
+++ b/packages/app/src/modules/declaration/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { COMPLIANCE_PATHS } from "~/modules/declaration-remuneration/steps/compliancePath/constants";
-import { sirenInputSchema } from "~/modules/my-space/schemas";
+import { sirenInputSchema } from "~/modules/my-space";
 
 export const submitDeclarationSchema = z.object({}).optional();
 

--- a/packages/app/src/modules/declaration/schemas.ts
+++ b/packages/app/src/modules/declaration/schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { COMPLIANCE_PATHS } from "~/modules/declaration-remuneration/steps/compliancePath/constants";
+import { getCurrentYear } from "~/modules/domain";
 import { sirenInputSchema } from "~/modules/my-space/schemas";
 
 export const submitDeclarationSchema = z.object({}).optional();
@@ -18,7 +19,11 @@ export const submitJointEvaluationSchema = z.object({}).optional();
 
 export const declarationHistoryInputSchema = z.object({
 	siren: sirenInputSchema.shape.siren,
-	year: z.number().int(),
+	year: z
+		.number()
+		.int()
+		.min(2018)
+		.max(getCurrentYear() + 1),
 	limit: z.number().int().min(1).max(50).default(10),
 	offset: z.number().int().min(0).default(0),
 });

--- a/packages/app/src/modules/declaration/schemas.ts
+++ b/packages/app/src/modules/declaration/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { COMPLIANCE_PATHS } from "~/modules/declaration-remuneration/steps/compliancePath/constants";
-import { sirenInputSchema } from "~/modules/my-space";
+import { sirenInputSchema } from "~/modules/my-space/schemas";
 
 export const submitDeclarationSchema = z.object({}).optional();
 

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -1571,4 +1571,146 @@ describe("declarationRouter", () => {
 			expect(stepChange).toBeUndefined();
 		});
 	});
+
+	describe("getStatusHistory", () => {
+		const SIREN = "339787277";
+		const YEAR = 2026;
+
+		const mockHistoryItem = {
+			id: "hist-1",
+			eventType: "declaration_submit" as const,
+			value: null,
+			round: 1,
+			createdAt: new Date("2026-01-15T10:00:00Z"),
+			actorFirstName: "Alice",
+			actorLastName: "Dupont",
+			actorEmail: "alice@example.fr",
+		};
+
+		function buildMockDb(responses: unknown[][]) {
+			let callIndex = 0;
+
+			const select = vi.fn().mockImplementation(() => {
+				const idx = callIndex++;
+				const rows = responses[idx] ?? [];
+
+				const offset = vi.fn().mockResolvedValue(rows);
+				const limitResult = Object.assign(Promise.resolve(rows), { offset });
+				const limit = vi.fn().mockReturnValue(limitResult);
+				const orderBy = vi.fn().mockReturnValue({ limit });
+				const where = vi
+					.fn()
+					.mockImplementation(() =>
+						Object.assign(Promise.resolve(rows), { limit, orderBy }),
+					);
+				const leftJoin = vi.fn().mockReturnValue({ where });
+				const from = vi.fn().mockReturnValue({ where, leftJoin });
+
+				return { from };
+			});
+
+			return { select } as unknown;
+		}
+
+		it("returns history items with actor for an authorized user", async () => {
+			const mockDb = buildMockDb([
+				[{ siren: SIREN }],
+				[{ id: "decl-1" }],
+				[mockHistoryItem],
+				[{ total: 1 }],
+			]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getStatusHistory({
+				siren: SIREN,
+				year: YEAR,
+			});
+
+			expect(result.items).toHaveLength(1);
+			expect(result.total).toBe(1);
+			expect(result.items[0]).toMatchObject({
+				id: "hist-1",
+				eventType: "declaration_submit",
+				actor: {
+					firstName: "Alice",
+					lastName: "Dupont",
+					email: "alice@example.fr",
+				},
+			});
+		});
+
+		it("returns null actor when actorEmail is null", async () => {
+			const itemWithoutActor = { ...mockHistoryItem, actorEmail: null };
+			const mockDb = buildMockDb([
+				[{ siren: SIREN }],
+				[{ id: "decl-1" }],
+				[itemWithoutActor],
+				[{ total: 1 }],
+			]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getStatusHistory({
+				siren: SIREN,
+				year: YEAR,
+			});
+
+			expect(result.items[0]?.actor).toBeNull();
+		});
+
+		it("throws FORBIDDEN when user has no access to the siren", async () => {
+			const mockDb = buildMockDb([[]]);
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.getStatusHistory({ siren: SIREN, year: YEAR }),
+			).rejects.toMatchObject({ code: "FORBIDDEN" });
+		});
+
+		it("throws NOT_FOUND when declaration does not exist", async () => {
+			const mockDb = buildMockDb([[{ siren: SIREN }], []]);
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.getStatusHistory({ siren: SIREN, year: YEAR }),
+			).rejects.toMatchObject({ code: "NOT_FOUND" });
+		});
+
+		it("skips access check when admin is impersonating the siren", async () => {
+			const impersonation = { siren: SIREN, name: "Test Co" };
+			const mockDb = buildMockDb([
+				[{ id: "decl-1" }],
+				[mockHistoryItem],
+				[{ total: 1 }],
+			]);
+			const caller = await createCaller(mockDb, null, impersonation);
+
+			const result = await caller.getStatusHistory({
+				siren: SIREN,
+				year: YEAR,
+			});
+
+			expect(result.total).toBe(1);
+		});
+
+		it("returns correct total and subset for paginated queries", async () => {
+			const item2 = { ...mockHistoryItem, id: "hist-2" };
+			const mockDb = buildMockDb([
+				[{ siren: SIREN }],
+				[{ id: "decl-1" }],
+				[item2],
+				[{ total: 5 }],
+			]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getStatusHistory({
+				siren: SIREN,
+				year: YEAR,
+				limit: 1,
+				offset: 1,
+			});
+
+			expect(result.items).toHaveLength(1);
+			expect(result.total).toBe(5);
+		});
+	});
 });

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -1587,8 +1587,14 @@ describe("declarationRouter", () => {
 			actorEmail: "alice@example.fr",
 		};
 
+		type SelectSpies = {
+			limit: ReturnType<typeof vi.fn>;
+			offset: ReturnType<typeof vi.fn>;
+		};
+
 		function buildMockDb(responses: unknown[][]) {
 			let callIndex = 0;
+			const selectSpies: SelectSpies[] = [];
 
 			const select = vi.fn().mockImplementation(() => {
 				const idx = callIndex++;
@@ -1606,14 +1612,15 @@ describe("declarationRouter", () => {
 				const leftJoin = vi.fn().mockReturnValue({ where });
 				const from = vi.fn().mockReturnValue({ where, leftJoin });
 
+				selectSpies.push({ limit, offset });
 				return { from };
 			});
 
-			return { select } as unknown;
+			return { db: { select } as unknown, selectSpies };
 		}
 
 		it("returns history items with actor for an authorized user", async () => {
-			const mockDb = buildMockDb([
+			const { db: mockDb } = buildMockDb([
 				[{ siren: SIREN }],
 				[{ id: "decl-1" }],
 				[mockHistoryItem],
@@ -1641,7 +1648,7 @@ describe("declarationRouter", () => {
 
 		it("returns null actor when actorEmail is null", async () => {
 			const itemWithoutActor = { ...mockHistoryItem, actorEmail: null };
-			const mockDb = buildMockDb([
+			const { db: mockDb } = buildMockDb([
 				[{ siren: SIREN }],
 				[{ id: "decl-1" }],
 				[itemWithoutActor],
@@ -1658,7 +1665,7 @@ describe("declarationRouter", () => {
 		});
 
 		it("throws FORBIDDEN when user has no access to the siren", async () => {
-			const mockDb = buildMockDb([[]]);
+			const { db: mockDb } = buildMockDb([[]]);
 			const caller = await createCaller(mockDb);
 
 			await expect(
@@ -1667,7 +1674,7 @@ describe("declarationRouter", () => {
 		});
 
 		it("throws NOT_FOUND when declaration does not exist", async () => {
-			const mockDb = buildMockDb([[{ siren: SIREN }], []]);
+			const { db: mockDb } = buildMockDb([[{ siren: SIREN }], []]);
 			const caller = await createCaller(mockDb);
 
 			await expect(
@@ -1677,7 +1684,7 @@ describe("declarationRouter", () => {
 
 		it("skips access check when admin is impersonating the siren", async () => {
 			const impersonation = { siren: SIREN, name: "Test Co" };
-			const mockDb = buildMockDb([
+			const { db: mockDb } = buildMockDb([
 				[{ id: "decl-1" }],
 				[mockHistoryItem],
 				[{ total: 1 }],
@@ -1694,7 +1701,7 @@ describe("declarationRouter", () => {
 
 		it("returns correct total and subset for paginated queries", async () => {
 			const item2 = { ...mockHistoryItem, id: "hist-2" };
-			const mockDb = buildMockDb([
+			const { db: mockDb, selectSpies } = buildMockDb([
 				[{ siren: SIREN }],
 				[{ id: "decl-1" }],
 				[item2],
@@ -1711,6 +1718,8 @@ describe("declarationRouter", () => {
 
 			expect(result.items).toHaveLength(1);
 			expect(result.total).toBe(5);
+			expect(selectSpies[2]?.limit).toHaveBeenCalledWith(1);
+			expect(selectSpies[2]?.offset).toHaveBeenCalledWith(1);
 		});
 	});
 });

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, count, desc, eq, isNull } from "drizzle-orm";
 import {
+	declarationHistoryInputSchema,
 	saveCompliancePathInputSchema,
 	submitJointEvaluationSchema,
 } from "~/modules/declaration/schemas";
@@ -22,8 +23,12 @@ import {
 	companyProcedure,
 	companyWriteProcedure,
 	createTRPCRouter,
+	protectedProcedure,
 } from "~/server/api/trpc";
-import { assertNotImpersonating } from "~/server/auth/companyAccess";
+import {
+	assertNotImpersonating,
+	isImpersonatingSiren,
+} from "~/server/auth/companyAccess";
 import {
 	companies,
 	declarationStatusHistory,
@@ -31,6 +36,8 @@ import {
 	employeeCategories,
 	gipMdsData,
 	jobCategories,
+	userCompanies,
+	users,
 } from "~/server/db/schema";
 import { applyAction, loadRules } from "~/server/rules/engine";
 import {
@@ -908,5 +915,98 @@ export const declarationRouter = createTRPCRouter({
 			});
 
 			return { success: true };
+		}),
+
+	getStatusHistory: protectedProcedure
+		.input(declarationHistoryInputSchema)
+		.query(async ({ ctx, input }) => {
+			if (!isImpersonatingSiren(ctx.session, input.siren)) {
+				const access = await ctx.db
+					.select({ siren: userCompanies.siren })
+					.from(userCompanies)
+					.where(
+						and(
+							eq(userCompanies.userId, ctx.session.user.id),
+							eq(userCompanies.siren, input.siren),
+						),
+					)
+					.limit(1);
+
+				if (access.length === 0) {
+					throw new TRPCError({
+						code: "FORBIDDEN",
+						message: "Accès refusé à cette entreprise.",
+					});
+				}
+			}
+
+			const [declaration] = await ctx.db
+				.select({ id: declarations.id })
+				.from(declarations)
+				.where(
+					and(
+						eq(declarations.siren, input.siren),
+						eq(declarations.year, input.year),
+						isNull(declarations.cancelledAt),
+					),
+				)
+				.limit(1);
+
+			if (!declaration) {
+				throw new TRPCError({
+					code: "NOT_FOUND",
+					message: "Déclaration introuvable.",
+				});
+			}
+
+			const historyWhere = eq(
+				declarationStatusHistory.declarationId,
+				declaration.id,
+			);
+
+			const [items, totalResult] = await Promise.all([
+				ctx.db
+					.select({
+						id: declarationStatusHistory.id,
+						eventType: declarationStatusHistory.eventType,
+						value: declarationStatusHistory.value,
+						round: declarationStatusHistory.round,
+						createdAt: declarationStatusHistory.createdAt,
+						actorFirstName: users.firstName,
+						actorLastName: users.lastName,
+						actorEmail: users.email,
+					})
+					.from(declarationStatusHistory)
+					.leftJoin(users, eq(declarationStatusHistory.actorUserId, users.id))
+					.where(historyWhere)
+					.orderBy(desc(declarationStatusHistory.createdAt))
+					.limit(input.limit)
+					.offset(input.offset),
+				ctx.db
+					.select({ total: count() })
+					.from(declarationStatusHistory)
+					.where(historyWhere),
+			]);
+
+			const total = totalResult[0]?.total ?? 0;
+
+			return {
+				items: items.map((row) => ({
+					id: row.id,
+					eventType: row.eventType,
+					value: row.value,
+					round: row.round,
+					createdAt: row.createdAt,
+					actor:
+						row.actorEmail !== null
+							? {
+									firstName: row.actorFirstName ?? null,
+									lastName: row.actorLastName ?? null,
+									email: row.actorEmail,
+								}
+							: null,
+				})),
+				total,
+			};
 		}),
 });

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -31,6 +31,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 
 	// ── declaration sensitive query (returns GIP MDS data) ─
 	"declaration.getOrCreate": AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA,
+	"declaration.getStatusHistory": AUDIT_ACTIONS.DECLARATION_HISTORY_READ,
 
 	// ── cse opinion mutations ──────────────────────────────
 	"cseOpinion.saveOpinions": AUDIT_ACTIONS.CSE_OPINION_SAVE,


### PR DESCRIPTION
Closes #3598

## Context

Sub-ticket of epic #3584 (Mon espace — historique d'une déclaration).

Exposes declaration status events via a new `declaration.getStatusHistory` tRPC query, joining the `declarationStatusHistory` table with `users` to surface actor PII (name + email).

## Changes

- `modules/declaration/schemas.ts` — new `declarationHistoryInputSchema` (siren, year, limit, offset)
- `modules/declaration/index.ts` — barrel re-export
- `server/api/routers/declaration.ts` — new `getStatusHistory` protectedProcedure with ownership gate + pagination + actor join
- `modules/audit/shared/actionKeys.ts` — `DECLARATION_HISTORY_READ` action key + `read_sensitive` category
- `server/audit/trpcMiddleware.ts` — `declaration.getStatusHistory` → `DECLARATION_HISTORY_READ` mapping
- `server/api/routers/__tests__/declaration.test.ts` — 6 new tests covering S2 + S7 scenarios

## Acceptance checklist

- [x] Query `declaration.getStatusHistory` exposed, `protectedProcedure`, access gated by `userCompanies` check
- [x] Returns `{ items, total }` with actor joined, sorted `createdAt DESC`, pagination `limit`/`offset`
- [x] Input schema in `modules/declaration/schemas.ts`, re-exported from barrel
- [x] Audit `read_sensitive` wired (3 points): `DECLARATION_HISTORY_READ` constant, category mapping, `PROCEDURE_TO_ACTION` entry
- [x] Tests added and green (`pnpm test`)
- [x] Typecheck green (`pnpm typecheck`)
- [x] Lint green (`pnpm lint:check`)