### PR TITLE
feat(shared): filename validation in FileUpload before MIME/size checks

### DIFF
--- a/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FILENAME_ERROR_MESSAGES } from "~/modules/shared";
 import { Step2Upload } from "../Step2Upload";
 
 const pushMock = vi.fn();
@@ -187,10 +188,23 @@ describe("Step2Upload", () => {
 		expect(fileInput).toHaveAttribute("aria-invalid", "true");
 	});
 
-	it("shows error for non-PDF file", () => {
+	it("shows the extension/MIME error for a .txt file", () => {
 		render(<Step2Upload declarationYear={2026} siren="123456789" />);
 
 		const file = new File(["content"], "test.txt", { type: "text/plain" });
+		const fileInput = getFileInput();
+
+		fireEvent.change(fileInput, { target: { files: [file] } });
+
+		expect(
+			screen.getByText(FILENAME_ERROR_MESSAGES.extension_mime_mismatch),
+		).toBeInTheDocument();
+	});
+
+	it("shows the unsupported-format error for a valid-named non-PDF file", () => {
+		render(<Step2Upload declarationYear={2026} siren="123456789" />);
+
+		const file = new File(["content"], "image.png", { type: "image/png" });
 		const fileInput = getFileInput();
 
 		fireEvent.change(fileInput, { target: { files: [file] } });

--- a/packages/app/src/modules/shared/FileUpload.tsx
+++ b/packages/app/src/modules/shared/FileUpload.tsx
@@ -189,6 +189,7 @@ export function FileUpload({
 				accept={accept}
 				aria-describedby={messagesId}
 				aria-invalid={error !== null}
+				aria-label="Sélectionner des fichiers"
 				className="fr-sr-only"
 				disabled={disabled}
 				id={inputId}

--- a/packages/app/src/modules/shared/FileUpload.tsx
+++ b/packages/app/src/modules/shared/FileUpload.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 
 import styles from "./FileUpload.module.scss";
+import { validateFileName } from "./fileNameValidation";
 import { FILE_TOO_LARGE_ERROR, MAX_FILE_SIZE } from "./uploadConfig";
 
 function formatFileSize(bytes: number): string {
@@ -54,6 +55,10 @@ export function FileUpload({
 
 	const validateFile = useCallback(
 		(file: File): string | null => {
+			const fileNameResult = validateFileName(file.name, file.type);
+			if (!fileNameResult.ok) {
+				return fileNameResult.message;
+			}
 			if (!allowedMimeTypes.includes(file.type)) {
 				return `Format de fichier non supporté. Formats acceptés : ${acceptLabel}.`;
 			}

--- a/packages/app/src/modules/shared/__tests__/FileUpload.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/FileUpload.test.tsx
@@ -114,7 +114,7 @@ describe("FileUpload filename validation", () => {
 	it("S5: rejects an invisible character with the invisible_char message", async () => {
 		const onChange = vi.fn();
 		render(<ControlledFileUpload onChange={onChange} />);
-		const file = new File(["pdf-bytes"], "avis‮cse.pdf", {
+		const file = new File(["pdf-bytes"], "avis\u202Ecse.pdf", {
 			type: PDF_MIME,
 		});
 

--- a/packages/app/src/modules/shared/__tests__/FileUpload.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/FileUpload.test.tsx
@@ -1,0 +1,300 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FileUpload } from "../FileUpload";
+import { FILENAME_ERROR_MESSAGES } from "../fileNameValidation";
+import { FILE_TOO_LARGE_ERROR } from "../uploadConfig";
+
+const PDF_MIME = "application/pdf";
+
+function ControlledFileUpload({
+	onChange,
+	allowedMimeTypes = [PDF_MIME, "image/png"],
+	maxFiles,
+	disabled,
+}: {
+	onChange?: (files: File[], error: string | null) => void;
+	allowedMimeTypes?: string[];
+	maxFiles?: number;
+	disabled?: boolean;
+}) {
+	const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+	const [error, setError] = useState<string | null>(null);
+
+	return (
+		<FileUpload
+			accept=".pdf,.png"
+			acceptLabel="pdf, png"
+			allowedMimeTypes={allowedMimeTypes}
+			disabled={disabled}
+			error={error}
+			inputId="test-upload"
+			maxFiles={maxFiles}
+			onFilesChange={(files, nextError) => {
+				setSelectedFiles(files);
+				setError(nextError);
+				onChange?.(files, nextError);
+			}}
+			selectedFiles={selectedFiles}
+		/>
+	);
+}
+
+function getInput() {
+	return document.getElementById("test-upload") as HTMLInputElement;
+}
+
+describe("FileUpload filename validation", () => {
+	it("S1: accepts a valid name with accents and emoji, no error and the file is listed", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["pdf-bytes"], "Mon avis CSE — été 2024 🎉.pdf", {
+			type: PDF_MIME,
+		});
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith([file], null);
+		expect(screen.queryByText(/caractères interdits/i)).not.toBeInTheDocument();
+		expect(
+			screen.queryByText("Mon avis CSE — été 2024 🎉.pdf"),
+		).toBeInTheDocument();
+	});
+
+	it("S2: rejects a forbidden character with the forbidden_char message and no file listed", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["pdf-bytes"], "avis<cse>.pdf", { type: PDF_MIME });
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith(
+			[],
+			FILENAME_ERROR_MESSAGES.forbidden_char,
+		);
+		expect(
+			screen.getByText(FILENAME_ERROR_MESSAGES.forbidden_char),
+		).toBeInTheDocument();
+		expect(screen.queryByText("avis<cse>.pdf")).not.toBeInTheDocument();
+	});
+
+	it("S3: rejects a name over 200 characters with a message mentioning 200", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const longName = `${"a".repeat(201)}.pdf`;
+		const file = new File(["pdf-bytes"], longName, { type: PDF_MIME });
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith([], FILENAME_ERROR_MESSAGES.too_long);
+		expect(screen.getByText(/200/)).toBeInTheDocument();
+		expect(
+			screen.getByText(FILENAME_ERROR_MESSAGES.too_long),
+		).toHaveTextContent("200");
+	});
+
+	it("S4: rejects an extension/MIME mismatch with the extension_mime_mismatch message", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["png-bytes"], "avis-cse.pdf", { type: "image/png" });
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith(
+			[],
+			FILENAME_ERROR_MESSAGES.extension_mime_mismatch,
+		);
+		expect(
+			screen.getByText(FILENAME_ERROR_MESSAGES.extension_mime_mismatch),
+		).toBeInTheDocument();
+	});
+
+	it("S5: rejects an invisible character with the invisible_char message", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["pdf-bytes"], "avis‮cse.pdf", {
+			type: PDF_MIME,
+		});
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith(
+			[],
+			FILENAME_ERROR_MESSAGES.invisible_char,
+		);
+		expect(
+			screen.getByText(FILENAME_ERROR_MESSAGES.invisible_char),
+		).toBeInTheDocument();
+	});
+
+	it("runs the filename check before the MIME check: a bad name with a disallowed MIME yields the filename error", async () => {
+		const onChange = vi.fn();
+		render(
+			<ControlledFileUpload
+				allowedMimeTypes={[PDF_MIME]}
+				onChange={onChange}
+			/>,
+		);
+		const file = new File(["x"], "avis<cse>.png", { type: "image/png" });
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith(
+			[],
+			FILENAME_ERROR_MESSAGES.forbidden_char,
+		);
+	});
+
+	it("still surfaces the MIME error for a valid name with a disallowed MIME type", async () => {
+		const onChange = vi.fn();
+		render(
+			<ControlledFileUpload
+				allowedMimeTypes={[PDF_MIME]}
+				onChange={onChange}
+			/>,
+		);
+		const file = new File(["x"], "image.png", { type: "image/png" });
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith(
+			[],
+			"Format de fichier non supporté. Formats acceptés : pdf, png.",
+		);
+	});
+
+	it("surfaces the size error for a valid name and MIME but oversized file", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["x"], "rapport.pdf", { type: PDF_MIME });
+		Object.defineProperty(file, "size", { value: 11 * 1024 * 1024 });
+
+		await userEvent.upload(getInput(), file);
+
+		expect(onChange).toHaveBeenCalledWith([], FILE_TOO_LARGE_ERROR);
+		expect(screen.getByText(FILE_TOO_LARGE_ERROR)).toBeInTheDocument();
+	});
+});
+
+describe("FileUpload interactions", () => {
+	it("opens the file picker when the select button is clicked", async () => {
+		render(<ControlledFileUpload />);
+		const clickSpy = vi.spyOn(getInput(), "click");
+
+		await userEvent.click(
+			screen.getByRole("button", { name: /sélectionner des fichiers/i }),
+		);
+
+		expect(clickSpy).toHaveBeenCalled();
+	});
+
+	it("removes a selected file when its delete button is clicked", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["pdf-bytes"], "rapport.pdf", { type: PDF_MIME });
+
+		await userEvent.upload(getInput(), file);
+		expect(screen.getByText("rapport.pdf")).toBeInTheDocument();
+
+		await userEvent.click(screen.getByRole("button", { name: "Supprimer" }));
+
+		expect(onChange).toHaveBeenLastCalledWith([], null);
+		expect(screen.queryByText("rapport.pdf")).not.toBeInTheDocument();
+	});
+
+	it("accepts a dropped file and lists it", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["pdf-bytes"], "rapport.pdf", { type: PDF_MIME });
+		const dropzone = screen.getByLabelText("Zone de dépôt de fichier");
+
+		fireEvent.dragEnter(dropzone);
+		fireEvent.dragOver(dropzone);
+		fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+		expect(onChange).toHaveBeenCalledWith([file], null);
+		expect(screen.getByText("rapport.pdf")).toBeInTheDocument();
+	});
+
+	it("rejects a dropped file with an invalid name", () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const file = new File(["pdf-bytes"], "avis<cse>.pdf", { type: PDF_MIME });
+		const dropzone = screen.getByLabelText("Zone de dépôt de fichier");
+
+		fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+		expect(onChange).toHaveBeenCalledWith(
+			[],
+			FILENAME_ERROR_MESSAGES.forbidden_char,
+		);
+	});
+
+	it("does not throw on drag enter, over and leave events", () => {
+		render(<ControlledFileUpload />);
+		const dropzone = screen.getByLabelText("Zone de dépôt de fichier");
+		const child = dropzone.querySelector("button") as HTMLElement;
+
+		expect(() => {
+			fireEvent.dragEnter(dropzone);
+			fireEvent.dragOver(dropzone);
+			fireEvent.dragLeave(dropzone, { relatedTarget: child });
+			fireEvent.dragLeave(dropzone, { relatedTarget: document.body });
+		}).not.toThrow();
+	});
+
+	it("ignores a change event with no selected files", () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+
+		fireEvent.change(getInput(), { target: { files: [] } });
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("ignores a drop with no files", () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload onChange={onChange} />);
+		const dropzone = screen.getByLabelText("Zone de dépôt de fichier");
+
+		fireEvent.drop(dropzone, { dataTransfer: { files: [] } });
+
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("caps the selection at maxFiles remaining slots", async () => {
+		const onChange = vi.fn();
+		render(<ControlledFileUpload maxFiles={2} onChange={onChange} />);
+		const fileA = new File(["a"], "a.pdf", { type: PDF_MIME });
+		const fileB = new File(["b"], "b.pdf", { type: PDF_MIME });
+		const fileC = new File(["c"], "c.pdf", { type: PDF_MIME });
+
+		await userEvent.upload(getInput(), [fileA, fileB, fileC]);
+
+		expect(onChange).toHaveBeenCalledWith([fileA, fileB], null);
+	});
+
+	it("disables the select button and the input when disabled", () => {
+		render(<ControlledFileUpload disabled />);
+
+		expect(
+			screen.getByRole("button", { name: /sélectionner des fichiers/i }),
+		).toBeDisabled();
+		expect(getInput()).toBeDisabled();
+	});
+
+	it.each([
+		[2 * 1024, /Ko/],
+		[2 * 1024 * 1024, /Mo/],
+	])("renders the human-readable size label for a %i-byte file", async (size, unit) => {
+		render(<ControlledFileUpload />);
+		const file = new File(["pdf-bytes"], "rapport.pdf", { type: PDF_MIME });
+		Object.defineProperty(file, "size", { value: size });
+
+		await userEvent.upload(getInput(), file);
+
+		expect(screen.getByText(unit)).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/shared/__tests__/useFileUploadForm.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/useFileUploadForm.test.tsx
@@ -9,6 +9,7 @@ import {
 	vi,
 } from "vitest";
 
+import { FILENAME_ERROR_MESSAGES } from "../fileNameValidation";
 import type { UploadFileResult } from "../uploadFile";
 import { useFileUploadForm } from "../useFileUploadForm";
 
@@ -93,6 +94,48 @@ describe("useFileUploadForm", () => {
 		});
 
 		expect(result.current.uploadError).toBe("Boom");
+	});
+
+	it("surfaces a validateFileName rejection in uploadError and keeps no file selected", () => {
+		const { result } = renderHook(() =>
+			useFileUploadForm({ flowType: "cse_opinion" }),
+		);
+
+		act(() => {
+			result.current.handleFilesChange(
+				[],
+				FILENAME_ERROR_MESSAGES.forbidden_char,
+			);
+		});
+
+		expect(result.current.uploadError).toBe(
+			FILENAME_ERROR_MESSAGES.forbidden_char,
+		);
+		expect(result.current.selectedFiles).toEqual([]);
+	});
+
+	it("never calls uploadFile for a file rejected by validateFileName", async () => {
+		const onAllUploaded = vi.fn();
+		const { result } = renderHook(() =>
+			useFileUploadForm({ flowType: "cse_opinion", onAllUploaded }),
+		);
+		attachDialog(result);
+
+		act(() => {
+			result.current.handleFilesChange(
+				[],
+				FILENAME_ERROR_MESSAGES.invisible_char,
+			);
+		});
+		await act(async () => {
+			await result.current.handleConfirm();
+		});
+
+		expect(uploadFileMock).not.toHaveBeenCalled();
+		expect(onAllUploaded).not.toHaveBeenCalled();
+		expect(result.current.uploadError).toBe(
+			FILENAME_ERROR_MESSAGES.invisible_char,
+		);
 	});
 
 	it("handleSubmit prevents default and shows an error when no file is selected", () => {


### PR DESCRIPTION
Closes #3604

## Résumé

Câble la validation du nom de fichier côté client dans le composant `FileUpload` :
- Appel de `validateFileName(file.name, file.type)` en tout premier dans `validateFile`, avant les checks MIME et taille
- Sur `{ ok: false, message }` → le message FR est retourné et affiché dans la zone `aria-live` existante, sans appel réseau
- Les checks MIME et taille existants restent en place, exécutés après le check filename
- Correction RGAA 11.1 : ajout `aria-label` sur l'input file caché

## Tests

- 21 nouveaux tests RTL sur `FileUpload` (S1 happy path avec accents/emoji, S2 char interdit, S3 longueur, S4 mismatch ext/MIME, S5 invisible char, plus couverture comportementale)
- 2 nouveaux tests `useFileUploadForm` (erreur filename remonte dans `uploadError`, `uploadFile` non appelée pour fichier rejeté)
- 1 test `Step2Upload` corrigé (évolution légitime : l'ordre filename/MIME change le message pour `.txt`/`text/plain`)

## Critères d'acceptation

- [x] Sur sélection d'un fichier au nom invalide, message FR affiché avant tout appel réseau
- [x] `uploadFile` non appelée pour les fichiers rejetés
- [x] Happy path S1 (accents/emoji) fluide, aucune régression MIME/taille
- [x] Tests RTL verts (2466 tests)
- [x] Typecheck vert
- [x] Lint vert