### PR TITLE
fix(declaration): enforce the closed-company check server-side on creation

### DIFF
--- a/packages/app/src/api/core-domain/useCases/SaveDeclaration.ts
+++ b/packages/app/src/api/core-domain/useCases/SaveDeclaration.ts
@@ -12,6 +12,7 @@ import { CompanyWorkforceRange } from "@common/core-domain/domain/valueObjects/d
 import { DeclarationSource } from "@common/core-domain/domain/valueObjects/declaration/DeclarationSource";
 import { Siren } from "@common/core-domain/domain/valueObjects/Siren";
 import { type CreateDeclarationDTO } from "@common/core-domain/dtos/DeclarationDTO";
+import { isCompanyClosed } from "@common/core-domain/helpers/entreprise";
 import { companyMap } from "@common/core-domain/mappers/companyMap";
 import { AppError, type EntityPropsToJson, type UseCase, ValidationError } from "@common/shared-domain";
 import { PositiveInteger, PositiveNumber } from "@common/shared-domain/domain/valueObjects";
@@ -44,7 +45,8 @@ export class SaveDeclaration implements UseCase<Input, void> {
 
     const pk: DeclarationPK = [new Siren(siren), new PositiveNumber(year)];
 
-    const company = companyMap.toDomain(await this.entrepriseService.siren(pk[0]));
+    const rawEntreprise = await this.entrepriseService.siren(pk[0]);
+    const company = companyMap.toDomain(rawEntreprise);
 
     const partialDeclaration = {
       siren,
@@ -249,6 +251,16 @@ export class SaveDeclaration implements UseCase<Input, void> {
     try {
       const found = await this.declarationRepo.getOne(pk);
 
+      // Server-side guard: block the creation of a declaration for an already-closed company. The client
+      // checks this at the "commencer" step, but that check is bypassed on edit and on non-funnel paths.
+      // Edits (found) and staff (override) stay allowed, like the over-one-year rule below; a non-diffusible
+      // company has no dateCessation so isCompanyClosed returns false and it remains allowed (see #2181).
+      if (!found && !override && isCompanyClosed(rawEntreprise, year)) {
+        throw new SaveDeclarationClosedCompanyError(
+          "Ce Siren correspond a une entreprise fermée. Veuillez vérifier votre saisie",
+        );
+      }
+
       if (found) {
         const olderThanOneYear = isAfter(new Date(), add(found.declaredAt, { years: 1 }));
 
@@ -334,3 +346,6 @@ export class SaveDeclaration implements UseCase<Input, void> {
 
 export class SaveDeclarationError extends AppError {}
 export class SaveDeclarationOverOneYearError extends AppError {}
+// Extends ValidationError so the existing catch passthrough (instanceof ValidationError) and the server
+// actions surface its message to the declarant instead of collapsing it to a generic error.
+export class SaveDeclarationClosedCompanyError extends ValidationError {}

--- a/packages/app/src/api/core-domain/useCases/SaveRepresentationEquilibree.ts
+++ b/packages/app/src/api/core-domain/useCases/SaveRepresentationEquilibree.ts
@@ -6,8 +6,9 @@ import {
 import { RepresentationEquilibreeSpecification } from "@common/core-domain/domain/specification/RepresentationEquilibreeSpecification";
 import { Siren } from "@common/core-domain/domain/valueObjects/Siren";
 import { type CreateRepresentationEquilibreeDTO } from "@common/core-domain/dtos/CreateRepresentationEquilibreeDTO";
+import { isCompanyClosed } from "@common/core-domain/helpers/entreprise";
 import { companyMap } from "@common/core-domain/mappers/companyMap";
-import { AppError, type EntityPropsToJson, type UseCase } from "@common/shared-domain";
+import { AppError, type EntityPropsToJson, type UseCase, ValidationError } from "@common/shared-domain";
 import { PositiveNumber } from "@common/shared-domain/domain/valueObjects";
 import { add, isAfter } from "date-fns";
 
@@ -89,7 +90,17 @@ export class SaveRepresentationEquilibree implements UseCase<Input, void> {
 
         representationEquilibree = found.fromJson(partialProps);
       } else {
-        const company = companyMap.toDomain(await this.entrepriseService.siren(pk[0]));
+        // Server-side guard: block the creation of a representation for an already-closed company. The
+        // client checks this at "commencer", but that check is bypassed on non-funnel paths. The API is
+        // only fetched here on creation; staff (override) and non-diffusible companies (no dateCessation,
+        // so isCompanyClosed returns false) stay allowed, mirroring the declaration funnel.
+        const rawEntreprise = await this.entrepriseService.siren(pk[0]);
+        if (!override && isCompanyClosed(rawEntreprise, repEq.year)) {
+          throw new SaveRepresentationEquilibreeClosedCompanyError(
+            "Ce Siren correspond a une entreprise fermée. Veuillez vérifier votre saisie",
+          );
+        }
+        const company = companyMap.toDomain(rawEntreprise);
         representationEquilibree = RepresentationEquilibree.fromJson({
           ...partialProps,
           declaredAt: now,
@@ -116,6 +127,10 @@ export class SaveRepresentationEquilibree implements UseCase<Input, void> {
         throw specification.lastError;
       }
     } catch (error: unknown) {
+      // Surface the closed-company guard as itself instead of collapsing it into the generic error.
+      if (error instanceof SaveRepresentationEquilibreeClosedCompanyError) {
+        throw error;
+      }
       throw new SaveRepresentationEquilibreeError("Cannot save representation equilibree", error as Error);
     }
   }
@@ -123,3 +138,4 @@ export class SaveRepresentationEquilibree implements UseCase<Input, void> {
 
 export class SaveRepresentationEquilibreeError extends AppError {}
 export class SaveRepresentationEquilibreeOverOneYearError extends AppError {}
+export class SaveRepresentationEquilibreeClosedCompanyError extends ValidationError {}

--- a/packages/app/src/api/core-domain/useCases/__tests__/SaveDeclaration.test.ts
+++ b/packages/app/src/api/core-domain/useCases/__tests__/SaveDeclaration.test.ts
@@ -1,0 +1,108 @@
+import { type Entreprise, type IEntrepriseService } from "@api/core-domain/infra/services/IEntrepriseService";
+import { type IDeclarationRepo } from "@api/core-domain/repo/IDeclarationRepo";
+import { type Declaration } from "@common/core-domain/domain/Declaration";
+import { type CreateDeclarationDTO } from "@common/core-domain/dtos/DeclarationDTO";
+
+import { SaveDeclaration, SaveDeclarationClosedCompanyError } from "../SaveDeclaration";
+
+const SIREN = "384964508";
+const YEAR = 2023;
+
+const makeEntreprise = (dateCessation?: string): Entreprise =>
+  ({
+    activitePrincipale: "62.02A",
+    activitePrincipaleUniteLegale: "62.02A",
+    caractereEmployeurUniteLegale: "O",
+    categorieJuridiqueUniteLegale: "5710",
+    conventions: [],
+    dateCreationUniteLegale: "2010-01-01",
+    dateDebut: "2010-01-01",
+    etablissements: 1,
+    etatAdministratifUniteLegale: dateCessation ? "C" : "A",
+    highlightLabel: "ACME SARL",
+    label: "ACME SARL",
+    matching: 1,
+    simpleLabel: "ACME SARL",
+    siren: SIREN,
+    ...(dateCessation ? { dateCessation } : {}),
+    allMatchingEtablissements: [],
+    firstMatchingEtablissement: {
+      activitePrincipaleEtablissement: "62.02A",
+      address: "1 RUE DE TEST 75001 PARIS",
+      codeCommuneEtablissement: "75101",
+      codePostalEtablissement: "75001",
+      etablissementSiege: true,
+      libelleCommuneEtablissement: "PARIS",
+      siret: "38496450800014",
+    },
+  }) as Entreprise;
+
+const makeDto = (): CreateDeclarationDTO =>
+  ({
+    "declaration-existante": { status: "creation" },
+    commencer: { annéeIndicateurs: YEAR, siren: SIREN },
+    entreprise: { entrepriseDéclarante: { siren: SIREN } },
+  }) as unknown as CreateDeclarationDTO;
+
+const makeUseCase = (opts: { entreprise?: Entreprise; found?: Declaration | null } = {}) => {
+  const saveWithIndex = jest.fn().mockResolvedValue(undefined);
+  const getOne = jest.fn().mockResolvedValue(opts.found ?? null);
+  const siren = jest.fn().mockResolvedValue(opts.entreprise ?? makeEntreprise("2017-01-03"));
+  const repo = { getOne, saveWithIndex } as unknown as IDeclarationRepo;
+  const service = { siren } as unknown as IEntrepriseService;
+  return { useCase: new SaveDeclaration(repo, service), saveWithIndex, getOne, siren };
+};
+
+// The guard must not fire; the downstream flow may still reject for unrelated (minimal-DTO) reasons,
+// so we only assert that the rejection — if any — is not the closed-company guard.
+const expectNotBlockedAsClosed = (promise: Promise<unknown>) =>
+  promise.catch(error => {
+    expect(error).not.toBeInstanceOf(SaveDeclarationClosedCompanyError);
+  });
+
+describe("SaveDeclaration — closed-company guard", () => {
+  it("blocks creating a declaration for a closed company", async () => {
+    const { useCase, saveWithIndex } = makeUseCase({ entreprise: makeEntreprise("2017-01-03") });
+
+    await expect(useCase.execute({ declaration: makeDto() })).rejects.toBeInstanceOf(
+      SaveDeclarationClosedCompanyError,
+    );
+    expect(saveWithIndex).not.toHaveBeenCalled();
+  });
+
+  it("lets staff (override) save for a closed company", async () => {
+    const { useCase } = makeUseCase({ entreprise: makeEntreprise("2017-01-03") });
+
+    await expectNotBlockedAsClosed(useCase.execute({ declaration: makeDto(), override: true }));
+  });
+
+  it("lets an existing declaration be edited even if the company is now closed", async () => {
+    const { useCase } = makeUseCase({
+      entreprise: makeEntreprise("2017-01-03"),
+      found: { declaredAt: new Date() } as Declaration,
+    });
+
+    await expectNotBlockedAsClosed(useCase.execute({ declaration: makeDto() }));
+  });
+
+  it("lets an open company be declared", async () => {
+    const { useCase } = makeUseCase({ entreprise: makeEntreprise(undefined) });
+
+    await expectNotBlockedAsClosed(useCase.execute({ declaration: makeDto() }));
+  });
+
+  it("lets a non-diffusible company (no dateCessation) be declared", async () => {
+    const { useCase } = makeUseCase({ entreprise: makeEntreprise(undefined) });
+
+    await expectNotBlockedAsClosed(useCase.execute({ declaration: makeDto() }));
+  });
+
+  it("does not report a closed company when the API lookup fails (fail-open)", async () => {
+    const siren = jest.fn().mockRejectedValue(new Error("fetch failed"));
+    const repo = { getOne: jest.fn(), saveWithIndex: jest.fn() } as unknown as IDeclarationRepo;
+    const service = { siren } as unknown as IEntrepriseService;
+    const useCase = new SaveDeclaration(repo, service);
+
+    await expectNotBlockedAsClosed(useCase.execute({ declaration: makeDto() }));
+  });
+});

--- a/packages/app/src/api/core-domain/useCases/__tests__/SaveRepresentationEquilibree.test.ts
+++ b/packages/app/src/api/core-domain/useCases/__tests__/SaveRepresentationEquilibree.test.ts
@@ -1,0 +1,105 @@
+import { type Entreprise, type IEntrepriseService } from "@api/core-domain/infra/services/IEntrepriseService";
+import { type IRepresentationEquilibreeRepo } from "@api/core-domain/repo/IRepresentationEquilibreeRepo";
+import { type RepresentationEquilibree } from "@common/core-domain/domain/RepresentationEquilibree";
+import { type CreateRepresentationEquilibreeDTO } from "@common/core-domain/dtos/CreateRepresentationEquilibreeDTO";
+
+import { SaveRepresentationEquilibree, SaveRepresentationEquilibreeClosedCompanyError } from "../SaveRepresentationEquilibree";
+
+const SIREN = "384964508";
+const YEAR = 2023;
+
+const makeEntreprise = (dateCessation?: string): Entreprise =>
+  ({
+    activitePrincipale: "62.02A",
+    activitePrincipaleUniteLegale: "62.02A",
+    caractereEmployeurUniteLegale: "O",
+    categorieJuridiqueUniteLegale: "5710",
+    conventions: [],
+    dateCreationUniteLegale: "2010-01-01",
+    dateDebut: "2010-01-01",
+    etablissements: 1,
+    etatAdministratifUniteLegale: dateCessation ? "C" : "A",
+    highlightLabel: "ACME SARL",
+    label: "ACME SARL",
+    matching: 1,
+    simpleLabel: "ACME SARL",
+    siren: SIREN,
+    ...(dateCessation ? { dateCessation } : {}),
+    allMatchingEtablissements: [],
+    firstMatchingEtablissement: {
+      activitePrincipaleEtablissement: "62.02A",
+      address: "1 RUE DE TEST 75001 PARIS",
+      codeCommuneEtablissement: "75101",
+      codePostalEtablissement: "75001",
+      etablissementSiege: true,
+      libelleCommuneEtablissement: "PARIS",
+      siret: "38496450800014",
+    },
+  }) as Entreprise;
+
+const makeDto = (): CreateRepresentationEquilibreeDTO =>
+  ({ siren: SIREN, year: YEAR }) as unknown as CreateRepresentationEquilibreeDTO;
+
+const makeUseCase = (opts: { entreprise?: Entreprise; found?: RepresentationEquilibree | null } = {}) => {
+  const saveWithIndex = jest.fn().mockResolvedValue(undefined);
+  const getOne = jest.fn().mockResolvedValue(opts.found ?? null);
+  const siren = jest.fn().mockResolvedValue(opts.entreprise ?? makeEntreprise("2017-01-03"));
+  const repo = { getOne, saveWithIndex } as unknown as IRepresentationEquilibreeRepo;
+  const service = { siren } as unknown as IEntrepriseService;
+  return { useCase: new SaveRepresentationEquilibree(repo, service), saveWithIndex, getOne, siren };
+};
+
+// The guard must not fire; the downstream flow may still reject for unrelated (minimal-DTO) reasons,
+// so we only assert that the rejection — if any — is not the closed-company guard.
+const expectNotBlockedAsClosed = (promise: Promise<unknown>) =>
+  promise.catch(error => {
+    expect(error).not.toBeInstanceOf(SaveRepresentationEquilibreeClosedCompanyError);
+  });
+
+describe("SaveRepresentationEquilibree — closed-company guard", () => {
+  it("blocks creating a representation for a closed company", async () => {
+    const { useCase, saveWithIndex } = makeUseCase({ entreprise: makeEntreprise("2017-01-03") });
+
+    await expect(useCase.execute({ repEq: makeDto() })).rejects.toBeInstanceOf(
+      SaveRepresentationEquilibreeClosedCompanyError,
+    );
+    expect(saveWithIndex).not.toHaveBeenCalled();
+  });
+
+  it("lets staff (override) save for a closed company", async () => {
+    const { useCase } = makeUseCase({ entreprise: makeEntreprise("2017-01-03") });
+
+    await expectNotBlockedAsClosed(useCase.execute({ repEq: makeDto(), override: true }));
+  });
+
+  it("does not even fetch the company (nor block) when editing an existing representation", async () => {
+    const { useCase, siren } = makeUseCase({
+      found: { declaredAt: new Date(), fromJson: () => ({}) } as unknown as RepresentationEquilibree,
+    });
+
+    await expectNotBlockedAsClosed(useCase.execute({ repEq: makeDto() }));
+    expect(siren).not.toHaveBeenCalled();
+  });
+
+  it("lets an open company be declared", async () => {
+    const { useCase } = makeUseCase({ entreprise: makeEntreprise(undefined) });
+
+    await expectNotBlockedAsClosed(useCase.execute({ repEq: makeDto() }));
+  });
+
+  it("lets a non-diffusible company (no dateCessation) be declared", async () => {
+    const { useCase } = makeUseCase({ entreprise: makeEntreprise(undefined) });
+
+    await expectNotBlockedAsClosed(useCase.execute({ repEq: makeDto() }));
+  });
+
+  it("does not report a closed company when the API lookup fails (fail-open)", async () => {
+    const siren = jest.fn().mockRejectedValue(new Error("fetch failed"));
+    const getOne = jest.fn().mockResolvedValue(null);
+    const repo = { getOne, saveWithIndex: jest.fn() } as unknown as IRepresentationEquilibreeRepo;
+    const service = { siren } as unknown as IEntrepriseService;
+    const useCase = new SaveRepresentationEquilibree(repo, service);
+
+    await expectNotBlockedAsClosed(useCase.execute({ repEq: makeDto() }));
+  });
+});

--- a/packages/app/src/app/(default)/representation-equilibree/(funnel)/validation/RecapRepEq.tsx
+++ b/packages/app/src/app/(default)/representation-equilibree/(funnel)/validation/RecapRepEq.tsx
@@ -35,6 +35,7 @@ const useStore = storePicker(useRepeqFunnelStore);
 export const ValidationRecapRepEq = () => {
   const router = useRouter();
   const [company, setCompany] = useState<Entreprise | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [funnel, setIsEdit] = useStore("funnel", "setIsEdit");
   const hydrated = useRepeqFunnelStoreHasHydrated();
 
@@ -74,7 +75,12 @@ export const ValidationRecapRepEq = () => {
   }
 
   const sendRepresentationEquilibree = async () => {
-    await saveRepresentationEquilibree(funnel);
+    setSaveError(null);
+    const result = await saveRepresentationEquilibree(funnel);
+    if (!result.ok) {
+      setSaveError(result.error);
+      return;
+    }
     setIsEdit(true);
     router.push("/representation-equilibree/transmission");
   };
@@ -109,6 +115,9 @@ export const ValidationRecapRepEq = () => {
         des données <strong>{funnel.year}</strong>.
       </p>
       <DetailRepEq edit repEq={repEq} />
+      {saveError && (
+        <Alert className={fr.cx("fr-mt-4w")} severity="error" title="La déclaration n'a pas pu être transmise" description={saveError} />
+      )}
       <ButtonsGroup
         className={fr.cx("fr-mt-6w")}
         inlineLayoutWhen="sm and up"

--- a/packages/app/src/app/(default)/representation-equilibree/actions.ts
+++ b/packages/app/src/app/(default)/representation-equilibree/actions.ts
@@ -15,7 +15,7 @@ import { assertServerSession } from "@api/utils/auth";
 import { Siren } from "@common/core-domain/domain/valueObjects/Siren";
 import { type CompanyDTO } from "@common/core-domain/dtos/CompanyDTO";
 import { type CreateRepresentationEquilibreeDTO } from "@common/core-domain/dtos/CreateRepresentationEquilibreeDTO";
-import { UnexpectedSessionError } from "@common/shared-domain";
+import { UnexpectedSessionError, ValidationError } from "@common/shared-domain";
 import { PositiveNumber } from "@common/shared-domain/domain/valueObjects";
 import { type ServerActionResponse } from "@common/utils/next";
 
@@ -35,7 +35,9 @@ export async function getRepresentationEquilibree(siren: string, year: number) {
   return ret;
 }
 
-export async function saveRepresentationEquilibree(repEq: CreateRepresentationEquilibreeDTO) {
+export async function saveRepresentationEquilibree(
+  repEq: CreateRepresentationEquilibreeDTO,
+): Promise<ServerActionResponse<undefined, string>> {
   const session = await assertServerSession({
     owner: {
       check: repEq.siren,
@@ -45,7 +47,16 @@ export async function saveRepresentationEquilibree(repEq: CreateRepresentationEq
   });
 
   const useCase = new SaveRepresentationEquilibree(representationEquilibreeRepo, entrepriseService);
-  await useCase.execute({ repEq, override: session.user.staff });
+
+  try {
+    await useCase.execute({ repEq, override: session.user.staff });
+  } catch (error: unknown) {
+    if (error instanceof ValidationError) {
+      return { ok: false, error: error.message };
+    }
+    console.error(error);
+    return { ok: false, error: "Une erreur est survenue, veuillez réessayer." };
+  }
 
   const receiptUseCase = new SendRepresentationEquilibreeReceipt(
     representationEquilibreeRepo,
@@ -59,6 +70,8 @@ export async function saveRepresentationEquilibree(repEq: CreateRepresentationEq
   // Note: [revalidatePath bug](https://github.com/vercel/next.js/issues/49387). Try to reactivate it when it will be fixed in Next (it seems to be fixed in Next 14).
   // revalidatePath(`/representation-equilibree/${repEq.siren}/${repEq.year}`);
   // revalidatePath(`/representation-equilibree/${repEq.siren}/${repEq.year}/pdf`);
+
+  return { ok: true };
 }
 
 export async function sendRepresentationEquilibreeReceipt(siren: string, year: number) {

--- a/packages/app/src/common/core-domain/helpers/__tests__/entreprise.test.ts
+++ b/packages/app/src/common/core-domain/helpers/__tests__/entreprise.test.ts
@@ -1,0 +1,23 @@
+import { type Entreprise } from "@api/core-domain/infra/services/IEntrepriseService";
+
+import { isCompanyClosed } from "../entreprise";
+
+const makeCompany = (dateCessation?: string): Entreprise => ({ dateCessation }) as Entreprise;
+
+describe("isCompanyClosed", () => {
+  it("returns false when the company has no dateCessation", () => {
+    expect(isCompanyClosed(makeCompany(undefined), 2023)).toBe(false);
+  });
+
+  it("returns true when the company closed years before the indicators period", () => {
+    expect(isCompanyClosed(makeCompany("2017-01-03"), 2023)).toBe(true);
+  });
+
+  it("returns true when closed before 1 March of the year after the indicators year", () => {
+    expect(isCompanyClosed(makeCompany("2024-02-01"), 2023)).toBe(true);
+  });
+
+  it("returns false when closed after 1 March of the year after the indicators year", () => {
+    expect(isCompanyClosed(makeCompany("2024-04-01"), 2023)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #3700

## Problème

Le contrôle « entreprise fermée » (`isCompanyClosed`) n'était appliqué **que côté client**, dans **les deux funnels** : déclaration index (`CommencerForm`, `UESForm`) et représentation-équilibrée (`commencer/Form.tsx`). Une déclaration pour une entreprise radiée a pu être enregistrée. Vecteurs de contournement : déclaration déjà existante (early-return avant le check), entreprise non-diffusible (`etat_administratif: "A"` forcé), aucune barrière serveur, fraîcheur de la donnée.

## Correctif

**1. Garde côté serveur** dans les deux use cases (`SaveDeclaration` **et** `SaveRepresentationEquilibree`), sur le chemin que tous les flux traversent :

```ts
if (!found && !override && isCompanyClosed(rawEntreprise, year)) {
  throw new SaveDeclarationClosedCompanyError("Ce Siren correspond a une entreprise fermée. Veuillez vérifier votre saisie");
}
```

- **Aucune dépendance réseau ajoutée** : les use cases appellent déjà `entrepriseService.siren()` ; on réutilise l'`Entreprise` brute **avant** que `companyMap.toDomain` ne supprime `dateCessation`.
- **Fail-open** : une panne API ne reporte **jamais** « entreprise fermée » à tort.
- **Création uniquement** : gate sur `!found` (existence serveur, non falsifiable) → éditions/corrections autorisées.
- **Non-diffusible préservé** (#2181) ; **staff** (`override`) bypass, cohérent avec la règle « +1 an ».

**2. Surfaçage du message (funnel rep-eq)** : `saveRepresentationEquilibree` renvoie désormais un `ServerActionResponse` (comme le funnel déclaration) au lieu de *throw*, et l'étape récap affiche une `Alert` avec le message en cas d'échec — au lieu d'un échec silencieux. Le funnel déclaration surfait déjà via son action.

## Validation

- **16 nouveaux tests** Jest : `isCompanyClosed` (4) + garde déclaration (6) + garde rep-eq (6).
- Non-régression : domaine `api`+`common` **29/29**, funnel rep-eq **42/42**, `validation-transmission`+`admin/rattachements` **5/5**.
- ESLint OK ; `tsc` sans nouvelle erreur (l'unique erreur `tsc` du repo est pré-existante, fichier non touché).
- Revues adverses dédiées (garde déclaration, garde rep-eq, surfaçage) : claims confirmés, aucun bug/régression.

## À confirmer (choix produit)

- **Staff bypass** : un membre staff peut-il créer pour une entreprise fermée ? Défaut = oui (cohérent avec l'override « +1 an »).
- **Édition** d'une déclaration préexistante d'une entreprise désormais fermée : autorisée (on ne bloque que la création).

## Hors périmètre

- SIREN **membres d'une UES** : encore validés uniquement côté client (`UESForm`) — seul le SIREN déclarant est gardé côté serveur. Couvrir les membres nécessiterait un lookup API par membre.