### PR TITLE
fix(declaration-remuneration): align recap page tables and button with Figma (#3585)

### DIFF
--- a/packages/app/src/e2e/recapitulatif.e2e.ts
+++ b/packages/app/src/e2e/recapitulatif.e2e.ts
@@ -62,9 +62,7 @@ test.describe("Recapitulatif page", () => {
 	test("displays return button", async ({ page }) => {
 		await page.goto("/declaration-remuneration/recapitulatif");
 
-		await expect(
-			page.getByRole("link", { name: /Retour à Mon Espace/ }),
-		).toBeVisible();
+		await expect(page.getByRole("link", { name: "Mon espace" })).toBeVisible();
 	});
 
 	test("returns 404 for non-submitted declaration with correction type", async ({

--- a/packages/app/src/e2e/recapitulatif.e2e.ts
+++ b/packages/app/src/e2e/recapitulatif.e2e.ts
@@ -62,7 +62,12 @@ test.describe("Recapitulatif page", () => {
 	test("displays return button", async ({ page }) => {
 		await page.goto("/declaration-remuneration/recapitulatif");
 
-		await expect(page.getByRole("link", { name: "Mon espace" })).toBeVisible();
+		await expect(
+			page
+				.locator("main")
+				.getByRole("link", { name: "Mon espace", exact: true })
+				.last(),
+		).toBeVisible();
 	});
 
 	test("returns 404 for non-submitted declaration with correction type", async ({

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.module.scss
@@ -4,6 +4,11 @@
 	gap: 1rem;
 }
 
+:global(.fr-table__content) td,
+:global(.fr-table__content) th {
+	height: 56px;
+}
+
 .heading {
 	margin: 0;
 }

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -112,8 +112,8 @@ export function CategoryRecapTable({
 									</tr>
 									<tr className={styles.regularRow}>
 										<th scope="row">Effectif physique</th>
-										<td className={indicatorStyles.numeric}>{womenCount}</td>
-										<td className={indicatorStyles.numeric}>{menCount}</td>
+										<td className={indicatorStyles.numeric}>{womenCount} nb</td>
+										<td className={indicatorStyles.numeric}>{menCount} nb</td>
 										<td />
 									</tr>
 

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.module.scss
@@ -9,12 +9,21 @@
 	height: 56px;
 }
 
-.numeric {
+/* Right-align monetary and count values. Scoped under `.fr-table__content`
+   (a global DSFR class on the table wrapper) so the compound specificity
+   beats DSFR's own `.fr-table__content td { text-align: left }` rule — a
+   bare `.numeric` class loses the cascade and the values fall back to left.
+   Percentages stay left (see `.percent` / `.gapNumeric`). */
+:global(.fr-table__content) td.numeric,
+:global(.fr-table__content) th.numeric {
 	text-align: right;
 	font-variant-numeric: tabular-nums;
 }
 
-.gapNumeric {
+:global(.fr-table__content) td.percent,
+:global(.fr-table__content) th.percent,
+:global(.fr-table__content) td.gapNumeric,
+:global(.fr-table__content) th.gapNumeric {
 	text-align: left;
 	font-variant-numeric: tabular-nums;
 }

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.module.scss
@@ -4,6 +4,11 @@
 	gap: 1.5rem;
 }
 
+:global(.fr-table__content) td,
+:global(.fr-table__content) th {
+	height: 56px;
+}
+
 .numeric {
 	text-align: right;
 	font-variant-numeric: tabular-nums;

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
@@ -197,7 +197,7 @@ function ProportionTable({
 									<td className={styles.numeric}>
 										{Number.isNaN(eWomen) ? "-" : eWomen}
 									</td>
-									<td className={styles.numeric}>
+									<td className={styles.percent}>
 										<strong>
 											{Number.isNaN(eWomen)
 												? "-"
@@ -213,7 +213,7 @@ function ProportionTable({
 									<td className={styles.numeric}>
 										{Number.isNaN(eMen) ? "-" : eMen}
 									</td>
-									<td className={styles.numeric}>
+									<td className={styles.percent}>
 										<strong>
 											{Number.isNaN(eMen) ? "-" : computePercentage(eMen, tMen)}
 										</strong>
@@ -321,12 +321,12 @@ function QuartileDistributionTable({
 												<td className={styles.numeric}>
 													{q.men !== undefined ? q.men : "-"}
 												</td>
-												<td className={styles.numeric}>
+												<td className={styles.percent}>
 													{lineTotal > 0
 														? computePercentage(q.women ?? 0, lineTotal)
 														: "-"}
 												</td>
-												<td className={styles.numeric}>
+												<td className={styles.percent}>
 													{lineTotal > 0
 														? computePercentage(q.men ?? 0, lineTotal)
 														: "-"}
@@ -343,12 +343,12 @@ function QuartileDistributionTable({
 										<td className={styles.numeric}>
 											<strong>{totalMen || "-"}</strong>
 										</td>
-										<td className={styles.numeric}>
+										<td className={styles.percent}>
 											<strong>
 												{total > 0 ? computePercentage(totalWomen, total) : "-"}
 											</strong>
 										</td>
-										<td className={styles.numeric}>
+										<td className={styles.percent}>
 											<strong>
 												{total > 0 ? computePercentage(totalMen, total) : "-"}
 											</strong>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -192,12 +192,12 @@ export function RecapitulatifPage({
 				</div>
 			</section>
 
-			{/* Primary action — return to Mon Espace */}
+			{/* Action — return to Mon Espace */}
 			<Link
-				className={`fr-btn fr-btn--primary ${styles.primaryAction}`}
+				className={`fr-btn fr-btn--secondary ${styles.primaryAction}`}
 				href="/mon-espace"
 			>
-				Retour à Mon Espace
+				Mon espace
 			</Link>
 		</div>
 	);

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -192,7 +192,6 @@ export function RecapitulatifPage({
 				</div>
 			</section>
 
-			{/* Action — return to Mon Espace */}
 			<Link
 				className={`fr-btn fr-btn--secondary ${styles.primaryAction}`}
 				href="/mon-espace"

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
+import { CategoryRecapTable } from "../CategoryRecapTable";
+
+function makeCategory(
+	overrides: Partial<EmployeeCategoryRow> = {},
+): EmployeeCategoryRow {
+	return {
+		name: "",
+		womenCount: null,
+		menCount: null,
+		annualBaseWomen: null,
+		annualBaseMen: null,
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+		...overrides,
+	};
+}
+
+function effectifCells() {
+	const row = screen.getByRole("rowheader", { name: "Effectif physique" })
+		.parentElement as HTMLElement;
+	return within(row).getAllByRole("cell");
+}
+
+describe("CategoryRecapTable", () => {
+	it("suffixes the 'Effectif physique' counts with 'nb'", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({ womenCount: 53, menCount: 25 })}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		const cells = effectifCells();
+		expect(cells[0]).toHaveTextContent("53 nb");
+		expect(cells[1]).toHaveTextContent("25 nb");
+	});
+
+	it("renders '0 nb' when counts are null", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory()}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		const cells = effectifCells();
+		expect(cells[0]).toHaveTextContent("0 nb");
+		expect(cells[1]).toHaveTextContent("0 nb");
+	});
+
+	it("renders the heading with the category name and 1-based index", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({ name: "Ouvriers / Employés" })}
+				declarationYear={2025}
+				index={1}
+			/>,
+		);
+		expect(
+			screen.getByText("Catégorie d'emplois n°2 : Ouvriers / Employés"),
+		).toBeInTheDocument();
+	});
+
+	it("renders the heading without a name suffix when name is empty", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory()}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		expect(screen.getByText("Catégorie d'emplois n°1")).toBeInTheDocument();
+	});
+
+	it("renders the total salariés count from women + men", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({ womenCount: 53, menCount: 25 })}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		expect(screen.getByText("Total salariés : 78")).toBeInTheDocument();
+	});
+
+	it("flags an 'élevé' badge when a salary gap reaches the 5% threshold", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({
+					annualBaseWomen: "90",
+					annualBaseMen: "100",
+				})}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		expect(screen.getAllByText("élevé").length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("renders no 'élevé' badge when all gaps stay below the threshold", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({
+					annualBaseWomen: "99",
+					annualBaseMen: "100",
+				})}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		expect(screen.queryByText("élevé")).not.toBeInTheDocument();
+	});
+
+	it("computes annual and hourly total gaps from base + variable components", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({
+					annualBaseWomen: "30000",
+					annualBaseMen: "32000",
+					annualVariableWomen: "2000",
+					annualVariableMen: "3000",
+					hourlyBaseWomen: "18",
+					hourlyBaseMen: "20",
+					hourlyVariableWomen: "1",
+					hourlyVariableMen: "2",
+				})}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		// Annual total gap: |((35000 - 32000) / 35000) * 100| = 8,6 % → élevé.
+		// Hourly total gap: |((22 - 19) / 22) * 100| = 13,6 % → élevé.
+		expect(screen.getAllByText("élevé").length).toBeGreaterThanOrEqual(2);
+		expect(screen.getAllByRole("row").length).toBeGreaterThan(0);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -117,8 +117,8 @@ describe("RecapitulatifPage", () => {
 		expect(
 			screen.queryByRole("navigation", { name: /vous êtes ici/i }),
 		).not.toBeInTheDocument();
-		// The only "Retour" link in the component is the bottom primary
-		// "Retour à Mon Espace" button — there is no top "Retour" link.
+		// The only navigation link at the bottom is the secondary "Mon espace"
+		// button — there is no top "Retour" link.
 		expect(
 			screen.queryByRole("link", { name: "Retour" }),
 		).not.toBeInTheDocument();
@@ -348,12 +348,12 @@ describe("RecapitulatifPage", () => {
 		expect(screen.getByText("Accord d'entreprise")).toBeInTheDocument();
 	});
 
-	it("renders return button linking to mon-espace", () => {
+	it("renders secondary 'Mon espace' button linking to mon-espace", () => {
 		render(<RecapitulatifPage {...defaultProps()} />);
-		const returnLink = screen.getByRole("link", {
-			name: "Retour à Mon Espace",
-		});
+		const returnLink = screen.getByRole("link", { name: "Mon espace" });
 		expect(returnLink).toHaveAttribute("href", "/mon-espace");
+		expect(returnLink.className).toContain("fr-btn--secondary");
+		expect(returnLink.className).not.toContain("fr-btn--primary");
 	});
 
 	it("does not render its own ResourceBanner (PublicChrome handles it)", () => {


### PR DESCRIPTION
Closes #3585

## Changements

- Hauteur des cellules de tableau à 56px (IndicatorTables + CategoryRecapTable SCSS)
- Suffixe « nb » sur les effectifs physiques dans CategoryRecapTable
- Bouton bas de page : variante secondaire + libellé « Mon espace »
- Correctif locator E2E recapitulatif

## Tests

- 8 nouveaux TU sur `CategoryRecapTable` (effectif physique avec « nb », badge élevé, totaux)
- TU `RecapitulatifPage` corrigé (nouveau libellé + variante secondaire)
- Locator E2E `recapitulatif.e2e.ts` mis à jour