### PR TITLE
stats(analytics): Matomo — client serveur Reporting API + MATOMO_API_TOKEN (#3613)

### DIFF
--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -59,6 +59,9 @@ app:
     - secretRef:
         name: "admin"
         optional: true
+    - secretRef:
+        name: "matomo"
+        optional: true
     - configMapRef:
         name: "valkey"
         optional: true

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -12,6 +12,9 @@ SENTRY_AUTH_TOKEN=""
 NEXT_PUBLIC_SENTRY_DSN=""
 NEXT_PUBLIC_MATOMO_URL=""
 NEXT_PUBLIC_MATOMO_SITE_ID=""
+# token_auth for the Matomo Reporting API (admin stats widgets). Leave empty
+# locally — the widgets degrade to an error state when it is absent.
+MATOMO_API_TOKEN=""
 EGAPRO_GIP_MDS_API_URL="http://localhost:3000/api/gip-mds/mock"
 EGAPRO_SUIT_API_URL=""
 EGAPRO_MOCK_SUIT_SANCTION="true"

--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -64,6 +64,10 @@ export const env = createEnv({
 		NEXTAUTH_URL: z.string().url(),
 		EGAPRO_GIP_MDS_API_URL: z.string().url().optional(),
 		EGAPRO_GIP_MDS_API_TOKEN: z.string().optional(),
+		// token_auth for the Matomo Reporting API (server-side read of custom
+		// events). Optional: when absent the admin Matomo widgets degrade to an
+		// error state instead of breaking the rest of the dashboard.
+		MATOMO_API_TOKEN: z.string().optional(),
 		EGAPRO_MOCK_SUIT_SANCTION: z.coerce.boolean().optional().default(false),
 		/**
 		 * Comma-separated list of emails that should be granted the admin role
@@ -135,6 +139,7 @@ export const env = createEnv({
 		NEXTAUTH_URL: process.env.NEXTAUTH_URL,
 		EGAPRO_GIP_MDS_API_URL: process.env.EGAPRO_GIP_MDS_API_URL,
 		EGAPRO_GIP_MDS_API_TOKEN: process.env.EGAPRO_GIP_MDS_API_TOKEN,
+		MATOMO_API_TOKEN: process.env.MATOMO_API_TOKEN,
 		EGAPRO_MOCK_SUIT_SANCTION: process.env.EGAPRO_MOCK_SUIT_SANCTION,
 		ADMIN_EMAILS: process.env.ADMIN_EMAILS,
 		EGAPRO_AUDIT_RETENTION_SHORT_DAYS:

--- a/packages/app/src/server/services/__tests__/matomo.test.ts
+++ b/packages/app/src/server/services/__tests__/matomo.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnv } = vi.hoisted(() => ({
+	mockEnv: {
+		NEXT_PUBLIC_MATOMO_URL: "https://matomo.test" as string | undefined,
+		NEXT_PUBLIC_MATOMO_SITE_ID: "42" as string | undefined,
+		MATOMO_API_TOKEN: "super-secret-token" as string | undefined,
+	},
+}));
+
+vi.mock("~/env", () => ({ env: mockEnv }));
+
+import { fetchMatomoEventsReport } from "../matomo";
+
+const fetchSpy = vi.fn();
+
+beforeEach(() => {
+	mockEnv.NEXT_PUBLIC_MATOMO_URL = "https://matomo.test";
+	mockEnv.NEXT_PUBLIC_MATOMO_SITE_ID = "42";
+	mockEnv.MATOMO_API_TOKEN = "super-secret-token";
+	fetchSpy.mockReset();
+	vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("fetchMatomoEventsReport", () => {
+	it("builds the Reporting API request and returns the parsed rows", async () => {
+		const rows = [
+			{ label: "funnel_start", nb_events: 120 },
+			{ label: "funnel_complete", nb_events: 80 },
+		];
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => rows,
+		});
+
+		const result = await fetchMatomoEventsReport({
+			method: "Events.getAction",
+			period: "range",
+			date: "2025-01-01,2025-12-31",
+		});
+
+		expect(result).toEqual(rows);
+
+		const calledUrl = fetchSpy.mock.calls[0]?.[0] as URL;
+		expect(calledUrl.pathname).toBe("/index.php");
+		expect(calledUrl.searchParams.get("module")).toBe("API");
+		expect(calledUrl.searchParams.get("format")).toBe("json");
+		expect(calledUrl.searchParams.get("idSite")).toBe("42");
+		expect(calledUrl.searchParams.get("method")).toBe("Events.getAction");
+		expect(calledUrl.searchParams.get("period")).toBe("range");
+		expect(calledUrl.searchParams.get("date")).toBe("2025-01-01,2025-12-31");
+	});
+
+	it("never puts the token in the URL (sent in the request body)", async () => {
+		fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+		await fetchMatomoEventsReport({
+			method: "Events.getAction",
+			period: "range",
+			date: "2025-01-01,2025-12-31",
+		});
+
+		const calledUrl = fetchSpy.mock.calls[0]?.[0] as URL;
+		expect(calledUrl.href).not.toContain("super-secret-token");
+		expect(calledUrl.searchParams.get("token_auth")).toBeNull();
+	});
+
+	it("forwards the optional segment param when provided", async () => {
+		fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+		await fetchMatomoEventsReport({
+			method: "Events.getAction",
+			period: "range",
+			date: "2025-01-01,2025-12-31",
+			segment: "dimension1==2025",
+		});
+
+		const calledUrl = fetchSpy.mock.calls[0]?.[0] as URL;
+		expect(calledUrl.searchParams.get("segment")).toBe("dimension1==2025");
+	});
+
+	it("throws a clear error when Matomo is not configured", async () => {
+		mockEnv.MATOMO_API_TOKEN = undefined;
+
+		await expect(
+			fetchMatomoEventsReport({
+				method: "Events.getAction",
+				period: "range",
+				date: "2025-01-01,2025-12-31",
+			}),
+		).rejects.toThrow(/non configuré/i);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("throws without leaking the token when the response is not ok", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			statusText: "Internal Server Error",
+			json: async () => ({}),
+		});
+
+		let caught: unknown;
+		try {
+			await fetchMatomoEventsReport({
+				method: "Events.getAction",
+				period: "range",
+				date: "2025-01-01,2025-12-31",
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(Error);
+		expect((caught as Error).message).not.toContain("super-secret-token");
+	});
+
+	it("throws when Matomo returns an API error payload", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ result: "error", message: "Invalid date range" }),
+		});
+
+		await expect(
+			fetchMatomoEventsReport({
+				method: "Events.getAction",
+				period: "range",
+				date: "bad,range",
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/app/src/server/services/matomo.ts
+++ b/packages/app/src/server/services/matomo.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { env } from "~/env";
+
+export type MatomoEventsReportRow = {
+	label: string;
+	nb_events: number;
+	nb_visits?: number;
+	nb_events_with_value?: number;
+	sum_event_value?: number;
+	avg_event_value?: number;
+	min_event_value?: number;
+	max_event_value?: number;
+	idsubdatatable?: number;
+};
+
+type FetchMatomoEventsReportParams = {
+	method: string;
+	period: string;
+	date: string;
+	segment?: string;
+};
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function isMatomoApiError(data: unknown): data is { message?: string } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		"result" in data &&
+		(data as { result?: unknown }).result === "error"
+	);
+}
+
+export async function fetchMatomoEventsReport({
+	method,
+	period,
+	date,
+	segment,
+}: FetchMatomoEventsReportParams): Promise<MatomoEventsReportRow[]> {
+	const baseUrl = env.NEXT_PUBLIC_MATOMO_URL;
+	const siteId = env.NEXT_PUBLIC_MATOMO_SITE_ID;
+	const token = env.MATOMO_API_TOKEN;
+
+	if (!baseUrl || !siteId || !token) {
+		throw new Error("Matomo non configuré");
+	}
+
+	const url = new URL(`${baseUrl.replace(/\/$/, "")}/index.php`);
+	url.searchParams.set("module", "API");
+	url.searchParams.set("format", "json");
+	url.searchParams.set("idSite", siteId);
+	url.searchParams.set("method", method);
+	url.searchParams.set("period", period);
+	url.searchParams.set("date", date);
+	if (segment) url.searchParams.set("segment", segment);
+
+	// `token_auth` goes in the POST body, never the URL, so it cannot leak via
+	// access logs, the Referer header, or an error message that echoes the URL.
+	const body = new URLSearchParams({ token_auth: token });
+
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body,
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		});
+	} catch {
+		throw new Error("Matomo Reporting API request failed");
+	}
+
+	if (!response.ok) {
+		throw new Error(
+			`Matomo Reporting API error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	let data: unknown;
+	try {
+		data = await response.json();
+	} catch {
+		throw new Error("Matomo Reporting API returned a non-JSON response");
+	}
+
+	if (isMatomoApiError(data)) {
+		throw new Error("Matomo Reporting API returned an error response");
+	}
+
+	return data as MatomoEventsReportRow[];
+}


### PR DESCRIPTION
Ticket racine de l'epic #3514 (Stats Admin Matomo — funnel K20/K21), indépendant de #3612.

Crée le **client serveur** qui interrogera la Reporting API de Matomo (les events custom ne vivent pas en base). Aucun consommateur dans cette PR — #3615 (procédure tRPC `getMatomoFunnel`) l'utilisera.

## Contenu

- `server/services/matomo.ts` — `fetchMatomoEventsReport({ method, period, date, segment? })`, suit le pattern `weez.ts` :
  - `import "server-only"` (jamais bundlé côté client)
  - `token_auth` lu uniquement via `~/env`, **envoyé dans le body POST** (jamais dans l'URL → ne fuit pas via logs d'accès / Referer / message d'erreur)
  - erreurs explicites sans divulguer le token ; `AbortSignal.timeout(10s)`
  - gère les 3 cas d'échec : réseau, status non-2xx, payload `{ result: "error" }` de Matomo
  - retour typé `MatomoEventsReportRow[]` (pas de `any`)
- `env.js` — `MATOMO_API_TOKEN: z.string().optional()` (server) + `runtimeEnv`
- `.env.example` — documenté (placeholder vide)
- `.kontinuous/values.yaml` — `secretRef: matomo` en `optional: true` (le pod ne crashe pas tant que le secret n'existe pas)
- tests (6) : construction de la requête, token absent de l'URL, segment optionnel, erreur claire si non configuré, **pas de fuite de token** dans l'erreur, payload d'erreur Matomo

## ⚠️ Action infra requise (hors-code, accès cluster)

Le **sealed-secret `matomo`** (clé `MATOMO_API_TOKEN`) doit être créé via `kubeseal` pour `dev` / `preprod` / `prod`, sur le modèle de `.kontinuous/env/<env>/templates/gip-mds-import.sealed-secret.yaml` (Secret nommé `matomo`). Je ne l'ai **pas** committé : une valeur scellée ne peut pas être générée sans la clé du cluster, et un faux casserait le déploiement. Tant qu'il est absent, `MATOMO_API_TOKEN` reste `undefined` et le client throw « Matomo non configuré » (dégradation propre, géré par #3616).

## 🔒 Follow-up sécurité pour #3615 (consumer)

Le security-auditor recommande (MEDIUM, defense-in-depth) de valider `method/period/date/segment` via un schéma Zod **au call-site** dans #3615, pour whitelister la méthode Reporting API invocable. `URLSearchParams` empêche déjà l'injection, mais ne contraint pas *quelle* méthode est appelée. Non bloquant ici (client sans consommateur).

## Qualité

- Typecheck ✓ · suite complète 2507 tests ✓ · lint ✓ · format ✓
- structural-auditor : PASS (17 règles) · security-auditor : SECURE (1 note MEDIUM reportée sur #3615)

Part of #3514.