### PR TITLE
fix(second-declaration): alignement visuel Figma — parcours mise en conformité indicateur par catégorie

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
@@ -7,15 +7,6 @@
 	border-radius: 4px;
 }
 
-.nextStepsCompact {
-	display: flex;
-	flex-direction: column;
-	gap: 1rem;
-	padding: 1.875rem;
-	background: var(--background-alt-blue-france);
-	border-radius: 4px;
-}
-
 .section {
 	display: flex;
 	flex-direction: column;

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -17,11 +17,9 @@ export function NextStepsBox({
 	siren,
 	isSecondDeclaration,
 }: Props) {
-	const containerClass = styles.nextSteps;
-
 	return (
 		<>
-			<div className={containerClass}>
+			<div className={styles.nextSteps}>
 				<h3 className="fr-h4 fr-mb-0">Prochaines étapes</h3>
 
 				<div className={styles.section}>

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -17,9 +17,7 @@ export function NextStepsBox({
 	siren,
 	isSecondDeclaration,
 }: Props) {
-	const containerClass = isSecondDeclaration
-		? styles.nextStepsCompact
-		: styles.nextSteps;
+	const containerClass = styles.nextSteps;
 
 	return (
 		<>
@@ -27,11 +25,9 @@ export function NextStepsBox({
 				<h3 className="fr-h4 fr-mb-0">Prochaines étapes</h3>
 
 				<div className={styles.section}>
-					{!isSecondDeclaration && (
-						<h4 className="fr-text--bold fr-text--md fr-mb-0">
-							Informer et consulter le CSE
-						</h4>
-					)}
+					<h4 className="fr-text--bold fr-text--md fr-mb-0">
+						Informer et consulter le CSE
+					</h4>
 
 					<p className="fr-mb-0">
 						Au cours du temps imparti pour réaliser votre déclaration, vous
@@ -64,45 +60,26 @@ export function NextStepsBox({
 					</div>
 				</div>
 
-				{!isSecondDeclaration && hasGapsAboveThreshold && (
-					<hr className={styles.separator} />
-				)}
+				{hasGapsAboveThreshold && <hr className={styles.separator} />}
 
 				{hasGapsAboveThreshold && (
 					<div className={styles.section}>
-						{isSecondDeclaration ? (
-							<p className="fr-text--bold fr-mb-0">
-								Des écarts ont été de nouveau détectés
+						<div className={styles.alertHeader}>
+							<p
+								className={`fr-badge fr-badge--warning fr-badge--sm ${styles.alertBadge}`}
+							>
+								Écarts détectés
 							</p>
-						) : (
-							<div className={styles.alertHeader}>
-								<p
-									className={`fr-badge fr-badge--warning fr-badge--sm ${styles.alertBadge}`}
-								>
-									Écarts détectés
-								</p>
-								<h4 className="fr-text--bold fr-text--md fr-mb-0">
-									Actions à engager
-								</h4>
-							</div>
-						)}
+							<h4 className="fr-text--bold fr-text--md fr-mb-0">
+								Actions à engager
+							</h4>
+						</div>
 
 						<p className="fr-mb-0">
 							Suite à l&apos;analyse de vos données de l&apos;indicateur par
-							catégorie de salariés,{" "}
-							{isSecondDeclaration ? (
-								<>
-									<strong>des écarts &ge; 5 % ont été identifiés</strong>. Vous
-									devez{" "}
-									<strong>engager un des parcours de mise en conformité</strong>{" "}
-									suivant&nbsp;:
-								</>
-							) : (
-								<>
-									des écarts &ge; 5 % ont été identifiés. Vous devez engager un
-									des parcours de mise en conformité suivant&nbsp;:
-								</>
-							)}
+							catégorie de salariés, des écarts &ge; 5 % ont été identifiés.
+							Vous devez engager un des parcours de mise en conformité
+							suivant&nbsp;:
 						</p>
 
 						<ul>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
@@ -77,3 +77,10 @@
 	// Figma spec: intro paragraph uses title-grey, not the default body grey.
 	color: var(--text-title-grey);
 }
+
+.gapGrid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	column-gap: 1.5rem;
+	row-gap: 0.25rem;
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -14,7 +14,7 @@ import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import stepStyles from "../Step6Review.module.scss";
 import { CardTitle } from "../step6/CardTitle";
-import { GapColumn } from "../step6/GapColumn";
+import { GapBadge } from "../step6/GapBadge";
 import { parseEmployeeCategories } from "../step6/parseStep5Categories";
 import { BASE_PATH } from "./constants";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
@@ -83,15 +83,15 @@ export function SecondDeclarationStep3Review({
 		>
 			<div className={common.flexBetween}>
 				<h1 className="fr-h4 fr-mb-0">
-					Parcours de mise en conformité pour l&apos;indicateur par catégorie de
-					salariés
+					Parcours de mise en conformité pour l&apos;indicateur
+					par&nbsp;catégorie de salariés
 				</h1>
 				<SavedIndicator hasData={true} />
 			</div>
 
 			<SecondDeclarationStepIndicator currentStep={3} />
 
-			<p className={`fr-mb-0 ${common.mentionGrey}`}>
+			<p className={`fr-mb-0 ${stepStyles.intro}`}>
 				Vérifiez que toutes les informations ont été complétées avant de
 				soumettre votre seconde déclaration des écarts de rémunération par
 				catégorie de salariés aux services du ministère chargé du travail.
@@ -101,37 +101,42 @@ export function SecondDeclarationStep3Review({
 
 			<div className={stepStyles.card}>
 				<CardTitle tooltipId="tooltip-second-decl-categories">
-					Écart de rémunération par catégories de salariés (salaire de base et
-					primes)
+					Écart de rémunération par catégories de salariés
 				</CardTitle>
 				{parsed.length > 0 ? (
 					parsed.map((cat) => (
 						<div key={cat.index}>
-							<p className="fr-text--bold fr-mb-0">
-								[Catégorie d&apos;emplois n°{cat.index + 1}]
+							<p className="fr-text--sm fr-text--bold fr-mb-0">
+								Catégorie d&apos;emplois n°{cat.index + 1} : {cat.name}
 							</p>
 							<div className={stepStyles.sideBySide}>
-								<GapColumn
-									columns={[
-										{ label: "Salaire de base", gap: cat.annualBaseGap },
-										{
-											label: "Composantes variables ou complémentaires",
-											gap: cat.annualVariableGap,
-										},
-									]}
-									title="Annuelle brute"
-								/>
+								<div className={stepStyles.column}>
+									<p className="fr-text--bold fr-text--sm fr-mb-0">
+										Annuelle brute
+									</p>
+									<div className={stepStyles.gapGrid}>
+										<p className="fr-text--sm fr-mb-0">Salaire de base</p>
+										<p className="fr-text--sm fr-mb-0">
+											Composantes variables ou complémentaires
+										</p>
+										<GapBadge gap={cat.annualBaseGap} />
+										<GapBadge gap={cat.annualVariableGap} />
+									</div>
+								</div>
 								<div className={stepStyles.verticalSeparator} />
-								<GapColumn
-									columns={[
-										{ label: "Salaire de base", gap: cat.hourlyBaseGap },
-										{
-											label: "Composantes variables ou complémentaires",
-											gap: cat.hourlyVariableGap,
-										},
-									]}
-									title="Horaire brute"
-								/>
+								<div className={stepStyles.column}>
+									<p className="fr-text--bold fr-text--sm fr-mb-0">
+										Horaire brute
+									</p>
+									<div className={stepStyles.gapGrid}>
+										<p className="fr-text--sm fr-mb-0">Salaire de base</p>
+										<p className="fr-text--sm fr-mb-0">
+											Composantes variables ou complémentaires
+										</p>
+										<GapBadge gap={cat.hourlyBaseGap} />
+										<GapBadge gap={cat.hourlyVariableGap} />
+									</div>
+								</div>
 							</div>
 						</div>
 					))

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
@@ -92,6 +92,10 @@ describe("SecondDeclarationStep3Review", () => {
 				/Parcours de mise en conformité pour l.indicateur par catégorie de salariés/,
 			),
 		).toBeInTheDocument();
+		// Non-breaking space keeps "par catégorie" on the same line (Figma spec)
+		expect(screen.getByRole("heading", { level: 1 }).textContent).toContain(
+			"par\u00A0catégorie",
+		);
 		expect(screen.getByText("Étape 3 sur 3")).toBeInTheDocument();
 	});
 
@@ -104,7 +108,54 @@ describe("SecondDeclarationStep3Review", () => {
 				siren="532847196"
 			/>,
 		);
-		expect(screen.getByText(/Catégorie d.emplois n°1/)).toBeInTheDocument();
+		expect(
+			screen.getByText("Catégorie d'emplois n°1 : Ingénieurs"),
+		).toBeInTheDocument();
+	});
+
+	it("does not bracket the category title", () => {
+		render(
+			<SecondDeclarationStep3Review
+				declarationYear={2025}
+				hasCse={null}
+				secondDeclarationCategories={mockCategories}
+				siren="532847196"
+			/>,
+		);
+		expect(
+			screen.queryByText(/\[Catégorie d.emplois n°1\]/),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders the card title without the base-and-bonus parenthetical", () => {
+		render(
+			<SecondDeclarationStep3Review
+				declarationYear={2025}
+				hasCse={null}
+				secondDeclarationCategories={mockCategories}
+				siren="532847196"
+			/>,
+		);
+		expect(
+			screen.getByText("Écart de rémunération par catégories de salariés"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/salaire de base et primes/),
+		).not.toBeInTheDocument();
+	});
+
+	it("always shows the CSE consultation heading for second declaration", () => {
+		render(
+			<SecondDeclarationStep3Review
+				declarationYear={2025}
+				hasCse={null}
+				secondDeclarationCategories={mockCategories}
+				siren="532847196"
+			/>,
+		);
+		expect(
+			screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders gap columns", () => {
@@ -208,8 +259,9 @@ describe("SecondDeclarationStep3Review", () => {
 				siren="532847196"
 			/>,
 		);
+		expect(screen.getByText("Écarts détectés")).toBeInTheDocument();
 		expect(
-			screen.getByText("Des écarts ont été de nouveau détectés"),
+			screen.getByRole("heading", { name: "Actions à engager" }),
 		).toBeInTheDocument();
 	});
 
@@ -238,8 +290,9 @@ describe("SecondDeclarationStep3Review", () => {
 				siren="532847196"
 			/>,
 		);
+		expect(screen.queryByText("Écarts détectés")).not.toBeInTheDocument();
 		expect(
-			screen.queryByText("Des écarts ont été de nouveau détectés"),
+			screen.queryByRole("heading", { name: "Actions à engager" }),
 		).not.toBeInTheDocument();
 	});
 
@@ -358,5 +411,29 @@ describe("SecondDeclarationStep3Review", () => {
 			/>,
 		);
 		expect(screen.getByText("Aucune donnée renseignée.")).toBeInTheDocument();
+	});
+
+	it("closes the modal without submitting when Annuler is clicked", async () => {
+		const user = userEvent.setup();
+		render(
+			<SecondDeclarationStep3Review
+				declarationYear={2025}
+				hasCse={null}
+				secondDeclarationCategories={mockCategories}
+				siren="532847196"
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /soumettre/i }));
+		const submitDialog = document.getElementById("submit-declaration-modal");
+		if (!submitDialog) throw new Error("submit dialog not found");
+		const cancelButton = within(submitDialog).getByRole("button", {
+			name: /annuler/i,
+			hidden: true,
+		});
+		await user.click(cancelButton);
+
+		expect(mockMutate).not.toHaveBeenCalled();
+		expect(mockPush).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
Closes #3581

## Corrections visuelles (7 points Figma node 7548:86742)

- **Intro paragraph** : `common.mentionGrey` → `stepStyles.intro` (weight 500 + `text-title-grey` au lieu de gris mention)
- **h1** : ajout `&nbsp;` entre « par » et « catégorie » (typographie FR, volontairement divergent du Figma)
- **Libellé catégorie** : affichage `Catégorie d'emplois n°N : <nom>` — sans crochets, avec le nom réel via `cat.name`
- **Taille titre catégorie** : `fr-text--bold` → `fr-text--sm fr-text--bold` (14 px au lieu de 16 px)
- **Titre carte** : suppression du suffixe « (salaire de base et primes) »
- **Alignement valeurs** : remplacement de `GapColumn` par un CSS grid 2 colonnes local (`stepStyles.gapGrid`) — labels en ligne 1, badges en ligne 2, valeurs toujours alignées quelle que soit la hauteur du libellé
- **Prochaines étapes** : `nextStepsCompact` → `nextSteps` (padding 32 px / gap 32 px) ; « Informer et consulter le CSE » toujours visible ; badge `fr-badge--warning` « Écarts détectés » + h4 « Actions à engager » pour les deux cas (suppression de la branche compacte `isSecondDeclaration`)

## Fichiers modifiés

- `SecondDeclarationStep3Review.tsx`
- `NextStepsBox.tsx`
- `Step6Review.module.scss` (ajout `.gapGrid`)
- `SecondDeclarationStep3Review.test.tsx` (1 test corrigé, 4 nouveaux)

## Qualité

- 2427/2427 tests ✓ — typecheck ✓ — lint/format ✓ — RGAA PASS — security SECURE