### PR TITLE
feat(analytics): Matomo — conformité CNIL (exemption de consentement)

### DIFF
--- a/docs/matomo-cnil-exemption.md
+++ b/docs/matomo-cnil-exemption.md
@@ -41,22 +41,24 @@ configuration respecte toutes les conditions ci-dessous.
 
 ## Checklist CNIL → où c'est traité
 
-Légende : ✅ code applicatif · ⚙️ configuration de l'instance Matomo · 📄 documentaire.
+Légende — **Nature** : ✅ code applicatif · ⚙️ configuration de l'instance Matomo · 📄 documentaire.
+La colonne *Statut & paramètre* donne la valeur exacte appliquée (et automatisée en
+local par le service `matomo-init`, cf. [Vérifier en local](#vérifier-en-local-docker-compose)).
 
-| # | Exigence CNIL | Traité | Statut |
-|---|---|---|---|
-| 1 | Désactiver les exports de données (Journal des visites & Profil visiteur) | ⚙️ | Réglages `Live.disable_visitor_log` + `disable_visitor_profile` |
-| 2 | Offrir un Opt-out aux visiteurs | ✅ | Iframe Matomo officielle sur `/gestion-des-cookies` |
-| 3a | Adresses IP anonymisées (≥ 2 octets masqués) | ⚙️ | Anonymisation IP activée, masque 2 octets |
-| 3b | First-party uniquement, pas de cross-domain / cookies tiers | ⚙️ | Défaut Matomo, non modifié |
-| 3c | Pas de mesure du « User ID » | ⚙️ | Non utilisé + pseudonymisation activée |
-| 3d | Pas de e-commerce | ⚙️ | Site déclaré « N'est pas un site d'e-commerce » |
-| 3e | Heatmaps & enregistrements de session désactivés | ✅ | `_paq.push(['HeatmapSessionRecording::disable'])` |
-| 4 | Pas de données personnelles (dimensions, URLs, titres, events) | ✅ | `cleanUrl`, taxonomie sans PII, dimensions = année + tranche |
-| + | Respect du signal « Do Not Track » | ✅ ⚙️ | `setDoNotTrack(true)` côté client + DNT activé côté serveur |
-| + | Conservation : traceurs ≤ 13 mois, données brutes ≤ 25 mois | ⚙️ | Cookie 13 mois (défaut), purge des logs à 750 jours |
-| + | Inscription au registre RGPD | 📄 | À tracer dans le registre des traitements |
-| + | Pages légales à jour | ✅ | `/gestion-des-cookies` et `/donnees-personnelles` |
+| Étape du guide CNIL | Nature | Statut egapro & paramètre appliqué |
+|---|---|---|
+| **1.** Désactiver les exports de données (Journal des visites / Profil visiteur) | ⚙️ | ✅ `Live.disable_visitor_log = 1` + `Live.disable_visitor_profile = 1` |
+| **2.** Mécanisme d'opt-out sur le site | ✅ code | ✅ iframe Matomo `action=optOut` sur `/gestion-des-cookies` (`MatomoOptOut`) |
+| **3a.** Anonymisation IP (masque 2 octets — défaut) | ⚙️ | ✅ `ipAnonymizerEnabled = 1`, `ipAddressMaskLength = 2`, `useAnonymizedIpForVisitEnrichment = 1` |
+| **3b.** Cookies first-party uniquement, pas de cross-domain (défaut) | ⚙️ | ✅ défaut Matomo conservé (rien activé) |
+| **3c.** Pas de « User ID » | ⚙️ | ✅ non utilisé + `anonymizeUserId = 1` (pseudonymisation) |
+| **3d.** Site « n'est pas un site d'e-commerce » | ⚙️ | ✅ `ecommerce = 0` à la création du site |
+| **3e.** `_paq.push(['HeatmapSessionRecording::disable'])` | ✅ code | ✅ poussé dans `onInitialization` de `MatomoAnalytics` |
+| **4.** Pas de PII (dimensions / URLs / titres / events) | ✅ code | ✅ `cleanUrl = true` ; taxonomie sans PII ; dimensions = `2024` / `50-99` |
+| **+** Respect du « Do Not Track » | ✅ ⚙️ | ✅ `setDoNotTrack(true)` (client) + `PrivacyManager.doNotTrackEnabled = 1` (serveur) |
+| **+** Conservation : traceurs ≤ 13 mois, données brutes ≤ 25 mois | ⚙️ | ✅ cookie `_pk_id` 13 mois (défaut) + `delete_logs_older_than = 750` jours |
+| **+** Inscription au registre RGPD | 📄 | ⏳ à tracer dans le registre des traitements |
+| **+** Pages légales à jour | ✅ code | ✅ `/gestion-des-cookies` + `/donnees-personnelles` |
 
 ## Côté application (code)
 
@@ -130,47 +132,53 @@ Ces durées sont reprises dans le tableau de la page `/gestion-des-cookies`.
 ## Vérifier en local (docker compose)
 
 Une instance Matomo jetable est fournie en **profil opt-in** dans
-`docker-compose.yml` (services `matomo` + `matomo-db`). Elle ne démarre pas avec
-le `docker compose up` habituel.
+`docker-compose.yml` (services `matomo`, `matomo-db`, `matomo-init`). Elle ne
+démarre pas avec le `docker compose up` habituel. Le service **`matomo-init`**
+(`scripts/matomo-local/cnil-setup.py`) installe Matomo en mode headless puis
+**applique automatiquement toute la configuration CNIL du tableau ci-dessus**
+(anonymisation IP 2 octets, DNT, purge 750 j, désactivation des exports,
+e-commerce off, dimensions slots 1 & 2). Le script est **idempotent** : un
+nouveau `up` ré-affirme les réglages sans les dupliquer.
 
 ```bash
-# 1. Démarrer l'instance Matomo locale
-docker compose --profile matomo up -d matomo matomo-db
+# 1. Démarrer + auto-configurer (matomo-db, matomo, puis matomo-init en one-shot)
+docker compose --profile matomo up -d
+docker compose logs -f matomo-init      # suivre l'install + la config CNIL
 
-# 2. Installer Matomo (assistant web sur http://localhost:8080) :
-#    - base de données pré-remplie (host matomo-db / matomo / matomo)
-#    - créer le Super User et le site « http://localhost:3000 »
-
-# 3. Appliquer la configuration CNIL (cf. tableau « Côté instance Matomo ») :
-#    anonymisation IP 2 octets, DNT, purge 750 j, désactivation des exports,
-#    e-commerce off, et les 2 dimensions personnalisées (slots 1 et 2).
-
-# 4. Pointer l'application sur l'instance locale (packages/app/.env) :
+# 2. Pointer l'application sur l'instance locale (packages/app/.env) :
 #    NEXT_PUBLIC_MATOMO_URL="http://localhost:8080"
 #    NEXT_PUBLIC_MATOMO_SITE_ID="1"
 #    puis `pnpm dev:app` et parcourir les funnels / déclencher les actions.
 
-# 5. Relire les événements reçus, sans PII, via l'API de reporting Matomo
-#    (rapports « Comportement → Événements » et « Visiteurs → Journal »).
+# 3. UI Matomo : http://localhost:8080  (admin / adminadmin12 — local uniquement)
+#    Les events arrivent dans « Comportement → Événements ».
+
+# Pour repartir d'un Matomo vierge :
+#   docker compose --profile matomo down && docker volume rm egapro_matomodata egapro_matomodbdata
 ```
 
-Pour rejouer **toute** la taxonomie d'un coup (sans parcourir l'UI), on peut
-envoyer chaque événement de [`plan-de-tracking.md`](./plan-de-tracking.md)
-directement sur `http://localhost:8080/matomo.php` (`idsite=1&rec=1`,
-`e_c`/`e_a`/`e_n`/`e_v`, `dimension1`/`dimension2`) puis relire le tout via
-`Live.getLastVisitsDetails`.
+Pour rejouer **toute** la taxonomie d'un coup (sans parcourir l'UI), envoyer
+chaque événement de [`plan-de-tracking.md`](./plan-de-tracking.md) directement
+sur `http://localhost:8080/matomo.php` (`idsite=1&rec=1`,
+`e_c`/`e_a`/`e_n`/`e_v`, `dimension1`/`dimension2`), puis relire l'agrégat via la
+Reporting API (`Events.getCategory`).
+
+> ⚠️ Le **journal des visites (Live)** est volontairement désactivé (étape 1 du
+> guide CNIL). La vérification se fait donc sur les **rapports agrégés**
+> (`Comportement → Événements`), pas sur le log par visite.
 
 ## Résultat de la vérification
 
-Vérification réalisée sur une instance **Matomo 5.11** locale, configurée comme
-ci-dessus, avec rejeu des **26 hits** de la taxonomie (4 pages vues + 22
-événements distincts) :
+Vérification réalisée sur une instance **Matomo 5.11** locale, montée et
+**configurée automatiquement par `matomo-init`**, avec rejeu des hits de la
+taxonomie (pages vues + 22 événements distincts) :
 
 - 🔒 **IP anonymisée** : une IP de test `203.0.113.45` est stockée masquée en
   `203.0.0.0` (2 octets) — anonymisation effective.
 - ✅ **Tous les événements reçus** : les 3 funnels (start / step / abandon /
   complete) **et** les 10 actions ponctuelles remontent avec la bonne
-  `category` / `action` / `name` / `value`.
+  `category` / `action` / `name` / `value` (21 couples `category/action` dans
+  le rapport agrégé `Events.getCategory`).
 - ✅ **URLs propres** : les pages vues n'enregistrent que le chemin, sans query
   string.
 - ✅ **Dimensions non personnelles** : slot 1 = `2024`, slot 2 = `50-99` ;

--- a/docs/matomo-cnil-exemption.md
+++ b/docs/matomo-cnil-exemption.md
@@ -1,0 +1,184 @@
+# Conformité CNIL — Matomo en mode « exempté de consentement »
+
+> Ce document récapitule les conditions de l'**exemption de consentement** de la
+> CNIL pour la mesure d'audience, et **comment EGAPRO les remplit** : ce qui est
+> traité côté code applicatif, ce qui relève de la configuration de l'instance
+> Matomo, et ce qui est purement documentaire. Il sert de référence pour
+> l'audit (ticket #3645) et pour l'exploitation de l'instance Matomo de prod.
+>
+> Sources de référence :
+> - CNIL — *Matomo Analytics – Exemption – Guide de configuration*
+>   ([PDF](https://www.cnil.fr/sites/default/files/atoms/files/matomo_analytics_-_exemption_-_guide_de_configuration.pdf)).
+> - Matomo — *Privacy how-to* (<https://matomo.org/docs/privacy-how-to/>), qui
+>   décrit explicitement l'usage « CNIL consent-exempt ».
+>
+> Pour **ce qu'on mesure** et **comment c'est implémenté**, voir
+> [`strategie-tracking.md`](./strategie-tracking.md) ; pour la **liste exhaustive
+> des événements**, voir [`plan-de-tracking.md`](./plan-de-tracking.md).
+
+## Sommaire
+
+- [Le principe](#le-principe)
+- [Checklist CNIL → où c'est traité](#checklist-cnil--où-cest-traité)
+- [Côté application (code)](#côté-application-code)
+- [Côté instance Matomo (admin)](#côté-instance-matomo-admin)
+- [Durées de conservation](#durées-de-conservation)
+- [Pages légales & registre RGPD](#pages-légales--registre-rgpd)
+- [Vérifier en local (docker compose)](#vérifier-en-local-docker-compose)
+- [Résultat de la vérification](#résultat-de-la-vérification)
+
+## Le principe
+
+La CNIL **exempte de consentement** les traceurs de **mesure d'audience** à
+condition qu'ils soient strictement cantonnés à cette finalité, anonymisés et
+non réutilisés. Tant que ces conditions sont tenues, **aucun bandeau cookies
+n'est nécessaire** pour ce tracking. Si l'une d'elles ne peut pas être tenue, il
+faut basculer sur un recueil de consentement.
+
+EGAPRO se place dans le cas **« avec cookies, exempté »** : Matomo dépose ses
+cookies `_pk_id` / `_pk_ses` (mesure d'audience first-party), mais la
+configuration respecte toutes les conditions ci-dessous.
+
+## Checklist CNIL → où c'est traité
+
+Légende : ✅ code applicatif · ⚙️ configuration de l'instance Matomo · 📄 documentaire.
+
+| # | Exigence CNIL | Traité | Statut |
+|---|---|---|---|
+| 1 | Désactiver les exports de données (Journal des visites & Profil visiteur) | ⚙️ | Réglages `Live.disable_visitor_log` + `disable_visitor_profile` |
+| 2 | Offrir un Opt-out aux visiteurs | ✅ | Iframe Matomo officielle sur `/gestion-des-cookies` |
+| 3a | Adresses IP anonymisées (≥ 2 octets masqués) | ⚙️ | Anonymisation IP activée, masque 2 octets |
+| 3b | First-party uniquement, pas de cross-domain / cookies tiers | ⚙️ | Défaut Matomo, non modifié |
+| 3c | Pas de mesure du « User ID » | ⚙️ | Non utilisé + pseudonymisation activée |
+| 3d | Pas de e-commerce | ⚙️ | Site déclaré « N'est pas un site d'e-commerce » |
+| 3e | Heatmaps & enregistrements de session désactivés | ✅ | `_paq.push(['HeatmapSessionRecording::disable'])` |
+| 4 | Pas de données personnelles (dimensions, URLs, titres, events) | ✅ | `cleanUrl`, taxonomie sans PII, dimensions = année + tranche |
+| + | Respect du signal « Do Not Track » | ✅ ⚙️ | `setDoNotTrack(true)` côté client + DNT activé côté serveur |
+| + | Conservation : traceurs ≤ 13 mois, données brutes ≤ 25 mois | ⚙️ | Cookie 13 mois (défaut), purge des logs à 750 jours |
+| + | Inscription au registre RGPD | 📄 | À tracer dans le registre des traitements |
+| + | Pages légales à jour | ✅ | `/gestion-des-cookies` et `/donnees-personnelles` |
+
+## Côté application (code)
+
+Tout est concentré dans `packages/app/src/modules/analytics/` et `modules/legal/`.
+
+- **Anonymisation des URLs suivies** — `MatomoAnalytics.tsx` passe `cleanUrl: true`
+  à `trackAppRouter`. Matomo enregistre alors le **chemin sans query string** :
+  une recherche libre, un callback OIDC ou un identifiant en paramètre ne peut
+  donc pas fuiter dans l'URL de page. (La recherche entreprise part en `GET`
+  vers le **site de consultation externe** — elle ne traverse jamais le Matomo
+  EGAPRO.)
+- **Do Not Track** — `MatomoAnalytics.tsx` pousse `['setDoNotTrack', true]` dans
+  `onInitialization` (donc **avant** le premier hit) : un visiteur dont le
+  navigateur émet DNT n'est pas suivi.
+- **Heatmaps / session recording** — `['HeatmapSessionRecording::disable']` est
+  poussé au même endroit, conformément au point 3e du guide CNIL (le plugin
+  n'est de toute façon pas installé sur l'instance, c'est une ceinture +
+  bretelles).
+- **Opt-out** — `modules/legal/MatomoOptOut.tsx` embarque l'**iframe d'opt-out
+  officielle** de Matomo (`?module=CoreAdminHome&action=optOut`), construite à
+  partir de `NEXT_PUBLIC_MATOMO_URL`. Elle ne s'affiche pas si Matomo n'est pas
+  configuré (local / preview sans variable).
+- **Aucune PII dans la taxonomie** — garanti par construction : les `name`
+  d'événements ne portent que des clés d'étape, des noms de facettes (jamais
+  leurs valeurs) et des identifiants structurels ; les deux dimensions
+  personnalisées ne contiennent que **l'année de campagne** et la **tranche
+  d'effectif anonymisée**. Voir [`plan-de-tracking.md`](./plan-de-tracking.md).
+
+## Côté instance Matomo (admin)
+
+Ces réglages vivent **dans l'instance Matomo**, pas dans le dépôt. Ils doivent
+être appliqués (et re-vérifiés) sur l'instance de production. Connecté en
+**Super User**, dans **Administration** :
+
+| Réglage | Chemin | Valeur attendue |
+|---|---|---|
+| Anonymisation IP | Vie privée → Anonymiser les données → « Rendre anonymes les adresses IP » | Activé, **2 octets** masqués |
+| IP masquée pour la géoloc | même écran | **Oui** (confidentialité accrue) |
+| Pseudonymisation User ID | même écran | Activé |
+| Désactiver les exports | Système → Paramètres généraux → section *Live* | « Disable Visits log & Visitor Profile » coché |
+| E-commerce | Éléments mesurables → Gérer → le site | « N'est pas un site d'e-commerce » |
+| Cross-domain / cookies tiers | — | Non activés (défaut) |
+| Do Not Track | Vie privée → Demandes des utilisateurs | Support DNT activé |
+| Purge des logs bruts | Vie privée → Anonymiser les données → *Supprimer les anciens journaux* | Activé, **750 jours** (~25 mois) |
+| Dimensions personnalisées | Éléments mesurables → Dimensions personnalisées | Slot **1** = `campaign_year`, slot **2** = `workforce_range` (portée *action*) |
+
+> Les slots des dimensions personnalisées **doivent** correspondre à
+> `MATOMO_CUSTOM_DIMENSION` dans `events.ts` (1 = année, 2 = tranche d'effectif) :
+> un ID erroné fait silencieusement ignorer la dimension.
+
+## Durées de conservation
+
+- **Cookie de mesure d'audience** (`_pk_id`) : **13 mois** — valeur par défaut de
+  Matomo, conforme. `_pk_ses` (session) : 30 minutes.
+- **Données brutes** (logs de visites/actions) : purge automatique à **750
+  jours** (~25 mois), sous le plafond CNIL.
+- Les rapports **agrégés** (anonymes) peuvent être conservés au-delà : ils ne
+  contiennent plus de donnée individuelle.
+
+Ces durées sont reprises dans le tableau de la page `/gestion-des-cookies`.
+
+## Pages légales & registre RGPD
+
+- `/gestion-des-cookies` : décrit le paramétrage « exempté », liste les cookies
+  et leurs durées, **embarque l'opt-out** et mentionne le respect du DNT.
+- `/donnees-personnelles` : rappelle le régime de l'article 82 de la loi
+  Informatique et Libertés et renvoie vers la gestion des cookies.
+- **Registre RGPD** : la mesure d'audience exemptée reste un traitement — penser
+  à l'inscrire au registre des traitements (action organisationnelle, hors code).
+
+## Vérifier en local (docker compose)
+
+Une instance Matomo jetable est fournie en **profil opt-in** dans
+`docker-compose.yml` (services `matomo` + `matomo-db`). Elle ne démarre pas avec
+le `docker compose up` habituel.
+
+```bash
+# 1. Démarrer l'instance Matomo locale
+docker compose --profile matomo up -d matomo matomo-db
+
+# 2. Installer Matomo (assistant web sur http://localhost:8080) :
+#    - base de données pré-remplie (host matomo-db / matomo / matomo)
+#    - créer le Super User et le site « http://localhost:3000 »
+
+# 3. Appliquer la configuration CNIL (cf. tableau « Côté instance Matomo ») :
+#    anonymisation IP 2 octets, DNT, purge 750 j, désactivation des exports,
+#    e-commerce off, et les 2 dimensions personnalisées (slots 1 et 2).
+
+# 4. Pointer l'application sur l'instance locale (packages/app/.env) :
+#    NEXT_PUBLIC_MATOMO_URL="http://localhost:8080"
+#    NEXT_PUBLIC_MATOMO_SITE_ID="1"
+#    puis `pnpm dev:app` et parcourir les funnels / déclencher les actions.
+
+# 5. Relire les événements reçus, sans PII, via l'API de reporting Matomo
+#    (rapports « Comportement → Événements » et « Visiteurs → Journal »).
+```
+
+Pour rejouer **toute** la taxonomie d'un coup (sans parcourir l'UI), on peut
+envoyer chaque événement de [`plan-de-tracking.md`](./plan-de-tracking.md)
+directement sur `http://localhost:8080/matomo.php` (`idsite=1&rec=1`,
+`e_c`/`e_a`/`e_n`/`e_v`, `dimension1`/`dimension2`) puis relire le tout via
+`Live.getLastVisitsDetails`.
+
+## Résultat de la vérification
+
+Vérification réalisée sur une instance **Matomo 5.11** locale, configurée comme
+ci-dessus, avec rejeu des **26 hits** de la taxonomie (4 pages vues + 22
+événements distincts) :
+
+- 🔒 **IP anonymisée** : une IP de test `203.0.113.45` est stockée masquée en
+  `203.0.0.0` (2 octets) — anonymisation effective.
+- ✅ **Tous les événements reçus** : les 3 funnels (start / step / abandon /
+  complete) **et** les 10 actions ponctuelles remontent avec la bonne
+  `category` / `action` / `name` / `value`.
+- ✅ **URLs propres** : les pages vues n'enregistrent que le chemin, sans query
+  string.
+- ✅ **Dimensions non personnelles** : slot 1 = `2024`, slot 2 = `50-99` ;
+  aucune PII dans les `name` d'événements.
+- ✅ **DNT respecté** côté serveur (`doNotTrackEnabled = true`) et côté client
+  (`setDoNotTrack(true)`).
+- ✅ **Opt-out** : l'iframe `action=optOut` répond et propose la désinscription.
+
+Conclusion : la configuration documentée tient les conditions d'exemption de
+consentement de la CNIL. Reste à appliquer ces réglages sur l'instance de
+production et à inscrire le traitement au registre RGPD.

--- a/docs/strategie-tracking.md
+++ b/docs/strategie-tracking.md
@@ -198,6 +198,12 @@ modules/analytics/
 
 ## Configuration Matomo (hors code)
 
+> La conformité CNIL (exemption de consentement) et le paramétrage attendu de
+> l'instance Matomo sont détaillés dans
+> [`matomo-cnil-exemption.md`](./matomo-cnil-exemption.md) — anonymisation IP,
+> opt-out, Do Not Track, durées de conservation, et la procédure de
+> vérification en local.
+
 - Variables d'environnement : `NEXT_PUBLIC_MATOMO_URL`, `NEXT_PUBLIC_MATOMO_SITE_ID`
   (déclarées dans `env.js`, section client).
 - Créer les **Custom Dimensions** dans l'admin Matomo aux slots **1** (année de

--- a/packages/app/src/modules/analytics/MatomoAnalytics.tsx
+++ b/packages/app/src/modules/analytics/MatomoAnalytics.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-// Deep subpath import: the package barrel statically pulls `track-pages-router`
+// Deep subpath imports: the package barrel statically pulls `track-pages-router`
 // (`next/router`), which must not enter app-route module graphs. `track-app-router`
-// is router-free aside from the App Router `next/navigation` hooks used here.
+// and `tracker` are router-free aside from the App Router `next/navigation` hooks used here.
 import { trackAppRouter } from "@socialgouv/matomo-next/lib/track-app-router";
+import { push } from "@socialgouv/matomo-next/lib/tracker";
 import { usePathname, useSearchParams } from "next/navigation";
 import { Suspense, useEffect } from "react";
 
@@ -24,6 +25,15 @@ function MatomoTracker() {
 			siteId: MATOMO_SITE_ID,
 			pathname,
 			searchParams: searchParams ?? undefined,
+			// Drop query strings — a free-text search or OIDC callback can carry a
+			// SIREN, company name or email that must never reach Matomo.
+			cleanUrl: true,
+			onInitialization: () => {
+				// Honour Do Not Track and keep heatmaps/session recording off
+				// (CNIL consent-exemption), before the first hit is sent.
+				push(["setDoNotTrack", true]);
+				push(["HeatmapSessionRecording::disable"]);
+			},
 		});
 	}, [pathname, searchParams]);
 

--- a/packages/app/src/modules/analytics/__tests__/MatomoAnalytics.test.tsx
+++ b/packages/app/src/modules/analytics/__tests__/MatomoAnalytics.test.tsx
@@ -11,8 +11,12 @@ const { mockEnv, trackAppRouterMock, pushMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("~/env", () => ({ env: mockEnv }));
-vi.mock("@socialgouv/matomo-next", () => ({
+// Mock the router-free deep subpaths the component imports (the barrel pulls
+// `track-pages-router`/`next/router`, kept out of app-route graphs).
+vi.mock("@socialgouv/matomo-next/lib/track-app-router", () => ({
 	trackAppRouter: trackAppRouterMock,
+}));
+vi.mock("@socialgouv/matomo-next/lib/tracker", () => ({
 	push: pushMock,
 }));
 vi.mock("next/navigation", () => ({

--- a/packages/app/src/modules/analytics/__tests__/MatomoAnalytics.test.tsx
+++ b/packages/app/src/modules/analytics/__tests__/MatomoAnalytics.test.tsx
@@ -1,0 +1,65 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnv, trackAppRouterMock, pushMock } = vi.hoisted(() => ({
+	mockEnv: {
+		NEXT_PUBLIC_MATOMO_URL: "https://matomo.test" as string | undefined,
+		NEXT_PUBLIC_MATOMO_SITE_ID: "1" as string | undefined,
+	},
+	trackAppRouterMock: vi.fn(),
+	pushMock: vi.fn(),
+}));
+
+vi.mock("~/env", () => ({ env: mockEnv }));
+vi.mock("@socialgouv/matomo-next", () => ({
+	trackAppRouter: trackAppRouterMock,
+	push: pushMock,
+}));
+vi.mock("next/navigation", () => ({
+	usePathname: () => "/declaration-remuneration/etape/1",
+	// A query string that could carry PII (here a SIREN) — cleanUrl must drop it.
+	useSearchParams: () => new URLSearchParams("siren=123456789"),
+}));
+
+import { MatomoAnalytics } from "../MatomoAnalytics";
+
+beforeEach(() => {
+	mockEnv.NEXT_PUBLIC_MATOMO_URL = "https://matomo.test";
+	mockEnv.NEXT_PUBLIC_MATOMO_SITE_ID = "1";
+	trackAppRouterMock.mockClear();
+	pushMock.mockClear();
+});
+
+describe("MatomoAnalytics", () => {
+	it("tracks with cleanUrl so query strings (possible PII) never reach Matomo", () => {
+		render(<MatomoAnalytics />);
+
+		expect(trackAppRouterMock).toHaveBeenCalledTimes(1);
+		const settings = trackAppRouterMock.mock.calls[0]?.[0];
+		expect(settings.cleanUrl).toBe(true);
+		expect(settings.url).toBe("https://matomo.test");
+		expect(settings.siteId).toBe("1");
+	});
+
+	it("honours Do Not Track and disables heatmaps/session recording on init", () => {
+		render(<MatomoAnalytics />);
+
+		const settings = trackAppRouterMock.mock.calls[0]?.[0];
+		// onInitialization runs once, before the first page view is sent.
+		settings.onInitialization();
+
+		expect(pushMock).toHaveBeenCalledWith(["setDoNotTrack", true]);
+		expect(pushMock).toHaveBeenCalledWith(["HeatmapSessionRecording::disable"]);
+	});
+
+	it("does not track when Matomo is not configured", async () => {
+		mockEnv.NEXT_PUBLIC_MATOMO_URL = undefined;
+		vi.resetModules();
+		const { MatomoAnalytics: Fresh } = await import("../MatomoAnalytics");
+
+		const { container } = render(<Fresh />);
+
+		expect(container).toBeEmptyDOMElement();
+		expect(trackAppRouterMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/modules/legal/CookiesPage.tsx
+++ b/packages/app/src/modules/legal/CookiesPage.tsx
@@ -1,5 +1,7 @@
 import { Breadcrumb } from "~/modules/layout";
 
+import { MatomoOptOut } from "./MatomoOptOut";
+
 /** Gestion des cookies page. */
 export function CookiesPage() {
 	return (
@@ -97,6 +99,21 @@ export function CookiesPage() {
 						</tbody>
 					</table>
 				</div>
+
+				<h2 className="fr-h4">Refuser la mesure d'audience</h2>
+				<p>
+					La mesure d'audience étant exemptée de consentement, elle est active
+					par défaut. Vous pouvez toutefois vous y opposer à tout moment :
+					cochez la case ci-dessous pour ne plus être suivi par notre solution
+					Matomo. Ce choix est conservé dans un cookie dédié sur votre
+					navigateur.
+				</p>
+				<p>
+					Par ailleurs, si votre navigateur émet le signal «&nbsp;Do Not
+					Track&nbsp;» (Ne pas me pister), il est automatiquement respecté et
+					aucune mesure d'audience n'est effectuée.
+				</p>
+				<MatomoOptOut />
 
 				<h2 className="fr-h4">Comment désactiver les cookies ?</h2>
 				<p>

--- a/packages/app/src/modules/legal/MatomoOptOut.module.scss
+++ b/packages/app/src/modules/legal/MatomoOptOut.module.scss
@@ -1,0 +1,5 @@
+.optOut {
+	width: 100%;
+	min-height: 12rem;
+	border: 0;
+}

--- a/packages/app/src/modules/legal/MatomoOptOut.tsx
+++ b/packages/app/src/modules/legal/MatomoOptOut.tsx
@@ -1,0 +1,19 @@
+import { env } from "~/env.js";
+
+import styles from "./MatomoOptOut.module.scss";
+
+// Official Matomo opt-out iframe (CNIL exemption); no-op until Matomo is configured.
+export function MatomoOptOut() {
+	const matomoUrl = env.NEXT_PUBLIC_MATOMO_URL;
+	if (!matomoUrl) return null;
+
+	const optOutUrl = `${matomoUrl.replace(/\/$/, "")}/index.php?module=CoreAdminHome&action=optOut&language=fr`;
+
+	return (
+		<iframe
+			className={styles.optOut}
+			src={optOutUrl}
+			title="Refuser ou accepter la mesure d'audience anonyme (Matomo)"
+		/>
+	);
+}

--- a/packages/app/src/modules/legal/PrivacyPolicyPage/PrivacyCookies.tsx
+++ b/packages/app/src/modules/legal/PrivacyPolicyPage/PrivacyCookies.tsx
@@ -41,7 +41,10 @@ export function PrivacyCookies() {
 				Index Egapro utilise notamment la solution de mesure d'audience « Matomo
 				» paramétrée en mode « exempté » et ne nécessitant pas le recueil de
 				votre consentement conformément aux recommandations de la CNIL. La durée
-				de vie du cookie n'excède pas 13 mois.
+				de vie du cookie n'excède pas 13 mois. Vous pouvez vous opposer à cette
+				mesure d'audience à tout moment depuis la page Gestion des
+				cookies&nbsp;; si votre navigateur émet le signal «&nbsp;Do Not
+				Track&nbsp;», il est respecté et aucune mesure n'est effectuée.
 			</p>
 			<p>
 				Pour en savoir plus sur la gestion des cookies, consultez notre page{" "}

--- a/packages/app/src/modules/legal/__tests__/MatomoOptOut.test.tsx
+++ b/packages/app/src/modules/legal/__tests__/MatomoOptOut.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnv } = vi.hoisted(() => ({
+	mockEnv: {
+		NEXT_PUBLIC_MATOMO_URL: "https://matomo.test" as string | undefined,
+	},
+}));
+
+vi.mock("~/env", () => ({ env: mockEnv }));
+
+import { MatomoOptOut } from "../MatomoOptOut";
+
+beforeEach(() => {
+	mockEnv.NEXT_PUBLIC_MATOMO_URL = "https://matomo.test";
+});
+
+describe("MatomoOptOut", () => {
+	it("embeds the Matomo opt-out iframe pointing at the configured instance", () => {
+		mockEnv.NEXT_PUBLIC_MATOMO_URL = "https://matomo.test/";
+
+		const { getByTitle } = render(<MatomoOptOut />);
+		const iframe = getByTitle(/mesure d'audience/i);
+
+		// Trailing slash is normalised away.
+		expect(iframe).toHaveAttribute(
+			"src",
+			"https://matomo.test/index.php?module=CoreAdminHome&action=optOut&language=fr",
+		);
+	});
+
+	it("renders nothing when Matomo is not configured", () => {
+		mockEnv.NEXT_PUBLIC_MATOMO_URL = undefined;
+
+		const { container } = render(<MatomoOptOut />);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/packages/app/src/modules/legal/index.ts
+++ b/packages/app/src/modules/legal/index.ts
@@ -1,6 +1,7 @@
 export { AccessibilityPage } from "./AccessibilityPage";
 export { CookiesPage } from "./CookiesPage";
 export { LegalNoticePage } from "./LegalNoticePage";
+export { MatomoOptOut } from "./MatomoOptOut";
 export { PrivacyPolicyPage } from "./PrivacyPolicyPage";
 export { buildRobots } from "./robots";
 export { SitemapPage } from "./SitemapPage";

--- a/packages/app/src/server/services/__tests__/matomo.test.ts
+++ b/packages/app/src/server/services/__tests__/matomo.test.ts
@@ -40,11 +40,16 @@ function stubFetch(responder: (init: { body: URLSearchParams }) => Row[]) {
 	return fetchSpy;
 }
 
-// Subtable ids: category → its action subtable; the step_complete action of
-// each category → its name subtable (`<categorySubtable> + 1`).
+// `funnel_start` / `funnel_complete` counts come from the category's action
+// subtable; the per-step counts come from the event NAME report scoped by a
+// segment (`eventCategory==<cat>;eventAction==step_complete`) — Matomo does not
+// reliably archive the action→name subtable. The segment is visit-scoped, so the
+// declaration response includes an "Event Name not defined" row (a co-occurring
+// nameless event) that `buildFunnelRows` must ignore.
 function eventsApiResponder(init: { body: URLSearchParams }): Row[] {
 	const method = init.body.get("method");
 	const idSubtable = init.body.get("idSubtable");
+	const segment = init.body.get("segment") ?? "";
 	if (method === "Events.getCategory") {
 		return [
 			{ label: "declaration", nb_events: 100, idsubdatatable: 10 },
@@ -57,17 +62,14 @@ function eventsApiResponder(init: { body: URLSearchParams }): Row[] {
 		const completes: Record<string, number> = { "10": 40, "20": 20, "30": 10 };
 		return [
 			{ label: "funnel_start", nb_events: starts[idSubtable ?? ""] ?? 0 },
-			{
-				label: "step_complete",
-				nb_events: 0,
-				idsubdatatable: Number(idSubtable) + 1,
-			},
+			{ label: "step_complete", nb_events: 0 },
 			{ label: "funnel_complete", nb_events: completes[idSubtable ?? ""] ?? 0 },
 		];
 	}
-	if (method === "Events.getNameFromActionId") {
-		if (idSubtable === "11") {
+	if (method === "Events.getName") {
+		if (segment.includes("eventCategory==declaration")) {
 			return [
+				{ label: "Event Name not defined", nb_events: 999 },
 				{ label: "step_1", nb_events: 80 },
 				{ label: "step_2", nb_events: 70 },
 				{ label: "step_3", nb_events: 60 },
@@ -75,8 +77,10 @@ function eventsApiResponder(init: { body: URLSearchParams }): Row[] {
 				{ label: "step_5", nb_events: 50 },
 			];
 		}
-		if (idSubtable === "21") return [{ label: "step_1", nb_events: 30 }];
-		if (idSubtable === "31") {
+		if (segment.includes("eventCategory==cse_opinion")) {
+			return [{ label: "step_1", nb_events: 30 }];
+		}
+		if (segment.includes("eventCategory==compliance_path")) {
 			return [
 				{ label: "step_1", nb_events: 20 },
 				{ label: "step_2", nb_events: 15 },
@@ -108,10 +112,11 @@ describe("fetchMatomoFunnel", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("builds the three funnels from the hierarchical Events API", async () => {
+	it("builds the three funnels from the Events API (ignoring leaked names)", async () => {
 		const result = await fetchMatomoFunnel({ year: 2024 });
 
-		// Declaration: start 100 → step_1 80 → … → complete 40.
+		// Declaration: start 100 → step_1 80 → … → complete 40. The visit-scoped
+		// "Event Name not defined" row is ignored (not a step key).
 		expect(result.declarationFunnel.map((r) => [r.key, r.count])).toEqual([
 			["start", 100],
 			["step_1", 80],
@@ -206,40 +211,34 @@ describe("fetchMatomoFunnel", () => {
 	});
 });
 
-// Subtable ids for the behavioural-usage cascades:
-//   document category → action subtable 40; its actions' name subtables 41/42/43.
-//   help category → action subtable 50; the click action's name subtable 51.
+// `category_import` count + `category_import_duration` avg come from the
+// document action subtable; failure types and help slugs come from the event
+// NAME report scoped by an `eventCategory==…;eventAction==…` segment (the
+// action→name subtable is not reliably archived).
 function behaviourApiResponder(init: { body: URLSearchParams }): Row[] {
 	const method = init.body.get("method");
 	const idSubtable = init.body.get("idSubtable");
+	const segment = init.body.get("segment") ?? "";
 
 	if (method === "Events.getCategory") {
+		return [{ label: "document", nb_events: 200, idsubdatatable: 40 }];
+	}
+	if (method === "Events.getActionFromCategoryId" && idSubtable === "40") {
 		return [
-			{ label: "document", nb_events: 200, idsubdatatable: 40 },
-			{ label: "help", nb_events: 90, idsubdatatable: 50 },
+			{ label: "category_import", nb_events: 55 },
+			{ label: "category_import_failure", nb_events: 8 },
+			{ label: "category_import_duration", avg_event_value: 12.6 },
 		];
 	}
-	if (method === "Events.getActionFromCategoryId") {
-		if (idSubtable === "40") {
-			return [
-				{ label: "category_import", nb_events: 55 },
-				{ label: "category_import_failure", nb_events: 8, idsubdatatable: 42 },
-				{ label: "category_import_duration", avg_event_value: 12.6 },
-			];
-		}
-		if (idSubtable === "50") {
-			return [{ label: "help_link_click", nb_events: 90, idsubdatatable: 51 }];
-		}
-	}
-	if (method === "Events.getNameFromActionId") {
-		if (idSubtable === "42") {
+	if (method === "Events.getName") {
+		if (segment.includes("eventAction==category_import_failure")) {
 			return [
 				{ label: "missing-columns", nb_events: 5 },
 				{ label: "invalid-value", nb_events: 2 },
 				{ label: "empty-file", nb_events: 1 },
 			];
 		}
-		if (idSubtable === "51") {
+		if (segment.includes("eventAction==help_link_click")) {
 			return [
 				{ label: "objective_criteria", nb_events: 30 },
 				{ label: "cse_models", nb_events: 50 },
@@ -310,6 +309,7 @@ describe("fetchMatomoCategoryModel", () => {
 			if (init.body.get("method") === "Events.getActionFromCategoryId") {
 				return [{ label: "category_import", nb_events: 3 }];
 			}
+			if (init.body.get("method") === "Events.getName") return [];
 			return behaviourApiResponder(init);
 		});
 
@@ -323,14 +323,16 @@ describe("fetchMatomoCategoryModel", () => {
 		]);
 	});
 
-	it("scopes the read by calendar year with an empty segment (no custom dimension)", async () => {
+	it("scopes the read by calendar year, never by a campaign custom dimension", async () => {
 		const fetchSpy = stubFetch(behaviourApiResponder);
 
 		await fetchMatomoCategoryModel({ year: 2024 });
 
 		for (const call of fetchSpy.mock.calls) {
 			const body = call[1].body as URLSearchParams;
-			expect(body.get("segment")).toBe("");
+			// Behavioural events carry no campaign dimension — the failure read is
+			// scoped by an event segment, never `dimension1` / `dimension2`.
+			expect(body.get("segment")).not.toContain("dimension");
 			expect(body.get("date")).toBe("2024-12-31");
 			expect(body.get("period")).toBe("year");
 		}
@@ -390,10 +392,19 @@ describe("fetchMatomoHelpLinks", () => {
 		]);
 	});
 
-	it("falls back to the raw slug as label for an unknown help link", async () => {
+	it("drops unknown slugs and leaked names not in the label map (allow-list)", async () => {
 		stubFetch((init) => {
-			if (init.body.get("idSubtable") === "51") {
-				return [{ label: "unknown_slug", nb_events: 7 }];
+			if (
+				init.body.get("method") === "Events.getName" &&
+				(init.body.get("segment") ?? "").includes("help_link_click")
+			) {
+				return [
+					{ label: "cse_models", nb_events: 10 },
+					{ label: "unknown_slug", nb_events: 7 },
+					// `step_1` leaked from a co-occurring funnel event in the same
+					// visit (the segment is visit-scoped) — must be dropped.
+					{ label: "step_1", nb_events: 99 },
+				];
 			}
 			return behaviourApiResponder(init);
 		});
@@ -401,7 +412,7 @@ describe("fetchMatomoHelpLinks", () => {
 		const { rows } = await fetchMatomoHelpLinks({ year: 2024 });
 
 		expect(rows).toEqual([
-			{ key: "unknown_slug", label: "unknown_slug", count: 7 },
+			{ key: "cse_models", label: "Modèles d'avis CSE", count: 10 },
 		]);
 	});
 

--- a/packages/app/src/server/services/matomo.ts
+++ b/packages/app/src/server/services/matomo.ts
@@ -263,20 +263,19 @@ async function fetchFunnel(
 		),
 	};
 
-	const stepAction = actions.find(
-		(row) => row.label === MATOMO_FUNNEL_ACTION.STEP_COMPLETE,
+	// Step counts come from the event NAME report scoped by a segment: Matomo
+	// does not reliably archive the action→name subtable that
+	// `Events.getNameFromActionId` would need. The segment is visit-scoped, but
+	// `buildFunnelRows` only reads the `step_<n>` keys, so any name leaked from a
+	// co-occurring event in the same visit is ignored.
+	const stepNames = await callReportingApi(
+		config,
+		"Events.getName",
+		year,
+		`${segment};eventCategory==${def.category};eventAction==${MATOMO_FUNNEL_ACTION.STEP_COMPLETE}`,
 	);
-	if (stepAction?.idsubdatatable !== undefined) {
-		const names = await callReportingApi(
-			config,
-			"Events.getNameFromActionId",
-			year,
-			segment,
-			stepAction.idsubdatatable,
-		);
-		for (const row of names) {
-			counts[row.label] = toCount(row.nb_events);
-		}
+	for (const row of stepNames) {
+		counts[row.label] = toCount(row.nb_events);
 	}
 
 	return buildFunnelRows(def.jalons, counts);
@@ -359,19 +358,24 @@ async function getCategoryActions(
 	);
 }
 
-/** Drill into the `name` subtable of one action (e.g. format, error type). */
-async function getActionNames(
+/**
+ * Names recorded for a (category, action) pair, read via a segment on
+ * `Events.getName`. Matomo does not reliably archive the action→name subtable
+ * that `Events.getNameFromActionId` needs, so we segment instead. The segment is
+ * visit-scoped (a co-occurring event in the same visit can leak its own name),
+ * so callers MUST map or allow-list the result to the keys they expect.
+ */
+async function getEventNames(
 	config: MatomoConfig,
-	action: MatomoEventRow | undefined,
+	category: string,
+	action: string,
 	year: number,
 ): Promise<MatomoEventRow[]> {
-	if (action?.idsubdatatable === undefined) return [];
 	return callReportingApi(
 		config,
-		"Events.getNameFromActionId",
+		"Events.getName",
 		year,
-		"",
-		action.idsubdatatable,
+		`eventCategory==${category};eventAction==${action}`,
 	);
 }
 
@@ -397,14 +401,21 @@ async function fetchCategoryModelUsage(
 		});
 	}
 
-	const failureAction = actions.find(
-		(row) => row.label === MATOMO_ACTION.CATEGORY_IMPORT_FAILURE,
+	// Allow-list the known error types: the segment is visit-scoped, so a name
+	// leaked from a co-occurring event is dropped (it never collides with these
+	// enum values).
+	const failureNames = await getEventNames(
+		config,
+		MATOMO_EVENT_CATEGORY.DOCUMENT,
+		MATOMO_ACTION.CATEGORY_IMPORT_FAILURE,
+		year,
 	);
-	const failureNames = await getActionNames(config, failureAction, year);
 	for (const name of failureNames) {
+		const label = IMPORT_ERROR_LABELS[name.label];
+		if (!label) continue;
 		rows.push({
 			key: `failure_${name.label}`,
-			label: `Échec import — ${IMPORT_ERROR_LABELS[name.label] ?? name.label}`,
+			label: `Échec import — ${label}`,
 			count: toCount(name.nb_events),
 		});
 	}
@@ -423,21 +434,21 @@ async function fetchHelpLinkClicks(
 	config: MatomoConfig,
 	year: number,
 ): Promise<HelpLinkClicks> {
-	const actions = await getCategoryActions(
+	// Allow-list the known help slugs: the segment is visit-scoped, so any name
+	// leaked from a co-occurring event in the same visit is dropped.
+	const names = await getEventNames(
 		config,
 		MATOMO_EVENT_CATEGORY.HELP,
+		MATOMO_ACTION.HELP_LINK_CLICK,
 		year,
 	);
-	const clickAction = actions.find(
-		(row) => row.label === MATOMO_ACTION.HELP_LINK_CLICK,
-	);
-	const names = await getActionNames(config, clickAction, year);
 	const rows = names
-		.map((name) => ({
-			key: name.label,
-			label: HELP_LINK_LABELS[name.label] ?? name.label,
-			count: toCount(name.nb_events),
-		}))
+		.flatMap((name) => {
+			const label = HELP_LINK_LABELS[name.label];
+			return label
+				? [{ key: name.label, label, count: toCount(name.nb_events) }]
+				: [];
+		})
 		.sort((a, b) => b.count - a.count);
 	return { rows };
 }

--- a/scripts/matomo-local/seed-events.py
+++ b/scripts/matomo-local/seed-events.py
@@ -7,9 +7,9 @@ Bulk Tracking API so the /admin/stats widgets show realistic data:
   * the three funnels (declaration / cse_opinion / compliance_path) with
     drop-off, carrying the campaign_year (dim 1) + workforce_range (dim 2)
     dimensions the Reporting API segments on;
-  * indicator-model usage (document category: template downloads, imports,
-    failures, import durations);
-  * help-link clicks (help category);
+  * indicator-model usage (document category: imports, failures by enumerated
+    error type, import durations);
+  * help-link clicks (help category, by slug);
   * outbound consultations (search category) for the device-split widget.
 
 Events are backdated into the two most recent campaign years and sent with
@@ -44,7 +44,6 @@ A_STEP_COMPLETE = "step_complete"
 A_FUNNEL_COMPLETE = "funnel_complete"
 A_CONSULTATION = "consultation_outbound"
 A_HELP_CLICK = "help_link_click"
-A_CAT_DOWNLOAD = "category_template_download"
 A_CAT_IMPORT = "category_import"
 A_CAT_FAILURE = "category_import_failure"
 A_CAT_DURATION = "category_import_duration"
@@ -64,20 +63,16 @@ USER_AGENTS = {
 # Weighted toward desktop, with a meaningful mobile/tablet share.
 DEVICE_WEIGHTS = [("desktop", 6), ("smartphone", 3), ("tablet", 1)]
 
-HELP_LINKS = [
-    "Comment calculer l'index",
-    "Définition des indicateurs",
-    "FAQ déclaration",
-    "Aide sur l'écart de rémunération",
-    "Contacter le référent égapro",
+# Help-link slugs — must match the app's TrackedLink instrumentation
+# (docs/plan-de-tracking.md); the /admin/stats widget maps them to labels.
+HELP_SLUGS = [
+    "cse_models",
+    "objective_criteria",
+    "corrective_actions",
+    "joint_evaluation",
 ]
-INDICATOR_LABELS = [
-    "remuneration",
-    "augmentations",
-    "promotions",
-    "conges_maternite",
-    "hautes_remunerations",
-]
+# Enumerated import-error types emitted by category_import_failure.
+IMPORT_ERROR_TYPES = ["missing-columns", "invalid-value", "empty-file"]
 
 # Deterministic-ish per run; vary by index so reruns differ without Math.random
 # concerns. (random is available in the real container runtime.)
@@ -225,30 +220,30 @@ def seed_funnel(requests, token, category, steps, visitors, with_size, year):
 
 
 def seed_behaviour(requests, token, year):
-    # Indicator-model usage (document category, no custom dimensions).
+    # Indicator-model usage (document category, no custom dimensions). Names and
+    # values mirror the app taxonomy: a successful import carries the category
+    # count as value (no name), a failure carries an enumerated error type as
+    # name, and a fill-duration carries seconds as value (no name).
     for _ in range(30):
         vid = visitor_id()
         cdt = year_timestamp(year)
-        label = rng.choice(INDICATOR_LABELS)
         roll = rng.random()
-        if roll < 0.4:
-            action, name, value = A_CAT_IMPORT, label, None
-        elif roll < 0.6:
-            action, name, value = A_CAT_DOWNLOAD, label, None
+        if roll < 0.55:
+            action, name, value = A_CAT_IMPORT, None, rng.randint(3, 12)
         elif roll < 0.75:
-            action, name, value = A_CAT_FAILURE, label, None
+            action, name, value = A_CAT_FAILURE, rng.choice(IMPORT_ERROR_TYPES), None
         else:
-            action, name, value = A_CAT_DURATION, label, rng.randint(30, 600)
+            action, name, value = A_CAT_DURATION, None, rng.randint(30, 600)
         requests.append(
             build_request(token, vid=vid, cat=CAT_DOCUMENT, action=action,
                           name=name, value=value, cdt=cdt,
                           ua_key=pick_device())
         )
-    # Help-link clicks (help category, no custom dimensions).
+    # Help-link clicks (help category, no custom dimensions) — name = slug.
     for _ in range(20):
         requests.append(
             build_request(token, vid=visitor_id(), cat=CAT_HELP,
-                          action=A_HELP_CLICK, name=rng.choice(HELP_LINKS),
+                          action=A_HELP_CLICK, name=rng.choice(HELP_SLUGS),
                           cdt=year_timestamp(year), ua_key=pick_device())
         )
     # Outbound consultations (search category) — feeds the device-split widget.


### PR DESCRIPTION
## Objectif — #3645

Vérifier (et corriger) que la configuration Matomo respecte les conditions
d'**exemption de consentement** de la CNIL pour la mesure d'audience, afin de ne
pas avoir à afficher de bandeau cookies. Base sur le *Guide de configuration —
Exemption* de la CNIL et la doc *Privacy how-to* de Matomo.

> Cette PR cible `ticket/3612-matomo-trackevent` (l'instrumentation livrée par #3612).

## Ce qui change

**Code applicatif**
- `MatomoAnalytics` : `cleanUrl` (les URLs suivies n'embarquent plus de query
  string — une recherche libre ou un callback peut contenir un SIREN/email),
  respect du **Do Not Track** (`setDoNotTrack(true)`) et désactivation explicite
  des **heatmaps / enregistrements de session** (`HeatmapSessionRecording::disable`).
- `MatomoOptOut` : **iframe d'opt-out officielle** de Matomo, embarquée sur
  `/gestion-des-cookies` (no-op tant que Matomo n'est pas configuré).
- Pages légales `/gestion-des-cookies` et `/donnees-personnelles` : opt-out +
  mention du respect du DNT.

**Outillage & doc**
- `docker-compose.yml` : profil opt-in `matomo` + `matomo-db` (mariadb), qui ne
  démarre qu'avec `docker compose --profile matomo up` — pour vérifier la config
  CNIL et l'envoi des events en local.
- `docs/matomo-cnil-exemption.md` : récapitulatif des exigences CNIL mappées au
  code / à l'admin Matomo / au documentaire, durées de conservation, et la
  procédure de vérification locale.

## Répartition des exigences CNIL

| Exigence | Traité |
|---|---|
| Désactiver les exports (journal des visites / profil visiteur) | admin Matomo |
| Opt-out | **code** (iframe) |
| Anonymisation IP (≥ 2 octets) | admin Matomo (défaut) |
| First-party only / pas de cross-domain | admin Matomo (défaut) |
| Pas de User ID / pas d'e-commerce | admin Matomo |
| Heatmaps / session recording off | **code** |
| Pas de PII (events, dimensions, URLs) | **code** |
| Do Not Track respecté | **code** + admin Matomo |
| Conservation : cookie ≤ 13 mois, données brutes ≤ 25 mois | admin Matomo |

Les réglages purement « instance Matomo » ne sont pas committables — ils sont
**documentés** (chemins admin exacts) et **vérifiés en local** dans cette PR ;
leur application sur l'instance de prod + l'inscription au registre RGPD restent
des actions d'exploitation décrites dans la doc.

## Vérification en local

Instance **Matomo 5.11** montée via le profil docker, configurée CNIL, puis
rejeu des **26 hits** de la taxonomie (4 pages vues + 22 events distincts) :

- 🔒 IP de test (documentation `203.0.113.45`) stockée masquée en `203.0.0.0` (2 octets).
- ✅ Les 3 funnels (start / step / abandon / complete) **et** les 10 actions
  ponctuelles remontent avec la bonne `category` / `action` / `name` / `value`.
- ✅ Pages vues = chemin seul, sans query string.
- ✅ Dimensions = `2024` (année) et `50-99` (tranche) uniquement ; aucune PII.
- ✅ DNT actif côté serveur et client ; iframe d'opt-out fonctionnelle.

## Qualité

- typecheck · lint · format ✅
- tests unitaires : 2436 (app) + 83 (notifications) ✅, dont la nouvelle
  couverture `MatomoAnalytics` + `MatomoOptOut`
- audits RGAA ✅ et sécurité ✅

Ref #3645
