### PR TITLE
fix(recherche-entreprise): retry transient network failures on the company lookup

### DIFF
--- a/packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts
+++ b/packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts
@@ -18,6 +18,29 @@ import {
 
 const RECHERCHE_ENTREPRISE_URL = new URL("https://recherche-entreprises.api.gouv.fr/");
 
+const MAX_FETCH_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 150;
+
+const wait = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+// The public recherche-entreprises API intermittently refuses a connection (ECONNREFUSED) from the
+// cluster's egress. A short retry on thrown network errors absorbs the blip instead of surfacing a
+// server error that blocks the whole declaration funnel. HTTP error statuses are returned untouched.
+async function fetchWithRetry(url: URL | string, init?: RequestInit, attempts = MAX_FETCH_ATTEMPTS): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await wait(RETRY_BASE_DELAY_MS * attempt);
+      }
+    }
+  }
+  throw lastError;
+}
+
 // API response types
 interface ApiEtablissement {
   activite_principale?: string;
@@ -73,7 +96,7 @@ export class RechercheEntrepriseService implements IEntrepriseService {
       ).toString();
       const url = new URL(`search?${stringifiedParams}`, RECHERCHE_ENTREPRISE_URL);
 
-      const response = await fetch(url, {
+      const response = await fetchWithRetry(url, {
         headers: {
           Referer: "egapro",
         },
@@ -136,7 +159,7 @@ export class RechercheEntrepriseService implements IEntrepriseService {
       const stringifiedParams = new URLSearchParams({ q: validatedSiren, per_page: "1" }).toString();
       const url = new URL(`search?${stringifiedParams}`, RECHERCHE_ENTREPRISE_URL);
 
-      const response = await fetch(url, {
+      const response = await fetchWithRetry(url, {
         headers: {
           Referer: "egapro",
         },
@@ -176,7 +199,7 @@ export class RechercheEntrepriseService implements IEntrepriseService {
       const stringifiedParams = new URLSearchParams({ q: validatedSiret, per_page: "1" }).toString();
       const url = new URL(`search?${stringifiedParams}`, RECHERCHE_ENTREPRISE_URL);
 
-      const response = await fetch(url, {
+      const response = await fetchWithRetry(url, {
         headers: {
           Referer: "egapro",
         },

--- a/packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts
+++ b/packages/app/src/api/core-domain/infra/services/impl/RechercheEntrepriseService.ts
@@ -20,20 +20,38 @@ const RECHERCHE_ENTREPRISE_URL = new URL("https://recherche-entreprises.api.gouv
 
 const MAX_FETCH_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 150;
+// Connection-level failures a retry can plausibly recover from. DNS ENOTFOUND, an aborted request or a
+// malformed URL are deliberately excluded — they never succeed on retry.
+const TRANSIENT_ERROR_CODES = new Set(["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT", "ENOTCONN"]);
 
 const wait = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
+function isTransientNetworkError(error: unknown): boolean {
+  if (error instanceof Error && error.name === "AbortError") return false;
+  if (typeof error !== "object" || error === null) return false;
+  // undici exposes the OS code on `error.cause.code`, or on the sub-errors of an AggregateError when
+  // several addresses were tried (dual-stack "Happy Eyeballs").
+  const cause = (error as { cause?: { code?: string; errors?: Array<{ code?: string }> } }).cause;
+  if (!cause) return false;
+  if (cause.code !== undefined) return TRANSIENT_ERROR_CODES.has(cause.code);
+  if (Array.isArray(cause.errors)) {
+    return cause.errors.some(sub => sub?.code !== undefined && TRANSIENT_ERROR_CODES.has(sub.code));
+  }
+  return false;
+}
+
 // The public recherche-entreprises API intermittently refuses a connection (ECONNREFUSED) from the
-// cluster's egress. A short retry on thrown network errors absorbs the blip instead of surfacing a
+// cluster's egress. A short retry on transient connection errors absorbs the blip instead of surfacing a
 // server error that blocks the whole declaration funnel. HTTP error statuses are returned untouched.
-async function fetchWithRetry(url: URL | string, init?: RequestInit, attempts = MAX_FETCH_ATTEMPTS): Promise<Response> {
+async function fetchWithRetry(url: URL | string, init?: RequestInit): Promise<Response> {
   let lastError: unknown;
-  for (let attempt = 1; attempt <= attempts; attempt++) {
+  for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
     try {
       return await fetch(url, init);
     } catch (error) {
+      if (!isTransientNetworkError(error)) throw error;
       lastError = error;
-      if (attempt < attempts) {
+      if (attempt < MAX_FETCH_ATTEMPTS) {
         await wait(RETRY_BASE_DELAY_MS * attempt);
       }
     }

--- a/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
+++ b/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
@@ -133,6 +133,40 @@ describe("RechercheEntrepriseService", () => {
 		});
 	});
 
+	describe("siren — transient network retry", () => {
+		const econnrefused = () => Object.assign(new TypeError("fetch failed"), { cause: { code: "ECONNREFUSED" } });
+
+		it("retries a thrown network error and resolves on a later attempt", async () => {
+			global.fetch = jest
+				.fn()
+				.mockRejectedValueOnce(econnrefused())
+				.mockResolvedValueOnce({
+					ok: true,
+					status: 200,
+					json: async () => ({ results: [{ siren: TEST_SIREN, nom_raison_sociale: "ACME SARL" }] }),
+				} as Response);
+
+			const entreprise = await service.siren(siren);
+
+			expect(entreprise.simpleLabel).toBe("ACME SARL");
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+		});
+
+		it("gives up after the max number of attempts and wraps the error", async () => {
+			global.fetch = jest.fn().mockRejectedValue(econnrefused());
+
+			await expect(service.siren(siren)).rejects.toBeInstanceOf(EntrepriseServiceError);
+			expect(global.fetch).toHaveBeenCalledTimes(3);
+		});
+
+		it("does not retry on an HTTP error status", async () => {
+			mockFetchOnce({}, { status: StatusCodes.INTERNAL_SERVER_ERROR });
+
+			await expect(service.siren(siren)).rejects.toBeInstanceOf(EntrepriseServiceError);
+			expect(global.fetch).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	describe("search", () => {
 		it("maps API results into Entreprise[]", async () => {
 			mockFetchOnce({ results: [makeApiResult()] });

--- a/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
+++ b/packages/app/src/api/core-domain/infra/services/impl/__tests__/RechercheEntrepriseService.test.ts
@@ -165,6 +165,40 @@ describe("RechercheEntrepriseService", () => {
 			await expect(service.siren(siren)).rejects.toBeInstanceOf(EntrepriseServiceError);
 			expect(global.fetch).toHaveBeenCalledTimes(1);
 		});
+
+		it("does not retry a non-transient network error (e.g. DNS ENOTFOUND)", async () => {
+			global.fetch = jest
+				.fn()
+				.mockRejectedValue(Object.assign(new TypeError("fetch failed"), { cause: { code: "ENOTFOUND" } }));
+
+			await expect(service.siren(siren)).rejects.toBeInstanceOf(EntrepriseServiceError);
+			expect(global.fetch).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not retry an aborted request", async () => {
+			global.fetch = jest.fn().mockRejectedValue(Object.assign(new Error("aborted"), { name: "AbortError" }));
+
+			await expect(service.siren(siren)).rejects.toBeInstanceOf(EntrepriseServiceError);
+			expect(global.fetch).toHaveBeenCalledTimes(1);
+		});
+
+		it("retries an AggregateError whose sub-errors are transient (dual-stack)", async () => {
+			global.fetch = jest
+				.fn()
+				.mockRejectedValueOnce(
+					Object.assign(new TypeError("fetch failed"), { cause: { errors: [{ code: "ECONNREFUSED" }] } }),
+				)
+				.mockResolvedValueOnce({
+					ok: true,
+					status: 200,
+					json: async () => ({ results: [{ siren: TEST_SIREN, nom_raison_sociale: "ACME SARL" }] }),
+				} as Response);
+
+			const entreprise = await service.siren(siren);
+
+			expect(entreprise.simpleLabel).toBe("ACME SARL");
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+		});
 	});
 
 	describe("search", () => {


### PR DESCRIPTION
Closes #3699

## Problème

Sur l'étape 1 de la déclaration (`/declaration/commencer`), la saisie d'un Siren remonte parfois **« Une erreur serveur est survenue. Veuillez réessayer. »** et bloque tout le parcours.

La cause n'est pas le Siren : `getCompany()` interroge l'API `recherche-entreprises.api.gouv.fr`, et cet appel échoue **par intermittence** avec un `ECONNREFUSED` (la connexion sortante est refusée ponctuellement). L'erreur réseau est enrobée en `EntrepriseServiceError("Unknown Siren error.")` puis convertie en `API_ERROR`, ce qui fige l'étape 1. Le lookup ne sert pourtant qu'au **préremplissage** des infos entreprise.

## Correctif

Wrapper `fetchWithRetry` dans `RechercheEntrepriseService` : sur une **erreur réseau levée** (le cas `ECONNREFUSED`), on réessaie jusqu'à 3 fois avec un court backoff (150 ms puis 300 ms) avant d'abandonner. Appliqué aux 3 appels (`search` / `siren` / `siret`).

- Le retry ne se déclenche **que** sur exception réseau — les statuts HTTP (404, 500…) sont renvoyés tels quels, donc le comportement métier (not-found, entreprise fermée, non-diffusible) est **inchangé**.
- Un hoquet réseau transitoire est absorbé silencieusement au lieu de bloquer le déclarant.

## Validation

- Tests Jest du service : **22/22**, dont 3 nouveaux (retry-puis-succès, abandon après le nombre max de tentatives, absence de retry sur statut HTTP).
- ESLint + Prettier : OK sur les fichiers modifiés.

## Limite connue

Le retry couvre les **échecs transitoires** (le cas observé en prod). Une indisponibilité **prolongée** de l'API bloquerait toujours le parcours — couvrir ce cas demanderait une UI de **saisie manuelle** des infos entreprise sur l'étape suivante (à arbitrer côté produit, hors périmètre de ce correctif).