### PR TITLE
fix(declaration-remuneration): decouple draft read from campaign deadline (#3594)

### DIFF
--- a/packages/app/src/server/api/routers/__tests__/declarationDraft.integration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDraft.integration.test.ts
@@ -1,0 +1,126 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+import { declarationDraftRouter } from "~/server/api/routers/declarationDraft";
+import { db } from "~/server/db";
+
+describe("declarationDraftRouter save/get roundtrip (real Postgres)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN = "987654321";
+	const YEAR = 2025;
+	const USER_ID = "draft-integration-test-user";
+	const USER_EMAIL = "draft-integration@example.fr";
+	const USER_SIRET = `${SIREN}00015`;
+
+	function createCaller() {
+		return declarationDraftRouter.createCaller({
+			db,
+			session: {
+				user: {
+					id: USER_ID,
+					email: USER_EMAIL,
+					siret: USER_SIRET,
+					isAdmin: false,
+					impersonation: null,
+				},
+				expires: "",
+			},
+			headers: new Headers(),
+		} as never);
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await sql`DELETE FROM app_declaration WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user_company WHERE user_id = ${USER_ID}`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await sql`DELETE FROM app_declaration WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user_company WHERE user_id = ${USER_ID}`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+
+		await sql`
+			INSERT INTO app_user (id, email)
+			VALUES (${USER_ID}, ${USER_EMAIL})
+		`;
+		await sql`
+			INSERT INTO app_company (siren, name)
+			VALUES (${SIREN}, 'Draft Roundtrip Company')
+		`;
+		await sql`
+			INSERT INTO app_user_company (user_id, siren)
+			VALUES (${USER_ID}, ${SIREN})
+		`;
+	});
+
+	it("persists a saved slice and returns it on a subsequent get", async () => {
+		const caller = createCaller();
+		const data = { workforce: 50, payGap: 3.5 };
+
+		const saveResult = await caller.save({
+			siren: SIREN,
+			year: YEAR,
+			slice: { kind: "main", step: "step1", data },
+		});
+		expect(saveResult).toEqual({ ok: true });
+
+		const draft = await caller.get({ siren: SIREN, year: YEAR });
+
+		expect(draft).not.toBeNull();
+		expect(draft).toEqual({ main: { step1: data } });
+	});
+
+	it("merges successive saves of different slices into a single draft", async () => {
+		const caller = createCaller();
+
+		await caller.save({
+			siren: SIREN,
+			year: YEAR,
+			slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+		});
+		await caller.save({
+			siren: SIREN,
+			year: YEAR,
+			slice: { kind: "cse", step: "opinion", data: { value: "favorable" } },
+		});
+
+		const draft = await caller.get({ siren: SIREN, year: YEAR });
+
+		expect(draft).toEqual({
+			main: { step1: { workforce: 50 } },
+			cse: { opinion: { value: "favorable" } },
+		});
+	});
+
+	it("stamps draftUpdatedAt so the freshly saved draft is not TTL-expired", async () => {
+		const caller = createCaller();
+
+		await caller.save({
+			siren: SIREN,
+			year: YEAR,
+			slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+		});
+
+		const rows = await sql<{ draftUpdatedAt: Date | null }[]>`
+			SELECT draft_updated_at AS "draftUpdatedAt"
+			FROM app_declaration
+			WHERE siren = ${SIREN} AND year = ${YEAR} AND cancelled_at IS NULL
+		`;
+		const draftUpdatedAt = rows[0]?.draftUpdatedAt;
+
+		expect(draftUpdatedAt).toBeInstanceOf(Date);
+		expect(Date.now() - (draftUpdatedAt as Date).getTime()).toBeLessThan(
+			30 * 24 * 3600 * 1000,
+		);
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
@@ -28,12 +28,6 @@ vi.mock("~/server/audit/log", () => ({
 	logAction: (...args: unknown[]) => mockLogAction(...args),
 }));
 
-const mockGetCampaignDeadlines = vi.fn();
-vi.mock("~/server/db/getCampaignDeadlines", () => ({
-	getCampaignDeadlines: (...args: unknown[]) =>
-		mockGetCampaignDeadlines(...args),
-}));
-
 const SIREN = "123456789";
 const YEAR = 2024;
 const USER_SIRET = "12345678900015";
@@ -102,20 +96,9 @@ function createCaller(
 	);
 }
 
-function futureDeadline() {
-	return {
-		decl1ModificationDeadline: new Date(Date.now() + 365 * 24 * 3600 * 1000),
-	};
-}
-
-function pastDeadline() {
-	return { decl1ModificationDeadline: new Date(Date.now() - 1000) };
-}
-
 describe("declarationDraftRouter", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
-		mockGetCampaignDeadlines.mockResolvedValue(futureDeadline());
 	});
 
 	afterEach(() => {
@@ -171,9 +154,8 @@ describe("declarationDraftRouter", () => {
 			expect(result).toBeNull();
 		});
 
-		it("returns null when decl1ModificationDeadline has passed", async () => {
-			mockGetCampaignDeadlines.mockResolvedValue(pastDeadline());
-
+		it("returns draft when campaign deadline is past but TTL is not expired", async () => {
+			// #3594: draft read is decoupled from the campaign deadline — only the 30-day TTL gates it.
 			const draftData = { main: { step1: { workforce: 50 } } };
 			const { db } = createMockDb([
 				[{ siren: SIREN }],
@@ -183,7 +165,7 @@ describe("declarationDraftRouter", () => {
 
 			const result = await caller.get({ siren: SIREN, year: YEAR });
 
-			expect(result).toBeNull();
+			expect(result).toEqual(draftData);
 		});
 
 		it("throws FORBIDDEN when user does not own the siren", async () => {

--- a/packages/app/src/server/api/routers/declarationDraft.ts
+++ b/packages/app/src/server/api/routers/declarationDraft.ts
@@ -10,7 +10,6 @@ import {
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { isImpersonatingSiren } from "~/server/auth/companyAccess";
 import type { DB } from "~/server/db";
-import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { declarations, userCompanies } from "~/server/db/schema";
 
 const DRAFT_TTL_MS = 30 * 24 * 3600 * 1000;
@@ -39,14 +38,8 @@ async function assertOwnership(
 	}
 }
 
-async function isDraftExpired(
-	draftUpdatedAt: Date,
-	year: number,
-): Promise<boolean> {
-	const now = Date.now();
-	if (now - draftUpdatedAt.getTime() > DRAFT_TTL_MS) return true;
-	const { decl1ModificationDeadline } = await getCampaignDeadlines(year);
-	return now > decl1ModificationDeadline.getTime();
+function isDraftExpired(draftUpdatedAt: Date): boolean {
+	return Date.now() - draftUpdatedAt.getTime() > DRAFT_TTL_MS;
 }
 
 export const declarationDraftRouter = createTRPCRouter({
@@ -77,7 +70,7 @@ export const declarationDraftRouter = createTRPCRouter({
 		const row = rows[0];
 		if (!row || row.draft === null || row.draftUpdatedAt === null) return null;
 
-		if (await isDraftExpired(row.draftUpdatedAt, year)) return null;
+		if (isDraftExpired(row.draftUpdatedAt)) return null;
 
 		return row.draft as DraftBlob;
 	}),


### PR DESCRIPTION
## Contexte

Bug #3594. Sur le funnel de déclaration, modifier une saisie puis recharger la page faisait réapparaître l'ancienne valeur : le brouillon était bien écrit en base mais jamais relu.

## Root cause

`declarationDraft.get` rejetait le brouillon via `isDraftExpired(draftUpdatedAt, year)` dès que `now > decl1ModificationDeadline(year)`, alors que `declarationDraft.save` n'applique **aucun** contrôle d'expiration. Cette **asymétrie write/read** écrivait un brouillon illisible → perte de données silencieuse au rechargement. Sur les environnements sans ligne `app_campaign_deadline`, le défaut (1ᵉʳ juin de l'année) rendait tout brouillon illisible en seconde moitié d'année.

## Fix

- `isDraftExpired` devient un check **synchrone, TTL-only** (30 jours, `DRAFT_TTL_MS`) ; l'import `getCampaignDeadlines` est retiré et `get` l'appelle sans `await` ni `year`.
- La date limite de modification de campagne reste appliquée à la **soumission** de la déclaration — hors périmètre brouillon. `getDefaultCampaignDeadlines` n'est pas touché.

## Tests

- `declarationDraft.test.ts` : le scénario « past deadline → null » devient « deadline passée mais TTL non expiré → brouillon retourné » ; mocks de deadline (`futureDeadline`/`pastDeadline`/`mockGetCampaignDeadlines`) supprimés ; test TTL 30 j conservé.
- Nouveau `declarationDraft.integration.test.ts` (Postgres réel, `pnpm test:integration`) : roundtrip save → get, merge de slices, fraîcheur `draftUpdatedAt`. Couvre l'asymétrie que le test unit mocké ne voit pas.

## Validation locale

typecheck ✓ · unit 22/22 ✓ · integration 3/3 ✓ · lint ✓ · format ✓ · audit structural PASS · audit security SECURE.
