### PR TITLE
stats(analytics): Matomo — instrumentation funnel de déclaration K20/K21 (#3614)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { getCompanySizeRange } from "~/modules/domain";
 import type { GipPrefillData } from "./shared/gipMdsMapping";
+import { useFunnelTracking } from "./shared/useFunnelTracking";
 import { Step1Workforce } from "./steps/Step1Workforce";
 import { Step2PayGap } from "./steps/Step2PayGap";
 import { Step3VariablePay } from "./steps/Step3VariablePay";
@@ -46,6 +48,15 @@ export function StepPageClient({
 	initialSource,
 	hasCse = null,
 }: StepPageClientProps) {
+	const workforce =
+		declaration.totalWomen !== null && declaration.totalMen !== null
+			? declaration.totalWomen + declaration.totalMen
+			: null;
+	const sizeRange =
+		workforce !== null ? getCompanySizeRange(workforce) : undefined;
+
+	useFunnelTracking({ step, year: declaration.year, sizeRange });
+
 	switch (step) {
 		case 1:
 			return (

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/useFunnelTracking.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/useFunnelTracking.test.ts
@@ -1,0 +1,155 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { trackEventMock } = vi.hoisted(() => ({ trackEventMock: vi.fn() }));
+
+vi.mock("~/modules/analytics", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/analytics")>();
+	return { ...actual, trackEvent: trackEventMock };
+});
+
+import {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+} from "~/modules/analytics";
+
+import { trackFunnelComplete, useFunnelTracking } from "../useFunnelTracking";
+
+const nowSpy = vi.spyOn(Date, "now");
+
+beforeEach(() => {
+	sessionStorage.clear();
+	trackEventMock.mockReset();
+	nowSpy.mockReturnValue(1_000);
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+function lastEvent() {
+	return trackEventMock.mock.calls.at(-1)?.[0];
+}
+
+describe("useFunnelTracking", () => {
+	it("emits funnel_start once on entering step 1, with the campaign-year dimension", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+
+		expect(trackEventMock).toHaveBeenCalledTimes(1);
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_START,
+			dimensions: { [MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024" },
+		});
+	});
+
+	it("does not re-emit funnel_start on a fresh mount at step 1 (anti-double via sessionStorage)", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+		trackEventMock.mockReset();
+
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+
+		expect(trackEventMock).not.toHaveBeenCalled();
+	});
+
+	it("emits step_complete with the step key, duration in seconds and both dimensions on a forward transition", () => {
+		const { rerender } = renderHook((props) => useFunnelTracking(props), {
+			initialProps: {
+				step: 1,
+				year: 2024,
+				sizeRange: undefined as string | undefined,
+			},
+		});
+		trackEventMock.mockReset();
+
+		nowSpy.mockReturnValue(6_000);
+		rerender({ step: 2, year: 2024, sizeRange: "50-99" });
+
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.STEP_COMPLETE,
+			name: "step_1",
+			value: 5,
+			dimensions: {
+				[MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024",
+				[MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE]: "50-99",
+			},
+		});
+	});
+
+	it("emits funnel_abandon with the current step key and total duration on beforeunload", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+		trackEventMock.mockReset();
+
+		nowSpy.mockReturnValue(9_000);
+		window.dispatchEvent(new Event("beforeunload"));
+
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_ABANDON,
+			name: "step_1",
+			value: 8,
+			dimensions: { [MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024" },
+		});
+	});
+
+	it("does not emit any PII (only category, action, name, value, anonymised dimensions)", () => {
+		const { rerender } = renderHook((props) => useFunnelTracking(props), {
+			initialProps: {
+				step: 1,
+				year: 2024,
+				sizeRange: "50-99" as string | undefined,
+			},
+		});
+		nowSpy.mockReturnValue(3_000);
+		rerender({ step: 2, year: 2024, sizeRange: "50-99" });
+
+		for (const call of trackEventMock.mock.calls) {
+			const event = call[0];
+			expect(Object.keys(event).sort()).not.toContain("siren");
+			const serialised = JSON.stringify(event);
+			expect(serialised).not.toMatch(/\d{9}/);
+			expect(serialised).not.toMatch(/@/);
+		}
+	});
+});
+
+describe("trackFunnelComplete", () => {
+	it("emits funnel_complete with the total duration and clears the funnel state", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+		trackEventMock.mockReset();
+
+		nowSpy.mockReturnValue(11_000);
+		trackFunnelComplete({ sizeRange: "50-99" });
+
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_COMPLETE,
+			value: 10,
+			dimensions: {
+				[MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024",
+				[MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE]: "50-99",
+			},
+		});
+
+		trackEventMock.mockReset();
+		window.dispatchEvent(new Event("beforeunload"));
+		expect(trackEventMock).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op when no funnel is in progress", () => {
+		trackFunnelComplete({ sizeRange: undefined });
+		expect(trackEventMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/useFunnelTracking.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/useFunnelTracking.ts
@@ -1,0 +1,145 @@
+import { useEffect } from "react";
+
+import {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+	MATOMO_FUNNEL_STEP_KEYS,
+	trackEvent,
+} from "~/modules/analytics";
+
+const STORAGE_KEY = "egapro:declaration-funnel";
+const FIRST_FUNNEL_STEP = 1;
+const LAST_FUNNEL_STEP = MATOMO_FUNNEL_STEP_KEYS.length - 1;
+
+type FunnelState = {
+	startedAt: number;
+	stepEnteredAt: number;
+	currentStep: number;
+	year: number;
+};
+
+type FunnelContext = {
+	step: number;
+	year: number;
+	sizeRange?: string;
+};
+
+function readState(): FunnelState | null {
+	if (typeof window === "undefined") return null;
+	const raw = sessionStorage.getItem(STORAGE_KEY);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as FunnelState;
+	} catch {
+		return null;
+	}
+}
+
+function writeState(state: FunnelState): void {
+	if (typeof window === "undefined") return;
+	sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function clearState(): void {
+	if (typeof window === "undefined") return;
+	sessionStorage.removeItem(STORAGE_KEY);
+}
+
+function buildDimensions(
+	year: number,
+	sizeRange?: string,
+): Record<number, string> {
+	const dimensions: Record<number, string> = {
+		[MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: String(year),
+	};
+	if (sizeRange) {
+		dimensions[MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE] = sizeRange;
+	}
+	return dimensions;
+}
+
+function elapsedSeconds(from: number, to: number): number {
+	return Math.round((to - from) / 1000);
+}
+
+function handleStepEnter({ step, year, sizeRange }: FunnelContext): void {
+	if (step < FIRST_FUNNEL_STEP || step > LAST_FUNNEL_STEP) return;
+
+	const now = Date.now();
+	const state = readState();
+
+	if (!state) {
+		if (step === FIRST_FUNNEL_STEP) {
+			trackEvent({
+				category: MATOMO_EVENT_CATEGORY.DECLARATION,
+				action: MATOMO_DECLARATION_ACTION.FUNNEL_START,
+				dimensions: buildDimensions(year, sizeRange),
+			});
+		}
+		writeState({ startedAt: now, stepEnteredAt: now, currentStep: step, year });
+		return;
+	}
+
+	if (step > state.currentStep) {
+		trackEvent({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.STEP_COMPLETE,
+			name: MATOMO_FUNNEL_STEP_KEYS[state.currentStep],
+			value: elapsedSeconds(state.stepEnteredAt, now),
+			dimensions: buildDimensions(year, sizeRange),
+		});
+		writeState({ ...state, currentStep: step, stepEnteredAt: now });
+		return;
+	}
+
+	if (step < state.currentStep) {
+		writeState({ ...state, currentStep: step, stepEnteredAt: now });
+	}
+}
+
+function emitAbandon(sizeRange?: string): void {
+	const state = readState();
+	if (!state) return;
+	trackEvent({
+		category: MATOMO_EVENT_CATEGORY.DECLARATION,
+		action: MATOMO_DECLARATION_ACTION.FUNNEL_ABANDON,
+		name: MATOMO_FUNNEL_STEP_KEYS[state.currentStep],
+		value: elapsedSeconds(state.startedAt, Date.now()),
+		dimensions: buildDimensions(state.year, sizeRange),
+	});
+}
+
+export function useFunnelTracking({
+	step,
+	year,
+	sizeRange,
+}: FunnelContext): void {
+	useEffect(() => {
+		handleStepEnter({ step, year, sizeRange });
+	}, [step, year, sizeRange]);
+
+	useEffect(() => {
+		function handleBeforeUnload(): void {
+			emitAbandon(sizeRange);
+		}
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+	}, [sizeRange]);
+}
+
+export function trackFunnelComplete({
+	sizeRange,
+}: {
+	sizeRange?: string;
+}): void {
+	const state = readState();
+	if (!state) return;
+	trackEvent({
+		category: MATOMO_EVENT_CATEGORY.DECLARATION,
+		action: MATOMO_DECLARATION_ACTION.FUNNEL_COMPLETE,
+		value: elapsedSeconds(state.startedAt, Date.now()),
+		dimensions: buildDimensions(state.year, sizeRange),
+	});
+	clearState();
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -2,10 +2,15 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
-import { computeGap, GAP_ALERT_THRESHOLD } from "~/modules/domain";
+import {
+	computeGap,
+	GAP_ALERT_THRESHOLD,
+	getCompanySizeRange,
+} from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import { getCurrentStageHref } from "../shared/complianceNavigation";
+import { trackFunnelComplete } from "../shared/useFunnelTracking";
 import { FormActions } from "../shared/FormActions";
 import { NextStepsBox } from "../shared/NextStepsBox";
 import { SavedIndicator } from "../shared/SavedIndicator";
@@ -54,8 +59,16 @@ export function Step6Review({
 }: Props) {
 	const router = useRouter();
 	const modalRef = useRef<HTMLDialogElement>(null);
+	const workforce =
+		declaration.totalWomen !== null && declaration.totalMen !== null
+			? declaration.totalWomen + declaration.totalMen
+			: null;
 	const submitMutation = api.declaration.submit.useMutation({
 		onSuccess: () => {
+			trackFunnelComplete({
+				sizeRange:
+					workforce !== null ? getCompanySizeRange(workforce) : undefined,
+			});
 			router.push("/declaration-remuneration/parcours-conformite");
 		},
 	});

--- a/packages/app/src/modules/domain/__tests__/companySize.test.ts
+++ b/packages/app/src/modules/domain/__tests__/companySize.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	COMPANY_SIZE_RANGES,
 	classifyCompanySize,
+	getCompanySizeRange,
 	isCseRequired,
 } from "../shared/companySize";
 
@@ -76,5 +77,20 @@ describe("COMPANY_SIZE_RANGES", () => {
 			max: null,
 			label: "250 salariés et plus",
 		});
+	});
+});
+
+describe("getCompanySizeRange", () => {
+	it("maps a workforce to its bucket key", () => {
+		expect(getCompanySizeRange(0)).toBe("<50");
+		expect(getCompanySizeRange(49)).toBe("<50");
+		expect(getCompanySizeRange(50)).toBe("50-99");
+		expect(getCompanySizeRange(99)).toBe("50-99");
+		expect(getCompanySizeRange(100)).toBe("100-149");
+		expect(getCompanySizeRange(149)).toBe("100-149");
+		expect(getCompanySizeRange(150)).toBe("150-249");
+		expect(getCompanySizeRange(249)).toBe("150-249");
+		expect(getCompanySizeRange(250)).toBe("250+");
+		expect(getCompanySizeRange(10000)).toBe("250+");
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -16,6 +16,7 @@ export { isObligatedForYear } from "./shared/companyObligation";
 export {
 	COMPANY_SIZE_RANGES,
 	classifyCompanySize,
+	getCompanySizeRange,
 	isCseRequired,
 } from "./shared/companySize";
 // Global score computation (sum of sub-scores from the EgaPro index)

--- a/packages/app/src/modules/domain/shared/companySize.ts
+++ b/packages/app/src/modules/domain/shared/companySize.ts
@@ -31,3 +31,17 @@ export const COMPANY_SIZE_RANGES: Record<
 	"150-249": { min: 150, max: 249, label: "150 à 249 salariés" },
 	"250+": { min: 250, max: null, label: "250 salariés et plus" },
 };
+
+/** Map a workforce headcount to its `CompanySizeRange` bucket key. */
+export function getCompanySizeRange(workforce: number): CompanySizeRange {
+	const entry = (
+		Object.entries(COMPANY_SIZE_RANGES) as Array<
+			[CompanySizeRange, (typeof COMPANY_SIZE_RANGES)[CompanySizeRange]]
+		>
+	).find(
+		([, { min, max }]) =>
+			workforce >= min && (max === null || workforce <= max),
+	);
+
+	return entry ? entry[0] : "250+";
+}


### PR DESCRIPTION
Implémente #3614. **Ouverte pour revue** — remplace #3621 (mergée par erreur).

⚠️ **PR empilée** : base = `ticket/3613-matomo-reporting-client`. À merger après #3612 (dont elle dépend) et #3613.

Contenu : hook `useFunnelTracking` (timings `sessionStorage`, events funnel au mount, `beforeunload`→abandon) + `trackFunnelComplete` dans Step6Review + `getCompanySizeRange` (domaine). Anonymisation testée (aucun PII). Limitation `beforeunload` best-effort documentée. Détail : issue #3614.

Qualité : typecheck ✓ · 2515 tests ✓ · lint ✓ · format ✓ · rgaa PASS.

Part of #3514.