### PR TITLE
feat(cseOpinion): matrice fichiers × types de contenu — page import (#3632)

### DIFF
--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import {
+	computeContentTypeColumns,
 	mapOpinionsFromDb,
 	Step1Opinions,
 	Step2Upload,
@@ -57,16 +58,32 @@ export default async function CseOpinionStepPage({ params }: StepPageProps) {
 	}
 
 	if (step === 2) {
-		const [declarationData, { files }] = await Promise.all([
-			api.declaration.getOrCreate(),
-			api.cseOpinion.getFiles(),
-		]);
+		const [declarationData, { files }, { opinions }, { associations }] =
+			await Promise.all([
+				api.declaration.getOrCreate(),
+				api.cseOpinion.getFiles(),
+				api.cseOpinion.get(),
+				api.cseOpinion.getFileContentTypes(),
+			]);
 		const hasSecondDeclaration = declarationData.hasSubmittedSecondDeclaration;
+		const firstGap = opinions.find(
+			(opinion) => opinion.declarationNumber === 1 && opinion.type === "gap",
+		);
+		const secondGap = opinions.find(
+			(opinion) => opinion.declarationNumber === 2 && opinion.type === "gap",
+		);
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration,
+			firstDeclGapConsulted: firstGap?.gapConsulted ?? null,
+			secondDeclGapConsulted: secondGap?.gapConsulted ?? null,
+		});
 		return (
 			<Step2Upload
+				columns={columns}
 				declarationYear={declarationData.declaration.year}
 				existingFiles={files}
 				hasSecondDeclaration={hasSecondDeclaration}
+				initialAssociations={associations}
 				siren={declarationData.declaration.siren}
 			/>
 		);

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -6,21 +6,34 @@ import { useCallback, useMemo, useState } from "react";
 
 import { useReadOnlyGuard } from "~/modules/auth";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
-import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { FileUpload, getDsfrModal, useFileUploadForm } from "~/modules/shared";
 import { api } from "~/trpc/react";
-
+import { ContentTypeMatrix } from "./components/ContentTypeMatrix";
 import { CseStepIndicator } from "./components/CseStepIndicator";
 import { OpinionSummaryBox } from "./components/OpinionSummaryBox";
 import { SubmitConfirmationModal } from "./components/SubmitConfirmationModal";
+import {
+	buildAssociationMap,
+	clearFileAssociations,
+	getMissingColumns,
+	toAssociationPayload,
+} from "./contentTypeColumns";
 import formStyles from "./shared/formActions.module.scss";
-import { MAX_CSE_FILES, type UploadedFile } from "./types";
+import {
+	type AssociationMap,
+	type ContentTypeColumn,
+	MAX_CSE_FILES,
+	type StoredFileContentType,
+	type UploadedFile,
+} from "./types";
 
 type Props = {
 	declarationYear: number;
 	siren: string;
 	hasSecondDeclaration?: boolean;
 	existingFiles?: UploadedFile[];
+	columns: ContentTypeColumn[];
+	initialAssociations?: StoredFileContentType[];
 };
 
 export function Step2Upload({
@@ -28,11 +41,17 @@ export function Step2Upload({
 	siren,
 	hasSecondDeclaration = true,
 	existingFiles = [],
+	columns,
+	initialAssociations = [],
 }: Props) {
 	const router = useRouter();
 	const utils = api.useUtils();
 	const [deletingFileId, setDeletingFileId] = useState<string | null>(null);
 	const [finalizeError, setFinalizeError] = useState<string | null>(null);
+	const [associationError, setAssociationError] = useState<string | null>(null);
+	const [associations, setAssociations] = useState<AssociationMap>(() =>
+		buildAssociationMap(columns, initialAssociations),
+	);
 	const readOnlyGuard = useReadOnlyGuard();
 
 	const emptyDbValues = useMemo(() => ({}), []);
@@ -46,12 +65,36 @@ export function Step2Upload({
 
 	const refreshFileList = useCallback(() => {
 		void utils.cseOpinion.getFiles.invalidate();
+		void utils.cseOpinion.getFileContentTypes.invalidate();
 		router.refresh();
 	}, [utils, router]);
 
+	const setTypesMutation = api.cseOpinion.setFileContentTypes.useMutation({
+		onError: () =>
+			setAssociationError(
+				"Une erreur est survenue lors de l'enregistrement. Veuillez réessayer.",
+			),
+		onSuccess: () => setAssociationError(null),
+	});
+
+	const handleToggle = useCallback(
+		(columnId: string, fileId: string, checked: boolean) => {
+			const next: AssociationMap = {
+				...associations,
+				[columnId]: checked ? fileId : null,
+			};
+			setAssociations(next);
+			setTypesMutation.mutate({
+				associations: toAssociationPayload(columns, next),
+			});
+		},
+		[associations, columns, setTypesMutation],
+	);
+
 	const deleteMutation = api.cseOpinion.deleteFile.useMutation({
-		onSuccess: () => {
+		onSuccess: (_data, variables) => {
 			setDeletingFileId(null);
+			setAssociations((prev) => clearFileAssociations(prev, variables.fileId));
 			refreshFileList();
 		},
 		onError: () => setDeletingFileId(null),
@@ -76,52 +119,76 @@ export function Step2Upload({
 		closeModal,
 		handleConfirm,
 		handleFilesChange,
-		handleSubmit,
 		isPending,
 		modalRef,
 		selectedFiles,
 		uploadError,
 	} = useFileUploadForm({
 		flowType: "cse_opinion",
-		onUploaded: refreshFileList,
-		onAllUploaded: () => {
-			void finalizeAndRedirect();
-		},
+		onAllUploaded: refreshFileList,
 	});
 
-	const skipUploadSubmit = useCallback(
+	const missingColumns = useMemo(
+		() => getMissingColumns(columns, associations),
+		[columns, associations],
+	);
+
+	const hasSelectedFiles = selectedFiles.length > 0;
+	const hasExistingFiles = existingFiles.length > 0;
+	const isComplete = missingColumns.length === 0;
+	const isSubmitting = isPending || finalizeMutation.isPending;
+	const showMissingError = !hasSelectedFiles && hasExistingFiles && !isComplete;
+
+	const openFinalizeModal = useCallback(() => {
+		const dialog = modalRef.current;
+		if (!dialog) return;
+		const modal = getDsfrModal(dialog);
+		if (modal) {
+			modal.disclose();
+		} else {
+			dialog.showModal();
+		}
+	}, [modalRef]);
+
+	const handleFormSubmit = useCallback(
 		(event: React.FormEvent) => {
 			event.preventDefault();
 			setFinalizeError(null);
-			const dialog = modalRef.current;
-			if (!dialog) return;
-			const modal = getDsfrModal(dialog);
-			if (modal) {
-				modal.disclose();
-			} else {
-				dialog.showModal();
+			if (hasSelectedFiles) {
+				void handleConfirm();
+				return;
 			}
+			if (!hasExistingFiles || !isComplete) return;
+			openFinalizeModal();
 		},
-		[modalRef],
+		[
+			hasSelectedFiles,
+			handleConfirm,
+			hasExistingFiles,
+			isComplete,
+			openFinalizeModal,
+		],
 	);
 
-	const hasExistingFiles = existingFiles.length > 0;
-	const hasSelectedFiles = selectedFiles.length > 0;
-	const formSubmit =
-		!hasSelectedFiles && hasExistingFiles ? skipUploadSubmit : handleSubmit;
-	const confirmAction = hasSelectedFiles
-		? handleConfirm
-		: () => {
-				closeModal();
-				void finalizeAndRedirect();
-			};
+	const confirmFinalize = useCallback(() => {
+		closeModal();
+		void finalizeAndRedirect();
+	}, [closeModal, finalizeAndRedirect]);
 
 	const remainingSlots = MAX_CSE_FILES - existingFiles.length;
-	const isSubmitting = isPending || finalizeMutation.isPending;
+	const submitDisabled =
+		isSubmitting ||
+		readOnlyGuard.isReadOnly ||
+		(!hasSelectedFiles && (!hasExistingFiles || !isComplete));
+	const submitLabel = isSubmitting
+		? "Envoi en cours…"
+		: hasSelectedFiles
+			? "Importer le ou les fichiers"
+			: "Soumettre";
 
 	return (
 		<>
-			<form autoComplete="off" onSubmit={formSubmit}>
+			<form autoComplete="off" onSubmit={handleFormSubmit}>
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">
@@ -134,7 +201,8 @@ export function Step2Upload({
 
 				<div>
 					<label className="fr-label" htmlFor="cse-file-upload">
-						Veuillez importer l&apos;ensemble des avis de votre CSE
+						Veuillez joindre les avis émis par votre CSE et renseigner le type
+						de document correspondant.
 						<span className="fr-hint-text">
 							Taille maximale : 10 Mo par fichier. Format supporté : pdf.
 							{existingFiles.length > 0 &&
@@ -142,18 +210,6 @@ export function Step2Upload({
 						</span>
 					</label>
 				</div>
-
-				{existingFiles.map((file) => (
-					<ExistingFileCard
-						file={file}
-						isDeleting={deletingFileId === file.id}
-						key={file.id}
-						onDelete={(fileId) => {
-							setDeletingFileId(fileId);
-							deleteMutation.mutate({ fileId });
-						}}
-					/>
-				))}
 
 				<FileUpload
 					accept=".pdf"
@@ -166,6 +222,39 @@ export function Step2Upload({
 					onFilesChange={handleFilesChange}
 					selectedFiles={selectedFiles}
 				/>
+
+				{hasExistingFiles && (
+					<div className="fr-mt-4w">
+						<ContentTypeMatrix
+							associations={associations}
+							columns={columns}
+							deletingFileId={deletingFileId}
+							disabled={readOnlyGuard.isReadOnly}
+							files={existingFiles}
+							onDelete={(fileId) => {
+								setDeletingFileId(fileId);
+								deleteMutation.mutate({ fileId });
+							}}
+							onToggle={handleToggle}
+						/>
+					</div>
+				)}
+
+				<div aria-live="polite">
+					{showMissingError && (
+						<div className="fr-alert fr-alert--error fr-mt-3w">
+							<h2 className="fr-alert__title">Un avis CSE est manquant</h2>
+							{missingColumns.map((column) => (
+								<p key={column.id}>{column.missingMessage}</p>
+							))}
+						</div>
+					)}
+					{associationError && (
+						<div className="fr-alert fr-alert--error fr-mt-3w">
+							<p>{associationError}</p>
+						</div>
+					)}
+				</div>
 
 				<div className="fr-mt-4w">
 					<OpinionSummaryBox
@@ -193,10 +282,10 @@ export function Step2Upload({
 						<button
 							{...readOnlyGuard.buttonProps}
 							className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-							disabled={isSubmitting || readOnlyGuard.isReadOnly}
+							disabled={submitDisabled}
 							type="submit"
 						>
-							{isSubmitting ? "Envoi en cours\u2026" : "Soumettre"}
+							{submitLabel}
 						</button>
 						{readOnlyGuard.tooltip}
 					</span>
@@ -207,58 +296,8 @@ export function Step2Upload({
 				declarationYear={declarationYear}
 				modalRef={modalRef}
 				onClose={closeModal}
-				onSubmit={confirmAction}
+				onSubmit={confirmFinalize}
 			/>
 		</>
-	);
-}
-
-type ExistingFileCardProps = {
-	file: UploadedFile;
-	isDeleting: boolean;
-	onDelete: (fileId: string) => void;
-};
-
-function ExistingFileCard({
-	file,
-	isDeleting,
-	onDelete,
-}: ExistingFileCardProps) {
-	const readOnlyGuard = useReadOnlyGuard();
-	return (
-		<div className="fr-card fr-card--no-border fr-p-3w fr-mb-2w">
-			<p className="fr-text--md fr-mb-0">{file.fileName}</p>
-			<p className="fr-text--xs fr-text--mention-grey fr-mb-1w">
-				PDF — Importé le {new Date(file.uploadedAt).toLocaleDateString("fr-FR")}
-			</p>
-			<div>
-				<p className="fr-message fr-message--valid fr-mb-0">Fichier transmis</p>
-				<div className="fr-mt-1w">
-					<a
-						className="fr-btn fr-btn--tertiary fr-btn--sm fr-icon-eye-line"
-						href={`/api/v1/files/${file.id}`}
-						rel="noopener noreferrer"
-						target="_blank"
-						title={`Visualiser ${file.fileName}`}
-					>
-						Visualiser
-						<NewTabNotice />
-					</a>
-					<span>
-						<button
-							{...readOnlyGuard.buttonProps}
-							className="fr-btn fr-btn--tertiary fr-btn--sm fr-icon-delete-line fr-ml-1w"
-							disabled={isDeleting || readOnlyGuard.isReadOnly}
-							onClick={() => onDelete(file.id)}
-							title={`Supprimer ${file.fileName}`}
-							type="button"
-						>
-							{isDeleting ? "Suppression\u2026" : "Supprimer"}
-						</button>
-						{readOnlyGuard.tooltip}
-					</span>
-				</div>
-			</div>
-		</div>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
@@ -7,17 +7,30 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { computeContentTypeColumns } from "../contentTypeColumns";
 import { Step2Upload } from "../Step2Upload";
+import type {
+	ContentTypeColumn,
+	StoredFileContentType,
+	UploadedFile,
+} from "../types";
 
 const pushMock = vi.fn();
 const refreshMock = vi.fn();
-const invalidateMock = vi.fn();
+const invalidateFilesMock = vi.fn();
+const invalidateTypesMock = vi.fn();
+const deleteMutateMock = vi.fn();
+const finalizeMutateAsyncMock = vi.fn();
+const setTypesMutateMock = vi.fn();
 let deleteMutationOptions: {
+	onSuccess?: (data: unknown, variables: { fileId: string }) => void;
+	onError?: () => void;
+} = {};
+let setTypesMutationOptions: {
 	onSuccess?: () => void;
 	onError?: () => void;
 } = {};
-const deleteMutateMock = vi.fn();
-const finalizeMutateAsyncMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
 	useRouter: () => ({
@@ -37,15 +50,9 @@ vi.mock("~/trpc/react", () => ({
 	api: {
 		cseOpinion: {
 			deleteFile: {
-				useMutation: (
-					options: { onSuccess?: () => void; onError?: () => void } = {},
-				) => {
+				useMutation: (options: typeof deleteMutationOptions = {}) => {
 					deleteMutationOptions = options;
-					return {
-						mutate: deleteMutateMock,
-						isPending: false,
-						error: null,
-					};
+					return { mutate: deleteMutateMock, isPending: false, error: null };
 				},
 			},
 			finalize: {
@@ -55,10 +62,17 @@ vi.mock("~/trpc/react", () => ({
 					error: null,
 				}),
 			},
+			setFileContentTypes: {
+				useMutation: (options: typeof setTypesMutationOptions = {}) => {
+					setTypesMutationOptions = options;
+					return { mutate: setTypesMutateMock, isPending: false, error: null };
+				},
+			},
 		},
 		useUtils: () => ({
 			cseOpinion: {
-				getFiles: { invalidate: invalidateMock },
+				getFiles: { invalidate: invalidateFilesMock },
+				getFileContentTypes: { invalidate: invalidateTypesMock },
 			},
 		}),
 	},
@@ -68,27 +82,61 @@ const { uploadFile: uploadFileMock } = (await import(
 	"~/modules/shared/uploadFile"
 )) as unknown as { uploadFile: ReturnType<typeof vi.fn> };
 
+const SINGLE_COLUMN = computeContentTypeColumns({
+	hasSecondDeclaration: false,
+	firstDeclGapConsulted: false,
+	secondDeclGapConsulted: null,
+});
+
+const DUAL_COLUMNS = computeContentTypeColumns({
+	hasSecondDeclaration: true,
+	firstDeclGapConsulted: true,
+	secondDeclGapConsulted: true,
+});
+
 function getFileInput() {
 	return document.getElementById("cse-file-upload") as HTMLInputElement;
 }
 
-function makeFile(name: string, id: string) {
+function makeFile(name: string, id: string): UploadedFile {
 	return { id, fileName: name, uploadedAt: new Date("2026-03-15") };
+}
+
+function renderStep(
+	props: {
+		existingFiles?: UploadedFile[];
+		columns?: ContentTypeColumn[];
+		initialAssociations?: StoredFileContentType[];
+		hasSecondDeclaration?: boolean;
+	} = {},
+) {
+	return render(
+		<Step2Upload
+			columns={props.columns ?? SINGLE_COLUMN}
+			declarationYear={2026}
+			existingFiles={props.existingFiles}
+			hasSecondDeclaration={props.hasSecondDeclaration}
+			initialAssociations={props.initialAssociations}
+			siren="123456789"
+		/>,
+	);
 }
 
 describe("Step2Upload", () => {
 	beforeEach(() => {
 		pushMock.mockReset();
 		refreshMock.mockReset();
-		invalidateMock.mockReset();
+		invalidateFilesMock.mockReset();
+		invalidateTypesMock.mockReset();
 		deleteMutateMock.mockReset();
 		finalizeMutateAsyncMock.mockReset();
 		finalizeMutateAsyncMock.mockResolvedValue({ success: true });
+		setTypesMutateMock.mockReset();
 		uploadFileMock.mockReset();
 		deleteMutationOptions = {};
+		setTypesMutationOptions = {};
 		// jsdom doesn't implement <dialog>; stub showModal/close so the dialog
-		// actually toggles its `open` attribute and its contents become visible
-		// to Testing Library queries.
+		// actually toggles its `open` attribute and its contents become visible.
 		HTMLDialogElement.prototype.showModal = function showModal() {
 			this.setAttribute("open", "");
 		};
@@ -102,7 +150,7 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the page title", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep();
 
 		expect(
 			screen.getByText("Transmettre l'avis ou les avis du CSE"),
@@ -110,22 +158,22 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the stepper at step 2", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep();
 
 		expect(screen.getByText(/Étape 2 sur 2/)).toBeInTheDocument();
 	});
 
 	it("renders the file upload instructions", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep();
 
 		expect(
-			screen.getByText(/Veuillez importer l'ensemble des avis de votre CSE/),
+			screen.getByText(/renseigner le type de document correspondant/),
 		).toBeInTheDocument();
 		expect(screen.getByText(/Taille maximale.*pdf/)).toBeInTheDocument();
 	});
 
 	it("renders the dropzone with select button", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep();
 
 		expect(
 			screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
@@ -133,67 +181,49 @@ describe("Step2Upload", () => {
 		expect(screen.getByText("ou glisser-les ici")).toBeInTheDocument();
 	});
 
-	it("renders a hidden file input", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+	it("renders a hidden file input accepting pdf", () => {
+		renderStep();
 
 		const fileInput = getFileInput();
-		expect(fileInput).toBeInTheDocument();
 		expect(fileInput).toHaveAttribute("type", "file");
 		expect(fileInput).toHaveAttribute("accept", ".pdf");
 	});
 
 	it("renders the opinion summary box", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep({ hasSecondDeclaration: true });
 
 		expect(screen.getByText("Avis CSE à transmettre :")).toBeInTheDocument();
 		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
 		expect(screen.getByText("Deuxième déclaration")).toBeInTheDocument();
 	});
 
-	it("renders previous link and add file button", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+	it("renders previous link and submit button", () => {
+		renderStep();
 
 		const previousLink = screen.getByRole("link", { name: /Précédent/ });
-		expect(previousLink).toBeInTheDocument();
 		expect(previousLink).toHaveAttribute("href", "/avis-cse/etape/1");
-
 		expect(
-			screen.getByRole("button", { name: /Soumettre/ }),
+			screen.getByRole("button", { name: "Soumettre" }),
 		).toBeInTheDocument();
 	});
 
-	it("shows error when submitting without file", async () => {
-		const user = userEvent.setup();
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+	it("disables the submit button when no file has been added yet", () => {
+		renderStep();
 
-		await user.click(screen.getByRole("button", { name: /Soumettre/ }));
-
-		expect(
-			screen.getByText(
-				"Veuillez sélectionner au moins un fichier avant de soumettre.",
-			),
-		).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Soumettre" })).toBeDisabled();
 	});
 
-	it("sets aria-invalid on file input when error occurs", async () => {
-		const user = userEvent.setup();
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+	it("does not render the matrix when there is no existing file", () => {
+		renderStep();
 
-		const fileInput = getFileInput();
-		expect(fileInput).toHaveAttribute("aria-invalid", "false");
-
-		await user.click(screen.getByRole("button", { name: /Soumettre/ }));
-
-		expect(fileInput).toHaveAttribute("aria-invalid", "true");
+		expect(screen.queryByRole("table")).not.toBeInTheDocument();
 	});
 
 	it("shows error for non-PDF file", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep();
 
 		const file = new File(["content"], "test.txt", { type: "text/plain" });
-		const fileInput = getFileInput();
-
-		fireEvent.change(fileInput, { target: { files: [file] } });
+		fireEvent.change(getFileInput(), { target: { files: [file] } });
 
 		expect(
 			screen.getByText(
@@ -203,15 +233,13 @@ describe("Step2Upload", () => {
 	});
 
 	it("shows error for file exceeding 10 MB", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep();
 
 		const largeContent = new ArrayBuffer(11 * 1024 * 1024);
 		const file = new File([largeContent], "large.pdf", {
 			type: "application/pdf",
 		});
-		const fileInput = getFileInput();
-
-		fireEvent.change(fileInput, { target: { files: [file] } });
+		fireEvent.change(getFileInput(), { target: { files: [file] } });
 
 		expect(
 			screen.getByText("La taille du fichier ne doit pas dépasser 10 Mo."),
@@ -219,142 +247,13 @@ describe("Step2Upload", () => {
 	});
 
 	it("renders the confirmation modal dialog", () => {
-		const { container } = render(
-			<Step2Upload declarationYear={2026} siren="123456789" />,
-		);
+		const { container } = renderStep();
 
 		const dialog = container.querySelector("dialog");
-		expect(dialog).toBeInTheDocument();
 		expect(dialog).toHaveAttribute("id", "cse-submit-modal");
 	});
 
-	it("accepts PDF file and shows file card", () => {
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
-
-		const file = new File(["content"], "avis-cse.pdf", {
-			type: "application/pdf",
-		});
-		const fileInput = getFileInput();
-
-		fireEvent.change(fileInput, { target: { files: [file] } });
-
-		expect(screen.getByText("avis-cse.pdf")).toBeInTheDocument();
-		expect(screen.getByText("Importation réussie")).toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: /Supprimer/ }),
-		).toBeInTheDocument();
-	});
-
-	it("removes file when delete button is clicked", async () => {
-		const user = userEvent.setup();
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
-
-		const file = new File(["content"], "avis-cse.pdf", {
-			type: "application/pdf",
-		});
-		const fileInput = getFileInput();
-
-		fireEvent.change(fileInput, { target: { files: [file] } });
-
-		expect(screen.getByText("avis-cse.pdf")).toBeInTheDocument();
-
-		await user.click(screen.getByRole("button", { name: /Supprimer/ }));
-
-		expect(screen.queryByText("avis-cse.pdf")).not.toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
-		).toBeInTheDocument();
-	});
-
-	it("shows existing file cards when files are provided", () => {
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[
-					makeFile("avis-1.pdf", "file-1"),
-					makeFile("avis-2.pdf", "file-2"),
-				]}
-				siren="123456789"
-			/>,
-		);
-
-		expect(screen.getByText("avis-1.pdf")).toBeInTheDocument();
-		expect(screen.getByText("avis-2.pdf")).toBeInTheDocument();
-		expect(screen.getAllByText("Fichier transmis")).toHaveLength(2);
-	});
-
-	it("renders a view link for each existing file", () => {
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[
-					makeFile("avis-1.pdf", "file-1"),
-					makeFile("avis-2.pdf", "file-2"),
-				]}
-				siren="123456789"
-			/>,
-		);
-
-		const viewLinks = screen.getAllByRole("link", { name: /Visualiser/ });
-		expect(viewLinks).toHaveLength(2);
-		expect(viewLinks[0]).toHaveAttribute("href", "/api/v1/files/file-1");
-		expect(viewLinks[1]).toHaveAttribute("href", "/api/v1/files/file-2");
-		expect(viewLinks[0]).toHaveAttribute("target", "_blank");
-	});
-
-	it("shows submit button when files exist but under limit", () => {
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
-				siren="123456789"
-			/>,
-		);
-
-		expect(
-			screen.getByRole("button", { name: /Soumettre/ }),
-		).toBeInTheDocument();
-	});
-
-	it("shows file count in hint text", () => {
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[
-					makeFile("avis-1.pdf", "file-1"),
-					makeFile("avis-2.pdf", "file-2"),
-				]}
-				siren="123456789"
-			/>,
-		);
-
-		expect(screen.getByText(/2\/4 fichiers/)).toBeInTheDocument();
-	});
-
-	it("disables dropzone when max files reached", () => {
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[
-					makeFile("avis-1.pdf", "f1"),
-					makeFile("avis-2.pdf", "f2"),
-					makeFile("avis-3.pdf", "f3"),
-					makeFile("avis-4.pdf", "f4"),
-				]}
-				siren="123456789"
-			/>,
-		);
-
-		const selectButton = screen.getByRole("button", {
-			name: /Sélectionner des fichiers/,
-		});
-		expect(selectButton).toBeDisabled();
-		expect(
-			screen.getByRole("button", { name: /Soumettre/ }),
-		).toBeInTheDocument();
-	});
-
-	it("uploads the file then finalizes and redirects on success", async () => {
+	it("stages a PDF file, switches the submit label to import and uploads without finalizing", async () => {
 		const user = userEvent.setup();
 		uploadFileMock.mockResolvedValue({
 			ok: true,
@@ -362,18 +261,17 @@ describe("Step2Upload", () => {
 			fileName: "avis.pdf",
 		});
 
-		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+		renderStep();
 
-		const file = new File(["content"], "avis.pdf", {
-			type: "application/pdf",
-		});
+		const file = new File(["content"], "avis.pdf", { type: "application/pdf" });
 		fireEvent.change(getFileInput(), { target: { files: [file] } });
 
-		await user.click(screen.getByRole("button", { name: /Soumettre/ }));
+		expect(screen.getByText("avis.pdf")).toBeInTheDocument();
+		const submit = screen.getByRole("button", {
+			name: "Importer le ou les fichiers",
+		});
 
-		const certifyCheckbox = screen.getByRole("checkbox");
-		await user.click(certifyCheckbox);
-		await user.click(screen.getByRole("button", { name: "Valider" }));
+		await user.click(submit);
 
 		await waitFor(() => {
 			expect(uploadFileMock).toHaveBeenCalledWith(file, {
@@ -381,31 +279,200 @@ describe("Step2Upload", () => {
 			});
 		});
 		await waitFor(() => {
-			expect(invalidateMock).toHaveBeenCalled();
+			expect(invalidateFilesMock).toHaveBeenCalled();
 		});
+		expect(invalidateTypesMock).toHaveBeenCalled();
 		expect(refreshMock).toHaveBeenCalled();
-		await waitFor(() => {
-			expect(finalizeMutateAsyncMock).toHaveBeenCalled();
+		expect(finalizeMutateAsyncMock).not.toHaveBeenCalled();
+		expect(pushMock).not.toHaveBeenCalled();
+	});
+
+	it("renders the matrix with the existing files and the required content-type columns", () => {
+		renderStep({
+			columns: DUAL_COLUMNS,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			hasSecondDeclaration: true,
 		});
-		await waitFor(() => {
-			expect(pushMock).toHaveBeenCalledWith("/avis-cse/confirmation");
+
+		expect(screen.getByRole("link", { name: /avis-1\.pdf/ })).toHaveAttribute(
+			"href",
+			"/api/v1/files/file-1",
+		);
+		expect(screen.getAllByRole("checkbox")).toHaveLength(DUAL_COLUMNS.length);
+	});
+
+	it("shows the file count in the hint text", () => {
+		renderStep({
+			existingFiles: [
+				makeFile("avis-1.pdf", "file-1"),
+				makeFile("avis-2.pdf", "file-2"),
+			],
+		});
+
+		expect(screen.getByText(/2\/4 fichiers/)).toBeInTheDocument();
+	});
+
+	it("disables the dropzone when the max number of files is reached", () => {
+		renderStep({
+			existingFiles: [
+				makeFile("avis-1.pdf", "f1"),
+				makeFile("avis-2.pdf", "f2"),
+				makeFile("avis-3.pdf", "f3"),
+				makeFile("avis-4.pdf", "f4"),
+			],
+		});
+
+		expect(
+			screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
+		).toBeDisabled();
+	});
+
+	it("blocks the submit and lists the missing content type when the matrix is incomplete (S8)", () => {
+		renderStep({
+			columns: DUAL_COLUMNS,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			hasSecondDeclaration: true,
+		});
+
+		expect(screen.getByRole("button", { name: "Soumettre" })).toBeDisabled();
+		expect(screen.getByText("Un avis CSE est manquant")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Ajoutez l'avis d'exactitude des données et des méthodes de calcul de la première déclaration, ou indiquez s'il est déjà inclus dans l'un des fichiers déposés.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("persists the full association payload through setFileContentTypes when a checkbox is toggled (S7)", async () => {
+		const user = userEvent.setup();
+		renderStep({
+			columns: DUAL_COLUMNS,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			hasSecondDeclaration: true,
+		});
+
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Exactitude — 1re déclaration — avis-1.pdf",
+			}),
+		);
+
+		expect(setTypesMutateMock).toHaveBeenCalledWith({
+			associations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+			],
 		});
 	});
 
-	it("finalizes without uploading when only existing files are present", async () => {
+	it("allows one file to cover several content types (S7)", async () => {
 		const user = userEvent.setup();
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
-				siren="123456789"
-			/>,
+		renderStep({
+			columns: DUAL_COLUMNS,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			hasSecondDeclaration: true,
+		});
+
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Exactitude — 1re déclaration — avis-1.pdf",
+			}),
+		);
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Justification — 1re déclaration — avis-1.pdf",
+			}),
 		);
 
-		await user.click(screen.getByRole("button", { name: /Soumettre/ }));
+		expect(setTypesMutateMock).toHaveBeenLastCalledWith({
+			associations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+				{ declarationNumber: 1, type: "gap", fileId: "file-1" },
+			],
+		});
+	});
 
-		const certifyCheckbox = screen.getByRole("checkbox");
-		await user.click(certifyCheckbox);
+	it("frees a content type and re-persists when its checkbox is unchecked (S6)", async () => {
+		const user = userEvent.setup();
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			initialAssociations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+			],
+		});
+
+		await user.click(
+			screen.getByRole("checkbox", { name: "Exactitude — avis-1.pdf" }),
+		);
+
+		expect(setTypesMutateMock).toHaveBeenCalledWith({ associations: [] });
+		expect(
+			screen.getByRole("checkbox", { name: "Exactitude — avis-1.pdf" }),
+		).not.toBeChecked();
+	});
+
+	it("surfaces an error when persisting the association fails", () => {
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+		});
+
+		act(() => {
+			setTypesMutationOptions.onError?.();
+		});
+
+		expect(
+			screen.getByText(
+				"Une erreur est survenue lors de l'enregistrement. Veuillez réessayer.",
+			),
+		).toBeInTheDocument();
+
+		act(() => {
+			setTypesMutationOptions.onSuccess?.();
+		});
+
+		expect(
+			screen.queryByText(
+				"Une erreur est survenue lors de l'enregistrement. Veuillez réessayer.",
+			),
+		).not.toBeInTheDocument();
+	});
+
+	it("hydrates the matrix from the stored associations on return (S10)", () => {
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			initialAssociations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+			],
+		});
+
+		expect(
+			screen.getByRole("checkbox", { name: "Exactitude — avis-1.pdf" }),
+		).toBeChecked();
+		expect(
+			screen.queryByText("Un avis CSE est manquant"),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Soumettre" })).toBeEnabled();
+	});
+
+	it("opens the finalize modal then finalizes and redirects when the matrix is complete", async () => {
+		const user = userEvent.setup();
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			initialAssociations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+			],
+		});
+
+		await user.click(screen.getByRole("button", { name: "Soumettre" }));
+
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Je certifie que les avis transmis sont conformes.",
+			}),
+		);
 		await user.click(screen.getByRole("button", { name: "Valider" }));
 
 		await waitFor(() => {
@@ -417,22 +484,51 @@ describe("Step2Upload", () => {
 		});
 	});
 
+	it("discloses the finalize modal through the DSFR runtime when available", async () => {
+		const user = userEvent.setup();
+		const disclose = vi.fn();
+		// Simulate the DSFR JS runtime so getDsfrModal returns its modal API.
+		(
+			window as unknown as { dsfr: () => { modal: { disclose: () => void } } }
+		).dsfr = () => ({ modal: { disclose } });
+
+		try {
+			renderStep({
+				columns: SINGLE_COLUMN,
+				existingFiles: [makeFile("avis-1.pdf", "file-1")],
+				initialAssociations: [
+					{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+				],
+			});
+
+			await user.click(screen.getByRole("button", { name: "Soumettre" }));
+
+			expect(disclose).toHaveBeenCalled();
+		} finally {
+			delete (window as unknown as { dsfr?: unknown }).dsfr;
+		}
+	});
+
 	it("shows an error and does not redirect when finalize fails", async () => {
 		const user = userEvent.setup();
 		finalizeMutateAsyncMock.mockRejectedValueOnce(
 			new Error("Au moins un fichier d'avis CSE doit être transmis."),
 		);
 
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
-				siren="123456789"
-			/>,
-		);
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			initialAssociations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+			],
+		});
 
-		await user.click(screen.getByRole("button", { name: /Soumettre/ }));
-		await user.click(screen.getByRole("checkbox"));
+		await user.click(screen.getByRole("button", { name: "Soumettre" }));
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Je certifie que les avis transmis sont conformes.",
+			}),
+		);
 		await user.click(screen.getByRole("button", { name: "Valider" }));
 
 		await waitFor(() => {
@@ -443,40 +539,70 @@ describe("Step2Upload", () => {
 		expect(pushMock).not.toHaveBeenCalled();
 	});
 
-	it("invalidates the file list and clears the deleting state on delete success", () => {
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
-				siren="123456789"
-			/>,
+	it("falls back to a generic error when finalize rejects with a non-Error value", async () => {
+		const user = userEvent.setup();
+		finalizeMutateAsyncMock.mockRejectedValueOnce("boom");
+
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			initialAssociations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+			],
+		});
+
+		await user.click(screen.getByRole("button", { name: "Soumettre" }));
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Je certifie que les avis transmis sont conformes.",
+			}),
 		);
+		await user.click(screen.getByRole("button", { name: "Valider" }));
 
-		const deleteButton = screen.getByTitle("Supprimer avis-1.pdf");
-		fireEvent.click(deleteButton);
+		await waitFor(() => {
+			expect(
+				screen.getByText("Erreur lors de la validation du dépôt."),
+			).toBeInTheDocument();
+		});
+		expect(pushMock).not.toHaveBeenCalled();
+	});
 
+	it("clears the association and refreshes on delete success", () => {
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+			initialAssociations: [
+				{ declarationNumber: 1, type: "accuracy", fileId: "file-1" },
+			],
+		});
+
+		expect(
+			screen.getByRole("checkbox", { name: "Exactitude — avis-1.pdf" }),
+		).toBeChecked();
+
+		fireEvent.click(screen.getByRole("button", { name: "Supprimer" }));
 		expect(deleteMutateMock).toHaveBeenCalledWith({ fileId: "file-1" });
 
 		act(() => {
-			deleteMutationOptions.onSuccess?.();
+			deleteMutationOptions.onSuccess?.(undefined, { fileId: "file-1" });
 		});
-		expect(invalidateMock).toHaveBeenCalled();
+
+		expect(invalidateFilesMock).toHaveBeenCalled();
+		expect(invalidateTypesMock).toHaveBeenCalled();
 		expect(refreshMock).toHaveBeenCalled();
+		expect(
+			screen.getByRole("checkbox", { name: "Exactitude — avis-1.pdf" }),
+		).not.toBeChecked();
 	});
 
 	it("clears the deleting state when the delete mutation fails", () => {
-		render(
-			<Step2Upload
-				declarationYear={2026}
-				existingFiles={[makeFile("avis-1.pdf", "file-1")]}
-				siren="123456789"
-			/>,
-		);
+		renderStep({
+			columns: SINGLE_COLUMN,
+			existingFiles: [makeFile("avis-1.pdf", "file-1")],
+		});
 
-		const deleteButton = screen.getByTitle("Supprimer avis-1.pdf");
-		fireEvent.click(deleteButton);
+		fireEvent.click(screen.getByRole("button", { name: "Supprimer" }));
 
-		// Simulate the failure callback registered with the mutation.
 		expect(() => {
 			act(() => {
 				deleteMutationOptions.onError?.();

--- a/packages/app/src/modules/cseOpinion/__tests__/contentTypeColumns.test.ts
+++ b/packages/app/src/modules/cseOpinion/__tests__/contentTypeColumns.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildAssociationMap,
+	buildColumnId,
+	clearFileAssociations,
+	computeContentTypeColumns,
+	getMissingColumns,
+	toAssociationPayload,
+} from "../contentTypeColumns";
+import type {
+	AssociationMap,
+	ContentTypeColumn,
+	StoredFileContentType,
+} from "../types";
+
+describe("buildColumnId", () => {
+	it("joins the declaration number and the type with a colon", () => {
+		expect(buildColumnId(1, "accuracy")).toBe("1:accuracy");
+		expect(buildColumnId(2, "gap")).toBe("2:gap");
+	});
+});
+
+describe("computeContentTypeColumns", () => {
+	it("returns only the first-declaration accuracy column when there is a single declaration without consulted gap (S1)", () => {
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration: false,
+			firstDeclGapConsulted: false,
+			secondDeclGapConsulted: null,
+		});
+
+		expect(columns.map((column) => column.id)).toEqual(["1:accuracy"]);
+		expect(columns[0]?.label).toBe("Exactitude");
+		expect(columns[0]?.declarationLabel).toBeNull();
+	});
+
+	it("adds the first-declaration gap column without declaration suffix when the gap was consulted on a single declaration (S2)", () => {
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration: false,
+			firstDeclGapConsulted: true,
+			secondDeclGapConsulted: null,
+		});
+
+		expect(columns.map((column) => column.id)).toEqual(["1:accuracy", "1:gap"]);
+		expect(columns.every((column) => column.declarationLabel === null)).toBe(
+			true,
+		);
+		expect(columns[1]?.label).toBe("Justification");
+	});
+
+	it("builds the four columns with declaration suffixes when both declarations consulted their gap (S3)", () => {
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration: true,
+			firstDeclGapConsulted: true,
+			secondDeclGapConsulted: true,
+		});
+
+		expect(columns.map((column) => column.id)).toEqual([
+			"1:accuracy",
+			"1:gap",
+			"2:accuracy",
+			"2:gap",
+		]);
+		expect(columns[0]?.declarationLabel).toBe("1re déclaration");
+		expect(columns[2]?.declarationLabel).toBe("2e déclaration");
+	});
+
+	it("hides the second-declaration gap column when the second gap was not consulted (S4)", () => {
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration: true,
+			firstDeclGapConsulted: true,
+			secondDeclGapConsulted: false,
+		});
+
+		expect(columns.map((column) => column.id)).toEqual([
+			"1:accuracy",
+			"1:gap",
+			"2:accuracy",
+		]);
+	});
+
+	it("hides the first-declaration gap column when the first gap was not consulted but the second was", () => {
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration: true,
+			firstDeclGapConsulted: false,
+			secondDeclGapConsulted: true,
+		});
+
+		expect(columns.map((column) => column.id)).toEqual([
+			"1:accuracy",
+			"2:accuracy",
+			"2:gap",
+		]);
+	});
+
+	it("treats a null gapConsulted as not consulted", () => {
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration: true,
+			firstDeclGapConsulted: null,
+			secondDeclGapConsulted: null,
+		});
+
+		expect(columns.map((column) => column.id)).toEqual([
+			"1:accuracy",
+			"2:accuracy",
+		]);
+	});
+
+	it("includes the ordinal in the missing message only when a second declaration exists", () => {
+		const single = computeContentTypeColumns({
+			hasSecondDeclaration: false,
+			firstDeclGapConsulted: true,
+			secondDeclGapConsulted: null,
+		});
+		const dual = computeContentTypeColumns({
+			hasSecondDeclaration: true,
+			firstDeclGapConsulted: true,
+			secondDeclGapConsulted: true,
+		});
+
+		expect(single[0]?.missingMessage).toBe(
+			"Ajoutez l'avis d'exactitude des données et des méthodes de calcul, ou indiquez s'il est déjà inclus dans l'un des fichiers déposés.",
+		);
+		expect(dual[3]?.missingMessage).toBe(
+			"Ajoutez l'avis justifiant les écarts ≥ 5 % de la deuxième déclaration, ou indiquez s'il est déjà inclus dans l'un des fichiers déposés.",
+		);
+	});
+
+	it("exposes a distinct description per accuracy column and a shared gap description", () => {
+		const columns = computeContentTypeColumns({
+			hasSecondDeclaration: true,
+			firstDeclGapConsulted: true,
+			secondDeclGapConsulted: true,
+		});
+
+		expect(columns[0]?.description).toContain("l'ensemble des indicateurs");
+		expect(columns[2]?.description).toContain("la seconde déclaration");
+		expect(columns[1]?.description).toBe(columns[3]?.description);
+	});
+});
+
+function columns(
+	...ids: Array<[1 | 2, "accuracy" | "gap"]>
+): ContentTypeColumn[] {
+	return ids.map(([declarationNumber, type]) => ({
+		id: buildColumnId(declarationNumber, type),
+		declarationNumber,
+		type,
+		label: type === "accuracy" ? "Exactitude" : "Justification",
+		declarationLabel: null,
+		description: "",
+		missingMessage: "",
+	}));
+}
+
+describe("buildAssociationMap", () => {
+	it("initialises every column to null", () => {
+		const map = buildAssociationMap(columns([1, "accuracy"], [1, "gap"]), []);
+
+		expect(map).toEqual({ "1:accuracy": null, "1:gap": null });
+	});
+
+	it("applies stored associations whose column exists", () => {
+		const stored: StoredFileContentType[] = [
+			{ declarationNumber: 1, type: "accuracy", fileId: "file-a" },
+			{ declarationNumber: 1, type: "gap", fileId: "file-b" },
+		];
+
+		const map = buildAssociationMap(
+			columns([1, "accuracy"], [1, "gap"]),
+			stored,
+		);
+
+		expect(map).toEqual({ "1:accuracy": "file-a", "1:gap": "file-b" });
+	});
+
+	it("ignores stored associations that target a column not currently displayed", () => {
+		const stored: StoredFileContentType[] = [
+			{ declarationNumber: 2, type: "gap", fileId: "stale" },
+		];
+
+		const map = buildAssociationMap(columns([1, "accuracy"]), stored);
+
+		expect(map).toEqual({ "1:accuracy": null });
+	});
+});
+
+describe("toAssociationPayload", () => {
+	it("keeps only columns that point to a file", () => {
+		const cols = columns([1, "accuracy"], [1, "gap"], [2, "accuracy"]);
+		const map: AssociationMap = {
+			"1:accuracy": "file-a",
+			"1:gap": null,
+			"2:accuracy": "file-a",
+		};
+
+		expect(toAssociationPayload(cols, map)).toEqual([
+			{ declarationNumber: 1, type: "accuracy", fileId: "file-a" },
+			{ declarationNumber: 2, type: "accuracy", fileId: "file-a" },
+		]);
+	});
+
+	it("returns an empty payload when no column is associated", () => {
+		const cols = columns([1, "accuracy"]);
+
+		expect(toAssociationPayload(cols, { "1:accuracy": null })).toEqual([]);
+	});
+});
+
+describe("getMissingColumns", () => {
+	it("returns the columns that have no associated file", () => {
+		const cols = columns([1, "accuracy"], [1, "gap"]);
+		const map: AssociationMap = { "1:accuracy": "file-a", "1:gap": null };
+
+		expect(getMissingColumns(cols, map).map((column) => column.id)).toEqual([
+			"1:gap",
+		]);
+	});
+
+	it("returns an empty list when every column is filled", () => {
+		const cols = columns([1, "accuracy"]);
+
+		expect(getMissingColumns(cols, { "1:accuracy": "file-a" })).toEqual([]);
+	});
+});
+
+describe("clearFileAssociations", () => {
+	it("nulls every column pointing to the removed file and keeps the others", () => {
+		const map: AssociationMap = {
+			"1:accuracy": "file-a",
+			"1:gap": "file-b",
+			"2:accuracy": "file-a",
+		};
+
+		expect(clearFileAssociations(map, "file-a")).toEqual({
+			"1:accuracy": null,
+			"1:gap": "file-b",
+			"2:accuracy": null,
+		});
+	});
+
+	it("leaves the map unchanged when the file is not associated", () => {
+		const map: AssociationMap = { "1:accuracy": "file-a", "1:gap": null };
+
+		expect(clearFileAssociations(map, "file-z")).toEqual({
+			"1:accuracy": "file-a",
+			"1:gap": null,
+		});
+	});
+});

--- a/packages/app/src/modules/cseOpinion/components/ContentTypeMatrix.module.scss
+++ b/packages/app/src/modules/cseOpinion/components/ContentTypeMatrix.module.scss
@@ -1,0 +1,32 @@
+.matrix {
+	margin-bottom: 0;
+}
+
+.columnHeader {
+	vertical-align: top;
+}
+
+.columnLabel {
+	display: block;
+	font-weight: 700;
+}
+
+.columnSubLabel {
+	display: block;
+	font-weight: 400;
+}
+
+.fileCell {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 0.25rem;
+}
+
+.checkboxCell {
+	text-align: center;
+
+	:global(.fr-checkbox-group) {
+		display: inline-flex;
+	}
+}

--- a/packages/app/src/modules/cseOpinion/components/ContentTypeMatrix.tsx
+++ b/packages/app/src/modules/cseOpinion/components/ContentTypeMatrix.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
+
+import type { AssociationMap, ContentTypeColumn, UploadedFile } from "../types";
+import styles from "./ContentTypeMatrix.module.scss";
+
+type Props = {
+	files: UploadedFile[];
+	columns: ContentTypeColumn[];
+	associations: AssociationMap;
+	onToggle: (columnId: string, fileId: string, checked: boolean) => void;
+	onDelete: (fileId: string) => void;
+	deletingFileId: string | null;
+	disabled?: boolean;
+};
+
+function columnHeaderId(column: ContentTypeColumn): string {
+	return `matrix-col-${column.declarationNumber}-${column.type}`;
+}
+
+function checkboxLabel(column: ContentTypeColumn, fileName: string): string {
+	const declarationPart = column.declarationLabel
+		? ` — ${column.declarationLabel}`
+		: "";
+	return `${column.label}${declarationPart} — ${fileName}`;
+}
+
+export function ContentTypeMatrix({
+	files,
+	columns,
+	associations,
+	onToggle,
+	onDelete,
+	deletingFileId,
+	disabled = false,
+}: Props) {
+	return (
+		<div className={`fr-table fr-table--bordered ${styles.matrix}`}>
+			<div className="fr-table__wrapper">
+				<div className="fr-table__container">
+					<div className="fr-table__content">
+						<table>
+							<caption className="fr-sr-only">
+								Associez chaque fichier déposé aux types de contenu requis.
+							</caption>
+							<thead>
+								<tr>
+									<th className="fr-cell--fixed" scope="col">
+										Fichier
+									</th>
+									{columns.map((column) => (
+										<th
+											className={`fr-cell--multiline ${styles.columnHeader}`}
+											id={columnHeaderId(column)}
+											key={column.id}
+											scope="col"
+										>
+											<span className={styles.columnLabel}>{column.label}</span>
+											{column.declarationLabel && (
+												<span className={styles.columnSubLabel}>
+													{column.declarationLabel}
+												</span>
+											)}
+										</th>
+									))}
+								</tr>
+							</thead>
+							<tbody>
+								{files.map((file) => {
+									const fileHeaderId = `matrix-file-${file.id}`;
+									return (
+										<tr key={file.id}>
+											<th
+												className="fr-cell--fixed fr-cell--multiline"
+												id={fileHeaderId}
+												scope="row"
+											>
+												<span className={styles.fileCell}>
+													<a
+														className="fr-link"
+														href={`/api/v1/files/${file.id}`}
+														rel="noopener noreferrer"
+														target="_blank"
+														title={`Visualiser ${file.fileName}`}
+													>
+														{file.fileName}
+														<NewTabNotice />
+													</a>
+													<span className="fr-text--xs fr-text--mention-grey fr-mb-0">
+														PDF
+													</span>
+													<button
+														className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-delete-line fr-btn--icon-left"
+														disabled={disabled || deletingFileId === file.id}
+														onClick={() => onDelete(file.id)}
+														type="button"
+													>
+														{deletingFileId === file.id
+															? "Suppression…"
+															: "Supprimer"}
+													</button>
+												</span>
+											</th>
+											{columns.map((column) => {
+												const associatedFileId =
+													associations[column.id] ?? null;
+												const checked = associatedFileId === file.id;
+												const lockedByOther =
+													associatedFileId !== null &&
+													associatedFileId !== file.id;
+												const inputId = `matrix-${file.id}-${column.id}`;
+												return (
+													<td
+														className={`fr-cell--center ${styles.checkboxCell}`}
+														headers={`${fileHeaderId} ${columnHeaderId(column)}`}
+														key={column.id}
+													>
+														<div className="fr-checkbox-group fr-checkbox-group--sm">
+															<input
+																checked={checked}
+																disabled={disabled || lockedByOther}
+																id={inputId}
+																onChange={(event) =>
+																	onToggle(
+																		column.id,
+																		file.id,
+																		event.target.checked,
+																	)
+																}
+																type="checkbox"
+															/>
+															<label
+																className="fr-label fr-sr-only"
+																htmlFor={inputId}
+															>
+																{checkboxLabel(column, file.fileName)}
+															</label>
+														</div>
+													</td>
+												);
+											})}
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/cseOpinion/components/__tests__/ContentTypeMatrix.test.tsx
+++ b/packages/app/src/modules/cseOpinion/components/__tests__/ContentTypeMatrix.test.tsx
@@ -1,0 +1,199 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	buildColumnId,
+	computeContentTypeColumns,
+} from "~/modules/cseOpinion/contentTypeColumns";
+import type { AssociationMap, UploadedFile } from "~/modules/cseOpinion/types";
+import { ContentTypeMatrix } from "../ContentTypeMatrix";
+
+const COLUMNS = computeContentTypeColumns({
+	hasSecondDeclaration: true,
+	firstDeclGapConsulted: true,
+	secondDeclGapConsulted: true,
+});
+
+const SINGLE_FILE: UploadedFile = {
+	id: "file-1",
+	fileName: "avis-1.pdf",
+	uploadedAt: new Date("2026-03-15"),
+};
+
+const FILES: UploadedFile[] = [
+	SINGLE_FILE,
+	{ id: "file-2", fileName: "avis-2.pdf", uploadedAt: new Date("2026-03-16") },
+];
+
+function emptyMap(): AssociationMap {
+	return COLUMNS.reduce<AssociationMap>((map, column) => {
+		map[column.id] = null;
+		return map;
+	}, {});
+}
+
+function renderMatrix(
+	overrides: Partial<React.ComponentProps<typeof ContentTypeMatrix>> = {},
+) {
+	const props = {
+		files: FILES,
+		columns: COLUMNS,
+		associations: emptyMap(),
+		onToggle: vi.fn(),
+		onDelete: vi.fn(),
+		deletingFileId: null,
+		...overrides,
+	};
+	return { ...render(<ContentTypeMatrix {...props} />), props };
+}
+
+describe("ContentTypeMatrix", () => {
+	it("renders one row per file with a view link pointing to the file endpoint", () => {
+		renderMatrix();
+
+		const viewLinks = screen.getAllByRole("link", { name: /avis-1\.pdf/ });
+		expect(viewLinks[0]).toHaveAttribute("href", "/api/v1/files/file-1");
+		expect(viewLinks[0]).toHaveAttribute("target", "_blank");
+		expect(screen.getByRole("link", { name: /avis-2\.pdf/ })).toHaveAttribute(
+			"href",
+			"/api/v1/files/file-2",
+		);
+	});
+
+	it("renders one checkbox per file and column combination", () => {
+		renderMatrix();
+
+		expect(screen.getAllByRole("checkbox")).toHaveLength(
+			FILES.length * COLUMNS.length,
+		);
+	});
+
+	it("checks only the checkbox of the column associated to a file", () => {
+		const associations = emptyMap();
+		associations[buildColumnId(1, "accuracy")] = "file-1";
+
+		renderMatrix({ associations });
+
+		expect(
+			screen.getByRole("checkbox", {
+				name: "Exactitude — 1re déclaration — avis-1.pdf",
+			}),
+		).toBeChecked();
+		expect(
+			screen.getByRole("checkbox", {
+				name: "Exactitude — 1re déclaration — avis-2.pdf",
+			}),
+		).not.toBeChecked();
+	});
+
+	it("disables the same column for other files once it is taken (column exclusivity, S5)", () => {
+		const associations = emptyMap();
+		associations[buildColumnId(1, "accuracy")] = "file-1";
+
+		renderMatrix({ associations });
+
+		expect(
+			screen.getByRole("checkbox", {
+				name: "Exactitude — 1re déclaration — avis-1.pdf",
+			}),
+		).toBeEnabled();
+		expect(
+			screen.getByRole("checkbox", {
+				name: "Exactitude — 1re déclaration — avis-2.pdf",
+			}),
+		).toBeDisabled();
+	});
+
+	it("calls onToggle with the column id, file id and the new checked state", async () => {
+		const user = userEvent.setup();
+		const { props } = renderMatrix();
+
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Justification — 2e déclaration — avis-2.pdf",
+			}),
+		);
+
+		expect(props.onToggle).toHaveBeenCalledWith(
+			buildColumnId(2, "gap"),
+			"file-2",
+			true,
+		);
+	});
+
+	it("reports unchecking with checked=false so the column frees up (S6)", async () => {
+		const user = userEvent.setup();
+		const associations = emptyMap();
+		associations[buildColumnId(1, "accuracy")] = "file-1";
+		const { props } = renderMatrix({ associations });
+
+		await user.click(
+			screen.getByRole("checkbox", {
+				name: "Exactitude — 1re déclaration — avis-1.pdf",
+			}),
+		);
+
+		expect(props.onToggle).toHaveBeenCalledWith(
+			buildColumnId(1, "accuracy"),
+			"file-1",
+			false,
+		);
+	});
+
+	it("calls onDelete with the file id when its delete button is clicked", async () => {
+		const user = userEvent.setup();
+		const { props } = renderMatrix({ files: [SINGLE_FILE] });
+
+		await user.click(screen.getByRole("button", { name: "Supprimer" }));
+
+		expect(props.onDelete).toHaveBeenCalledWith("file-1");
+	});
+
+	it("shows the deleting label and disables only the deleting file's button", () => {
+		renderMatrix({ deletingFileId: "file-1" });
+
+		expect(screen.getByText("Suppression…")).toBeInTheDocument();
+		expect(screen.getByText("Suppression…")).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Supprimer" })).toBeEnabled();
+	});
+
+	it("disables every interactive control when the matrix is globally disabled", () => {
+		renderMatrix({ disabled: true });
+
+		for (const checkbox of screen.getAllByRole("checkbox")) {
+			expect(checkbox).toBeDisabled();
+		}
+		for (const button of screen.getAllByRole("button", { name: "Supprimer" })) {
+			expect(button).toBeDisabled();
+		}
+	});
+
+	it("omits the declaration sub-label when there is a single declaration", () => {
+		const singleColumns = computeContentTypeColumns({
+			hasSecondDeclaration: false,
+			firstDeclGapConsulted: true,
+			secondDeclGapConsulted: null,
+		});
+		const associations = singleColumns.reduce<AssociationMap>((map, column) => {
+			map[column.id] = null;
+			return map;
+		}, {});
+
+		render(
+			<ContentTypeMatrix
+				associations={associations}
+				columns={singleColumns}
+				deletingFileId={null}
+				files={[SINGLE_FILE]}
+				onDelete={vi.fn()}
+				onToggle={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("checkbox", { name: "Exactitude — avis-1.pdf" }),
+		).toBeInTheDocument();
+		expect(screen.queryByText("1re déclaration")).not.toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/cseOpinion/contentTypeColumns.ts
+++ b/packages/app/src/modules/cseOpinion/contentTypeColumns.ts
@@ -1,0 +1,145 @@
+import type {
+	AssociationMap,
+	ContentType,
+	ContentTypeColumn,
+	ContentTypeColumnsInput,
+	DeclarationNumber,
+	FileContentTypeAssociation,
+	StoredFileContentType,
+} from "./types";
+
+const ACCURACY_DESCRIPTIONS: Record<DeclarationNumber, string> = {
+	1: "Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs",
+	2: "Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés",
+};
+
+const GAP_DESCRIPTION =
+	"Justification des écarts ≥ 5 % par des critères objectifs et non sexistes de l'indicateur de rémunération par catégorie de salariés";
+
+const TYPE_LABELS: Record<ContentType, string> = {
+	accuracy: "Exactitude",
+	gap: "Justification",
+};
+
+const DECLARATION_LABELS: Record<DeclarationNumber, string> = {
+	1: "1re déclaration",
+	2: "2e déclaration",
+};
+
+const DECLARATION_ORDINALS: Record<DeclarationNumber, string> = {
+	1: "première",
+	2: "deuxième",
+};
+
+const TYPE_ERROR_PHRASES: Record<ContentType, string> = {
+	accuracy: "d'exactitude des données et des méthodes de calcul",
+	gap: "justifiant les écarts ≥ 5 %",
+};
+
+export function buildColumnId(declarationNumber: number, type: string): string {
+	return `${declarationNumber}:${type}`;
+}
+
+function buildColumn(
+	declarationNumber: DeclarationNumber,
+	type: ContentType,
+	hasSecondDeclaration: boolean,
+): ContentTypeColumn {
+	const description =
+		type === "accuracy"
+			? ACCURACY_DESCRIPTIONS[declarationNumber]
+			: GAP_DESCRIPTION;
+	const declarationPart = hasSecondDeclaration
+		? ` de la ${DECLARATION_ORDINALS[declarationNumber]} déclaration`
+		: "";
+
+	return {
+		id: buildColumnId(declarationNumber, type),
+		declarationNumber,
+		type,
+		label: TYPE_LABELS[type],
+		declarationLabel: hasSecondDeclaration
+			? DECLARATION_LABELS[declarationNumber]
+			: null,
+		description,
+		missingMessage: `Ajoutez l'avis ${TYPE_ERROR_PHRASES[type]}${declarationPart}, ou indiquez s'il est déjà inclus dans l'un des fichiers déposés.`,
+	};
+}
+
+export function computeContentTypeColumns({
+	hasSecondDeclaration,
+	firstDeclGapConsulted,
+	secondDeclGapConsulted,
+}: ContentTypeColumnsInput): ContentTypeColumn[] {
+	const specs: { declarationNumber: DeclarationNumber; type: ContentType }[] = [
+		{ declarationNumber: 1, type: "accuracy" },
+	];
+
+	if (firstDeclGapConsulted === true) {
+		specs.push({ declarationNumber: 1, type: "gap" });
+	}
+
+	if (hasSecondDeclaration) {
+		specs.push({ declarationNumber: 2, type: "accuracy" });
+		if (secondDeclGapConsulted === true) {
+			specs.push({ declarationNumber: 2, type: "gap" });
+		}
+	}
+
+	return specs.map((spec) =>
+		buildColumn(spec.declarationNumber, spec.type, hasSecondDeclaration),
+	);
+}
+
+export function buildAssociationMap(
+	columns: ContentTypeColumn[],
+	associations: StoredFileContentType[],
+): AssociationMap {
+	const map: AssociationMap = {};
+	for (const column of columns) {
+		map[column.id] = null;
+	}
+	for (const association of associations) {
+		const id = buildColumnId(association.declarationNumber, association.type);
+		if (id in map) {
+			map[id] = association.fileId;
+		}
+	}
+	return map;
+}
+
+export function toAssociationPayload(
+	columns: ContentTypeColumn[],
+	map: AssociationMap,
+): FileContentTypeAssociation[] {
+	const payload: FileContentTypeAssociation[] = [];
+	for (const column of columns) {
+		const fileId = map[column.id];
+		if (fileId) {
+			payload.push({
+				declarationNumber: column.declarationNumber,
+				type: column.type,
+				fileId,
+			});
+		}
+	}
+	return payload;
+}
+
+export function getMissingColumns(
+	columns: ContentTypeColumn[],
+	map: AssociationMap,
+): ContentTypeColumn[] {
+	return columns.filter((column) => !map[column.id]);
+}
+
+export function clearFileAssociations(
+	map: AssociationMap,
+	fileId: string,
+): AssociationMap {
+	const next: AssociationMap = {};
+	for (const key of Object.keys(map)) {
+		next[key] = map[key] === fileId ? null : (map[key] ?? null);
+	}
+	return next;
+}

--- a/packages/app/src/modules/cseOpinion/index.ts
+++ b/packages/app/src/modules/cseOpinion/index.ts
@@ -1,5 +1,6 @@
 export { ConfirmationPage } from "./ConfirmationPage";
 export { CseOpinionLayout } from "./CseOpinionLayout";
+export { computeContentTypeColumns } from "./contentTypeColumns";
 export { mapOpinionsFromDb } from "./mapOpinionsFromDb";
 export { Step1Opinions } from "./Step1Opinions";
 export { Step2Upload } from "./Step2Upload";
@@ -8,5 +9,10 @@ export {
 	saveOpinionsSchema,
 	setFileContentTypesSchema,
 } from "./schemas";
-export type { CseOpinionStep1Data, OpinionType, UploadedFile } from "./types";
+export type {
+	ContentTypeColumn,
+	CseOpinionStep1Data,
+	OpinionType,
+	UploadedFile,
+} from "./types";
 export { MAX_CSE_FILES, STEP_TITLES, TOTAL_STEPS } from "./types";

--- a/packages/app/src/modules/cseOpinion/types.ts
+++ b/packages/app/src/modules/cseOpinion/types.ts
@@ -6,6 +6,40 @@ export type UploadedFile = {
 	uploadedAt: Date;
 };
 
+export type DeclarationNumber = 1 | 2;
+
+export type ContentType = "accuracy" | "gap";
+
+export type ContentTypeColumn = {
+	id: string;
+	declarationNumber: DeclarationNumber;
+	type: ContentType;
+	label: string;
+	declarationLabel: string | null;
+	description: string;
+	missingMessage: string;
+};
+
+export type ContentTypeColumnsInput = {
+	hasSecondDeclaration: boolean;
+	firstDeclGapConsulted: boolean | null;
+	secondDeclGapConsulted: boolean | null;
+};
+
+export type FileContentTypeAssociation = {
+	declarationNumber: DeclarationNumber;
+	type: ContentType;
+	fileId: string;
+};
+
+export type StoredFileContentType = {
+	declarationNumber: number;
+	type: string;
+	fileId: string;
+};
+
+export type AssociationMap = Record<string, string | null>;
+
 export type CseOpinionStep1Data = {
 	firstDeclAccuracyOpinion: OpinionType | null;
 	firstDeclAccuracyDate: string | null;


### PR DESCRIPTION
Closes #3632

Sous-ticket de l'epic #3476 (refonte des pages avis CSE). Implémente la **matrice fichiers × types de contenu** sur l'étape 2 du parcours `/avis-cse` (`Step2Upload`). S'appuie sur l'API d'association livrée par #3631.

## Changements

- **`contentTypeColumns.ts`** (créé, fonctions pures) — calcul des colonnes affichées à partir de `hasSecondDeclaration` + `gapConsulted` par déclaration :

  | Colonne | Affichée si |
  |---|---|
  | Exactitude (décl. 1) | toujours |
  | Justification (décl. 1) | `firstDeclGapConsulted === true` |
  | Exactitude (décl. 2) | `hasSecondDeclaration` |
  | Justification (décl. 2) | `hasSecondDeclaration && secondDeclGapConsulted === true` |

  Suffixe « 1re/2e déclaration » retiré quand une seule déclaration. Helpers `buildAssociationMap` / `toAssociationPayload` / `getMissingColumns` / `clearFileAssociations`.

- **`components/ContentTypeMatrix.tsx`** (créé) — table DSFR à double entrée : fichiers en lignes (`<th scope="row">` + lien Visualiser + Supprimer), types de contenu en colonnes de checkbox. **Exclusivité par colonne** (une checkbox cochée désactive la même colonne sur les autres fichiers — aligné sur la contrainte unique `(declarationId, declarationNumber, type)` côté DB) ; **multi-types par fichier** autorisé.

- **`Step2Upload.tsx`** — intègre la matrice : hydratation depuis les associations existantes, persistance via `setFileContentTypes` (#3631) à chaque toggle, **blocage du submit** + alerte `fr-alert--error` « Un avis CSE est manquant » tant qu'un type affiché n'est pas couvert. Le `finalize` serveur reste le filet de sécurité.

- **`page.tsx`** (étape 2) — fetch `cseOpinion.get()` + `getFileContentTypes()`, calcule les colonnes côté serveur et hydrate la matrice.

## Accessibilité (RGAA)

Matrice = tableau de données : `<caption>` (sr-only), entêtes colonnes/lignes liées aux cellules via `scope` + `id`/`headers`, chaque checkbox dotée d'un `<label>` explicite (type de contenu + nom de fichier). État `disabled` porté nativement. Audit RGAA : PASS.

## Décisions / notes de revue

- **`OpinionSummaryBox` conservé** sous la matrice : les 3 maquettes Figma le montrent (libellés courts dans les entêtes de matrice, descriptions complètes dans l'encart « Avis CSE à transmettre »). La matrice est l'élément interactif ajouté ; l'encart reste le rappel descriptif.
- **Flux d'upload** : tant que des fichiers sont sélectionnés (non envoyés), le bouton les importe (« Importer le ou les fichiers ») sans la modale de certification ; une fois la matrice complète et aucun fichier en attente, le submit ouvre la modale de finalisation. L'association doit se faire entre l'import et la finalisation, d'où la suppression de l'auto-finalize après upload.
- **Pas de nouvelle surface serveur** : la matrice consomme les procédures `get` / `getFileContentTypes` / `setFileContentTypes` / `finalize` / `deleteFile` de #3631 (déjà auditées + câblées audit-logging). Audit sécurité : SECURE.

## Test plan

- `pnpm typecheck` / `pnpm lint:check` / `pnpm format:check` : verts.
- `pnpm test` : suite complète verte. Couverture : `contentTypeColumns.ts` 100 % ; `ContentTypeMatrix.tsx` 100 % lignes/fonctions ; `Step2Upload.tsx` 100 % lignes/fonctions.
- Scénarios PO **S1–S8, S10** couverts en TU (colonnes, suffixe, exclusivité, décochage, multi-types, blocage submit, hydratation).
- Route `/avis-cse/etape/2` rendue côté serveur sans erreur (compile/SSR OK) en local.

## Vérification visuelle

Fidélité Figma vérifiée par lecture structurelle (libellés verbatim, structure `fr-table`, entêtes bold + sous-ligne déclaration en regular, alerte d'erreur titre + description). Le rendu authentifié (login ProConnect requis) sera à valider sur la review app — l'environnement local ne dispose pas des secrets ProConnect / VPN.
