### PR TITLE
feat(mon-espace): mono-entreprise — switchers → SIRET affiché (#3685)

### DIFF
--- a/packages/app/src/app/(default)/mon-espace/mes-declarations/SelectSiren.tsx
+++ b/packages/app/src/app/(default)/mon-espace/mes-declarations/SelectSiren.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import { fr } from "@codegouvfr/react-dsfr";
-import { Button } from "@codegouvfr/react-dsfr/Button";
-import SelectNext from "@codegouvfr/react-dsfr/SelectNext";
-import { Grid, GridCol, Icon } from "@design-system";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { first } from "lodash";
-import { useRouter } from "next/navigation";
-import { signIn } from "next-auth/react";
-import { useEffect } from "react";
-import { useForm } from "react-hook-form";
-import { z } from "zod";
+import { Grid, GridCol } from "@design-system";
 
 export const SelectSiren = ({
   sirenListWithCompanyName,
@@ -19,77 +10,21 @@ export const SelectSiren = ({
   currentSiren?: string;
   sirenListWithCompanyName: Array<{ companyName: string; siren: string }>;
 }) => {
-  const router = useRouter();
-  const sirenSchema = z.object({
-    siren: z
-      .string()
-      .length(9)
-      .regex(/^\d+$/)
-      .refine(siren => sirenList.includes(siren), {
-        message: "Vous n'avez pas les droits sur ce Siren.",
-      }),
-  });
-
-  type sirenFormType = z.infer<typeof sirenSchema>;
-
-  const {
-    register,
-    handleSubmit,
-    watch,
-    formState: { isValid },
-  } = useForm<sirenFormType>({
-    resolver: zodResolver(sirenSchema),
-  });
-
-  const sirenValue = watch("siren");
-  const sirenList = sirenListWithCompanyName.map(({ siren }) => siren);
-
-  const onSubmit = (data: sirenFormType) => {
-    router.push(`/mon-espace/mes-declarations?siren=${data.siren}`);
-  };
-
-  useEffect(() => {
-    if (isValid && sirenValue !== currentSiren) {
-      handleSubmit(onSubmit)();
-    }
-  }, [sirenValue, isValid, handleSubmit, onSubmit]);
+  const active = sirenListWithCompanyName.find(data => data.siren === currentSiren) ?? sirenListWithCompanyName[0];
+  if (!active) return null;
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <Grid>
-        <GridCol sm={3}>
-          <SelectNext
-            label="Numéro Siren de l'entreprise"
-            nativeSelectProps={{
-              ...register("siren"),
-            }}
-            options={sirenList.map(value => ({
-              value,
-              label: value,
-              selected: currentSiren ? value === currentSiren : value === first(sirenList),
-            }))}
-          />
-        </GridCol>
-        <GridCol sm={9}>
-          <div className={fr.cx("fr-pt-10v", "fr-pl-2v")}>
-            <span className={fr.cx("fr-icon-building-line", "fr-pr-2v")} aria-hidden="true"></span>
-            <span>{sirenListWithCompanyName.find(data => data.siren === sirenValue)?.companyName || ""}</span>
-          </div>
-        </GridCol>
-      </Grid>
-      <div className={fr.cx("fr-pt-3v")}>
-        Vous ne trouvez pas dans la liste déroulante l'entreprise rattachée à votre compte ProConnect, cliquez sur ce
-        bouton : <br />
-        <Button
-          onClick={e => {
-            e.preventDefault();
-            signIn("moncomptepro", { redirect: false });
-          }}
-        >
-          <Icon icon="fr-icon-refresh-line" />
-          Rafraichir
-        </Button>
-      </div>
-    </form>
+    <Grid>
+      <GridCol sm={3}>
+        <p className={fr.cx("fr-text--bold", "fr-mb-0")}>Numéro Siren de l'entreprise</p>
+        <p className={fr.cx("fr-mb-0")}>{active.siren}</p>
+      </GridCol>
+      <GridCol sm={9}>
+        <div className={fr.cx("fr-pt-3v", "fr-pl-2v")}>
+          <span className={fr.cx("fr-icon-building-line", "fr-pr-2v")} aria-hidden="true"></span>
+          <span>{active.companyName}</span>
+        </div>
+      </GridCol>
+    </Grid>
   );
 };

--- a/packages/app/src/app/(default)/mon-espace/mes-declarations/page.tsx
+++ b/packages/app/src/app/(default)/mon-espace/mes-declarations/page.tsx
@@ -4,7 +4,7 @@ import { type DeclarationDTO } from "@common/core-domain/dtos/DeclarationDTO";
 import { type DeclarationOpmcDTO } from "@common/core-domain/dtos/DeclarationOpmcDTO";
 import { type RepresentationEquilibreeDTO } from "@common/core-domain/dtos/RepresentationEquilibreeDTO";
 import { type NextServerPageProps } from "@common/utils/next";
-import { Box, Heading, Link } from "@design-system";
+import { Box, Heading } from "@design-system";
 import { MessageProvider } from "@design-system/client";
 import { getCompany } from "@globalActions/company";
 import { redirect } from "next/navigation";
@@ -20,8 +20,6 @@ import { RepeqList } from "./RepeqList";
 import { SelectSiren } from "./SelectSiren";
 import { SelectSirenStaff } from "./SelectSirenStaff";
 
-const proconnectManageOrganisationsUrl = process.env.EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL;
-
 const InfoText = () => (
   <>
     <p>
@@ -36,13 +34,6 @@ const InfoText = () => (
       cliquant sur le Siren, vous accédez à la déclaration transmise. A la colonne « <b>OBJECTIFS ET MESURES</b> », vous
       avez accès à la déclaration des mesures de correction lorsque l’index est inférieur à 75 points et des objectifs
       de progression lorsque l’index est inférieur à 85 points.
-    </p>
-    <p>
-      <br />
-      Vous souhaitez rattacher votre adresse email à une autre entreprise,{" "}
-      <Link target="_blank" href={`${proconnectManageOrganisationsUrl}`}>
-        cliquez ici
-      </Link>
     </p>
   </>
 );

--- a/packages/app/src/app/(default)/mon-espace/mes-entreprises/SelectSiren.tsx
+++ b/packages/app/src/app/(default)/mon-espace/mes-entreprises/SelectSiren.tsx
@@ -1,64 +1,36 @@
 "use client";
 
 import { fr } from "@codegouvfr/react-dsfr";
-import { Button } from "@codegouvfr/react-dsfr/Button";
-import { Select } from "@codegouvfr/react-dsfr/Select";
-import { Grid, GridCol, Icon } from "@design-system";
+import { Grid, GridCol } from "@design-system";
 import { getCompany } from "@globalActions/company";
-import { useRouter } from "next/navigation";
-import { signIn } from "next-auth/react";
 import { useEffect, useState } from "react";
 
 export const SelectSiren = ({ sirenList, loadedSiren }: { loadedSiren?: string; sirenList: string[] }) => {
-  const router = useRouter();
-  const [currentSiren, setCurrentSiren] = useState<string>(loadedSiren ? loadedSiren : "");
-  const [selectedCompanyName, setSelectedCompanyName] = useState<string>("");
+  const activeSiren = loadedSiren ?? sirenList[0] ?? "";
+  const [companyName, setCompanyName] = useState<string>("");
 
   useEffect(() => {
-    if (currentSiren !== "") {
-      getCompany(currentSiren).then(company => {
-        if (company.ok) setSelectedCompanyName(company?.data?.simpleLabel ?? "");
+    if (activeSiren) {
+      getCompany(activeSiren).then(company => {
+        if (company.ok) setCompanyName(company?.data?.simpleLabel ?? "");
       });
-      if (loadedSiren != currentSiren) router.push(`/mon-espace/mes-entreprises?siren=${currentSiren}`);
     }
-  }, [currentSiren, router, loadedSiren]);
+  }, [activeSiren]);
+
+  if (!activeSiren) return null;
 
   return (
-    <>
-      <Grid>
-        <GridCol sm={3}>
-          <Select
-            label="Numéro Siren de l'entreprise"
-            nativeSelectProps={{ onChange: event => setCurrentSiren(event.target.value), value: currentSiren }}
-          >
-            <option value="">Sélectionner un siren</option>
-            {sirenList.map((value, key) => (
-              <option key={`siren-${key}`} value={value}>
-                {value}
-              </option>
-            ))}
-          </Select>
-        </GridCol>
-        <GridCol sm={6}>
-          <div className={fr.cx("fr-pt-10v", "fr-pl-2v")}>
-            <span className={fr.cx("fr-icon-building-line", "fr-pr-2v")} aria-hidden="true"></span>
-            <span>{selectedCompanyName}</span>
-          </div>
-        </GridCol>
-      </Grid>
-      <div className={fr.cx("fr-pt-3v")}>
-        Vous ne trouvez pas dans la liste déroulante l'entreprise rattachée à votre compte ProConnect, cliquez sur ce
-        bouton : <br />
-        <Button
-          onClick={e => {
-            e.preventDefault();
-            signIn("moncomptepro", { redirect: false });
-          }}
-        >
-          <Icon icon="fr-icon-refresh-line" />
-          Rafraichir
-        </Button>
-      </div>
-    </>
+    <Grid>
+      <GridCol sm={3}>
+        <p className={fr.cx("fr-text--bold", "fr-mb-0")}>Numéro Siren de l'entreprise</p>
+        <p className={fr.cx("fr-mb-0")}>{activeSiren}</p>
+      </GridCol>
+      <GridCol sm={6}>
+        <div className={fr.cx("fr-pt-3v", "fr-pl-2v")}>
+          <span className={fr.cx("fr-icon-building-line", "fr-pr-2v")} aria-hidden="true"></span>
+          <span>{companyName}</span>
+        </div>
+      </GridCol>
+    </Grid>
   );
 };

--- a/packages/app/src/app/(default)/mon-espace/mes-entreprises/page.tsx
+++ b/packages/app/src/app/(default)/mon-espace/mes-entreprises/page.tsx
@@ -13,7 +13,6 @@ import { EmailOwnerList } from "../EmailOwnerList";
 import { SelectSiren } from "./SelectSiren";
 
 const proconnectSignInUrl = config.proconnect.signinUrl;
-const proconnectManageOrganisationsUrl = config.proconnect.manageOrganisationUrl;
 
 export const MesEntreprisesInfoAlert = () => (
   <Alert
@@ -33,13 +32,6 @@ export const MesEntreprisesInfoAlert = () => (
             créer un nouveau compte ProConnect
           </Link>{" "}
           avec cette adresse.
-        </p>
-        <p>
-          <br />
-          Vous souhaitez rattacher votre adresse email à une autre entreprise,{" "}
-          <Link target="_blank" href={`${proconnectManageOrganisationsUrl}`}>
-            cliquez ici
-          </Link>
         </p>
       </>
     }


### PR DESCRIPTION
Sous-ticket **#3685** de l'epic #3647 — « Mon espace » au modèle mono-entreprise.

## Changement
- `mes-declarations/SelectSiren.tsx` et `mes-entreprises/SelectSiren.tsx` : le switcher (dropdown de Siren + bouton **« Rafraichir »** `signIn`) devient un **affichage en lecture seule** du SIRET actif + raison sociale.
- Retrait du lien « Vous souhaitez rattacher votre adresse email à une autre entreprise → cliquez ici » dans `mes-declarations` et `mes-entreprises` (+ consts/imports devenus inutiles).
- `SelectSirenStaff` (parcours staff) inchangé.

Hors scope (volontaire) : le flag `isEmailLogin` reste (consommé largement ailleurs) mais ses branches sont inertes (flag faux). Le full-retrait du flag dépasse ce ticket.

Base : `epic/3647`. Refs #3685.
