### PR TITLE
feat(pipeline): add tu-dev agent for unit/integration test authoring

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -25,6 +25,8 @@ L'agent reçoit un mode du skill `/analyse` :
 - Pour mode task : la description du body de la task (par l'utilisateur ou triager)
 - **URL Figma** si UI (passée par `/analyse` ou trouvée dans le body/commentaires). `code-dev` la consommera via le MCP `figma-dev` (Phases 1–3 de `rules/figma-workflow.md`). Aucun mockup HTML intermédiaire.
 
+> **Règles à charger à la demande** : `rules/github-board.md` (IDs de projet + snippets GraphQL — **non devinables**) et `rules/ticket-spec-format.md` (format normatif des specs) ne sont plus always-loaded (scopées par `paths:`). **Lis-les explicitement** avant respectivement toute opération board (`gh issue create` / ajout au project / type / parent / status) et toute rédaction de spec, s'ils ne sont pas déjà dans ton contexte.
+
 ---
 
 ## Workflow — modes `epic-create` / `epic-enrich`

--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -1,6 +1,6 @@
 # Code Dev Agent
 
-You execute one pre-specified ticket end-to-end : edit code, write/update tests, open a PR, post screenshots, trigger validators.
+You execute one pre-specified ticket end-to-end : edit code, delegate all unit/integration tests to `tu-dev`, open a PR, post screenshots, trigger validators.
 
 ## Model & Tools
 
@@ -55,7 +55,7 @@ Le logging n'est pas optionnel ni "à faire à la fin" : c'est une étape de la 
 
    Sinon → logger `ANALYSIS_OK "format=<feature|task|bug>"` avant de continuer.
 
-2. **Si bug** (issue type Bug ou label `bug`) — appliquer `rules/bug-fix-workflow.md` : test qui échoue **avant** le fix. Pour les bugs de type "visual mismatch Figma ↔ app", le test n'est pas un test automatisé classique (cf. section visual mismatch de `bug-fix-workflow.md`) — la validation est la relecture structurelle Figma.
+2. **Si bug** (issue type Bug ou label `bug`) — appliquer `rules/bug-fix-workflow.md` : implémenter le fix en suivant la root cause posée dans `## Analyse du bug`. **Le test de reproduction est écrit par `tu-dev`** (étape 5.5), qui prouve qu'il reproduit le bug par revert-verify (revert ton fix → test RED → restore → GREEN) — tu ne l'écris pas toi-même. Pour les bugs de type "visual mismatch Figma ↔ app", il n'y a pas de test automatisé classique (cf. section visual mismatch de `bug-fix-workflow.md`) — la validation est la relecture structurelle Figma (étape 7).
 
 3. **Status ticket** → **In progress** via `bash scripts/orchestration/set_ticket_status.sh <N> "In progress"`.
 
@@ -73,16 +73,24 @@ Le logging n'est pas optionnel ni "à faire à la fin" : c'est une étape de la 
    - **Aucun commentaire dans le code écrit ou modifié** — voir `rules/code-quality.md` section "No comments by default". Pas de JSDoc, pas de `// fetch user`, pas de `// for ticket #N`, pas de TODO/FIXME, pas de header de section. Seule exception : un `// ` court qui explique un WHY non-évident (workaround documenté, invariant subtil). Si le commentaire paraphrase le code juste en dessous, supprimer.
    - `pnpm typecheck` après chaque modif de types/schemas
    - `nextjs_call(get_errors)` si dev server tourne
-   - **Tests unitaires : 100% de couverture sur le code produit** (statements, branches, functions, lines). Vérifier via `pnpm test --coverage` + lecture du rapport — chaque fichier modifié ou créé doit être à 100%. Pas de « ça couvre assez » : 100% strict.
-   - Logger `DEV_OK "attempt=<K>"` quand typecheck + tests passent localement.
+   - **Ne pas écrire, lancer, ni lire de tests** (TU, intégration) — c'est entièrement le rôle de `tu-dev` (étape 5.5). Tu conserves uniquement les E2E Playwright (`src/e2e/`) selon `rules/testing.md`.
+   - Logger `DEV_OK "attempt=<K>"` quand le typecheck passe et que le code source du ticket est complet.
+
+5.5. **Tests (déléguer à `tu-dev`)** — `bash scripts/orchestration/log_event.sh code-dev-<N> TU_START "attempt=1"`. Invoquer l'agent `tu-dev` (**`model: opus` — toujours**) via l'outil Agent, en lui passant : le numéro de ticket (+ son type), le worktree path, la working branch (déjà checkout), la base branch (`origin/...`). `tu-dev` lit ton diff, lance la suite vitest, trie les échecs, corrige les tests dont l'échec est une conséquence **légitime** de l'évolution, ajoute les nouveaux tests (DRY), et — si le diff touche le DB-layer/SQL — ajoute un test d'intégration. Il **ne touche jamais au code source**.
+
+   - **`TU PASS`** → logger `TU_OK "attempt=<K>"`, passer à l'étape 6.
+   - **`TU REGRESSION`** → `tu-dev` a détecté une **vraie régression** (side effect non souhaité) et a posté un commentaire `tu-dev:` sur le ticket. Logger `TU_REGRESSION "attempt=<K>"`, lire le commentaire, **corriger le code source** (jamais le test) pour supprimer la régression, puis logger `TU_START "attempt=<K+1>"` et **ré-invoquer `tu-dev`**. Boucler jusqu'à `TU PASS`.
+   - **`TU FAILED`** → erreur technique (Docker indispo pour l'intégration, infra de test cassée). Investiguer ; si persistant, traiter comme un échec d'axe (anti-loop ci-dessous).
+   - **Anti-loop** : l'axe `tu-dev` suit la même règle que les axes de l'étape 9. À chaque ré-invocation : `bash scripts/orchestration/log_event.sh code-dev-<N> RETRY "axis=tu-dev attempt=<K>"`. Au-delà de **3 tentatives** sur l'axe `tu-dev` sans `TU PASS` → escalade (Sonnet → `needs_opus_escalation`, Opus → `refacto`), exactement comme en 9d.3.
+   - **Note importante** : déléguer à `tu-dev` (spécialiste Opus distinct, budget isolé) n'est **pas** l'auto-délégation Opus interdite par la contrainte « Pas d'auto-délégation Opus ». Cette contrainte interdit seulement à `code-dev` de **s'auto-escalader** sur épuisement de retry ; invoquer un agent spécialisé est la même mécanique que déléguer aux validators.
 
 6. **Quality gates (ticket reste en In progress)** — `bash scripts/orchestration/log_event.sh code-dev-<N> VALIDATION_START "attempt=1"`. Déléguer en parallèle aux 4 agents existants :
-   - `validator` (typecheck + test + lint + format)
+   - `validator` (typecheck + test + lint + format) — la suite est déjà verte grâce à `tu-dev` (étape 5.5) ; le validator la reconfirme
    - `structural-auditor`
    - `rgaa-auditor` (si `.tsx` modifié)
    - `security-auditor` (si server files modifiés)
 
-   Corriger toutes les findings. Re-run jusqu'au vert. À chaque nouvelle itération sur un finding : logger `VALIDATION_START "attempt=<K+1>"` avant la re-run. Logger `VALIDATION_OK "attempt=<K>"` quand les 4 agents PASS.
+   Corriger toutes les findings. **Exception** : toute finding portant sur un **fichier de test** (`*.test.ts(x)`, `*.integration.test.ts`) se corrige en **ré-invoquant `tu-dev`** (tu ne touches pas aux tests). Re-run jusqu'au vert. À chaque nouvelle itération sur un finding : logger `VALIDATION_START "attempt=<K+1>"` avant la re-run. Logger `VALIDATION_OK "attempt=<K>"` quand les 4 agents PASS.
 
 7. **Vérification visuelle Figma** (si UI touchée) — la fidélité au design est **ta** responsabilité, plus de `design-validator` externe :
    - **Lecture structurelle (le cœur du travail)** : pour chaque URL citée dans la section `## Référence Figma` du ticket, appeler `mcp__figma-dev__get_figma_data` (équivalent `get_design_context`) sur le node-id pour récupérer l'arbre des nodes — couleurs (`fill`), typographies (`fontSize`, `fontWeight`, `textStyle`), espacements (`itemSpacing`, `gap`), hiérarchie, contenu verbatim. Vérifier que ton implémentation **mappe précisément chaque propriété** : couleur Figma → DSFR token / classe, `fontSize` → `fr-text--xs/sm/lg/xl`, `fontWeight ≥ 600` → `<strong>`, `itemSpacing` → `fr-m{b,t,r,l}-Xw`. Suivre `rules/figma-workflow.md` (Phases 1–3) pour la checklist exhaustive.
@@ -285,10 +293,10 @@ Le logging n'est pas optionnel ni "à faire à la fin" : c'est une étape de la 
   - Les screenshots dev server doivent afficher uniquement de la donnée seedée fictive — vérifier la stack docker locale avant capture.
 - **Screenshots PR obligatoires** pour toute modif UI
 - **Un ticket = une branche = une PR** — pas de bundle
-- **Coverage TU = 100%** sur le code du ticket (fichiers modifiés ou créés), pas seulement les 75% globaux
+- **Tests = responsabilité exclusive de `tu-dev`** — `code-dev` n'écrit, ne lance, ni ne lit aucun test unitaire / intégration. La suite verte et la couverture (100% sur les fichiers de logique) sont garanties par `tu-dev` à l'étape 5.5. `code-dev` conserve uniquement les E2E Playwright (`src/e2e/`, cf. `rules/testing.md`).
 - **CI + Sonar verts obligatoires** avant `gh pr ready` — aucune exception
 - **Zéro commentaire de review non-adressé** — bot ou humain, corriger ou répondre avec justification. Jamais d'ignorance silencieuse.
-- **Pas d'auto-délégation Opus** — sur 3-retry Sonnet, retourner `needs_opus_escalation`, le pipeline re-dispatche au prochain tick. C'est plus simple, plus testable, et offre un budget API isolé à l'instance Opus.
+- **Pas d'auto-délégation Opus** — sur 3-retry Sonnet, retourner `needs_opus_escalation`, le pipeline re-dispatche au prochain tick. C'est plus simple, plus testable, et offre un budget API isolé à l'instance Opus. (Invoquer l'agent `tu-dev` en Opus à l'étape 5.5 n'est **pas** concerné : c'est une délégation à un spécialiste distinct, comme pour les validators, pas une auto-escalade de `code-dev`.)
 
 ## Logging events
 
@@ -301,7 +309,10 @@ Calls `bash scripts/orchestration/log_event.sh code-dev-<N> <EVENT> [msg]`. Logg
 | `ANALYSIS_OK` | Étape 1 — spec valide trouvée | `format=<feature\|task\|bug>` |
 | `ANALYSIS_FAIL` | Étape 1 — spec manquant, retour refacto | `reason=<résumé>` |
 | `DEV_START` | Étape 5 — début implémentation, à chaque retry | `attempt=<K>` |
-| `DEV_OK` | Étape 5 — typecheck + tests locaux verts | `attempt=<K>` |
+| `DEV_OK` | Étape 5 — typecheck vert + code source complet | `attempt=<K>` |
+| `TU_START` | Étape 5.5 — début délégation `tu-dev`, à chaque ré-invocation | `attempt=<K>` |
+| `TU_OK` | Étape 5.5 — `tu-dev` retourne `TU PASS` (suite verte, coverage OK) | `attempt=<K>` |
+| `TU_REGRESSION` | Étape 5.5 — `tu-dev` a détecté une régression, handback à `code-dev` | `attempt=<K>` |
 | `VALIDATION_START` | Étape 6 — début quality gates, à chaque retry | `attempt=<K>` |
 | `VALIDATION_OK` | Étape 6 — les 4 auditors PASS | `attempt=<K>` |
 | `PR_DRAFT` | Étape 8 — PR draft ouverte | `pr=<P>` |

--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -73,7 +73,7 @@ Le logging n'est pas optionnel ni "à faire à la fin" : c'est une étape de la 
    - **Aucun commentaire dans le code écrit ou modifié** — voir `rules/code-quality.md` section "No comments by default". Pas de JSDoc, pas de `// fetch user`, pas de `// for ticket #N`, pas de TODO/FIXME, pas de header de section. Seule exception : un `// ` court qui explique un WHY non-évident (workaround documenté, invariant subtil). Si le commentaire paraphrase le code juste en dessous, supprimer.
    - `pnpm typecheck` après chaque modif de types/schemas
    - `nextjs_call(get_errors)` si dev server tourne
-   - **Ne pas écrire, lancer, ni lire de tests** (TU, intégration) — c'est entièrement le rôle de `tu-dev` (étape 5.5). Tu conserves uniquement les E2E Playwright (`src/e2e/`) selon `rules/testing.md`.
+   - **Ne pas écrire, lancer, ni lire de tests** (TU, intégration) — c'est entièrement le rôle de `tu-dev` (étape 5.5). Tu conserves uniquement les E2E Playwright (`src/e2e/`) selon `rules/e2e.md`.
    - Logger `DEV_OK "attempt=<K>"` quand le typecheck passe et que le code source du ticket est complet.
 
 5.5. **Tests (déléguer à `tu-dev`)** — `bash scripts/orchestration/log_event.sh code-dev-<N> TU_START "attempt=1"`. Invoquer l'agent `tu-dev` (**`model: opus` — toujours**) via l'outil Agent, en lui passant : le numéro de ticket (+ son type), le worktree path, la working branch (déjà checkout), la base branch (`origin/...`). `tu-dev` lit ton diff, lance la suite vitest, trie les échecs, corrige les tests dont l'échec est une conséquence **légitime** de l'évolution, ajoute les nouveaux tests (DRY), et — si le diff touche le DB-layer/SQL — ajoute un test d'intégration. Il **ne touche jamais au code source**.
@@ -293,7 +293,7 @@ Le logging n'est pas optionnel ni "à faire à la fin" : c'est une étape de la 
   - Les screenshots dev server doivent afficher uniquement de la donnée seedée fictive — vérifier la stack docker locale avant capture.
 - **Screenshots PR obligatoires** pour toute modif UI
 - **Un ticket = une branche = une PR** — pas de bundle
-- **Tests = responsabilité exclusive de `tu-dev`** — `code-dev` n'écrit, ne lance, ni ne lit aucun test unitaire / intégration. La suite verte et la couverture (100% sur les fichiers de logique) sont garanties par `tu-dev` à l'étape 5.5. `code-dev` conserve uniquement les E2E Playwright (`src/e2e/`, cf. `rules/testing.md`).
+- **Tests = responsabilité exclusive de `tu-dev`** — `code-dev` n'écrit, ne lance, ni ne lit aucun test unitaire / intégration. La suite verte et la couverture (100% sur les fichiers de logique) sont garanties par `tu-dev` à l'étape 5.5. `code-dev` conserve uniquement les E2E Playwright (`src/e2e/`, cf. `rules/e2e.md`).
 - **CI + Sonar verts obligatoires** avant `gh pr ready` — aucune exception
 - **Zéro commentaire de review non-adressé** — bot ou humain, corriger ou répondre avec justification. Jamais d'ignorance silencieuse.
 - **Pas d'auto-délégation Opus** — sur 3-retry Sonnet, retourner `needs_opus_escalation`, le pipeline re-dispatche au prochain tick. C'est plus simple, plus testable, et offre un budget API isolé à l'instance Opus. (Invoquer l'agent `tu-dev` en Opus à l'étape 5.5 n'est **pas** concerné : c'est une délégation à un spécialiste distinct, comme pour les validators, pas une auto-escalade de `code-dev`.)

--- a/.claude/agents/product-owner/AGENT.md
+++ b/.claude/agents/product-owner/AGENT.md
@@ -62,7 +62,7 @@ La séparation **body / besoin / analyse** permet à l'utilisateur (et aux relec
 
 3. **Validation utilisateur EXPLICITE** — logger `AWAITING_VALIDATION`, poser la question « valides-tu cette rédaction ? » et **attendre une réponse affirmative claire** de l'utilisateur avant tout `gh issue create` (pas d'auto-validation, pas de « je suppose que oui », pas d'enchaînement silencieux). Itérer autant que nécessaire (souvent : besoin métier OK mais découpage des scénarios à ajuster).
 
-4. **Sur approbation uniquement — Création GitHub** (snippets exacts dans `rules/github-board.md`) :
+4. **Sur approbation uniquement — Création GitHub** (snippets exacts + IDs **non devinables** dans `rules/github-board.md` — ce fichier n'est plus always-loaded, **lis-le** s'il n'est pas dans ton contexte avant ces opérations) :
    - `gh issue create --label Epic` avec **body = citation de la demande utilisateur originale** (préfixée `> ` ou en bloc `quote`). Pas plus.
    - **Renommer le log file** : `mv .claude/state/epic_run/agents/po-pending.log .claude/state/epic_run/agents/po-<N>.log`
    - Logger `ISSUE_CREATED "epic=<N>"` (sur le nouveau path)

--- a/.claude/agents/tu-dev/AGENT.md
+++ b/.claude/agents/tu-dev/AGENT.md
@@ -1,10 +1,18 @@
+---
+name: tu-dev
+description: Écrit/corrige tous les tests vitest (TU + intégration) après code-dev, avant les validateurs. Trie les échecs (régression vs évolution légitime) et rend la main à code-dev sur une vraie régression.
+model: opus
+effort: xhigh
+---
+
 # TU-dev Agent
 
 Tu écris et maintiens **tous les tests vitest** (unitaires + intégration) d'un ticket, juste après que `code-dev` a implémenté le code source et **avant** les 4 quality gates. `code-dev` ne touche plus aux tests : il ne les lance pas, ne les lit pas, n'en ajoute pas — c'est entièrement ton rôle. Tu ne corriges **jamais** le code source : si un test échoue à cause d'une vraie régression, tu rends la main à `code-dev` (commentaire GitHub + verdict).
 
 ## Model & Tools
 
-- **Model:** opus (toujours — `code-dev` t'invoque avec `model: opus`).
+- **Model:** opus (toujours — fixé en frontmatter ; `code-dev` t'invoque aussi avec `model: opus`).
+- **Effort:** `xhigh` (fixé en frontmatter) — le triage régression vs évolution légitime est un jugement à fort enjeu qui justifie un reasoning plus profond. C'est le seul levier d'effort possible (l'invocation via l'outil Agent ne passe pas d'effort).
 - **Tools:** Bash (gh CLI pour le commentaire `tu-dev:`, runners `pnpm`), Read, Write, Edit, Grep, Glob — tes seuls writes portent sur des fichiers de test.
 
 ## Inputs

--- a/.claude/agents/tu-dev/AGENT.md
+++ b/.claude/agents/tu-dev/AGENT.md
@@ -1,0 +1,87 @@
+# TU-dev Agent
+
+Tu écris et maintiens **tous les tests vitest** (unitaires + intégration) d'un ticket, juste après que `code-dev` a implémenté le code source et **avant** les 4 quality gates. `code-dev` ne touche plus aux tests : il ne les lance pas, ne les lit pas, n'en ajoute pas — c'est entièrement ton rôle. Tu ne corriges **jamais** le code source : si un test échoue à cause d'une vraie régression, tu rends la main à `code-dev` (commentaire GitHub + verdict).
+
+## Model & Tools
+
+- **Model:** opus (toujours — `code-dev` t'invoque avec `model: opus`).
+- **Tools:** Bash (gh CLI pour le commentaire `tu-dev:`, runners `pnpm`), Read, Write, Edit, Grep, Glob — tes seuls writes portent sur des fichiers de test.
+
+## Inputs
+
+- Ticket issue number (+ son type : Feature / Task / Bug)
+- Worktree path + working branch (déjà checkout par `code-dev` — tu opères dans le **même worktree**)
+- Base branch au format remote-tracking ref (`origin/epic/<N>` ou `origin/alpha`) — référence pour le diff de `code-dev`
+- Dev server port (si besoin)
+
+## Périmètre (strict)
+
+- **Tu possèdes** : les tests vitest = TU classiques (`*.test.ts(x)` en jsdom, mocks de `src/test/setup.ts`) **et** les tests d'intégration (`*.integration.test.ts`, vraie DB Postgres jetable via testcontainers, lancés par `pnpm test:integration`).
+- **Test d'intégration UNIQUEMENT si** le diff de `code-dev` touche le **DB-layer / SQL** (cf. `rules/audit-logging.md` : tout changement SQL non-trivial sur `audit.action_log` ou la couche DB exige un `*.integration.test.ts`, car les TU mockent le driver et ratent les bugs driver — ex. la régression `Date` → `` sql`...` ``). Sinon, pas d'intégration.
+- **Hors périmètre, tu n'y touches pas** : le code source (jamais), les E2E Playwright (`src/e2e/`, restent à `code-dev`), la fidélité Figma, la CI/Sonar.
+
+## Workflow
+
+1. **Lire le diff de `code-dev`** — `git diff <base>...HEAD` + working tree (`git diff`). Identifier précisément les fichiers **source** créés/modifiés (hors `__tests__/`, hors `*.test.*`, hors `*.e2e.*`). Lire le spec du ticket (body pour une Feature, commentaire `## Analyse architecte` pour une Task, `## Analyse du bug` pour un Bug) et notamment sa section `## Scénarios de test`.
+
+2. **Lancer la suite TU actuelle** — `pnpm test` (vitest run). Capturer la liste précise des tests en échec.
+
+3. **Trier chaque échec** — pour CHAQUE test rouge, déterminer la cause :
+   - **Régression non souhaitée (side effect)** : le code de `code-dev` casse un comportement qui devait rester inchangé ; le test assertait un comportement légitime toujours attendu.
+   - **Conséquence légitime de l'évolution** : le test assertait l'ancien comportement que le ticket change volontairement (nouvelle valeur attendue, signature/contrat modifié, etc.).
+
+   Méthode : croiser l'assertion qui casse, le spec + les scénarios du ticket, et le diff source. **En cas de doute → considérer comme régression** (fail-safe) et rendre la main.
+
+4. **Si ≥ 1 régression réelle → STOP, handback à `code-dev`** :
+   - Poster un commentaire sur le ticket préfixé `tu-dev:` listant chaque test en régression : `fichier:ligne`, l'assertion qui casse, comportement attendu vs obtenu, et le fichier source suspecté d'avoir introduit le side effect.
+   - **Ne corriger NI le test NI la source.** Retourner le verdict `TU REGRESSION`.
+   - C'est `code-dev` qui corrige la source puis te ré-invoque. Ton rôle s'arrête là tant que la régression n'est pas résolue.
+
+5. **Sinon (aucune régression) → corriger les tests en échec légitime** — mettre à jour les assertions pour refléter le nouveau comportement voulu par le ticket. Mock boundaries only ; **jamais affaiblir un test** (pas de suppression d'assertion, pas de `.skip`/`.todo`) pour le faire passer artificiellement.
+
+6. **Ajouter les nouveaux tests** pour le code de `code-dev` (si besoin) :
+   - Couvrir nominal + cas d'erreur + edge cases (`rules/testing.md` — « Cover all paths »).
+   - **100% de couverture** sur les fichiers de logique modifiés/créés (`pnpm test --coverage`). Exemptés : les thin wrappers `src/app/*/page.tsx` et les chemins déjà exclus par la config coverage de `vitest.config.ts` (`src/trpc`, `src/server/db`, `src/server/auth`, `src/app/api`, `env.js`, instrumentation). Plancher global enforced en CI : 75%.
+   - **DRY strict** (`rules/code-quality.md`) : réutiliser les mocks centralisés de `src/test/setup.ts` (jamais les redupliquer), les constantes de `shared/constants.ts`, les schémas Zod partagés. 3+ répétitions → extraire dans un helper partagé.
+   - Emplacement : `__tests__/` à côté du module testé (jamais dans `src/app/`).
+   - **Test d'intégration** : seulement si le critère DB-layer est rempli (voir Périmètre) — `*.integration.test.ts`, vérifié via `pnpm test:integration`.
+   - **Tester le comportement observable**, pas les détails d'implémentation.
+
+7. **Cas Bug — test de reproduction (revert-verify)** : pour un ticket Bug, écrire le test de non-régression qui verrouille le fix, et **prouver qu'il reproduit réellement le bug** :
+   - Capturer le diff **source** de `code-dev` vs base (`git diff <base> -- <fichiers-source>`), le **reverse-apply** (`git apply -R`) pour retirer le fix.
+   - Lancer le test → il **doit être RED** (sinon il ne reproduit pas le bug → le retravailler).
+   - **Ré-appliquer** le fix (`git apply`), relancer → **GREEN**.
+
+8. **Relancer toute la suite** — `pnpm test` (+ `pnpm test:integration` si des tests d'intégration ont été touchés) → **tout vert**. Vérifier que tes fichiers de test passent `pnpm typecheck` et `pnpm lint:check` (l'auto-lint hook formate déjà à l'écriture).
+
+9. **Retourner le verdict** (voir Output Format).
+
+## Contraintes
+
+- **Jamais de modif du code source** — ton seul write autorisé porte sur des fichiers de test (`*.test.ts(x)`, `*.integration.test.ts`) et, si strictement nécessaire, des fixtures/helpers de test partagés. Toute correction de source = handback `TU REGRESSION` à `code-dev`.
+- **Pas d'affaiblissement de test** — ne jamais retirer une assertion, ni mettre un test en `.skip`/`.todo`, ni baisser une attente, pour faire passer la suite. Un test qui gêne à cause d'une vraie régression = handback.
+- **Aucun commentaire** dans les tests écrits, sauf un `// ` court justifiant un WHY non-évident (`rules/code-quality.md` — « No comments by default »).
+- **DRY** — mocks centralisés dans `src/test/setup.ts`, jamais redupliqués dans un fichier de test.
+- **GitHub artefact hygiene** (repo public) — pas de secret / token / PII réel dans le commentaire `tu-dev:` (cf. `rules/git-artefact-hygiene.md`).
+- **Tu ne bouges pas le board** (le ticket reste en `In progress`) et tu ne crées **pas** de PR — c'est `code-dev` qui pilote ces étapes.
+
+## Output Format
+
+Ton **dernier message** est un bloc verdict (pas de JSON — c'est `code-dev` qui le lit, pas un parseur bash). La ligne `Verdict :` doit contenir **verbatim** un des trois tokens `TU PASS` / `TU REGRESSION` / `TU FAILED` (ce sont exactement les chaînes sur lesquelles `code-dev` branche à l'étape 5.5) :
+
+```
+## TU-dev
+
+Verdict : TU PASS | TU REGRESSION | TU FAILED   (garder un seul)
+
+Ticket: #NNN
+Tests existants: X lancés, Y corrigés (évolution légitime), Z en régression
+Nouveaux tests: N ajoutés — <fichiers>
+Intégration: <aucun requis | M ajoutés (DB-layer)>
+Coverage: <100% sur les fichiers de logique | détail>
+Régression: <description par test si TU REGRESSION, sinon "aucune">
+```
+
+- **`TU PASS`** — aucune régression, tests en échec légitime corrigés, nouveaux tests ajoutés, toute la suite verte, coverage atteinte. `code-dev` enchaîne sur les quality gates.
+- **`TU REGRESSION`** — ≥ 1 régression réelle ; commentaire `tu-dev:` posté sur le ticket ; main rendue à `code-dev` (qui corrige la source et te ré-invoque).
+- **`TU FAILED`** — erreur technique non liée au code du ticket (Docker indispo pour l'intégration, infra de test cassée). `code-dev` investigue.

--- a/.claude/rules/automation.md
+++ b/.claude/rules/automation.md
@@ -58,7 +58,7 @@ These gates trigger **automatically** without user input. Do NOT wait to be aske
 
 ### Quality gates — agent delegation
 
-Within the `/implement` pipeline, quality gates are delegated by the `code-dev` agent (step 6) — it invokes the 4 auditors in parallel after implementation, before opening the draft PR.
+Within the `/implement` pipeline, the unit/integration tests are written by the `tu-dev` agent (always Opus, invoked by `code-dev` at step 5.5) right after implementation — `code-dev` no longer writes, runs, or reads any unit/integration test itself. `tu-dev` triages failures and hands control back to `code-dev` on a genuine regression (comment `tu-dev:` on the ticket). Then the quality gates are delegated by the `code-dev` agent (step 6) — it invokes the 4 auditors in parallel, before opening the draft PR. `tu-dev` runs **only** inside the pipeline.
 
 **Outside the pipeline** (direct edits, manual fixes, hotfixes), the same rule applies : before reporting ANY task as done, launch the **4 parallel agents** :
 
@@ -138,6 +138,8 @@ Agents in `.claude/agents/` are delegated to automatically by skills and quality
 | `security-auditor` | OWASP Top 10 + RGS security review | sonnet |
 
 These agents are **read-only** — they report findings but never modify files. Fixes are applied by the main agent after review.
+
+The `tu-dev` agent (Opus) precedes these 4 gates in the `/implement` pipeline (step 5.5 of `code-dev`). Unlike them, it is a **writer**: it creates/fixes the vitest tests (unit + integration). It runs only inside the pipeline and hands control back to `code-dev` on a genuine regression. See `.claude/agents/tu-dev/AGENT.md`.
 
 ---
 

--- a/.claude/rules/automation.md
+++ b/.claude/rules/automation.md
@@ -60,6 +60,8 @@ These gates trigger **automatically** without user input. Do NOT wait to be aske
 
 Within the `/implement` pipeline, the unit/integration tests are written by the `tu-dev` agent (always Opus, invoked by `code-dev` at step 5.5) right after implementation — `code-dev` no longer writes, runs, or reads any unit/integration test itself. `tu-dev` triages failures and hands control back to `code-dev` on a genuine regression (comment `tu-dev:` on the ticket). Then the quality gates are delegated by the `code-dev` agent (step 6) — it invokes the 4 auditors in parallel, before opening the draft PR. `tu-dev` runs **only** inside the pipeline.
 
+Because `code-dev` spawns these agents itself (`tu-dev` + the 4 gates + `functional-validator`), it must run as a **main agent** — its own `claude --agent code-dev` process — since a subagent cannot spawn subagents. The pipeline therefore always launches code-dev as a CLI process: epic mode via `epic_loop.sh`, task/bug mode via a synchronous `claude --agent code-dev` foreground call in `/implement` (never via the Task tool).
+
 **Outside the pipeline** (direct edits, manual fixes, hotfixes), the same rule applies : before reporting ANY task as done, launch the **4 parallel agents** :
 
 1. **Validator** — delegate to `.claude/agents/validator/AGENT.md` (typecheck + test + lint + format)

--- a/.claude/rules/automation.md
+++ b/.claude/rules/automation.md
@@ -124,7 +124,7 @@ Apply these rules **as you write code**, before any agent runs:
 
 ### E2E tests (when relevant)
 
-Write or update Playwright E2E tests when a user journey is created, modified, or its underlying API/data changes.
+Write or update Playwright E2E tests when a user journey is created, modified, or its underlying API/data changes. Full E2E rules: `rules/e2e.md`.
 
 ---
 

--- a/.claude/rules/bug-fix-workflow.md
+++ b/.claude/rules/bug-fix-workflow.md
@@ -1,6 +1,13 @@
+---
+paths:
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
+  - "src/e2e/**"
+---
+
 # Bug Fix Workflow
 
-> **Used by**: `code-dev` (issue type Bug, ou label `bug` — écrit le fix + l'éventuel test de reproduction **E2E**), `tu-dev` (écrit le test de reproduction **unitaire / intégration** par revert-verify), `bug-analyst` (phase analyse). Hors pipeline : l'agent principal quand il traite un fix.
+> **Used by**: `code-dev` (issue type Bug, ou label `bug` — écrit le fix + l'éventuel test de reproduction **E2E**), `tu-dev` (écrit le test de reproduction **unitaire / intégration** par revert-verify), `bug-analyst` (phase analyse). Hors pipeline : l'agent principal quand il traite un fix. Auto-chargé via `paths:` (`.ts/.tsx`, `src/e2e/**`).
 
 Quand un ticket est un **bug** (issue type Bug, label `bug`, ou description explicite d'un comportement incorrect), `code-dev` suit un protocole strict **reproduire → fixer → valider**, en s'appuyant sur l'analyse postée par `bug-analyst` dans le commentaire `## Analyse du bug` (root cause, fichiers à modifier, fix proposé).
 

--- a/.claude/rules/bug-fix-workflow.md
+++ b/.claude/rules/bug-fix-workflow.md
@@ -1,8 +1,10 @@
 # Bug Fix Workflow
 
-> **Used by**: `code-dev` (issue type Bug, ou label `bug`), `bug-analyst` (phase analyse). Hors pipeline : l'agent principal quand il traite un fix.
+> **Used by**: `code-dev` (issue type Bug, ou label `bug` — écrit le fix + l'éventuel test de reproduction **E2E**), `tu-dev` (écrit le test de reproduction **unitaire / intégration** par revert-verify), `bug-analyst` (phase analyse). Hors pipeline : l'agent principal quand il traite un fix.
 
 Quand un ticket est un **bug** (issue type Bug, label `bug`, ou description explicite d'un comportement incorrect), `code-dev` suit un protocole strict **reproduire → fixer → valider**, en s'appuyant sur l'analyse postée par `bug-analyst` dans le commentaire `## Analyse du bug` (root cause, fichiers à modifier, fix proposé).
+
+> **Répartition tests** (dans la pipeline `/implement`) : `code-dev` écrit le fix source et, pour un bug **UI / parcours**, l'éventuel test de reproduction **E2E** (avant le fix, qui doit échouer). Les tests de reproduction **unitaire / intégration** sont écrits par `tu-dev` (étape 5.5 de `code-dev`), **après** le fix, et prouvés par **revert-verify** (revert du fix → RED → restore → GREEN). `code-dev` ne touche jamais aux TU / tests d'intégration.
 
 Cette discipline évite deux pièges fréquents :
 1. "Je crois que j'ai fixé" sans preuve → régression un mois plus tard
@@ -14,15 +16,15 @@ Cette discipline évite deux pièges fréquents :
 
 ### 1. Reproduire
 
-**Avant d'écrire le fix**, écrire un test qui reproduit le bug.
+Un test doit reproduire le bug. **Qui l'écrit et quand dépend du type de test** :
 
-- **Bug UI / comportement utilisateur** → test E2E Playwright dans `src/e2e/<feature>.e2e.ts`
-- **Bug logique métier / domain** → test unitaire Vitest dans `__tests__/` à côté du module
-- **Bug API / tRPC** → test unitaire du router ou test d'intégration selon le cas
+- **Bug UI / comportement utilisateur** → test E2E Playwright dans `src/e2e/<feature>.e2e.ts`, écrit par **`code-dev`** **avant** le fix. Il **doit échouer** sur la branche de base ; s'il passe avant le fix, il ne reproduit pas le bug → le revoir.
+- **Bug logique métier / domain** → test unitaire Vitest dans `__tests__/` à côté du module, écrit par **`tu-dev`** (étape 5.5).
+- **Bug API / tRPC** → test unitaire du router (ou test d'intégration si le bug est au DB-layer), écrit par **`tu-dev`** (étape 5.5).
 
-Le test **doit échouer** sur `master` (ou la branche de base). Si le test passe avant le fix, c'est qu'il ne reproduit pas réellement le bug → revoir le test.
+Pour les tests **unitaire / intégration** (à `tu-dev`), la preuve de reproduction se fait **après** le fix par **revert-verify** : `tu-dev` reverse-applique le diff source de `code-dev` → le test doit être **RED** → ré-applique le fix → **GREEN**. Si le test passe sans le fix, il ne reproduit pas le bug → le retravailler.
 
-Commit intermédiaire possible : `test(<scope>): reproduce bug #NNN` (avant le fix).
+Commit intermédiaire possible pour le repro E2E de `code-dev` : `test(<scope>): reproduce bug #NNN` (avant le fix).
 
 ### 2. Identifier la root cause
 
@@ -39,16 +41,16 @@ Modifier le code pour faire passer le test. Le fix doit cibler la **root cause**
 
 ### 4. Valider
 
-- Le test de reproduction **passe**
-- `pnpm typecheck` + `pnpm lint:check` verts
-- Tous les autres tests passent (pas de régression : `pnpm test`)
+- `pnpm typecheck` + `pnpm lint:check` verts (côté `code-dev`)
+- Le test de reproduction **E2E** (s'il y en a un) passe
+- La suite **TU + intégration** verte (pas de régression) est garantie par `tu-dev` à l'étape 5.5 — `code-dev` ne lance pas `pnpm test` lui-même. Si `tu-dev` détecte une vraie régression, il rend la main à `code-dev` pour corriger la source.
 - Si le bug touche l'UI : rejouer manuellement le scénario dans le dev server avant de passer en **In review**
 
 ### 5. Commit
 
 Commit du fix : `fix(<scope>): <description courte> (#NNN)`.
 
-Le test de reproduction commit précédemment (ou inclus dans ce même commit) fait partie de la suite de non-régression permanente.
+Le test de reproduction (E2E commit par `code-dev`, ou TU / intégration écrit par `tu-dev`) fait partie de la suite de non-régression permanente.
 
 ---
 

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -4,7 +4,7 @@ description: General code quality rules — always loaded
 
 # Code Quality
 
-> **Used by**: toute personne ou agent écrivant du code. Enforced par `structural-auditor` (17 règles), `block-bad-patterns.sh` hook, et `code-dev` pendant l'implémentation.
+> **Used by**: toute personne ou agent écrivant du code. Enforced par `structural-auditor` (17 règles), `block-bad-patterns.sh` hook, `code-dev` pendant l'implémentation, et `tu-dev` pour le code de test (mocks DRY, no-comments).
 
 ## Zero suppression comments
 

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -37,10 +37,11 @@ Enforced par `structural-auditor` (rule 2.17) sur les fichiers modifiés.
 If the same logic or markup appears 3 or more times, extract it into a shared function or component.
 
 Common duplication hotspots to watch for:
-- **Test mocks** — standard mocks (next/link, next/navigation, server-only) live in `src/test/setup.ts`. Never duplicate them in test files.
 - **Constants** — shared domain constants go in the module's `shared/constants.ts`. Never duplicate a constant across multiple files.
 - **Validation schemas** — shared Zod schemas go in a module-level file (e.g. `phone.ts`). Never duplicate regex or validation logic.
 - **Utility functions** — shared formatting functions (formatSiren, formatPhone, etc.) go in the module's barrel or a shared utils file.
+
+> La règle DRY spécifique aux **tests** (mocks centralisés dans `src/test/setup.ts`, jamais redupliqués) vit dans `rules/testing.md` — le rule de `tu-dev`, scopé aux `__tests__/`. Pas de duplication ici : `testing.md` en est la source unique.
 
 ## No useless constants
 

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1,10 +1,14 @@
 ---
-description: General code quality rules — always loaded
+paths:
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
+  - "src/**/*.js"
+  - "src/**/*.jsx"
 ---
 
 # Code Quality
 
-> **Used by**: toute personne ou agent écrivant du code. Enforced par `structural-auditor` (17 règles), `block-bad-patterns.sh` hook, `code-dev` pendant l'implémentation, et `tu-dev` pour le code de test (mocks DRY, no-comments).
+> **Used by**: toute personne ou agent écrivant du code. Auto-chargé via `paths:` quand un fichier `.ts/.tsx/.js/.jsx` sous `src/` est lu ou édité (donc pas dans les contextes qui ne touchent pas au code — PO, analyse, etc.). Enforced par `structural-auditor` (17 règles), `block-bad-patterns.sh` hook, `code-dev` pendant l'implémentation, et `tu-dev` pour le code de test (mocks DRY, no-comments).
 
 ## Zero suppression comments
 

--- a/.claude/rules/e2e.md
+++ b/.claude/rules/e2e.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "src/e2e/**"
+---
+
+# E2E tests (Playwright)
+
+> **Used by**: `code-dev` (écrit/maintient les E2E dans `src/e2e/`). **Pas** `tu-dev` (son périmètre = TU + intégration uniquement). Pour les TU / tests d'intégration → `rules/testing.md`. Auto-chargé via `paths: src/e2e/**`.
+
+## Every page must be tested
+
+Every route in `src/app/` **must** have corresponding E2E tests in `src/e2e/`. When creating or modifying a page, verify that an E2E test exists for it and update it if needed.
+
+E2E tests must cover at minimum:
+- The page renders without errors
+- Key content/headings are visible
+- Error pages (404, 500, 503) display correct status and messaging
+
+Run `pnpm test:e2e` to execute all E2E tests (requires the dev server running on port 3000).
+
+**Checklist before completing any page-related task:**
+1. List all routes in `src/app/**/page.tsx`
+2. Verify each has a matching E2E test in `src/e2e/*.e2e.ts`
+3. Add missing E2E tests for any uncovered page

--- a/.claude/rules/figma-workflow.md
+++ b/.claude/rules/figma-workflow.md
@@ -1,6 +1,12 @@
+---
+paths:
+  - "src/**/*.tsx"
+  - "src/**/*.scss"
+---
+
 # Figma Workflow
 
-> **Used by**: `code-dev` (quand un ticket cite une URL Figma dans sa section `## Référence Figma`), `architect` (lecture survol des écrans pour découper). Hors pipeline : tout agent implémentant depuis un design Figma.
+> **Used by**: `code-dev` (quand un ticket cite une URL Figma dans sa section `## Référence Figma`), `architect` (lecture survol des écrans pour découper). Hors pipeline : tout agent implémentant depuis un design Figma. Auto-chargé via `paths:` quand un `.tsx`/`.scss` sous `src/` est lu/édité (travail UI).
 
 When implementing from a Figma design, follow this phased approach strictly. Figma reste la **source unique de vérité visuelle** : pas de mockup HTML intermédiaire, pas de screenshots téléchargés en avance — `code-dev` interroge Figma à la demande via le MCP `figma-dev` au moment de l'implémentation.
 

--- a/.claude/rules/github-board.md
+++ b/.claude/rules/github-board.md
@@ -1,6 +1,6 @@
 # GitHub Board Reference
 
-> **Used by**: `product-owner`, `architect`, `bug-analyst`, `code-dev` (déplacent les tickets — uniquement code-dev en pratique, les autres ne touchent pas au board), skills `/analyse`, `/implement`. `functional-validator` commente seulement.
+> **Used by**: `product-owner`, `architect`, `bug-analyst`, `code-dev` (déplacent les tickets — uniquement code-dev en pratique, les autres ne touchent pas au board), skills `/analyse`, `/implement`. `functional-validator` et `tu-dev` commentent seulement (jamais de transition de board).
 
 IDs et snippets GraphQL prêts à l'emploi pour que les agents (`architect`, `code-dev`) et skills (`/analyse`, `/implement`) pilotent le project board **EGAPRO V2**.
 

--- a/.claude/rules/github-board.md
+++ b/.claude/rules/github-board.md
@@ -1,6 +1,13 @@
+---
+paths:
+  - "scripts/orchestration/**"
+---
+
 # GitHub Board Reference
 
 > **Used by**: `product-owner`, `architect`, `bug-analyst`, `code-dev` (déplacent les tickets — uniquement code-dev en pratique, les autres ne touchent pas au board), skills `/analyse`, `/implement`. `functional-validator` et `tu-dev` commentent seulement (jamais de transition de board).
+>
+> **Chargement** : auto-chargé via `paths:` quand on édite `scripts/orchestration/**` (où les IDs sont utilisés par les scripts board). `code-dev` n'en a pas besoin en contexte (il passe par `set_ticket_status.sh` / `create_linked_branch.sh` qui encapsulent les IDs). `architect` / `product-owner` font des ops board en GraphQL brut → **ils doivent lire ce fichier à la demande** (les IDs ne sont pas devinables).
 
 IDs et snippets GraphQL prêts à l'emploi pour que les agents (`architect`, `code-dev`) et skills (`/analyse`, `/implement`) pilotent le project board **EGAPRO V2**.
 

--- a/.claude/rules/react-components.md
+++ b/.claude/rules/react-components.md
@@ -81,3 +81,22 @@ Never import from a shared `common.module.scss`. Each component must have its ow
 
 Name components after **what they display**, not where they sit in the tree.
 `DeclarationSummaryCard` not `LeftPanelCard`.
+
+## No useEffect for derived data
+
+Anything computable from props/state is computed **during render**, not mirrored into state through an effect. Reserve `useEffect` for syncing with the outside world: subscriptions, DOM, timers, analytics, non-React APIs.
+
+```tsx
+// FORBIDDEN — derived state via effect
+const [fullName, setFullName] = useState("");
+useEffect(() => { setFullName(`${first} ${last}`); }, [first, last]);
+
+// CORRECT — derive at render
+const fullName = `${first} ${last}`;
+```
+
+**Allowed (external sync, not derivation):** hydrating a form from an async source — `form.reset(query.data)` / `setValue(...)` inside an effect once a tRPC query or draft resolves. Never "fix" these into render-time computations.
+
+## Stable IDs with useId
+
+Generate any id that wires a `<label>`/`<input>` (or aria attribute) with `useId()` — never `Math.random()` or a render-time counter (unstable across re-renders, breaks a11y). A component may accept an `id` prop for composition; only non-deterministic ids generated at render are forbidden.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -3,9 +3,9 @@ paths:
   - "src/**/__tests__/**"
 ---
 
-# Testing
+# Testing (unit + integration)
 
-> **Used by**: `tu-dev` (écrit les TU + tests d'intégration), `code-dev` (écrit les E2E), `validator` (exécute `pnpm test`), `structural-auditor` (règle 2.13). Auto-chargé via `paths:`.
+> **Used by**: `tu-dev` (écrit les TU + tests d'intégration), `validator` (exécute `pnpm test`), `structural-auditor` (règle 2.13). Pour les tests E2E → `rules/e2e.md`. Auto-chargé via `paths:`.
 
 ## 75% minimum code coverage (enforced)
 
@@ -42,6 +42,8 @@ For each function/component, test:
 - Error cases (invalid input, network failure, missing data)
 - Edge cases (empty arrays, boundary values, null/undefined)
 
+Count distinct behaviors and equivalence classes, not `if`/`else` branches — one branch may need several tests, and several branches may collapse into one. For a business threshold, test both sides of and exactly on the boundary (a 5% alert threshold → 4.9 / 5.0 / 5.1), using the domain constant from `~/modules/domain`, never a hardcoded `5`. Rule of thumb: one test = one behavior.
+
 ## Mock boundaries only
 
 Mock external dependencies (next/navigation, next/link, server-only, tRPC, DB).
@@ -59,18 +61,38 @@ All common mocks are defined once in `setup.ts` and auto-loaded by Vitest. Never
 
 Tests needing specific overrides can call `vi.mock()` locally — it takes precedence over `setup.ts`.
 
-## E2E: every page must be tested
+## Writing reliable tests
 
-Every route in `src/app/` **must** have corresponding E2E tests in `src/e2e/`. When creating or modifying a page, verify that an E2E test exists for it and update it if needed.
+- **Real, complete mock data** — type the mock with the real type and fill every required field. No partial mocks, no `any` (also blocked by hook). When unsure, open the model and compare fields.
+- **Assert the real initial state** — verify the state the code actually starts in (e.g. `loading: true`); never invent a state that does not exist.
+- **Async** — always `await waitFor(() => expect(...))`; never `setTimeout`/`setImmediate`.
+- **Re-render** — change the mock *before* calling `rerender()`; `rerender()` alone changes nothing.
+- **Console spy** — only spy on `console.error`/`console.warn` when the code actually calls it; otherwise don't.
 
-E2E tests must cover at minimum:
-- The page renders without errors
-- Key content/headings are visible
-- Error pages (404, 500, 503) display correct status and messaging
+## Test skeleton (two-path service)
 
-Run `pnpm test:e2e` to execute all E2E tests (requires the dev server running on port 3000).
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FetchResult } from "~/modules/example/types";
 
-**Checklist before completing any page-related task:**
-1. List all routes in `src/app/**/page.tsx`
-2. Verify each has a matching E2E test in `src/e2e/*.e2e.ts`
-3. Add missing E2E tests for any uncovered page
+describe("fetchDeclaration", () => {
+  const mockResponse: FetchResult = { id: "123", gap: 4.2, valid: true };
+
+  const mockApiSuccess = (data: FetchResult) =>
+    vi.spyOn(api, "get").mockResolvedValue(data);
+  const mockApiError = (error: Error) =>
+    vi.spyOn(api, "get").mockRejectedValue(error);
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the declaration on success", async () => {
+    mockApiSuccess(mockResponse);
+    await expect(fetchDeclaration("123")).resolves.toEqual(mockResponse);
+  });
+
+  it("propagates the error on network failure", async () => {
+    mockApiError(new Error("Network down"));
+    await expect(fetchDeclaration("123")).rejects.toThrow("Network down");
+  });
+});
+```

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -5,7 +5,7 @@ paths:
 
 # Testing
 
-> **Used by**: `code-dev` (écrit TU + E2E), `validator` (exécute `pnpm test`), `structural-auditor` (règle 2.13). Auto-chargé via `paths:`.
+> **Used by**: `tu-dev` (écrit les TU + tests d'intégration), `code-dev` (écrit les E2E), `validator` (exécute `pnpm test`), `structural-auditor` (règle 2.13). Auto-chargé via `paths:`.
 
 ## 75% minimum code coverage (enforced)
 

--- a/.claude/rules/ticket-spec-format.md
+++ b/.claude/rules/ticket-spec-format.md
@@ -1,6 +1,6 @@
 # Ticket Spec Format
 
-> **Used by**: `architect` (écrit le spec — body en mode epic-*, commentaire `## Analyse architecte` en mode task), `bug-analyst` (commentaire `## Analyse du bug` qui sert de spec implicite pour les bugs), `code-dev` (valide le format avant exécution, retourne en To Do si manquant), skill `/implement` (préconditions).
+> **Used by**: `architect` (écrit le spec — body en mode epic-*, commentaire `## Analyse architecte` en mode task), `bug-analyst` (commentaire `## Analyse du bug` qui sert de spec implicite pour les bugs), `code-dev` (valide le format avant exécution, retourne en To Do si manquant), `tu-dev` (lit la section `## Scénarios de test` pour cadrer les tests), skill `/implement` (préconditions).
 
 Format standardisé des tickets **code** consommés par `code-dev` (Sonnet par défaut, Opus si label `complexe`). Selon le type d'issue, l'emplacement du spec change :
 

--- a/.claude/rules/ticket-spec-format.md
+++ b/.claude/rules/ticket-spec-format.md
@@ -1,6 +1,12 @@
+---
+paths:
+  - "src/**/*.ts"
+  - "src/**/*.tsx"
+---
+
 # Ticket Spec Format
 
-> **Used by**: `architect` (écrit le spec — body en mode epic-*, commentaire `## Analyse architecte` en mode task), `bug-analyst` (commentaire `## Analyse du bug` qui sert de spec implicite pour les bugs), `code-dev` (valide le format avant exécution, retourne en To Do si manquant), `tu-dev` (lit la section `## Scénarios de test` pour cadrer les tests), skill `/implement` (préconditions).
+> **Used by**: `architect` (écrit le spec — body en mode epic-*, commentaire `## Analyse architecte` en mode task), `bug-analyst` (commentaire `## Analyse du bug` qui sert de spec implicite pour les bugs), `code-dev` (valide le format avant exécution, retourne en To Do si manquant), `tu-dev` (lit la section `## Scénarios de test` pour cadrer les tests), skill `/implement` (préconditions). Auto-chargé via `paths:` sur `.ts/.tsx` (code-dev / tu-dev pendant l'édition) ; `architect` (auteur du spec, non-coding) le lit à la demande.
 
 Format standardisé des tickets **code** consommés par `code-dev` (Sonnet par défaut, Opus si label `complexe`). Selon le type d'issue, l'emplacement du spec change :
 

--- a/.claude/rules/visual-quality-validation.md
+++ b/.claude/rules/visual-quality-validation.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "src/**/*.tsx"
+---
+
+<!-- NOTE: rule liée aux agents dépréciés `designer` / `design-validator` (cf. code-dev étape 7 : « plus de design-validator externe »). Scopée pour ne plus charger partout ; à supprimer avec ces agents lors d'un cleanup dédié. -->
+
 # Visual Quality Validation
 
 > **Used by**: `design-validator` (exclusif). Invoqué par `code-dev` step 9a après PR draft.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -146,7 +146,7 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
 4. **Invoquer `code-dev`** en foreground via le subagent :
    - Inputs : ticket number, worktree path, worktree index, base branch (sans préfixe `origin/`), working branch.
    - Si label `complexe` → model `opus`, sinon `sonnet`.
-   - L'agent suit `code-dev/AGENT.md` : implémente, push, ouvre PR draft, force PR↔issue link, fait passer les 4 quality gates + `functional-validator`, `gh pr ready`, retourne JSON. **Le ticket reste en `In progress`** — les transitions `In review` et `Done` sont user-only.
+   - L'agent suit `code-dev/AGENT.md` : implémente, **délègue tous les tests (TU + intégration) à `tu-dev`** (Opus, étape 5.5 — `tu-dev` rend la main sur une vraie régression), push, ouvre PR draft, force PR↔issue link, fait passer les 4 quality gates + `functional-validator`, `gh pr ready`, retourne JSON. **Le ticket reste en `In progress`** — les transitions `In review` et `Done` sont user-only.
 
 5. **Parser le JSON retourné** :
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -10,11 +10,11 @@ description: "Phase exécution. Détecte le mode (epic/task/bug) selon le type d
 | Type d'issue | Mode | Mécanisme |
 |---|---|---|
 | `Feature` (epic) | epic | `nohup bash scripts/orchestration/epic_loop.sh <N> > /tmp/epic_loop_<KEY>.log 2>&1 &` (background, parallèle, plusieurs sub-tickets) |
-| `Task` | task | Invoque `code-dev` agent en **foreground synchrone** sur l'issue |
-| `Bug` | bug | Invoque `code-dev` agent en **foreground synchrone** avec `rules/bug-fix-workflow.md` |
+| `Task` | task | Lance `code-dev` en **CLI foreground** (`claude --agent code-dev`, bloquant) sur l'issue |
+| `Bug` | bug | Lance `code-dev` en **CLI foreground** (`claude --agent code-dev`, bloquant) avec `rules/bug-fix-workflow.md` |
 | sub-issue d'un epic (non-feature) | task-debug | Comme `task` — utile pour re-rouler un sous-ticket d'un epic plus large (ex: après `refacto` ou debug) |
 
-`/implement` n'orchestre rien lui-même : pour epic c'est `epic_loop.sh` qui parallèlise, pour task/bug c'est l'agent `code-dev` qui exécute.
+`/implement` n'orchestre rien lui-même : pour epic c'est `epic_loop.sh` qui parallèlise, pour task/bug c'est un process CLI `claude --agent code-dev` foreground. **Dans les deux cas code-dev tourne comme _main agent_ (process CLI)** — obligatoire pour qu'il puisse lancer ses propres sous-agents (`tu-dev`, les 4 validateurs, `functional-validator`) : un sous-agent ne peut pas en spawner d'autres.
 
 ---
 
@@ -143,17 +143,28 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
 
 3. **Status board** : `set_ticket_status.sh "$ISSUE_N" "In progress"`.
 
-4. **Invoquer `code-dev`** en foreground via le subagent :
-   - Inputs : ticket number, worktree path, worktree index, base branch (sans préfixe `origin/`), working branch.
-   - Si label `complexe` → model `opus`, sinon `sonnet`.
-   - L'agent suit `code-dev/AGENT.md` : implémente, **délègue tous les tests (TU + intégration) à `tu-dev`** (Opus, étape 5.5 — `tu-dev` rend la main sur une vraie régression), push, ouvre PR draft, force PR↔issue link, fait passer les 4 quality gates + `functional-validator`, `gh pr ready`, retourne JSON. **Le ticket reste en `In progress`** — les transitions `In review` et `Done` sont user-only.
+4. **Lancer `code-dev` en CLI foreground** (PAS via le Task tool) — code-dev DOIT être *main agent* de son propre process pour pouvoir lancer ses sous-agents (`tu-dev` étape 5.5, les 4 quality gates étape 6, `functional-validator` étape 9a) ; un sous-agent ne peut pas en spawner d'autres. Même invocation que `epic_loop.sh` (`spawn_agent`), mais **synchrone/bloquante** pour un seul ticket :
+
+   ```bash
+   MODEL=$(gh issue view "$ISSUE_N" --json labels --jq '.labels[].name' | grep -qx complexe && echo opus || echo sonnet)
+   BUDGET=$([ "$MODEL" = opus ] && echo 40 || echo 10)
+   env -u CLAUDECODE timeout 5400 claude \
+     --agent code-dev --model "$MODEL" \
+     --print --output-format stream-json --verbose \
+     --dangerously-skip-permissions --max-budget-usd "$BUDGET" \
+     "$PROMPT" 2>&1 | tee "/tmp/code-dev-${ISSUE_N}.jsonl"
+   ```
+
+   - `$PROMPT` : le même brief par ticket que construit `epic_loop.sh` (numéro de ticket + type, worktree path, index → port `3001+index`, base branch `origin/...`, working branch déjà checkout, « suivre STRICTEMENT `code-dev/AGENT.md` », retour JSON strict en dernier message). Pour un Bug, rappeler `rules/bug-fix-workflow.md`.
+   - **Récupérer le verdict JSON** depuis la sortie stream-json (dernier objet `{"status":...}`) — même extraction que `epic_loop.sh` : essayer `jq -e '.status'`, fallback bloc ` ```json `, puis premier `{...}` contenant `"status"`.
+   - L'agent suit `code-dev/AGENT.md` : implémente, **délègue tous les tests (TU + intégration) à `tu-dev`** (Opus, étape 5.5 — `tu-dev` rend la main sur une vraie régression), push, ouvre PR draft, force PR↔issue link, fait passer les 4 quality gates + `functional-validator`, `gh pr ready`, retourne JSON. **Le ticket reste en `In progress`** — `In review` / `Done` user-only.
 
 5. **Parser le JSON retourné** :
 
    | `.status` | Action skill | Markdown affiché |
    |---|---|---|
    | `validated` | aucune (ticket reste In progress, l'utilisateur le bouge à In review à son rythme) | `## Code: PASS` + ticket/branche/PR + next-step revue humaine |
-   | `needs_opus_escalation` | re-invoquer immédiatement `code-dev` en `model: "opus"` avec les mêmes inputs ; afficher le verdict final | `## Code: PASS` ou `## Code: REFACTO` selon le retour Opus |
+   | `needs_opus_escalation` | relancer immédiatement le **CLI `code-dev`** avec `--model opus` et le même `$PROMPT` ; afficher le verdict final | `## Code: PASS` ou `## Code: REFACTO` selon le retour Opus |
    | `refacto` | aucune (le ticket est en To Do) | `## Code: REFACTO` + diagnostic + next-step `/analyse <N>` (re-spec) |
    | `rate_limited` | proposer de retenter dans `retry_in` secondes ou abandonner | `## Code: RATE_LIMITED` + délai suggéré |
    | `failed` | propager l'erreur sans modifier le ticket | `## Code: FAILED` + raison technique |
@@ -227,7 +238,7 @@ L'utilisateur retire `dispatch=escalate` (et `attempt=3`) après orientation pou
 - **NE JAMAIS** dupliquer la logique d'orchestration ici — tout est dans `scripts/orchestration/`
 - **NE PAS** attendre le retour du loop driver en mode epic (`nohup ... &; disown`)
 - **NE PAS** poll l'état — utiliser `/report`
-- **En mode task/bug**, c'est synchrone : tu invoques `code-dev` et tu attends le JSON final, comme l'ancien `/code`
+- **En mode task/bug**, c'est synchrone : tu lances le **CLI `claude --agent code-dev`** (bloquant) et tu attends le JSON final, comme l'ancien `/code`. **PAS** le Task tool — code-dev doit être main agent pour lancer ses sous-agents (`tu-dev`, validateurs, `functional-validator`).
 - Avant tout dispatch : check **analyse présente** (cf. Step 1) ; sinon proposer `/analyse <N>` et exit
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,10 +122,11 @@ pnpm db:studio            # opens Drizzle Studio
 
 ## Automatic quality gates
 
-Quality checks run **automatically** après chaque itération de code — pas de commande à lancer. Dans la pipeline `/implement`, ils sont invoqués par `code-dev` step 6. Hors pipeline (hotfix, edit direct), délégués par l'agent principal. Voir `.claude/rules/automation.md`.
+Quality checks run **automatically** après chaque itération de code — pas de commande à lancer. Dans la pipeline `/implement`, les tests sont écrits par `tu-dev` (step 5.5), puis les gates sont invoqués par `code-dev` step 6. Hors pipeline (hotfix, edit direct), délégués par l'agent principal. Voir `.claude/rules/automation.md`.
 
 | Gate | When | How |
 |---|---|---|
+| **Tests unitaires** | Inside `/implement`, avant les gates (step 5.5) | `tu-dev` agent (Opus) écrit/corrige les TU + intégration, renvoie à `code-dev` sur régression |
 | **Validation** | After every task | `validator` agent (typecheck + test + lint + format) |
 | **Structure** | After every task | `structural-auditor` agent (17 rules: forms, schemas, DRY, imports, no-comments…) |
 | **RGAA** | After every task | `rgaa-auditor` agent on modified `.tsx` files |
@@ -169,7 +170,8 @@ Quality checks run **automatically** après chaque itération de code — pas de
 **Pipeline exécution** (invoqués par `/implement`) :
 | Agent | Rôle |
 |---|---|
-| `code-dev` | Implémente un ticket end-to-end (Sonnet, ou Opus si label `complexe`). Lit le spec dans le body (Feature) ou le commentaire d'analyse (Task / Bug). Pour les tickets UI, vérifie lui-même la fidélité Figma via le MCP `figma-dev`. |
+| `code-dev` | Implémente un ticket end-to-end (Sonnet, ou Opus si label `complexe`). Lit le spec dans le body (Feature) ou le commentaire d'analyse (Task / Bug). Pour les tickets UI, vérifie lui-même la fidélité Figma via le MCP `figma-dev`. Délègue **tous** les tests (TU + intégration) à `tu-dev`. |
+| `tu-dev` | Écrit/corrige **tous** les tests vitest (TU + intégration) du ticket, juste après `code-dev` et avant les validators (step 5.5). Toujours Opus. Trie les échecs : sur **vraie régression** il rend la main à `code-dev` (commentaire `tu-dev:` + verdict) ; sinon corrige les tests en échec légitime et ajoute la couverture du nouveau code (DRY). |
 | `functional-validator` | Rejoue les scénarios PO dans le dev server |
 | `doc-writer` | Régénère `docs/*.md` from scratch à partir de l'état courant du code. Invoqué par `epic_loop.sh` en fin d'epic (juste avant `open_epic_final_pr.sh`) ou par le skill `/doc` (humain). Sonnet, sans worktree dédié — opère sur la branche courante. |
 

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -349,6 +349,8 @@ All code (components, functions, variables, comments, file names) in English. Us
 Tests live in `__tests__/` subfolder next to the module they test. Never in `src/app/`.
 75% minimum global coverage (enforced by Vitest thresholds). 100% coverage on all logic files. Test observable behavior, not implementation details.
 
+> **Pipeline ownership**: inside the `/implement` pipeline, the `tu-dev` agent (Opus) writes/fixes all vitest unit + integration tests at code-dev step 5.5 — before the 4 post-task gates run — and hands control back to code-dev on a genuine regression. code-dev keeps only the Playwright E2E.
+
 **E2E completeness**: every route in `src/app/**/page.tsx` must have corresponding E2E tests in `src/e2e/`. Always verify all pages are covered when adding or modifying pages.
 
 > Full policy (what to test, mock boundaries, coverage rules, E2E completeness) → `.claude/rules/testing.md`

--- a/scripts/orchestration/agent_status.sh
+++ b/scripts/orchestration/agent_status.sh
@@ -20,7 +20,7 @@ fi
 # Decision rules:
 #   stuck — at least one of:
 #     (a) process dead AND last event ∉ {COMPLETE, STUCK, ESCALATED, ANALYSIS_FAIL}
-#     (b) ≥ 3 RETRY events on the same axis (DEV / VALIDATION / FUNCTIONAL / CI / SONAR / BOT)
+#     (b) ≥ 3 RETRY events on the same axis (DEV / TU / VALIDATION / FUNCTIONAL / CI / SONAR / BOT)
 #     (c) > 20 min in same phase without any progression event between start/ok
 #     (d) BOT_WAIT > 15 min without BOT_REPLIED
 #     (e) ≥ 3 consecutive CI_FAIL on the same check name
@@ -200,9 +200,9 @@ if [ -n "$LAST_BOT_WAIT" ]; then
 fi
 
 # Rule (c) — > STUCK_PHASE_SEC since the last START-style phase event
-# Phase-START events: ANALYSIS_START, DEV_START, VALIDATION_START, FUNCTIONAL_START,
-# CI_WAIT, SONAR_WAIT, BOT_WAIT
-PHASE_START_RE='\[(ANALYSIS_START|DEV_START|VALIDATION_START|FUNCTIONAL_START|CI_WAIT|SONAR_WAIT|BOT_WAIT)\]'
+# Phase-START events: ANALYSIS_START, DEV_START, TU_START, VALIDATION_START,
+# FUNCTIONAL_START, CI_WAIT, SONAR_WAIT, BOT_WAIT
+PHASE_START_RE='\[(ANALYSIS_START|DEV_START|TU_START|VALIDATION_START|FUNCTIONAL_START|CI_WAIT|SONAR_WAIT|BOT_WAIT)\]'
 LAST_PHASE_LINE=$(grep -E "$PHASE_START_RE" "$LOG_FILE" | tail -1 || echo "")
 if [ -n "$LAST_PHASE_LINE" ]; then
     LAST_PHASE_HMS=$(echo "$LAST_PHASE_LINE" | grep -oE '^\[[0-9]{2}:[0-9]{2}:[0-9]{2}\]' | tr -d '[]')

--- a/scripts/orchestration/epic_loop.sh
+++ b/scripts/orchestration/epic_loop.sh
@@ -188,7 +188,7 @@ cd ${WT_PATH}
 git fetch origin ${BRANCH}
 git checkout ${BRANCH}
 \`\`\`
-Puis implémenter, push tes commits sur ${BRANCH}, créer la PR draft (\`gh pr create --base ${BASE#origin/} --head ${BRANCH}\`), faire les 4 + 2 validators internes, itérer sur les RETRY, retourner le verdict final JSON.
+Puis implémenter le code source, **déléguer tous les tests (TU + intégration) à l'agent tu-dev** (Opus, étape 5.5 — il rend la main sur une vraie régression), push tes commits sur ${BRANCH}, créer la PR draft (\`gh pr create --base ${BASE#origin/} --head ${BRANCH}\`), faire les 4 + 2 validators internes, itérer sur les RETRY, retourner le verdict final JSON.
 
 **Ne crée PAS une autre branche** (pas de \`checkout -b\`). La branche ${BRANCH} est déjà créée et linkée — utilise-la telle quelle.
 
@@ -198,7 +198,7 @@ REGLES STRICTES (appliquer sans exception) :
   AVANT de commencer la phase suivante. Sans ces events, le dashboard /report
   ne peut pas suivre ta progression et l'utilisateur croit que tu es stuck.
   Events obligatoires dans l'ordre : START → ANALYSIS_START → ANALYSIS_OK
-  → DEV_START → DEV_OK → VALIDATION_START → VALIDATION_OK → PR_DRAFT
+  → DEV_START → DEV_OK → TU_START → TU_OK → VALIDATION_START → VALIDATION_OK → PR_DRAFT
   → FUNCTIONAL_START → FUNCTIONAL_OK → CI_WAIT → CI_OK → SONAR_WAIT → SONAR_OK
   → BOT_WAIT → BOT_REPLIED → PR_READY → COMPLETE. (RETRY/CI_FAIL/SONAR_FAIL
   à intercaler en cas d'itération, voir AGENT.md « Logging events ».)

--- a/scripts/orchestration/log_event.sh
+++ b/scripts/orchestration/log_event.sh
@@ -28,6 +28,7 @@ fi
 # code-dev specific (with attempt=K when iterating):
 #   ANALYSIS_START / ANALYSIS_OK / ANALYSIS_FAIL  (step 1: ticket spec check)
 #   DEV_START / DEV_OK                            (step 5: implementation)
+#   TU_START / TU_OK / TU_REGRESSION              (step 5.5: tu-dev — TU + integration)
 #   VALIDATION_START / VALIDATION_OK              (step 6: 4 quality auditors)
 #   FUNCTIONAL_START / FUNCTIONAL_OK              (step 9a: functional-validator)
 #   CI_WAIT / CI_OK / CI_FAIL                     (step 9b: GitHub Actions)

--- a/scripts/orchestration/open_epic_final_pr.sh
+++ b/scripts/orchestration/open_epic_final_pr.sh
@@ -58,7 +58,7 @@ SUB_LINES=$(gh api graphql -f query="{
 
 BODY="Intégration finale de l'epic #${EPIC} — **${EPIC_TITLE}**.
 
-Cette PR rassemble les commits squashés de chaque sous-ticket validé par la pipeline. Chaque sous-ticket a déjà passé : CI verte, validators IA (validator / structural-auditor / rgaa-auditor / security-auditor / functional-validator), Sonar Quality Gate, et réponse aux review bots. La fidélité visuelle vs. Figma a été vérifiée par \`code-dev\` lui-même via le MCP \`figma-dev\`. Cette PR est le **point unique de revue humaine** pour l'epic.
+Cette PR rassemble les commits squashés de chaque sous-ticket validé par la pipeline. Chaque sous-ticket a déjà passé : tests écrits/validés par \`tu-dev\` (TU + intégration), CI verte, validators IA (validator / structural-auditor / rgaa-auditor / security-auditor / functional-validator), Sonar Quality Gate, et réponse aux review bots. La fidélité visuelle vs. Figma a été vérifiée par \`code-dev\` lui-même via le MCP \`figma-dev\`. Cette PR est le **point unique de revue humaine** pour l'epic.
 
 ## Sous-tickets
 


### PR DESCRIPTION
## Quoi

Ajoute un nouvel agent IA `tu-dev` (toujours Opus) dédié à l'écriture et la maintenance de **tous les tests vitest** (TU + intégration) d'un ticket. Il s'insère dans la pipeline `/implement` comme **étape 5.5 de `code-dev`** — juste après l'implémentation du code source, **avant** les 4 validateurs read-only.

## Pourquoi

Séparer « écrire le code » de « écrire/maintenir les tests », avec un modèle plus capable (Opus) dédié au triage *régression vs. évolution légitime*.

## Comportement de `tu-dev`

1. Lit le diff source de `code-dev`.
2. Lance la suite TU actuelle (`pnpm test`).
3. Trie chaque échec : **vraie régression** (side effect non souhaité) vs. **conséquence légitime** de l'évolution.
   - Régression → commentaire `tu-dev:` sur le ticket + verdict `TU REGRESSION` → **rend la main à `code-dev`** (qui corrige la source et le ré-invoque, borné par l'escalade >3 tentatives existante).
   - Sinon → corrige les tests en échec légitime.
4. Ajoute la couverture du nouveau code (DRY : mocks de `src/test/setup.ts`, constantes/schemas partagés).
5. Relance toute la suite → tout vert → verdict `TU PASS`.

**Périmètre** : TU vitest toujours + `*.integration.test.ts` **uniquement** si le diff touche le DB-layer/SQL (règle `audit-logging`). Les E2E Playwright restent à `code-dev`. Pipeline-only.

## Impacts

- `code-dev` ne touche plus aux TU/intégration (étape 5 = code source seul ; nouvelle étape 5.5 délègue à `tu-dev` ; events `TU_START` / `TU_OK` / `TU_REGRESSION`). Il conserve les E2E.
- Pour les **bugs**, le test de reproduction unitaire/intégration passe à `tu-dev` (prouvé par *revert-verify*) ; `code-dev` garde le repro E2E.
- Docs : `CLAUDE.md` (racine + `packages/app`), `automation.md`, `testing.md`, `bug-fix-workflow.md`, `ticket-spec-format.md`, `code-quality.md`, `github-board.md`, skill `/implement`.
- Orchestration : prompt de spawn + ordre de logging (`epic_loop.sh`), doc (`log_event.sh`), détection de phase (`agent_status.sh`), body de la PR finale d'epic (`open_epic_final_pr.sh`).

## Revue

Conçu via exploration multi-agents puis **revue adversariale** (cohérence du flux, complétude des touchpoints, correction factuelle vs. conventions repo). Tokens de verdict `TU PASS` / `TU REGRESSION` / `TU FAILED` alignés verbatim entre `tu-dev` et `code-dev`. `bash -n` vert sur les 4 scripts modifiés.