### PR TITLE
stats(analytics): Matomo — wrapper trackEvent + taxonomie (#3612)

### DIFF
--- a/packages/app/src/modules/analytics/__tests__/trackEvent.test.ts
+++ b/packages/app/src/modules/analytics/__tests__/trackEvent.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnv, pushMock, sendEventMock } = vi.hoisted(() => ({
+	mockEnv: {
+		NEXT_PUBLIC_MATOMO_URL: "https://matomo.test" as string | undefined,
+		NEXT_PUBLIC_MATOMO_SITE_ID: "1" as string | undefined,
+	},
+	pushMock: vi.fn(),
+	sendEventMock: vi.fn(),
+}));
+
+vi.mock("~/env", () => ({ env: mockEnv }));
+vi.mock("@socialgouv/matomo-next", () => ({
+	push: pushMock,
+	sendEvent: sendEventMock,
+}));
+
+import {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+	MATOMO_FUNNEL_STEP_KEYS,
+} from "../shared/events";
+import { trackEvent } from "../trackEvent";
+
+beforeEach(() => {
+	mockEnv.NEXT_PUBLIC_MATOMO_URL = "https://matomo.test";
+	mockEnv.NEXT_PUBLIC_MATOMO_SITE_ID = "1";
+	pushMock.mockClear();
+	sendEventMock.mockClear();
+});
+
+describe("trackEvent", () => {
+	it("emits a typed event via sendEvent when Matomo is configured", () => {
+		trackEvent({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.STEP_COMPLETE,
+			name: "step_2",
+			value: 42,
+		});
+
+		expect(sendEventMock).toHaveBeenCalledWith({
+			category: "declaration",
+			action: "step_complete",
+			name: "step_2",
+			value: 42,
+		});
+	});
+
+	it("omits name and value when they are not provided", () => {
+		trackEvent({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_START,
+		});
+
+		expect(sendEventMock).toHaveBeenCalledWith({
+			category: "declaration",
+			action: "funnel_start",
+		});
+	});
+
+	it("sets each custom dimension before emitting the event", () => {
+		trackEvent({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_START,
+			dimensions: {
+				[MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2025",
+				[MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE]: "50-99",
+			},
+		});
+
+		expect(pushMock).toHaveBeenCalledWith([
+			"setCustomDimension",
+			MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR,
+			"2025",
+		]);
+		expect(pushMock).toHaveBeenCalledWith([
+			"setCustomDimension",
+			MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE,
+			"50-99",
+		]);
+
+		const firstDimensionOrder = pushMock.mock.invocationCallOrder[0];
+		const eventOrder = sendEventMock.mock.invocationCallOrder[0];
+		expect(firstDimensionOrder).toBeLessThan(eventOrder ?? Infinity);
+	});
+
+	it("is a silent no-op when Matomo is not configured", () => {
+		mockEnv.NEXT_PUBLIC_MATOMO_URL = undefined;
+
+		trackEvent({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_START,
+		});
+
+		expect(sendEventMock).not.toHaveBeenCalled();
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("MATOMO_FUNNEL_STEP_KEYS", () => {
+	it("derives one stable, untranslated key per declaration step", () => {
+		expect(MATOMO_FUNNEL_STEP_KEYS).toEqual([
+			"step_0",
+			"step_1",
+			"step_2",
+			"step_3",
+			"step_4",
+			"step_5",
+			"step_6",
+		]);
+	});
+});

--- a/packages/app/src/modules/analytics/index.ts
+++ b/packages/app/src/modules/analytics/index.ts
@@ -1,1 +1,9 @@
 export { MatomoAnalytics } from "./MatomoAnalytics";
+export type { MatomoEvent } from "./shared/events";
+export {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+	MATOMO_FUNNEL_STEP_KEYS,
+} from "./shared/events";
+export { trackEvent } from "./trackEvent";

--- a/packages/app/src/modules/analytics/shared/events.ts
+++ b/packages/app/src/modules/analytics/shared/events.ts
@@ -1,0 +1,32 @@
+import { DECLARATION_STEPS } from "~/modules/domain";
+
+export const MATOMO_EVENT_CATEGORY = {
+	DECLARATION: "declaration",
+} as const;
+
+export const MATOMO_DECLARATION_ACTION = {
+	FUNNEL_START: "funnel_start",
+	STEP_COMPLETE: "step_complete",
+	FUNNEL_COMPLETE: "funnel_complete",
+	FUNNEL_ABANDON: "funnel_abandon",
+} as const;
+
+export const MATOMO_FUNNEL_STEP_KEYS: readonly string[] = DECLARATION_STEPS.map(
+	(entry) => `step_${entry.step}`,
+);
+
+// Slot IDs must match the Custom Dimension slots configured in the Matomo
+// admin (out-of-code coordination); a wrong ID makes the dimension silently
+// ignored. Centralised here so the value is never duplicated as a magic number.
+export const MATOMO_CUSTOM_DIMENSION = {
+	CAMPAIGN_YEAR: 1,
+	WORKFORCE_RANGE: 2,
+} as const;
+
+export type MatomoEvent = {
+	category: string;
+	action: string;
+	name?: string;
+	value?: number;
+	dimensions?: Record<number, string>;
+};

--- a/packages/app/src/modules/analytics/trackEvent.ts
+++ b/packages/app/src/modules/analytics/trackEvent.ts
@@ -1,0 +1,41 @@
+import { push, sendEvent } from "@socialgouv/matomo-next";
+
+import { env } from "~/env.js";
+
+import type { MatomoEvent } from "./shared/events";
+
+function isMatomoConfigured(): boolean {
+	// `push`/`sendEvent` write to `window._paq`; bail on the server so the
+	// module stays safe to import and call from isomorphic code.
+	if (typeof window === "undefined") return false;
+
+	return Boolean(env.NEXT_PUBLIC_MATOMO_URL && env.NEXT_PUBLIC_MATOMO_SITE_ID);
+}
+
+export function trackEvent({
+	category,
+	action,
+	name,
+	value,
+	dimensions,
+}: MatomoEvent): void {
+	if (!isMatomoConfigured()) return;
+
+	if (dimensions) {
+		for (const [dimensionId, dimensionValue] of Object.entries(dimensions)) {
+			push([
+				"setCustomDimension",
+				Number(dimensionId),
+				dimensionValue,
+			] as const);
+		}
+	}
+
+	if (name !== undefined && value !== undefined) {
+		sendEvent({ category, action, name, value });
+	} else if (name !== undefined) {
+		sendEvent({ category, action, name });
+	} else {
+		sendEvent({ category, action });
+	}
+}


### PR DESCRIPTION
Fondation de l'epic #3514 (Stats Admin Matomo — funnel de déclaration K20/K21).

Pose la brique de base d'émission d'events custom Matomo, réutilisable côté client (instrumentation) et serveur (Reporting API). Aucun consommateur dans cette PR.

## Contenu

- `modules/analytics/shared/events.ts` — taxonomie isomorphe :
  - `MATOMO_EVENT_CATEGORY` (`declaration`)
  - `MATOMO_DECLARATION_ACTION` (`funnel_start` / `step_complete` / `funnel_complete` / `funnel_abandon`)
  - `MATOMO_FUNNEL_STEP_KEYS` — clés d'étape stables (`step_0`…`step_6`) **dérivées de `DECLARATION_STEPS`** du domaine, non traduites
  - `MATOMO_CUSTOM_DIMENSION` (`CAMPAIGN_YEAR`, `WORKFORCE_RANGE`) — IDs de slot
  - type `MatomoEvent`
- `modules/analytics/trackEvent.ts` — wrapper :
  - émission via `sendEvent` **typé** de `@socialgouv/matomo-next` (omet nativement les args `undefined` en queue)
  - `push(["setCustomDimension", id, val])` pour chaque custom dimension fournie, **avant** l'event (pas de helper typé pour les dimensions)
  - no-op silencieux si Matomo non configuré **ou** en SSR (guard `typeof window`)
- `modules/analytics/index.ts` — exports barrel
- tests unitaires (5) : émission typée, omission name/value, ordre dimensions→event, no-op non configuré, dérivation des step keys

## ⚠️ Coordination requise (hors-code)

Les IDs `MATOMO_CUSTOM_DIMENSION.{CAMPAIGN_YEAR: 1, WORKFORCE_RANGE: 2}` doivent correspondre aux slots de **Custom Dimension définis côté admin Matomo**. Valeurs `1`/`2` posées par convention — à aligner avec l'équipe analytics avant la collecte réelle (#3614/#3615), sinon les dimensions seront silencieusement ignorées.

## Qualité

- Typecheck ✓ · suite complète 2467 tests ✓ · lint ✓ · format ✓
- structural-auditor : PASS (17 règles)
- Aucune PII émise (responsabilité documentée dans le contrat de type)

Part of #3514.