### PR TITLE
feat(my-space): wire history link in DeclarationProcessPanel

### DIFF
--- a/packages/app/src/e2e/declaration-history.e2e.ts
+++ b/packages/app/src/e2e/declaration-history.e2e.ts
@@ -37,7 +37,7 @@ test.describe("Declaration history page", () => {
 			page.getByText(`Démarche des indicateurs de rémunération ${year}`),
 		).toBeVisible();
 
-		const items = page.locator("ul > li");
+		const items = page.locator("main ul > li");
 		await expect(items).toHaveCount(3);
 	});
 
@@ -47,11 +47,11 @@ test.describe("Declaration history page", () => {
 
 		await expect(page.getByRole("button", { name: "Voir plus" })).toBeVisible();
 
-		await expect(page.locator("ul > li")).toHaveCount(10);
+		await expect(page.locator("main ul > li")).toHaveCount(10);
 
 		await page.getByRole("button", { name: "Voir plus" }).click();
 
-		await expect(page.locator("ul > li")).toHaveCount(13);
+		await expect(page.locator("main ul > li")).toHaveCount(13);
 		await expect(
 			page.getByRole("button", { name: "Voir plus" }),
 		).not.toBeVisible();

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRef } from "react";
 
 import type {
@@ -66,7 +67,11 @@ export function DeclarationProcessPanel({
 				</div>
 				<div className={styles.panelContent}>
 					<div>
-						<PanelHeader lastActionDate={lastActionDate} year={year} />
+						<PanelHeader
+							lastActionDate={lastActionDate}
+							siren={siren}
+							year={year}
+						/>
 						{(variant === "start" || variant === "compliance_choice") && (
 							<StartAlert />
 						)}
@@ -105,9 +110,11 @@ function getCtaLabel(variant: PanelVariant): string {
 
 function PanelHeader({
 	year,
+	siren,
 	lastActionDate,
 }: {
 	year: number;
+	siren: string;
 	lastActionDate: string | null;
 }) {
 	return (
@@ -125,9 +132,12 @@ function PanelHeader({
 						<span>Dernière action le {lastActionDate}</span>
 					</>
 				)}
-				<button className={`fr-link ${styles.historyLink}`} type="button">
+				<Link
+					className={`fr-link ${styles.historyLink}`}
+					href={`/mon-espace/historique/${siren}/${year}`}
+				>
 					Voir l'historique
-				</button>
+				</Link>
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -82,9 +82,14 @@ describe("DeclarationProcessPanel", () => {
 			).toBeInTheDocument();
 		});
 
-		it("renders the history link", () => {
-			const { panel } = renderPanel("start");
-			expect(panel.getByText("Voir l'historique")).toBeInTheDocument();
+		it("renders the history link pointing to the history route", () => {
+			const { dialog } = renderPanel("start");
+			const link = dialog.querySelector("a.fr-link");
+			expect(link).toBeInTheDocument();
+			expect(link).toHaveAttribute(
+				"href",
+				`/mon-espace/historique/${BASE_PROPS.siren}/${BASE_PROPS.year}`,
+			);
 		});
 
 		it("renders the info alert", () => {


### PR DESCRIPTION
## Contexte

Closes #3601

Ticket de l'epic #3584 — page d'historique des déclarations.

## Changements

- `DeclarationProcessPanel.tsx` : le bouton « Voir l'historique » dans `PanelHeader` est transformé en lien `next/link` pointant vers `/mon-espace/historique/<siren>/<year>`. La prop `siren` est transmise depuis `DeclarationProcessPanel` jusqu'à `PanelHeader`.
- `DeclarationProcessPanel.test.tsx` : le test existant est mis à jour pour vérifier le `href` du lien plutôt que la simple présence du texte.

## Test plan

- [ ] Tests unitaires verts : `pnpm test` (27/27)
- [ ] Typecheck vert : `pnpm typecheck`
- [ ] Lint + format verts : `pnpm lint:check && pnpm format:check`