### PR TITLE
feat(cseOpinion): association fichier ↔ type de contenu — backend (#3631)

### DIFF
--- a/packages/app/drizzle/0038_striped_xavin.sql
+++ b/packages/app/drizzle/0038_striped_xavin.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "app_cse_opinion_file" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"declaration_id" varchar(255) NOT NULL,
+	"declaration_number" integer NOT NULL,
+	"type" varchar(20) NOT NULL,
+	"file_id" varchar(255) NOT NULL,
+	"created_at" timestamp with time zone,
+	"updated_at" timestamp with time zone,
+	CONSTRAINT "cse_opinion_file_decl_number_type_idx" UNIQUE("declaration_id","declaration_number","type")
+);
+--> statement-breakpoint
+ALTER TABLE "app_cse_opinion_file" ADD CONSTRAINT "app_cse_opinion_file_declaration_id_app_declaration_id_fk" FOREIGN KEY ("declaration_id") REFERENCES "public"."app_declaration"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_cse_opinion_file" ADD CONSTRAINT "app_cse_opinion_file_file_id_app_file_id_fk" FOREIGN KEY ("file_id") REFERENCES "public"."app_file"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "cse_opinion_file_declaration_idx" ON "app_cse_opinion_file" USING btree ("declaration_id");

--- a/packages/app/drizzle/meta/0038_snapshot.json
+++ b/packages/app/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,2599 @@
+{
+  "id": "ad008fc0-1b4a-49c8-aa20-297648323b8e",
+  "prevId": "6cf8f8fd-d111-479a-a07f-df7898b2714e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_admin_impersonation_event": {
+      "name": "app_admin_impersonation_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_impersonation_event_admin_started_idx": {
+          "name": "admin_impersonation_event_admin_started_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_admin_impersonation_event_siren_app_company_siren_fk": {
+          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_campaign_deadline": {
+      "name": "app_campaign_deadline",
+      "schema": "",
+      "columns": {
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gip_publication_date": {
+          "name": "gip_publication_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_start_date": {
+          "name": "campaign_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decl1_modification_deadline": {
+          "name": "decl1_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_justification_deadline": {
+          "name": "decl1_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_joint_evaluation_deadline": {
+          "name": "decl1_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_modification_deadline": {
+          "name": "decl2_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_justification_deadline": {
+          "name": "decl2_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_joint_evaluation_deadline": {
+          "name": "decl2_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_company": {
+      "name": "app_company",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naf_code": {
+          "name": "naf_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce": {
+          "name": "workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_cse": {
+          "name": "has_cse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion_file": {
+      "name": "app_cse_opinion_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_file_declaration_idx": {
+          "name": "cse_opinion_file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_cse_opinion_file_file_id_app_file_id_fk": {
+          "name": "app_cse_opinion_file_file_id_app_file_id_fk",
+          "tableFrom": "app_cse_opinion_file",
+          "tableTo": "app_file",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_file_decl_number_type_idx": {
+          "name": "cse_opinion_file_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion": {
+      "name": "app_cse_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gap_consulted": {
+          "name": "gap_consulted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_date": {
+          "name": "opinion_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_declaration_idx": {
+          "name": "cse_opinion_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_decl_number_type_idx": {
+          "name": "cse_opinion_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration_status_history": {
+      "name": "app_declaration_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "declaration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "decl_status_history_declaration_idx": {
+          "name": "decl_status_history_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
+          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration": {
+      "name": "app_declaration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_women": {
+          "name": "total_women",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_men": {
+          "name": "total_men",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remuneration_score": {
+          "name": "remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_remuneration_score": {
+          "name": "variable_remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quartile_score": {
+          "name": "quartile_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_score": {
+          "name": "category_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_declaration_path_choice": {
+          "name": "first_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_declaration_path_choice": {
+          "name": "second_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_women": {
+          "name": "indicator_a_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_men": {
+          "name": "indicator_a_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_women": {
+          "name": "indicator_a_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_men": {
+          "name": "indicator_a_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_women": {
+          "name": "indicator_b_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_men": {
+          "name": "indicator_b_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_women": {
+          "name": "indicator_b_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_men": {
+          "name": "indicator_b_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_women": {
+          "name": "indicator_c_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_men": {
+          "name": "indicator_c_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_women": {
+          "name": "indicator_c_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_men": {
+          "name": "indicator_c_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_women": {
+          "name": "indicator_d_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_men": {
+          "name": "indicator_d_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_women": {
+          "name": "indicator_d_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_men": {
+          "name": "indicator_d_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_women": {
+          "name": "indicator_e_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_men": {
+          "name": "indicator_e_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold1": {
+          "name": "indicator_f_annual_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold2": {
+          "name": "indicator_f_annual_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold3": {
+          "name": "indicator_f_annual_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women1": {
+          "name": "indicator_f_annual_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women2": {
+          "name": "indicator_f_annual_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women3": {
+          "name": "indicator_f_annual_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women4": {
+          "name": "indicator_f_annual_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men1": {
+          "name": "indicator_f_annual_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men2": {
+          "name": "indicator_f_annual_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men3": {
+          "name": "indicator_f_annual_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men4": {
+          "name": "indicator_f_annual_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold1": {
+          "name": "indicator_f_hourly_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold2": {
+          "name": "indicator_f_hourly_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold3": {
+          "name": "indicator_f_hourly_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women1": {
+          "name": "indicator_f_hourly_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women2": {
+          "name": "indicator_f_hourly_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women3": {
+          "name": "indicator_f_hourly_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women4": {
+          "name": "indicator_f_hourly_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men1": {
+          "name": "indicator_f_hourly_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men2": {
+          "name": "indicator_f_hourly_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men3": {
+          "name": "indicator_f_hourly_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men4": {
+          "name": "indicator_f_hourly_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "declaration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "second_declaration_step": {
+          "name": "second_declaration_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_start": {
+          "name": "second_decl_reference_period_start",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_end": {
+          "name": "second_decl_reference_period_end",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cse_required": {
+          "name": "cse_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_version": {
+          "name": "rules_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2027.1'"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_updated_at": {
+          "name": "draft_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "declarations_siren_year_active_unique": {
+          "name": "declarations_siren_year_active_unique",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "cancelled_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "declaration_declarant_idx": {
+          "name": "declaration_declarant_idx",
+          "columns": [
+            {
+              "expression": "declarant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_siren_app_company_siren_fk": {
+          "name": "app_declaration_siren_app_company_siren_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_declaration_declarant_id_app_user_id_fk": {
+          "name": "app_declaration_declarant_id_app_user_id_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_employee_category": {
+      "name": "app_employee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_category_id": {
+          "name": "job_category_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_type": {
+          "name": "declaration_type",
+          "type": "declaration_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "women_count": {
+          "name": "women_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count": {
+          "name": "men_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_women": {
+          "name": "annual_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_men": {
+          "name": "annual_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_women": {
+          "name": "annual_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_men": {
+          "name": "annual_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_women": {
+          "name": "hourly_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_men": {
+          "name": "hourly_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_women": {
+          "name": "hourly_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_men": {
+          "name": "hourly_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_employee_category_job_category_id_app_job_category_id_fk": {
+          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
+          "tableFrom": "app_employee_category",
+          "tableTo": "app_job_category",
+          "columnsFrom": [
+            "job_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employee_category_job_type_idx": {
+          "name": "employee_category_job_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_category_id",
+            "declaration_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_export": {
+      "name": "app_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "export_year_version_idx": {
+          "name": "export_year_version_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_file": {
+      "name": "app_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "file_declaration_idx": {
+          "name": "file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_joint_eval_unique": {
+          "name": "file_joint_eval_unique",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"type\" = 'joint_evaluation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_gip_mds_data": {
+      "name": "app_gip_mds_data",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_ema": {
+          "name": "workforce_ema",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_global": {
+          "name": "men_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_global": {
+          "name": "women_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_hourly_global": {
+          "name": "men_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_hourly_global": {
+          "name": "women_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_variable": {
+          "name": "men_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_variable": {
+          "name": "women_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_women": {
+          "name": "global_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_men": {
+          "name": "global_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_women": {
+          "name": "global_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_men": {
+          "name": "global_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_women": {
+          "name": "variable_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_men": {
+          "name": "variable_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_women": {
+          "name": "variable_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_men": {
+          "name": "variable_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_women": {
+          "name": "global_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_men": {
+          "name": "global_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_women": {
+          "name": "global_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_men": {
+          "name": "global_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_women": {
+          "name": "variable_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_men": {
+          "name": "variable_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_women": {
+          "name": "variable_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_men": {
+          "name": "variable_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold1": {
+          "name": "annual_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold2": {
+          "name": "annual_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold3": {
+          "name": "annual_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold1": {
+          "name": "hourly_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold2": {
+          "name": "hourly_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold3": {
+          "name": "hourly_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_index": {
+          "name": "confidence_index",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_exotic_contracts": {
+          "name": "confidence_exotic_contracts",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_unit_measure": {
+          "name": "confidence_unit_measure",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_suspension_ratio": {
+          "name": "confidence_suspension_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_suspensions": {
+          "name": "confidence_long_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_end_suspensions": {
+          "name": "confidence_no_end_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_sick_leave_ratio": {
+          "name": "confidence_sick_leave_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_sick_leave": {
+          "name": "confidence_long_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_sick_leave": {
+          "name": "confidence_no_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota250": {
+          "name": "confidence_quota250",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota0": {
+          "name": "confidence_quota0",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_multi_year": {
+          "name": "confidence_multi_year",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_fp_ratio": {
+          "name": "confidence_fp_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_remuneration": {
+          "name": "confidence_extreme_remuneration",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_rate": {
+          "name": "confidence_extreme_rate",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gip_mds_data_siren_idx": {
+          "name": "gip_mds_data_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_gip_mds_data_siren_app_company_siren_fk": {
+          "name": "app_gip_mds_data_siren_app_company_siren_fk",
+          "tableFrom": "app_gip_mds_data",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_gip_mds_data_siren_year_pk": {
+          "name": "app_gip_mds_data_siren_year_pk",
+          "columns": [
+            "siren",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_global_setting": {
+      "name": "app_global_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "active_campaign_year": {
+          "name": "active_campaign_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_global_setting_updated_by_app_user_id_fk": {
+          "name": "app_global_setting_updated_by_app_user_id_fk",
+          "tableFrom": "app_global_setting",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_job_category": {
+      "name": "app_job_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_index": {
+          "name": "category_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_job_category_declaration_id_app_declaration_id_fk": {
+          "name": "app_job_category_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_job_category",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_category_declaration_index_idx": {
+          "name": "job_category_declaration_index_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "category_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_referent": {
+      "name": "app_referent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "referent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "substitute_name": {
+          "name": "substitute_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "substitute_email": {
+          "name": "substitute_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "referent_region_idx": {
+          "name": "referent_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user_company": {
+      "name": "app_user_company",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_company_user_id_idx": {
+          "name": "user_company_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_company_user_id_app_user_id_fk": {
+          "name": "app_user_company_user_id_app_user_id_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_company_siren_app_company_siren_fk": {
+          "name": "app_user_company_siren_app_company_siren_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_user_company_user_id_siren_pk": {
+          "name": "app_user_company_user_id_siren_pk",
+          "columns": [
+            "user_id",
+            "siren"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user": {
+      "name": "app_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "audit.action_log": {
+      "name": "action_log",
+      "schema": "audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_log_created_at_idx": {
+          "name": "action_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_user_idx": {
+          "name": "action_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_siren_idx": {
+          "name": "action_log_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_action_idx": {
+          "name": "action_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_category_created_at_idx": {
+          "name": "action_log_category_created_at_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.compliance_path": {
+      "name": "compliance_path",
+      "schema": "public",
+      "values": [
+        "justify",
+        "corrective_action",
+        "joint_evaluation"
+      ]
+    },
+    "public.declaration_event_type": {
+      "name": "declaration_event_type",
+      "schema": "public",
+      "values": [
+        "submit",
+        "path_choice",
+        "second_declaration_submit",
+        "joint_evaluation_submit",
+        "cse_opinion_submit",
+        "cancel",
+        "demarche_complete",
+        "step_change"
+      ]
+    },
+    "public.declaration_status": {
+      "name": "declaration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "awaiting_compliance_path_choice",
+        "corrective_actions_chosen",
+        "joint_evaluation_chosen",
+        "awaiting_revision_choice",
+        "revised_joint_evaluation_chosen",
+        "awaiting_cse_opinion",
+        "demarche_completed"
+      ]
+    },
+    "public.declaration_type": {
+      "name": "declaration_type",
+      "schema": "public",
+      "values": [
+        "initial",
+        "correction"
+      ]
+    },
+    "public.file_type": {
+      "name": "file_type",
+      "schema": "public",
+      "values": [
+        "cse_opinion",
+        "joint_evaluation"
+      ]
+    },
+    "public.referent_type": {
+      "name": "referent_type",
+      "schema": "public",
+      "values": [
+        "email",
+        "url"
+      ]
+    }
+  },
+  "schemas": {
+    "audit": "audit"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/app/drizzle/meta/0038_snapshot.json
+++ b/packages/app/drizzle/meta/0038_snapshot.json
@@ -1,2599 +1,2499 @@
 {
-  "id": "ad008fc0-1b4a-49c8-aa20-297648323b8e",
-  "prevId": "6cf8f8fd-d111-479a-a07f-df7898b2714e",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.app_admin_impersonation_event": {
-      "name": "app_admin_impersonation_event",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "admin_user_id": {
-          "name": "admin_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stopped_at": {
-          "name": "stopped_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "admin_impersonation_event_admin_started_idx": {
-          "name": "admin_impersonation_event_admin_started_idx",
-          "columns": [
-            {
-              "expression": "admin_user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "started_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
-          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "admin_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_admin_impersonation_event_siren_app_company_siren_fk": {
-          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_campaign_deadline": {
-      "name": "app_campaign_deadline",
-      "schema": "",
-      "columns": {
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "gip_publication_date": {
-          "name": "gip_publication_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "campaign_start_date": {
-          "name": "campaign_start_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decl1_modification_deadline": {
-          "name": "decl1_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_justification_deadline": {
-          "name": "decl1_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_joint_evaluation_deadline": {
-          "name": "decl1_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_modification_deadline": {
-          "name": "decl2_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_justification_deadline": {
-          "name": "decl2_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_joint_evaluation_deadline": {
-          "name": "decl2_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_company": {
-      "name": "app_company",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "address": {
-          "name": "address",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "naf_code": {
-          "name": "naf_code",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce": {
-          "name": "workforce",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "has_cse": {
-          "name": "has_cse",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion_file": {
-      "name": "app_cse_opinion_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_id": {
-          "name": "file_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_file_declaration_idx": {
-          "name": "cse_opinion_file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_cse_opinion_file_file_id_app_file_id_fk": {
-          "name": "app_cse_opinion_file_file_id_app_file_id_fk",
-          "tableFrom": "app_cse_opinion_file",
-          "tableTo": "app_file",
-          "columnsFrom": [
-            "file_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_file_decl_number_type_idx": {
-          "name": "cse_opinion_file_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion": {
-      "name": "app_cse_opinion",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "gap_consulted": {
-          "name": "gap_consulted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion": {
-          "name": "opinion",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion_date": {
-          "name": "opinion_date",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_declaration_idx": {
-          "name": "cse_opinion_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_decl_number_type_idx": {
-          "name": "cse_opinion_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration_status_history": {
-      "name": "app_declaration_status_history",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "event_type": {
-          "name": "event_type",
-          "type": "declaration_event_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "round": {
-          "name": "round",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "actor_user_id": {
-          "name": "actor_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "decl_status_history_declaration_idx": {
-          "name": "decl_status_history_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": false,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
-          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
-          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "actor_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration": {
-      "name": "app_declaration",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declarant_id": {
-          "name": "declarant_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "total_women": {
-          "name": "total_women",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total_men": {
-          "name": "total_men",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "remuneration_score": {
-          "name": "remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_remuneration_score": {
-          "name": "variable_remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "quartile_score": {
-          "name": "quartile_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "category_score": {
-          "name": "category_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "first_declaration_path_choice": {
-          "name": "first_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_declaration_path_choice": {
-          "name": "second_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_women": {
-          "name": "indicator_a_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_men": {
-          "name": "indicator_a_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_women": {
-          "name": "indicator_a_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_men": {
-          "name": "indicator_a_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_women": {
-          "name": "indicator_b_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_men": {
-          "name": "indicator_b_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_women": {
-          "name": "indicator_b_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_men": {
-          "name": "indicator_b_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_women": {
-          "name": "indicator_c_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_men": {
-          "name": "indicator_c_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_women": {
-          "name": "indicator_c_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_men": {
-          "name": "indicator_c_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_women": {
-          "name": "indicator_d_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_men": {
-          "name": "indicator_d_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_women": {
-          "name": "indicator_d_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_men": {
-          "name": "indicator_d_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_women": {
-          "name": "indicator_e_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_men": {
-          "name": "indicator_e_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold1": {
-          "name": "indicator_f_annual_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold2": {
-          "name": "indicator_f_annual_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold3": {
-          "name": "indicator_f_annual_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women1": {
-          "name": "indicator_f_annual_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women2": {
-          "name": "indicator_f_annual_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women3": {
-          "name": "indicator_f_annual_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women4": {
-          "name": "indicator_f_annual_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men1": {
-          "name": "indicator_f_annual_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men2": {
-          "name": "indicator_f_annual_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men3": {
-          "name": "indicator_f_annual_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men4": {
-          "name": "indicator_f_annual_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold1": {
-          "name": "indicator_f_hourly_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold2": {
-          "name": "indicator_f_hourly_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold3": {
-          "name": "indicator_f_hourly_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women1": {
-          "name": "indicator_f_hourly_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women2": {
-          "name": "indicator_f_hourly_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women3": {
-          "name": "indicator_f_hourly_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women4": {
-          "name": "indicator_f_hourly_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men1": {
-          "name": "indicator_f_hourly_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men2": {
-          "name": "indicator_f_hourly_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men3": {
-          "name": "indicator_f_hourly_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men4": {
-          "name": "indicator_f_hourly_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "declaration_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'draft'"
-        },
-        "second_declaration_step": {
-          "name": "second_declaration_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_start": {
-          "name": "second_decl_reference_period_start",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_end": {
-          "name": "second_decl_reference_period_end",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cse_required": {
-          "name": "cse_required",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "rules_version": {
-          "name": "rules_version",
-          "type": "varchar",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2027.1'"
-        },
-        "cancelled_at": {
-          "name": "cancelled_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft": {
-          "name": "draft",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft_updated_at": {
-          "name": "draft_updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "declarations_siren_year_active_unique": {
-          "name": "declarations_siren_year_active_unique",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "year",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "cancelled_at IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "declaration_declarant_idx": {
-          "name": "declaration_declarant_idx",
-          "columns": [
-            {
-              "expression": "declarant_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_siren_app_company_siren_fk": {
-          "name": "app_declaration_siren_app_company_siren_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_declaration_declarant_id_app_user_id_fk": {
-          "name": "app_declaration_declarant_id_app_user_id_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "declarant_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_employee_category": {
-      "name": "app_employee_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "job_category_id": {
-          "name": "job_category_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_type": {
-          "name": "declaration_type",
-          "type": "declaration_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "women_count": {
-          "name": "women_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count": {
-          "name": "men_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_women": {
-          "name": "annual_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_men": {
-          "name": "annual_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_women": {
-          "name": "annual_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_men": {
-          "name": "annual_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_women": {
-          "name": "hourly_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_men": {
-          "name": "hourly_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_women": {
-          "name": "hourly_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_men": {
-          "name": "hourly_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_employee_category_job_category_id_app_job_category_id_fk": {
-          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
-          "tableFrom": "app_employee_category",
-          "tableTo": "app_job_category",
-          "columnsFrom": [
-            "job_category_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "employee_category_job_type_idx": {
-          "name": "employee_category_job_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "job_category_id",
-            "declaration_type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_export": {
-      "name": "app_export",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "version": {
-          "name": "version",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'v1'"
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "s3_key": {
-          "name": "s3_key",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "row_count": {
-          "name": "row_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "export_year_version_idx": {
-          "name": "export_year_version_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "year",
-            "version"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_file": {
-      "name": "app_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_path": {
-          "name": "file_path",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "uploaded_at": {
-          "name": "uploaded_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "file_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "file_declaration_idx": {
-          "name": "file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "file_joint_eval_unique": {
-          "name": "file_joint_eval_unique",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"type\" = 'joint_evaluation'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_gip_mds_data": {
-      "name": "app_gip_mds_data",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "imported_at": {
-          "name": "imported_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_start": {
-          "name": "period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_end": {
-          "name": "period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce_ema": {
-          "name": "workforce_ema",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_global": {
-          "name": "men_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_global": {
-          "name": "women_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_hourly_global": {
-          "name": "men_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_hourly_global": {
-          "name": "women_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_variable": {
-          "name": "men_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_variable": {
-          "name": "women_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_women": {
-          "name": "global_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_men": {
-          "name": "global_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_women": {
-          "name": "global_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_men": {
-          "name": "global_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_women": {
-          "name": "variable_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_men": {
-          "name": "variable_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_women": {
-          "name": "variable_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_men": {
-          "name": "variable_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_women": {
-          "name": "global_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_men": {
-          "name": "global_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_women": {
-          "name": "global_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_men": {
-          "name": "global_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_women": {
-          "name": "variable_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_men": {
-          "name": "variable_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_women": {
-          "name": "variable_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_men": {
-          "name": "variable_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold1": {
-          "name": "annual_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold2": {
-          "name": "annual_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold3": {
-          "name": "annual_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold1": {
-          "name": "hourly_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold2": {
-          "name": "hourly_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold3": {
-          "name": "hourly_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_index": {
-          "name": "confidence_index",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_exotic_contracts": {
-          "name": "confidence_exotic_contracts",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_unit_measure": {
-          "name": "confidence_unit_measure",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_suspension_ratio": {
-          "name": "confidence_suspension_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_suspensions": {
-          "name": "confidence_long_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_end_suspensions": {
-          "name": "confidence_no_end_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_sick_leave_ratio": {
-          "name": "confidence_sick_leave_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_sick_leave": {
-          "name": "confidence_long_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_sick_leave": {
-          "name": "confidence_no_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota250": {
-          "name": "confidence_quota250",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota0": {
-          "name": "confidence_quota0",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_multi_year": {
-          "name": "confidence_multi_year",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_fp_ratio": {
-          "name": "confidence_fp_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_remuneration": {
-          "name": "confidence_extreme_remuneration",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_rate": {
-          "name": "confidence_extreme_rate",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "gip_mds_data_siren_idx": {
-          "name": "gip_mds_data_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_gip_mds_data_siren_app_company_siren_fk": {
-          "name": "app_gip_mds_data_siren_app_company_siren_fk",
-          "tableFrom": "app_gip_mds_data",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_gip_mds_data_siren_year_pk": {
-          "name": "app_gip_mds_data_siren_year_pk",
-          "columns": [
-            "siren",
-            "year"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_global_setting": {
-      "name": "app_global_setting",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "default": 1
-        },
-        "active_campaign_year": {
-          "name": "active_campaign_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_global_setting_updated_by_app_user_id_fk": {
-          "name": "app_global_setting_updated_by_app_user_id_fk",
-          "tableFrom": "app_global_setting",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "updated_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_job_category": {
-      "name": "app_job_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category_index": {
-          "name": "category_index",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source": {
-          "name": "source",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_job_category_declaration_id_app_declaration_id_fk": {
-          "name": "app_job_category_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_job_category",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "job_category_declaration_index_idx": {
-          "name": "job_category_declaration_index_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "category_index"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_referent": {
-      "name": "app_referent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "region": {
-          "name": "region",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county": {
-          "name": "county",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "referent_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "principal": {
-          "name": "principal",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "substitute_name": {
-          "name": "substitute_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "substitute_email": {
-          "name": "substitute_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "referent_region_idx": {
-          "name": "referent_region_idx",
-          "columns": [
-            {
-              "expression": "region",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user_company": {
-      "name": "app_user_company",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "user_company_user_id_idx": {
-          "name": "user_company_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_user_company_user_id_app_user_id_fk": {
-          "name": "app_user_company_user_id_app_user_id_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_user_company_siren_app_company_siren_fk": {
-          "name": "app_user_company_siren_app_company_siren_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_user_company_user_id_siren_pk": {
-          "name": "app_user_company_user_id_siren_pk",
-          "columns": [
-            "user_id",
-            "siren"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user": {
-      "name": "app_user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "first_name": {
-          "name": "first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_name": {
-          "name": "last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "phone": {
-          "name": "phone",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_admin": {
-          "name": "is_admin",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "audit.action_log": {
-      "name": "action_log",
-      "schema": "audit",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_email": {
-          "name": "user_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "action": {
-          "name": "action",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category": {
-          "name": "category",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_type": {
-          "name": "resource_type",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "resource_id": {
-          "name": "resource_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "varchar(45)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration_ms": {
-          "name": "duration_ms",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "action_log_created_at_idx": {
-          "name": "action_log_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_user_idx": {
-          "name": "action_log_user_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_siren_idx": {
-          "name": "action_log_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_action_idx": {
-          "name": "action_log_action_idx",
-          "columns": [
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_category_created_at_idx": {
-          "name": "action_log_category_created_at_idx",
-          "columns": [
-            {
-              "expression": "category",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.compliance_path": {
-      "name": "compliance_path",
-      "schema": "public",
-      "values": [
-        "justify",
-        "corrective_action",
-        "joint_evaluation"
-      ]
-    },
-    "public.declaration_event_type": {
-      "name": "declaration_event_type",
-      "schema": "public",
-      "values": [
-        "submit",
-        "path_choice",
-        "second_declaration_submit",
-        "joint_evaluation_submit",
-        "cse_opinion_submit",
-        "cancel",
-        "demarche_complete",
-        "step_change"
-      ]
-    },
-    "public.declaration_status": {
-      "name": "declaration_status",
-      "schema": "public",
-      "values": [
-        "draft",
-        "awaiting_compliance_path_choice",
-        "corrective_actions_chosen",
-        "joint_evaluation_chosen",
-        "awaiting_revision_choice",
-        "revised_joint_evaluation_chosen",
-        "awaiting_cse_opinion",
-        "demarche_completed"
-      ]
-    },
-    "public.declaration_type": {
-      "name": "declaration_type",
-      "schema": "public",
-      "values": [
-        "initial",
-        "correction"
-      ]
-    },
-    "public.file_type": {
-      "name": "file_type",
-      "schema": "public",
-      "values": [
-        "cse_opinion",
-        "joint_evaluation"
-      ]
-    },
-    "public.referent_type": {
-      "name": "referent_type",
-      "schema": "public",
-      "values": [
-        "email",
-        "url"
-      ]
-    }
-  },
-  "schemas": {
-    "audit": "audit"
-  },
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "ad008fc0-1b4a-49c8-aa20-297648323b8e",
+	"prevId": "6cf8f8fd-d111-479a-a07f-df7898b2714e",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_declaration_idx": {
+					"name": "cse_opinion_file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_file_id_app_file_id_fk": {
+					"name": "app_cse_opinion_file_file_id_app_file_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_file_decl_number_type_idx": {
+					"name": "cse_opinion_file_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_status_history": {
+			"name": "app_declaration_status_history",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "declaration_event_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"round": {
+					"name": "round",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"decl_status_history_declaration_idx": {
+					"name": "decl_status_history_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_status_history_actor_user_id_app_user_id_fk": {
+					"name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_declaration_path_choice": {
+					"name": "first_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_path_choice": {
+					"name": "second_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_required": {
+					"name": "cse_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"rules_version": {
+					"name": "rules_version",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'2027.1'"
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declarations_siren_year_active_unique": {
+					"name": "declarations_siren_year_active_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "cancelled_at IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.compliance_path": {
+			"name": "compliance_path",
+			"schema": "public",
+			"values": ["justify", "corrective_action", "joint_evaluation"]
+		},
+		"public.declaration_event_type": {
+			"name": "declaration_event_type",
+			"schema": "public",
+			"values": [
+				"submit",
+				"path_choice",
+				"second_declaration_submit",
+				"joint_evaluation_submit",
+				"cse_opinion_submit",
+				"cancel",
+				"demarche_complete",
+				"step_change"
+			]
+		},
+		"public.declaration_status": {
+			"name": "declaration_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"awaiting_compliance_path_choice",
+				"corrective_actions_chosen",
+				"joint_evaluation_chosen",
+				"awaiting_revision_choice",
+				"revised_joint_evaluation_chosen",
+				"awaiting_cse_opinion",
+				"demarche_completed"
+			]
+		},
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,279 +1,279 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1771922842861,
-      "tag": "0000_fuzzy_romulus",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1771928448125,
-      "tag": "0001_worthless_dragon_lord",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1772154191182,
-      "tag": "0002_lean_khan",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1772215461501,
-      "tag": "0003_absurd_komodo",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1772223004236,
-      "tag": "0004_next_jack_murdock",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1772611200000,
-      "tag": "0005_standardize_snake_case",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1772703893318,
-      "tag": "0006_lovely_korath",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1773158962249,
-      "tag": "0007_gigantic_doctor_faustus",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1773328599101,
-      "tag": "0008_powerful_omega_flight",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1773331852632,
-      "tag": "0009_hot_vector",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1773504000000,
-      "tag": "0010_gip_mds_data",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1773936000000,
-      "tag": "0011_add_export_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1774022400000,
-      "tag": "0012_export_date_to_year",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1774108800000,
-      "tag": "0013_add_gip_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1774195200000,
-      "tag": "0014_drop_session_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1774281600000,
-      "tag": "0015_drop_account_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1774368000000,
-      "tag": "0016_link_cse_joint_eval_to_declaration",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1774874768051,
-      "tag": "0017_flatten-indicator-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1774945983953,
-      "tag": "0018_rare_next_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1775050635448,
-      "tag": "0019_declaration_siren_fk",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1775200000000,
-      "tag": "0020_clean-user-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1775400000000,
-      "tag": "0021_add-campaign-deadlines",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1775450000000,
-      "tag": "0022_merge_file_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1775500000000,
-      "tag": "0023_add_audit_action_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1775600000000,
-      "tag": "0024_add_admin_impersonation_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1775700000000,
-      "tag": "0025_add_user_is_admin",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1775800000000,
-      "tag": "0026_add_referents_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1775900000000,
-      "tag": "0027_add_global_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1776000000000,
-      "tag": "0028_add_cse_opinion_completed_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1776100000000,
-      "tag": "0029_add_declaration_submitted_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1777379362370,
-      "tag": "0030_drop_job_category_detail",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1777500000000,
-      "tag": "0031_drop_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1778071563871,
-      "tag": "0032_sparkling_monster_badoon",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1778489783883,
-      "tag": "0033_add_cancelled_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1778584824979,
-      "tag": "0034_tranquil_catseye",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1778682813792,
-      "tag": "0035_status_history",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1779271468703,
-      "tag": "0036_add_step_change_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "7",
-      "when": 1779271468704,
-      "tag": "0037_pale_mikhail_rasputin",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "7",
-      "when": 1780674283597,
-      "tag": "0038_striped_xavin",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1771922842861,
+			"tag": "0000_fuzzy_romulus",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1771928448125,
+			"tag": "0001_worthless_dragon_lord",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1772154191182,
+			"tag": "0002_lean_khan",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1772215461501,
+			"tag": "0003_absurd_komodo",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1772223004236,
+			"tag": "0004_next_jack_murdock",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1772611200000,
+			"tag": "0005_standardize_snake_case",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1772703893318,
+			"tag": "0006_lovely_korath",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1773158962249,
+			"tag": "0007_gigantic_doctor_faustus",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1773328599101,
+			"tag": "0008_powerful_omega_flight",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1773331852632,
+			"tag": "0009_hot_vector",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1773504000000,
+			"tag": "0010_gip_mds_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1773936000000,
+			"tag": "0011_add_export_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1774022400000,
+			"tag": "0012_export_date_to_year",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1774108800000,
+			"tag": "0013_add_gip_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1774195200000,
+			"tag": "0014_drop_session_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1774281600000,
+			"tag": "0015_drop_account_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1774368000000,
+			"tag": "0016_link_cse_joint_eval_to_declaration",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1774874768051,
+			"tag": "0017_flatten-indicator-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1774945983953,
+			"tag": "0018_rare_next_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1775050635448,
+			"tag": "0019_declaration_siren_fk",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1775200000000,
+			"tag": "0020_clean-user-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1775400000000,
+			"tag": "0021_add-campaign-deadlines",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1775450000000,
+			"tag": "0022_merge_file_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1775500000000,
+			"tag": "0023_add_audit_action_log",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1775600000000,
+			"tag": "0024_add_admin_impersonation_events",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1775700000000,
+			"tag": "0025_add_user_is_admin",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1775800000000,
+			"tag": "0026_add_referents_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1775900000000,
+			"tag": "0027_add_global_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1776000000000,
+			"tag": "0028_add_cse_opinion_completed_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1776100000000,
+			"tag": "0029_add_declaration_submitted_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1777379362370,
+			"tag": "0030_drop_job_category_detail",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1777500000000,
+			"tag": "0031_drop_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1778071563871,
+			"tag": "0032_sparkling_monster_badoon",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1778489783883,
+			"tag": "0033_add_cancelled_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1778584824979,
+			"tag": "0034_tranquil_catseye",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1778682813792,
+			"tag": "0035_status_history",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779271468703,
+			"tag": "0036_add_step_change_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 37,
+			"version": "7",
+			"when": 1779271468704,
+			"tag": "0037_pale_mikhail_rasputin",
+			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1780674283597,
+			"tag": "0038_striped_xavin",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,272 +1,279 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1771922842861,
-			"tag": "0000_fuzzy_romulus",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1771928448125,
-			"tag": "0001_worthless_dragon_lord",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1772154191182,
-			"tag": "0002_lean_khan",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1772215461501,
-			"tag": "0003_absurd_komodo",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1772223004236,
-			"tag": "0004_next_jack_murdock",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1772611200000,
-			"tag": "0005_standardize_snake_case",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1772703893318,
-			"tag": "0006_lovely_korath",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1773158962249,
-			"tag": "0007_gigantic_doctor_faustus",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1773328599101,
-			"tag": "0008_powerful_omega_flight",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1773331852632,
-			"tag": "0009_hot_vector",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1773504000000,
-			"tag": "0010_gip_mds_data",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1773936000000,
-			"tag": "0011_add_export_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1774022400000,
-			"tag": "0012_export_date_to_year",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1774108800000,
-			"tag": "0013_add_gip_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1774195200000,
-			"tag": "0014_drop_session_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1774281600000,
-			"tag": "0015_drop_account_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1774368000000,
-			"tag": "0016_link_cse_joint_eval_to_declaration",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1774874768051,
-			"tag": "0017_flatten-indicator-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1774945983953,
-			"tag": "0018_rare_next_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1775050635448,
-			"tag": "0019_declaration_siren_fk",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1775200000000,
-			"tag": "0020_clean-user-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1775400000000,
-			"tag": "0021_add-campaign-deadlines",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1775450000000,
-			"tag": "0022_merge_file_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1775500000000,
-			"tag": "0023_add_audit_action_log",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1775600000000,
-			"tag": "0024_add_admin_impersonation_events",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1775700000000,
-			"tag": "0025_add_user_is_admin",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1775800000000,
-			"tag": "0026_add_referents_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1775900000000,
-			"tag": "0027_add_global_settings",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1776000000000,
-			"tag": "0028_add_cse_opinion_completed_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1776100000000,
-			"tag": "0029_add_declaration_submitted_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1777379362370,
-			"tag": "0030_drop_job_category_detail",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1777500000000,
-			"tag": "0031_drop_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1778071563871,
-			"tag": "0032_sparkling_monster_badoon",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1778489783883,
-			"tag": "0033_add_cancelled_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1778584824979,
-			"tag": "0034_tranquil_catseye",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1778682813792,
-			"tag": "0035_status_history",
-			"breakpoints": true
-		},
-		{
-			"idx": 36,
-			"version": "7",
-			"when": 1779271468703,
-			"tag": "0036_add_step_change_event_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 37,
-			"version": "7",
-			"when": 1779271468704,
-			"tag": "0037_pale_mikhail_rasputin",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1771922842861,
+      "tag": "0000_fuzzy_romulus",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771928448125,
+      "tag": "0001_worthless_dragon_lord",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772154191182,
+      "tag": "0002_lean_khan",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772215461501,
+      "tag": "0003_absurd_komodo",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772223004236,
+      "tag": "0004_next_jack_murdock",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772611200000,
+      "tag": "0005_standardize_snake_case",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1772703893318,
+      "tag": "0006_lovely_korath",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1773158962249,
+      "tag": "0007_gigantic_doctor_faustus",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1773328599101,
+      "tag": "0008_powerful_omega_flight",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1773331852632,
+      "tag": "0009_hot_vector",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1773504000000,
+      "tag": "0010_gip_mds_data",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1773936000000,
+      "tag": "0011_add_export_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1774022400000,
+      "tag": "0012_export_date_to_year",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1774108800000,
+      "tag": "0013_add_gip_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1774195200000,
+      "tag": "0014_drop_session_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1774281600000,
+      "tag": "0015_drop_account_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1774368000000,
+      "tag": "0016_link_cse_joint_eval_to_declaration",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1774874768051,
+      "tag": "0017_flatten-indicator-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1774945983953,
+      "tag": "0018_rare_next_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1775050635448,
+      "tag": "0019_declaration_siren_fk",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0020_clean-user-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1775400000000,
+      "tag": "0021_add-campaign-deadlines",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1775450000000,
+      "tag": "0022_merge_file_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1775500000000,
+      "tag": "0023_add_audit_action_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1775600000000,
+      "tag": "0024_add_admin_impersonation_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1775700000000,
+      "tag": "0025_add_user_is_admin",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1775800000000,
+      "tag": "0026_add_referents_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1775900000000,
+      "tag": "0027_add_global_settings",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0028_add_cse_opinion_completed_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1776100000000,
+      "tag": "0029_add_declaration_submitted_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1777379362370,
+      "tag": "0030_drop_job_category_detail",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1777500000000,
+      "tag": "0031_drop_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1778071563871,
+      "tag": "0032_sparkling_monster_badoon",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778489783883,
+      "tag": "0033_add_cancelled_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778584824979,
+      "tag": "0034_tranquil_catseye",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1778682813792,
+      "tag": "0035_status_history",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1779271468703,
+      "tag": "0036_add_step_change_event_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1779271468704,
+      "tag": "0037_pale_mikhail_rasputin",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1780674283597,
+      "tag": "0038_striped_xavin",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { Page } from "@playwright/test";
+import { setCseFileAssociationsForCurrentDeclaration } from "./db";
 
 const DUMMY_PDF = path.join(import.meta.dirname, "../fixtures/dummy.pdf");
 export const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
@@ -19,9 +20,18 @@ export async function fillCseStep1(page: Page, hasSecondDeclaration = false) {
 	await page.waitForURL("**/avis-cse/etape/2");
 }
 
-export async function submitCseStep2(page: Page) {
+export async function submitCseStep2(
+	page: Page,
+	associations: { declarationNumber: number; type: string }[] = [
+		{ declarationNumber: 1, type: "accuracy" },
+	],
+) {
 	await page.locator("#cse-file-upload").setInputFiles(DUMMY_PDF);
 	await page.getByRole("button", { name: "Soumettre" }).click();
+	await page
+		.getByText(/Je certifie que les avis transmis sont conformes/)
+		.waitFor({ state: "visible" });
+	await setCseFileAssociationsForCurrentDeclaration(associations);
 	await page
 		.getByText(/Je certifie que les avis transmis sont conformes/)
 		.click();

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { Page } from "@playwright/test";
-import { setCseFileAssociationsForCurrentDeclaration } from "./db";
+import { insertCseOpinionFileWithAssociations } from "./db";
 
 const DUMMY_PDF = path.join(import.meta.dirname, "../fixtures/dummy.pdf");
 export const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
@@ -26,12 +26,14 @@ export async function submitCseStep2(
 		{ declarationNumber: 1, type: "accuracy" },
 	],
 ) {
-	await page.locator("#cse-file-upload").setInputFiles(DUMMY_PDF);
+	await page.waitForURL("**/avis-cse/etape/2");
+	await insertCseOpinionFileWithAssociations(associations);
+	await page.reload();
+	await page.waitForURL("**/avis-cse/etape/2");
 	await page.getByRole("button", { name: "Soumettre" }).click();
 	await page
 		.getByText(/Je certifie que les avis transmis sont conformes/)
 		.waitFor({ state: "visible" });
-	await setCseFileAssociationsForCurrentDeclaration(associations);
 	await page
 		.getByText(/Je certifie que les avis transmis sont conformes/)
 		.click();

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -442,3 +442,38 @@ export async function setCseFileAssociationsForCurrentDeclaration(
 		await sql.end();
 	}
 }
+
+export async function insertCseOpinionFileWithAssociations(
+	associations: { declarationNumber: number; type: string }[],
+) {
+	const sql = createConnection();
+	try {
+		const decls = await sql<[{ id: string }]>`
+			SELECT id FROM app_declaration
+			WHERE siren = ${TEST_SIREN}
+			  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
+			LIMIT 1
+		`;
+		const declarationId = decls[0]?.id;
+		if (!declarationId) return;
+
+		const fileRows = await sql<[{ id: string }]>`
+			INSERT INTO app_file (id, declaration_id, file_name, file_path, uploaded_at, created_at, type)
+			VALUES (gen_random_uuid(), ${declarationId}, 'test-cse.pdf', '/tmp/test-cse.pdf', NOW(), NOW(), 'cse_opinion')
+			RETURNING id
+		`;
+		const fileId = fileRows[0]?.id;
+		if (!fileId) return;
+
+		await sql`DELETE FROM app_cse_opinion_file WHERE declaration_id = ${declarationId}`;
+
+		for (const assoc of associations) {
+			await sql`
+				INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id, created_at, updated_at)
+				VALUES (gen_random_uuid(), ${declarationId}, ${assoc.declarationNumber}, ${assoc.type}, ${fileId}, NOW(), NOW())
+			`;
+		}
+	} finally {
+		await sql.end();
+	}
+}

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -402,3 +402,43 @@ export async function setUserPhone(phone: string | null) {
 		await sql.end();
 	}
 }
+
+export async function setCseFileAssociationsForCurrentDeclaration(
+	associations: { declarationNumber: number; type: string }[],
+) {
+	const sql = createConnection();
+	try {
+		const decls = await sql<[{ id: string }]>`
+			SELECT id FROM app_declaration
+			WHERE siren = ${TEST_SIREN}
+			  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
+			LIMIT 1
+		`;
+		const declarationId = decls[0]?.id;
+		if (!declarationId) return;
+
+		const fileRows = await sql<[{ id: string }]>`
+			SELECT id FROM app_file
+			WHERE declaration_id = ${declarationId}
+			  AND type = 'cse_opinion'
+			ORDER BY uploaded_at DESC
+			LIMIT 1
+		`;
+		const fileId = fileRows[0]?.id;
+		if (!fileId) return;
+
+		await sql`
+			DELETE FROM app_cse_opinion_file
+			WHERE declaration_id = ${declarationId}
+		`;
+
+		for (const assoc of associations) {
+			await sql`
+				INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id, created_at, updated_at)
+				VALUES (gen_random_uuid(), ${declarationId}, ${assoc.declarationNumber}, ${assoc.type}, ${fileId}, NOW(), NOW())
+			`;
+		}
+	} finally {
+		await sql.end();
+	}
+}

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -31,6 +31,7 @@ export const AUDIT_ACTIONS = {
 	CSE_OPINION_UPLOAD_FILE: "cse_opinion.upload_file",
 	CSE_OPINION_DELETE_FILE: "cse_opinion.delete_file",
 	CSE_OPINION_FINALIZE: "cse_opinion.finalize",
+	CSE_OPINION_SET_FILE_TYPES: "cse_opinion.set_file_types",
 
 	// ── Joint evaluation mutations ─────────────────────────
 	JOINT_EVALUATION_UPLOAD_FILE: "joint_evaluation.upload_file",
@@ -130,6 +131,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.CSE_OPINION_UPLOAD_FILE]: "mutation",
 	[AUDIT_ACTIONS.CSE_OPINION_DELETE_FILE]: "mutation",
 	[AUDIT_ACTIONS.CSE_OPINION_FINALIZE]: "mutation",
+	[AUDIT_ACTIONS.CSE_OPINION_SET_FILE_TYPES]: "mutation",
 
 	[AUDIT_ACTIONS.JOINT_EVALUATION_UPLOAD_FILE]: "mutation",
 

--- a/packages/app/src/modules/cseOpinion/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/cseOpinion/__tests__/schemas.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { setFileContentTypesSchema } from "../schemas";
+
+describe("setFileContentTypesSchema", () => {
+	it("accepts a valid set of associations", () => {
+		const result = setFileContentTypesSchema.safeParse({
+			associations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+				{ declarationNumber: 2, type: "gap", fileId: "file-2" },
+			],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts an empty associations array", () => {
+		const result = setFileContentTypesSchema.safeParse({ associations: [] });
+
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a declarationNumber below 1", () => {
+		const result = setFileContentTypesSchema.safeParse({
+			associations: [{ declarationNumber: 0, type: "accuracy", fileId: "f" }],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects a declarationNumber above 2", () => {
+		const result = setFileContentTypesSchema.safeParse({
+			associations: [{ declarationNumber: 3, type: "accuracy", fileId: "f" }],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects a non-integer declarationNumber", () => {
+		const result = setFileContentTypesSchema.safeParse({
+			associations: [{ declarationNumber: 1.5, type: "accuracy", fileId: "f" }],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an unknown content type", () => {
+		const result = setFileContentTypesSchema.safeParse({
+			associations: [{ declarationNumber: 1, type: "other", fileId: "f" }],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an empty fileId", () => {
+		const result = setFileContentTypesSchema.safeParse({
+			associations: [{ declarationNumber: 1, type: "accuracy", fileId: "" }],
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/cseOpinion/index.ts
+++ b/packages/app/src/modules/cseOpinion/index.ts
@@ -3,6 +3,10 @@ export { CseOpinionLayout } from "./CseOpinionLayout";
 export { mapOpinionsFromDb } from "./mapOpinionsFromDb";
 export { Step1Opinions } from "./Step1Opinions";
 export { Step2Upload } from "./Step2Upload";
-export { deleteFileSchema, saveOpinionsSchema } from "./schemas";
+export {
+	deleteFileSchema,
+	saveOpinionsSchema,
+	setFileContentTypesSchema,
+} from "./schemas";
 export type { CseOpinionStep1Data, OpinionType, UploadedFile } from "./types";
 export { MAX_CSE_FILES, STEP_TITLES, TOTAL_STEPS } from "./types";

--- a/packages/app/src/modules/cseOpinion/schemas.ts
+++ b/packages/app/src/modules/cseOpinion/schemas.ts
@@ -18,3 +18,13 @@ export const saveOpinionsSchema = z.object({
 export const deleteFileSchema = z.object({
 	fileId: z.string().min(1),
 });
+
+export const setFileContentTypesSchema = z.object({
+	associations: z.array(
+		z.object({
+			declarationNumber: z.number().int().min(1).max(2),
+			type: z.enum(["accuracy", "gap"]),
+			fileId: z.string().min(1),
+		}),
+	),
+});

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.fileAssociations.integration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.fileAssociations.integration.test.ts
@@ -1,0 +1,102 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+
+describe("cse_opinion_file DB-level constraints", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN = "123456789";
+	const YEAR = 2025;
+	const USER_ID = "test-cse-assoc-user";
+	const USER_EMAIL = "test-cse-assoc@example.fr";
+	const DECL_ID = "decl-cse-assoc";
+	const FILE_ID = "file-cse-assoc";
+
+	async function cleanup() {
+		await sql`DELETE FROM app_cse_opinion_file WHERE declaration_id = ${DECL_ID}`;
+		await sql`DELETE FROM app_file WHERE declaration_id = ${DECL_ID}`;
+		await sql`DELETE FROM app_declaration WHERE id = ${DECL_ID}`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+
+		await sql`
+			INSERT INTO app_user (id, email)
+			VALUES (${USER_ID}, ${USER_EMAIL})
+		`;
+		await sql`
+			INSERT INTO app_company (siren, name)
+			VALUES (${SIREN}, 'Test Company')
+		`;
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id)
+			VALUES (${DECL_ID}, ${SIREN}, ${YEAR}, ${USER_ID})
+		`;
+		await sql`
+			INSERT INTO app_file (id, declaration_id, file_name, file_path, type, uploaded_at)
+			VALUES (${FILE_ID}, ${DECL_ID}, 'avis.pdf', ${`${SIREN}/2025/avis.pdf`}, 'cse_opinion', now())
+		`;
+	});
+
+	it("cascades the delete of a file to its content-type associations", async () => {
+		await sql`
+			INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id)
+			VALUES
+				('assoc-1', ${DECL_ID}, 1, 'accuracy', ${FILE_ID}),
+				('assoc-2', ${DECL_ID}, 1, 'gap', ${FILE_ID})
+		`;
+
+		const before = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count FROM app_cse_opinion_file WHERE file_id = ${FILE_ID}
+		`;
+		expect(before[0]?.count).toBe(2);
+
+		await sql`DELETE FROM app_file WHERE id = ${FILE_ID}`;
+
+		const after = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count FROM app_cse_opinion_file WHERE declaration_id = ${DECL_ID}
+		`;
+		expect(after[0]?.count).toBe(0);
+	});
+
+	it("allows the same file to cover several (declarationNumber, type) couples", async () => {
+		await sql`
+			INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id)
+			VALUES
+				('assoc-1', ${DECL_ID}, 1, 'accuracy', ${FILE_ID}),
+				('assoc-2', ${DECL_ID}, 2, 'gap', ${FILE_ID})
+		`;
+
+		const rows = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count FROM app_cse_opinion_file WHERE file_id = ${FILE_ID}
+		`;
+		expect(rows[0]?.count).toBe(2);
+	});
+
+	it("rejects two associations for the same (declaration, number, type) couple", async () => {
+		await sql`
+			INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id)
+			VALUES ('assoc-1', ${DECL_ID}, 1, 'accuracy', ${FILE_ID})
+		`;
+
+		await expect(
+			sql`
+				INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id)
+				VALUES ('assoc-2', ${DECL_ID}, 1, 'accuracy', ${FILE_ID})
+			`,
+		).rejects.toThrow(/unique/i);
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
@@ -44,6 +44,10 @@ type FinalizeOptions = {
 	txDraft?: Record<string, unknown> | null;
 	opinions?: Opinion[];
 	associations?: Association[];
+	// When true, the matching count query resolves to [] so its row is undefined,
+	// exercising the `?? 0` fallback in finalize().
+	emptyOpinionCountRow?: boolean;
+	emptyFileCountRow?: boolean;
 };
 
 // Select sequence of finalize():
@@ -62,6 +66,8 @@ function createMockDbForFinalize(options: FinalizeOptions = {}) {
 		txDraft = null,
 		opinions = FIRST_GAP_CONSULTED,
 		associations = ASSOCIATIONS_FIRST_GAP,
+		emptyOpinionCountRow = false,
+		emptyFileCountRow = false,
 	} = options;
 
 	const declarationLookupRow = { id: "decl-1" };
@@ -87,14 +93,16 @@ function createMockDbForFinalize(options: FinalizeOptions = {}) {
 	where.mockImplementation(() => {
 		const call = selectCallCount;
 		if (call === 2) {
-			return Object.assign(Promise.resolve([{ count: opinionCount }]), {
-				limit,
-			});
+			return Object.assign(
+				Promise.resolve(emptyOpinionCountRow ? [] : [{ count: opinionCount }]),
+				{ limit },
+			);
 		}
 		if (call === 3) {
-			return Object.assign(Promise.resolve([{ count: fileCount }]), {
-				limit,
-			});
+			return Object.assign(
+				Promise.resolve(emptyFileCountRow ? [] : [{ count: fileCount }]),
+				{ limit },
+			);
 		}
 		if (call === 5) {
 			return Object.assign(Promise.resolve(associations), { limit });
@@ -198,6 +206,26 @@ describe("cseOpinionRouter.finalize", () => {
 
 		await expect(caller.finalize()).rejects.toThrow(
 			"Les avis du CSE doivent être renseignés avant validation.",
+		);
+		expect(ctx.update).not.toHaveBeenCalled();
+	});
+
+	it("throws PRECONDITION_FAILED when the opinion count query returns no row", async () => {
+		const ctx = createMockDbForFinalize({ emptyOpinionCountRow: true });
+		const caller = await createCaller(ctx.db);
+
+		await expect(caller.finalize()).rejects.toThrow(
+			"Les avis du CSE doivent être renseignés avant validation.",
+		);
+		expect(ctx.update).not.toHaveBeenCalled();
+	});
+
+	it("throws PRECONDITION_FAILED when the file count query returns no row", async () => {
+		const ctx = createMockDbForFinalize({ emptyFileCountRow: true });
+		const caller = await createCaller(ctx.db);
+
+		await expect(caller.finalize()).rejects.toThrow(
+			"Au moins un fichier d'avis CSE doit être transmis.",
 		);
 		expect(ctx.update).not.toHaveBeenCalled();
 	});

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.finalize.test.ts
@@ -12,16 +12,58 @@ vi.mock("~/server/services/s3", () => ({
 	deleteFile: vi.fn(),
 }));
 
-function createMockDbForFinalize(
-	opinionCount: number,
-	fileCount: number,
-	declaration: Record<string, unknown> | null = {
-		id: "decl-1",
-		status: "awaiting_cse_opinion",
-		rulesVersion: "2027.1",
-	},
-	txDraft: Record<string, unknown> | null = null,
-) {
+const DEFAULT_DECLARATION = {
+	id: "decl-1",
+	status: "awaiting_cse_opinion",
+	rulesVersion: "2027.1",
+	secondDeclarationStep: null,
+};
+
+type Opinion = {
+	declarationNumber: number;
+	type: string;
+	gapConsulted: boolean | null;
+};
+type Association = { declarationNumber: number; type: string };
+
+const FIRST_GAP_CONSULTED: Opinion[] = [
+	{ declarationNumber: 1, type: "accuracy", gapConsulted: null },
+	{ declarationNumber: 1, type: "gap", gapConsulted: true },
+];
+
+// Covers every type required by FIRST_GAP_CONSULTED so finalize passes the guard.
+const ASSOCIATIONS_FIRST_GAP: Association[] = [
+	{ declarationNumber: 1, type: "accuracy" },
+	{ declarationNumber: 1, type: "gap" },
+];
+
+type FinalizeOptions = {
+	opinionCount?: number;
+	fileCount?: number;
+	declaration?: Record<string, unknown> | null;
+	txDraft?: Record<string, unknown> | null;
+	opinions?: Opinion[];
+	associations?: Association[];
+};
+
+// Select sequence of finalize():
+//   1 middleware declaration-id lookup (.where().limit)
+//   2 opinionCount (.where)
+//   3 fileCount (.where)
+//   4 declarationRow (.where().limit)
+//   5 existingAssociations (.where)
+//   6 opinions with gapConsulted (.where)
+//   7 (inside tx) declRow for draft purge (.where().limit)
+function createMockDbForFinalize(options: FinalizeOptions = {}) {
+	const {
+		opinionCount = 2,
+		fileCount = 1,
+		declaration = DEFAULT_DECLARATION,
+		txDraft = null,
+		opinions = FIRST_GAP_CONSULTED,
+		associations = ASSOCIATIONS_FIRST_GAP,
+	} = options;
+
 	const declarationLookupRow = { id: "decl-1" };
 
 	let selectCallCount = 0;
@@ -36,7 +78,7 @@ function createMockDbForFinalize(
 		if (call === 4) {
 			return Promise.resolve(declaration ? [declaration] : []);
 		}
-		if (call === 5 && txDraft !== null) {
+		if (call === 7 && txDraft !== null) {
 			return Promise.resolve([{ draft: txDraft }]);
 		}
 		return Promise.resolve([]);
@@ -53,6 +95,12 @@ function createMockDbForFinalize(
 			return Object.assign(Promise.resolve([{ count: fileCount }]), {
 				limit,
 			});
+		}
+		if (call === 5) {
+			return Object.assign(Promise.resolve(associations), { limit });
+		}
+		if (call === 6) {
+			return Object.assign(Promise.resolve(opinions), { limit });
 		}
 		return Object.assign(Promise.resolve([declarationLookupRow]), { limit });
 	});
@@ -122,7 +170,7 @@ describe("cseOpinionRouter.finalize", () => {
 	});
 
 	it("transitions awaiting_cse_opinion → demarche_completed and inserts cse_opinion_submit + demarche_complete events", async () => {
-		const ctx = createMockDbForFinalize(2, 1);
+		const ctx = createMockDbForFinalize();
 		const caller = await createCaller(ctx.db);
 
 		const result = await caller.finalize();
@@ -145,7 +193,7 @@ describe("cseOpinionRouter.finalize", () => {
 	});
 
 	it("throws PRECONDITION_FAILED when no opinions exist", async () => {
-		const ctx = createMockDbForFinalize(0, 1);
+		const ctx = createMockDbForFinalize({ opinionCount: 0 });
 		const caller = await createCaller(ctx.db);
 
 		await expect(caller.finalize()).rejects.toThrow(
@@ -155,7 +203,7 @@ describe("cseOpinionRouter.finalize", () => {
 	});
 
 	it("throws PRECONDITION_FAILED when no file has been uploaded", async () => {
-		const ctx = createMockDbForFinalize(2, 0);
+		const ctx = createMockDbForFinalize({ fileCount: 0 });
 		const caller = await createCaller(ctx.db);
 
 		await expect(caller.finalize()).rejects.toThrow(
@@ -165,14 +213,14 @@ describe("cseOpinionRouter.finalize", () => {
 	});
 
 	it("throws NOT_FOUND when declaration row vanished between lookup and finalize", async () => {
-		const ctx = createMockDbForFinalize(2, 1, null);
+		const ctx = createMockDbForFinalize({ declaration: null });
 		const caller = await createCaller(ctx.db);
 
 		await expect(caller.finalize()).rejects.toThrow("Déclaration introuvable");
 	});
 
 	it("refuses to finalize when the admin is impersonating", async () => {
-		const ctx = createMockDbForFinalize(2, 1);
+		const ctx = createMockDbForFinalize();
 		const caller = await createCaller(ctx.db, null, {
 			siren: "339787277",
 			name: "Acme",
@@ -184,7 +232,7 @@ describe("cseOpinionRouter.finalize", () => {
 
 	it("purges the cse draft slice and keeps other slices after finalize", async () => {
 		const txDraft = { cse: { step1: { foo: "bar" } }, main: { step1: {} } };
-		const ctx = createMockDbForFinalize(2, 1, undefined, txDraft);
+		const ctx = createMockDbForFinalize({ txDraft });
 		const caller = await createCaller(ctx.db);
 
 		await caller.finalize();
@@ -200,7 +248,7 @@ describe("cseOpinionRouter.finalize", () => {
 
 	it("sets draft to null when cse was the only slice after finalize", async () => {
 		const txDraft = { cse: { step1: { foo: "bar" } } };
-		const ctx = createMockDbForFinalize(2, 1, undefined, txDraft);
+		const ctx = createMockDbForFinalize({ txDraft });
 		const caller = await createCaller(ctx.db);
 
 		await caller.finalize();
@@ -215,7 +263,7 @@ describe("cseOpinionRouter.finalize", () => {
 	});
 
 	it("does not call draft update when no draft exists in cse finalize", async () => {
-		const ctx = createMockDbForFinalize(2, 1, undefined, null);
+		const ctx = createMockDbForFinalize({ txDraft: null });
 		const caller = await createCaller(ctx.db);
 
 		await caller.finalize();
@@ -225,5 +273,113 @@ describe("cseOpinionRouter.finalize", () => {
 		);
 		const purgeCall = setCalls.find((c) => "draft" in c);
 		expect(purgeCall).toBeUndefined();
+	});
+
+	describe("file-content-type association guard", () => {
+		it("passes when only (1, accuracy) is required and it is covered", async () => {
+			const ctx = createMockDbForFinalize({
+				opinions: [{ declarationNumber: 1, type: "gap", gapConsulted: false }],
+				associations: [{ declarationNumber: 1, type: "accuracy" }],
+			});
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).resolves.toEqual({ success: true });
+		});
+
+		it("throws PRECONDITION_FAILED when (1, accuracy) is not covered", async () => {
+			const ctx = createMockDbForFinalize({
+				opinions: [{ declarationNumber: 1, type: "gap", gapConsulted: false }],
+				associations: [],
+			});
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).rejects.toThrow(
+				"Le type de contenu « Exactitude » de la première déclaration doit être associé à un fichier avant validation.",
+			);
+			expect(ctx.update).not.toHaveBeenCalled();
+		});
+
+		it("requires (1, gap) when first declaration gapConsulted is true", async () => {
+			const ctx = createMockDbForFinalize({
+				opinions: [{ declarationNumber: 1, type: "gap", gapConsulted: true }],
+				associations: [{ declarationNumber: 1, type: "accuracy" }],
+			});
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).rejects.toThrow(
+				"Le type de contenu « Justification » de la première déclaration doit être associé à un fichier avant validation.",
+			);
+			expect(ctx.update).not.toHaveBeenCalled();
+		});
+
+		it("requires (2, accuracy) when a second declaration step exists", async () => {
+			const ctx = createMockDbForFinalize({
+				declaration: { ...DEFAULT_DECLARATION, secondDeclarationStep: "step1" },
+				opinions: [{ declarationNumber: 1, type: "gap", gapConsulted: false }],
+				associations: [{ declarationNumber: 1, type: "accuracy" }],
+			});
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).rejects.toThrow(
+				"Le type de contenu « Exactitude » de la deuxième déclaration doit être associé à un fichier avant validation.",
+			);
+			expect(ctx.update).not.toHaveBeenCalled();
+		});
+
+		it("requires (2, gap) when second declaration gapConsulted is true", async () => {
+			const ctx = createMockDbForFinalize({
+				declaration: { ...DEFAULT_DECLARATION, secondDeclarationStep: "step1" },
+				opinions: [
+					{ declarationNumber: 1, type: "gap", gapConsulted: false },
+					{ declarationNumber: 2, type: "gap", gapConsulted: true },
+				],
+				associations: [
+					{ declarationNumber: 1, type: "accuracy" },
+					{ declarationNumber: 2, type: "accuracy" },
+				],
+			});
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).rejects.toThrow(
+				"Le type de contenu « Justification » de la deuxième déclaration doit être associé à un fichier avant validation.",
+			);
+			expect(ctx.update).not.toHaveBeenCalled();
+		});
+
+		it("passes with a full two-declaration set when every required type is covered", async () => {
+			const ctx = createMockDbForFinalize({
+				declaration: { ...DEFAULT_DECLARATION, secondDeclarationStep: "step1" },
+				opinions: [
+					{ declarationNumber: 1, type: "gap", gapConsulted: true },
+					{ declarationNumber: 2, type: "gap", gapConsulted: true },
+				],
+				associations: [
+					{ declarationNumber: 1, type: "accuracy" },
+					{ declarationNumber: 1, type: "gap" },
+					{ declarationNumber: 2, type: "accuracy" },
+					{ declarationNumber: 2, type: "gap" },
+				],
+			});
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).resolves.toEqual({ success: true });
+		});
+
+		it("does not require (2, gap) when second declaration gapConsulted is false", async () => {
+			const ctx = createMockDbForFinalize({
+				declaration: { ...DEFAULT_DECLARATION, secondDeclarationStep: "step1" },
+				opinions: [
+					{ declarationNumber: 1, type: "gap", gapConsulted: false },
+					{ declarationNumber: 2, type: "gap", gapConsulted: false },
+				],
+				associations: [
+					{ declarationNumber: 1, type: "accuracy" },
+					{ declarationNumber: 2, type: "accuracy" },
+				],
+			});
+			const caller = await createCaller(ctx.db);
+
+			await expect(caller.finalize()).resolves.toEqual({ success: true });
+		});
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/cseOpinion.test.ts
@@ -27,6 +27,13 @@ vi.mock("~/server/db/schema", () => ({
 		uploadedAt: "uploadedAt",
 		type: "type",
 	},
+	cseOpinionFiles: {
+		id: "id",
+		declarationId: "declarationId",
+		declarationNumber: "declarationNumber",
+		type: "type",
+		fileId: "fileId",
+	},
 }));
 
 const mockDeleteS3File = vi.fn();
@@ -280,6 +287,166 @@ describe("cseOpinionRouter", () => {
 			await expect(caller.getFiles()).rejects.toThrow(
 				"SIRET manquant ou invalide dans la session",
 			);
+		});
+	});
+
+	describe("getFileContentTypes", () => {
+		it("returns associations for the current declaration", async () => {
+			const associations = [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+				{ declarationNumber: 1, type: "gap", fileId: "file-1" },
+			];
+			const mockDb = createMockDb(associations);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getFileContentTypes();
+
+			expect(mockSelect).toHaveBeenCalled();
+			expect(result).toEqual({ associations });
+		});
+
+		it("returns empty associations when none exist", async () => {
+			const mockDb = createMockDb([]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.getFileContentTypes();
+
+			expect(result).toEqual({ associations: [] });
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb();
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(caller.getFileContentTypes()).rejects.toThrow(
+				"SIRET manquant ou invalide dans la session",
+			);
+		});
+	});
+
+	describe("setFileContentTypes", () => {
+		it("replaces associations transactionally after validating files", async () => {
+			const mockDb = createMockDb([{ id: "file-1" }]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.setFileContentTypes({
+				associations: [
+					{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+					{ declarationNumber: 1, type: "gap", fileId: "file-1" },
+				],
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+			expect(mockInsert).toHaveBeenCalled();
+			expect(mockValues).toHaveBeenCalledWith([
+				expect.objectContaining({
+					declarationId: "decl-1",
+					declarationNumber: 1,
+					type: "accuracy",
+					fileId: "file-1",
+				}),
+				expect.objectContaining({
+					declarationId: "decl-1",
+					declarationNumber: 1,
+					type: "gap",
+					fileId: "file-1",
+				}),
+			]);
+		});
+
+		it("allows one file to be associated with several types", async () => {
+			const mockDb = createMockDb([{ id: "file-1" }]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.setFileContentTypes({
+				associations: [
+					{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+					{ declarationNumber: 2, type: "gap", fileId: "file-1" },
+				],
+			});
+
+			expect(result).toEqual({ success: true });
+			expect(mockValues).toHaveBeenCalledWith([
+				expect.objectContaining({ type: "accuracy", fileId: "file-1" }),
+				expect.objectContaining({ type: "gap", fileId: "file-1" }),
+			]);
+		});
+
+		it("throws BAD_REQUEST when the same (declarationNumber, type) is duplicated", async () => {
+			const mockDb = createMockDb([{ id: "file-1" }]);
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.setFileContentTypes({
+					associations: [
+						{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+						{ declarationNumber: 1, type: "accuracy", fileId: "file-2" },
+					],
+				}),
+			).rejects.toThrow(
+				"Chaque couple (numéro de déclaration, type) ne peut être associé qu'à un seul fichier.",
+			);
+			expect(mockTransaction).not.toHaveBeenCalled();
+		});
+
+		it("throws BAD_REQUEST when a fileId does not belong to the declaration", async () => {
+			const mockDb = createMockDb([]);
+			const caller = await createCaller(mockDb);
+
+			await expect(
+				caller.setFileContentTypes({
+					associations: [
+						{ declarationNumber: 1, type: "accuracy", fileId: "ghost" },
+					],
+				}),
+			).rejects.toThrow(
+				"Un ou plusieurs fichiers sont introuvables ou invalides pour cette déclaration.",
+			);
+			expect(mockTransaction).not.toHaveBeenCalled();
+		});
+
+		it("clears associations and skips validation when input is empty", async () => {
+			const mockDb = createMockDb([]);
+			const caller = await createCaller(mockDb);
+
+			const result = await caller.setFileContentTypes({ associations: [] });
+
+			expect(result).toEqual({ success: true });
+			expect(mockTransaction).toHaveBeenCalled();
+			expect(mockDelete).toHaveBeenCalled();
+			expect(mockInsert).not.toHaveBeenCalled();
+		});
+
+		it("throws when siret is missing", async () => {
+			const mockDb = createMockDb([{ id: "file-1" }]);
+			const caller = await createCaller(mockDb, null as never);
+
+			await expect(
+				caller.setFileContentTypes({
+					associations: [
+						{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+					],
+				}),
+			).rejects.toThrow("SIRET manquant ou invalide dans la session");
+		});
+
+		it("refuses setFileContentTypes when the admin is impersonating", async () => {
+			const mockDb = createMockDb([{ id: "file-1" }]);
+			const caller = await createCaller(mockDb, null, {
+				siren: "339787277",
+				name: "Acme",
+			});
+
+			await expect(
+				caller.setFileContentTypes({
+					associations: [
+						{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+					],
+				}),
+			).rejects.toThrow("Mode mimoquage");
+			expect(mockTransaction).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/app/src/server/api/routers/cseOpinion.ts
+++ b/packages/app/src/server/api/routers/cseOpinion.ts
@@ -1,8 +1,9 @@
 import { TRPCError } from "@trpc/server";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import {
 	deleteFileSchema,
 	saveOpinionsSchema,
+	setFileContentTypesSchema,
 } from "~/modules/cseOpinion/schemas";
 import {
 	createTRPCRouter,
@@ -10,6 +11,7 @@ import {
 	declarationWriteProcedure,
 } from "~/server/api/trpc";
 import {
+	cseOpinionFiles,
 	cseOpinions,
 	declarationStatusHistory,
 	declarations,
@@ -108,27 +110,105 @@ export const cseOpinionRouter = createTRPCRouter({
 		return { files: rows };
 	}),
 
+	getFileContentTypes: declarationProcedure.query(async ({ ctx }) => {
+		const rows = await ctx.db
+			.select({
+				declarationNumber: cseOpinionFiles.declarationNumber,
+				type: cseOpinionFiles.type,
+				fileId: cseOpinionFiles.fileId,
+			})
+			.from(cseOpinionFiles)
+			.where(eq(cseOpinionFiles.declarationId, ctx.declarationId));
+
+		return { associations: rows };
+	}),
+
+	setFileContentTypes: declarationWriteProcedure
+		.input(setFileContentTypesSchema)
+		.mutation(async ({ ctx, input }) => {
+			const { associations } = input;
+
+			const keys = associations.map((a) => `${a.declarationNumber}:${a.type}`);
+			const uniqueKeys = new Set(keys);
+			if (uniqueKeys.size !== keys.length) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message:
+						"Chaque couple (numéro de déclaration, type) ne peut être associé qu'à un seul fichier.",
+				});
+			}
+
+			if (associations.length > 0) {
+				const fileIds = [...new Set(associations.map((a) => a.fileId))];
+				const validFiles = await ctx.db
+					.select({ id: files.id })
+					.from(files)
+					.where(
+						and(
+							eq(files.declarationId, ctx.declarationId),
+							eq(files.type, "cse_opinion"),
+							inArray(files.id, fileIds),
+						),
+					);
+
+				if (validFiles.length !== fileIds.length) {
+					throw new TRPCError({
+						code: "BAD_REQUEST",
+						message:
+							"Un ou plusieurs fichiers sont introuvables ou invalides pour cette déclaration.",
+					});
+				}
+			}
+
+			await ctx.db.transaction(async (tx) => {
+				await tx
+					.delete(cseOpinionFiles)
+					.where(eq(cseOpinionFiles.declarationId, ctx.declarationId));
+
+				if (associations.length > 0) {
+					await tx.insert(cseOpinionFiles).values(
+						associations.map((a) => ({
+							declarationId: ctx.declarationId,
+							declarationNumber: a.declarationNumber,
+							type: a.type,
+							fileId: a.fileId,
+						})),
+					);
+				}
+			});
+
+			return { success: true };
+		}),
+
 	finalize: declarationWriteProcedure.mutation(async ({ ctx }) => {
-		const [opinionCount, fileCount, declarationRow] = await Promise.all([
-			ctx.db
-				.select({ count: sql<number>`count(*)::int` })
-				.from(cseOpinions)
-				.where(eq(cseOpinions.declarationId, ctx.declarationId)),
-			ctx.db
-				.select({ count: sql<number>`count(*)::int` })
-				.from(files)
-				.where(
-					and(
-						eq(files.declarationId, ctx.declarationId),
-						eq(files.type, "cse_opinion"),
+		const [opinionCount, fileCount, declarationRow, existingAssociations] =
+			await Promise.all([
+				ctx.db
+					.select({ count: sql<number>`count(*)::int` })
+					.from(cseOpinions)
+					.where(eq(cseOpinions.declarationId, ctx.declarationId)),
+				ctx.db
+					.select({ count: sql<number>`count(*)::int` })
+					.from(files)
+					.where(
+						and(
+							eq(files.declarationId, ctx.declarationId),
+							eq(files.type, "cse_opinion"),
+						),
 					),
-				),
-			ctx.db
-				.select()
-				.from(declarations)
-				.where(eq(declarations.id, ctx.declarationId))
-				.limit(1),
-		]);
+				ctx.db
+					.select()
+					.from(declarations)
+					.where(eq(declarations.id, ctx.declarationId))
+					.limit(1),
+				ctx.db
+					.select({
+						declarationNumber: cseOpinionFiles.declarationNumber,
+						type: cseOpinionFiles.type,
+					})
+					.from(cseOpinionFiles)
+					.where(eq(cseOpinionFiles.declarationId, ctx.declarationId)),
+			]);
 
 		if ((opinionCount[0]?.count ?? 0) === 0) {
 			throw new TRPCError({
@@ -149,6 +229,58 @@ export const cseOpinionRouter = createTRPCRouter({
 				code: "NOT_FOUND",
 				message: "Déclaration introuvable",
 			});
+		}
+
+		const opinions = await ctx.db
+			.select({
+				declarationNumber: cseOpinions.declarationNumber,
+				type: cseOpinions.type,
+				gapConsulted: cseOpinions.gapConsulted,
+			})
+			.from(cseOpinions)
+			.where(eq(cseOpinions.declarationId, ctx.declarationId));
+
+		const hasSecondDeclaration = declaration.secondDeclarationStep !== null;
+
+		const gapConsultedFirst = opinions.find(
+			(o) => o.declarationNumber === 1 && o.type === "gap",
+		)?.gapConsulted;
+		const gapConsultedSecond = opinions.find(
+			(o) => o.declarationNumber === 2 && o.type === "gap",
+		)?.gapConsulted;
+
+		type RequiredType = { declarationNumber: number; type: string };
+		const requiredTypes: RequiredType[] = [
+			{ declarationNumber: 1, type: "accuracy" },
+		];
+		if (gapConsultedFirst === true) {
+			requiredTypes.push({ declarationNumber: 1, type: "gap" });
+		}
+		if (hasSecondDeclaration) {
+			requiredTypes.push({ declarationNumber: 2, type: "accuracy" });
+			if (gapConsultedSecond === true) {
+				requiredTypes.push({ declarationNumber: 2, type: "gap" });
+			}
+		}
+
+		const coveredKeys = new Set(
+			existingAssociations.map((a) => `${a.declarationNumber}:${a.type}`),
+		);
+
+		for (const required of requiredTypes) {
+			const key = `${required.declarationNumber}:${required.type}`;
+			if (!coveredKeys.has(key)) {
+				const typeLabel =
+					required.type === "accuracy" ? "Exactitude" : "Justification";
+				const declLabel =
+					required.declarationNumber === 1
+						? "première déclaration"
+						: "deuxième déclaration";
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message: `Le type de contenu « ${typeLabel} » de la ${declLabel} doit être associé à un fichier avant validation.`,
+				});
+			}
 		}
 
 		const rules = loadRules(declaration.rulesVersion);

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -37,6 +37,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"cseOpinion.saveOpinions": AUDIT_ACTIONS.CSE_OPINION_SAVE,
 	"cseOpinion.deleteFile": AUDIT_ACTIONS.CSE_OPINION_DELETE_FILE,
 	"cseOpinion.finalize": AUDIT_ACTIONS.CSE_OPINION_FINALIZE,
+	"cseOpinion.setFileContentTypes": AUDIT_ACTIONS.CSE_OPINION_SET_FILE_TYPES,
 
 	// ── company mutations ──────────────────────────────────
 	"company.updateHasCse": AUDIT_ACTIONS.COMPANY_UPDATE_HAS_CSE,

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -246,6 +246,7 @@ export const declarationsRelations = relations(
 		jobCategories: many(jobCategories),
 		cseOpinions: many(cseOpinions),
 		files: many(files),
+		cseOpinionFiles: many(cseOpinionFiles),
 		statusHistory: many(declarationStatusHistory),
 	}),
 );
@@ -573,12 +574,60 @@ export const files = createTable(
 	],
 );
 
-export const filesRelations = relations(files, ({ one }) => ({
+export const filesRelations = relations(files, ({ one, many }) => ({
 	declaration: one(declarations, {
 		fields: [files.declarationId],
 		references: [declarations.id],
 	}),
+	cseOpinionFiles: many(cseOpinionFiles),
 }));
+
+// ── CSE opinion file associations ──────────────────────────────────
+
+export const cseOpinionFiles = createTable(
+	"cse_opinion_file",
+	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		declarationId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => declarations.id),
+		declarationNumber: d.integer().notNull(),
+		type: d.varchar({ length: 20 }).notNull(),
+		fileId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => files.id, { onDelete: "cascade" }),
+		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+	}),
+	(t) => [
+		unique("cse_opinion_file_decl_number_type_idx").on(
+			t.declarationId,
+			t.declarationNumber,
+			t.type,
+		),
+		index("cse_opinion_file_declaration_idx").on(t.declarationId),
+	],
+);
+
+export const cseOpinionFilesRelations = relations(
+	cseOpinionFiles,
+	({ one }) => ({
+		declaration: one(declarations, {
+			fields: [cseOpinionFiles.declarationId],
+			references: [declarations.id],
+		}),
+		file: one(files, {
+			fields: [cseOpinionFiles.fileId],
+			references: [files.id],
+		}),
+	}),
+);
 
 // ── Campaign deadlines (configurable per year) ────────────────────
 


### PR DESCRIPTION
Closes #3631

## Résumé

Mise en place du modèle de données et de l'API permettant d'associer chaque fichier d'avis CSE à un ou plusieurs types de contenu (Exactitude / Justification, par déclaration).

### Changements

- **Schéma DB** : nouvelle table `app_cse_opinion_file` avec contrainte d'unicité `(declarationId, declarationNumber, type)` et FK `fileId ON DELETE CASCADE`
- **Migration** : `drizzle/0038_striped_xavin.sql`
- **Schéma Zod** : `setFileContentTypesSchema` dans `modules/cseOpinion/schemas.ts`
- **tRPC** :
  - `cseOpinion.setFileContentTypes` : remplace transactionnellement les associations pour une déclaration ; valide l'exclusivité par type et l'appartenance des fichiers
  - `cseOpinion.getFileContentTypes` : retourne les associations existantes pour l'hydratation UI
  - `cseOpinion.finalize` : garde qui vérifie que chaque type requis est couvert avant la transition de statut (selon `gapConsulted` et la présence d'une 2e déclaration)
- **Audit** : `CSE_OPINION_SET_FILE_TYPES` câblé aux 3 points requis

## Plan de test

- [x] Typecheck vert
- [x] Suite vitest verte (2437 tests, 20 nouveaux)
- [x] Lint + format verts
- [x] Structural auditor : MINOR warnings uniquement (pre-existing)
- [x] RGAA auditor : PASS (ticket backend)
- [x] Security auditor : LOW (pre-existing pattern sur les queries non-sensibles)