### PR TITLE
fix(declaration-remuneration): parcours de mise en conformité 2ᵉ tour — fidélité Figma (#3582)

### DIFF
--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -84,9 +84,12 @@ test.describe("Path 3: gap + hasCse → compliance choice → justify", () => {
 			}),
 		).toBeVisible();
 		await expect(
-			page.getByText("Évaluation conjointe des rémunérations", {
-				exact: true,
-			}),
+			page.getByText(
+				"Mettre en place une évaluation conjointe des rémunérations",
+				{
+					exact: true,
+				},
+			),
 		).toBeVisible();
 		await expect(
 			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
@@ -212,9 +215,12 @@ test.describe("Path 8: gap + corrective action (gap persists) → second round c
 			}),
 		).toBeVisible();
 		await expect(
-			page.getByText("Évaluation conjointe des rémunérations", {
-				exact: true,
-			}),
+			page.getByText(
+				"Mettre en place une évaluation conjointe des rémunérations",
+				{
+					exact: true,
+				},
+			),
 		).toBeVisible();
 		await expect(
 			page.getByText("Actions correctives et seconde déclaration", {

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.module.scss
@@ -1,0 +1,6 @@
+.instructions {
+	// Figma: "MD - Texte standard - Medium" (500) in title-grey. DSFR ships no
+	// 500 weight utility (only regular/bold/heavy/light), hence the scoped rule.
+	color: var(--text-title-grey);
+	font-weight: 500;
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -17,6 +17,7 @@ import { api } from "~/trpc/react";
 import common from "../shared/common.module.scss";
 import { FormActions } from "../shared/FormActions";
 import { SavedIndicator } from "../shared/SavedIndicator";
+import styles from "./CompliancePathChoice.module.scss";
 import {
 	FirstRoundOptions,
 	getCompliancePathHref,
@@ -136,13 +137,8 @@ export function CompliancePathChoice({
 				year={currentYear}
 			/>
 
-			<h2 className="fr-h4 fr-mb-0">
-				Parcours de mise en conformité pour l&apos;indicateur par catégorie de
-				salariés
-			</h2>
-
 			<div className={common.flexColumnGap1}>
-				<p className="fr-mb-0 fr-text--medium">
+				<p className={`fr-mb-0 ${styles.instructions}`}>
 					{isSecondRound
 						? "Des écarts ≥ 5 % ont de nouveau été détectés, vous devez engager l'un des parcours suivants."
 						: "Des écarts ≥ 5 % ont été constatés, vous devez engager l'un des parcours suivants."}
@@ -160,10 +156,10 @@ export function CompliancePathChoice({
 
 			<div className={common.dataSection}>
 				<div className={common.flexColumnGapHalf}>
-					<h3 className="fr-h6 fr-mb-0">
+					<h2 className="fr-h6 fr-mb-0">
 						La justification est possible par des critères objectifs et non
 						sexistes
-					</h3>
+					</h2>
 					<p className="fr-mb-0">
 						<a
 							className="fr-link"

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -9,7 +9,7 @@ import { DraftLoadingState } from "~/modules/declaration-remuneration/shared/dra
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { useDraftAutoSave } from "~/modules/declaration-remuneration/shared/draft/useDraftAutoSave";
 import { useDraftHydration } from "~/modules/declaration-remuneration/shared/draft/useDraftHydration";
-import type { CampaignDeadlines } from "~/modules/domain";
+import { type CampaignDeadlines, formatLongDate } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
@@ -141,74 +141,86 @@ export function CompliancePathChoice({
 				salariés
 			</h2>
 
-			<p className="fr-mb-0">
-				Des écarts ≥ 5 % ont été constatés,{" "}
-				<span className="fr-text--medium">
-					vous devez engager l&apos;un des parcours suivants.
-				</span>
-			</p>
-
 			<div className={common.flexColumnGap1}>
-				<h3 className="fr-h6 fr-mb-0">
-					La justification est possible par des critères objectifs et non
-					sexistes
-				</h3>
-				<p className="fr-mb-0">
-					<a
-						className="fr-link"
-						href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-						rel="noopener noreferrer"
-						target="_blank"
-					>
-						Qu&apos;entend-on par critères objectifs et non sexistes ?
-						<NewTabNotice />
-					</a>
+				<p className="fr-mb-0 fr-text--medium">
+					{isSecondRound
+						? "Des écarts ≥ 5 % ont de nouveau été détectés, vous devez engager l'un des parcours suivants."
+						: "Des écarts ≥ 5 % ont été constatés, vous devez engager l'un des parcours suivants."}
 				</p>
+
+				<div className="fr-highlight fr-mb-0">
+					<p className="fr-mb-1w">
+						Date limite pour choisir un parcours de mise en conformité
+					</p>
+					<p className="fr-text--lg fr-text--bold fr-mb-0">
+						{formatLongDate(campaignDeadlines.pathChoiceDeadline)}
+					</p>
+				</div>
 			</div>
 
-			<Controller
-				control={form.control}
-				name="path"
-				render={({ field }) => (
-					<fieldset
-						aria-labelledby="compliance-path-legend"
-						className="fr-fieldset"
-					>
-						<legend className="fr-sr-only" id="compliance-path-legend">
-							Choix du parcours de mise en conformité
-						</legend>
+			<div className={common.dataSection}>
+				<div className={common.flexColumnGapHalf}>
+					<h3 className="fr-h6 fr-mb-0">
+						La justification est possible par des critères objectifs et non
+						sexistes
+					</h3>
+					<p className="fr-mb-0">
+						<a
+							className="fr-link"
+							href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+							rel="noopener noreferrer"
+							target="_blank"
+						>
+							Qu&apos;entend-on par critères objectifs et non sexistes ?
+							<NewTabNotice />
+						</a>
+					</p>
+				</div>
 
-						{isSecondRound ? (
-							<SecondRoundOptions
-								disabled={isImpersonating}
-								jointEvaluationDeadline={
-									campaignDeadlines.decl2JointEvaluationDeadline
-								}
-								justificationDeadline={
-									campaignDeadlines.decl2JustificationDeadline
-								}
-								selectedPath={field.value}
-								setSelectedPath={field.onChange}
-							/>
-						) : (
-							<FirstRoundOptions
-								correctiveActionDeadline={
-									campaignDeadlines.decl2ModificationDeadline
-								}
-								disabled={isImpersonating}
-								jointEvaluationDeadline={
-									campaignDeadlines.decl1JointEvaluationDeadline
-								}
-								justificationDeadline={
-									campaignDeadlines.decl1JustificationDeadline
-								}
-								selectedPath={field.value}
-								setSelectedPath={field.onChange}
-							/>
-						)}
-					</fieldset>
-				)}
-			/>
+				<Controller
+					control={form.control}
+					name="path"
+					render={({ field }) => (
+						<fieldset
+							aria-labelledby="compliance-path-legend"
+							className="fr-fieldset"
+						>
+							<legend className="fr-sr-only" id="compliance-path-legend">
+								Choix du parcours de mise en conformité
+							</legend>
+
+							{isSecondRound ? (
+								<SecondRoundOptions
+									disabled={isImpersonating}
+									jointEvaluationDeadline={
+										campaignDeadlines.decl2JointEvaluationDeadline
+									}
+									justificationDeadline={
+										campaignDeadlines.decl2JustificationDeadline
+									}
+									selectedPath={field.value}
+									setSelectedPath={field.onChange}
+								/>
+							) : (
+								<FirstRoundOptions
+									correctiveActionDeadline={
+										campaignDeadlines.decl2ModificationDeadline
+									}
+									disabled={isImpersonating}
+									jointEvaluationDeadline={
+										campaignDeadlines.decl1JointEvaluationDeadline
+									}
+									justificationDeadline={
+										campaignDeadlines.decl1JustificationDeadline
+									}
+									selectedPath={field.value}
+									setSelectedPath={field.onChange}
+								/>
+							)}
+						</fieldset>
+					)}
+				/>
+			</div>
 
 			<FormActions
 				isSubmitting={mutation.isPending}

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -82,7 +82,9 @@ describe("CompliancePathChoice", () => {
 			screen.getByText("Actions correctives et seconde déclaration"),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText("Évaluation conjointe des rémunérations"),
+			screen.getByText(
+				"Mettre en place une évaluation conjointe des rémunérations",
+			),
 		).toBeInTheDocument();
 	});
 
@@ -129,7 +131,7 @@ describe("CompliancePathChoice", () => {
 			/>,
 		);
 		const radio = screen.getByLabelText(
-			"Évaluation conjointe des rémunérations",
+			"Mettre en place une évaluation conjointe des rémunérations",
 		);
 		fireEvent.click(radio);
 
@@ -203,11 +205,70 @@ describe("CompliancePathChoice", () => {
 			/>,
 		);
 		expect(
-			screen.getByText("Évaluation conjointe des rémunérations"),
+			screen.getByText(
+				"Mettre en place une évaluation conjointe des rémunérations",
+			),
 		).toBeInTheDocument();
 		expect(
 			screen.queryByText("Actions correctives et seconde déclaration"),
 		).not.toBeInTheDocument();
+	});
+
+	it("renders the first-round instruction phrase by default", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+		expect(
+			screen.getByText(/Des écarts ≥ 5 % ont été constatés/),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/ont de nouveau été détectés/),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders the second-round instruction phrase and intermediate heading", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+				isSecondRound={true}
+			/>,
+		);
+		expect(
+			screen.getByText(/Des écarts ≥ 5 % ont de nouveau été détectés/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", {
+				name: "Si la justification n'est pas possible par des critères objectifs et non sexistes",
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("renders the path choice deadline highlight block", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+		expect(
+			screen.getByText(
+				"Date limite pour choisir un parcours de mise en conformité",
+			),
+		).toBeInTheDocument();
+		expect(screen.getByText("1 janvier 2027")).toBeInTheDocument();
 	});
 
 	it("renders previous link pointing to step 6", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -246,11 +246,42 @@ describe("CompliancePathChoice", () => {
 		expect(
 			screen.getByText(/Des écarts ≥ 5 % ont de nouveau été détectés/),
 		).toBeInTheDocument();
+		// Section headings sit at level 2 (the page h1 is the funnel title); the
+		// redundant "Parcours de mise en conformité" subtitle is not rendered, so
+		// the hierarchy must not skip from h1 to h3.
 		expect(
 			screen.getByRole("heading", {
+				level: 2,
 				name: "Si la justification n'est pas possible par des critères objectifs et non sexistes",
 			}),
 		).toBeInTheDocument();
+	});
+
+	it("uses the funnel title as h1 and keeps section headings at level 2", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: /Déclaration des indicateurs/,
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", {
+				level: 2,
+				name: "La justification est possible par des critères objectifs et non sexistes",
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("heading", { name: /Parcours de mise en conformité/ }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders the path choice deadline highlight block", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -184,6 +184,7 @@ describe("DraftLoadingGate", () => {
 					decl1JointEvaluationDeadline: new Date("2026-05-01"),
 					decl2JustificationDeadline: new Date("2026-09-01"),
 					decl2JointEvaluationDeadline: new Date("2026-11-01"),
+					pathChoiceDeadline: new Date("2027-01-01"),
 				}}
 				currentYear={2026}
 				declarationSiren="123456789"

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOption.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOption.module.scss
@@ -3,3 +3,7 @@
 	border-radius: 4px;
 	padding: 1rem;
 }
+
+.title {
+	color: var(--text-action-high-blue-france);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOption.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOption.module.scss
@@ -2,8 +2,10 @@
 	border: 1px solid var(--border-default-grey);
 	border-radius: 4px;
 	padding: 1rem;
-}
 
-.title {
-	color: var(--text-action-high-blue-france);
+	// Nested so the selector outranks DSFR's `.fr-label` colour, which has the
+	// same specificity but is loaded later in the cascade.
+	.title {
+		color: var(--text-action-high-blue-france);
+	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOption.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOption.tsx
@@ -44,7 +44,10 @@ export function CompliancePathOption({
 					type="radio"
 					value={value}
 				/>
-				<label className="fr-label fr-text--bold fr-h6 fr-mb-0" htmlFor={id}>
+				<label
+					className={`fr-label fr-text--bold fr-h6 fr-mb-0 ${styles.title}`}
+					htmlFor={id}
+				>
 					{title}
 				</label>
 			</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
@@ -120,10 +120,10 @@ export function SecondRoundOptions({
 				onChange={() => setSelectedPath("justify")}
 			/>
 
-			<h3 className="fr-h6 fr-mt-3w fr-mb-0">
+			<h2 className="fr-h6 fr-mt-3w fr-mb-0">
 				Si la justification n&apos;est pas possible par des critères objectifs
 				et non sexistes
-			</h3>
+			</h2>
 
 			<JointEvaluationOption
 				checked={selectedPath === "joint_evaluation"}
@@ -160,10 +160,10 @@ export function FirstRoundOptions({
 				onChange={() => setSelectedPath("justify")}
 			/>
 
-			<h3 className="fr-h6 fr-mt-3w fr-mb-0">
+			<h2 className="fr-h6 fr-mt-3w fr-mb-0">
 				Si la justification n&apos;est pas possible par des critères objectifs
 				et non sexistes
-			</h3>
+			</h2>
 
 			<div className="fr-fieldset__element fr-mt-2w">
 				<CompliancePathOption

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
@@ -13,27 +13,33 @@ export function getCompliancePathHref(path: CompliancePathValue): string {
 
 export function JointEvaluationOption({
 	checked,
+	className,
 	deadline,
 	disabled,
 	onChange,
 }: {
 	checked: boolean;
+	className?: string;
 	deadline: Date;
 	disabled?: boolean;
 	onChange: () => void;
 }) {
+	const elementClassName = ["fr-fieldset__element", className]
+		.filter(Boolean)
+		.join(" ");
+
 	return (
-		<div className="fr-fieldset__element">
+		<div className={elementClassName}>
 			<CompliancePathOption
 				checked={checked}
 				deadline={deadline}
 				disabled={disabled}
 				id="path-joint"
 				learnMoreHref="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-				learnMoreLabel="En savoir plus sur évaluation conjointe des rémunérations"
+				learnMoreLabel="En savoir plus sur l'évaluation conjointe des rémunérations"
 				name="compliance-path"
 				onChange={onChange}
-				title="Évaluation conjointe des rémunérations"
+				title="Mettre en place une évaluation conjointe des rémunérations"
 				value="joint_evaluation"
 			>
 				<p className="fr-mb-0">
@@ -113,8 +119,15 @@ export function SecondRoundOptions({
 				disabled={disabled}
 				onChange={() => setSelectedPath("justify")}
 			/>
+
+			<h3 className="fr-h6 fr-mt-3w fr-mb-0">
+				Si la justification n&apos;est pas possible par des critères objectifs
+				et non sexistes
+			</h3>
+
 			<JointEvaluationOption
 				checked={selectedPath === "joint_evaluation"}
+				className="fr-mt-2w"
 				deadline={jointEvaluationDeadline}
 				disabled={disabled}
 				onChange={() => setSelectedPath("joint_evaluation")}

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.module.scss
@@ -1,0 +1,16 @@
+.content {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.titleRow {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+
+	// Keep the success pictogram at its intrinsic size when the title wraps.
+	> svg {
+		flex-shrink: 0;
+	}
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
@@ -47,7 +47,6 @@ export function DeclarationSuccessBanner({
 							{isSecondDeclaration
 								? "Télécharger le récapitulatif de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
 								: "Télécharger le récapitulatif de la déclaration des indicateurs"}
-							<span className="fr-link__detail">PDF</span>
 						</a>
 					)}
 				</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
@@ -24,6 +24,7 @@ export function DeclarationSuccessBanner({
 				<div className={styles.content}>
 					<div className={styles.titleRow}>
 						<DsfrPictogram
+							className="fr-artwork--green-emeraude"
 							path="/dsfr/artwork/pictograms/system/success.svg"
 							size={44}
 						/>

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
@@ -1,5 +1,7 @@
 import { formatLongDate } from "~/modules/domain";
+import { DsfrPictogram } from "~/modules/layout/shared/DsfrPictogram";
 import { ResendReceiptButton } from "~/modules/mail";
+import styles from "./DeclarationSuccessBanner.module.scss";
 
 type Props = {
 	email: string;
@@ -19,36 +21,34 @@ export function DeclarationSuccessBanner({
 	return (
 		<div className="fr-grid-row fr-grid-row--gutters fr-p-4w fr-background-alt--blue-france">
 			<div className="fr-col-12 fr-col-md-6">
-				<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-					<div className="fr-col-auto">
-						<span
-							aria-hidden="true"
-							className="fr-icon-checkbox-circle-fill fr-icon--lg fr-text-default--success"
+				<div className={styles.content}>
+					<div className={styles.titleRow}>
+						<DsfrPictogram
+							path="/dsfr/artwork/pictograms/system/success.svg"
+							size={44}
 						/>
-					</div>
-					<div className="fr-col">
-						<p className="fr-text--bold fr-text--lg fr-mb-1w">
+						<p className="fr-text--bold fr-text--lg fr-mb-0">
 							{isSecondDeclaration
 								? "Votre seconde déclaration a été transmise"
 								: "Votre déclaration a été transmise"}
 						</p>
-						<p className="fr-mb-1w">
-							Vous pouvez modifier votre déclaration jusqu'au{" "}
-							<strong>{formatLongDate(modificationDeadline)}</strong>
-						</p>
-						{pdfDownloadHref && (
-							<a
-								className="fr-link fr-link--download"
-								download
-								href={pdfDownloadHref}
-							>
-								{isSecondDeclaration
-									? "Télécharger le récapitulatif de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
-									: "Télécharger le récapitulatif de la déclaration des indicateurs"}
-								<span className="fr-link__detail">PDF</span>
-							</a>
-						)}
 					</div>
+					<p className="fr-mb-0">
+						Vous pouvez modifier votre déclaration jusqu'au{" "}
+						<strong>{formatLongDate(modificationDeadline)}</strong>
+					</p>
+					{pdfDownloadHref && (
+						<a
+							className="fr-link fr-link--download"
+							download
+							href={pdfDownloadHref}
+						>
+							{isSecondDeclaration
+								? "Télécharger le récapitulatif de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+								: "Télécharger le récapitulatif de la déclaration des indicateurs"}
+							<span className="fr-link__detail">PDF</span>
+						</a>
+					)}
 				</div>
 			</div>
 			<div className="fr-col-12 fr-col-md-6">

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -4,6 +4,7 @@ import {
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
+	getPathChoiceDeadline,
 	getSecondDeclarationDeadline,
 	getWorkforceYear,
 	isDeadlinePassed,
@@ -57,6 +58,16 @@ describe("getSecondDeclarationDeadline", () => {
 	});
 });
 
+describe("getPathChoiceDeadline", () => {
+	it("returns January 1st of the following year", () => {
+		expect(getPathChoiceDeadline(2027)).toEqual(new Date(2027 + 1, 0, 1));
+	});
+
+	it("rolls over the year boundary", () => {
+		expect(getPathChoiceDeadline(2026)).toEqual(new Date(2027, 0, 1));
+	});
+});
+
 describe("getDefaultCampaignDeadlines", () => {
 	it("returns Date objects for a given year", () => {
 		const deadlines = getDefaultCampaignDeadlines(2027);
@@ -70,6 +81,12 @@ describe("getDefaultCampaignDeadlines", () => {
 		expect(deadlines.decl2JointEvaluationDeadline).toEqual(
 			new Date(2028, 1, 1),
 		);
+	});
+
+	it("exposes the derived path choice deadline at January 1st of year + 1", () => {
+		const deadlines = getDefaultCampaignDeadlines(2027);
+		expect(deadlines.pathChoiceDeadline).toEqual(getPathChoiceDeadline(2027));
+		expect(deadlines.pathChoiceDeadline).toEqual(new Date(2028, 0, 1));
 	});
 
 	it("leaves optional campaign dates null by default", () => {

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -5,6 +5,7 @@ export {
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
+	getPathChoiceDeadline,
 	getSecondDeclarationDeadline,
 	getWorkforceYear,
 	isDeadlinePassed,

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -20,6 +20,11 @@ export function getSecondDeclarationDeadline(year: number): string {
 	return `1 décembre ${year}`;
 }
 
+/** Returns the derived deadline to choose a compliance path (January 1st of the following year). */
+export function getPathChoiceDeadline(year: number): Date {
+	return new Date(year + 1, 0, 1);
+}
+
 /** Returns default campaign deadlines for a given year (fallback when no DB config exists). */
 export function getDefaultCampaignDeadlines(year: number): CampaignDeadlines {
 	return {
@@ -31,6 +36,7 @@ export function getDefaultCampaignDeadlines(year: number): CampaignDeadlines {
 		decl2ModificationDeadline: new Date(year, 11, 1),
 		decl2JustificationDeadline: new Date(year, 11, 1),
 		decl2JointEvaluationDeadline: new Date(year + 1, 1, 1),
+		pathChoiceDeadline: getPathChoiceDeadline(year),
 	};
 }
 

--- a/packages/app/src/modules/domain/types.ts
+++ b/packages/app/src/modules/domain/types.ts
@@ -34,4 +34,5 @@ export type CampaignDeadlines = {
 	decl2ModificationDeadline: Date;
 	decl2JustificationDeadline: Date;
 	decl2JointEvaluationDeadline: Date;
+	pathChoiceDeadline: Date;
 };

--- a/packages/app/src/modules/layout/shared/DsfrPictogram.tsx
+++ b/packages/app/src/modules/layout/shared/DsfrPictogram.tsx
@@ -1,4 +1,5 @@
 type Props = {
+	className?: string;
 	path: string;
 	size?: number;
 };
@@ -6,12 +7,14 @@ type Props = {
 /**
  * Official DSFR pictogram pattern using SVG <use> references.
  * Wraps the 3-layer artwork structure (decorative, minor, major).
+ * Pass a DSFR colour-scheme modifier (e.g. "fr-artwork--green-emeraude")
+ * through `className` to recolour the artwork.
  */
-export function DsfrPictogram({ path, size = 40 }: Props) {
+export function DsfrPictogram({ className, path, size = 40 }: Props) {
 	return (
 		<svg
 			aria-hidden="true"
-			className="fr-artwork"
+			className={className ? `fr-artwork ${className}` : "fr-artwork"}
 			height={`${size}px`}
 			viewBox="0 0 80 80"
 			width={`${size}px`}

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useState } from "react";
 
 import type { CampaignDeadlines } from "~/modules/domain";
-import { getDeclarationDisplayContext } from "~/modules/domain";
+import {
+	getDeclarationDisplayContext,
+	getDefaultCampaignDeadlines,
+} from "~/modules/domain";
 import {
 	DECLARATION_PROCESS_PANEL_ID,
 	DeclarationProcessPanel,
@@ -36,18 +39,10 @@ function toInputDate(d: Date): string {
 }
 
 function buildPresetDeadlines(preset: "future" | "past"): CampaignDeadlines {
+	// Reuse the domain deadline rules; the playground only picks a base year
+	// far in the future or in the past to force the "open" / "closed" states.
 	const base = preset === "future" ? 2099 : 2020;
-	return {
-		gipPublicationDate: null,
-		campaignStartDate: null,
-		decl1ModificationDeadline: new Date(base, 5, 1),
-		decl1JustificationDeadline: new Date(base, 5, 1),
-		decl1JointEvaluationDeadline: new Date(base, 7, 1),
-		decl2ModificationDeadline: new Date(base, 11, 1),
-		decl2JustificationDeadline: new Date(base, 11, 1),
-		decl2JointEvaluationDeadline: new Date(base + 1, 1, 1),
-		pathChoiceDeadline: new Date(base + 1, 0, 1),
-	};
+	return getDefaultCampaignDeadlines(base);
 }
 
 /**

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -46,6 +46,7 @@ function buildPresetDeadlines(preset: "future" | "past"): CampaignDeadlines {
 		decl2ModificationDeadline: new Date(base, 11, 1),
 		decl2JustificationDeadline: new Date(base, 11, 1),
 		decl2JointEvaluationDeadline: new Date(base + 1, 1, 1),
+		pathChoiceDeadline: new Date(base + 1, 0, 1),
 	};
 }
 

--- a/packages/app/src/server/db/getCampaignDeadlines.ts
+++ b/packages/app/src/server/db/getCampaignDeadlines.ts
@@ -2,7 +2,10 @@ import { eq } from "drizzle-orm";
 import { cache } from "react";
 
 import type { CampaignDeadlines } from "~/modules/domain";
-import { getDefaultCampaignDeadlines } from "~/modules/domain";
+import {
+	getDefaultCampaignDeadlines,
+	getPathChoiceDeadline,
+} from "~/modules/domain";
 
 import { db } from ".";
 import { campaignDeadlines } from "./schema";
@@ -43,6 +46,7 @@ export const getCampaignDeadlines = cache(
 			decl2ModificationDeadline: parseDate(row.decl2ModificationDeadline),
 			decl2JustificationDeadline: parseDate(row.decl2JustificationDeadline),
 			decl2JointEvaluationDeadline: parseDate(row.decl2JointEvaluationDeadline),
+			pathChoiceDeadline: getPathChoiceDeadline(year),
 		};
 	},
 );


### PR DESCRIPTION
Closes #3582

## Contexte

Bug de design (visual mismatch) sur l'écran **second tour** (`isSecondRound`) du parcours de mise en conformité pour l'indicateur par catégorie de salariés. Référence : Figma node `7548-87501`. Objectif : rendu iso pixel-perfect avec le Figma, en gardant un français correct (les coquilles du Figma ne sont **pas** recopiées).

## Changements

**Domaine (champ dérivé, sans migration ni form admin)**
- `CampaignDeadlines` gagne `pathChoiceDeadline: Date` (`domain/types.ts`).
- Nouvelle fonction pure `getPathChoiceDeadline(year)` = `1er janvier de year+1` (`domain/shared/campaign.ts`), exportée du barrel. Branchée dans `getDefaultCampaignDeadlines` **et** dans `server/db/getCampaignDeadlines.ts` (valeur dérivée, jamais lue en base).

**UI**
1. Ajout du `h3` « Si la justification n'est pas possible par des critères objectifs et non sexistes » entre les 2 radios du second tour.
2. Libellé de l'option corrigé → « Mettre en place une évaluation conjointe des rémunérations » (+ libellé « En savoir plus sur **l'**évaluation conjointe… »).
3. Titres de radio en bleu DSFR (`--text-action-high-blue-france`, #000091) via classe SCSS module — les `h3` de section restent gris (#161616).
4. Phrase d'instruction conditionnelle `isSecondRound` (« …ont **de nouveau été détectés**, … ») et toute la ligne en `fr-text--medium`.
5. Nouveau bloc `fr-highlight` (barre bleue à gauche) « Date limite pour choisir un parcours de mise en conformité » + date dérivée.
6. Rythme vertical aligné sur le Figma (sous-groupe titre+lien 8px, gap de section 24px, majeur 32px).

## Fidélité Figma (vérification structurelle, node 7548-87501)

| Propriété Figma | Valeur Figma | Implémentation |
|---|---|---|
| Instruction (second tour) | Medium 500, texte « ont de nouveau été détectés » | `fr-text--medium` sur toute la ligne, texte conditionnel |
| Titre option « éval. conjointe » | « Mettre en place une évaluation conjointe des rémunérations » | identique |
| Couleur titre radio | #000091 (artwork-major / text-action-high-blue-france), H6 Bold 20px | `var(--text-action-high-blue-france)` + `fr-h6 fr-text--bold` |
| h3 de section | #161616 (text-title-grey), H6 Bold 20px | couleur DSFR par défaut conservée (`fr-h6`) |
| Bloc date | `fr-highlight`, barre #6A6AF4, label MD régulier + date 20px Bold | `fr-highlight`, label MD + `fr-text--lg fr-text--bold` |
| Gaps | titre+lien 8px / section 24px / majeur 32px | `flexColumnGapHalf` / `dataSection` (1.5rem) / `flexColumnGap2` |

Les coquilles présentes dans le Figma (« Précèdent », « non sexiste » au singulier, « vos écart par des critère objectif », double espace dans « écarts  ≥ 5 % », « de l'indicateurs », « a defaut ») ne sont **pas** reprises — le français correct du code est conservé.

## Tests

- Domaine : `getPathChoiceDeadline` / `getDefaultCampaignDeadlines.pathChoiceDeadline` au 1er janvier de l'année suivante (+ roll-over).
- Composant : `CompliancePathChoice` en mode `isSecondRound` rend le `h3` manquant, la phrase « ont de nouveau été détectés » et le bloc `fr-highlight` daté ; le premier tour conserve « ont été constatés ». Le libellé corrigé de l'option est verrouillé par les assertions.
- Suite complète verte (typecheck + vitest + lint + format). Audits structure / RGAA / sécurité : OK.

> Note : l'écran second tour est derrière l'authentification ProConnect + un état de déclaration spécifique, non reproductible en local headless. La fidélité visuelle est vérifiée structurellement contre le node Figma et par les tests de composant qui rendent l'UI exacte du second tour.
