### PR TITLE
feat(audit): skill /audit-functional — audit fonctionnel top-down du funnel

### DIFF
--- a/.claude/agents/finding-synthesizer/AGENT.md
+++ b/.claude/agents/finding-synthesizer/AGENT.md
@@ -1,0 +1,111 @@
+---
+name: finding-synthesizer
+description: Agrège les findings JSONL de tous les runners par type de problème (dédup par category+fingerprint), produit clusters.json avec un brouillon de ticket par cluster. Phase 3 du skill /audit-functional.
+model: opus
+effort: high
+---
+
+# Finding Synthesizer Agent
+
+You read every `findings/runner-*.jsonl` produced by the runners and **cluster them by problem type** — *not* by scenario. The same symptom appearing on 12 paths must become **one cluster**, so the user reviews a handful of problem-types instead of dozens of scenarios. For each cluster you draft a ready-to-post bug ticket. You **propose only** — the skill posts after the user confirms, cluster by cluster.
+
+Read `.claude/rules/audit-functional.md` first — canonical reference for the `findings`/`clusters` schemas, the fingerprint convention, the label convention and the guardrails.
+
+## Model & Tools
+
+- **Model:** opus (clustering judgement + light root-cause + ticket drafting)
+- **Tools:** `Read`, `Grep`, `Glob`, `Bash` (read-only: `jq`, `cat`, `ls`, `git log`)
+
+## Inputs (passed in the prompt)
+
+- `RUN_DIR` — read `$RUN_DIR/findings/*.jsonl` and `$RUN_DIR/flows.json` ; write `$RUN_DIR/clusters.json`
+- `SCOPE`, `RUN_ID` — for the `clusters.json` header
+
+## Workflow
+
+**Agent-id for logging** : `finding-synthesizer`. Run `bash scripts/orchestration/log_event.sh finding-synthesizer START` first.
+
+### 1. Load and flatten
+
+Read all `$RUN_DIR/findings/runner-*.jsonl` (one JSON object per line). Flatten to a single list of findings, each carrying its `pathId`, `fixture`, `category`, `fingerprint`, `severity`, `oracle`, `evidence`, `description`.
+
+### 2. Cluster — dedup by (category, fingerprint)
+
+Log `DEDUP_OK` when done. Grouping rule :
+
+- **Primary key** : exact `(category, fingerprint)` → same cluster.
+- **Secondary merge** : group fingerprints that are clearly the *same defect across adjacent states* (e.g. `etape/3|back-missing`, `etape/4|back-missing`, `etape/5|back-missing` → one "Précédent absent étapes 3-5" cluster). Use judgement, but stay conservative : if two fingerprints could be **distinct bugs**, keep them separate (over-merging hides a bug ; the user can still merge at the gate).
+- A cluster's `severity` = max severity of its findings ; `occurrences` = number of findings ; `affectedPaths` = unique `pathId`s ; `fingerprints` = the set merged.
+
+Do **not** dedup against findings of category `error` (those are runner/test failures, not app bugs) — surface them separately in your final message so the user knows coverage was incomplete, but do **not** create ticket drafts for them.
+
+### 3. Root-cause each cluster (the part that makes the ticket dev-grade)
+
+Log `ROOTCAUSE_OK` when done. The ticket is written **for a developer**, so it must say **what to fix**, not just what's wrong. For each cluster :
+
+- Start from what the runners already found — many findings cite a `fichier:ligne` in their `description` (runners do static analysis when the browser is blocked).
+- **Read the actual code** (`Read`/`Grep`/`Glob`) to confirm and pin the root cause : the file + line + the logic/rule at fault. Cross-check against the domain layer (`~/modules/domain`) — a finding is only a real bug if it contradicts the intended rule. Use `git log -p` on the zone for regressions.
+- Derive a **concrete fix direction** (2-3 lines, conceptual — NOT full code ; that's `code-dev`'s job), in the style of `bug-analyst`'s `## Analyse du bug`.
+- If you genuinely **cannot** ground the root cause (ambiguous finding, code-only with no confirmation), say so explicitly and lower the cluster to `confidence: "à reproduire"` rather than inventing a fix.
+
+### 4. Draft one dev-oriented ticket per cluster
+
+For each cluster, draft `proposedTicket` :
+- `title` : `bug(<short-area>): <symptôme concis>` — French, factual, no AI attribution.
+- `label` : `bug/type:<category>`.
+- `body` : **written for a developer**, with these sections in order :
+
+  ```markdown
+  ## Contexte
+  Entreprise <classe de branche en clair, ex. "100-249 salariés, CSE oui, écart ≥ 5 %">, déclaration <draft|soumise>.
+
+  ## Reproduction (étapes)
+  1. <action concrète> — ex. « Aller sur /declaration-remuneration/etape/5 »
+  2. <action concrète> — ex. « Sans rien remplir, cliquer "Suivant" »
+  3. <observation> — ex. « L'erreur "Veuillez sélectionner la source…" bloque l'accès à l'étape 6 »
+  (tirées du `reproSteps` du finding si présent, sinon des `steps` du path dans flows.json — des ACTIONS, pas des intentions)
+
+  ## Comportement attendu vs obtenu
+  - Attendu : <…>
+  - Obtenu : <…>
+
+  ## Cause racine
+  `chemin/fichier.tsx:ligne` — <la logique/règle en cause, vérifiée dans le code>.
+
+  ## Correctif proposé
+  <2-3 lignes conceptuelles : quoi changer et où>. (Pas de code complet.)
+
+  ## Scénarios affectés
+  <pathIds>, classe(s) de branche concernée(s).
+  ```
+
+  Pas de screenshot (sortie v1 : on s'appuie sur les étapes écrites, pas l'image).
+
+### 5. Write `clusters.json`
+
+Log `CLUSTERS_WRITTEN`. Write `$RUN_DIR/clusters.json` per the schema in the rules, ordered by severity (high → low) then occurrences (desc). Each cluster carries its `confidence` (`browser` / `code` / `à reproduire`) and a `rootCause` (`fichier:ligne`) alongside the `proposedTicket`.
+
+## Constraints
+
+- **Cluster by type, not by scenario** — this is the whole point ; one ticket per problem-nature, with all affected scenarios listed inside.
+- **Conservative merging** — when unsure two fingerprints are the same bug, keep them apart.
+- **Propose only** — never run `gh issue create`, never touch the board. The skill owns posting after the user's per-cluster confirmation.
+- **GitHub artefact hygiene** (`.claude/rules/git-artefact-hygiene.md`) — repo is public. Scrub PII/SIREN/secrets from every `title`/`body`/`evidence` **now**, at synthesis time, so the drafts are safe to post as-is. Fixture SIRENs are fictitious but still reference companies by branch-class ("entreprise 100-249 salariés"), not by SIREN value. Run the secret-shaped regex check from the hygiene rule mentally before writing each body.
+- **Read-only** — only file written is `$RUN_DIR/clusters.json`.
+
+## Output Format
+
+Final message (markdown, human-readable — the skill renders this to the user before the gate) :
+
+```
+## Finding Synthesizer: DONE
+
+Findings ingested: <N>  (across <P> paths)
+Clusters: <C>  (high: <h>, medium: <m>, low: <l>)
+Runner errors (coverage gaps, no ticket): <E>  — <short list or "none">
+clusters.json: <RUN_DIR>/clusters.json
+
+| # | Catégorie | Titre | Sév. | Conf. | Cause racine | Paths |
+|---|---|---|---|---|---|---|
+| c1 | navigation | … | high | browser | `FormActions.tsx:42` | p2,p5,p7 |
+```

--- a/.claude/agents/flow-cartographer/AGENT.md
+++ b/.claude/agents/flow-cartographer/AGENT.md
@@ -1,0 +1,95 @@
+---
+name: flow-cartographer
+description: Cartographie en profondeur les chemins de test d'un parcours (assertion par étape, back systématique, validation/bornes, zéro fusion d'états), sous forme d'arbre JSON. Profondeur réglable. Phase 1 du skill /audit-functional.
+model: opus
+effort: xhigh
+---
+
+# Flow Cartographer Agent
+
+You map a slice of the app into a **broad, bug-hunting set of test paths** (`flows.json`) for `/audit-functional`. Your job is **breadth and depth**, not a minimal regression suite.
+
+> **Read this first — the objective changed.** Earlier versions produced a *minimal covering set* (cover each edge once, collapse "equivalent" states, cap ~30). That is the right goal for a regression suite, but the **exact wrong goal for a bug audit** : a bug can live at step 4 specifically, so "Précédent at step 4" is **not** equivalent to "Précédent at step 3" and must **not** be collapsed. Your unit of testing is the **per-step / per-edge assertion**, enumerated **systematically** across branch-classes. Expect dozens of paths per journey, not a handful.
+
+Read `.claude/rules/audit-functional.md` first — canonical reference for the `flows.json` schema, the fixture matrix, the oracle catalogue and the guardrails.
+
+## Model & Tools
+
+- **Model:** opus
+- **Tools:** `Read`, `Grep`, `Glob`, `Bash` (read-only: `jq`, `ls`), `mcp__playwright__*`, `mcp__next-devtools__nextjs_call`
+
+## Inputs (passed in the prompt)
+
+- `SCOPE` — the slice to map (v1: `declaration-funnel`)
+- `RUN_DIR` — where to write `flows.json`
+- `DEV_PORT` — dev server port (default 3000)
+- `DEPTH` — `quick` | `standard` | `exhaustive` (default `standard`) — see depth ladder below
+
+## Workflow
+
+**Agent-id for logging** : `flow-cartographer`. Run `bash scripts/orchestration/log_event.sh flow-cartographer START` first.
+
+### 1. Read the domain branches (`DOMAIN_READ`)
+
+Read — do not guess :
+- `~/modules/domain/shared/constants.ts` — `GAP_ALERT_THRESHOLD` (5), `COMPANY_SIZE_VOLUNTARY_MAX` (50), `COMPANY_SIZE_ANNUAL_MIN` (100), quartile counts.
+- `~/modules/domain/shared/declarationFlags.ts`, `companySize.ts` — fork conditions.
+- `~/modules/declaration-remuneration/shared/complianceNavigation.ts` — routing FSM.
+- `~/modules/declaration-remuneration/types.ts` — `TOTAL_STEPS`, step data shapes.
+- `~/modules/declaration-remuneration/StepPageClient.tsx`, `shared/FormActions.tsx`, each `steps/Step*.tsx` — the **fields per step** (you need them for the validation sweep) + Précédent/Suivant wiring.
+- `docs/parcours-utilisateurs.md`.
+
+### 2. Enumerate the COMPLETE node map (`NODE_MAP`)
+
+Visit the live app (`browser_navigate` + `browser_snapshot`) and list **every reachable state**, not a sample. For the declaration funnel that means : `intro`, `etape/1..6`, `recapitulatif`, `parcours-conformite` (choice), `parcours-conformite/etape/1..4` (**all four**, not just 1 and 4), `parcours-conformite/evaluation-conjointe`, `parcours-conformite/confirmation`, `avis-cse` step 1 **and** step 2 (upload), `avis-cse/confirmation`. Missing a node = a silent coverage hole — list them all in `nodes[]`. Use `nextjs_call(get_errors)` to flag routes that already error.
+
+### 3. Generate paths SYSTEMATICALLY — per branch-class, per step (`PATHS_PLANNED`)
+
+For **each fixture** (branch-class), generate these **path families**. Do **not** collapse across steps or across fixtures — each is its own path.
+
+1. **Forward traversal** — one path that walks `etape/1 → … → last reachable step`, asserting **at every step** : page renders, no console/runtime error, the value you just entered is still shown. Oracles: `no-console-error, no-runtime-error, no-5xx`.
+2. **Backward traversal** — walk forward to the last step, then click **Précédent at every step** down to 1, asserting **at each** : it lands on the expected previous step **and the data is preserved**. Oracles: `back-available, back-preserves-state`. (This is the one you must NOT collapse — one assertion *per back-edge*.)
+3. **Step-1 back-edge** — Précédent at `etape/1` → accueil.
+4. **Validation sweep** — for **each step that has required fields**, one path : submit empty (and, for `standard`+, submit one invalid field) → assert a DSFR `fr-error-text` appears and navigation is blocked. Oracles: `error-shown-on-invalid, forward-blocked`. (Read the `Step*.tsx` fields in step 1 to know what "invalid" means per field.)
+5. **Data-consistency** — fill the indicators, reach `etape/6`, assert each entered value and the computed gap match the recap. Oracles: `recap-matches-input, gap-matches-inputs`. For `gipPrefill` fixtures, add a `prefill-not-clobbered` path (modify a prefilled value, confirm it sticks).
+6. **Branch-specific** — only where reachable for that fixture :
+   - compliance fork (`workforce≥100 && gap≥5%`) : one path **per** compliance choice (justify / corrective_action / joint_evaluation), each through to confirmation ; the joint-evaluation upload (optional vs required) ; post-compliance → CSE redirect.
+   - CSE (`workforce≥100`) : opinions step, then the upload step — valid PDF, invalid file type, and the max-files boundary.
+   - already-submitted : deep-link to each `etape/N` with `status≠draft` → assert the redirect-to-recap guard ; modification of a submitted declaration if within deadline.
+
+### 4. Depth ladder
+
+| `DEPTH` | what to generate | rough size (funnel) |
+|---|---|---|
+| `quick` | families 1, 2, 6 only (forward, backward, branch-specific) — a fast smoke | ~15-25 paths |
+| `standard` (default) | **all** families 1–6, every step, every back-edge, empty-submit validation per step | ~60-120 paths |
+| `exhaustive` | `standard` + boundary values at every threshold (workforce 49/50/99/100/249/250, gap 4.9/5/5.1, quartiles at bounds) + pairwise combinations of fork conditions + deep-link/guard for every (step × status) | 150+ paths |
+
+If a family doesn't apply to a fixture (e.g. compliance for `voluntary`), skip it **and say so** — don't pad.
+
+### 5. Write `flows.json` (`FLOWS_WRITTEN`)
+
+Write `$RUN_DIR/flows.json` conforming to the schema. Each `path` references a `fixture`, lists concrete `steps` (`action` + `expect`) the runner executes, and the `oracles` to apply **at each step it walks**. Set `coverageCriterion` to `per-step-assertion` and record the `depth`.
+
+## Constraints
+
+- **No collapsing of "equivalent" states** — every step and every back-edge is its own assertion. This is the whole point.
+- **Complete node map** — `nodes[]` lists *every* reachable state, not a sample.
+- **Target, not cap** — aim for the depth-appropriate size. There is **no upper cap** ; if you stop short of a family, log it in `pruned[]` with the reason. **Never silently drop a step/edge.**
+- **Read-only** — no code edits, no git, no board mutation ; the only file you create is `$RUN_DIR/flows.json`. Fixtures stay abstract (`branchClass`/`workforce`/`hasCse`/`gipPrefill`/optional `status`) — never hardcode a SIREN.
+- **Hygiene** — keep `flows.json` free of real PII.
+
+## Output Format
+
+```
+## Flow Cartographer: DONE
+
+Scope: <scope>   Depth: <depth>
+Nodes: <N> (complete map)
+Fixtures: <F>
+Paths: <M>  — forward:<a> backward:<b> validation:<c> data-consistency:<d> branch-specific:<e>
+Pruned/declined families: <list with reasons, or "none">
+flows.json: <RUN_DIR>/flows.json
+
+Notable UI-only branches discovered: <bullets, or "none">
+```

--- a/.claude/agents/flow-runner/AGENT.md
+++ b/.claude/agents/flow-runner/AGENT.md
@@ -1,0 +1,83 @@
+---
+name: flow-runner
+description: Exécute en local un sous-ensemble de chemins de test du flows.json contre un SIREN de fixture assigné, applique les oracles d'incohérence (déterministe + LLM) et émet des findings JSONL. Phase 2 du skill /audit-functional.
+model: sonnet
+---
+
+# Flow Runner Agent
+
+You execute an **assigned subset of paths** from `flows.json` against an **assigned fixture SIREN**, on the local dev server, driving a browser. For each path you apply the **deterministic oracles first**, the **LLM judgement only on ambiguity**, and emit one JSONL finding line per path. You run in parallel with other runners — each owns a distinct SIREN, so there is no DB collision.
+
+Read `.claude/rules/audit-functional.md` first — canonical reference for the oracle catalogue, the `findings` schema, the fingerprint convention and the guardrails. You are modelled on `functional-validator` but parameterised by SIREN + path subset, and you write JSONL instead of a board comment.
+
+## Model & Tools
+
+- **Model:** sonnet
+- **Tools:** `Read`, `Bash` (read-only: `jq`, `cat`), `mcp__playwright__*`, `mcp__next-devtools__nextjs_call`
+
+## Inputs (passed in the prompt)
+
+- `RUN_DIR` — run directory ; read `$RUN_DIR/flows.json`, write `$RUN_DIR/findings/runner-<i>.jsonl`
+- `RUNNER_INDEX` — `i` (0-based) ; your output file is `runner-<i>.jsonl`
+- `PATH_IDS` — space-separated path ids you own (the orchestrator partitioned them)
+- `PORT` — **your dedicated app instance's port** ; base URL `http://localhost:<PORT>`
+- `FIXTURE` — the branch-class already seeded into that instance's own cloned DB
+
+## Workflow
+
+**Agent-id for logging** : `flow-runner-<RUNNER_INDEX>`. Run `bash scripts/orchestration/log_event.sh flow-runner-<i> START` first.
+
+### 1. Load your paths
+
+Read `$RUN_DIR/flows.json`, select the `paths` whose `id` is in `PATH_IDS`. Your instance `http://localhost:<PORT>` has its **own cloned database**, pre-seeded with the `FIXTURE` branch-class state (workforce / hasCse / GIP prefill / status). The funnel is bound to the **session SIREN** (the ProConnect identity) — you do **not** pick a company, the funnel uses it automatically. Because every runner has its own clone DB, your writes can never collide with another runner's, even though everyone shares the same identity.
+
+### 2. For each assigned path
+
+Navigate the funnel on **your** instance — always `http://localhost:<PORT>/declaration-remuneration/...`. To reach a deep step fast, use the **`[DEV] Remplir` button** (visible because `NEXT_PUBLIC_EGAPRO_ENV=dev`) instead of hand-filling every field. If a path needs a fresh draft and your declaration is dirty from a previous path, restart from `/etape/1` (the state is yours alone — no cross-runner impact).
+
+Then, per `step` in the path :
+- execute the `action` via `mcp__playwright__browser_*` (navigate / fill / click / select) ;
+- check the `expect` ;
+- run the path's listed `oracles` (see below).
+
+Capture evidence on any failure : `mcp__playwright__browser_take_screenshot` (to `/tmp/playwright-mcp/`), the relevant `browser_console_messages` lines, the failed `browser_network_requests`, and the current URL.
+
+### 3. Apply oracles — deterministic first, LLM only on ambiguity
+
+For each oracle in the path :
+
+1. **Deterministic check** (see the catalogue table in the rules). If it fails unambiguously → record a finding, set `oracle` to the oracle key, `llmJudged: false`.
+2. **Ambiguous case only** → make a single LLM judgement (« is the user really blocked? should Précédent exist here? is this console line an expected Next.js deprecation or a real runtime error? »). If it concludes there is a real incoherence → record a finding with `llmJudged: true`, `oracle: "llm"`.
+
+Deterministic-first is mandatory : it keeps false positives — and therefore user round-trips — low.
+
+Assign `category`, a stable `fingerprint` (`<route-or-node>|<symptom-key>`, **no volatile values** — no SIREN, timestamp, UUID), and `severity`.
+
+**Record `reproSteps`** on every finding : the **concrete, numbered actions you actually executed** that trigger the issue — real actions, not intentions. Ex. `["Aller sur /declaration-remuneration/etape/5", "Sans rien remplir, cliquer Suivant", "Observer: l'erreur 'Veuillez sélectionner la source…' bloque l'étape 6"]`. The synthesizer turns these into the ticket's reproduction section, so a developer must be able to replay them verbatim. If you spotted the issue via code/HTTP rather than the browser (browser blocked), say so and give the URL + the code location you saw.
+
+### 4. Emit findings
+
+Append **one JSON object per path** to `$RUN_DIR/findings/runner-<RUNNER_INDEX>.jsonl` (JSONL — one line per object, no enclosing array), conforming to the `findings` schema in the rules (each finding carries `reproSteps`). `status` is `ok` (no findings), `incoherent` (≥1 finding), `blocked` (couldn't finish — itself a `blocking` finding), `error` (technical runner failure, not an app bug), or `skipped`.
+
+Log `PATH_<id>_OK` / `PATH_<id>_FAIL` per path, then `RUN_DONE`.
+
+## Constraints
+
+- **Read-only** : no code edits, no git, no board mutation, no ticket creation. You only append to your `findings/runner-<i>.jsonl`.
+- **Stay on your PORT** : only ever navigate `http://localhost:<PORT>` (your dedicated instance). Never hit another runner's port or `:3000` — each port is a different isolated clone DB.
+- **No silent skips** : a path you couldn't run is emitted with `status: "error"` or `"skipped"` and a reason, never dropped.
+- **GitHub artefact hygiene** : scrub PII/SIREN/secrets out of `console`/`network`/`description` evidence (the synthesizer and the user will read these). Quote only the relevant console/network line, never a full dump.
+- **Distinguish app bug from test noise** : a 404 on a route the path expects to exist is a `crash` finding ; a dev-server-down is `status: "error"` (not a bug).
+
+## Output Format
+
+Final message (markdown, human-readable — invoked by the orchestrator script; the JSONL file is the real deliverable) :
+
+```
+## Flow Runner #<i>: DONE
+
+Instance: http://localhost:<PORT>  (fixture <FIXTURE>)
+Paths run: <count> (<ok> ok, <incoherent> incoherent, <blocked> blocked, <error> error)
+Findings: <total> (<high> high, <medium> medium, <low> low)
+Output: <RUN_DIR>/findings/runner-<i>.jsonl
+```

--- a/.claude/rules/audit-functional.md
+++ b/.claude/rules/audit-functional.md
@@ -1,0 +1,262 @@
+# Audit Functional — Reference
+
+> **Used by**: skill `/audit-functional`, agents `flow-cartographer`, `flow-runner`, `finding-synthesizer`, script `audit_run_parallel.sh`, seed `audit-seed-fixtures.mjs`. Chargé à la demande (pas de `paths:`, donc non auto-loadé). Référence canonique des schémas JSON, des oracles d'incohérence, de la convention de labels et des garde-fous.
+
+`/audit-functional` est un mode d'audit **top-down** séparé de la pipeline `/analyse`→`/implement`. Il parcourt un périmètre de l'app de bout en bout pour **découvrir** des incohérences fonctionnelles (blocages, retour-arrière cassé, données incohérentes, crashes) que les E2E ciblés ne couvrent pas, puis agrège les trouvailles **par type de problème** et crée un ticket bug par cluster — **après validation explicite de l'utilisateur**.
+
+**Périmètre v1** : funnel de déclaration (`/declaration-remuneration/etape/[1-6]` + parcours conformité). On-demand uniquement.
+
+---
+
+## Pipeline (4 phases)
+
+Le **skill** (`.claude/skills/audit-functional/SKILL.md`) est l'orchestrateur synchrone — pas un background loop (la Phase 4 exige un dialogue interactif).
+
+| Phase | Acteur | Entrée | Sortie |
+|---|---|---|---|
+| 0 — préflight | skill (bash) | `$ARGUMENTS` | `RUN_DIR`, dev server + DB OK |
+| 1 — cartographie | `flow-cartographer` (Opus) | code + navigateur | `flows.json` (covering set) |
+| 1.5 — provisioning | `manage_audit_instances.sh clone` + `audit-seed-fixtures.mjs` + `… start` | `flows.json` | N (DB clone + instance app) + `instances.map.json` |
+| 2 — exécution || | `audit_run_parallel.sh` → N × `flow-runner` (Sonnet) | `flows.json` + `instances.map.json` | `findings/runner-<i>.jsonl` |
+| 3 — synthèse | `finding-synthesizer` (Opus) | `findings/*.jsonl` | `clusters.json` |
+| 4 — gate + tickets | skill + utilisateur | `clusters.json` | issues bug (1/cluster confirmé) |
+
+**Isolation du parallélisme (modèle DB-bis)** : le funnel est lié au **SIREN de session** (`getEffectiveSiren` → SIRET ProConnect), pas à une company sélectionnable, et l'impersonation admin est read-only. Donc on **ne peut pas** isoler par SIREN pour des flux d'écriture. À la place, **deux isolations** :
+
+1. **Données** : une DB clonée par runner (`CREATE DATABASE … TEMPLATE egapro`, ~1,5 s) + une instance d'app par clone (port + `DATABASE_URL` propres). Tous les runners partagent la **même identité** (le SIRET de test — cookie host-bound, valable sur tous les ports) mais écrivent chacun dans leur DB → zéro collision.
+2. **Navigateur** : sans précaution, les serveurs @playwright/mcp des runners partagent **un seul profil Chrome** (même hash de config = même `~/.cache/ms-playwright/mcp-*`) → ils se sérialisent sur le SingletonLock. Fix : `manage_audit_instances.sh auth` extrait un storageState du profil connecté et écrit un `--mcp-config` qui lance chaque runner avec `--isolated --storage-state` → **un Chrome en mémoire par runner**, authentifié, sans verrou partagé (override non-strict de `playwright`, `next-devtools` préservé).
+
+L'audit reste read-only sur le **code** (pas de worktree) ; seules les DBs clonées (jetables) sont écrites. La DB de dev `egapro` n'est que la **source** du clone.
+
+---
+
+## RUN_DIR layout
+
+```
+.claude/state/audit_run/<run-id>/        # run-id = scope + timestamp, ex: declaration-funnel-20260606-141500
+  flows.json                             # phase 1
+  instances.map.json                     # phase 1.5 : { "<fixtureId>": { db, port, index, pid } }
+  instance-<port>.log                    # phase 1.5 : output de chaque instance app
+  findings/
+    runner-0.jsonl                       # phase 2 (une ligne par path)
+    runner-1.jsonl
+    ...
+  clusters.json                          # phase 3
+  run.meta.json                          # scope, run-id, dev port
+```
+
+Les screenshots vont dans `/tmp/playwright-mcp/` (config MCP utilisateur) et sont **référencés** par chemin depuis les findings (pas copiés dans `RUN_DIR`).
+
+---
+
+## Schéma `flows.json`
+
+Arbre de chemins de test orienté **découverte de bugs** : l'unité est l'**assertion par étape / par arête**, énumérée **systématiquement** par classe de branche (forward + back à **chaque** étape, validation par champ, cohérence, branches spécifiques). **Pas** de « covering set » minimal ni de fusion d'états « équivalents » — un bug peut vivre à l'étape 4 précisément. Profondeur réglable (`quick`/`standard`/`exhaustive`). Toute famille non couverte est comptée dans `pruned` (jamais de troncature silencieuse).
+
+```jsonc
+{
+  "scope": "declaration-funnel",
+  "coverageCriterion": "per-step-assertion",     // plus "edge-coverage" : on veut la largeur
+  "depth": "standard",                            // quick | standard | exhaustive
+  "generatedBy": "flow-cartographer",
+  "pruned": [                                      // familles déclinées (avec raison), PAS des collapses
+    { "reason": "compliance non applicable à fx-voluntary (workforce<100)", "count": 0 }
+  ],
+  "fixtures": [                                    // classes de branche → 1 company seedée chacune
+    {
+      "id": "fx-lt50",                            // référencé par paths[].fixture
+      "branchClass": "voluntary",                 // libellé humain
+      "workforce": 30,                            // < COMPANY_SIZE_VOLUNTARY_MAX (50)
+      "hasCse": false,
+      "gipPrefill": false,                        // GIP-MDS pré-rempli ou non
+      "gapAbleToTriggerAlert": false              // pourra-t-on atteindre un écart ≥ GAP_ALERT_THRESHOLD
+    }
+    // ~6-8 fixtures couvrant : <50 / 50-99 / 100-249 / 250+  ×  gap </≥ 5%  ×  CSE  ×  prefill
+  ],
+  "nodes": [                                       // états atteignables (optionnel mais utile pour le graphe)
+    { "id": "step1", "route": "/declaration-remuneration/etape/1", "label": "Effectifs" }
+  ],
+  "paths": [
+    {
+      "id": "p1",                                 // unique, référencé par les findings
+      "title": "Décl <50 nominal jusqu'au récap",
+      "fixture": "fx-lt50",                       // quelle company seedée utiliser
+      "branchConditions": ["workforce<50"],       // conditions métier exercées
+      "steps": [
+        { "node": "step1", "action": "remplir effectifs (femmes=10, hommes=20)", "expect": "étape 2 atteignable" },
+        { "node": "step6", "action": "ouvrir le récapitulatif", "expect": "valeurs saisies reflétées" }
+      ],
+      "oracles": ["no-console-error", "back-available", "recap-matches-input"]   // sous-ensemble du catalogue
+    }
+  ]
+}
+```
+
+---
+
+## Schéma `findings/runner-<i>.jsonl`
+
+Une ligne JSON par path exécuté (JSONL — un objet par ligne, pas de tableau englobant).
+
+```jsonc
+{
+  "pathId": "p7",
+  "fixture": "fx-100-gap6",
+  "runner": 1,
+  "status": "incoherent",                 // ok | incoherent | blocked | error | skipped
+  "findings": [                            // [] si status=ok
+    {
+      "category": "navigation",            // voir enum Catégories
+      "fingerprint": "etape/4|back-missing",   // route|symptom-key — clé de dédup (voir convention)
+      "severity": "high",                  // high | medium | low
+      "oracle": "back-available",          // oracle déterministe déclencheur, ou "llm" si jugement
+      "llmJudged": false,                  // true si c'est le fallback LLM qui a tranché
+      "evidence": {
+        "url": "/declaration-remuneration/etape/4",
+        "screenshot": "/tmp/playwright-mcp/p7-step4.png",   // annexe locale (non posté en v1)
+        "console": [],                     // lignes console pertinentes (scrubées)
+        "network": []                      // requêtes en échec pertinentes (status, url scrubée)
+      },
+      "reproSteps": [                       // actions CONCRÈTES rejouables (→ section Reproduction du ticket)
+        "Aller sur /declaration-remuneration/etape/4 (parcours alerte, 100-249 sal., écart ≥ 5 %)",
+        "Observer : aucun bouton Précédent rendu par FormActions"
+      ],
+      "description": "Bouton Précédent absent à l'étape 4 pour le parcours alerte (≥5%)."
+    }
+  ]
+}
+```
+
+`status` :
+- `ok` — tous les oracles passent.
+- `incoherent` — ≥1 finding (incohérence fonctionnelle).
+- `blocked` — le path n'a pas pu être terminé (l'utilisateur simulé est bloqué) → c'est lui-même un finding `blocking`.
+- `error` — échec technique du runner (dev server down, élément introuvable) → **pas** un bug applicatif, à diagnostiquer.
+- `skipped` — fixture indisponible / path hors périmètre.
+
+---
+
+## Schéma `clusters.json`
+
+Agrégation par **type de problème** (pas par scénario). Produit par `finding-synthesizer` après dédup.
+
+```jsonc
+{
+  "scope": "declaration-funnel",
+  "runId": "declaration-funnel-20260606-141500",
+  "totalFindings": 23,
+  "clusters": [
+    {
+      "id": "c1",
+      "category": "navigation",
+      "title": "Bouton Précédent absent (étapes 3-5, parcours alerte)",
+      "affectedPaths": ["p2", "p5", "p7"],          // traçabilité
+      "occurrences": 3,
+      "severity": "high",                           // sévérité max des findings du cluster
+      "confidence": "browser",                      // browser | code | à reproduire
+      "rootCause": "FormActions.tsx:42",            // fichier:ligne vérifié par le synthesizer
+      "fingerprints": ["etape/3|back-missing", "etape/4|back-missing", "etape/5|back-missing"],
+      "proposedTicket": {                           // brouillon dev-grade, prêt pour le gate
+        "title": "bug(navigation): retour arrière indisponible étapes 3-5 du funnel (parcours alerte)",
+        // corps ÉCRIT POUR UN DEV — sections obligatoires :
+        // ## Contexte · ## Reproduction (étapes = actions concrètes, depuis reproSteps)
+        // ## Comportement attendu vs obtenu · ## Cause racine (fichier:ligne)
+        // ## Correctif proposé (2-3 lignes, pas de code complet) · ## Scénarios affectés
+        "body": "## Contexte\n…\n## Reproduction (étapes)\n1. …\n2. …\n## Comportement attendu vs obtenu\n…\n## Cause racine\n`FormActions.tsx:42` — …\n## Correctif proposé\n…\n## Scénarios affectés\np2, p5, p7",
+        "label": "bug/type:navigation"
+      }
+    }
+  ]
+}
+```
+
+Le corps du ticket est **écrit pour un développeur** : la reproduction est une suite d'**actions concrètes** (issues du `reproSteps` des findings), suivie de la **cause racine** (`fichier:ligne`, vérifiée dans le code par le synthesizer) et d'un **correctif proposé**. Pas de screenshot en v1 — on s'appuie sur les étapes écrites. Ce corps alimente directement `/analyse #N` → `/implement #N`.
+
+---
+
+## Catalogue d'oracles (déterministe d'abord, LLM ensuite)
+
+Les oracles déterministes tranchent en premier ; le jugement LLM n'intervient **que** sur l'ambigu. Cet ordre réduit les faux positifs et le nombre d'allers-retours avec l'utilisateur.
+
+| Catégorie (`category`) | Oracle (`oracle`) | Test déterministe | Fallback LLM |
+|---|---|---|---|
+| `blocking` | `forward-blocked` | submit → erreur sans recovery ; état terminal sans action forward attendue | « l'utilisateur est-il réellement bloqué (pas juste une étape optionnelle) ? » |
+| `navigation` | `back-available` | bouton Précédent absent/désactivé là où `FormActions` devrait le rendre | « le retour devrait-il exister à cette étape ? » |
+| `navigation` | `back-preserves-state` | `browser_navigate_back` puis re-forward perd les données saisies | — |
+| `data-consistency` | `recap-matches-input` | valeur saisie à l'étape N ≠ valeur affichée au récap (étape 6) | jugement sémantique |
+| `data-consistency` | `gap-matches-inputs` | écart affiché ≠ écart recalculé depuis les inputs | jugement sémantique |
+| `data-consistency` | `prefill-not-clobbered` | pré-remplissage GIP écrasé sans action utilisateur | — |
+| `crash` | `no-console-error` | `browser_console_messages` contient une erreur non attendue | distinguer déprécation Next.js (attendu) vs `TypeError`/runtime (réel) |
+| `crash` | `no-5xx` | `browser_network_requests` contient un 5xx | — |
+| `crash` | `no-runtime-error` | `nextjs_call(get_errors)` non vide ; ErrorBoundary affiché ; 404 inattendu | — |
+| `validation` | `error-shown-on-invalid` | input invalide soumis sans message DSFR `fr-error-text` visible | — |
+| `visual` | (réservé) | écart structurel Figma ↔ app (hors v1, hook pour plus tard) | — |
+
+**Catégories (`category`)** — enum fermé : `blocking`, `navigation`, `data-consistency`, `crash`, `validation`, `visual`.
+
+**Convention `fingerprint`** : `<route-relative-ou-node>|<symptom-key>`, ex. `etape/4|back-missing`, `etape/6|recap-mismatch:totalWomen`. C'est la **clé de déduplication** : deux findings de même `fingerprint` sur des paths différents → **un seul cluster**. Le `symptom-key` doit être stable (pas de valeur volatile : pas de timestamp, pas d'UUID, pas de SIREN).
+
+---
+
+## Matrice de fixtures (état par DB clonée)
+
+Une **DB clonée par classe de branche**, chacune servie par sa propre instance d'app. Dans chaque clone, l'état de la classe de branche est posé sur le **SIREN de session** (`130025265`, le SIRET de test — déjà présent puisque la DB est clonée de `egapro`) : `workforce`, `hasCse`, présence d'une ligne GIP (`gipPrefill`), `status` (défaut `draft`). Pas de SIREN fictif : `audit-seed-fixtures.mjs` lit `flows.json.fixtures` + `instances.map.json` et seede l'état dans la DB de chaque fixture. Les agents/runners ne manipulent jamais un SIREN — ils ciblent un **port** d'instance.
+
+> **Limite connue** : une instance = une déclaration = un état de départ. Si deux paths d'une même fixture exigent des états différents (ex. `draft` vs `submitted`), le runner repart de `/etape/1` (sa DB est à lui seul) ou marque le path `skipped`. Le seed pose l'état par défaut (`draft` + contexte).
+
+Classes de branche couvertes (seuils tirés de `~/modules/domain/shared/constants.ts`) :
+
+| `branchClass` | workforce | hasCse | prefill | exerce |
+|---|---|---|---|---|
+| `voluntary` | < 50 | false | false | déclaration volontaire, pas de conformité ni CSE |
+| `triennial` | 50-99 | false | false | indicateurs sans G, pas de conformité, pas de CSE |
+| `annual-nogap` | 100-249 | true | true | déclaration complète, écart < 5% → pas de conformité |
+| `annual-alert` | 100-249 | true | true | écart ≥ 5% → propose le parcours conformité + CSE |
+| `large-annual` | 250+ | true | false | indicateur G annuel |
+
+> La liste exacte (5-8 entrées) est décidée par `flow-cartographer` selon le graphe réellement atteignable ; le tableau ci-dessus est le minimum de couverture.
+
+---
+
+## Convention de labels GitHub `bug/type:*`
+
+Aucune agrégation par type n'existait avant ce skill. On introduit des labels secondaires (le **type GitHub natif reste `Bug`** — `IT_kwDOAh0HH84Aa_K1`, cf. `github-board.md` snippet 7) :
+
+```
+bug/type:navigation
+bug/type:data-consistency
+bug/type:blocking
+bug/type:crash
+bug/type:validation
+bug/type:visual
+```
+
+Créés une fois via `gh label create "bug/type:navigation" --color BFD4F2 --description "..."` (idempotent : `|| true` si déjà présent). Un ticket issu d'un cluster porte : le type natif **Bug** + le label `bug` + le label `bug/type:<category>` du cluster.
+
+---
+
+## Garde-fous (hard rules)
+
+- **Read-only total** : aucun fichier source modifié, aucun commit, aucune branche, aucun worktree, dev server jamais redéployé. Les agents `flow-*` n'utilisent pas `git`.
+- **Création de tickets : dry-run par défaut, gate utilisateur explicite.** Un agent ne crée **jamais** d'issue seul (`flow-runner`/`finding-synthesizer` sont read-only et ne lancent **jamais** `gh issue create`). L'issue par défaut d'un audit = **la liste de tickets proposés**, rien de posté. Le skill ne poste qu'après (a) triage par cluster **et** (b) un **OK final explicite** listant exactement les issues à créer. Doute / ambiguïté / interruption → **ne rien poster**. Les clusters `confidence: code|à reproduire` sont **opt-in** (confirmation active requise).
+- **Board ≤ Backlog** : un ticket créé reste en `Backlog` (ou hors board). Jamais `In review`/`Done` (user-only ; cf. `set_ticket_status.sh` exit 3). En pratique le skill n'appelle pas le board au-delà de l'ajout optionnel au project en Backlog.
+- **Hygiène artefacts publics** (`.claude/rules/git-artefact-hygiene.md`) : scrub PII/SIREN/secrets avant tout `gh issue create` et dans les `evidence`/`description` des findings. Les fixtures utilisent des SIREN fictifs dédiés → pas de PII réelle.
+- **Jamais prod** : audit sur dev local uniquement (clones de la DB de dev + instances locales).
+- **Pas de modif `.claude/settings*.json`** ni d'auto-mémoire par les agents.
+- **Cleanup** : `manage_audit_instances.sh teardown <RUN_DIR>` arrête les N instances et **DROP** les DBs clonées (jetables) — settle + retry. La DB source `egapro` n'est jamais écrite par les runners. Idempotent.
+- **Récupération orphelins** : `manage_audit_instances.sh sweep` (sans RUN_DIR) est le filet de sécurité si un run est avorté avant le teardown — tue les process sur la plage de ports d'audit + DROP toute DB `audit_*` (jamais `egapro`). Lancé aussi avant chaque provisioning.
+
+---
+
+## Logging (`log_event.sh`) — observabilité `/report`
+
+Agent-ids : `flow-cartographer`, `flow-runner-<i>`, `finding-synthesizer`, `audit-orchestrator-<run-id>`.
+
+Events conseillés (à logger AVANT de passer à la phase suivante — discipline blocking comme `code-dev`) :
+
+```
+audit-orchestrator : START → CARTO_START → CARTO_OK → DB_CLONE×N → INSTANCE_SPAWN×N → INSTANCE_READY×N → SEED_OK → RUN_START → RUN_OK → SYNTH_OK → AWAITING_VALIDATION → TICKETS_CREATED → INSTANCES_TEARDOWN → COMPLETE
+flow-cartographer  : START → DOMAIN_READ → BROWSE_START → FLOWS_WRITTEN
+flow-runner-<i>    : START → PATH_<id>_OK | PATH_<id>_FAIL → RUN_DONE
+finding-synthesizer: START → DEDUP_OK → CLUSTERS_WRITTEN
+```

--- a/.claude/skills/audit-functional/SKILL.md
+++ b/.claude/skills/audit-functional/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: audit-functional
+description: "Audit fonctionnel top-down de l'app (séparé de /analyse-/implement). Cartographie les chemins de test, les exécute en parallèle réel en local via navigateur, agrège les incohérences par type et crée un ticket bug par cluster confirmé. Usage: /audit-functional [<scope>] [--from-flows <RUN_DIR>]"
+---
+
+# /audit-functional
+
+Audit fonctionnel **top-down** : parcourt un périmètre de l'app de bout en bout pour **découvrir** des incohérences (blocages, retour-arrière cassé, données affichées incohérentes, crashes) que les E2E ciblés ne couvrent pas. Séparé de la pipeline `/analyse`→`/implement`.
+
+Lis `.claude/rules/audit-functional.md` — référence canonique des schémas (`flows.json`, `findings`, `clusters`), des oracles, de la convention de labels `bug/type:*` et des garde-fous. **Tout est read-only** : aucun fichier source modifié, aucun commit, aucune création de ticket sans validation utilisateur explicite.
+
+Le skill est l'**orchestrateur synchrone** (pas un background loop — la Phase 4 exige un dialogue). Il enchaîne 4 phases, déléguant le travail lourd à 3 agents + 2 scripts.
+
+| Phase | Délégué à | Sortie |
+|---|---|---|
+| 1 — cartographie | agent `flow-cartographer` (Opus) | `flows.json` |
+| 1.5 — provisioning | `manage_audit_instances.sh clone` + `audit-seed-fixtures.mjs` + `… start` | N paires (DB clone + instance app) + `instances.map.json` |
+| 2 — exécution ‖ | `audit_run_parallel.sh` → N × `flow-runner` (Sonnet) | `findings/*.jsonl` |
+| 3 — synthèse | agent `finding-synthesizer` (Opus) | `clusters.json` |
+| 4 — gate + tickets | **toi (skill)** + utilisateur | issues bug (1/cluster confirmé) |
+
+**Périmètre v1** : `declaration-funnel` uniquement. On-demand.
+
+**Isolation (modèle DB-bis)** : le funnel est lié au **SIREN de session** (le SIRET ProConnect — `getEffectiveSiren`), pas à une company sélectionnable. Donc on **clone la DB** par runner et on démarre **une instance d'app par clone** (port + `DATABASE_URL` propres). Tous les runners utilisent la **même identité** (le SIRET de test) mais écrivent chacun dans leur DB → zéro collision. Clone via `CREATE DATABASE … TEMPLATE` (~1,5 s).
+
+---
+
+## Step 0 — Préflight
+
+**1. Parse les arguments + prépare le `RUN_DIR`** (créé avant tout, car le helper de stack y écrit son PID file) :
+
+```bash
+SCOPE="declaration-funnel"
+FROM_FLOWS=""
+ARGS="$ARGUMENTS"
+case "$ARGS" in
+  *--from-flows*)
+    FROM_FLOWS="$(echo "$ARGS" | sed -E 's#.*--from-flows[[:space:]]+([^[:space:]]+).*#\1#')"
+    ;;
+esac
+FIRST="$(echo "$ARGS" | awk '{print $1}')"
+[ -n "$FIRST" ] && [ "$FIRST" != "--from-flows" ] && SCOPE="$FIRST"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DEV_PORT="${AUDIT_DEV_PORT:-3000}"
+
+if [ -n "$FROM_FLOWS" ]; then
+  RUN_DIR="$FROM_FLOWS"; RUN_ID="$(basename "$RUN_DIR")"   # rejoue un run existant (saute la Phase 1)
+else
+  RUN_ID="${SCOPE}-$(date +%Y%m%d-%H%M%S)"
+  RUN_DIR="${REPO_ROOT}/.claude/state/audit_run/${RUN_ID}"
+fi
+mkdir -p "$RUN_DIR/findings"
+printf '{"scope":"%s","runId":"%s","devPort":%s}\n' "$SCOPE" "$RUN_ID" "$DEV_PORT" > "$RUN_DIR/run.meta.json"
+bash scripts/orchestration/log_event.sh "audit-orchestrator-${RUN_ID}" START "scope=$SCOPE dev_port=$DEV_PORT"
+```
+
+**2. Monte la stack (turnkey)** — le skill démarre lui-même docker DB + dev server (mode `dev`), ou réutilise un serveur déjà actif sur `:${DEV_PORT}`. Il **ne possède** le serveur que s'il l'a démarré (PID file dans `RUN_DIR`) — un serveur préexistant n'est jamais coupé.
+
+```bash
+DEV_STATE="$(bash scripts/orchestration/manage_dev_server.sh ensure "$RUN_DIR" | tail -1)"
+# DEV_STATE = "reused" (serveur de l'utilisateur, on n'y touche pas)
+#           | "started <pid>" (démarré par le skill → sera coupé en Step final)
+case "$DEV_STATE" in
+  reused*)  echo "Dev server réutilisé sur :${DEV_PORT} (assure NEXT_PUBLIC_EGAPRO_ENV=dev pour [DEV] Remplir)." ;;
+  started*) echo "Dev server démarré par le skill (${DEV_STATE})." ;;
+  *) echo "ERREUR: dev server indisponible — voir $RUN_DIR/dev-server.log" >&2; exit 1 ;;
+esac
+```
+
+> `manage_dev_server.sh ensure` fait : `docker compose up -d` (DB :5438) → réutilise `:${DEV_PORT}` s'il répond → sinon lance `NEXT_PUBLIC_EGAPRO_ENV=dev pnpm dev:app` détaché et poll jusqu'à readiness (≤ `AUDIT_DEV_READY_SECS`, défaut 150s). Si le serveur réutilisé n'est pas en mode `dev`, le bouton `[DEV] Remplir` manquera : prévenir l'utilisateur.
+
+Si `--from-flows`, **sauter la Phase 1** (cartographie) et reprendre au **Step 1.5** (re-provisioning depuis le `flows.json` existant) — le serveur de cartographie n'est alors pas nécessaire.
+
+---
+
+## Step 1 — Cartographie (agent `flow-cartographer`, Opus)
+
+Invoquer l'agent en **foreground synchrone** (comme `/implement` task/bug invoque `code-dev`) — process CLI avec son propre navigateur MCP :
+
+`DEPTH` règle l'ampleur (`quick` ~15-25, `standard` ~60-120, `exhaustive` 150+) :
+
+```bash
+DEPTH="${AUDIT_DEPTH:-standard}"   # quick | standard | exhaustive (passé en 2e mot d'argument si fourni)
+bash scripts/orchestration/log_event.sh "audit-orchestrator-${RUN_ID}" CARTO_START
+env -u CLAUDECODE claude \
+  --agent flow-cartographer --model opus \
+  --print --output-format stream-json --verbose \
+  --dangerously-skip-permissions --max-budget-usd "${AUDIT_BUDGET_CARTO:-20}" \
+  "Cartographie le scope '${SCOPE}'. RUN_DIR=${RUN_DIR}. DEV_PORT=${DEV_PORT}. DEPTH=${DEPTH}. Suis .claude/agents/flow-cartographer/AGENT.md : assertion PAR ÉTAPE, back systématique à chaque étape, validation/cohérence, ZÉRO fusion d'états équivalents. Écris ${RUN_DIR}/flows.json."
+bash scripts/orchestration/log_event.sh "audit-orchestrator-${RUN_ID}" CARTO_OK
+```
+
+**Checkpoint doux** : afficher le résumé de `flows.json` (nodes / fixtures / paths par famille / pruned). Au vu de l'ampleur (`standard` ⇒ 60-120 paths ⇒ autant de checks runner), **c'est le bon moment pour ajuster DEPTH ou élaguer** avant de provisionner. Proposer à l'utilisateur de relire/éditer `flows.json`. Pas un gate bloquant.
+
+---
+
+## Step 1.5 — Provisioning (N paires DB clone + instance app)
+
+Le funnel étant lié au SIREN de session, on isole **par DB** : on clone la DB de dev une fois par fixture, on seede l'état de la classe de branche dans chaque clone, et on démarre une instance d'app dédiée par clone.
+
+```bash
+# Le clone CREATE DATABASE … TEMPLATE egapro exige AUCUNE connexion à egapro
+# → couper d'abord le serveur de cartographie (:3000).
+bash scripts/orchestration/manage_dev_server.sh stop "$RUN_DIR"
+
+# 0) filet de sécurité : balayer les orphelins d'un éventuel run avorté
+#    (tue les process sur les ports d'audit + DROP toute DB audit_*).
+bash scripts/orchestration/manage_audit_instances.sh sweep
+
+# 1) cloner N DBs (TEMPLATE egapro) + écrire instances.map.json
+bash scripts/orchestration/manage_audit_instances.sh clone "$RUN_DIR"
+# 2) seeder l'état de chaque classe de branche dans SA DB clonée (SIREN de session)
+node packages/app/scripts/audit-seed-fixtures.mjs "$RUN_DIR"
+# 3) build une fois (NEXT_PUBLIC_EGAPRO_ENV=dev baké) puis une instance `next start`
+#    par clone (port + DATABASE_URL propres), poll readiness.
+#    N instances concurrentes DOIVENT être `next start` (lecture seule du .next) —
+#    deux `next dev` du même dossier se battent sur les presteps copy-* + .next.
+bash scripts/orchestration/manage_audit_instances.sh start "$RUN_DIR"
+
+# 4) isolation navigateur : extraire le storageState du profil MCP connecté +
+#    écrire un mcp-config (--isolated --storage-state) → chaque runner aura son
+#    PROPRE Chrome en mémoire (pas de verrou Chrome partagé = vrai parallèle).
+#    Sans cette étape, les runners se sérialisent sur un seul Chrome.
+bash scripts/orchestration/manage_audit_instances.sh auth "$RUN_DIR"
+
+bash scripts/orchestration/log_event.sh "audit-orchestrator-${RUN_ID}" SEED_OK
+```
+
+Résultat : `instances.map.json` = `{ "<fixtureId>": { db, port, index, pid } }`. Chaque instance `http://localhost:<port>` sert le funnel sur le **SIREN de session** avec sa propre DB clonée → isolation totale, identité unique. Si le clone échoue (« source database is being accessed ») → s'assurer qu'aucun serveur ne pointe sur `egapro`.
+
+---
+
+## Step 2 — Exécution parallèle (script `audit_run_parallel.sh`)
+
+```bash
+AUDIT_MAX_PARALLEL="${AUDIT_MAX_PARALLEL:-5}" \
+  bash scripts/orchestration/audit_run_parallel.sh "$RUN_DIR"
+```
+
+Le script fan-out **un `flow-runner` (Sonnet) par fixture**, chacun pilotant **son instance dédiée** (`http://localhost:<port>`, sa DB clonée, son navigateur), par vagues de `AUDIT_MAX_PARALLEL`. Chaque runner écrit `findings/runner-<i>.jsonl`.
+
+> **Première exécution** : démarrer avec `AUDIT_MAX_PARALLEL=2` avant de monter à 5 (RAM des instances `next dev`).
+
+Suivre l'avancement via `/report` (les agents loggent `flow-runner-<i>` et `audit-orchestrator-<run>`).
+
+---
+
+## Step 3 — Synthèse (agent `finding-synthesizer`, Opus)
+
+```bash
+env -u CLAUDECODE claude \
+  --agent finding-synthesizer --model opus \
+  --print --output-format stream-json --verbose \
+  --dangerously-skip-permissions --max-budget-usd "${AUDIT_BUDGET_SYNTH:-10}" \
+  "Synthétise les findings. RUN_DIR=${RUN_DIR}. SCOPE=${SCOPE}. RUN_ID=${RUN_ID}. Suis .claude/agents/finding-synthesizer/AGENT.md : dédup par (category,fingerprint), PUIS root-cause chaque cluster en LISANT le code (fichier:ligne), et écris ${RUN_DIR}/clusters.json — chaque proposedTicket a un corps DEV-GRADE (Contexte, Reproduction en actions concrètes, Attendu vs obtenu, Cause racine fichier:ligne, Correctif proposé, Scénarios affectés). Pas de screenshot."
+bash scripts/orchestration/log_event.sh "audit-orchestrator-${RUN_ID}" SYNTH_OK
+```
+
+---
+
+## Step 4 — Gate utilisateur + création des tickets
+
+**C'est toi (le skill) qui tiens ce gate** — `finding-synthesizer` ne fait que *proposer*.
+
+> ⛔ **HARD GATE — dry-run par défaut.** À ce stade **AUCUN `gh issue create` n'a été lancé et n'est lancé tant que l'utilisateur n'a pas approuvé explicitement.** L'issue d'un audit, par défaut, c'est **la liste de tickets proposés** — rien de posté. La création est une action utilisateur **séparée et délibérée**. En cas de doute, de réponse ambiguë, ou d'interruption → **ne rien poster**.
+
+1. Lire `${RUN_DIR}/clusters.json`. **Rendre les clusters en markdown** (tableau : #, catégorie, titre, sévérité, **confiance**, **cause racine** `fichier:ligne`, paths) + le détail de chaque cluster : le **corps de ticket dev-grade** proposé (Contexte · Reproduction en actions · Attendu vs obtenu · Cause racine · Correctif proposé · Scénarios affectés). Pas de screenshot en v1.
+2. `log_event … AWAITING_VALIDATION`. **Triage par cluster, puis confirmation finale explicite** :
+   - pour chaque cluster, l'utilisateur **confirme** / **rejette** (faux positif) / **fusionne** / **édite** (titre, corps, sévérité) avant post ;
+   - puis afficher **exactement la liste des issues qui vont être créées** (titres + labels) et **attendre un OK final explicite** (ex. « oui, crée ces N tickets »). Tant que cet OK n'est pas donné, **ne lancer aucun `gh`**.
+   - par défaut, ne pré-cocher que les clusters `confidence: browser` ; les `code` / `à reproduire` sont **opt-in** (l'utilisateur doit les confirmer activement).
+3. **Avant création** : s'assurer que les labels `bug/type:*` existent (idempotent) :
+
+```bash
+for t in navigation data-consistency blocking crash validation visual; do
+  gh label create "bug/type:$t" --color BFD4F2 --description "Audit fonctionnel : $t" 2>/dev/null || true
+done
+```
+
+4. Pour chaque cluster **confirmé**, créer **un** ticket bug (scrubber le body — hygiène artefacts, repo public) :
+
+```bash
+# Scrub check OBLIGATOIRE avant post (cf. git-artefact-hygiene.md)
+echo "$BODY" | grep -E '(ghp_|sk-ant-|sk-proj-|AKIA[A-Z0-9]{16}|eyJ[A-Za-z0-9_=-]{20,}\.|postgres://[^@]+:[^@]+@|Bearer\s+[A-Za-z0-9._-]{20,})' \
+  && { echo "STOP: secret détecté, je ne poste pas" >&2; exit 1; }
+
+ISSUE_URL=$(gh issue create --title "$TITLE" --body "$BODY" --label "bug" --label "$CLUSTER_LABEL")
+ISSUE_N=$(echo "$ISSUE_URL" | sed -E 's#.*/issues/([0-9]+)#\1#')
+
+# Type natif Bug (gh issue edit ne supporte pas --type → GraphQL, cf. github-board.md snippet 7)
+NODE_ID=$(gh api graphql -f query='query($n:Int!){repository(owner:"SocialGouv",name:"egapro"){issue(number:$n){id}}}' -F n=$ISSUE_N --jq '.data.repository.issue.id')
+gh api graphql -f query='mutation($issueId:ID!,$typeId:ID!){updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$typeId}){issue{number}}}' \
+  -f issueId="$NODE_ID" -f typeId="IT_kwDOAh0HH84Aa_K1"   # Bug
+```
+
+> **Board** : laisser le ticket en `Backlog` (ou hors board). **Ne jamais** appeler `set_ticket_status.sh` au-delà de Backlog — `In review`/`Done` sont user-only.
+
+5. `log_event … TICKETS_CREATED` puis `COMPLETE`.
+
+---
+
+## Step final — Report
+
+```
+## Audit fonctionnel : DONE
+
+Scope: <scope>   RUN_DIR: <RUN_DIR>
+Fixtures: <N>   Instances: <N ports>   Paths exécutés: <M>   Findings: <F>
+Clusters: <C>  (confirmés: <k>, rejetés: <r>)
+Tickets bug créés: #N1 (bug/type:navigation), #N2 (bug/type:data-consistency), …
+Coverage gaps (runner errors, sans ticket): <E ou "aucun">
+
+Relancer (re-provision depuis le flows.json existant) : /audit-functional --from-flows <RUN_DIR>
+Teardown (instances + DBs clonées) : bash scripts/orchestration/manage_audit_instances.sh teardown <RUN_DIR>
+```
+
+**Fermeture de la stack** — arrêter les N instances et **supprimer les DBs clonées** (le cartography server `:3000` a déjà été coupé en Step 1.5) :
+
+```bash
+bash scripts/orchestration/manage_audit_instances.sh teardown "$RUN_DIR"
+# stoppe chaque instance (par PID) puis DROP chaque DB clonée. Idempotent.
+# (AUDIT_KEEP_DEV=1 pour laisser tourner si l'utilisateur veut inspecter une instance avant teardown)
+```
+
+Le `DROP DATABASE` des clones efface tout l'état seedé/écrit pendant le run — pas de teardown de fixtures séparé. Proposer ensuite un re-run avec `--from-flows <RUN_DIR>` (re-provisionne depuis le `flows.json` existant, saute la cartographie).
+
+---
+
+## Règles
+
+- **Read-only total** — aucun fichier source modifié, aucun commit, aucune branche, aucun worktree. Les agents `flow-*` n'utilisent pas `git`.
+- **Gate avant création de ticket** — un ticket n'est créé qu'après confirmation explicite, **par cluster**. Pas d'auto-création.
+- **Agrégation par type, pas par scénario** — un ticket = une nature de problème, avec tous les scénarios affectés listés dedans (évite l'explosion d'A/R et de tickets).
+- **Board ≤ Backlog** — jamais `In review`/`Done`.
+- **Hygiène artefacts publics** (`.claude/rules/git-artefact-hygiene.md`) — scrub PII/SIREN/secrets avant tout `gh issue create`. L'audit n'utilise que le SIREN de test (clones), jamais de PII réelle.
+- **Jamais prod** — audit local uniquement (clones de la DB de dev).
+- **Cycle de vie de la stack** — cartographie sur un serveur `:3000`/egapro (read-only, coupé avant le clone) ; exécution sur N instances + N DBs clonées, **toutes détruites au teardown** (`manage_audit_instances.sh teardown`). Le clone TEMPLATE exige qu'aucun serveur ne soit connecté à `egapro`.
+- **Récupération si abandon/crash** — le teardown ne tourne que sur le chemin nominal. Si un run est interrompu (les instances/DBs fuient), lancer `bash scripts/orchestration/manage_audit_instances.sh sweep` : il tue les process sur les ports d'audit et DROP toute DB `audit_*` (jamais la source `egapro` ni les autres ports). Ce `sweep` est aussi exécuté **avant** chaque provisioning pour repartir propre.
+- **Isolation par DB** — jamais d'écriture concurrente sur la même DB : chaque runner a sa DB clonée. La DB de dev `egapro` n'est que la **source** du clone (jamais écrite par les runners).
+
+---
+
+## Référence
+
+- Rule : `.claude/rules/audit-functional.md` (schémas, oracles, labels, garde-fous)
+- Agents : `.claude/agents/{flow-cartographer,flow-runner,finding-synthesizer}/AGENT.md`
+- Scripts : `scripts/orchestration/manage_dev_server.sh` (serveur cartographie), `scripts/orchestration/manage_audit_instances.sh` (clone DBs + N instances + teardown + sweep), `scripts/orchestration/audit_run_parallel.sh` (runners par port), `packages/app/scripts/audit-seed-fixtures.mjs` (état par clone)
+- Board GraphQL : `.claude/rules/github-board.md` (snippet 7 = type Bug)
+- Hygiène : `.claude/rules/git-artefact-hygiene.md`

--- a/packages/app/scripts/audit-extract-auth.mjs
+++ b/packages/app/scripts/audit-extract-auth.mjs
@@ -1,0 +1,109 @@
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+/**
+ * Audit functional — extract a Playwright storageState from the logged-in
+ * @playwright/mcp Chrome profile, so each parallel flow-runner can launch its
+ * OWN isolated browser (`--isolated --storage-state <file>`) instead of sharing
+ * one Chrome profile (whose SingletonLock serialises parallel runners).
+ *
+ * Auto-detects (override via env):
+ *   - the logged-in profile: newest `~/.cache/ms-playwright/mcp-*` dir whose
+ *     Default/Cookies references `localhost` (AUDIT_AUTH_PROFILE to force)
+ *   - the chrome executable: newest `~/.cache/ms-playwright/chromium-*` build
+ *     (AUDIT_CHROME_EXEC to force; empty → let Playwright pick its default)
+ *
+ * Usage: node scripts/audit-extract-auth.mjs <out-storage-state.json>
+ * Exits non-zero (with a clear message) if no logged-in profile is found.
+ */
+
+const MS_PW = path.join(homedir(), ".cache", "ms-playwright");
+
+function newestProfileWithLocalhost() {
+	if (process.env.AUDIT_AUTH_PROFILE) return process.env.AUDIT_AUTH_PROFILE;
+	if (!existsSync(MS_PW)) return null;
+	const candidates = readdirSync(MS_PW)
+		.filter((d) => d.startsWith("mcp-"))
+		.map((d) => path.join(MS_PW, d))
+		.filter((d) => existsSync(path.join(d, "Default", "Cookies")))
+		.map((d) => {
+			const cookies = path.join(d, "Default", "Cookies");
+			let hasLocalhost = false;
+			try {
+				hasLocalhost = readFileSync(cookies).includes("localhost");
+			} catch {}
+			return { dir: d, mtime: statSync(cookies).mtimeMs, hasLocalhost };
+		})
+		.filter((c) => c.hasLocalhost)
+		.sort((a, b) => b.mtime - a.mtime);
+	return candidates[0]?.dir ?? null;
+}
+
+function newestChromeExecutable() {
+	if (process.env.AUDIT_CHROME_EXEC !== undefined)
+		return process.env.AUDIT_CHROME_EXEC || undefined;
+	if (!existsSync(MS_PW)) return undefined;
+	// Linux layout; Playwright falls back to its own default if this is absent.
+	const builds = readdirSync(MS_PW)
+		.filter((d) => /^chromium-\d+$/.test(d))
+		.map((d) => ({ d, n: Number(d.split("-")[1]) }))
+		.sort((a, b) => b.n - a.n);
+	for (const { d } of builds) {
+		const exe = path.join(MS_PW, d, "chrome-linux64", "chrome");
+		if (existsSync(exe)) return exe;
+	}
+	return undefined;
+}
+
+async function main() {
+	const out = process.argv[2];
+	if (!out) {
+		console.error("Usage: node scripts/audit-extract-auth.mjs <out.json>");
+		process.exit(2);
+	}
+	const profile = newestProfileWithLocalhost();
+	if (!profile) {
+		console.error(
+			"[audit-auth] No logged-in @playwright/mcp profile found (~/.cache/ms-playwright/mcp-* with a localhost cookie). Log in once to the local app via the Playwright MCP browser, then retry.",
+		);
+		process.exit(1);
+	}
+	const executablePath = newestChromeExecutable();
+	let chromium;
+	try {
+		({ chromium } = await import("playwright"));
+	} catch {
+		({ chromium } = await import("@playwright/test"));
+	}
+	const ctx = await chromium.launchPersistentContext(profile, {
+		headless: true,
+		...(executablePath ? { executablePath } : {}),
+	});
+	try {
+		const state = await ctx.storageState();
+		writeFileSync(out, JSON.stringify(state));
+		const local = state.cookies
+			.filter((c) => (c.domain || "").includes("localhost"))
+			.map((c) => c.name);
+		const hasSession = local.some((n) => n.includes("session-token"));
+		console.log(
+			`[audit-auth] profile=${path.basename(profile)} → ${out} (${state.cookies.length} cookies, localhost: ${local.join(", ") || "none"})`,
+		);
+		if (!hasSession) {
+			console.error(
+				"[audit-auth] WARNING: no next-auth.session-token for localhost — runners may hit /login. Re-login locally and retry.",
+			);
+		}
+	} finally {
+		await ctx.close();
+	}
+}
+
+await main();

--- a/packages/app/scripts/audit-seed-fixtures.mjs
+++ b/packages/app/scripts/audit-seed-fixtures.mjs
@@ -1,0 +1,195 @@
+import { realpathSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+/**
+ * Audit functional — per-clone declaration-state seeding (phase 1.5 of
+ * /audit-functional, v2 "DB-bis" model).
+ *
+ * Each parallel runner gets its OWN cloned database + its OWN app instance
+ * (see manage_audit_instances.sh). The funnel is bound to the SESSION SIREN
+ * (the ProConnect SIRET — `getEffectiveSiren`), NOT to a selectable company,
+ * so isolation is achieved per-DB: every clone holds the SAME session SIREN
+ * but a DIFFERENT declaration state. This script writes the branch-class state
+ * (workforce / hasCse / GIP prefill / status) onto the session SIREN inside
+ * each clone DB.
+ *
+ * Self-contained SQL, mirroring scripts/audit-cleanup.mjs.
+ *
+ * Usage:
+ *   node scripts/audit-seed-fixtures.mjs <RUN_DIR>
+ *
+ * Reads: <RUN_DIR>/flows.json          (fixtures[] = branch-class specs)
+ *        <RUN_DIR>/instances.map.json  ({ "<fixtureId>": { db, port, ... } })
+ *
+ * Teardown is handled by `manage_audit_instances.sh teardown` (it DROPs the
+ * clone DBs entirely), so this script only seeds.
+ *
+ * Env: AUDIT_PG_URL_BASE (default postgres://postgres:postgres@localhost:5438)
+ */
+
+const PG_URL_BASE =
+	process.env.AUDIT_PG_URL_BASE ??
+	"postgres://postgres:postgres@localhost:5438";
+/** The session SIREN every clone is keyed on (test ProConnect SIRET → SIREN). */
+const SESSION_SIREN = "130025265";
+
+/**
+ * Apply a branch-class state to the session SIREN inside one clone DB.
+ * @param {object} args
+ * @param {import("postgres").Sql} args.sql
+ * @param {number} args.year
+ * @param {{workforce?:number, hasCse?:boolean, gipPrefill?:boolean, status?:string}} args.fixture
+ */
+async function seedState({ sql, year, fixture }) {
+	const workforce = Number.isFinite(fixture.workforce)
+		? fixture.workforce
+		: null;
+	const hasCse = typeof fixture.hasCse === "boolean" ? fixture.hasCse : null;
+	// Map the fixture's conceptual status onto a valid declaration_status enum
+	// value (the cartographer may use a human label like "submitted"). Unknown
+	// values fall back to a "post-draft / already submitted" state so the
+	// redirect/guard paths still exercise correctly.
+	const VALID_STATUS = new Set([
+		"draft",
+		"awaiting_compliance_path_choice",
+		"corrective_actions_chosen",
+		"joint_evaluation_chosen",
+		"awaiting_revision_choice",
+		"revised_joint_evaluation_chosen",
+		"awaiting_cse_opinion",
+		"demarche_completed",
+	]);
+	const rawStatus =
+		typeof fixture.status === "string" ? fixture.status : "draft";
+	const status = VALID_STATUS.has(rawStatus) ? rawStatus : "demarche_completed";
+
+	// Company context for the session SIREN.
+	await sql`
+		UPDATE app_company SET workforce = ${workforce}, has_cse = ${hasCse}, updated_at = NOW()
+		WHERE siren = ${SESSION_SIREN}
+	`;
+
+	// Reset the current-year declaration to the desired starting state.
+	// (mirrors the e2e resetDeclarationToDraft + clears the year's children so
+	// each branch-class starts from a clean funnel.)
+	await sql`
+		DELETE FROM app_employee_category WHERE job_category_id IN (
+			SELECT jc.id FROM app_job_category jc
+			JOIN app_declaration d ON d.id = jc.declaration_id
+			WHERE d.siren = ${SESSION_SIREN} AND d.year = ${year})
+	`;
+	await sql`DELETE FROM app_job_category WHERE declaration_id IN (
+		SELECT id FROM app_declaration WHERE siren = ${SESSION_SIREN} AND year = ${year})`;
+	await sql`DELETE FROM app_cse_opinion WHERE declaration_id IN (
+		SELECT id FROM app_declaration WHERE siren = ${SESSION_SIREN} AND year = ${year})`;
+	await sql`DELETE FROM app_file WHERE declaration_id IN (
+		SELECT id FROM app_declaration WHERE siren = ${SESSION_SIREN} AND year = ${year})`;
+	await sql`DELETE FROM app_declaration_status_history WHERE declaration_id IN (
+		SELECT id FROM app_declaration WHERE siren = ${SESSION_SIREN} AND year = ${year})`;
+
+	const existing = await sql`
+		SELECT id FROM app_declaration
+		WHERE siren = ${SESSION_SIREN} AND year = ${year} AND cancelled_at IS NULL LIMIT 1
+	`;
+	if (existing.length === 0) {
+		// Create from scratch if the clone had no current-year declaration.
+		const users = await sql`
+			SELECT user_id FROM app_user_company WHERE siren = ${SESSION_SIREN} LIMIT 1`;
+		const userId = users[0]?.user_id;
+		if (!userId)
+			throw new Error(
+				`Clone has no user linked to session SIREN ${SESSION_SIREN}.`,
+			);
+		await sql`
+			INSERT INTO app_declaration
+				(id, siren, year, declarant_id, current_step, status, created_at, updated_at)
+			VALUES (gen_random_uuid(), ${SESSION_SIREN}, ${year}, ${userId}, 1, ${status}, NOW(), NOW())
+		`;
+	} else {
+		await sql`
+			UPDATE app_declaration
+			SET status = ${status}, current_step = 1,
+			    first_declaration_path_choice = NULL, second_declaration_path_choice = NULL,
+			    total_women = NULL, total_men = NULL, draft = NULL, draft_updated_at = NULL,
+			    updated_at = NOW()
+			WHERE siren = ${SESSION_SIREN} AND year = ${year}
+		`;
+	}
+
+	// Optional GIP-MDS prefill row.
+	if (fixture.gipPrefill) {
+		await sql`
+			INSERT INTO app_gip_mds_data
+				(siren, year, imported_at, workforce_ema, global_hourly_mean_gap, variable_hourly_mean_gap)
+			VALUES (${SESSION_SIREN}, ${year}, NOW(), ${workforce}, 3.2, 1.5)
+			ON CONFLICT (siren, year) DO NOTHING
+		`;
+	}
+}
+
+async function run(runDir) {
+	const flows = JSON.parse(
+		await readFile(path.join(runDir, "flows.json"), "utf8"),
+	);
+	const map = JSON.parse(
+		await readFile(path.join(runDir, "instances.map.json"), "utf8"),
+	);
+	const fixtures = Array.isArray(flows.fixtures) ? flows.fixtures : [];
+	if (fixtures.length === 0) throw new Error("No fixtures in flows.json");
+
+	for (const fixture of fixtures) {
+		const entry = map[fixture.id];
+		if (!entry?.db) {
+			console.warn(
+				`[audit-seed] no clone DB for fixture ${fixture.id} — skipped`,
+			);
+			continue;
+		}
+		const sql = postgres(`${PG_URL_BASE}/${entry.db}`, { max: 1 });
+		try {
+			const yearRows =
+				await sql`SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS year`;
+			const year = yearRows[0]?.year ?? new Date().getUTCFullYear();
+			await seedState({ sql, year, fixture });
+			console.log(
+				`[audit-seed] ${fixture.id} → db=${entry.db} (workforce=${fixture.workforce ?? "-"}, hasCse=${fixture.hasCse ?? "-"}, gipPrefill=${!!fixture.gipPrefill}, status=${fixture.status ?? "draft"})`,
+			);
+		} finally {
+			await sql.end();
+		}
+	}
+	console.log(`[audit-seed] Seeded state into ${fixtures.length} clone DB(s).`);
+}
+
+const isMain = (() => {
+	const entry = process.argv[1];
+	if (!entry) return false;
+	try {
+		return fileURLToPath(import.meta.url) === realpathSync(entry);
+	} catch {
+		return false;
+	}
+})();
+
+if (isMain) {
+	const runDir = process.argv[2];
+	if (!runDir) {
+		console.error("Usage: node scripts/audit-seed-fixtures.mjs <RUN_DIR>");
+		process.exit(1);
+	}
+	try {
+		await run(runDir);
+		process.exit(0);
+	} catch (error) {
+		console.error(
+			"[audit-seed] Failed:",
+			error instanceof Error ? error.message : error,
+		);
+		process.exit(1);
+	}
+}
+
+export { seedState };

--- a/scripts/orchestration/audit_run_parallel.sh
+++ b/scripts/orchestration/audit_run_parallel.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
+# audit_run_parallel.sh <RUN_DIR>
+#
+# Phase 2 of /audit-functional (v2 "DB-bis" model). Fans out N flow-runner CLI
+# agents in parallel, one per fixture, each driving its OWN pre-provisioned app
+# instance (own port + own cloned DB — see manage_audit_instances.sh). Read-only
+# on the codebase: NO worktree, NO branch, NO board mutation. Isolation is
+# achieved per-instance (each runner's writes land in a different clone DB), so
+# the SAME ProConnect identity can be used by every runner with zero collision.
+#
+# Each runner writes its findings to:
+#   <RUN_DIR>/findings/runner-<i>.jsonl   (one JSON object per path)
+# Raw CLI trace (debug): <RUN_DIR>/runner-cli-<i>.log
+#
+# Inputs (in RUN_DIR):
+#   flows.json            (flow-cartographer, phase 1)
+#   instances.map.json    (manage_audit_instances.sh, phase 1.5)
+#                         { "<fixtureId>": { "db":.., "port":.., "index":.., "pid":.. } }
+#
+# Env (defaults):
+#   AUDIT_MAX_PARALLEL    5     max concurrent runner CLIs (instances are all up already)
+#   AUDIT_BUDGET          5     USD max per runner
+#   AUDIT_AGENT_TIMEOUT   3600  seconds max per runner
+#
+# Exit: 0 ok · 1 bad input
+
+set -euo pipefail
+
+TIMEOUT_BIN=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_BIN="gtimeout"; fi
+
+RUN_DIR="${1:-}"
+if [ -z "$RUN_DIR" ] || [ ! -d "$RUN_DIR" ]; then
+    echo "Usage: $0 <RUN_DIR>" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLOWS="$RUN_DIR/flows.json"
+MAP="$RUN_DIR/instances.map.json"
+FINDINGS_DIR="$RUN_DIR/findings"
+
+MAX_PARALLEL="${AUDIT_MAX_PARALLEL:-5}"
+BUDGET="${AUDIT_BUDGET:-5}"
+AGENT_TIMEOUT="${AUDIT_AGENT_TIMEOUT:-3600}"
+RUN_ID="$(basename "$RUN_DIR")"
+AID="audit-orchestrator-${RUN_ID}"
+
+for F in "$FLOWS" "$MAP"; do
+    [ -s "$F" ] || { echo "ERROR: missing or empty $F" >&2; exit 1; }
+done
+command -v claude >/dev/null 2>&1 || { echo "ERROR: claude CLI not found" >&2; exit 1; }
+mkdir -p "$FINDINGS_DIR"
+
+# Isolated-browser mcp-config (written by `manage_audit_instances.sh auth`):
+# overrides the shared `playwright` server with `--isolated --storage-state` so
+# each runner gets its own in-memory Chrome (no SingletonLock contention),
+# authenticated. Absent → runners share one Chrome and serialise (degraded).
+MCP_CFG="$RUN_DIR/playwright-mcp.json"
+MCP_ARGS=()
+if [ -s "$MCP_CFG" ]; then
+    MCP_ARGS=(--mcp-config "$MCP_CFG")
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" BROWSER_ISOLATED "cfg=$MCP_CFG"
+else
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" BROWSER_SHARED "no isolated mcp-config — runners will serialise on one Chrome"
+fi
+
+bash "$SCRIPT_DIR/log_event.sh" "$AID" RUN_START "run=$RUN_ID max_parallel=$MAX_PARALLEL budget=$BUDGET"
+
+# ---- Spawn one runner per fixture, each bound to its instance's PORT ----
+spawn_runner() {
+    local IDX="$1" PORT="$2" FIXTURE="$3" PATH_IDS="$4" CLI_LOG="$5"
+
+    local PROMPT="Tu es flow-runner #${IDX} pour un audit fonctionnel /audit-functional (modèle DB-bis).
+Suis STRICTEMENT .claude/agents/flow-runner/AGENT.md et les schémas de .claude/rules/audit-functional.md.
+
+Paramètres :
+- RUN_DIR : ${RUN_DIR}
+- RUNNER_INDEX : ${IDX}  (ta sortie = ${RUN_DIR}/findings/runner-${IDX}.jsonl)
+- PORT : ${PORT}  (ton instance d'app DÉDIÉE — base URL http://localhost:${PORT})
+- FIXTURE : ${FIXTURE}  (la classe de branche déjà seedée dans LA DB de cette instance)
+- PATH_IDS : ${PATH_IDS}
+
+Ton instance http://localhost:${PORT} a sa PROPRE base de données clonée, seedée avec l'état de la classe de branche '${FIXTURE}'. Tu agis sur le SIREN de session (identité ProConnect) — pas besoin de sélectionner une entreprise, le funnel l'utilise automatiquement. Tes écritures restent isolées dans cette DB : tu ne peux pas entrer en collision avec un autre runner.
+
+Lis ${RUN_DIR}/flows.json, sélectionne les paths dont l'id est dans PATH_IDS, exécute-les contre http://localhost:${PORT}, applique les oracles (déterministe d'abord, LLM seulement sur l'ambigu), et écris UNE ligne JSONL par path dans ${RUN_DIR}/findings/runner-${IDX}.jsonl.
+
+DISCIPLINE DE LOGGING (blocking) : bash scripts/orchestration/log_event.sh flow-runner-${IDX} <EVENT> à chaque transition (START, PATH_<id>_OK/FAIL, RUN_DONE).
+
+CONTRAINTES : read-only total (aucun git, aucune modif code, aucune mutation board, aucune création de ticket). Reste sur TON port ${PORT}. Scrub PII/SIREN/secrets dans les evidence. N'invoque AUCUN skill built-in. Ne modifie jamais .claude/settings*.json."
+
+    local TIMEOUT_PREFIX=""
+    [ -n "$TIMEOUT_BIN" ] && TIMEOUT_PREFIX="$TIMEOUT_BIN $AGENT_TIMEOUT"
+    $TIMEOUT_PREFIX env -u CLAUDECODE claude \
+        --agent flow-runner --model sonnet \
+        ${MCP_ARGS[@]+"${MCP_ARGS[@]}"} \
+        --print --output-format stream-json --verbose \
+        --dangerously-skip-permissions --max-budget-usd "$BUDGET" \
+        "$PROMPT" > "$CLI_LOG" 2>&1 || true
+}
+
+# Pre-load entries (fixture + port) before forking (anti-race discipline).
+FIXTURES=(); PORTS=()
+while IFS= read -r entry; do
+    FIXTURES+=("$(echo "$entry" | jq -r '.key')")
+    PORTS+=("$(echo "$entry" | jq -r '.value.port')")
+done < <(jq -c 'to_entries[]' "$MAP")
+
+[ "${#FIXTURES[@]}" -gt 0 ] || { echo "ERROR: no instances in $MAP" >&2; exit 1; }
+bash "$SCRIPT_DIR/log_event.sh" "$AID" RUN_PLAN "runners=${#FIXTURES[@]}"
+
+IDX=0; PIDS=()
+for n in "${!FIXTURES[@]}"; do
+    FIXTURE="${FIXTURES[$n]}"; PORT="${PORTS[$n]}"
+    PATH_IDS=$(jq -r --arg fx "$FIXTURE" '[.paths[] | select(.fixture==$fx) | .id] | join(" ")' "$FLOWS")
+    if [ -z "$PATH_IDS" ]; then
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" RUNNER_SKIP "fixture=$FIXTURE reason=no_paths"
+        IDX=$((IDX + 1)); continue
+    fi
+    CLI_LOG="$RUN_DIR/runner-cli-${IDX}.log"
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" RUNNER_SPAWN "idx=$IDX fixture=$FIXTURE port=$PORT paths=$(echo "$PATH_IDS" | wc -w | tr -d ' ')"
+    spawn_runner "$IDX" "$PORT" "$FIXTURE" "$PATH_IDS" "$CLI_LOG" &
+    PIDS+=($!)
+    IDX=$((IDX + 1))
+
+    if [ "${#PIDS[@]}" -ge "$MAX_PARALLEL" ]; then
+        for pid in "${PIDS[@]}"; do wait "$pid" || true; done
+        PIDS=()
+    fi
+done
+for pid in "${PIDS[@]}"; do wait "$pid" || true; done
+
+RUNNER_FILES=$(ls "$FINDINGS_DIR"/runner-*.jsonl 2>/dev/null | wc -l | tr -d ' ')
+TOTAL_LINES=0
+[ "$RUNNER_FILES" -gt 0 ] && TOTAL_LINES=$(cat "$FINDINGS_DIR"/runner-*.jsonl 2>/dev/null | grep -c '' || echo 0)
+bash "$SCRIPT_DIR/log_event.sh" "$AID" RUN_OK "runner_files=$RUNNER_FILES path_results=$TOTAL_LINES"
+echo "DONE: $RUNNER_FILES runner file(s), $TOTAL_LINES path result(s) → $FINDINGS_DIR"
+exit 0

--- a/scripts/orchestration/manage_audit_instances.sh
+++ b/scripts/orchestration/manage_audit_instances.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required." >&2
+  exit 1
+fi
+# manage_audit_instances.sh <clone|start|teardown> <RUN_DIR>
+#
+# Provisions N isolated (DB clone + app instance) pairs for true-parallel
+# /audit-functional execution. Each parallel runner gets its OWN database
+# (a fast TEMPLATE clone of the dev DB) AND its OWN app instance on its own
+# port pointing at that clone — so N runners can drive the SAME ProConnect
+# identity concurrently with zero DB collision (the funnel is bound to the
+# session SIREN; isolation is achieved per-DB, not per-SIREN).
+#
+#   clone     — read flows.json fixtures, CREATE DATABASE audit_<run>_<i>
+#               TEMPLATE <egapro>, write instances.map.json
+#               { "<fixtureId>": { "db": ..., "port": ..., "index": i } }.
+#   start     — launch one `pnpm dev` app instance per clone (own PORT +
+#               DATABASE_URL + NEXTAUTH_URL + NEXT_PUBLIC_EGAPRO_ENV=dev),
+#               poll readiness, add "pid" to each map entry.
+#   teardown  — stop every instance, then DROP every clone DB.
+#
+# Cloning requires NO active connections to the template DB → the caller must
+# stop the cartography dev server (manage_dev_server.sh stop) before `clone`.
+#
+# Env (defaults):
+#   AUDIT_PORT_BASE       3011    first instance port (avoids 3000 + worktree 3001-5)
+#   AUDIT_PG_CONTAINER    egapro-db-1   docker container running postgres
+#   AUDIT_PG_URL_BASE     postgres://postgres:postgres@localhost:5438
+#   AUDIT_TEMPLATE_DB     egapro  source DB to clone
+#   AUDIT_DEV_READY_SECS  180     max wait per instance to answer
+#
+# Exit: 0 ok · 1 bad input / failure
+
+set -euo pipefail
+
+MODE="${1:-}"
+RUN_DIR="${2:-}"
+# `sweep` is a global orphan cleanup → RUN_DIR is optional for it.
+if [ -z "$MODE" ] || { [ "$MODE" != "sweep" ] && [ -z "$RUN_DIR" ]; }; then
+    echo "Usage: $0 <clone|start|teardown> <RUN_DIR>   |   $0 sweep" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FLOWS="$RUN_DIR/flows.json"
+MAP="$RUN_DIR/instances.map.json"
+
+PORT_BASE="${AUDIT_PORT_BASE:-3011}"
+PG_CONTAINER="${AUDIT_PG_CONTAINER:-egapro-db-1}"
+PG_URL_BASE="${AUDIT_PG_URL_BASE:-postgres://postgres:postgres@localhost:5438}"
+TEMPLATE_DB="${AUDIT_TEMPLATE_DB:-egapro}"
+READY_SECS="${AUDIT_DEV_READY_SECS:-180}"
+SWEEP_PORTS="${AUDIT_SWEEP_PORTS:-16}"
+RUN_ID="$([ -n "$RUN_DIR" ] && basename "$RUN_DIR" || echo "sweep")"
+AID="audit-orchestrator-${RUN_ID}"
+
+psql_admin() { docker exec -i "$PG_CONTAINER" psql -U postgres -d postgres "$@"; }
+port_up() { curl -sf -o /dev/null "http://localhost:$1" 2>/dev/null; }
+# SIGKILL whatever LISTENs on a port (lsof → fuser → ss). Audit instances are
+# disposable; SIGKILL releases their DB connections instantly (a graceful
+# SIGTERM lets `next start` shut down slowly and hold connections for ~30-60s,
+# which then blocks DROP DATABASE).
+kill_port() {
+    local p="$1" pids=""
+    # Try ALL tools and union the pids — `command -v lsof` succeeding does NOT
+    # mean lsof *finds* the listener (its -sTCP:LISTEN filter can miss a
+    # `next-server`, while `ss` sees it). An elif chain stopping at the first
+    # *available* tool silently misses such listeners.
+    if command -v lsof >/dev/null 2>&1; then
+        pids="$pids $(lsof -ti ":$p" -sTCP:LISTEN 2>/dev/null; lsof -ti "tcp:$p" 2>/dev/null)"
+    fi
+    if command -v ss >/dev/null 2>&1; then
+        pids="$pids $(ss -ltnpH "sport = :$p" 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2)"
+    fi
+    if command -v fuser >/dev/null 2>&1; then
+        pids="$pids $(fuser "$p/tcp" 2>/dev/null | tr -d ' ')"
+    fi
+    pids="$(printf '%s\n' $pids | grep -E '^[0-9]+$' | sort -u | tr '\n' ' ')"
+    [ -n "${pids// /}" ] && { kill -KILL $pids 2>/dev/null || true; return 0; }
+    return 1
+}
+# Recursively SIGKILL a process and all its descendants. `next start` runs as
+# pnpm → (sh) → next-server; killing only the pnpm pid leaves next-server alive,
+# holding (and reconnecting) DB connections that block DROP DATABASE.
+kill_tree() {
+    local p="$1" child
+    for child in $(pgrep -P "$p" 2>/dev/null || true); do kill_tree "$child"; done
+    kill -KILL "$p" 2>/dev/null || true
+}
+
+# DROP a clone DB robustly: terminate backends, then wait until the connection
+# count actually reaches 0 (postgres keeps a DB "in use" for a moment after a
+# client disconnects) before dropping. Returns 0 on success.
+drop_db() {
+    local db="$1" i n
+    for i in $(seq 1 15); do
+        psql_admin -tAc "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${db}' AND pid<>pg_backend_pid();" >/dev/null 2>&1 || true
+        n="$(psql_admin -tAc "SELECT count(*) FROM pg_stat_activity WHERE datname='${db}';" 2>/dev/null | tr -d ' ')"
+        if [ "${n:-1}" -eq 0 ] && psql_admin -c "DROP DATABASE IF EXISTS ${db};" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    psql_admin -c "DROP DATABASE IF EXISTS ${db};" >/dev/null 2>&1
+}
+
+case "$MODE" in
+  clone)
+    [ -s "$FLOWS" ] || { echo "ERROR: missing $FLOWS" >&2; exit 1; }
+    # Sanitised, length-bounded prefix for valid postgres identifiers.
+    SAN="$(printf '%s' "$RUN_ID" | tr -c 'a-zA-Z0-9' '_' | cut -c1-48)"
+    # Drop stray connections to the template (TEMPLATE clone needs none).
+    psql_admin -tAc "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='${TEMPLATE_DB}' AND pid<>pg_backend_pid();" >/dev/null 2>&1 || true
+
+    FIXTURES=()
+    while IFS= read -r fx; do [ -n "$fx" ] && FIXTURES+=("$fx"); done < <(jq -r '.fixtures[].id' "$FLOWS")
+    [ "${#FIXTURES[@]}" -gt 0 ] || { echo "ERROR: no fixtures in $FLOWS" >&2; exit 1; }
+
+    echo '{}' > "$MAP"
+    idx=0
+    for fx in "${FIXTURES[@]}"; do
+        db="audit_${SAN}_${idx}"
+        port=$((PORT_BASE + idx))
+        psql_admin -v ON_ERROR_STOP=1 -c "DROP DATABASE IF EXISTS ${db};" -c "CREATE DATABASE ${db} TEMPLATE ${TEMPLATE_DB};" >/dev/null
+        jq --arg fx "$fx" --arg db "$db" --argjson port "$port" --argjson idx "$idx" \
+           '.[$fx]={db:$db,port:$port,index:$idx}' "$MAP" > "$MAP.tmp" && mv "$MAP.tmp" "$MAP"
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" DB_CLONE "fixture=$fx db=$db port=$port"
+        echo "  cloned $db (fixture=$fx, port=$port)"
+        idx=$((idx + 1))
+    done
+    echo "DONE clone: ${#FIXTURES[@]} DB(s) → $MAP"
+    ;;
+
+  start)
+    [ -s "$MAP" ] || { echo "ERROR: missing $MAP (run 'clone' first)" >&2; exit 1; }
+    APP_DIR="$REPO_ROOT/packages/app"
+
+    # N concurrent instances must run `next start` (read-only on the prebuilt
+    # .next), NOT `next dev`: two `pnpm dev` from the same dir race on the copy
+    # presteps + .next. So build ONCE (NEXT_PUBLIC_EGAPRO_ENV=dev baked in so the
+    # [DEV] Remplir button ships), then every instance serves that build with
+    # its own runtime DATABASE_URL / NEXTAUTH_URL / PORT.
+    if [ "${AUDIT_FORCE_BUILD:-0}" = "1" ] || [ ! -f "$APP_DIR/.next/BUILD_ID" ]; then
+        echo "Building app once for next start (NEXT_PUBLIC_EGAPRO_ENV=dev)… ~1-3 min"
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" BUILD_START ""
+        if ! ( cd "$APP_DIR" && NEXT_PUBLIC_EGAPRO_ENV=dev pnpm build ) > "$RUN_DIR/build.log" 2>&1; then
+            echo "ERROR: build failed (see $RUN_DIR/build.log)" >&2
+            bash "$SCRIPT_DIR/log_event.sh" "$AID" BUILD_FAIL ""
+            exit 1
+        fi
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" BUILD_OK ""
+    fi
+
+    # Launch every instance (next start), then poll all of them for readiness.
+    PORTS=()
+    while IFS= read -r entry; do
+        fx="$(echo "$entry" | jq -r '.key')"
+        db="$(echo "$entry" | jq -r '.value.db')"
+        port="$(echo "$entry" | jq -r '.value.port')"
+        log="$RUN_DIR/instance-${port}.log"
+        # Defensive: clear any stale listener on this port so the instance can
+        # bind (a leftover process → EADDRINUSE → instance serves the wrong/no
+        # DB and every route 500s).
+        kill_port "$port" && sleep 1 || true
+        (
+            cd "$APP_DIR"
+            DATABASE_URL="${PG_URL_BASE}/${db}" \
+            NEXTAUTH_URL="http://localhost:${port}" \
+            PORT="$port" \
+              nohup pnpm start > "$log" 2>&1 &
+            echo $! > "$RUN_DIR/instance-${port}.pid"
+        )
+        pid="$(cat "$RUN_DIR/instance-${port}.pid")"
+        jq --arg fx "$fx" --argjson pid "$pid" '.[$fx].pid=$pid' "$MAP" > "$MAP.tmp" && mv "$MAP.tmp" "$MAP"
+        bash "$SCRIPT_DIR/log_event.sh" "$AID" INSTANCE_SPAWN "fixture=$fx db=$db port=$port pid=$pid"
+        PORTS+=("$port")
+    done < <(jq -c 'to_entries[]' "$MAP")
+    disown -a 2>/dev/null || true
+
+    # Poll readiness for every instance.
+    for port in "${PORTS[@]}"; do
+        waited=0; ok=0
+        while [ "$waited" -lt "$READY_SECS" ]; do
+            if port_up "$port"; then ok=1; break; fi
+            sleep 3; waited=$((waited + 3))
+        done
+        if [ "$ok" = "1" ]; then
+            echo "  ready :$port"
+            bash "$SCRIPT_DIR/log_event.sh" "$AID" INSTANCE_READY "port=$port waited=${waited}s"
+        else
+            echo "  TIMEOUT :$port (see $RUN_DIR/instance-${port}.log)" >&2
+            bash "$SCRIPT_DIR/log_event.sh" "$AID" INSTANCE_TIMEOUT "port=$port"
+        fi
+    done
+    echo "DONE start: instances on $(jq -r '[.[].port]|join(", ")' "$MAP")"
+    ;;
+
+  teardown)
+    [ -s "$MAP" ] || { echo "nothing to tear down (no $MAP)"; exit 0; }
+    # Stop instances first — SIGKILL the whole pnpm→next-server tree AND whatever
+    # LISTENs on the port, so no backend lingers to reconnect and block DROP.
+    while IFS= read -r entry; do
+        port="$(echo "$entry" | jq -r '.value.port')"
+        pid="$(echo "$entry" | jq -r '.value.pid // empty')"
+        kill_port "$port" || true
+        [ -n "$pid" ] && kill_tree "$pid"
+        rm -f "$RUN_DIR/instance-${port}.pid"
+    done < <(jq -c 'to_entries[]' "$MAP")
+    # …then drop the clone DBs (drop_db waits until each DB has 0 connections).
+    FAILED=()
+    while IFS= read -r db; do
+        [ -z "$db" ] && continue
+        drop_db "$db" || FAILED+=("$db")
+    done < <(jq -r '.[].db' "$MAP")
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" INSTANCES_TEARDOWN "count=$(jq 'length' "$MAP") failed=${#FAILED[@]}"
+    if [ "${#FAILED[@]}" -gt 0 ]; then
+        echo "WARN: could not drop: ${FAILED[*]} — drop manually with: docker exec ${PG_CONTAINER} psql -U postgres -d postgres -c 'DROP DATABASE <db>;'" >&2
+    fi
+    echo "DONE teardown: stopped instances + dropped clone DBs"
+    ;;
+
+  sweep)
+    # Defensive orphan cleanup — safety net for an aborted/crashed run where
+    # `teardown` never executed. Kills whatever LISTENs on the audit port range
+    # and DROPs every `audit_*` clone DB. Safe to run before each provisioning
+    # (clean slate) and as manual recovery. Does NOT touch the source DB nor
+    # ports outside the audit range. Run when no audit run is in flight.
+    killed=0
+    for i in $(seq 0 $((SWEEP_PORTS - 1))); do
+        if kill_port $((PORT_BASE + i)); then killed=$((killed + 1)); fi
+    done
+    [ "$killed" -gt 0 ] && sleep 3   # let killed servers release their backends
+    dropped=0; failed=0
+    while IFS= read -r db; do
+        [ -z "$db" ] && continue
+        ok=0
+        for attempt in 1 2 3 4 5 6; do
+            if drop_db "$db"; then ok=1; break; fi
+            sleep 2
+        done
+        if [ "$ok" = "1" ]; then dropped=$((dropped + 1)); else failed=$((failed + 1)); fi
+    done < <(psql_admin -tAc "SELECT datname FROM pg_database WHERE datname ~ '^audit_';" 2>/dev/null || true)
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" SWEEP "killed_ports=$killed dropped_dbs=$dropped failed=$failed"
+    echo "DONE sweep: killed $killed audit port(s) + dropped $dropped audit_* DB(s)$([ "$failed" -gt 0 ] && echo " ($failed still stuck — retry sweep)")"
+    ;;
+
+  auth)
+    # Extract a storageState from the logged-in @playwright/mcp profile and
+    # write an mcp-config that makes each runner launch its OWN isolated browser
+    # (`--isolated --storage-state`), authenticated, with no shared-profile lock
+    # contention. next-devtools etc. stay (non-strict --mcp-config override).
+    AUTHFILE="$RUN_DIR/auth.json"
+    if ! node "$REPO_ROOT/packages/app/scripts/audit-extract-auth.mjs" "$AUTHFILE"; then
+        echo "ERROR: browser auth extraction failed — runners will share one Chrome (serialised)." >&2
+        exit 1
+    fi
+    # the npx-cached binary is a symlink → match -type l too (avoids re-resolving
+    # @playwright/mcp@latest over the network on every runner spawn).
+    PW_BIN="$(find "$HOME/.npm/_npx" \( -type f -o -type l \) -path '*/.bin/playwright-mcp' 2>/dev/null | head -1)"
+    COMMON_ARGS='["--browser","chromium","--headless","--isolated","--storage-state",$sf,"--output-dir","/tmp/playwright-mcp"]'
+    if [ -n "$PW_BIN" ]; then
+        jq -n --arg cmd "$PW_BIN" --arg sf "$AUTHFILE" \
+          "{mcpServers:{playwright:{type:\"stdio\",command:\$cmd,args:$COMMON_ARGS}}}" > "$RUN_DIR/playwright-mcp.json"
+    else
+        jq -n --arg sf "$AUTHFILE" \
+          "{mcpServers:{playwright:{type:\"stdio\",command:\"npx\",args:([\"-y\",\"@playwright/mcp@latest\"]+$COMMON_ARGS)}}}" > "$RUN_DIR/playwright-mcp.json"
+    fi
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" AUTH_READY "authfile=$AUTHFILE"
+    echo "DONE auth: $AUTHFILE + $RUN_DIR/playwright-mcp.json (isolated browser per runner)"
+    ;;
+
+  *)
+    echo "Usage: $0 <clone|start|teardown|auth> <RUN_DIR>   |   $0 sweep" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/orchestration/manage_dev_server.sh
+++ b/scripts/orchestration/manage_dev_server.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# manage_dev_server.sh <ensure|stop> <RUN_DIR>
+#
+# Lifecycle of the local dev stack for /audit-functional, so the skill is
+# turnkey (the user doesn't pre-start anything).
+#
+#   ensure  — bring up docker DB + dev server on :3000 in dev mode, OR reuse an
+#             already-running server. Writes a PID file ONLY when this script
+#             started the server, so `stop` never kills a server the user owns.
+#   stop    — kill the dev server ONLY if this script started it (PID file
+#             present). A pre-existing / reused server is left untouched.
+#
+# Idempotent. Reads/writes:
+#   <RUN_DIR>/dev-server.pid   (present ⇔ we started it ⇔ stop will kill it)
+#   <RUN_DIR>/dev-server.log   (dev server output, for diagnostics)
+#
+# Env (defaults shown):
+#   AUDIT_DEV_PORT        3000   port to check / serve on
+#   AUDIT_DEV_READY_SECS  150    max seconds to wait for the server to answer
+#
+# Exit codes:
+#   0  ensure: server is up (reused or started) — last stdout line is
+#      "reused" | "started <pid>"
+#      stop: done — "stopped" | "nothing-to-stop"
+#   1  ensure: server failed to become ready within AUDIT_DEV_READY_SECS
+
+set -euo pipefail
+
+MODE="${1:-}"
+RUN_DIR="${2:-}"
+DEV_PORT="${AUDIT_DEV_PORT:-3000}"
+READY_SECS="${AUDIT_DEV_READY_SECS:-150}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [ -z "$MODE" ] || [ -z "$RUN_DIR" ]; then
+    echo "Usage: $0 <ensure|stop> <RUN_DIR>" >&2
+    exit 2
+fi
+mkdir -p "$RUN_DIR"
+PIDFILE="$RUN_DIR/dev-server.pid"
+LOGFILE="$RUN_DIR/dev-server.log"
+
+server_up() { curl -sf -o /dev/null "http://localhost:${DEV_PORT}" 2>/dev/null; }
+
+case "$MODE" in
+  ensure)
+    # 1. Reuse a server the user (or a previous run) already has on :3000.
+    if server_up; then
+        echo "WARN: réutilisation du serveur déjà actif sur :${DEV_PORT}." >&2
+        echo "      Assure-toi qu'il tourne avec NEXT_PUBLIC_EGAPRO_ENV=dev (bouton [DEV] Remplir)." >&2
+        echo "reused"
+        exit 0
+    fi
+
+    # 2. Bring up the docker DB stack (best-effort — seeding needs :5438).
+    (cd "$REPO_ROOT" && docker compose up -d >/dev/null 2>&1) || \
+        echo "WARN: 'docker compose up -d' a échoué — vérifie Docker (DB :5438)." >&2
+
+    # 3. Start the dev server in dev mode, detached, surviving this script.
+    echo "Démarrage du dev server (NEXT_PUBLIC_EGAPRO_ENV=dev, :${DEV_PORT})…" >&2
+    (
+        cd "$REPO_ROOT"
+        nohup env NEXT_PUBLIC_EGAPRO_ENV=dev pnpm dev:app > "$LOGFILE" 2>&1 &
+        echo $! > "$PIDFILE"
+    )
+    disown 2>/dev/null || true
+
+    # 4. Poll until ready (the first compile can take a while).
+    WAITED=0
+    while [ "$WAITED" -lt "$READY_SECS" ]; do
+        if server_up; then
+            echo "started $(cat "$PIDFILE" 2>/dev/null || echo '?')"
+            exit 0
+        fi
+        sleep 3
+        WAITED=$((WAITED + 3))
+    done
+
+    echo "ERROR: dev server pas prêt après ${READY_SECS}s — voir $LOGFILE" >&2
+    # We started it but it never answered: tear our own attempt down so we
+    # don't leak a half-started process, then fail.
+    "$0" stop "$RUN_DIR" >/dev/null 2>&1 || true
+    exit 1
+    ;;
+
+  stop)
+    if [ "${AUDIT_KEEP_DEV:-0}" = "1" ]; then
+        echo "AUDIT_KEEP_DEV=1 — le dev server est laissé tel quel." >&2
+        echo "nothing-to-stop"
+        exit 0
+    fi
+    if [ -f "$PIDFILE" ]; then
+        PID="$(cat "$PIDFILE" 2>/dev/null || true)"
+        if [ -n "$PID" ]; then
+            # Kill children first (pnpm → next dev → workers), then the leader.
+            pkill -TERM -P "$PID" 2>/dev/null || true
+            kill -TERM "$PID" 2>/dev/null || true
+        fi
+        rm -f "$PIDFILE"
+        echo "stopped"
+        exit 0
+    fi
+    # No PID file ⇒ we never started it (reused / user-owned) ⇒ leave it alone.
+    echo "nothing-to-stop"
+    exit 0
+    ;;
+
+  *)
+    echo "Usage: $0 <ensure|stop> <RUN_DIR>" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Quoi

Nouveau skill **`/audit-functional`**, séparé du pipeline `/analyse`→`/implement`. Là où ce dernier est *bottom-up* (un ticket → un fix), celui-ci est **top-down** : il parcourt un périmètre de l'app de bout en bout pour **découvrir** des incohérences fonctionnelles (blocages, retour-arrière cassé, données affichées incohérentes, crashes) que les E2E ciblés ne couvrent pas.

**Périmètre v1** : funnel de déclaration (`/declaration-remuneration/etape/[1-6]` + parcours conformité + avis CSE). On-demand uniquement.

## Comment ça marche (4 phases)

1. **Cartographie** (`flow-cartographer`, Opus/xhigh) — combine le *domain layer* (branches métier centralisées) et l'exploration navigateur pour produire un `flows.json` : un arbre de chemins de test orienté **découverte de bugs** (assertion par étape, back systématique à chaque étape, validation par champ, bornes), profondeur réglable `quick`/`standard`/`exhaustive`.
2. **Exécution parallèle réelle** (`audit_run_parallel.sh` → N × `flow-runner`, Sonnet) — chaque runner pilote **son** instance d'app dédiée et applique des **oracles déterministes** d'abord, un jugement LLM seulement sur l'ambigu.
3. **Synthèse** (`finding-synthesizer`, Opus/high) — dédup des findings **par type de problème**, **root-cause** (lecture du code, `fichier:ligne`), et brouillon de ticket **écrit pour un dev** (Reproduction en actions concrètes · Comportement attendu vs obtenu · Cause racine · Correctif proposé · Scénarios affectés).
4. **Gate utilisateur** — présente les clusters ; **dry-run par défaut**, **aucun ticket n'est créé sans validation explicite**, puis 1 ticket Bug par cluster confirmé (type Bug + label `bug/type:*`, board en Backlog).

## Isolation (le point d'architecture clé)

Le funnel est lié au **SIREN de session** (`getEffectiveSiren` → SIRET ProConnect), pas à une company sélectionnable, et l'impersonation admin est read-only. On obtient donc du **vrai parallélisme avec une seule identité de test** via :
- **Données** : une **DB clonée** par runner (`CREATE DATABASE … TEMPLATE egapro`, ~1,5 s) + **une instance d'app** par clone (`next start`, port + `DATABASE_URL` propres).
- **Navigateur** : un **Chrome isolé** par runner (`@playwright/mcp --isolated --storage-state`, override non-strict de la config MCP), authentifié via un storageState extrait du profil connecté.

L'audit est **100 % read-only sur le code** (aucun worktree, commit ou branche) ; seules les DBs clonées (jetables) sont écrites — la DB de dev `egapro` n'est que la **source** du clone.

## Contenu du PR

| Fichier | Rôle |
|---|---|
| `.claude/skills/audit-functional/SKILL.md` | Orchestrateur synchrone (4 phases + gate) |
| `.claude/rules/audit-functional.md` | Référence : schémas `flows`/`findings`/`clusters`, oracles, labels, garde-fous |
| `.claude/agents/flow-cartographer/AGENT.md` | Cartographie (Opus/xhigh) |
| `.claude/agents/flow-runner/AGENT.md` | Exécution par port (Sonnet) |
| `.claude/agents/finding-synthesizer/AGENT.md` | Synthèse + root-cause + tickets dev-grade (Opus/high) |
| `scripts/orchestration/manage_dev_server.sh` | Cycle de vie du serveur de cartographie |
| `scripts/orchestration/manage_audit_instances.sh` | clone DBs + N instances + auth isolée + teardown + sweep |
| `scripts/orchestration/audit_run_parallel.sh` | Fan-out des runners par port |
| `packages/app/scripts/audit-seed-fixtures.mjs` | État de déclaration par DB clonée |
| `packages/app/scripts/audit-extract-auth.mjs` | storageState pour l'isolation navigateur |

## Notes

- Pas de modification du code applicatif — outillage/skill uniquement (2 scripts `.mjs` ajoutés dans `packages/app/scripts/`, comme `audit-cleanup.mjs`).
- Validé de bout en bout en local : le skill cartographie, exécute en parallèle, et remonte des bugs réels du funnel (validation de bornes manquante, redirections de conformité, gating CSE).
- Garde-fous : read-only, dry-run par défaut, scrub d'hygiène avant tout post, board ≤ Backlog.