### PR TITLE
stats(analytics): Matomo — procédure tRPC getMatomoFunnel (#3615)

### DIFF
--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -59,6 +59,9 @@ app:
     - secretRef:
         name: "admin"
         optional: true
+    - secretRef:
+        name: "matomo"
+        optional: true
     - configMapRef:
         name: "valkey"
         optional: true

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -12,6 +12,9 @@ SENTRY_AUTH_TOKEN=""
 NEXT_PUBLIC_SENTRY_DSN=""
 NEXT_PUBLIC_MATOMO_URL=""
 NEXT_PUBLIC_MATOMO_SITE_ID=""
+# token_auth for the Matomo Reporting API (admin stats widgets). Leave empty
+# locally — the widgets degrade to an error state when it is absent.
+MATOMO_API_TOKEN=""
 EGAPRO_GIP_MDS_API_URL="http://localhost:3000/api/gip-mds/mock"
 EGAPRO_SUIT_API_URL=""
 EGAPRO_MOCK_SUIT_SANCTION="true"

--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -64,6 +64,10 @@ export const env = createEnv({
 		NEXTAUTH_URL: z.string().url(),
 		EGAPRO_GIP_MDS_API_URL: z.string().url().optional(),
 		EGAPRO_GIP_MDS_API_TOKEN: z.string().optional(),
+		// token_auth for the Matomo Reporting API (server-side read of custom
+		// events). Optional: when absent the admin Matomo widgets degrade to an
+		// error state instead of breaking the rest of the dashboard.
+		MATOMO_API_TOKEN: z.string().optional(),
 		EGAPRO_MOCK_SUIT_SANCTION: z.coerce.boolean().optional().default(false),
 		/**
 		 * Comma-separated list of emails that should be granted the admin role
@@ -135,6 +139,7 @@ export const env = createEnv({
 		NEXTAUTH_URL: process.env.NEXTAUTH_URL,
 		EGAPRO_GIP_MDS_API_URL: process.env.EGAPRO_GIP_MDS_API_URL,
 		EGAPRO_GIP_MDS_API_TOKEN: process.env.EGAPRO_GIP_MDS_API_TOKEN,
+		MATOMO_API_TOKEN: process.env.MATOMO_API_TOKEN,
 		EGAPRO_MOCK_SUIT_SANCTION: process.env.EGAPRO_MOCK_SUIT_SANCTION,
 		ADMIN_EMAILS: process.env.ADMIN_EMAILS,
 		EGAPRO_AUDIT_RETENTION_SHORT_DAYS:

--- a/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
@@ -26,6 +26,7 @@ type Props = {
 	caption: string;
 	rows: FunnelRow[];
 	dropThreshold: number;
+	unitNoun?: string;
 };
 
 // DSFR illustration palette tokens. ECharts only accepts resolved CSS color
@@ -150,12 +151,13 @@ type LabelFormatterParams = {
 export function buildTooltipFormatter(
 	dropThreshold: number,
 	dsfrPalette: DsfrPalette = FALLBACK_DSFR_PALETTE,
+	unitNoun = "déclarations",
 ): (params: TooltipFormatterParams) => string {
 	return (params) => {
 		const { row } = params.data;
 		const head =
 			`<strong>${row.label}</strong><br/>` +
-			`${formatCount(row.count)} déclarations (${row.pctOfStart} % du funnel)`;
+			`${formatCount(row.count)} ${unitNoun} (${row.pctOfStart} % du funnel)`;
 		if (row.pctDropFromPrev === null) {
 			return head;
 		}
@@ -175,11 +177,12 @@ export function buildEchartsOption(
 	rows: FunnelRow[],
 	dropThreshold: number,
 	dsfrPalette: DsfrPalette = FALLBACK_DSFR_PALETTE,
+	unitNoun = "déclarations",
 ): echarts.EChartsCoreOption {
 	return {
 		tooltip: {
 			trigger: "item",
-			formatter: buildTooltipFormatter(dropThreshold, dsfrPalette),
+			formatter: buildTooltipFormatter(dropThreshold, dsfrPalette, unitNoun),
 		},
 		legend: {
 			show: true,
@@ -245,7 +248,12 @@ export function buildEchartsOption(
 	};
 }
 
-export function CompletionFunnelChart({ caption, rows, dropThreshold }: Props) {
+export function CompletionFunnelChart({
+	caption,
+	rows,
+	dropThreshold,
+	unitNoun = "déclarations",
+}: Props) {
 	const dsfrPalette = useDsfrPalette();
 	const hasData = rows.some((row) => row.count > 0);
 	if (!hasData) {
@@ -259,12 +267,12 @@ export function CompletionFunnelChart({ caption, rows, dropThreshold }: Props) {
 		);
 	}
 
-	const option = buildEchartsOption(rows, dropThreshold, dsfrPalette);
+	const option = buildEchartsOption(rows, dropThreshold, dsfrPalette, unitNoun);
 
 	return (
 		<figure className={styles.chartWrapper}>
 			<figcaption className="fr-sr-only">
-				{caption}. Nombre de déclarations à chaque jalon du funnel, avec le
+				{caption}. Nombre de {unitNoun} à chaque jalon du funnel, avec le
 				pourcentage du funnel et la chute par rapport à l'étape précédente. Les
 				données équivalentes sont disponibles dans le tableau ci-dessous.
 			</figcaption>

--- a/packages/app/src/modules/admin/stats/MatomoFunnelChart.tsx
+++ b/packages/app/src/modules/admin/stats/MatomoFunnelChart.tsx
@@ -1,0 +1,55 @@
+import { FUNNEL_DROP_ALERT_THRESHOLD } from "~/modules/domain";
+
+import { CompletionFunnelChart } from "./CompletionFunnelChart";
+import type { FunnelRow, MatomoFunnelOutput } from "./types";
+
+export function buildMatomoFunnelRows(data: MatomoFunnelOutput): FunnelRow[] {
+	const entries = [
+		{ key: "funnel_start", label: "Entrées", count: data.startedCount },
+		...data.steps.map((step) => ({
+			key: step.stepKey,
+			label: step.label,
+			count: step.completedCount,
+		})),
+		{
+			key: "funnel_complete",
+			label: "Complétions",
+			count: data.completedCount,
+		},
+	];
+
+	const start = data.startedCount;
+	let previous: number | null = null;
+
+	return entries.map((entry) => {
+		const pctOfStart = start > 0 ? Math.round((entry.count / start) * 100) : 0;
+		const pctDropFromPrev =
+			previous !== null && previous > 0
+				? Math.round(((previous - entry.count) / previous) * 100)
+				: null;
+		previous = entry.count;
+		return {
+			key: entry.key,
+			label: entry.label,
+			count: entry.count,
+			pctOfStart,
+			pctDropFromPrev,
+		};
+	});
+}
+
+type Props = {
+	caption: string;
+	data: MatomoFunnelOutput;
+};
+
+export function MatomoFunnelChart({ caption, data }: Props) {
+	return (
+		<CompletionFunnelChart
+			caption={caption}
+			dropThreshold={FUNNEL_DROP_ALERT_THRESHOLD}
+			rows={buildMatomoFunnelRows(data)}
+			unitNoun="parcours"
+		/>
+	);
+}

--- a/packages/app/src/modules/admin/stats/MatomoFunnelTable.tsx
+++ b/packages/app/src/modules/admin/stats/MatomoFunnelTable.tsx
@@ -1,0 +1,72 @@
+import { formatCount } from "./formatters";
+import type { MatomoFunnelOutput } from "./types";
+
+function formatDurationSeconds(value: number | null): string {
+	if (value === null) return "—";
+	if (value < 60) return `${value} s`;
+	const minutes = Math.floor(value / 60);
+	const seconds = value % 60;
+	return seconds === 0 ? `${minutes} min` : `${minutes} min ${seconds} s`;
+}
+
+type Props = {
+	caption: string;
+	data: MatomoFunnelOutput;
+};
+
+/**
+ * Accessible alternative to `<MatomoFunnelChart>` — the same K20/K21 dataset as
+ * a DSFR table, with the per-step average durations the funnel chart cannot
+ * show. Required for RGAA because the chart is rendered as a canvas.
+ */
+export function MatomoFunnelTable({ caption, data }: Props) {
+	return (
+		<details className="fr-mt-3w">
+			<summary className="fr-text--sm">
+				Consulter les données du graphique sous forme de tableau
+			</summary>
+			<div className="fr-table fr-table--bordered fr-mt-2w">
+				<div className="fr-table__wrapper">
+					<div className="fr-table__container">
+						<div className="fr-table__content">
+							<table>
+								<caption className="fr-sr-only">{caption}</caption>
+								<thead>
+									<tr>
+										<th scope="col">Étape</th>
+										<th scope="col">Parcours</th>
+										<th scope="col">Durée moyenne</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<th scope="row">Entrées</th>
+										<td>{formatCount(data.startedCount)}</td>
+										<td>—</td>
+									</tr>
+									{data.steps.map((step) => (
+										<tr key={step.stepKey}>
+											<th scope="row">{step.label}</th>
+											<td>{formatCount(step.completedCount)}</td>
+											<td>{formatDurationSeconds(step.avgDurationSeconds)}</td>
+										</tr>
+									))}
+									<tr>
+										<th scope="row">Complétions</th>
+										<td>{formatCount(data.completedCount)}</td>
+										<td>—</td>
+									</tr>
+									<tr>
+										<th scope="row">Abandons</th>
+										<td>{formatCount(data.abandonedCount)}</td>
+										<td>—</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+		</details>
+	);
+}

--- a/packages/app/src/modules/admin/stats/StatsDashboard.tsx
+++ b/packages/app/src/modules/admin/stats/StatsDashboard.tsx
@@ -14,6 +14,9 @@ import { CampaignProgressionTable } from "./CampaignProgressionTable";
 import { CampaignRateTile } from "./CampaignRateTile";
 import { CompletionFunnelChart } from "./CompletionFunnelChart";
 import { CompletionFunnelTable } from "./CompletionFunnelTable";
+import { formatCount } from "./formatters";
+import { MatomoFunnelChart } from "./MatomoFunnelChart";
+import { MatomoFunnelTable } from "./MatomoFunnelTable";
 import { StagnationDaysFilter } from "./StagnationDaysFilter";
 import styles from "./StatsDashboard.module.scss";
 import { StepDropoffChart } from "./StepDropoffChart";
@@ -73,6 +76,14 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 	);
 
 	const funnelQuery = api.adminStats.getCompletionFunnel.useQuery(
+		{ year: activeYear, sizeRange },
+		{
+			enabled: selectedYears.length > 0,
+			placeholderData: (prev) => prev,
+		},
+	);
+
+	const matomoFunnelQuery = api.adminStats.getMatomoFunnel.useQuery(
 		{ year: activeYear, sizeRange },
 		{
 			enabled: selectedYears.length > 0,
@@ -337,6 +348,60 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 										Aucune déclaration avec CSE pour ces filtres.
 									</p>
 								)}
+							</section>
+						</div>
+					</div>
+				)}
+			</section>
+
+			<section className="fr-mt-6w" id="comportement">
+				<h2 className="fr-h2">
+					Parcours de déclaration — comportement réel (Matomo)
+				</h2>
+				<p>
+					Funnel comportemental du parcours de déclaration mesuré via Matomo :
+					entrées dans le tunnel, progression et durée moyenne par étape,
+					complétions et abandons — pour la campagne {activeYear}.
+				</p>
+
+				{matomoFunnelQuery.isLoading && !matomoFunnelQuery.data && (
+					<p aria-live="polite" className="fr-mt-4w">
+						Chargement des données Matomo…
+					</p>
+				)}
+				{matomoFunnelQuery.isError && (
+					<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-4w">
+						<p>
+							Les statistiques Matomo sont indisponibles pour le moment. Les
+							autres indicateurs de cette page restent consultables.
+						</p>
+					</div>
+				)}
+
+				{matomoFunnelQuery.data && (
+					<div className="fr-grid-row fr-grid-row--gutters fr-mt-4w">
+						<div className="fr-col-12">
+							<section
+								aria-labelledby="matomo-funnel-heading"
+								className={styles.card}
+							>
+								<h3 className="fr-h3" id="matomo-funnel-heading">
+									Funnel du parcours de déclaration
+								</h3>
+								<p className="fr-text--sm fr-text-mention--grey">
+									{formatCount(matomoFunnelQuery.data.startedCount)} entrées ·{" "}
+									{formatCount(matomoFunnelQuery.data.completedCount)}{" "}
+									complétions ·{" "}
+									{formatCount(matomoFunnelQuery.data.abandonedCount)} abandons
+								</p>
+								<MatomoFunnelChart
+									caption="Funnel du parcours de déclaration — comportement réel (Matomo)"
+									data={matomoFunnelQuery.data}
+								/>
+								<MatomoFunnelTable
+									caption="Funnel du parcours de déclaration — comportement réel (Matomo)"
+									data={matomoFunnelQuery.data}
+								/>
 							</section>
 						</div>
 					</div>

--- a/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelChart.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMatomoFunnelRows } from "../MatomoFunnelChart";
+
+describe("buildMatomoFunnelRows", () => {
+	it("builds Entrées → steps → Complétions rows with funnel percentages", () => {
+		const rows = buildMatomoFunnelRows({
+			startedCount: 1000,
+			completedCount: 400,
+			abandonedCount: 600,
+			steps: [
+				{
+					stepKey: "step_1",
+					label: "Effectifs",
+					completedCount: 900,
+					avgDurationSeconds: 12,
+				},
+				{
+					stepKey: "step_2",
+					label: "Écart de rémunération",
+					completedCount: 700,
+					avgDurationSeconds: 30,
+				},
+			],
+		});
+
+		expect(rows).toEqual([
+			{
+				key: "funnel_start",
+				label: "Entrées",
+				count: 1000,
+				pctOfStart: 100,
+				pctDropFromPrev: null,
+			},
+			{
+				key: "step_1",
+				label: "Effectifs",
+				count: 900,
+				pctOfStart: 90,
+				pctDropFromPrev: 10,
+			},
+			{
+				key: "step_2",
+				label: "Écart de rémunération",
+				count: 700,
+				pctOfStart: 70,
+				pctDropFromPrev: 22,
+			},
+			{
+				key: "funnel_complete",
+				label: "Complétions",
+				count: 400,
+				pctOfStart: 40,
+				pctDropFromPrev: 43,
+			},
+		]);
+	});
+
+	it("returns zero percentages and no drop when there are no entries", () => {
+		const rows = buildMatomoFunnelRows({
+			startedCount: 0,
+			completedCount: 0,
+			abandonedCount: 0,
+			steps: [],
+		});
+
+		expect(rows).toEqual([
+			{
+				key: "funnel_start",
+				label: "Entrées",
+				count: 0,
+				pctOfStart: 0,
+				pctDropFromPrev: null,
+			},
+			{
+				key: "funnel_complete",
+				label: "Complétions",
+				count: 0,
+				pctOfStart: 0,
+				pctDropFromPrev: null,
+			},
+		]);
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelTable.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelTable.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MatomoFunnelTable } from "../MatomoFunnelTable";
+
+const DATA = {
+	startedCount: 1000,
+	completedCount: 400,
+	abandonedCount: 600,
+	steps: [
+		{
+			stepKey: "step_1",
+			label: "Effectifs",
+			completedCount: 900,
+			avgDurationSeconds: 12,
+		},
+		{
+			stepKey: "step_2",
+			label: "Écart de rémunération",
+			completedCount: 700,
+			avgDurationSeconds: null,
+		},
+	],
+};
+
+describe("MatomoFunnelTable", () => {
+	it("renders the funnel bounds, per-step counts and durations", () => {
+		render(<MatomoFunnelTable caption="Funnel Matomo" data={DATA} />);
+
+		expect(screen.getByText("Entrées")).toBeInTheDocument();
+		expect(screen.getByText("Complétions")).toBeInTheDocument();
+		expect(screen.getByText("Abandons")).toBeInTheDocument();
+		expect(screen.getByText("Effectifs")).toBeInTheDocument();
+		expect(screen.getByText("Écart de rémunération")).toBeInTheDocument();
+
+		const stepRow = screen.getByText("Effectifs").closest("tr");
+		expect(stepRow).not.toBeNull();
+		expect(stepRow).toHaveTextContent("900");
+		expect(stepRow).toHaveTextContent("12");
+
+		const nullDurationRow = screen
+			.getByText("Écart de rémunération")
+			.closest("tr");
+		expect(nullDurationRow).toHaveTextContent("—");
+	});
+
+	it("provides an accessible caption", () => {
+		render(<MatomoFunnelTable caption="Funnel Matomo" data={DATA} />);
+		expect(
+			screen.getByRole("table", { name: "Funnel Matomo" }),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.campaign.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.campaign.test.tsx
@@ -5,6 +5,7 @@ const progressionUseQueryMock = vi.fn();
 const stepDurationsUseQueryMock = vi.fn();
 const stepDropoffUseQueryMock = vi.fn();
 const funnelUseQueryMock = vi.fn();
+const matomoFunnelUseQueryMock = vi.fn();
 const statsUseQueryMock = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
@@ -24,6 +25,9 @@ vi.mock("~/trpc/react", () => ({
 			},
 			getCompletionFunnel: {
 				useQuery: (...args: unknown[]) => funnelUseQueryMock(...args),
+			},
+			getMatomoFunnel: {
+				useQuery: (...args: unknown[]) => matomoFunnelUseQueryMock(...args),
 			},
 		},
 	},
@@ -53,6 +57,12 @@ vi.mock("../CompletionFunnelChart", () => ({
 vi.mock("../CompletionFunnelTable", () => ({
 	CompletionFunnelTable: () => <div data-testid="funnel-table" />,
 }));
+vi.mock("../MatomoFunnelChart", () => ({
+	MatomoFunnelChart: () => <div data-testid="matomo-funnel-chart" />,
+}));
+vi.mock("../MatomoFunnelTable", () => ({
+	MatomoFunnelTable: () => <div data-testid="matomo-funnel-table" />,
+}));
 vi.mock("../CampaignRateTile", () => ({
 	CampaignRateTile: () => <div data-testid="campaign-rate-tile" />,
 }));
@@ -67,6 +77,7 @@ const defaultMocks = () =>
 		stepDurationsUseQueryMock,
 		stepDropoffUseQueryMock,
 		funnelUseQueryMock,
+		matomoFunnelUseQueryMock,
 	});
 
 describe("StatsDashboard — campaign section states", () => {
@@ -75,6 +86,7 @@ describe("StatsDashboard — campaign section states", () => {
 		stepDurationsUseQueryMock.mockReset();
 		stepDropoffUseQueryMock.mockReset();
 		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
 		statsUseQueryMock.mockReset();
 		defaultMocks();
 	});
@@ -215,6 +227,7 @@ describe("StatsDashboard — query options", () => {
 		stepDurationsUseQueryMock.mockReset();
 		stepDropoffUseQueryMock.mockReset();
 		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
 		statsUseQueryMock.mockReset();
 		defaultMocks();
 	});

--- a/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.test.tsx
@@ -5,6 +5,7 @@ const progressionUseQueryMock = vi.fn();
 const stepDurationsUseQueryMock = vi.fn();
 const stepDropoffUseQueryMock = vi.fn();
 const funnelUseQueryMock = vi.fn();
+const matomoFunnelUseQueryMock = vi.fn();
 const statsUseQueryMock = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
@@ -24,6 +25,9 @@ vi.mock("~/trpc/react", () => ({
 			},
 			getCompletionFunnel: {
 				useQuery: (...args: unknown[]) => funnelUseQueryMock(...args),
+			},
+			getMatomoFunnel: {
+				useQuery: (...args: unknown[]) => matomoFunnelUseQueryMock(...args),
 			},
 		},
 	},
@@ -53,6 +57,12 @@ vi.mock("../CompletionFunnelChart", () => ({
 vi.mock("../CompletionFunnelTable", () => ({
 	CompletionFunnelTable: () => <div data-testid="funnel-table" />,
 }));
+vi.mock("../MatomoFunnelChart", () => ({
+	MatomoFunnelChart: () => <div data-testid="matomo-funnel-chart" />,
+}));
+vi.mock("../MatomoFunnelTable", () => ({
+	MatomoFunnelTable: () => <div data-testid="matomo-funnel-table" />,
+}));
 vi.mock("../CampaignRateTile", () => ({
 	CampaignRateTile: () => <div data-testid="campaign-rate-tile" />,
 }));
@@ -70,6 +80,7 @@ const defaultMocks = () =>
 		stepDurationsUseQueryMock,
 		stepDropoffUseQueryMock,
 		funnelUseQueryMock,
+		matomoFunnelUseQueryMock,
 	});
 
 describe("StatsDashboard — structure and filters", () => {
@@ -78,6 +89,7 @@ describe("StatsDashboard — structure and filters", () => {
 		stepDurationsUseQueryMock.mockReset();
 		stepDropoffUseQueryMock.mockReset();
 		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
 		statsUseQueryMock.mockReset();
 		defaultMocks();
 	});
@@ -246,5 +258,71 @@ describe("StatsDashboard — funnel section", () => {
 			| { placeholderData: (prev: unknown) => unknown }
 			| undefined;
 		expect(options?.placeholderData("prev-value")).toBe("prev-value");
+	});
+});
+
+describe("StatsDashboard — Matomo behavioural funnel (K20/K21)", () => {
+	beforeEach(() => {
+		progressionUseQueryMock.mockReset();
+		stepDurationsUseQueryMock.mockReset();
+		stepDropoffUseQueryMock.mockReset();
+		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
+		statsUseQueryMock.mockReset();
+		defaultMocks();
+	});
+
+	it("renders the Matomo funnel section with chart and table when data is available (S8)", () => {
+		matomoFunnelUseQueryMock.mockReturnValue({
+			data: {
+				startedCount: 120,
+				completedCount: 80,
+				abandonedCount: 40,
+				steps: [
+					{
+						stepKey: "step_1",
+						label: "Effectifs",
+						completedCount: 110,
+						avgDurationSeconds: 12,
+					},
+				],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		render(
+			<StatsDashboard availableYears={[2026, 2025, 2024]} currentYear={2026} />,
+		);
+		expect(
+			screen.getByRole("heading", { name: /comportement réel \(Matomo\)/i }),
+		).toBeInTheDocument();
+		expect(screen.getByTestId("matomo-funnel-chart")).toBeInTheDocument();
+		expect(screen.getByTestId("matomo-funnel-table")).toBeInTheDocument();
+	});
+
+	it("shows a Matomo error alert without breaking the DB widgets (S13)", () => {
+		matomoFunnelUseQueryMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		render(
+			<StatsDashboard availableYears={[2026, 2025, 2024]} currentYear={2026} />,
+		);
+		expect(
+			screen.getByText(/statistiques Matomo sont indisponibles/i),
+		).toBeInTheDocument();
+		expect(screen.getAllByTestId("funnel-chart").length).toBeGreaterThan(0);
+		expect(screen.queryByTestId("matomo-funnel-chart")).not.toBeInTheDocument();
+	});
+
+	it("synchronises the Matomo query with the active year filter (S11)", () => {
+		render(
+			<StatsDashboard availableYears={[2026, 2025, 2024]} currentYear={2026} />,
+		);
+		const input = matomoFunnelUseQueryMock.mock.calls[0]?.[0] as {
+			year: number;
+		};
+		expect(input.year).toBe(2026);
 	});
 });

--- a/packages/app/src/modules/admin/stats/__tests__/helpers/statsDashboardMocks.ts
+++ b/packages/app/src/modules/admin/stats/__tests__/helpers/statsDashboardMocks.ts
@@ -13,6 +13,7 @@ type QueryMocks = {
 	stepDurationsUseQueryMock: Mock;
 	stepDropoffUseQueryMock: Mock;
 	funnelUseQueryMock: Mock;
+	matomoFunnelUseQueryMock: Mock;
 };
 
 export function setDefaultMocks(mocks: QueryMocks) {
@@ -38,6 +39,16 @@ export function setDefaultMocks(mocks: QueryMocks) {
 	});
 	mocks.funnelUseQueryMock.mockReturnValue({
 		data: emptyFunnelData,
+		isLoading: false,
+		isError: false,
+	});
+	mocks.matomoFunnelUseQueryMock.mockReturnValue({
+		data: {
+			startedCount: 0,
+			completedCount: 0,
+			abandonedCount: 0,
+			steps: [],
+		},
 		isLoading: false,
 		isError: false,
 	});

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -16,6 +16,7 @@ export type {
 	GetCampaignProgressionInput,
 	GetCampaignStatsInput,
 	GetCompletionFunnelInput,
+	GetMatomoFunnelInput,
 	GetStepDropoffRateInput,
 	GetStepDurationsInput,
 } from "./schemas";
@@ -23,6 +24,7 @@ export {
 	getCampaignProgressionSchema,
 	getCampaignStatsSchema,
 	getCompletionFunnelSchema,
+	getMatomoFunnelSchema,
 	getStepDropoffRateSchema,
 	getStepDurationsSchema,
 } from "./schemas";
@@ -32,6 +34,8 @@ export type {
 	CampaignStats,
 	CompletionFunnelOutput,
 	FunnelRow,
+	MatomoFunnelOutput,
+	MatomoFunnelRow,
 	StepDropoffRow,
 	StepDurationRow,
 } from "./types";

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -6,6 +6,8 @@ export { CampaignRateTile } from "./CampaignRateTile";
 export { CompletionFunnelChart } from "./CompletionFunnelChart";
 export { CompletionFunnelTable } from "./CompletionFunnelTable";
 export { formatCount, formatDays, formatPercent } from "./formatters";
+export { MatomoFunnelChart } from "./MatomoFunnelChart";
+export { MatomoFunnelTable } from "./MatomoFunnelTable";
 export { StagnationDaysFilter } from "./StagnationDaysFilter";
 export { StatsDashboard } from "./StatsDashboard";
 export { StepDropoffChart } from "./StepDropoffChart";

--- a/packages/app/src/modules/admin/stats/matomoFunnel.ts
+++ b/packages/app/src/modules/admin/stats/matomoFunnel.ts
@@ -1,0 +1,79 @@
+import {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+} from "~/modules/analytics/shared/events";
+import { type CompanySizeRange, getStepLabel } from "~/modules/domain";
+import type { MatomoEventsReportRow } from "~/server/services/matomo";
+import type { MatomoFunnelOutput, MatomoFunnelRow } from "./types";
+
+// Campaign year N is declared in early N+1, so the funnel is filtered on the
+// CAMPAIGN_YEAR custom dimension, not the event date — the Matomo query spans a
+// wide range and lets the segment do the year scoping.
+export const MATOMO_FUNNEL_DATE_RANGE = "2020-01-01,today";
+
+export function buildMatomoFunnelSegment({
+	year,
+	sizeRange,
+}: {
+	year: number;
+	sizeRange?: CompanySizeRange;
+}): string {
+	const parts = [
+		`eventCategory==${MATOMO_EVENT_CATEGORY.DECLARATION}`,
+		`dimension${MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR}==${year}`,
+	];
+	if (sizeRange) {
+		parts.push(
+			`dimension${MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE}==${sizeRange}`,
+		);
+	}
+	return parts.join(";");
+}
+
+function parseStepNumber(stepKey: string): number | null {
+	const match = /^step_(\d+)$/.exec(stepKey);
+	return match?.[1] !== undefined ? Number(match[1]) : null;
+}
+
+function countForAction(rows: MatomoEventsReportRow[], action: string): number {
+	return rows.find((row) => row.label === action)?.nb_events ?? 0;
+}
+
+export function mapMatomoFunnel(
+	actionRows: MatomoEventsReportRow[],
+	stepRows: MatomoEventsReportRow[],
+): MatomoFunnelOutput {
+	const steps: MatomoFunnelRow[] = stepRows
+		.map((row): (MatomoFunnelRow & { step: number }) | null => {
+			const step = parseStepNumber(row.label);
+			if (step === null) return null;
+			const avg = row.avg_event_value;
+			return {
+				step,
+				stepKey: row.label,
+				label: getStepLabel(step),
+				completedCount: row.nb_events ?? 0,
+				avgDurationSeconds: typeof avg === "number" ? Math.round(avg) : null,
+			};
+		})
+		.filter((row): row is MatomoFunnelRow & { step: number } => row !== null)
+		.sort((a, b) => a.step - b.step)
+		.map(({ step: _step, ...row }) => row);
+
+	return {
+		startedCount: countForAction(
+			actionRows,
+			MATOMO_DECLARATION_ACTION.FUNNEL_START,
+		),
+		completedCount: countForAction(
+			actionRows,
+			MATOMO_DECLARATION_ACTION.FUNNEL_COMPLETE,
+		),
+		abandonedCount: countForAction(
+			actionRows,
+			MATOMO_DECLARATION_ACTION.FUNNEL_ABANDON,
+		),
+		steps,
+	};
+}

--- a/packages/app/src/modules/admin/stats/schemas.ts
+++ b/packages/app/src/modules/admin/stats/schemas.ts
@@ -88,3 +88,15 @@ export const getCompletionFunnelSchema = z.object({
 export type GetCompletionFunnelInput = z.infer<
 	typeof getCompletionFunnelSchema
 >;
+
+/**
+ * Input for `adminStats.getMatomoFunnel`. Same `{ year, sizeRange? }` filter
+ * couple as the DB-backed widgets — but applied to Matomo via a segment on the
+ * campaign-year / workforce custom dimensions, never a calendar date range.
+ */
+export const getMatomoFunnelSchema = z.object({
+	year: z.number().int().min(2000).max(2100),
+	sizeRange: z.enum(COMPANY_SIZE_RANGE_KEYS).optional(),
+});
+
+export type GetMatomoFunnelInput = z.infer<typeof getMatomoFunnelSchema>;

--- a/packages/app/src/modules/admin/stats/types.ts
+++ b/packages/app/src/modules/admin/stats/types.ts
@@ -113,3 +113,25 @@ export type CompletionFunnelOutput = {
 	revisionFunnel: FunnelRow[];
 	cseFunnel: FunnelRow[];
 };
+
+/**
+ * One declaration-funnel step as measured by Matomo (`adminStats.getMatomoFunnel`).
+ * `avgDurationSeconds` is null when Matomo reported no timed completion.
+ */
+export type MatomoFunnelRow = {
+	stepKey: string;
+	label: string;
+	completedCount: number;
+	avgDurationSeconds: number | null;
+};
+
+/**
+ * Output of `adminStats.getMatomoFunnel` — the behavioural funnel of the
+ * declaration journey collected via Matomo events (K20/K21).
+ */
+export type MatomoFunnelOutput = {
+	startedCount: number;
+	completedCount: number;
+	abandonedCount: number;
+	steps: MatomoFunnelRow[];
+};

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -61,6 +61,7 @@ export const AUDIT_ACTIONS = {
 	ADMIN_STATS_GET_STEP_DURATIONS: "admin_stats.get_step_durations",
 	ADMIN_STATS_GET_STEP_DROPOFF_RATE: "admin_stats.get_step_dropoff_rate",
 	ADMIN_STATS_GET_COMPLETION_FUNNEL: "admin_stats.get_completion_funnel",
+	ADMIN_STATS_GET_MATOMO_FUNNEL: "admin_stats.get_matomo_funnel",
 
 	// ── Declaration draft ─────────────────────────────────
 	DRAFT_READ: "declaration_draft.read",
@@ -149,6 +150,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DURATIONS]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DROPOFF_RATE]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_COMPLETION_FUNNEL]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_FUNNEL]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_SAVE]: "mutation",
 	[AUDIT_ACTIONS.DRAFT_CLEAR]: "mutation",

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { getCompanySizeRange } from "~/modules/domain";
 import type { GipPrefillData } from "./shared/gipMdsMapping";
+import { useFunnelTracking } from "./shared/useFunnelTracking";
 import { Step1Workforce } from "./steps/Step1Workforce";
 import { Step2PayGap } from "./steps/Step2PayGap";
 import { Step3VariablePay } from "./steps/Step3VariablePay";
@@ -46,6 +48,15 @@ export function StepPageClient({
 	initialSource,
 	hasCse = null,
 }: StepPageClientProps) {
+	const workforce =
+		declaration.totalWomen !== null && declaration.totalMen !== null
+			? declaration.totalWomen + declaration.totalMen
+			: null;
+	const sizeRange =
+		workforce !== null ? getCompanySizeRange(workforce) : undefined;
+
+	useFunnelTracking({ step, year: declaration.year, sizeRange });
+
 	switch (step) {
 		case 1:
 			return (

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/useFunnelTracking.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/useFunnelTracking.test.ts
@@ -1,0 +1,155 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { trackEventMock } = vi.hoisted(() => ({ trackEventMock: vi.fn() }));
+
+vi.mock("~/modules/analytics", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/analytics")>();
+	return { ...actual, trackEvent: trackEventMock };
+});
+
+import {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+} from "~/modules/analytics";
+
+import { trackFunnelComplete, useFunnelTracking } from "../useFunnelTracking";
+
+const nowSpy = vi.spyOn(Date, "now");
+
+beforeEach(() => {
+	sessionStorage.clear();
+	trackEventMock.mockReset();
+	nowSpy.mockReturnValue(1_000);
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+function lastEvent() {
+	return trackEventMock.mock.calls.at(-1)?.[0];
+}
+
+describe("useFunnelTracking", () => {
+	it("emits funnel_start once on entering step 1, with the campaign-year dimension", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+
+		expect(trackEventMock).toHaveBeenCalledTimes(1);
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_START,
+			dimensions: { [MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024" },
+		});
+	});
+
+	it("does not re-emit funnel_start on a fresh mount at step 1 (anti-double via sessionStorage)", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+		trackEventMock.mockReset();
+
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+
+		expect(trackEventMock).not.toHaveBeenCalled();
+	});
+
+	it("emits step_complete with the step key, duration in seconds and both dimensions on a forward transition", () => {
+		const { rerender } = renderHook((props) => useFunnelTracking(props), {
+			initialProps: {
+				step: 1,
+				year: 2024,
+				sizeRange: undefined as string | undefined,
+			},
+		});
+		trackEventMock.mockReset();
+
+		nowSpy.mockReturnValue(6_000);
+		rerender({ step: 2, year: 2024, sizeRange: "50-99" });
+
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.STEP_COMPLETE,
+			name: "step_1",
+			value: 5,
+			dimensions: {
+				[MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024",
+				[MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE]: "50-99",
+			},
+		});
+	});
+
+	it("emits funnel_abandon with the current step key and total duration on beforeunload", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+		trackEventMock.mockReset();
+
+		nowSpy.mockReturnValue(9_000);
+		window.dispatchEvent(new Event("beforeunload"));
+
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_ABANDON,
+			name: "step_1",
+			value: 8,
+			dimensions: { [MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024" },
+		});
+	});
+
+	it("does not emit any PII (only category, action, name, value, anonymised dimensions)", () => {
+		const { rerender } = renderHook((props) => useFunnelTracking(props), {
+			initialProps: {
+				step: 1,
+				year: 2024,
+				sizeRange: "50-99" as string | undefined,
+			},
+		});
+		nowSpy.mockReturnValue(3_000);
+		rerender({ step: 2, year: 2024, sizeRange: "50-99" });
+
+		for (const call of trackEventMock.mock.calls) {
+			const event = call[0];
+			expect(Object.keys(event).sort()).not.toContain("siren");
+			const serialised = JSON.stringify(event);
+			expect(serialised).not.toMatch(/\d{9}/);
+			expect(serialised).not.toMatch(/@/);
+		}
+	});
+});
+
+describe("trackFunnelComplete", () => {
+	it("emits funnel_complete with the total duration and clears the funnel state", () => {
+		renderHook((props) => useFunnelTracking(props), {
+			initialProps: { step: 1, year: 2024, sizeRange: undefined },
+		});
+		trackEventMock.mockReset();
+
+		nowSpy.mockReturnValue(11_000);
+		trackFunnelComplete({ sizeRange: "50-99" });
+
+		expect(lastEvent()).toEqual({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.FUNNEL_COMPLETE,
+			value: 10,
+			dimensions: {
+				[MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: "2024",
+				[MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE]: "50-99",
+			},
+		});
+
+		trackEventMock.mockReset();
+		window.dispatchEvent(new Event("beforeunload"));
+		expect(trackEventMock).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op when no funnel is in progress", () => {
+		trackFunnelComplete({ sizeRange: undefined });
+		expect(trackEventMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/useFunnelTracking.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/useFunnelTracking.ts
@@ -1,0 +1,145 @@
+import { useEffect } from "react";
+
+import {
+	MATOMO_CUSTOM_DIMENSION,
+	MATOMO_DECLARATION_ACTION,
+	MATOMO_EVENT_CATEGORY,
+	MATOMO_FUNNEL_STEP_KEYS,
+	trackEvent,
+} from "~/modules/analytics";
+
+const STORAGE_KEY = "egapro:declaration-funnel";
+const FIRST_FUNNEL_STEP = 1;
+const LAST_FUNNEL_STEP = MATOMO_FUNNEL_STEP_KEYS.length - 1;
+
+type FunnelState = {
+	startedAt: number;
+	stepEnteredAt: number;
+	currentStep: number;
+	year: number;
+};
+
+type FunnelContext = {
+	step: number;
+	year: number;
+	sizeRange?: string;
+};
+
+function readState(): FunnelState | null {
+	if (typeof window === "undefined") return null;
+	const raw = sessionStorage.getItem(STORAGE_KEY);
+	if (!raw) return null;
+	try {
+		return JSON.parse(raw) as FunnelState;
+	} catch {
+		return null;
+	}
+}
+
+function writeState(state: FunnelState): void {
+	if (typeof window === "undefined") return;
+	sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function clearState(): void {
+	if (typeof window === "undefined") return;
+	sessionStorage.removeItem(STORAGE_KEY);
+}
+
+function buildDimensions(
+	year: number,
+	sizeRange?: string,
+): Record<number, string> {
+	const dimensions: Record<number, string> = {
+		[MATOMO_CUSTOM_DIMENSION.CAMPAIGN_YEAR]: String(year),
+	};
+	if (sizeRange) {
+		dimensions[MATOMO_CUSTOM_DIMENSION.WORKFORCE_RANGE] = sizeRange;
+	}
+	return dimensions;
+}
+
+function elapsedSeconds(from: number, to: number): number {
+	return Math.round((to - from) / 1000);
+}
+
+function handleStepEnter({ step, year, sizeRange }: FunnelContext): void {
+	if (step < FIRST_FUNNEL_STEP || step > LAST_FUNNEL_STEP) return;
+
+	const now = Date.now();
+	const state = readState();
+
+	if (!state) {
+		if (step === FIRST_FUNNEL_STEP) {
+			trackEvent({
+				category: MATOMO_EVENT_CATEGORY.DECLARATION,
+				action: MATOMO_DECLARATION_ACTION.FUNNEL_START,
+				dimensions: buildDimensions(year, sizeRange),
+			});
+		}
+		writeState({ startedAt: now, stepEnteredAt: now, currentStep: step, year });
+		return;
+	}
+
+	if (step > state.currentStep) {
+		trackEvent({
+			category: MATOMO_EVENT_CATEGORY.DECLARATION,
+			action: MATOMO_DECLARATION_ACTION.STEP_COMPLETE,
+			name: MATOMO_FUNNEL_STEP_KEYS[state.currentStep],
+			value: elapsedSeconds(state.stepEnteredAt, now),
+			dimensions: buildDimensions(year, sizeRange),
+		});
+		writeState({ ...state, currentStep: step, stepEnteredAt: now });
+		return;
+	}
+
+	if (step < state.currentStep) {
+		writeState({ ...state, currentStep: step, stepEnteredAt: now });
+	}
+}
+
+function emitAbandon(sizeRange?: string): void {
+	const state = readState();
+	if (!state) return;
+	trackEvent({
+		category: MATOMO_EVENT_CATEGORY.DECLARATION,
+		action: MATOMO_DECLARATION_ACTION.FUNNEL_ABANDON,
+		name: MATOMO_FUNNEL_STEP_KEYS[state.currentStep],
+		value: elapsedSeconds(state.startedAt, Date.now()),
+		dimensions: buildDimensions(state.year, sizeRange),
+	});
+}
+
+export function useFunnelTracking({
+	step,
+	year,
+	sizeRange,
+}: FunnelContext): void {
+	useEffect(() => {
+		handleStepEnter({ step, year, sizeRange });
+	}, [step, year, sizeRange]);
+
+	useEffect(() => {
+		function handleBeforeUnload(): void {
+			emitAbandon(sizeRange);
+		}
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+	}, [sizeRange]);
+}
+
+export function trackFunnelComplete({
+	sizeRange,
+}: {
+	sizeRange?: string;
+}): void {
+	const state = readState();
+	if (!state) return;
+	trackEvent({
+		category: MATOMO_EVENT_CATEGORY.DECLARATION,
+		action: MATOMO_DECLARATION_ACTION.FUNNEL_COMPLETE,
+		value: elapsedSeconds(state.startedAt, Date.now()),
+		dimensions: buildDimensions(state.year, sizeRange),
+	});
+	clearState();
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -2,10 +2,15 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
-import { computeGap, GAP_ALERT_THRESHOLD } from "~/modules/domain";
+import {
+	computeGap,
+	GAP_ALERT_THRESHOLD,
+	getCompanySizeRange,
+} from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import { getCurrentStageHref } from "../shared/complianceNavigation";
+import { trackFunnelComplete } from "../shared/useFunnelTracking";
 import { FormActions } from "../shared/FormActions";
 import { NextStepsBox } from "../shared/NextStepsBox";
 import { SavedIndicator } from "../shared/SavedIndicator";
@@ -54,8 +59,16 @@ export function Step6Review({
 }: Props) {
 	const router = useRouter();
 	const modalRef = useRef<HTMLDialogElement>(null);
+	const workforce =
+		declaration.totalWomen !== null && declaration.totalMen !== null
+			? declaration.totalWomen + declaration.totalMen
+			: null;
 	const submitMutation = api.declaration.submit.useMutation({
 		onSuccess: () => {
+			trackFunnelComplete({
+				sizeRange:
+					workforce !== null ? getCompanySizeRange(workforce) : undefined,
+			});
 			router.push("/declaration-remuneration/parcours-conformite");
 		},
 	});

--- a/packages/app/src/modules/domain/__tests__/companySize.test.ts
+++ b/packages/app/src/modules/domain/__tests__/companySize.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	COMPANY_SIZE_RANGES,
 	classifyCompanySize,
+	getCompanySizeRange,
 	isCseRequired,
 } from "../shared/companySize";
 
@@ -76,5 +77,20 @@ describe("COMPANY_SIZE_RANGES", () => {
 			max: null,
 			label: "250 salariés et plus",
 		});
+	});
+});
+
+describe("getCompanySizeRange", () => {
+	it("maps a workforce to its bucket key", () => {
+		expect(getCompanySizeRange(0)).toBe("<50");
+		expect(getCompanySizeRange(49)).toBe("<50");
+		expect(getCompanySizeRange(50)).toBe("50-99");
+		expect(getCompanySizeRange(99)).toBe("50-99");
+		expect(getCompanySizeRange(100)).toBe("100-149");
+		expect(getCompanySizeRange(149)).toBe("100-149");
+		expect(getCompanySizeRange(150)).toBe("150-249");
+		expect(getCompanySizeRange(249)).toBe("150-249");
+		expect(getCompanySizeRange(250)).toBe("250+");
+		expect(getCompanySizeRange(10000)).toBe("250+");
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -16,6 +16,7 @@ export { isObligatedForYear } from "./shared/companyObligation";
 export {
 	COMPANY_SIZE_RANGES,
 	classifyCompanySize,
+	getCompanySizeRange,
 	isCseRequired,
 } from "./shared/companySize";
 // Global score computation (sum of sub-scores from the EgaPro index)

--- a/packages/app/src/modules/domain/shared/companySize.ts
+++ b/packages/app/src/modules/domain/shared/companySize.ts
@@ -31,3 +31,17 @@ export const COMPANY_SIZE_RANGES: Record<
 	"150-249": { min: 150, max: 249, label: "150 à 249 salariés" },
 	"250+": { min: 250, max: null, label: "250 salariés et plus" },
 };
+
+/** Map a workforce headcount to its `CompanySizeRange` bucket key. */
+export function getCompanySizeRange(workforce: number): CompanySizeRange {
+	const entry = (
+		Object.entries(COMPANY_SIZE_RANGES) as Array<
+			[CompanySizeRange, (typeof COMPANY_SIZE_RANGES)[CompanySizeRange]]
+		>
+	).find(
+		([, { min, max }]) =>
+			workforce >= min && (max === null || workforce <= max),
+	);
+
+	return entry ? entry[0] : "250+";
+}

--- a/packages/app/src/server/api/routers/__tests__/adminStats.matomo.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.matomo.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchMatomoMock } = vi.hoisted(() => ({ fetchMatomoMock: vi.fn() }));
+
+vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
+vi.mock("~/server/db", () => ({ db: {} }));
+vi.mock("~/server/services/matomo", () => ({
+	fetchMatomoEventsReport: fetchMatomoMock,
+}));
+
+const adminSession = {
+	user: { id: "admin-1", email: "a@b.c", isAdmin: true },
+	expires: "",
+};
+
+const ACTION_ROWS = [
+	{ label: "funnel_start", nb_events: 100 },
+	{ label: "step_complete", nb_events: 250 },
+	{ label: "funnel_complete", nb_events: 60 },
+	{ label: "funnel_abandon", nb_events: 40 },
+];
+
+const STEP_ROWS = [
+	{ label: "step_2", nb_events: 70, avg_event_value: 30 },
+	{ label: "step_1", nb_events: 90, avg_event_value: 12 },
+];
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("adminStatsRouter.getMatomoFunnel", () => {
+	it("maps the Matomo report to funnel counts and per-step rows with domain labels", async () => {
+		fetchMatomoMock.mockImplementation(
+			async ({ method }: { method: string }) =>
+				method === "Events.getAction" ? ACTION_ROWS : STEP_ROWS,
+		);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getMatomoFunnel({
+			year: 2026,
+			sizeRange: "50-99",
+		});
+
+		expect(result.startedCount).toBe(100);
+		expect(result.completedCount).toBe(60);
+		expect(result.abandonedCount).toBe(40);
+		expect(result.steps).toEqual([
+			{
+				stepKey: "step_1",
+				label: "Effectifs",
+				completedCount: 90,
+				avgDurationSeconds: 12,
+			},
+			{
+				stepKey: "step_2",
+				label: "Écart de rémunération",
+				completedCount: 70,
+				avgDurationSeconds: 30,
+			},
+		]);
+	});
+
+	it("filters via a segment on the campaign-year and workforce custom dimensions (not by date)", async () => {
+		fetchMatomoMock.mockResolvedValue([]);
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await caller.getMatomoFunnel({ year: 2026, sizeRange: "50-99" });
+
+		const segments = fetchMatomoMock.mock.calls.map(
+			(call) => (call[0] as { segment: string }).segment,
+		);
+		expect(segments.length).toBeGreaterThan(0);
+		expect(segments.every((s) => s.includes("dimension1==2026"))).toBe(true);
+		expect(segments.every((s) => s.includes("dimension2==50-99"))).toBe(true);
+	});
+
+	it("propagates the error when the Matomo client throws (no silent empty data)", async () => {
+		fetchMatomoMock.mockRejectedValue(new Error("Matomo non configuré"));
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.getMatomoFunnel({ year: 2026 })).rejects.toThrow(
+			/Matomo/,
+		);
+	});
+
+	it("rejects non-admin callers", async () => {
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: {},
+			session: { user: { id: "u", email: "u@x", isAdmin: false }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.getMatomoFunnel({ year: 2026 })).rejects.toThrow(
+			/administrateurs/i,
+		);
+	});
+});

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -1,9 +1,15 @@
 import { and, between, eq, gte, inArray, type SQL, sql } from "drizzle-orm";
 
 import {
+	buildMatomoFunnelSegment,
+	MATOMO_FUNNEL_DATE_RANGE,
+	mapMatomoFunnel,
+} from "~/modules/admin/stats/matomoFunnel";
+import {
 	getCampaignProgressionSchema,
 	getCampaignStatsSchema,
 	getCompletionFunnelSchema,
+	getMatomoFunnelSchema,
 	getStepDropoffRateSchema,
 	getStepDurationsSchema,
 } from "~/modules/admin/stats/schemas";
@@ -13,9 +19,11 @@ import type {
 	CampaignStats,
 	CompletionFunnelOutput,
 	FunnelRow,
+	MatomoFunnelOutput,
 	StepDropoffRow,
 	StepDurationRow,
 } from "~/modules/admin/stats/types";
+import { MATOMO_DECLARATION_ACTION } from "~/modules/analytics/shared/events";
 import {
 	COMPANY_SIZE_ANNUAL_MIN,
 	COMPANY_SIZE_RANGES,
@@ -40,6 +48,7 @@ import {
 	declarations,
 	gipMdsData,
 } from "~/server/db/schema";
+import { fetchMatomoEventsReport } from "~/server/services/matomo";
 
 /** Minimum number of completed transitions before showing a median / p90. */
 const STEP_DURATION_MIN_SAMPLE = 5;
@@ -996,6 +1005,26 @@ export const adminStatsRouter = createTRPCRouter({
 				),
 				cseFunnel: buildFunnelRows(FUNNEL_CSE_KEY_STEPS, cseCounts),
 			};
+		}),
+	getMatomoFunnel: adminProcedure
+		.input(getMatomoFunnelSchema)
+		.query(async ({ input }): Promise<MatomoFunnelOutput> => {
+			const segment = buildMatomoFunnelSegment(input);
+			const [actionRows, stepRows] = await Promise.all([
+				fetchMatomoEventsReport({
+					method: "Events.getAction",
+					period: "range",
+					date: MATOMO_FUNNEL_DATE_RANGE,
+					segment,
+				}),
+				fetchMatomoEventsReport({
+					method: "Events.getName",
+					period: "range",
+					date: MATOMO_FUNNEL_DATE_RANGE,
+					segment: `${segment};eventAction==${MATOMO_DECLARATION_ACTION.STEP_COMPLETE}`,
+				}),
+			]);
+			return mapMatomoFunnel(actionRows, stepRows);
 		}),
 });
 function countDeclarationsWithEvent(opts: {

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -74,6 +74,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 		AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DROPOFF_RATE,
 	"adminStats.getCompletionFunnel":
 		AUDIT_ACTIONS.ADMIN_STATS_GET_COMPLETION_FUNNEL,
+	"adminStats.getMatomoFunnel": AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_FUNNEL,
 
 	// ── gip mds ────────────────────────────────────────────
 	"gipMds.importFromUrl": AUDIT_ACTIONS.GIP_MDS_IMPORT,

--- a/packages/app/src/server/services/__tests__/matomo.test.ts
+++ b/packages/app/src/server/services/__tests__/matomo.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnv } = vi.hoisted(() => ({
+	mockEnv: {
+		NEXT_PUBLIC_MATOMO_URL: "https://matomo.test" as string | undefined,
+		NEXT_PUBLIC_MATOMO_SITE_ID: "42" as string | undefined,
+		MATOMO_API_TOKEN: "super-secret-token" as string | undefined,
+	},
+}));
+
+vi.mock("~/env", () => ({ env: mockEnv }));
+
+import { fetchMatomoEventsReport } from "../matomo";
+
+const fetchSpy = vi.fn();
+
+beforeEach(() => {
+	mockEnv.NEXT_PUBLIC_MATOMO_URL = "https://matomo.test";
+	mockEnv.NEXT_PUBLIC_MATOMO_SITE_ID = "42";
+	mockEnv.MATOMO_API_TOKEN = "super-secret-token";
+	fetchSpy.mockReset();
+	vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("fetchMatomoEventsReport", () => {
+	it("builds the Reporting API request and returns the parsed rows", async () => {
+		const rows = [
+			{ label: "funnel_start", nb_events: 120 },
+			{ label: "funnel_complete", nb_events: 80 },
+		];
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => rows,
+		});
+
+		const result = await fetchMatomoEventsReport({
+			method: "Events.getAction",
+			period: "range",
+			date: "2025-01-01,2025-12-31",
+		});
+
+		expect(result).toEqual(rows);
+
+		const calledUrl = fetchSpy.mock.calls[0]?.[0] as URL;
+		expect(calledUrl.pathname).toBe("/index.php");
+		expect(calledUrl.searchParams.get("module")).toBe("API");
+		expect(calledUrl.searchParams.get("format")).toBe("json");
+		expect(calledUrl.searchParams.get("idSite")).toBe("42");
+		expect(calledUrl.searchParams.get("method")).toBe("Events.getAction");
+		expect(calledUrl.searchParams.get("period")).toBe("range");
+		expect(calledUrl.searchParams.get("date")).toBe("2025-01-01,2025-12-31");
+	});
+
+	it("never puts the token in the URL (sent in the request body)", async () => {
+		fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+		await fetchMatomoEventsReport({
+			method: "Events.getAction",
+			period: "range",
+			date: "2025-01-01,2025-12-31",
+		});
+
+		const calledUrl = fetchSpy.mock.calls[0]?.[0] as URL;
+		expect(calledUrl.href).not.toContain("super-secret-token");
+		expect(calledUrl.searchParams.get("token_auth")).toBeNull();
+	});
+
+	it("forwards the optional segment param when provided", async () => {
+		fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+		await fetchMatomoEventsReport({
+			method: "Events.getAction",
+			period: "range",
+			date: "2025-01-01,2025-12-31",
+			segment: "dimension1==2025",
+		});
+
+		const calledUrl = fetchSpy.mock.calls[0]?.[0] as URL;
+		expect(calledUrl.searchParams.get("segment")).toBe("dimension1==2025");
+	});
+
+	it("throws a clear error when Matomo is not configured", async () => {
+		mockEnv.MATOMO_API_TOKEN = undefined;
+
+		await expect(
+			fetchMatomoEventsReport({
+				method: "Events.getAction",
+				period: "range",
+				date: "2025-01-01,2025-12-31",
+			}),
+		).rejects.toThrow(/non configuré/i);
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("throws without leaking the token when the response is not ok", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			statusText: "Internal Server Error",
+			json: async () => ({}),
+		});
+
+		let caught: unknown;
+		try {
+			await fetchMatomoEventsReport({
+				method: "Events.getAction",
+				period: "range",
+				date: "2025-01-01,2025-12-31",
+			});
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(Error);
+		expect((caught as Error).message).not.toContain("super-secret-token");
+	});
+
+	it("throws when Matomo returns an API error payload", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ result: "error", message: "Invalid date range" }),
+		});
+
+		await expect(
+			fetchMatomoEventsReport({
+				method: "Events.getAction",
+				period: "range",
+				date: "bad,range",
+			}),
+		).rejects.toThrow();
+	});
+});

--- a/packages/app/src/server/services/matomo.ts
+++ b/packages/app/src/server/services/matomo.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { env } from "~/env";
+
+export type MatomoEventsReportRow = {
+	label: string;
+	nb_events: number;
+	nb_visits?: number;
+	nb_events_with_value?: number;
+	sum_event_value?: number;
+	avg_event_value?: number;
+	min_event_value?: number;
+	max_event_value?: number;
+	idsubdatatable?: number;
+};
+
+type FetchMatomoEventsReportParams = {
+	method: string;
+	period: string;
+	date: string;
+	segment?: string;
+};
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function isMatomoApiError(data: unknown): data is { message?: string } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		"result" in data &&
+		(data as { result?: unknown }).result === "error"
+	);
+}
+
+export async function fetchMatomoEventsReport({
+	method,
+	period,
+	date,
+	segment,
+}: FetchMatomoEventsReportParams): Promise<MatomoEventsReportRow[]> {
+	const baseUrl = env.NEXT_PUBLIC_MATOMO_URL;
+	const siteId = env.NEXT_PUBLIC_MATOMO_SITE_ID;
+	const token = env.MATOMO_API_TOKEN;
+
+	if (!baseUrl || !siteId || !token) {
+		throw new Error("Matomo non configuré");
+	}
+
+	const url = new URL(`${baseUrl.replace(/\/$/, "")}/index.php`);
+	url.searchParams.set("module", "API");
+	url.searchParams.set("format", "json");
+	url.searchParams.set("idSite", siteId);
+	url.searchParams.set("method", method);
+	url.searchParams.set("period", period);
+	url.searchParams.set("date", date);
+	if (segment) url.searchParams.set("segment", segment);
+
+	// `token_auth` goes in the POST body, never the URL, so it cannot leak via
+	// access logs, the Referer header, or an error message that echoes the URL.
+	const body = new URLSearchParams({ token_auth: token });
+
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/x-www-form-urlencoded",
+			},
+			body,
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		});
+	} catch {
+		throw new Error("Matomo Reporting API request failed");
+	}
+
+	if (!response.ok) {
+		throw new Error(
+			`Matomo Reporting API error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	let data: unknown;
+	try {
+		data = await response.json();
+	} catch {
+		throw new Error("Matomo Reporting API returned a non-JSON response");
+	}
+
+	if (isMatomoApiError(data)) {
+		throw new Error("Matomo Reporting API returned an error response");
+	}
+
+	return data as MatomoEventsReportRow[];
+}


### PR DESCRIPTION
Implémente #3615. **Ouverte pour revue** — remplace #3622 (mergée par erreur).

⚠️ **PR empilée** : base = `ticket/3614-funnel-instrumentation`. Dépend de #3612 + #3613. À merger après eux.

Contenu : procédure `adminStats.getMatomoFunnel` (adminProcedure, segment sur custom dimensions, mapper pur `matomoFunnel.ts`) + audit `read_sensitive`. Sécurité : method/period/date hardcodés, segment depuis inputs validés. Détail : issue #3615.

Qualité : typecheck ✓ · 2519 tests ✓ · lint ✓ · format ✓ · structural/security verts.

Part of #3514.