### PR TITLE
fix(a11y): résumé des tableaux complexes du parcours rémunération (RGAA 5.1)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -81,15 +81,21 @@ export function CategoryRecapTable({
 			: null;
 
 	const heading = `Catégorie d'emplois n°${index + 1}${category.name ? ` : ${category.name}` : ""}`;
+	const summaryId = `category-recap-summary-${index}`;
+	const tableSummary =
+		"Tableau complexe comparant la rémunération des femmes et des hommes pour cette catégorie d'emplois. Quatre colonnes : intitulé de la ligne, valeur pour les femmes, valeur pour les hommes, et écart en pourcentage (seuil réglementaire de 5 %). Les lignes sont regroupées en trois sections : l'effectif physique, la rémunération annuelle brute, puis la rémunération horaire brute, chacune détaillant le salaire de base, les composantes variables ou complémentaires, et le total.";
 
 	return (
 		<section className={styles.section}>
 			<p className={`fr-text--bold ${styles.heading}`}>{heading}</p>
+			<p className="fr-sr-only" id={summaryId}>
+				{tableSummary}
+			</p>
 			<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
 				<div className="fr-table__wrapper">
 					<div className="fr-table__container">
 						<div className="fr-table__content">
-							<table>
+							<table aria-describedby={summaryId}>
 								<caption>{`${heading} – ${declarationYear}`}</caption>
 								<thead>
 									<tr>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
@@ -263,15 +263,20 @@ function QuartileDistributionTable({
 	}
 
 	const trancheKind = unit === "€" ? "annuelle brute" : "horaire brute";
+	const summaryId = `quartile-recap-summary-${unit === "€" ? "annual" : "hourly"}`;
+	const tableSummary = `Tableau complexe de répartition des effectifs par quartile de rémunération ${trancheKind}. Sept colonnes : l'intitulé du quartile, la tranche de rémunération (bornes minimale et maximale regroupées sous un en-tête commun), le nombre de femmes, le nombre d'hommes, le pourcentage de femmes et le pourcentage d'hommes. Les lignes correspondent aux quatre quartiles, suivies d'une ligne de total pour l'ensemble des salariés.`;
 
 	return (
 		<div className={styles.subTable}>
 			<p className={`fr-text--bold ${styles.subTitle}`}>{title}</p>
+			<p className="fr-sr-only" id={summaryId}>
+				{tableSummary}
+			</p>
 			<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
 				<div className="fr-table__wrapper">
 					<div className="fr-table__container">
 						<div className="fr-table__content">
-							<table>
+							<table aria-describedby={summaryId}>
 								<caption>{caption}</caption>
 								<thead>
 									<tr>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -47,19 +47,24 @@ export function QuartileTable({
 	const totalAll = totalWomen + totalMen;
 	const trancheSuffix =
 		tableType === "annual" ? "annuelle brute" : "horaire brute";
+	const summaryId = `quartile-summary-${tableType}`;
+	const tableSummary = `Tableau complexe de répartition des effectifs par quartile de rémunération ${trancheSuffix}. Sept colonnes : l'intitulé du quartile, la tranche de rémunération (bornes minimale et maximale regroupées sous un en-tête commun), le nombre de femmes, le nombre d'hommes, le pourcentage de femmes et le pourcentage d'hommes. Les lignes correspondent aux quatre quartiles, suivies d'une ligne de total pour l'ensemble des salariés.`;
 
 	return (
 		<div className={stepStyles.tableWrapper}>
 			<h3 className="fr-h5 fr-mb-0">{title}</h3>
 			<div className={stepStyles.tableSection}>
 				{readingNote}
+				<p className="fr-sr-only" id={summaryId}>
+					{tableSummary}
+				</p>
 				<div
 					className={`fr-table fr-table--no-scroll fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
 				>
 					<div className="fr-table__wrapper">
 						<div className="fr-table__container">
 							<div className="fr-table__content">
-								<table>
+								<table aria-describedby={summaryId}>
 									<caption className="fr-sr-only">{title}</caption>
 									<colgroup>
 										<col className={stepStyles.colRowLabel} />

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -208,103 +208,111 @@ export function CategoryDataTable({
 		!Number.isNaN(womenInt) && !Number.isNaN(menInt) ? womenInt + menInt : null;
 
 	const idPrefix = `cat-${catIndex}`;
+	const summaryId = `${idPrefix}-summary`;
+	const tableSummary =
+		"Tableau complexe de saisie de la rémunération des femmes et des hommes pour cette catégorie d'emplois. Quatre colonnes : intitulé de la ligne, champ de saisie pour les femmes, champ de saisie pour les hommes, et écart calculé en pourcentage (seuil réglementaire de 5 %). Les lignes sont regroupées en trois sections : l'effectif physique, la rémunération annuelle brute moyenne, puis la rémunération horaire brute moyenne, chacune avec le salaire de base, les composantes variables ou complémentaires, et le total.";
 	return (
-		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
-			<div className="fr-table__wrapper">
-				<div className="fr-table__container">
-					<div className="fr-table__content">
-						<table>
-							<caption>Données catégorie {catIndex + 1}</caption>
-							<thead>
-								<tr>
-									<th className={stepStyles.nameColumnHeader} scope="col">
-										{/* row label */}
-									</th>
-									<th scope="col">Femmes</th>
-									<th scope="col">Hommes</th>
-									<th scope="col">
-										<strong>Écart</strong>
-										<br />
-										<span className={common.fontRegular}>
-											Seuil réglementaire : 5%
-										</span>
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td className={stepStyles.sectionHeader} colSpan={4}>
-										<strong>
-											Total salariés
-											{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
-										</strong>
-									</td>
-								</tr>
-								<tr className={stepStyles.dataRow}>
-									<td>Effectif physique</td>
-									<td>
-										<div className={stepStyles.inputCell}>
-											<input
-												aria-label={`Effectif femmes, catégorie ${catIndex + 1}`}
-												className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
-												disabled={disabled}
-												id={`${idPrefix}-women-count`}
-												inputMode="numeric"
-												onChange={pos(catIndex, "womenCount", true)}
-												pattern="[0-9]*"
-												type="text"
-												value={cat.womenCount}
-											/>
-											<span className="fr-text--sm">nb</span>
-										</div>
-									</td>
-									<td>
-										<div className={stepStyles.inputCell}>
-											<input
-												aria-label={`Effectif hommes, catégorie ${catIndex + 1}`}
-												className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
-												disabled={disabled}
-												id={`${idPrefix}-men-count`}
-												inputMode="numeric"
-												onChange={pos(catIndex, "menCount", true)}
-												pattern="[0-9]*"
-												type="text"
-												value={cat.menCount}
-											/>
-											<span className="fr-text--sm">nb</span>
-										</div>
-									</td>
-									<td />
-								</tr>
+		<>
+			<p className="fr-sr-only" id={summaryId}>
+				{tableSummary}
+			</p>
+			<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
+				<div className="fr-table__wrapper">
+					<div className="fr-table__container">
+						<div className="fr-table__content">
+							<table aria-describedby={summaryId}>
+								<caption>Données catégorie {catIndex + 1}</caption>
+								<thead>
+									<tr>
+										<th className={stepStyles.nameColumnHeader} scope="col">
+											{/* row label */}
+										</th>
+										<th scope="col">Femmes</th>
+										<th scope="col">Hommes</th>
+										<th scope="col">
+											<strong>Écart</strong>
+											<br />
+											<span className={common.fontRegular}>
+												Seuil réglementaire : 5%
+											</span>
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td className={stepStyles.sectionHeader} colSpan={4}>
+											<strong>
+												Total salariés
+												{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
+											</strong>
+										</td>
+									</tr>
+									<tr className={stepStyles.dataRow}>
+										<td>Effectif physique</td>
+										<td>
+											<div className={stepStyles.inputCell}>
+												<input
+													aria-label={`Effectif femmes, catégorie ${catIndex + 1}`}
+													className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
+													disabled={disabled}
+													id={`${idPrefix}-women-count`}
+													inputMode="numeric"
+													onChange={pos(catIndex, "womenCount", true)}
+													pattern="[0-9]*"
+													type="text"
+													value={cat.womenCount}
+												/>
+												<span className="fr-text--sm">nb</span>
+											</div>
+										</td>
+										<td>
+											<div className={stepStyles.inputCell}>
+												<input
+													aria-label={`Effectif hommes, catégorie ${catIndex + 1}`}
+													className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
+													disabled={disabled}
+													id={`${idPrefix}-men-count`}
+													inputMode="numeric"
+													onChange={pos(catIndex, "menCount", true)}
+													pattern="[0-9]*"
+													type="text"
+													value={cat.menCount}
+												/>
+												<span className="fr-text--sm">nb</span>
+											</div>
+										</td>
+										<td />
+									</tr>
 
-								<RemunerationSection
-									blur={blur}
-									cat={cat}
-									catIndex={catIndex}
-									disabled={disabled}
-									fields={ANNUAL_FIELDS}
-									idPrefix={idPrefix}
-									pos={pos}
-									scope="annuel"
-									sectionLabel="Rémunération annuelle brute moyenne"
-								/>
+									<RemunerationSection
+										blur={blur}
+										cat={cat}
+										catIndex={catIndex}
+										disabled={disabled}
+										fields={ANNUAL_FIELDS}
+										idPrefix={idPrefix}
+										pos={pos}
+										scope="annuel"
+										sectionLabel="Rémunération annuelle brute moyenne"
+									/>
 
-								<RemunerationSection
-									blur={blur}
-									cat={cat}
-									catIndex={catIndex}
-									disabled={disabled}
-									fields={HOURLY_FIELDS}
-									idPrefix={idPrefix}
-									pos={pos}
-									scope="horaire"
-									sectionLabel="Rémunération horaire brute moyenne"
-								/>
-							</tbody>
-						</table>
+									<RemunerationSection
+										blur={blur}
+										cat={cat}
+										catIndex={catIndex}
+										disabled={disabled}
+										fields={HOURLY_FIELDS}
+										idPrefix={idPrefix}
+										pos={pos}
+										scope="horaire"
+										sectionLabel="Rémunération horaire brute moyenne"
+									/>
+								</tbody>
+							</table>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }


### PR DESCRIPTION
## Contexte

Audit d'accessibilité : les tableaux **complexes** (cellules fusionnées via `colSpan`/`colgroup`) du parcours de déclaration de rémunération n'avaient pas de **résumé**.

> Critère **RGAA 5.1** / DSFR : « Un tableau est dit complexe lorsqu'il y a des cellules fusionnées. Le tableau doit avoir un résumé pour aider les personnes qui en ont besoin d'appréhender le contenu présenté. »

Ces tableaux avaient déjà un `<caption>` (titre, critère 5.4) mais le résumé (5.1) est une exigence **distincte** : il décrit la *structure* (sections, colonnes) pour qu'une personne au lecteur d'écran sache à quoi s'attendre avant de naviguer dans les cellules fusionnées.

## Changements

Ajout d'un résumé associé à chaque tableau complexe via `aria-describedby` pointant vers un paragraphe `fr-sr-only` (l'attribut HTML `summary` étant obsolète en HTML5). 4 tableaux concernés :

| Tableau | Page |
|---|---|
| `CategoryDataTable` (catégories de salariés — saisie) | `/declaration-remuneration/etape/5` |
| `CategoryRecapTable` (catégories de salariés — récap) | `/declaration-remuneration/recapitulatif` |
| `QuartileTable` (quartiles — saisie) | `/declaration-remuneration/etape/4` |
| `QuartileDistributionTable` dans `IndicatorTables` (quartiles — récap) | `/declaration-remuneration/recapitulatif` |

Chaque résumé décrit le nombre de colonnes, leur rôle (femmes / hommes / écart, seuil 5 %) et les sections de lignes. `id` unique par instance (index de catégorie, type de tranche).

## Hors périmètre

Confort pour les personnes en **loupe / zoom** qui perdent la vue d'ensemble : nécessite des techniques distinctes (en-têtes `sticky`, empilement responsive) — à traiter dans un ticket séparé.

## Tests

- `pnpm typecheck` : propre sur les fichiers modifiés
- `pnpm biome check` : OK
- Tests vitest des pages concernées (récap, étape 4, étape 5) : **67 passés**
