### PR TITLE
feat(auth): ProConnect eidas0 + session mono-entreprise (#3680)

### DIFF
--- a/packages/app/src/api/core-domain/infra/auth/ProConnectProvider.ts
+++ b/packages/app/src/api/core-domain/infra/auth/ProConnectProvider.ts
@@ -36,7 +36,11 @@ export function ProConnectProvider<P extends ProConnectProfile>(
     allowDangerousEmailAccountLinking: true,
     wellKnown: `${proconnectDiscoveryUrl}/.well-known/openid-configuration`,
     authorization: {
-      params: { scope },
+      // eidas0 = lowest *authorized* assurance level, i.e. the most permissive
+      // request we can make: the user keeps all their organizations selectable
+      // in the ProConnect picker (a stricter level would filter the list).
+      // https://partenaires.proconnect.gouv.fr/docs/ressources/norme_eidas
+      params: { scope, acr_values: "eidas0" },
     },
     checks: ["pkce", "state"],
     userinfo: {

--- a/packages/app/src/api/core-domain/infra/auth/config.ts
+++ b/packages/app/src/api/core-domain/infra/auth/config.ts
@@ -258,7 +258,13 @@ export const authConfig: AuthOptions = {
               logger.error({ error }, "Error while syncing ownerships");
             }
           }
-          const companiesList = organizations.map(orga => ({
+          // ProConnect mono-entreprise: the session carries only the single
+          // active organization the user authenticated as (the one selected in
+          // the ProConnect picker). Switching company requires re-authentication.
+          // Ownership of every org ProConnect returns is still synced above, so
+          // historical access to the user's other companies is preserved in DB.
+          const activeOrganization = organizations.slice(0, 1);
+          const companiesList = activeOrganization.map(orga => ({
             siren: orga.siren || orga.siret.substring(0, 9),
             label: orga.label,
           }));


### PR DESCRIPTION
Sous-ticket **#3680** de l'epic #3647 (bascule auth V1 moncomptepro → ProConnect).

## Changement
- `ProConnectProvider.ts` : `acr_values: "eidas0"` dans la requête d'autorisation — niveau d'assurance le plus permissif *autorisé*, pour que l'utilisateur garde toutes ses organisations sélectionnables dans le picker ProConnect.
- `config.ts` (callback `jwt`) : la session ne porte plus que **l'organisation active** (`organizations[0]`) au lieu de toute la liste. Le `SyncOwnership` continue d'enregistrer en base toutes les orgs renvoyées (accès historique préservé). Le type `companies` reste un tableau (taille 1) — le retrait de l'UI multi-entreprise est fait dans #3684 / #3685.

## Validation
- CI V1 (typecheck / lint / format / build / jest) sur cette PR.
- Validation comportementale finale : **login sandbox ProConnect** sur preprod (dépend de #3681).

Base : `epic/3647` (← `master`). Closes #3680.

