### PR TITLE
stats(analytics): Matomo — widget funnel dans /admin/stats (#3616)

### DIFF
--- a/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
@@ -26,6 +26,7 @@ type Props = {
 	caption: string;
 	rows: FunnelRow[];
 	dropThreshold: number;
+	unitNoun?: string;
 };
 
 // DSFR illustration palette tokens. ECharts only accepts resolved CSS color
@@ -150,12 +151,13 @@ type LabelFormatterParams = {
 export function buildTooltipFormatter(
 	dropThreshold: number,
 	dsfrPalette: DsfrPalette = FALLBACK_DSFR_PALETTE,
+	unitNoun = "déclarations",
 ): (params: TooltipFormatterParams) => string {
 	return (params) => {
 		const { row } = params.data;
 		const head =
 			`<strong>${row.label}</strong><br/>` +
-			`${formatCount(row.count)} déclarations (${row.pctOfStart} % du funnel)`;
+			`${formatCount(row.count)} ${unitNoun} (${row.pctOfStart} % du funnel)`;
 		if (row.pctDropFromPrev === null) {
 			return head;
 		}
@@ -175,11 +177,12 @@ export function buildEchartsOption(
 	rows: FunnelRow[],
 	dropThreshold: number,
 	dsfrPalette: DsfrPalette = FALLBACK_DSFR_PALETTE,
+	unitNoun = "déclarations",
 ): echarts.EChartsCoreOption {
 	return {
 		tooltip: {
 			trigger: "item",
-			formatter: buildTooltipFormatter(dropThreshold, dsfrPalette),
+			formatter: buildTooltipFormatter(dropThreshold, dsfrPalette, unitNoun),
 		},
 		legend: {
 			show: true,
@@ -245,7 +248,12 @@ export function buildEchartsOption(
 	};
 }
 
-export function CompletionFunnelChart({ caption, rows, dropThreshold }: Props) {
+export function CompletionFunnelChart({
+	caption,
+	rows,
+	dropThreshold,
+	unitNoun = "déclarations",
+}: Props) {
 	const dsfrPalette = useDsfrPalette();
 	const hasData = rows.some((row) => row.count > 0);
 	if (!hasData) {
@@ -259,12 +267,12 @@ export function CompletionFunnelChart({ caption, rows, dropThreshold }: Props) {
 		);
 	}
 
-	const option = buildEchartsOption(rows, dropThreshold, dsfrPalette);
+	const option = buildEchartsOption(rows, dropThreshold, dsfrPalette, unitNoun);
 
 	return (
 		<figure className={styles.chartWrapper}>
 			<figcaption className="fr-sr-only">
-				{caption}. Nombre de déclarations à chaque jalon du funnel, avec le
+				{caption}. Nombre de {unitNoun} à chaque jalon du funnel, avec le
 				pourcentage du funnel et la chute par rapport à l'étape précédente. Les
 				données équivalentes sont disponibles dans le tableau ci-dessous.
 			</figcaption>

--- a/packages/app/src/modules/admin/stats/MatomoFunnelChart.tsx
+++ b/packages/app/src/modules/admin/stats/MatomoFunnelChart.tsx
@@ -1,0 +1,55 @@
+import { FUNNEL_DROP_ALERT_THRESHOLD } from "~/modules/domain";
+
+import { CompletionFunnelChart } from "./CompletionFunnelChart";
+import type { FunnelRow, MatomoFunnelOutput } from "./types";
+
+export function buildMatomoFunnelRows(data: MatomoFunnelOutput): FunnelRow[] {
+	const entries = [
+		{ key: "funnel_start", label: "Entrées", count: data.startedCount },
+		...data.steps.map((step) => ({
+			key: step.stepKey,
+			label: step.label,
+			count: step.completedCount,
+		})),
+		{
+			key: "funnel_complete",
+			label: "Complétions",
+			count: data.completedCount,
+		},
+	];
+
+	const start = data.startedCount;
+	let previous: number | null = null;
+
+	return entries.map((entry) => {
+		const pctOfStart = start > 0 ? Math.round((entry.count / start) * 100) : 0;
+		const pctDropFromPrev =
+			previous !== null && previous > 0
+				? Math.round(((previous - entry.count) / previous) * 100)
+				: null;
+		previous = entry.count;
+		return {
+			key: entry.key,
+			label: entry.label,
+			count: entry.count,
+			pctOfStart,
+			pctDropFromPrev,
+		};
+	});
+}
+
+type Props = {
+	caption: string;
+	data: MatomoFunnelOutput;
+};
+
+export function MatomoFunnelChart({ caption, data }: Props) {
+	return (
+		<CompletionFunnelChart
+			caption={caption}
+			dropThreshold={FUNNEL_DROP_ALERT_THRESHOLD}
+			rows={buildMatomoFunnelRows(data)}
+			unitNoun="parcours"
+		/>
+	);
+}

--- a/packages/app/src/modules/admin/stats/MatomoFunnelTable.tsx
+++ b/packages/app/src/modules/admin/stats/MatomoFunnelTable.tsx
@@ -1,0 +1,72 @@
+import { formatCount } from "./formatters";
+import type { MatomoFunnelOutput } from "./types";
+
+function formatDurationSeconds(value: number | null): string {
+	if (value === null) return "—";
+	if (value < 60) return `${value} s`;
+	const minutes = Math.floor(value / 60);
+	const seconds = value % 60;
+	return seconds === 0 ? `${minutes} min` : `${minutes} min ${seconds} s`;
+}
+
+type Props = {
+	caption: string;
+	data: MatomoFunnelOutput;
+};
+
+/**
+ * Accessible alternative to `<MatomoFunnelChart>` — the same K20/K21 dataset as
+ * a DSFR table, with the per-step average durations the funnel chart cannot
+ * show. Required for RGAA because the chart is rendered as a canvas.
+ */
+export function MatomoFunnelTable({ caption, data }: Props) {
+	return (
+		<details className="fr-mt-3w">
+			<summary className="fr-text--sm">
+				Consulter les données du graphique sous forme de tableau
+			</summary>
+			<div className="fr-table fr-table--bordered fr-mt-2w">
+				<div className="fr-table__wrapper">
+					<div className="fr-table__container">
+						<div className="fr-table__content">
+							<table>
+								<caption className="fr-sr-only">{caption}</caption>
+								<thead>
+									<tr>
+										<th scope="col">Étape</th>
+										<th scope="col">Parcours</th>
+										<th scope="col">Durée moyenne</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<th scope="row">Entrées</th>
+										<td>{formatCount(data.startedCount)}</td>
+										<td>—</td>
+									</tr>
+									{data.steps.map((step) => (
+										<tr key={step.stepKey}>
+											<th scope="row">{step.label}</th>
+											<td>{formatCount(step.completedCount)}</td>
+											<td>{formatDurationSeconds(step.avgDurationSeconds)}</td>
+										</tr>
+									))}
+									<tr>
+										<th scope="row">Complétions</th>
+										<td>{formatCount(data.completedCount)}</td>
+										<td>—</td>
+									</tr>
+									<tr>
+										<th scope="row">Abandons</th>
+										<td>{formatCount(data.abandonedCount)}</td>
+										<td>—</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+					</div>
+				</div>
+			</div>
+		</details>
+	);
+}

--- a/packages/app/src/modules/admin/stats/StatsDashboard.tsx
+++ b/packages/app/src/modules/admin/stats/StatsDashboard.tsx
@@ -14,6 +14,9 @@ import { CampaignProgressionTable } from "./CampaignProgressionTable";
 import { CampaignRateTile } from "./CampaignRateTile";
 import { CompletionFunnelChart } from "./CompletionFunnelChart";
 import { CompletionFunnelTable } from "./CompletionFunnelTable";
+import { formatCount } from "./formatters";
+import { MatomoFunnelChart } from "./MatomoFunnelChart";
+import { MatomoFunnelTable } from "./MatomoFunnelTable";
 import { StagnationDaysFilter } from "./StagnationDaysFilter";
 import styles from "./StatsDashboard.module.scss";
 import { StepDropoffChart } from "./StepDropoffChart";
@@ -73,6 +76,14 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 	);
 
 	const funnelQuery = api.adminStats.getCompletionFunnel.useQuery(
+		{ year: activeYear, sizeRange },
+		{
+			enabled: selectedYears.length > 0,
+			placeholderData: (prev) => prev,
+		},
+	);
+
+	const matomoFunnelQuery = api.adminStats.getMatomoFunnel.useQuery(
 		{ year: activeYear, sizeRange },
 		{
 			enabled: selectedYears.length > 0,
@@ -337,6 +348,60 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 										Aucune déclaration avec CSE pour ces filtres.
 									</p>
 								)}
+							</section>
+						</div>
+					</div>
+				)}
+			</section>
+
+			<section className="fr-mt-6w" id="comportement">
+				<h2 className="fr-h2">
+					Parcours de déclaration — comportement réel (Matomo)
+				</h2>
+				<p>
+					Funnel comportemental du parcours de déclaration mesuré via Matomo :
+					entrées dans le tunnel, progression et durée moyenne par étape,
+					complétions et abandons — pour la campagne {activeYear}.
+				</p>
+
+				{matomoFunnelQuery.isLoading && !matomoFunnelQuery.data && (
+					<p aria-live="polite" className="fr-mt-4w">
+						Chargement des données Matomo…
+					</p>
+				)}
+				{matomoFunnelQuery.isError && (
+					<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-4w">
+						<p>
+							Les statistiques Matomo sont indisponibles pour le moment. Les
+							autres indicateurs de cette page restent consultables.
+						</p>
+					</div>
+				)}
+
+				{matomoFunnelQuery.data && (
+					<div className="fr-grid-row fr-grid-row--gutters fr-mt-4w">
+						<div className="fr-col-12">
+							<section
+								aria-labelledby="matomo-funnel-heading"
+								className={styles.card}
+							>
+								<h3 className="fr-h3" id="matomo-funnel-heading">
+									Funnel du parcours de déclaration
+								</h3>
+								<p className="fr-text--sm fr-text-mention--grey">
+									{formatCount(matomoFunnelQuery.data.startedCount)} entrées ·{" "}
+									{formatCount(matomoFunnelQuery.data.completedCount)}{" "}
+									complétions ·{" "}
+									{formatCount(matomoFunnelQuery.data.abandonedCount)} abandons
+								</p>
+								<MatomoFunnelChart
+									caption="Funnel du parcours de déclaration — comportement réel (Matomo)"
+									data={matomoFunnelQuery.data}
+								/>
+								<MatomoFunnelTable
+									caption="Funnel du parcours de déclaration — comportement réel (Matomo)"
+									data={matomoFunnelQuery.data}
+								/>
 							</section>
 						</div>
 					</div>

--- a/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelChart.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMatomoFunnelRows } from "../MatomoFunnelChart";
+
+describe("buildMatomoFunnelRows", () => {
+	it("builds Entrées → steps → Complétions rows with funnel percentages", () => {
+		const rows = buildMatomoFunnelRows({
+			startedCount: 1000,
+			completedCount: 400,
+			abandonedCount: 600,
+			steps: [
+				{
+					stepKey: "step_1",
+					label: "Effectifs",
+					completedCount: 900,
+					avgDurationSeconds: 12,
+				},
+				{
+					stepKey: "step_2",
+					label: "Écart de rémunération",
+					completedCount: 700,
+					avgDurationSeconds: 30,
+				},
+			],
+		});
+
+		expect(rows).toEqual([
+			{
+				key: "funnel_start",
+				label: "Entrées",
+				count: 1000,
+				pctOfStart: 100,
+				pctDropFromPrev: null,
+			},
+			{
+				key: "step_1",
+				label: "Effectifs",
+				count: 900,
+				pctOfStart: 90,
+				pctDropFromPrev: 10,
+			},
+			{
+				key: "step_2",
+				label: "Écart de rémunération",
+				count: 700,
+				pctOfStart: 70,
+				pctDropFromPrev: 22,
+			},
+			{
+				key: "funnel_complete",
+				label: "Complétions",
+				count: 400,
+				pctOfStart: 40,
+				pctDropFromPrev: 43,
+			},
+		]);
+	});
+
+	it("returns zero percentages and no drop when there are no entries", () => {
+		const rows = buildMatomoFunnelRows({
+			startedCount: 0,
+			completedCount: 0,
+			abandonedCount: 0,
+			steps: [],
+		});
+
+		expect(rows).toEqual([
+			{
+				key: "funnel_start",
+				label: "Entrées",
+				count: 0,
+				pctOfStart: 0,
+				pctDropFromPrev: null,
+			},
+			{
+				key: "funnel_complete",
+				label: "Complétions",
+				count: 0,
+				pctOfStart: 0,
+				pctDropFromPrev: null,
+			},
+		]);
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelTable.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/MatomoFunnelTable.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MatomoFunnelTable } from "../MatomoFunnelTable";
+
+const DATA = {
+	startedCount: 1000,
+	completedCount: 400,
+	abandonedCount: 600,
+	steps: [
+		{
+			stepKey: "step_1",
+			label: "Effectifs",
+			completedCount: 900,
+			avgDurationSeconds: 12,
+		},
+		{
+			stepKey: "step_2",
+			label: "Écart de rémunération",
+			completedCount: 700,
+			avgDurationSeconds: null,
+		},
+	],
+};
+
+describe("MatomoFunnelTable", () => {
+	it("renders the funnel bounds, per-step counts and durations", () => {
+		render(<MatomoFunnelTable caption="Funnel Matomo" data={DATA} />);
+
+		expect(screen.getByText("Entrées")).toBeInTheDocument();
+		expect(screen.getByText("Complétions")).toBeInTheDocument();
+		expect(screen.getByText("Abandons")).toBeInTheDocument();
+		expect(screen.getByText("Effectifs")).toBeInTheDocument();
+		expect(screen.getByText("Écart de rémunération")).toBeInTheDocument();
+
+		const stepRow = screen.getByText("Effectifs").closest("tr");
+		expect(stepRow).not.toBeNull();
+		expect(stepRow).toHaveTextContent("900");
+		expect(stepRow).toHaveTextContent("12");
+
+		const nullDurationRow = screen
+			.getByText("Écart de rémunération")
+			.closest("tr");
+		expect(nullDurationRow).toHaveTextContent("—");
+	});
+
+	it("provides an accessible caption", () => {
+		render(<MatomoFunnelTable caption="Funnel Matomo" data={DATA} />);
+		expect(
+			screen.getByRole("table", { name: "Funnel Matomo" }),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.campaign.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.campaign.test.tsx
@@ -5,6 +5,7 @@ const progressionUseQueryMock = vi.fn();
 const stepDurationsUseQueryMock = vi.fn();
 const stepDropoffUseQueryMock = vi.fn();
 const funnelUseQueryMock = vi.fn();
+const matomoFunnelUseQueryMock = vi.fn();
 const statsUseQueryMock = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
@@ -24,6 +25,9 @@ vi.mock("~/trpc/react", () => ({
 			},
 			getCompletionFunnel: {
 				useQuery: (...args: unknown[]) => funnelUseQueryMock(...args),
+			},
+			getMatomoFunnel: {
+				useQuery: (...args: unknown[]) => matomoFunnelUseQueryMock(...args),
 			},
 		},
 	},
@@ -53,6 +57,12 @@ vi.mock("../CompletionFunnelChart", () => ({
 vi.mock("../CompletionFunnelTable", () => ({
 	CompletionFunnelTable: () => <div data-testid="funnel-table" />,
 }));
+vi.mock("../MatomoFunnelChart", () => ({
+	MatomoFunnelChart: () => <div data-testid="matomo-funnel-chart" />,
+}));
+vi.mock("../MatomoFunnelTable", () => ({
+	MatomoFunnelTable: () => <div data-testid="matomo-funnel-table" />,
+}));
 vi.mock("../CampaignRateTile", () => ({
 	CampaignRateTile: () => <div data-testid="campaign-rate-tile" />,
 }));
@@ -67,6 +77,7 @@ const defaultMocks = () =>
 		stepDurationsUseQueryMock,
 		stepDropoffUseQueryMock,
 		funnelUseQueryMock,
+		matomoFunnelUseQueryMock,
 	});
 
 describe("StatsDashboard — campaign section states", () => {
@@ -75,6 +86,7 @@ describe("StatsDashboard — campaign section states", () => {
 		stepDurationsUseQueryMock.mockReset();
 		stepDropoffUseQueryMock.mockReset();
 		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
 		statsUseQueryMock.mockReset();
 		defaultMocks();
 	});
@@ -215,6 +227,7 @@ describe("StatsDashboard — query options", () => {
 		stepDurationsUseQueryMock.mockReset();
 		stepDropoffUseQueryMock.mockReset();
 		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
 		statsUseQueryMock.mockReset();
 		defaultMocks();
 	});

--- a/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.test.tsx
@@ -5,6 +5,7 @@ const progressionUseQueryMock = vi.fn();
 const stepDurationsUseQueryMock = vi.fn();
 const stepDropoffUseQueryMock = vi.fn();
 const funnelUseQueryMock = vi.fn();
+const matomoFunnelUseQueryMock = vi.fn();
 const statsUseQueryMock = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
@@ -24,6 +25,9 @@ vi.mock("~/trpc/react", () => ({
 			},
 			getCompletionFunnel: {
 				useQuery: (...args: unknown[]) => funnelUseQueryMock(...args),
+			},
+			getMatomoFunnel: {
+				useQuery: (...args: unknown[]) => matomoFunnelUseQueryMock(...args),
 			},
 		},
 	},
@@ -53,6 +57,12 @@ vi.mock("../CompletionFunnelChart", () => ({
 vi.mock("../CompletionFunnelTable", () => ({
 	CompletionFunnelTable: () => <div data-testid="funnel-table" />,
 }));
+vi.mock("../MatomoFunnelChart", () => ({
+	MatomoFunnelChart: () => <div data-testid="matomo-funnel-chart" />,
+}));
+vi.mock("../MatomoFunnelTable", () => ({
+	MatomoFunnelTable: () => <div data-testid="matomo-funnel-table" />,
+}));
 vi.mock("../CampaignRateTile", () => ({
 	CampaignRateTile: () => <div data-testid="campaign-rate-tile" />,
 }));
@@ -70,6 +80,7 @@ const defaultMocks = () =>
 		stepDurationsUseQueryMock,
 		stepDropoffUseQueryMock,
 		funnelUseQueryMock,
+		matomoFunnelUseQueryMock,
 	});
 
 describe("StatsDashboard — structure and filters", () => {
@@ -78,6 +89,7 @@ describe("StatsDashboard — structure and filters", () => {
 		stepDurationsUseQueryMock.mockReset();
 		stepDropoffUseQueryMock.mockReset();
 		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
 		statsUseQueryMock.mockReset();
 		defaultMocks();
 	});
@@ -246,5 +258,71 @@ describe("StatsDashboard — funnel section", () => {
 			| { placeholderData: (prev: unknown) => unknown }
 			| undefined;
 		expect(options?.placeholderData("prev-value")).toBe("prev-value");
+	});
+});
+
+describe("StatsDashboard — Matomo behavioural funnel (K20/K21)", () => {
+	beforeEach(() => {
+		progressionUseQueryMock.mockReset();
+		stepDurationsUseQueryMock.mockReset();
+		stepDropoffUseQueryMock.mockReset();
+		funnelUseQueryMock.mockReset();
+		matomoFunnelUseQueryMock.mockReset();
+		statsUseQueryMock.mockReset();
+		defaultMocks();
+	});
+
+	it("renders the Matomo funnel section with chart and table when data is available (S8)", () => {
+		matomoFunnelUseQueryMock.mockReturnValue({
+			data: {
+				startedCount: 120,
+				completedCount: 80,
+				abandonedCount: 40,
+				steps: [
+					{
+						stepKey: "step_1",
+						label: "Effectifs",
+						completedCount: 110,
+						avgDurationSeconds: 12,
+					},
+				],
+			},
+			isLoading: false,
+			isError: false,
+		});
+		render(
+			<StatsDashboard availableYears={[2026, 2025, 2024]} currentYear={2026} />,
+		);
+		expect(
+			screen.getByRole("heading", { name: /comportement réel \(Matomo\)/i }),
+		).toBeInTheDocument();
+		expect(screen.getByTestId("matomo-funnel-chart")).toBeInTheDocument();
+		expect(screen.getByTestId("matomo-funnel-table")).toBeInTheDocument();
+	});
+
+	it("shows a Matomo error alert without breaking the DB widgets (S13)", () => {
+		matomoFunnelUseQueryMock.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+		});
+		render(
+			<StatsDashboard availableYears={[2026, 2025, 2024]} currentYear={2026} />,
+		);
+		expect(
+			screen.getByText(/statistiques Matomo sont indisponibles/i),
+		).toBeInTheDocument();
+		expect(screen.getAllByTestId("funnel-chart").length).toBeGreaterThan(0);
+		expect(screen.queryByTestId("matomo-funnel-chart")).not.toBeInTheDocument();
+	});
+
+	it("synchronises the Matomo query with the active year filter (S11)", () => {
+		render(
+			<StatsDashboard availableYears={[2026, 2025, 2024]} currentYear={2026} />,
+		);
+		const input = matomoFunnelUseQueryMock.mock.calls[0]?.[0] as {
+			year: number;
+		};
+		expect(input.year).toBe(2026);
 	});
 });

--- a/packages/app/src/modules/admin/stats/__tests__/helpers/statsDashboardMocks.ts
+++ b/packages/app/src/modules/admin/stats/__tests__/helpers/statsDashboardMocks.ts
@@ -13,6 +13,7 @@ type QueryMocks = {
 	stepDurationsUseQueryMock: Mock;
 	stepDropoffUseQueryMock: Mock;
 	funnelUseQueryMock: Mock;
+	matomoFunnelUseQueryMock: Mock;
 };
 
 export function setDefaultMocks(mocks: QueryMocks) {
@@ -38,6 +39,16 @@ export function setDefaultMocks(mocks: QueryMocks) {
 	});
 	mocks.funnelUseQueryMock.mockReturnValue({
 		data: emptyFunnelData,
+		isLoading: false,
+		isError: false,
+	});
+	mocks.matomoFunnelUseQueryMock.mockReturnValue({
+		data: {
+			startedCount: 0,
+			completedCount: 0,
+			abandonedCount: 0,
+			steps: [],
+		},
 		isLoading: false,
 		isError: false,
 	});

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -6,6 +6,8 @@ export { CampaignRateTile } from "./CampaignRateTile";
 export { CompletionFunnelChart } from "./CompletionFunnelChart";
 export { CompletionFunnelTable } from "./CompletionFunnelTable";
 export { formatCount, formatDays, formatPercent } from "./formatters";
+export { MatomoFunnelChart } from "./MatomoFunnelChart";
+export { MatomoFunnelTable } from "./MatomoFunnelTable";
 export { StagnationDaysFilter } from "./StagnationDaysFilter";
 export { StatsDashboard } from "./StatsDashboard";
 export { StepDropoffChart } from "./StepDropoffChart";


### PR DESCRIPTION
Implémente #3616 (dernier ticket de l'epic). **Ouverte pour revue** — remplace #3623 (mergée par erreur).

⚠️ **PR empilée** : base = `ticket/3615-matomo-funnel-trpc`. À merger en dernier.

Contenu : widget funnel dans `/admin/stats` (réutilise `CompletionFunnelChart` via prop `unitNoun` rétro-compatible + table accessible). États loading/erreur(S13)/vide. Rendu « funnel chart + table » (choix validé, pas de Figma). Détail : issue #3616.

Qualité : typecheck ✓ · 2526 tests ✓ · lint ✓ · format ✓ · rgaa PASS.

Part of #3514.