### PR TITLE
feat(declaration-history): page UI Historique des modifications (#3600)

### DIFF
--- a/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
+++ b/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+
+import { DeclarationHistoryPage } from "~/modules/declarationHistory";
+import { auth } from "~/server/auth";
+
+type Props = {
+	params: Promise<{ siren: string; year: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { year } = await params;
+	return {
+		title: `Historique des modifications ${year} — Egapro`,
+	};
+}
+
+export default async function Page({ params }: Props) {
+	const session = await auth();
+
+	if (!session?.user) {
+		redirect("/login");
+	}
+
+	const { siren, year: yearParam } = await params;
+	const year = Number.parseInt(yearParam, 10);
+
+	if (siren.length !== 9 || Number.isNaN(year) || year < 2018) {
+		notFound();
+	}
+
+	return <DeclarationHistoryPage siren={siren} year={year} />;
+}

--- a/packages/app/src/e2e/declaration-history.e2e.ts
+++ b/packages/app/src/e2e/declaration-history.e2e.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+import { TEST_SIREN } from "./constants";
+import {
+	ensureCurrentYearDeclaration,
+	getCurrentDbYear,
+	resetDeclarationToDraft,
+} from "./helpers/db";
+import { insertHistoryEvents } from "./helpers/declaration-history";
+
+test.describe("Declaration history page", () => {
+	test.describe.configure({ mode: "serial" });
+	test.setTimeout(60_000);
+
+	let year: number;
+
+	test.beforeAll(async () => {
+		year = await getCurrentDbYear();
+		await ensureCurrentYearDeclaration();
+		await insertHistoryEvents(3, year);
+	});
+
+	test.afterAll(async () => {
+		await resetDeclarationToDraft();
+	});
+
+	test("displays history entries (S2)", async ({ page }) => {
+		await page.goto(`/mon-espace/historique/${TEST_SIREN}/${year}`);
+
+		await expect(
+			page.getByRole("heading", {
+				level: 1,
+				name: "Historique des modifications",
+			}),
+		).toBeVisible();
+		await expect(
+			page.getByText(`Démarche des indicateurs de rémunération ${year}`),
+		).toBeVisible();
+
+		const items = page.locator("ul > li");
+		await expect(items).toHaveCount(3);
+	});
+
+	test("shows Voir plus button and loads more items (S5)", async ({ page }) => {
+		await insertHistoryEvents(13, year);
+		await page.goto(`/mon-espace/historique/${TEST_SIREN}/${year}`);
+
+		await expect(page.getByRole("button", { name: "Voir plus" })).toBeVisible();
+
+		await expect(page.locator("ul > li")).toHaveCount(10);
+
+		await page.getByRole("button", { name: "Voir plus" }).click();
+
+		await expect(page.locator("ul > li")).toHaveCount(13);
+		await expect(
+			page.getByRole("button", { name: "Voir plus" }),
+		).not.toBeVisible();
+	});
+});

--- a/packages/app/src/e2e/helpers/declaration-history.ts
+++ b/packages/app/src/e2e/helpers/declaration-history.ts
@@ -1,0 +1,33 @@
+import postgres from "postgres";
+import { TEST_SIREN } from "../constants";
+
+const DEFAULT_DB_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
+
+function createConnection() {
+	const url = process.env.DATABASE_URL ?? DEFAULT_DB_URL;
+	return postgres(url, { max: 1 });
+}
+
+export async function insertHistoryEvents(count: number, year: number) {
+	const sql = createConnection();
+	try {
+		const decl = await sql`
+			SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year} LIMIT 1
+		`;
+		const declarationId = decl[0]?.id as string | undefined;
+		if (!declarationId) return;
+
+		await sql`DELETE FROM app_declaration_status_history WHERE declaration_id = ${declarationId}`;
+
+		for (let i = 0; i < count; i++) {
+			const createdAt = new Date(Date.now() - i * 60_000);
+			await sql`
+				INSERT INTO app_declaration_status_history
+				(id, declaration_id, event_type, created_at)
+				VALUES (gen_random_uuid(), ${declarationId}, 'submit', ${createdAt})
+			`;
+		}
+	} finally {
+		await sql.end();
+	}
+}

--- a/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
+++ b/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Breadcrumb } from "~/modules/layout";
+import { api } from "~/trpc/react";
+import type { HistoryItem } from "./HistoryEntry";
+import { HistoryEntry } from "./HistoryEntry";
+
+type EntryRowProps = { item: HistoryItem; showDivider: boolean };
+
+function EntryRow({ item, showDivider }: EntryRowProps) {
+	return (
+		<>
+			{showDivider && <hr className="fr-hr fr-mt-0" />}
+			<HistoryEntry item={item} />
+		</>
+	);
+}
+
+const LIMIT = 10;
+
+type Props = {
+	siren: string;
+	year: number;
+};
+
+export function DeclarationHistoryPage({ siren, year }: Props) {
+	const [offset, setOffset] = useState(0);
+	const [allItems, setAllItems] = useState<HistoryItem[]>([]);
+	const [total, setTotal] = useState(0);
+	const loadedOffsets = useRef(new Set<number>());
+
+	const { data, isFetching } = api.declaration.getStatusHistory.useQuery({
+		siren,
+		year,
+		limit: LIMIT,
+		offset,
+	});
+
+	useEffect(() => {
+		if (!data || loadedOffsets.current.has(offset)) return;
+		loadedOffsets.current.add(offset);
+		setTotal(data.total);
+		setAllItems((prev) =>
+			offset === 0 ? [...data.items] : [...prev, ...data.items],
+		);
+	}, [data, offset]);
+
+	const hasMore = allItems.length < total;
+
+	return (
+		<main id="content">
+			<div className="fr-container fr-py-4w">
+				<Breadcrumb
+					items={[
+						{ label: "Mon espace", href: "/mon-espace" },
+						{ label: "Historique des actions" },
+					]}
+				/>
+				<h1 className="fr-h1 fr-mt-3w">Historique des modifications</h1>
+				<p className="fr-text--lg fr-mb-4w">
+					Démarche des indicateurs de rémunération {year}
+				</p>
+
+				{allItems.length === 0 && !isFetching ? (
+					<p>Aucune action enregistrée pour cette démarche.</p>
+				) : (
+					<ul className="fr-m-0 fr-p-0">
+						{allItems.map((item, index) => (
+							<EntryRow item={item} key={item.id} showDivider={index > 0} />
+						))}
+					</ul>
+				)}
+
+				{hasMore && (
+					<div className="fr-mt-3w">
+						<button
+							className="fr-btn fr-btn--tertiary-no-outline"
+							disabled={isFetching}
+							onClick={() => setOffset((o) => o + LIMIT)}
+							type="button"
+						>
+							Voir plus
+						</button>
+					</div>
+				)}
+			</div>
+		</main>
+	);
+}

--- a/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
+++ b/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
@@ -1,24 +1,5 @@
-"use client";
-
-import { useEffect, useRef, useState } from "react";
-
 import { Breadcrumb } from "~/modules/layout";
-import { api } from "~/trpc/react";
-import type { HistoryItem } from "./HistoryEntry";
-import { HistoryEntry } from "./HistoryEntry";
-
-type EntryRowProps = { item: HistoryItem; showDivider: boolean };
-
-function EntryRow({ item, showDivider }: EntryRowProps) {
-	return (
-		<>
-			{showDivider && <hr className="fr-hr fr-mt-0" />}
-			<HistoryEntry item={item} />
-		</>
-	);
-}
-
-const LIMIT = 10;
+import { HistoryListSection } from "./HistoryListSection";
 
 type Props = {
 	siren: string;
@@ -26,29 +7,6 @@ type Props = {
 };
 
 export function DeclarationHistoryPage({ siren, year }: Props) {
-	const [offset, setOffset] = useState(0);
-	const [allItems, setAllItems] = useState<HistoryItem[]>([]);
-	const [total, setTotal] = useState(0);
-	const loadedOffsets = useRef(new Set<number>());
-
-	const { data, isFetching } = api.declaration.getStatusHistory.useQuery({
-		siren,
-		year,
-		limit: LIMIT,
-		offset,
-	});
-
-	useEffect(() => {
-		if (!data || loadedOffsets.current.has(offset)) return;
-		loadedOffsets.current.add(offset);
-		setTotal(data.total);
-		setAllItems((prev) =>
-			offset === 0 ? [...data.items] : [...prev, ...data.items],
-		);
-	}, [data, offset]);
-
-	const hasMore = allItems.length < total;
-
 	return (
 		<main id="content">
 			<div className="fr-container fr-py-4w">
@@ -62,29 +20,7 @@ export function DeclarationHistoryPage({ siren, year }: Props) {
 				<p className="fr-text--lg fr-mb-4w">
 					Démarche des indicateurs de rémunération {year}
 				</p>
-
-				{allItems.length === 0 && !isFetching ? (
-					<p>Aucune action enregistrée pour cette démarche.</p>
-				) : (
-					<ul className="fr-m-0 fr-p-0">
-						{allItems.map((item, index) => (
-							<EntryRow item={item} key={item.id} showDivider={index > 0} />
-						))}
-					</ul>
-				)}
-
-				{hasMore && (
-					<div className="fr-mt-3w">
-						<button
-							className="fr-btn fr-btn--tertiary-no-outline"
-							disabled={isFetching}
-							onClick={() => setOffset((o) => o + LIMIT)}
-							type="button"
-						>
-							Voir plus
-						</button>
-					</div>
-				)}
+				<HistoryListSection siren={siren} year={year} />
 			</div>
 		</main>
 	);

--- a/packages/app/src/modules/declarationHistory/HistoryEntry.tsx
+++ b/packages/app/src/modules/declarationHistory/HistoryEntry.tsx
@@ -1,10 +1,19 @@
 import Link from "next/link";
-import type { RouterOutputs } from "~/trpc/react";
-import type { HistoryEventDisplay } from "./eventDisplay";
+import type { DeclarationEventType, HistoryEventDisplay } from "./eventDisplay";
 import { getHistoryEventDisplay } from "./eventDisplay";
 
-export type HistoryItem =
-	RouterOutputs["declaration"]["getStatusHistory"]["items"][number];
+export type HistoryItem = {
+	id: string;
+	eventType: DeclarationEventType;
+	value: string | null;
+	round: number | null;
+	createdAt: Date;
+	actor: {
+		firstName: string | null;
+		lastName: string | null;
+		email: string;
+	} | null;
+};
 
 type Props = {
 	item: HistoryItem;

--- a/packages/app/src/modules/declarationHistory/HistoryEntry.tsx
+++ b/packages/app/src/modules/declarationHistory/HistoryEntry.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+import type { RouterOutputs } from "~/trpc/react";
+import type { HistoryEventDisplay } from "./eventDisplay";
+import { getHistoryEventDisplay } from "./eventDisplay";
+
+export type HistoryItem =
+	RouterOutputs["declaration"]["getStatusHistory"]["items"][number];
+
+type Props = {
+	item: HistoryItem;
+};
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+	day: "numeric",
+	month: "long",
+	year: "numeric",
+});
+
+const timeFormatter = new Intl.DateTimeFormat("fr-FR", {
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+});
+
+function formatActorName(actor: HistoryItem["actor"]): string {
+	if (!actor) return "Système";
+	const parts = [actor.firstName, actor.lastName].filter(Boolean);
+	return parts.length > 0 ? parts.join(" ") : actor.email;
+}
+
+function PageLink({ display }: { display: HistoryEventDisplay }) {
+	if (!display.pageLabel) return null;
+
+	return (
+		<span>
+			<span className="fr-text--sm fr-text-mention--grey">Page : </span>
+			{display.pageHref ? (
+				<Link className="fr-link fr-text--sm" href={display.pageHref}>
+					{display.pageLabel}
+				</Link>
+			) : (
+				<span className="fr-text--sm">{display.pageLabel}</span>
+			)}
+		</span>
+	);
+}
+
+export function HistoryEntry({ item }: Props) {
+	const createdAt = new Date(item.createdAt);
+	const display = getHistoryEventDisplay({
+		eventType: item.eventType,
+		value: item.value,
+		round: item.round,
+	});
+	const actorName = formatActorName(item.actor);
+
+	return (
+		<li className="fr-py-3w">
+			<div className="fr-grid-row fr-grid-row--gutters">
+				<div className="fr-col-12 fr-col-md-2">
+					<time
+						className="fr-text--sm fr-text--bold"
+						dateTime={createdAt.toISOString()}
+					>
+						{dateFormatter.format(createdAt)}
+					</time>
+					<br />
+					<span className="fr-text--sm fr-text-mention--grey">
+						{timeFormatter.format(createdAt)}
+					</span>
+				</div>
+				<div className="fr-col-12 fr-col-md-4">
+					<span className="fr-text--sm fr-text--bold">{actorName}</span>
+					{item.actor && (
+						<>
+							<br />
+							<span className="fr-text--sm fr-text-mention--grey">
+								{item.actor.email}
+							</span>
+						</>
+					)}
+				</div>
+				<div className="fr-col-12 fr-col-md-6">
+					<PageLink display={display} />
+				</div>
+			</div>
+		</li>
+	);
+}

--- a/packages/app/src/modules/declarationHistory/HistoryListSection.tsx
+++ b/packages/app/src/modules/declarationHistory/HistoryListSection.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { api } from "~/trpc/react";
+import type { HistoryItem } from "./HistoryEntry";
+import { HistoryEntry } from "./HistoryEntry";
+
+const LIMIT = 10;
+
+type Props = {
+	siren: string;
+	year: number;
+};
+
+type EntryRowProps = { item: HistoryItem; showDivider: boolean };
+
+function EntryRow({ item, showDivider }: EntryRowProps) {
+	return (
+		<>
+			{showDivider && <hr className="fr-hr fr-mt-0" />}
+			<HistoryEntry item={item} />
+		</>
+	);
+}
+
+export function HistoryListSection({ siren, year }: Props) {
+	const [offset, setOffset] = useState(0);
+	const [allItems, setAllItems] = useState<HistoryItem[]>([]);
+	const [total, setTotal] = useState(0);
+	const loadedOffsets = useRef(new Set<number>());
+
+	const { data, isFetching } = api.declaration.getStatusHistory.useQuery({
+		siren,
+		year,
+		limit: LIMIT,
+		offset,
+	});
+
+	useEffect(() => {
+		if (!data || loadedOffsets.current.has(offset)) return;
+		loadedOffsets.current.add(offset);
+		setTotal(data.total);
+		setAllItems((prev) =>
+			offset === 0 ? [...data.items] : [...prev, ...data.items],
+		);
+	}, [data, offset]);
+
+	const hasMore = allItems.length < total;
+
+	if (allItems.length === 0 && !isFetching) {
+		return <p>Aucune action enregistrée pour cette démarche.</p>;
+	}
+
+	return (
+		<>
+			<ul className="fr-m-0 fr-p-0">
+				{allItems.map((item, index) => (
+					<EntryRow item={item} key={item.id} showDivider={index > 0} />
+				))}
+			</ul>
+
+			{hasMore && (
+				<div className="fr-mt-3w">
+					<button
+						className="fr-btn fr-btn--tertiary-no-outline"
+						disabled={isFetching}
+						onClick={() => setOffset((o) => o + LIMIT)}
+						type="button"
+					>
+						Voir plus
+					</button>
+				</div>
+			)}
+		</>
+	);
+}

--- a/packages/app/src/modules/declarationHistory/__tests__/DeclarationHistoryPage.test.tsx
+++ b/packages/app/src/modules/declarationHistory/__tests__/DeclarationHistoryPage.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			getStatusHistory: {
+				useQuery: mockUseQuery,
+			},
+		},
+	},
+}));
+
+import { DeclarationHistoryPage } from "../DeclarationHistoryPage";
+
+const makeItem = (id: string) => ({
+	id,
+	eventType: "submit" as const,
+	value: null,
+	round: null,
+	createdAt: new Date("2026-09-28T13:10:00Z"),
+	actor: {
+		firstName: "Maria",
+		lastName: "Dupont",
+		email: "maria.dupont@example.fr",
+	},
+});
+
+describe("DeclarationHistoryPage", () => {
+	it("renders title and subtitle", async () => {
+		mockUseQuery.mockReturnValue({
+			data: { items: [], total: 0 },
+			isFetching: false,
+		});
+
+		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
+
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: "Historique des modifications",
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Démarche des indicateurs de rémunération 2026"),
+		).toBeInTheDocument();
+	});
+
+	it("renders breadcrumb with Mon espace link", async () => {
+		mockUseQuery.mockReturnValue({
+			data: { items: [], total: 0 },
+			isFetching: false,
+		});
+
+		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
+
+		expect(screen.getByRole("link", { name: "Mon espace" })).toHaveAttribute(
+			"href",
+			"/mon-espace",
+		);
+	});
+
+	it("shows empty state when no items and not fetching", async () => {
+		mockUseQuery.mockReturnValue({
+			data: { items: [], total: 0 },
+			isFetching: false,
+		});
+
+		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText("Aucune action enregistrée pour cette démarche."),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("renders history items when data is loaded", async () => {
+		const items = [makeItem("item-1"), makeItem("item-2")];
+		mockUseQuery.mockReturnValue({
+			data: { items, total: 2 },
+			isFetching: false,
+		});
+
+		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(screen.getAllByText("Maria Dupont")).toHaveLength(2);
+		});
+	});
+
+	it("does not show Voir plus when all items are loaded", async () => {
+		mockUseQuery.mockReturnValue({
+			data: { items: [makeItem("item-1")], total: 1 },
+			isFetching: false,
+		});
+
+		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("button", { name: "Voir plus" }),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it("shows Voir plus button when more items exist", async () => {
+		const items = Array.from({ length: 10 }, (_, i) => makeItem(`item-${i}`));
+		mockUseQuery.mockReturnValue({
+			data: { items, total: 15 },
+			isFetching: false,
+		});
+
+		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Voir plus" }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("loads more items when Voir plus is clicked", async () => {
+		const firstPage = Array.from({ length: 10 }, (_, i) =>
+			makeItem(`item-${i}`),
+		);
+		const secondPage = Array.from({ length: 3 }, (_, i) =>
+			makeItem(`more-${i}`),
+		);
+
+		mockUseQuery
+			.mockReturnValueOnce({
+				data: { items: firstPage, total: 13 },
+				isFetching: false,
+			})
+			.mockReturnValue({
+				data: { items: secondPage, total: 13 },
+				isFetching: false,
+			});
+
+		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Voir plus" }),
+			).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByRole("button", { name: "Voir plus" }));
+
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("button", { name: "Voir plus" }),
+			).not.toBeInTheDocument();
+		});
+	});
+});

--- a/packages/app/src/modules/declarationHistory/__tests__/DeclarationHistoryPage.test.tsx
+++ b/packages/app/src/modules/declarationHistory/__tests__/DeclarationHistoryPage.test.tsx
@@ -1,41 +1,14 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
-
-vi.mock("~/trpc/react", () => ({
-	api: {
-		declaration: {
-			getStatusHistory: {
-				useQuery: mockUseQuery,
-			},
-		},
-	},
+vi.mock("../HistoryListSection", () => ({
+	HistoryListSection: () => <div data-testid="history-list-section" />,
 }));
 
 import { DeclarationHistoryPage } from "../DeclarationHistoryPage";
 
-const makeItem = (id: string) => ({
-	id,
-	eventType: "submit" as const,
-	value: null,
-	round: null,
-	createdAt: new Date("2026-09-28T13:10:00Z"),
-	actor: {
-		firstName: "Maria",
-		lastName: "Dupont",
-		email: "maria.dupont@example.fr",
-	},
-});
-
 describe("DeclarationHistoryPage", () => {
-	it("renders title and subtitle", async () => {
-		mockUseQuery.mockReturnValue({
-			data: { items: [], total: 0 },
-			isFetching: false,
-		});
-
+	it("renders title and subtitle", () => {
 		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
 
 		expect(
@@ -49,12 +22,7 @@ describe("DeclarationHistoryPage", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders breadcrumb with Mon espace link", async () => {
-		mockUseQuery.mockReturnValue({
-			data: { items: [], total: 0 },
-			isFetching: false,
-		});
-
+	it("renders breadcrumb with Mon espace link", () => {
 		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
 
 		expect(screen.getByRole("link", { name: "Mon espace" })).toHaveAttribute(
@@ -63,98 +31,9 @@ describe("DeclarationHistoryPage", () => {
 		);
 	});
 
-	it("shows empty state when no items and not fetching", async () => {
-		mockUseQuery.mockReturnValue({
-			data: { items: [], total: 0 },
-			isFetching: false,
-		});
-
+	it("renders the history list section", () => {
 		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
 
-		await waitFor(() => {
-			expect(
-				screen.getByText("Aucune action enregistrée pour cette démarche."),
-			).toBeInTheDocument();
-		});
-	});
-
-	it("renders history items when data is loaded", async () => {
-		const items = [makeItem("item-1"), makeItem("item-2")];
-		mockUseQuery.mockReturnValue({
-			data: { items, total: 2 },
-			isFetching: false,
-		});
-
-		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
-
-		await waitFor(() => {
-			expect(screen.getAllByText("Maria Dupont")).toHaveLength(2);
-		});
-	});
-
-	it("does not show Voir plus when all items are loaded", async () => {
-		mockUseQuery.mockReturnValue({
-			data: { items: [makeItem("item-1")], total: 1 },
-			isFetching: false,
-		});
-
-		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
-
-		await waitFor(() => {
-			expect(
-				screen.queryByRole("button", { name: "Voir plus" }),
-			).not.toBeInTheDocument();
-		});
-	});
-
-	it("shows Voir plus button when more items exist", async () => {
-		const items = Array.from({ length: 10 }, (_, i) => makeItem(`item-${i}`));
-		mockUseQuery.mockReturnValue({
-			data: { items, total: 15 },
-			isFetching: false,
-		});
-
-		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
-
-		await waitFor(() => {
-			expect(
-				screen.getByRole("button", { name: "Voir plus" }),
-			).toBeInTheDocument();
-		});
-	});
-
-	it("loads more items when Voir plus is clicked", async () => {
-		const firstPage = Array.from({ length: 10 }, (_, i) =>
-			makeItem(`item-${i}`),
-		);
-		const secondPage = Array.from({ length: 3 }, (_, i) =>
-			makeItem(`more-${i}`),
-		);
-
-		mockUseQuery
-			.mockReturnValueOnce({
-				data: { items: firstPage, total: 13 },
-				isFetching: false,
-			})
-			.mockReturnValue({
-				data: { items: secondPage, total: 13 },
-				isFetching: false,
-			});
-
-		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
-
-		await waitFor(() => {
-			expect(
-				screen.getByRole("button", { name: "Voir plus" }),
-			).toBeInTheDocument();
-		});
-
-		await userEvent.click(screen.getByRole("button", { name: "Voir plus" }));
-
-		await waitFor(() => {
-			expect(
-				screen.queryByRole("button", { name: "Voir plus" }),
-			).not.toBeInTheDocument();
-		});
+		expect(screen.getByTestId("history-list-section")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declarationHistory/__tests__/HistoryEntry.test.tsx
+++ b/packages/app/src/modules/declarationHistory/__tests__/HistoryEntry.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { HistoryItem } from "../HistoryEntry";
+import { HistoryEntry } from "../HistoryEntry";
+
+const baseItem: HistoryItem = {
+	id: "item-1",
+	eventType: "submit",
+	value: null,
+	round: null,
+	createdAt: new Date("2026-09-28T13:10:00Z"),
+	actor: {
+		firstName: "Maria",
+		lastName: "Dupont",
+		email: "maria.dupont@example.fr",
+	},
+};
+
+describe("HistoryEntry", () => {
+	it("renders actor name and email", () => {
+		render(
+			<ul>
+				<HistoryEntry item={baseItem} />
+			</ul>,
+		);
+		expect(screen.getByText("Maria Dupont")).toBeInTheDocument();
+		expect(screen.getByText("maria.dupont@example.fr")).toBeInTheDocument();
+	});
+
+	it("renders page link for submit event", () => {
+		render(
+			<ul>
+				<HistoryEntry item={baseItem} />
+			</ul>,
+		);
+		const link = screen.getByRole("link", {
+			name: "Récapitulatif de votre déclaration",
+		});
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/recapitulatif",
+		);
+	});
+
+	it("renders 'Système' when actor is null", () => {
+		render(
+			<ul>
+				<HistoryEntry item={{ ...baseItem, actor: null }} />
+			</ul>,
+		);
+		expect(screen.getByText("Système")).toBeInTheDocument();
+	});
+
+	it("renders actor email as name when firstName and lastName are null", () => {
+		render(
+			<ul>
+				<HistoryEntry
+					item={{
+						...baseItem,
+						actor: { firstName: null, lastName: null, email: "only@email.fr" },
+					}}
+				/>
+			</ul>,
+		);
+		expect(screen.getAllByText("only@email.fr").length).toBeGreaterThan(0);
+	});
+
+	it("renders page label as plain text when pageHref is null", () => {
+		render(
+			<ul>
+				<HistoryEntry item={{ ...baseItem, eventType: "cancel" }} />
+			</ul>,
+		);
+		expect(
+			screen.queryByRole("link", { name: /annulation/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders step page link for step_change event with round", () => {
+		render(
+			<ul>
+				<HistoryEntry
+					item={{ ...baseItem, eventType: "step_change", round: 1 }}
+				/>
+			</ul>,
+		);
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute(
+			"href",
+			expect.stringContaining("/declaration-remuneration/etape/"),
+		);
+	});
+
+	it("renders date and time in the time element", () => {
+		render(
+			<ul>
+				<HistoryEntry item={baseItem} />
+			</ul>,
+		);
+		const timeEl = screen.getByRole("time");
+		expect(timeEl).toHaveAttribute("dateTime", "2026-09-28T13:10:00.000Z");
+	});
+});

--- a/packages/app/src/modules/declarationHistory/__tests__/HistoryListSection.test.tsx
+++ b/packages/app/src/modules/declarationHistory/__tests__/HistoryListSection.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseQuery } = vi.hoisted(() => ({ mockUseQuery: vi.fn() }));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declaration: {
+			getStatusHistory: {
+				useQuery: mockUseQuery,
+			},
+		},
+	},
+}));
+
+import { HistoryListSection } from "../HistoryListSection";
+
+const makeItem = (id: string) => ({
+	id,
+	eventType: "submit" as const,
+	value: null,
+	round: null,
+	createdAt: new Date("2026-09-28T13:10:00Z"),
+	actor: {
+		firstName: "Maria",
+		lastName: "Dupont",
+		email: "maria.dupont@example.fr",
+	},
+});
+
+describe("HistoryListSection", () => {
+	it("shows empty state when no items and not fetching", async () => {
+		mockUseQuery.mockReturnValue({
+			data: { items: [], total: 0 },
+			isFetching: false,
+		});
+
+		render(<HistoryListSection siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByText("Aucune action enregistrée pour cette démarche."),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("renders history items when data is loaded", async () => {
+		const items = [makeItem("item-1"), makeItem("item-2")];
+		mockUseQuery.mockReturnValue({
+			data: { items, total: 2 },
+			isFetching: false,
+		});
+
+		render(<HistoryListSection siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(screen.getAllByText("Maria Dupont")).toHaveLength(2);
+		});
+	});
+
+	it("does not show Voir plus when all items are loaded", async () => {
+		mockUseQuery.mockReturnValue({
+			data: { items: [makeItem("item-1")], total: 1 },
+			isFetching: false,
+		});
+
+		render(<HistoryListSection siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("button", { name: "Voir plus" }),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it("shows Voir plus button when more items exist", async () => {
+		const items = Array.from({ length: 10 }, (_, i) => makeItem(`item-${i}`));
+		mockUseQuery.mockReturnValue({
+			data: { items, total: 15 },
+			isFetching: false,
+		});
+
+		render(<HistoryListSection siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Voir plus" }),
+			).toBeInTheDocument();
+		});
+	});
+
+	it("loads more items when Voir plus is clicked", async () => {
+		const firstPage = Array.from({ length: 10 }, (_, i) =>
+			makeItem(`item-${i}`),
+		);
+		const secondPage = Array.from({ length: 3 }, (_, i) =>
+			makeItem(`more-${i}`),
+		);
+
+		mockUseQuery
+			.mockReturnValueOnce({
+				data: { items: firstPage, total: 13 },
+				isFetching: false,
+			})
+			.mockReturnValue({
+				data: { items: secondPage, total: 13 },
+				isFetching: false,
+			});
+
+		render(<HistoryListSection siren="130025265" year={2026} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Voir plus" }),
+			).toBeInTheDocument();
+		});
+
+		await userEvent.click(screen.getByRole("button", { name: "Voir plus" }));
+
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("button", { name: "Voir plus" }),
+			).not.toBeInTheDocument();
+		});
+	});
+});

--- a/packages/app/src/modules/declarationHistory/eventDisplay.ts
+++ b/packages/app/src/modules/declarationHistory/eventDisplay.ts
@@ -1,4 +1,4 @@
-import { STEP_TITLES } from "~/modules/declaration-remuneration";
+import { STEP_TITLES } from "~/modules/declaration-remuneration/types";
 import type { DeclarationEventType as DomainEventType } from "~/modules/domain";
 
 export type DeclarationEventType = DomainEventType | "step_change";

--- a/packages/app/src/modules/declarationHistory/index.ts
+++ b/packages/app/src/modules/declarationHistory/index.ts
@@ -1,6 +1,8 @@
+export { DeclarationHistoryPage } from "./DeclarationHistoryPage";
 export type {
 	DeclarationEventType,
 	HistoryEvent,
 	HistoryEventDisplay,
 } from "./eventDisplay";
 export { getHistoryEventDisplay } from "./eventDisplay";
+export type { HistoryItem } from "./HistoryEntry";


### PR DESCRIPTION
Closes #3600

## Summary

- Adds route `mon-espace/historique/[siren]/[year]` — thin wrapper with auth guard and `generateMetadata`
- `DeclarationHistoryPage`: client component with offset-based "Voir plus" pagination consuming `api.declaration.getStatusHistory` (#3598)
- `HistoryEntry`: renders each event with FR-formatted date/time, actor name + email (fallback "Système"), and page link via `getHistoryEventDisplay` (#3599)
- E2E test covers list display (S2) and load-more flow (S5)
- Unit tests: 7 for `HistoryEntry`, 7 for `DeclarationHistoryPage` (all green)

## Test plan

- [ ] Navigate to `/mon-espace/historique/[SIREN]/[YEAR]` — history entries displayed chronologically (recent → oldest)
- [ ] Each entry shows date, time, actor name + email, page link
- [ ] Actor null → fallback "Système" shown
- [ ] More than 10 entries → "Voir plus" button visible; click appends next page; button disappears when all loaded
- [ ] No entries → empty state message shown
- [ ] Mobile 375px: layout stacks vertically, no horizontal scroll
- [ ] Unauthenticated → redirected to /login
- [ ] Invalid SIREN (wrong length) or year → 404