### PR TITLE
feat(declaration): sélecteur entreprise → SIRET actif, funnels mono-entreprise (#3684)

### DIFF
--- a/packages/app/src/app/(default)/index-egapro/declaration/commencer/CommencerForm.tsx
+++ b/packages/app/src/app/(default)/index-egapro/declaration/commencer/CommencerForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { fr } from "@codegouvfr/react-dsfr";
-import { Button } from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import { Select } from "@codegouvfr/react-dsfr/Select";
 import { config } from "@common/config";
@@ -18,15 +17,15 @@ import {
 } from "@common/dict";
 import { zodFr } from "@common/utils/zod";
 import { SkeletonForm } from "@components/utils/skeleton/SkeletonForm";
-import { BackNextButtonsGroup, Icon, Link } from "@design-system";
+import { BackNextButtonsGroup } from "@design-system";
 import { getCompany } from "@globalActions/company";
 import { CLOSED_COMPANY_ERROR, CompanyErrorCodes } from "@globalActions/companyErrorCodes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useDeclarationFormManager } from "@services/apiClient/useDeclarationFormManager";
-import { sortBy } from "lodash";
 import { useRouter } from "next/navigation";
 import { type Session } from "next-auth";
-import { signIn, useSession } from "next-auth/react";
+import { useSession } from "next-auth/react";
+import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -141,7 +140,7 @@ export const prepareDataWithExistingDeclaration = async (
   }
 };
 
-export const CommencerForm = ({ monCompteProHost }: { monCompteProHost: string }) => {
+export const CommencerForm = () => {
   const router = useRouter();
   const { formData, saveFormData, resetFormData } = useDeclarationFormManager();
 
@@ -164,11 +163,19 @@ export const CommencerForm = ({ monCompteProHost }: { monCompteProHost: string }
     watch,
   } = methods;
 
+  const activeSiren = user?.companies?.[0]?.siren;
+  useEffect(() => {
+    if (activeSiren) {
+      setValue("siren", activeSiren, { shouldValidate: true });
+    }
+  }, [activeSiren, setValue]);
+
   if (!user?.companies.length && !user?.staff) return <SkeletonForm fields={2} />;
 
   const year = watch("annéeIndicateurs");
 
   const companies = user.companies;
+  const activeCompany = companies[0];
 
   const saveAndGoNext = async ({ siren, annéeIndicateurs }: FormType, formData: DeclarationDTO) => {
     try {
@@ -270,43 +277,18 @@ export const CommencerForm = ({ monCompteProHost }: { monCompteProHost: string }
               }}
             />
           ) : (
-            <Select
-              label="Numéro Siren de l’entreprise ou de l’entreprise déclarant pour le compte de l'unité économique et sociale (UES) *"
+            <Input
+              label="Numéro Siren de l’entreprise"
+              hintText="Entreprise sélectionnée lors de la connexion ProConnect."
               state={errors.siren && "error"}
               stateRelatedMessage={errors.siren?.message}
-              nativeSelectProps={register("siren")}
-            >
-              <option value="" disabled>
-                Sélectionnez une entreprise
-              </option>
-              {sortBy(companies, "siren").map(company => (
-                <option key={company.siren} value={company.siren}>
-                  {company.siren}
-                  {company.label ? ` (${company.label})` : ""}
-                </option>
-              ))}
-            </Select>
+              nativeInputProps={{
+                value: activeCompany ? `${activeCompany.siren}${activeCompany.label ? ` (${activeCompany.label})` : ""}` : "",
+                readOnly: true,
+              }}
+            />
           )}
 
-          <p>
-            Vous souhaitez rattacher votre adresse email à une autre entreprise,{" "}
-            <Link href={`${monCompteProHost}`} target="_blank">
-              cliquez ici
-            </Link>
-          </p>
-          <div className={fr.cx("fr-pt-3v")}>
-            Vous ne trouvez pas dans la liste déroulante l'entreprise rattachée à votre compte ProConnect, cliquez sur
-            ce bouton : <br />
-            <Button
-              onClick={e => {
-                e.preventDefault();
-                signIn("moncomptepro", { redirect: false });
-              }}
-            >
-              <Icon icon="fr-icon-refresh-line" />
-              Rafraichir
-            </Button>
-          </div>
           <BackNextButtonsGroup
             className={fr.cx("fr-my-6w")}
             backLabel="Réinitialiser"

--- a/packages/app/src/app/(default)/index-egapro/declaration/commencer/page.tsx
+++ b/packages/app/src/app/(default)/index-egapro/declaration/commencer/page.tsx
@@ -83,7 +83,7 @@ const CommencerPage = async () => {
         }
         className={fr.cx("fr-mb-4w")}
       />
-      <CommencerForm monCompteProHost={proconnectManageOrganisationsUrl ?? ""} />
+      <CommencerForm />
     </>
   );
 };

--- a/packages/app/src/app/(default)/representation-equilibree/(funnel)/commencer/Form.tsx
+++ b/packages/app/src/app/(default)/representation-equilibree/(funnel)/commencer/Form.tsx
@@ -1,21 +1,18 @@
 "use client";
 
 import { fr } from "@codegouvfr/react-dsfr";
-import { Button } from "@codegouvfr/react-dsfr/Button";
 import Input from "@codegouvfr/react-dsfr/Input";
 import Select from "@codegouvfr/react-dsfr/Select";
 import { createSteps } from "@common/core-domain/dtos/CreateRepresentationEquilibreeDTO";
 import { isCompanyClosed } from "@common/core-domain/helpers/entreprise";
 import { REPEQ_ADMIN_YEARS, YEARS } from "@common/dict";
-import { BackNextButtonsGroup, FormLayout, Icon, Link } from "@design-system";
+import { BackNextButtonsGroup, FormLayout } from "@design-system";
 import { getCompany } from "@globalActions/company";
 import { CompanyErrorCodes } from "@globalActions/companyErrorCodes";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { sortBy } from "lodash";
 import { useRouter } from "next/navigation";
 import { type Session } from "next-auth";
-import { signIn } from "next-auth/react";
-import { useTransition } from "react";
+import { useEffect, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -29,7 +26,7 @@ const buildConfirmMessage = ({ siren, year }: { siren: string; year: number }) =
   `Vous avez commencé une déclaration avec le Siren ${siren} et l'année ${year}. Voulez-vous commencer une nouvelle déclaration et supprimer les données déjà enregistrées ?`;
 
 const OWNER_ERROR = "Vous n'avez pas les droits sur ce Siren.";
-export const CommencerForm = ({ session, monCompteProHost }: { monCompteProHost: string; session: Session }) => {
+export const CommencerForm = ({ session }: { session: Session }) => {
   const router = useRouter();
   const { funnel, saveFunnel, resetFunnel, isEdit, setIsEdit } = useRepeqFunnelStore();
   const [isPending, startTransition] = useTransition();
@@ -60,6 +57,13 @@ export const CommencerForm = ({ session, monCompteProHost }: { monCompteProHost:
     resolver: zodResolver(schemaWithOwnedSiren),
     defaultValues: funnel,
   });
+
+  const activeSiren = companies[0]?.siren;
+  useEffect(() => {
+    if (activeSiren) {
+      setValue("siren", activeSiren, { shouldValidate: true });
+    }
+  }, [activeSiren, setValue]);
 
   const saveAndGoNext = async (siren: string, year: number) =>
     startTransition(async () => {
@@ -168,42 +172,17 @@ export const CommencerForm = ({ session, monCompteProHost }: { monCompteProHost:
               }}
             />
           ) : (
-            <Select
-              label="Numéro Siren de l’entreprise *"
+            <Input
+              label="Numéro Siren de l’entreprise"
+              hintText="Entreprise sélectionnée lors de la connexion ProConnect."
               state={errors.siren && "error"}
               stateRelatedMessage={errors.siren?.message}
-              nativeSelectProps={register("siren")}
-            >
-              <option value="" disabled>
-                Sélectionnez une entreprise
-              </option>
-              {sortBy(companies, "siren").map(company => (
-                <option key={company.siren} value={company.siren}>
-                  {company.siren}
-                  {company.label ? ` (${company.label})` : ""}
-                </option>
-              ))}
-            </Select>
-          )}
-          <p>
-            Vous souhaitez rattacher votre adresse email à une autre entreprise,{" "}
-            <Link href={`${monCompteProHost}`} target="_blank">
-              cliquez ici
-            </Link>
-          </p>
-          <div className={fr.cx("fr-pt-3v")}>
-            Vous ne trouvez pas dans la liste déroulante l'entreprise rattachée à votre compte ProConnect, cliquez sur
-            ce bouton : <br />
-            <Button
-              onClick={e => {
-                e.preventDefault();
-                signIn("moncomptepro", { redirect: false });
+              nativeInputProps={{
+                value: companies[0] ? `${companies[0].siren}${companies[0].label ? ` (${companies[0].label})` : ""}` : "",
+                readOnly: true,
               }}
-            >
-              <Icon icon="fr-icon-refresh-line" />
-              Rafraichir
-            </Button>
-          </div>
+            />
+          )}
           <BackNextButtonsGroup
             className={fr.cx("fr-my-6w")}
             backProps={{

--- a/packages/app/src/app/(default)/representation-equilibree/(funnel)/commencer/page.tsx
+++ b/packages/app/src/app/(default)/representation-equilibree/(funnel)/commencer/page.tsx
@@ -70,7 +70,7 @@ const CommencerPage = async () => {
         description="Si vous souhaitez visualiser ou modifier votre déclaration déjà transmise, veuillez saisir les informations
           correspondantes à la déclaration."
       />
-      <CommencerForm session={session} monCompteProHost={proconnectManageOrganisationsUrl ?? ""} />
+      <CommencerForm session={session} />
     </>
   );
 };


### PR DESCRIPTION
Sous-ticket **#3684** de l'epic #3647 — modèle mono-entreprise dans les deux funnels de déclaration.

## Changement (index-egapro + représentation équilibrée, page `commencer`)
- Le `<Select>` multi-entreprises (branche non-staff) est remplacé par un **affichage en lecture seule du SIRET actif** (`companies[0]`), la valeur `siren` du formulaire étant fixée via `setValue` (la validation d'appartenance passe toujours).
- Retrait du texte « Vous souhaitez rattacher votre adresse email à une autre entreprise → cliquez ici ».
- Retrait du bloc « Vous ne trouvez pas… » + bouton **« Rafraichir »** (`signIn`).
- Branche **staff** (saisie Siren libre) inchangée.
- Prop `monCompteProHost` devenue inutile retirée des deux formulaires et de leurs `page.tsx`.

Base : `epic/3647`. Refs #3684.
