### PR TITLE
feat(upload): validate filename server-side before pipeline

### DIFF
--- a/packages/app/src/app/api/upload/__tests__/route.test.ts
+++ b/packages/app/src/app/api/upload/__tests__/route.test.ts
@@ -53,6 +53,23 @@ function buildRequest(
 	return new Request("http://localhost/api/upload", init as RequestInit);
 }
 
+// HTTP header values are ByteStrings (Latin-1), so a non-Latin-1 filename
+// (e.g. the U+202E RTL-override) cannot be set on a real `Request` header. A
+// browser percent-decodes the value before the handler reads it, so in
+// production the handler does receive the raw codepoint. We reproduce that by
+// overriding `headers.get("x-filename")` while leaving every other header and
+// the body intact, exercising the handler's branch with the exact input.
+function buildRequestWithRawFilename(
+	headers: Record<string, string>,
+	rawFileName: string,
+): Request {
+	const request = buildRequest({ ...headers, "X-Filename": "placeholder.pdf" });
+	const realGet = request.headers.get.bind(request.headers);
+	request.headers.get = (name: string) =>
+		name.toLowerCase() === "x-filename" ? rawFileName : realGet(name);
+	return request;
+}
+
 describe("POST /api/upload", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -174,6 +191,131 @@ describe("POST /api/upload", () => {
 
 		expect(response.status).toBe(400);
 		expect(mocks.runUploadPipeline).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 invalid_filename when the name exceeds 200 characters", async () => {
+		validSession();
+		const { POST } = await import("../route");
+		const response = await POST(
+			buildRequest({
+				"Content-Type": "application/pdf",
+				"X-Filename": `${"a".repeat(197)}.pdf`,
+				"X-Flow-Type": "cse_opinion",
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.reason).toBe("invalid_filename");
+		expect(body.error).toContain("200");
+		expect(mocks.runUploadPipeline).not.toHaveBeenCalled();
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "cse_opinion.upload_file",
+				status: "failure",
+				errorMessage: "HTTP 400 invalid_filename: too_long",
+			}),
+		);
+	});
+
+	it("returns 400 invalid_filename when the name contains a forbidden character", async () => {
+		validSession();
+		const { POST } = await import("../route");
+		const response = await POST(
+			buildRequest({
+				"Content-Type": "application/pdf",
+				"X-Filename": "avis<cse.pdf",
+				"X-Flow-Type": "cse_opinion",
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.reason).toBe("invalid_filename");
+		expect(mocks.runUploadPipeline).not.toHaveBeenCalled();
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "cse_opinion.upload_file",
+				status: "failure",
+				errorMessage: "HTTP 400 invalid_filename: forbidden_char",
+			}),
+		);
+	});
+
+	it("returns 400 invalid_filename when the name contains an invisible character", async () => {
+		validSession();
+		const { POST } = await import("../route");
+		const response = await POST(
+			buildRequestWithRawFilename(
+				{
+					"Content-Type": "application/pdf",
+					"X-Flow-Type": "cse_opinion",
+				},
+				"avis‮cse.pdf",
+			),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.reason).toBe("invalid_filename");
+		expect(mocks.runUploadPipeline).not.toHaveBeenCalled();
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "cse_opinion.upload_file",
+				status: "failure",
+				errorMessage: "HTTP 400 invalid_filename: invisible_char",
+			}),
+		);
+	});
+
+	it("returns 400 invalid_filename when the extension does not match the declared MIME type", async () => {
+		validSession();
+		const { POST } = await import("../route");
+		const response = await POST(
+			buildRequest({
+				"Content-Type": "image/png",
+				"X-Filename": "avis-cse.pdf",
+				"X-Flow-Type": "cse_opinion",
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.reason).toBe("invalid_filename");
+		expect(mocks.runUploadPipeline).not.toHaveBeenCalled();
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "cse_opinion.upload_file",
+				status: "failure",
+				errorMessage: "HTTP 400 invalid_filename: extension_mime_mismatch",
+			}),
+		);
+	});
+
+	it("does not short-circuit a valid filename: the pipeline runs normally", async () => {
+		validSession();
+		mocks.runUploadPipeline.mockResolvedValue({
+			ok: true,
+			fileId: "file-uuid",
+			fileName: "avis-cse.pdf",
+			filePath: "123456789/2027/file-uuid.pdf",
+		});
+
+		const { POST } = await import("../route");
+		const response = await POST(
+			buildRequest({
+				"Content-Type": "application/pdf",
+				"X-Filename": "avis-cse.pdf",
+				"X-Flow-Type": "cse_opinion",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.reason).toBeUndefined();
+		expect(mocks.runUploadPipeline).toHaveBeenCalledWith(
+			expect.objectContaining({ fileName: "avis-cse.pdf" }),
+		);
 	});
 
 	it("returns 200 with fileId + fileName on pipeline success and audits the success row", async () => {

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { AUDIT_ACTIONS, type AuditActionKey } from "~/modules/audit";
 import { getCurrentYear } from "~/modules/domain";
-import { parseSiren, validateFileName } from "~/modules/shared";
+import { validateFileName } from "~/modules/shared/fileNameValidation";
+import { parseSiren } from "~/modules/shared/parseSiren";
 import {
 	ALLOWED_UPLOAD_MIME_TYPES,
 	type FlowType,

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { AUDIT_ACTIONS, type AuditActionKey } from "~/modules/audit";
 import { getCurrentYear } from "~/modules/domain";
-import { parseSiren } from "~/modules/shared/parseSiren";
+import { parseSiren, validateFileName } from "~/modules/shared";
 import {
 	ALLOWED_UPLOAD_MIME_TYPES,
 	type FlowType,
@@ -182,6 +182,26 @@ export async function POST(request: Request): Promise<Response> {
 			{
 				error: `Type de fichier non autorisé : ${contentType}. Types acceptés : ${ALLOWED_UPLOAD_MIME_TYPES.join(", ")}.`,
 			},
+			{ status: 400 },
+		);
+	}
+
+	const fileNameValidation = validateFileName(fileName, contentType);
+	if (!fileNameValidation.ok) {
+		writeFailure({
+			action,
+			flowType,
+			fileName,
+			fileId: null,
+			errorMessage: `HTTP 400 invalid_filename: ${fileNameValidation.reason}`,
+			userId,
+			userEmail,
+			siren,
+			requestContext,
+			startedAt,
+		});
+		return Response.json(
+			{ reason: "invalid_filename", error: fileNameValidation.message },
 			{ status: 400 },
 		);
 	}

--- a/packages/app/src/modules/shared/uploadFile.ts
+++ b/packages/app/src/modules/shared/uploadFile.ts
@@ -3,6 +3,7 @@ import type { FlowType } from "./uploadConfig";
 export type UploadFailureReason =
 	| "missing_flow"
 	| "missing_filename"
+	| "invalid_filename"
 	| "wrong_type"
 	| "too_large"
 	| "empty"
@@ -72,6 +73,7 @@ export async function uploadFile(
 const VALID_REASONS = new Set<UploadFailureReason>([
 	"missing_flow",
 	"missing_filename",
+	"invalid_filename",
 	"wrong_type",
 	"too_large",
 	"empty",

--- a/packages/app/src/modules/shared/useFileUploadForm.ts
+++ b/packages/app/src/modules/shared/useFileUploadForm.ts
@@ -122,6 +122,8 @@ function formatUploadError(
 			return "Non authentifié. Merci de vous reconnecter.";
 		case "not_found":
 			return "Déclaration introuvable pour l'année en cours.";
+		case "invalid_filename":
+			return serverError;
 		case "too_large":
 		case "wrong_type":
 		case "empty":


### PR DESCRIPTION
Closes #3605

## Summary

Câble la validation de nom de fichier côté serveur dans le route handler `/api/upload` : toute requête avec un nom invalide est rejetée avant `runUploadPipeline`, un audit `failure` est écrit avec le motif détaillé, et un `reason: "invalid_filename"` typé est propagé jusqu'au client.

## Changes

- **`route.ts`** — import `validateFileName` depuis le barrel `~/modules/shared` ; appel entre la vérification `isAllowedType` et `runUploadPipeline` ; en cas d'échec : `writeFailure` avec `errorMessage: "HTTP 400 invalid_filename: <reason>"` + retour `{ reason: "invalid_filename", error: <FR> }` HTTP 400. Fixe aussi l'import `parseSiren` pour utiliser le barrel.
- **`uploadFile.ts`** — `"invalid_filename"` ajouté dans l'union `UploadFailureReason` et dans `VALID_REASONS` (source de vérité runtime).
- **`useFileUploadForm.ts`** — `case "invalid_filename": return serverError` dans `formatUploadError` (propage le message FR du serveur tel quel).
- **`route.test.ts`** — 5 tests : 4 cas d'échec (too_long / forbidden_char / invisible_char / extension_mime_mismatch) vérifiant HTTP 400, body typé, audit, et `runUploadPipeline` non invoqué ; 1 happy path vérifiant que le pipeline est bien appelé sur un nom valide.

## Test plan

- [ ] `pnpm typecheck` — vert (0 erreur)
- [ ] `pnpm test` — vert (2449 tests, 5 nouveaux)
- [ ] `pnpm lint:check` / `pnpm format:check` — vert (880 fichiers)
- [ ] Security audit — SECURE (validation input côté serveur, audit sur tous les chemins d'échec, aucun secret dans les métadonnées)

## Notes

Aucune migration BDD (option backward-compat validée par le PO). Les findings structural-auditor restants (file >400 lignes, inline `uploadAuditMetadataSchema`, JSDoc) sont des dettes pré-existantes avant ce ticket et nécessitent un ticket de refactoring dédié.