### PR TITLE
stats(analytics): Matomo — procédure tRPC getMatomoFunnel (#3615)

### DIFF
--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -16,6 +16,7 @@ export type {
 	GetCampaignProgressionInput,
 	GetCampaignStatsInput,
 	GetCompletionFunnelInput,
+	GetMatomoFunnelInput,
 	GetStepDropoffRateInput,
 	GetStepDurationsInput,
 } from "./schemas";
@@ -23,6 +24,7 @@ export {
 	getCampaignProgressionSchema,
 	getCampaignStatsSchema,
 	getCompletionFunnelSchema,
+	getMatomoFunnelSchema,
 	getStepDropoffRateSchema,
 	getStepDurationsSchema,
 } from "./schemas";
@@ -32,6 +34,8 @@ export type {
 	CampaignStats,
 	CompletionFunnelOutput,
 	FunnelRow,
+	MatomoFunnelOutput,
+	MatomoFunnelRow,
 	StepDropoffRow,
 	StepDurationRow,
 } from "./types";

--- a/packages/app/src/modules/admin/stats/matomoFunnel.ts
+++ b/packages/app/src/modules/admin/stats/matomoFunnel.ts
@@ -1,0 +1,79 @@
+import {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+} from "~/modules/analytics";
+import { type CompanySizeRange, getStepLabel } from "~/modules/domain";
+import type { MatomoEventsReportRow } from "~/server/services/matomo";
+import type { MatomoFunnelOutput, MatomoFunnelRow } from "./types";
+
+// Campaign year N is declared in early N+1, so the funnel is filtered on the
+// CAMPAIGN_YEAR custom dimension, not the event date — the Matomo query spans a
+// wide range and lets the segment do the year scoping.
+export const MATOMO_FUNNEL_DATE_RANGE = "2020-01-01,today";
+
+export function buildMatomoFunnelSegment({
+	year,
+	sizeRange,
+}: {
+	year: number;
+	sizeRange?: CompanySizeRange;
+}): string {
+	const parts = [
+		`eventCategory==${MATOMO_EVENT_CATEGORY.DECLARATION}`,
+		`dimension${MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR}==${year}`,
+	];
+	if (sizeRange) {
+		parts.push(
+			`dimension${MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE}==${sizeRange}`,
+		);
+	}
+	return parts.join(";");
+}
+
+function parseStepNumber(stepKey: string): number | null {
+	const match = /^step_(\d+)$/.exec(stepKey);
+	return match?.[1] !== undefined ? Number(match[1]) : null;
+}
+
+function countForAction(rows: MatomoEventsReportRow[], action: string): number {
+	return rows.find((row) => row.label === action)?.nb_events ?? 0;
+}
+
+export function mapMatomoFunnel(
+	actionRows: MatomoEventsReportRow[],
+	stepRows: MatomoEventsReportRow[],
+): MatomoFunnelOutput {
+	const steps: MatomoFunnelRow[] = stepRows
+		.map((row): (MatomoFunnelRow & { step: number }) | null => {
+			const step = parseStepNumber(row.label);
+			if (step === null) return null;
+			const avg = row.avg_event_value;
+			return {
+				step,
+				stepKey: row.label,
+				label: getStepLabel(step),
+				completedCount: row.nb_events ?? 0,
+				avgDurationSeconds: typeof avg === "number" ? Math.round(avg) : null,
+			};
+		})
+		.filter((row): row is MatomoFunnelRow & { step: number } => row !== null)
+		.sort((a, b) => a.step - b.step)
+		.map(({ step: _step, ...row }) => row);
+
+	return {
+		startedCount: countForAction(
+			actionRows,
+			MATOMO_DECLARATION_ACTION.FUNNEL_START,
+		),
+		completedCount: countForAction(
+			actionRows,
+			MATOMO_DECLARATION_ACTION.FUNNEL_COMPLETE,
+		),
+		abandonedCount: countForAction(
+			actionRows,
+			MATOMO_DECLARATION_ACTION.FUNNEL_ABANDON,
+		),
+		steps,
+	};
+}

--- a/packages/app/src/modules/admin/stats/schemas.ts
+++ b/packages/app/src/modules/admin/stats/schemas.ts
@@ -88,3 +88,15 @@ export const getCompletionFunnelSchema = z.object({
 export type GetCompletionFunnelInput = z.infer<
 	typeof getCompletionFunnelSchema
 >;
+
+/**
+ * Input for `adminStats.getMatomoFunnel`. Same `{ year, sizeRange? }` filter
+ * couple as the DB-backed widgets — but applied to Matomo via a segment on the
+ * campaign-year / workforce custom dimensions, never a calendar date range.
+ */
+export const getMatomoFunnelSchema = z.object({
+	year: z.number().int().min(2000).max(2100),
+	sizeRange: z.enum(COMPANY_SIZE_RANGE_KEYS).optional(),
+});
+
+export type GetMatomoFunnelInput = z.infer<typeof getMatomoFunnelSchema>;

--- a/packages/app/src/modules/admin/stats/types.ts
+++ b/packages/app/src/modules/admin/stats/types.ts
@@ -113,3 +113,25 @@ export type CompletionFunnelOutput = {
 	revisionFunnel: FunnelRow[];
 	cseFunnel: FunnelRow[];
 };
+
+/**
+ * One declaration-funnel step as measured by Matomo (`adminStats.getMatomoFunnel`).
+ * `avgDurationSeconds` is null when Matomo reported no timed completion.
+ */
+export type MatomoFunnelRow = {
+	stepKey: string;
+	label: string;
+	completedCount: number;
+	avgDurationSeconds: number | null;
+};
+
+/**
+ * Output of `adminStats.getMatomoFunnel` — the behavioural funnel of the
+ * declaration journey collected via Matomo events (K20/K21).
+ */
+export type MatomoFunnelOutput = {
+	startedCount: number;
+	completedCount: number;
+	abandonedCount: number;
+	steps: MatomoFunnelRow[];
+};

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -61,6 +61,7 @@ export const AUDIT_ACTIONS = {
 	ADMIN_STATS_GET_STEP_DURATIONS: "admin_stats.get_step_durations",
 	ADMIN_STATS_GET_STEP_DROPOFF_RATE: "admin_stats.get_step_dropoff_rate",
 	ADMIN_STATS_GET_COMPLETION_FUNNEL: "admin_stats.get_completion_funnel",
+	ADMIN_STATS_GET_MATOMO_FUNNEL: "admin_stats.get_matomo_funnel",
 
 	// ── Declaration draft ─────────────────────────────────
 	DRAFT_READ: "declaration_draft.read",
@@ -149,6 +150,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DURATIONS]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DROPOFF_RATE]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_COMPLETION_FUNNEL]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_FUNNEL]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_SAVE]: "mutation",
 	[AUDIT_ACTIONS.DRAFT_CLEAR]: "mutation",

--- a/packages/app/src/server/api/routers/__tests__/adminStats.matomo.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.matomo.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMatomoMock } = vi.hoisted(() => ({ fetchMatomoMock: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
+vi.mock("~/server/db", () => ({ db: {} }));
+vi.mock("~/server/services/matomo", () => ({
+	fetchMatomoEventsReport: fetchMatomoMock,
+}));
+
+const adminSession = {
+	user: { id: "admin-1", email: "a@b.c", isAdmin: true },
+	expires: "",
+};
+
+const ACTION_ROWS = [
+	{ label: "funnel_start", nb_events: 100 },
+	{ label: "step_complete", nb_events: 250 },
+	{ label: "funnel_complete", nb_events: 60 },
+	{ label: "funnel_abandon", nb_events: 40 },
+];
+
+const STEP_ROWS = [
+	{ label: "step_2", nb_events: 70, avg_event_value: 30 },
+	{ label: "step_1", nb_events: 90, avg_event_value: 12 },
+];
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("adminStatsRouter.getMatomoFunnel", () => {
+	it("maps the Matomo report to funnel counts and per-step rows with domain labels", async () => {
+		fetchMatomoMock.mockImplementation(
+			async ({ method }: { method: string }) =>
+				method === "Events.getAction" ? ACTION_ROWS : STEP_ROWS,
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getMatomoFunnel({
+			year: 2026,
+			sizeRange: "50-99",
+		});
+
+		expect(result.startedCount).toBe(100);
+		expect(result.completedCount).toBe(60);
+		expect(result.abandonedCount).toBe(40);
+		expect(result.steps).toEqual([
+			{
+				stepKey: "step_1",
+				label: "Effectifs",
+				completedCount: 90,
+				avgDurationSeconds: 12,
+			},
+			{
+				stepKey: "step_2",
+				label: "Écart de rémunération",
+				completedCount: 70,
+				avgDurationSeconds: 30,
+			},
+		]);
+	});
+
+	it("filters via a segment on the campaign-year and workforce custom dimensions (not by date)", async () => {
+		fetchMatomoMock.mockResolvedValue([]);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await caller.getMatomoFunnel({ year: 2026, sizeRange: "50-99" });
+
+		const segments = fetchMatomoMock.mock.calls.map(
+			(call) => (call[0] as { segment: string }).segment,
+		);
+		expect(segments.length).toBeGreaterThan(0);
+		expect(segments.every((s) => s.includes("dimension1==2026"))).toBe(true);
+		expect(segments.every((s) => s.includes("dimension2==50-99"))).toBe(true);
+	});
+
+	it("propagates the error when the Matomo client throws (no silent empty data)", async () => {
+		fetchMatomoMock.mockRejectedValue(new Error("Matomo non configuré"));
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.getMatomoFunnel({ year: 2026 })).rejects.toThrow(
+			/Matomo/,
+		);
+	});
+
+	it("rejects non-admin callers", async () => {
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: { user: { id: "u", email: "u@x", isAdmin: false }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.getMatomoFunnel({ year: 2026 })).rejects.toThrow(
+			/administrateurs/i,
+		);
+	});
+});

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -1,9 +1,15 @@
 import { and, between, eq, gte, inArray, type SQL, sql } from "drizzle-orm";
 
 import {
+	buildMatomoFunnelSegment,
+	mapMatomoFunnel,
+	MATOMO_FUNNEL_DATE_RANGE,
+} from "~/modules/admin/stats/matomoFunnel";
+import {
 	getCampaignProgressionSchema,
 	getCampaignStatsSchema,
 	getCompletionFunnelSchema,
+	getMatomoFunnelSchema,
 	getStepDropoffRateSchema,
 	getStepDurationsSchema,
 } from "~/modules/admin/stats/schemas";
@@ -13,9 +19,11 @@ import type {
 	CampaignStats,
 	CompletionFunnelOutput,
 	FunnelRow,
+	MatomoFunnelOutput,
 	StepDropoffRow,
 	StepDurationRow,
 } from "~/modules/admin/stats/types";
+import { MATOMO_DECLARATION_ACTION } from "~/modules/analytics";
 import {
 	COMPANY_SIZE_ANNUAL_MIN,
 	COMPANY_SIZE_RANGES,
@@ -40,6 +48,7 @@ import {
 	declarations,
 	gipMdsData,
 } from "~/server/db/schema";
+import { fetchMatomoEventsReport } from "~/server/services/matomo";
 
 /** Minimum number of completed transitions before showing a median / p90. */
 const STEP_DURATION_MIN_SAMPLE = 5;
@@ -996,6 +1005,26 @@ export const adminStatsRouter = createTRPCRouter({
 				),
 				cseFunnel: buildFunnelRows(FUNNEL_CSE_KEY_STEPS, cseCounts),
 			};
+		}),
+	getMatomoFunnel: adminProcedure
+		.input(getMatomoFunnelSchema)
+		.query(async ({ input }): Promise<MatomoFunnelOutput> => {
+			const segment = buildMatomoFunnelSegment(input);
+			const [actionRows, stepRows] = await Promise.all([
+				fetchMatomoEventsReport({
+					method: "Events.getAction",
+					period: "range",
+					date: MATOMO_FUNNEL_DATE_RANGE,
+					segment,
+				}),
+				fetchMatomoEventsReport({
+					method: "Events.getName",
+					period: "range",
+					date: MATOMO_FUNNEL_DATE_RANGE,
+					segment: `${segment};eventAction==${MATOMO_DECLARATION_ACTION.STEP_COMPLETE}`,
+				}),
+			]);
+			return mapMatomoFunnel(actionRows, stepRows);
 		}),
 });
 function countDeclarationsWithEvent(opts: {

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -74,6 +74,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 		AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DROPOFF_RATE,
 	"adminStats.getCompletionFunnel":
 		AUDIT_ACTIONS.ADMIN_STATS_GET_COMPLETION_FUNNEL,
+	"adminStats.getMatomoFunnel": AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_FUNNEL,
 
 	// ── gip mds ────────────────────────────────────────────
 	"gipMds.importFromUrl": AUDIT_ACTIONS.GIP_MDS_IMPORT,


### PR DESCRIPTION
Couche data du widget admin Matomo (epic #3514). Expose le funnel K20/K21 collecté dans Matomo via une procédure tRPC, en consommant le client Reporting API (#3613) et la taxonomie (#3612). Dépend de #3612 + #3613.

## Contenu

- `modules/admin/stats/schemas.ts` — `getMatomoFunnelSchema` : input `{ year, sizeRange? }`, **même couple de filtres** que les autres widgets (réutilise `CompanySizeRange`).
- `modules/admin/stats/types.ts` — `MatomoFunnelRow` + `MatomoFunnelOutput`.
- `modules/admin/stats/matomoFunnel.ts` (nouveau, helper pur testable) :
  - `buildMatomoFunnelSegment({ year, sizeRange })` → **segment Matomo sur les custom dimensions** `CAMPAIGN_YEAR` / `WORKFORCE_RANGE` (+ `eventCategory==declaration`)
  - `mapMatomoFunnel(actionRows, stepRows)` → `MatomoFunnelOutput` (entrées/complétions/abandons + par étape `{ stepKey, label via getStepLabel, completedCount, avgDurationSeconds }`)
- `server/api/routers/adminStats.ts` — procédure `getMatomoFunnel` (`adminProcedure`), 2 appels : `Events.getAction` (totaux) + `Events.getName` segmenté `eventAction==step_complete` (durées par étape).
- `modules/admin/stats/index.ts` — exports schéma + types (pour #3616).

## Décision clé — filtrage par dimension, pas par date

L'année de campagne ≠ la date de l'event (index N déclaré début N+1). Le filtrage `{ year, sizeRange }` est appliqué via un **segment sur les custom dimensions**, sur une plage de dates large (`2020-01-01,today`). Cohérent avec les widgets DB.

## Helper extrait (hors liste de fichiers du ticket)

`adminStats.ts` fait déjà ~1080 lignes (>800). Plutôt que de l'alourdir, la logique pure (segment + mapping) est dans `matomoFunnel.ts`, testable en isolation. La procédure reste fine (~20 lignes).

## 🔒 Sécurité (follow-up #3613 traité)

`method`/`period`/`date` **hardcodés** ; le segment est construit uniquement depuis des inputs validés (`year` = `z.number().int()`, `sizeRange` = `z.enum`). Aucune injection possible (whitelist + encodage `URLSearchParams`). `adminProcedure` (admin-only). Erreur Matomo remontée proprement (pas de données vides silencieuses).

## 🛡️ Audit logging — ajouté sur recommandation des auditors

Le ticket laissait l'arbitrage au security-auditor. Verdict (security + structural) : toutes les autres queries `adminStats.*` (dont `getCompletionFunnel`, équivalent agrégé) sont auditées `read_sensitive` — invariant documenté dans le docstring du router. Pour cohérence, `getMatomoFunnel` est câblée en `read_sensitive` (3 points : `AUDIT_ACTIONS`, `AUDIT_ACTION_CATEGORIES`, `PROCEDURE_TO_ACTION`).

## ⚠️ À valider sur Matomo live

Le mapping suppose une forme de réponse de l'Events Reporting API (`Events.getAction` / `Events.getName` avec `label`/`nb_events`/`avg_event_value`). À confirmer/ajuster contre une instance Matomo réelle une fois les 2 custom dimensions configurées (cf. #3612). La logique de mapping est isolée dans `matomoFunnel.ts` pour faciliter l'ajustement.

## Qualité

- Typecheck ✓ · suite complète 2519 tests ✓ · lint ✓ · format ✓
- structural-auditor : PASS · security-auditor : SECURE (auth/injection/erreur)

Depends on #3612, #3613. Part of #3514.