### PR TITLE
fix(infra): #3593 — restaure le téléchargement des référents en V1

### DIFF
--- a/.kontinuous/env/prod/archive/http.yaml
+++ b/.kontinuous/env/prod/archive/http.yaml
@@ -136,6 +136,14 @@ spec:
     services:
     - name: nginx
       port: 80
+  - kind: Rule
+    match: Host(`egapro.travail.gouv.fr`) && PathPrefix(`/apiv2/public/referents_egalite_professionnelle`)
+    middlewares:
+    - name: security-headers-nginx
+    priority: 10000
+    services:
+    - name: nginx
+      port: 80
   tls:
     secretName: api-crt
 ---


### PR DESCRIPTION
## Contexte

Closes #3593

Le téléchargement du fichier des référents en V1 (prod, branche `master`) renvoie une **404** :

```
GET /apiv2/public/referents_egalite_professionnelle.xlsx → 404
body: {"error":"/v2/public/referents_egalite_professionnelle.xlsx"}
```

Le corps `{"error":…}` est servi par l'**ancienne API Python**, pas par l'app Next.js.

## Cause racine (routing traefik)

L'export des référents a été migré de l'API Python vers l'app Next.js (#2244). Il vit désormais dans l'app (`packages/app/src/app/api/public/referents_egalite_professionnelle/[ext]/route.ts`), atteint via le rewrite `/apiv2/:path*` → `/api/:path*` de `next.config.js`. La requête doit donc arriver sur **nginx → app**.

Or dans `.kontinuous/env/prod/archive/http.yaml` :
- IngressRoute `api` : `PathPrefix(/api)` + `strip-api-prefix`, **priority 100**. `PathPrefix(/api)` matche **aussi** `/apiv2`, qui devient `/v2/...` après strip → service Python → 404.
- IngressRoute `nginx` (catch-all) : **priority 50**.

`/apiv2/*` matchait les deux règles, et `100 > 50` faisait gagner la route Python.

**Régression** : #3202 a baissé la priorité du catch-all nginx de `10000 → 50` pour réparer le routing `/api/* → Python`, ce qui a cassé `/apiv2/* → app` en effet de bord.

## Fix

Ajout d'une règle dédiée à priorité supérieure (`10000`) dans l'IngressRoute `nginx`, alignée sur les overrides existants (`/api/auth`, `/api/monitoring`, `/index-egapro/recherche`), pour router `/apiv2/public/referents_egalite_professionnelle` vers nginx → app. Le compromis `/api/* → Python` réparé par #3202 reste intact.

## Vérification post-déploiement

```
curl -I https://egapro.travail.gouv.fr/apiv2/public/referents_egalite_professionnelle.xlsx
→ 200 + Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
```