### PR TITLE
feat(auth): déconnexion OIDC end-session — fix reconnexion silencieuse (#3682)

### DIFF
--- a/packages/app/src/api/core-domain/infra/auth/config.ts
+++ b/packages/app/src/api/core-domain/infra/auth/config.ts
@@ -44,6 +44,8 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT extends DefaultJWT, Session {
     email: string;
+    // ProConnect id_token, kept for RP-initiated logout (id_token_hint).
+    id_token?: string | null;
   }
 }
 
@@ -199,6 +201,10 @@ export const authConfig: AuthOptions = {
           }
         }
         if (trigger !== "signUp") return token;
+        // Keep the ProConnect id_token for RP-initiated logout.
+        if (account?.id_token) {
+          token.id_token = account.id_token;
+        }
         token.user = {
           companiesHash: "",
           email: token.email,

--- a/packages/app/src/api/core-domain/infra/auth/proconnect-logout.ts
+++ b/packages/app/src/api/core-domain/infra/auth/proconnect-logout.ts
@@ -1,0 +1,23 @@
+const discoveryUrl = process.env.EGAPRO_PROCONNECT_DISCOVERY_URL;
+
+interface OidcConfig {
+  end_session_endpoint?: string;
+}
+
+/**
+ * Fetch the OIDC `end_session_endpoint` from the ProConnect discovery document.
+ * Returns null when the discovery URL is unset or unreachable, so the logout
+ * route can fall back to a plain redirect home.
+ */
+export async function fetchEndSessionEndpoint(): Promise<string | null> {
+  if (!discoveryUrl) {
+    return null;
+  }
+  try {
+    const response = await fetch(`${discoveryUrl}/.well-known/openid-configuration`);
+    const config = (await response.json()) as OidcConfig;
+    return config.end_session_endpoint ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/app/src/app/AuthHeaderItems.tsx
+++ b/packages/app/src/app/AuthHeaderItems.tsx
@@ -4,7 +4,7 @@ import { fr } from "@codegouvfr/react-dsfr";
 import { HeaderQuickAccessItem } from "@codegouvfr/react-dsfr/Header";
 import { ConfigContext } from "@components/utils/ConfigProvider";
 import { Skeleton } from "@design-system/utils/client/skeleton";
-import { signOut, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
 import { useContext } from "react";
 
 import { HeaderAccountMenu } from "./HeaderAccountMenu";
@@ -58,9 +58,13 @@ export const LoginLogoutHeaderItem = () => {
             iconId: "fr-icon-lock-unlock-line",
             buttonProps: {
               className: fr.cx("fr-btn--secondary"),
-              async onClick(e) {
+              onClick(e) {
                 e.preventDefault();
-                await signOut({ callbackUrl: "/" });
+                // RP-initiated logout: our route clears the local session and
+                // redirects to the ProConnect end_session_endpoint so the IdP
+                // session is terminated too. Without it the next login is
+                // silently re-authenticated on the previous organization.
+                window.location.href = "/api/auth/logout";
               },
             },
             text: "Se déconnecter",

--- a/packages/app/src/app/api/auth/logout/callback/route.ts
+++ b/packages/app/src/app/api/auth/logout/callback/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+/**
+ * post_logout_redirect_uri target hit by ProConnect after the IdP session is
+ * terminated. Sends the user back to the home page.
+ */
+export function GET(request: Request) {
+  const baseUrl = new URL(request.url).origin;
+  return NextResponse.redirect(new URL("/", baseUrl));
+}

--- a/packages/app/src/app/api/auth/logout/route.ts
+++ b/packages/app/src/app/api/auth/logout/route.ts
@@ -1,0 +1,61 @@
+import { fetchEndSessionEndpoint } from "@api/core-domain/infra/auth/proconnect-logout";
+import { config } from "@common/config";
+import { verify } from "jsonwebtoken";
+import { getToken, type JWT } from "next-auth/jwt";
+import { type NextRequest, NextResponse } from "next/server";
+
+const secret = config.api.security.auth.secret;
+
+/**
+ * RP-initiated logout. Reads the (custom HS256) session token to recover the
+ * ProConnect id_token, clears the local NextAuth cookie, and redirects to the
+ * ProConnect end_session_endpoint so the IdP session is terminated too.
+ * Without this, ProConnect keeps its session and the next login is silently
+ * re-authenticated on the previous organization.
+ */
+export async function GET(request: NextRequest) {
+  const token = await getToken({
+    req: request,
+    secret,
+    decode: async ({ token: rawToken, secret: decodeSecret }) => {
+      if (!rawToken) {
+        return null;
+      }
+      try {
+        return verify(rawToken, decodeSecret, { algorithms: ["HS256"] }) as JWT;
+      } catch {
+        return null;
+      }
+    },
+  });
+
+  const baseUrl = new URL(request.url).origin;
+  const redirectTarget = await buildLogoutRedirectUrl(token?.id_token ?? null, baseUrl);
+  const response = NextResponse.redirect(redirectTarget);
+
+  const isSecure = baseUrl.startsWith("https://");
+  const sessionCookieName = isSecure ? "__Secure-next-auth.session-token" : "next-auth.session-token";
+  response.cookies.set(sessionCookieName, "", {
+    expires: new Date(0),
+    path: "/",
+    secure: isSecure,
+    httpOnly: true,
+    sameSite: "lax",
+  });
+
+  return response;
+}
+
+async function buildLogoutRedirectUrl(idToken: string | null, baseUrl: string): Promise<URL> {
+  if (!idToken) {
+    return new URL("/", baseUrl);
+  }
+  const endSessionEndpoint = await fetchEndSessionEndpoint();
+  if (!endSessionEndpoint) {
+    return new URL("/", baseUrl);
+  }
+  const url = new URL(endSessionEndpoint);
+  url.searchParams.set("id_token_hint", idToken);
+  url.searchParams.set("post_logout_redirect_uri", `${baseUrl}/api/auth/logout/callback`);
+  return url;
+}


### PR DESCRIPTION
Sous-ticket **#3682** de l'epic #3647 — correctif du **bug de déconnexion** (reconnexion silencieuse).

## Problème
`signOut({ callbackUrl: "/" })` ne vidait que le cookie NextAuth local ; la session **ProConnect** restait active → la reconnexion suivante était silencieusement ré-authentifiée sur l'entreprise précédente.

## Changement
- Persiste l'`id_token` ProConnect dans le JWT (`id_token_hint`).
- `GET /api/auth/logout` : lit le token (HS256 custom), vide le cookie de session, redirige vers le `end_session_endpoint` OIDC avec `id_token_hint` + `post_logout_redirect_uri` ; fallback `/` si indisponible.
- `GET /api/auth/logout/callback` : cible du `post_logout_redirect_uri`, renvoie à l'accueil.
- `AuthHeaderItems` « Se déconnecter » passe par `/api/auth/logout`.

## Validation
- CI V1 (`check-all` = typecheck/lint/format).
- Repro du bug à rejouer sur la **sandbox** preprod (dépend de #3681). Le `post_logout_redirect_uri` `/api/auth/logout/callback` doit être enregistré côté client ProConnect (ops, #3686).

Base : `epic/3647`. Refs #3682.
