### PR TITLE
feat(auth): preserve target URL through login redirect

### DIFF
--- a/packages/app/src/__tests__/middleware.test.ts
+++ b/packages/app/src/__tests__/middleware.test.ts
@@ -19,16 +19,17 @@ vi.mock("~/env", () => ({
 import { middleware } from "~/middleware";
 
 function makeRequest(
-	pathname = "/admin",
+	pathnameAndSearch = "/admin",
 	headers: Record<string, string> = {},
 ): NextRequest {
-	const url = `http://localhost${pathname}`;
+	const url = `http://localhost${pathnameAndSearch}`;
+	const parsed = new URL(url);
 	const headerMap = new Map(
 		Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
 	);
 	return {
 		url,
-		nextUrl: { pathname },
+		nextUrl: { pathname: parsed.pathname, search: parsed.search },
 		headers: {
 			get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
 		},
@@ -45,6 +46,14 @@ describe("admin middleware", () => {
 		const res = await middleware(makeRequest("/admin/users"));
 		expect(res.headers.get("location")).toBe(
 			"http://localhost/login?callbackUrl=%2Fadmin%2Fusers",
+		);
+	});
+
+	it("preserves the query string in the callbackUrl", async () => {
+		mockGetToken.mockResolvedValue(null);
+		const res = await middleware(makeRequest("/admin/users?tab=active&page=2"));
+		expect(res.headers.get("location")).toBe(
+			"http://localhost/login?callbackUrl=%2Fadmin%2Fusers%3Ftab%3Dactive%26page%3D2",
 		);
 	});
 
@@ -66,6 +75,57 @@ describe("admin middleware", () => {
 		mockGetToken.mockResolvedValue({ id: "u1", isAdmin: true });
 		const res = await middleware(makeRequest("/admin"));
 		// NextResponse.next() does not set a redirect location
+		expect(res.headers.get("location")).toBeNull();
+	});
+});
+
+describe("session middleware (session-gated user routes)", () => {
+	beforeEach(() => {
+		mockGetToken.mockReset();
+	});
+
+	// Routes covered by the matcher block — must capture the requested URL into
+	// `callbackUrl` so the user lands back on the page they originally aimed at
+	// after ProConnect sign-in (ticket #3617).
+	const sessionGatedPaths = [
+		"/mon-espace/historique/123456789/2024",
+		"/declaration-remuneration/commencer",
+		"/avis-cse/2024/123456789",
+	];
+
+	for (const path of sessionGatedPaths) {
+		it(`redirects an unauthenticated user from ${path} to /login with callbackUrl`, async () => {
+			mockGetToken.mockResolvedValue(null);
+			const res = await middleware(makeRequest(path));
+			const expectedCallback = encodeURIComponent(path);
+			expect(res.headers.get("location")).toBe(
+				`http://localhost/login?callbackUrl=${expectedCallback}`,
+			);
+		});
+
+		it(`lets an authenticated user through on ${path}`, async () => {
+			mockGetToken.mockResolvedValue({ id: "u1" });
+			const res = await middleware(makeRequest(path));
+			// NextResponse.next() does not set a redirect location
+			expect(res.headers.get("location")).toBeNull();
+		});
+	}
+
+	it("preserves the query string when redirecting an unauthenticated user", async () => {
+		mockGetToken.mockResolvedValue(null);
+		const res = await middleware(makeRequest("/avis-cse?annee=2024"));
+		expect(res.headers.get("location")).toBe(
+			"http://localhost/login?callbackUrl=%2Favis-cse%3Fannee%3D2024",
+		);
+	});
+
+	it("does not enforce isAdmin on session-gated routes", async () => {
+		// A non-admin authenticated user must reach `/mon-espace`, unlike on
+		// `/admin/*` where they would be redirected away. Guards against a
+		// regression where the session middleware accidentally inherits the
+		// admin check.
+		mockGetToken.mockResolvedValue({ id: "u1", isAdmin: false });
+		const res = await middleware(makeRequest("/mon-espace"));
 		expect(res.headers.get("location")).toBeNull();
 	});
 });

--- a/packages/app/src/app/login/page.tsx
+++ b/packages/app/src/app/login/page.tsx
@@ -1,14 +1,21 @@
 import { redirect } from "next/navigation";
 
-import { LoginPage } from "~/modules/login";
+import { LoginPage, sanitizeCallbackUrl } from "~/modules/login";
 import { auth } from "~/server/auth";
 
-export default async function Page() {
+type PageProps = {
+	searchParams: Promise<{ callbackUrl?: string }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+	const { callbackUrl } = await searchParams;
+	const safeCallbackUrl = sanitizeCallbackUrl(callbackUrl);
+
 	const session = await auth();
 
 	if (session?.user) {
-		redirect("/mon-espace");
+		redirect(safeCallbackUrl ?? "/mon-espace");
 	}
 
-	return <LoginPage />;
+	return <LoginPage callbackUrl={safeCallbackUrl} />;
 }

--- a/packages/app/src/middleware.ts
+++ b/packages/app/src/middleware.ts
@@ -4,13 +4,19 @@ import { getToken } from "next-auth/jwt";
 import { env } from "~/env";
 
 /**
- * Next.js Edge middleware handling two independent concerns:
+ * Next.js Edge middleware handling three concerns:
  *
  * 1. `/admin/*` — backoffice guard. Decodes the NextAuth JWT and enforces
  *    `isAdmin`. Defense in depth: `src/app/admin/layout.tsx` re-checks the
  *    session on the Node runtime in case the token is missing the flag.
  *
- * 2. `/api/v1/*` — belt-and-suspenders against APISIX bypass. The APISIX
+ * 2. `/mon-espace/*`, `/declaration-remuneration/*`, `/avis-cse/*` — session
+ *    gating only (no `isAdmin` check). Captures the requested URL into
+ *    `callbackUrl` so the user returns to the page they originally aimed at
+ *    after ProConnect sign-in. The Node-runtime `auth()` guards in layouts
+ *    remain as defense in depth.
+ *
+ * 3. `/api/v1/*` — belt-and-suspenders against APISIX bypass. The APISIX
  *    gateway (see `.kontinuous/templates/apisix-suit.configmap.yaml`) injects
  *    `X-Gateway-Forwarded: <EGAPRO_GATEWAY_SHARED_SECRET>` via its
  *    `proxy-rewrite` plugin. A pod compromised in-cluster could otherwise
@@ -29,7 +35,20 @@ export async function middleware(request: NextRequest) {
 		return gatewayMiddleware(request);
 	}
 
-	return adminMiddleware(request);
+	if (pathname.startsWith("/admin")) {
+		return adminMiddleware(request);
+	}
+
+	return sessionMiddleware(request);
+}
+
+function redirectToLogin(request: NextRequest) {
+	const loginUrl = new URL("/login", request.url);
+	loginUrl.searchParams.set(
+		"callbackUrl",
+		`${request.nextUrl.pathname}${request.nextUrl.search}`,
+	);
+	return NextResponse.redirect(loginUrl);
 }
 
 async function adminMiddleware(request: NextRequest) {
@@ -40,13 +59,21 @@ async function adminMiddleware(request: NextRequest) {
 	// the `jwt` callback on sign-in, so a fresh token is the only way to get
 	// the correct flag.
 	if (!token || token.isAdmin === undefined) {
-		const loginUrl = new URL("/login", request.url);
-		loginUrl.searchParams.set("callbackUrl", request.nextUrl.pathname);
-		return NextResponse.redirect(loginUrl);
+		return redirectToLogin(request);
 	}
 
 	if (!token.isAdmin) {
 		return NextResponse.redirect(new URL("/mon-espace", request.url));
+	}
+
+	return NextResponse.next();
+}
+
+async function sessionMiddleware(request: NextRequest) {
+	const token = await getToken({ req: request, secret: env.AUTH_SECRET });
+
+	if (!token) {
+		return redirectToLogin(request);
 	}
 
 	return NextResponse.next();
@@ -94,5 +121,11 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 export const config = {
-	matcher: ["/admin/:path*", "/api/v1/:path*"],
+	matcher: [
+		"/admin/:path*",
+		"/api/v1/:path*",
+		"/mon-espace/:path*",
+		"/declaration-remuneration/:path*",
+		"/avis-cse/:path*",
+	],
 };

--- a/packages/app/src/modules/login/LoginForm.tsx
+++ b/packages/app/src/modules/login/LoginForm.tsx
@@ -2,6 +2,10 @@ import { LoginAccordion } from "./LoginAccordion";
 import styles from "./LoginForm.module.scss";
 import { ProConnectButton } from "./ProConnectButton";
 
+type Props = {
+	callbackUrl?: string;
+};
+
 /**
  * Left column of the login page: title, description, ProConnect button, accordion.
  *
@@ -9,7 +13,7 @@ import { ProConnectButton } from "./ProConnectButton";
  * - 32px (2rem) between the main content group and the accordion
  * - 24px (1.5rem) between title, description, and button within the group
  */
-export function LoginForm() {
+export function LoginForm({ callbackUrl }: Props) {
 	return (
 		<div className={styles.form}>
 			<div className={styles.content}>
@@ -19,7 +23,7 @@ export function LoginForm() {
 					sécurisée ProConnect et votre e-mail professionnel (contact utilisé en
 					cas de contrôle).
 				</p>
-				<ProConnectButton />
+				<ProConnectButton callbackUrl={callbackUrl} />
 			</div>
 			<LoginAccordion />
 		</div>

--- a/packages/app/src/modules/login/LoginPage.tsx
+++ b/packages/app/src/modules/login/LoginPage.tsx
@@ -3,14 +3,18 @@ import Image from "next/image";
 import { LoginForm } from "./LoginForm";
 import styles from "./LoginPage.module.scss";
 
-export function LoginPage() {
+type Props = {
+	callbackUrl?: string;
+};
+
+export function LoginPage({ callbackUrl }: Props) {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className={styles.container}>
 				<div className={styles.columns}>
 					<div className={styles.formColumn}>
 						<div className={styles.formInner}>
-							<LoginForm />
+							<LoginForm callbackUrl={callbackUrl} />
 						</div>
 					</div>
 

--- a/packages/app/src/modules/login/ProConnectButton.tsx
+++ b/packages/app/src/modules/login/ProConnectButton.tsx
@@ -11,14 +11,18 @@ import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 
 import styles from "./ProConnectButton.module.scss";
 
+type Props = {
+	callbackUrl?: string;
+};
+
 /** ProConnect authentication button with official branding and info link. */
-export function ProConnectButton() {
+export function ProConnectButton({ callbackUrl }: Props) {
 	function handleLogin(): void {
 		trackEvent({
 			category: MATOMO_EVENT_CATEGORY.AUTH,
 			action: MATOMO_ACTION.LOGIN_START,
 		});
-		void signIn("proconnect");
+		void signIn("proconnect", { callbackUrl: callbackUrl ?? "/mon-espace" });
 	}
 
 	return (

--- a/packages/app/src/modules/login/__tests__/LoginPage.test.tsx
+++ b/packages/app/src/modules/login/__tests__/LoginPage.test.tsx
@@ -1,6 +1,18 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { signInMock } = vi.hoisted(() => ({ signInMock: vi.fn() }));
+
+vi.mock("next-auth/react", () => ({
+	signIn: signInMock,
+	useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
 import { LoginPage } from "../LoginPage";
+
+beforeEach(() => {
+	signInMock.mockReset();
+});
 
 describe("LoginPage", () => {
 	it("renders the main landmark with id content", () => {
@@ -34,5 +46,27 @@ describe("LoginPage", () => {
 				name: /s'identifier avec\s*proconnect/i,
 			}),
 		).toBeInTheDocument();
+	});
+
+	it("forwards callbackUrl through to ProConnect signIn", () => {
+		// Observable behavior of the prop drill LoginPage → LoginForm →
+		// ProConnectButton: the deepest call receives the propagated URL.
+		render(<LoginPage callbackUrl="/admin/users" />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+		expect(signInMock).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/admin/users",
+		});
+	});
+
+	it("falls back to /mon-espace when no callbackUrl is provided", () => {
+		render(<LoginPage />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+		expect(signInMock).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/mon-espace",
+		});
 	});
 });

--- a/packages/app/src/modules/login/__tests__/ProConnectButton.test.tsx
+++ b/packages/app/src/modules/login/__tests__/ProConnectButton.test.tsx
@@ -1,6 +1,28 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { signInMock, trackEventMock } = vi.hoisted(() => ({
+	signInMock: vi.fn(),
+	trackEventMock: vi.fn(),
+}));
+
+vi.mock("next-auth/react", () => ({
+	signIn: signInMock,
+	useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
+vi.mock("~/modules/analytics", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/analytics")>();
+	return { ...actual, trackEvent: trackEventMock };
+});
+
+import { MATOMO_ACTION, MATOMO_EVENT_CATEGORY } from "~/modules/analytics";
 import { ProConnectButton } from "../ProConnectButton";
+
+beforeEach(() => {
+	signInMock.mockReset();
+	trackEventMock.mockReset();
+});
 
 describe("ProConnectButton", () => {
 	it("renders a button to trigger ProConnect sign-in", () => {
@@ -30,5 +52,36 @@ describe("ProConnectButton", () => {
 	it("uses the fr-connect-group container", () => {
 		const { container } = render(<ProConnectButton />);
 		expect(container.querySelector(".fr-connect-group")).toBeInTheDocument();
+	});
+
+	it("calls signIn with the provided callbackUrl on click", () => {
+		render(<ProConnectButton callbackUrl="/admin/users" />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+		expect(signInMock).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/admin/users",
+		});
+	});
+
+	it("falls back to /mon-espace when no callbackUrl is provided", () => {
+		render(<ProConnectButton />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+		expect(signInMock).toHaveBeenCalledWith("proconnect", {
+			callbackUrl: "/mon-espace",
+		});
+	});
+
+	it("emits a LOGIN_START analytics event on click", () => {
+		render(<ProConnectButton callbackUrl="/admin/users" />);
+		screen
+			.getByRole("button", { name: /s'identifier avec\s*proconnect/i })
+			.click();
+		expect(trackEventMock).toHaveBeenCalledWith({
+			category: MATOMO_EVENT_CATEGORY.AUTH,
+			action: MATOMO_ACTION.LOGIN_START,
+		});
 	});
 });

--- a/packages/app/src/modules/login/__tests__/sanitizeCallbackUrl.test.ts
+++ b/packages/app/src/modules/login/__tests__/sanitizeCallbackUrl.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeCallbackUrl } from "../sanitizeCallbackUrl";
+
+describe("sanitizeCallbackUrl", () => {
+	it("returns the path unchanged for a safe relative path", () => {
+		expect(sanitizeCallbackUrl("/admin/users")).toBe("/admin/users");
+	});
+
+	it("preserves the query string on a safe relative path", () => {
+		expect(sanitizeCallbackUrl("/mon-espace/historique/123456789/2024")).toBe(
+			"/mon-espace/historique/123456789/2024",
+		);
+		expect(sanitizeCallbackUrl("/avis-cse?annee=2024")).toBe(
+			"/avis-cse?annee=2024",
+		);
+	});
+
+	it("accepts the root path", () => {
+		expect(sanitizeCallbackUrl("/")).toBe("/");
+	});
+
+	it("returns undefined when value is undefined", () => {
+		expect(sanitizeCallbackUrl(undefined)).toBeUndefined();
+	});
+
+	it("returns undefined for an empty string", () => {
+		expect(sanitizeCallbackUrl("")).toBeUndefined();
+	});
+
+	it("rejects absolute URLs (open-redirect)", () => {
+		expect(sanitizeCallbackUrl("https://evil.com")).toBeUndefined();
+		expect(sanitizeCallbackUrl("http://evil.com/admin")).toBeUndefined();
+	});
+
+	it("rejects protocol-relative URLs (`//evil.com`)", () => {
+		expect(sanitizeCallbackUrl("//evil.com")).toBeUndefined();
+		expect(sanitizeCallbackUrl("//evil.com/path")).toBeUndefined();
+	});
+
+	it("rejects backslash-prefixed paths that browsers resolve as protocol-relative", () => {
+		expect(sanitizeCallbackUrl("/\\evil.com")).toBeUndefined();
+		expect(sanitizeCallbackUrl("/\\evil.com/admin")).toBeUndefined();
+	});
+
+	it("rejects paths that do not start with /", () => {
+		expect(sanitizeCallbackUrl("admin/users")).toBeUndefined();
+		expect(sanitizeCallbackUrl("javascript:alert(1)")).toBeUndefined();
+		expect(sanitizeCallbackUrl("mailto:foo@bar")).toBeUndefined();
+	});
+});

--- a/packages/app/src/modules/login/__tests__/sanitizeCallbackUrl.test.ts
+++ b/packages/app/src/modules/login/__tests__/sanitizeCallbackUrl.test.ts
@@ -48,4 +48,17 @@ describe("sanitizeCallbackUrl", () => {
 		expect(sanitizeCallbackUrl("javascript:alert(1)")).toBeUndefined();
 		expect(sanitizeCallbackUrl("mailto:foo@bar")).toBeUndefined();
 	});
+
+	it("rejects URL-encoded protocol-relative paths (`/%2F%2Fevil.com`)", () => {
+		expect(sanitizeCallbackUrl("/%2F%2Fevil.com")).toBeUndefined();
+		expect(sanitizeCallbackUrl("/%2Fevil.com")).toBeUndefined();
+	});
+
+	it("rejects URL-encoded backslash paths (`/%5Cevil.com`)", () => {
+		expect(sanitizeCallbackUrl("/%5Cevil.com")).toBeUndefined();
+	});
+
+	it("rejects malformed percent-encoding", () => {
+		expect(sanitizeCallbackUrl("/%E0%A4%A")).toBeUndefined();
+	});
 });

--- a/packages/app/src/modules/login/index.ts
+++ b/packages/app/src/modules/login/index.ts
@@ -1,1 +1,2 @@
 export { LoginPage } from "./LoginPage";
+export { sanitizeCallbackUrl } from "./sanitizeCallbackUrl";

--- a/packages/app/src/modules/login/sanitizeCallbackUrl.ts
+++ b/packages/app/src/modules/login/sanitizeCallbackUrl.ts
@@ -1,0 +1,9 @@
+export function sanitizeCallbackUrl(value?: string): string | undefined {
+	if (!value) return undefined;
+	if (!value.startsWith("/")) return undefined;
+	// Reject protocol-relative URLs (`//evil.com`, `/\evil.com`) which the
+	// browser resolves to a different origin — defense in depth against
+	// open-redirect on top of the NextAuth `redirect` callback.
+	if (value.startsWith("//") || value.startsWith("/\\")) return undefined;
+	return value;
+}

--- a/packages/app/src/modules/login/sanitizeCallbackUrl.ts
+++ b/packages/app/src/modules/login/sanitizeCallbackUrl.ts
@@ -1,9 +1,37 @@
+// Dummy base used purely to resolve relative paths; any value rejected by
+// `URL` parsing, or resolving to a different origin, is treated as unsafe.
+const DUMMY_ORIGIN = "https://internal.invalid";
+
+/**
+ * Returns `value` only when it is a safe, same-origin relative path; otherwise
+ * `undefined`. Defense in depth against open-redirect on top of the NextAuth
+ * `redirect` callback — the page-level redirect of an already-authenticated
+ * user bypasses that callback, so this guard is the only one on that path.
+ *
+ * Blocks absolute URLs, protocol-relative paths (`//evil.com`, `/\evil.com`)
+ * and their percent-encoded variants (`/%2F%2Fevil.com` decodes to
+ * `///evil.com`, `/%5Cevil.com` to `/\evil.com`), which a browser can collapse
+ * into a foreign authority. Malformed percent-encoding is rejected outright.
+ */
 export function sanitizeCallbackUrl(value?: string): string | undefined {
-	if (!value) return undefined;
-	if (!value.startsWith("/")) return undefined;
-	// Reject protocol-relative URLs (`//evil.com`, `/\evil.com`) which the
-	// browser resolves to a different origin — defense in depth against
-	// open-redirect on top of the NextAuth `redirect` callback.
-	if (value.startsWith("//") || value.startsWith("/\\")) return undefined;
+	if (!value?.startsWith("/")) return undefined;
+
+	// Decode once so percent-encoded protocol-relative bypasses are caught by
+	// the same check as their literal forms.
+	let decoded: string;
+	try {
+		decoded = decodeURIComponent(value);
+	} catch {
+		return undefined;
+	}
+	if (/^\/[/\\]/.test(value) || /^\/[/\\]/.test(decoded)) return undefined;
+
+	// Final guard: the value must resolve to our own origin and nothing else.
+	try {
+		if (new URL(value, DUMMY_ORIGIN).origin !== DUMMY_ORIGIN) return undefined;
+	} catch {
+		return undefined;
+	}
+
 	return value;
 }


### PR DESCRIPTION
Closes #3617

## Résumé

Centralise la capture de l'URL voulue dans le middleware Edge et la propage à travers le flux de sign-in ProConnect. Un utilisateur non connecté qui accède à une page protégée est désormais redirigé vers cette page après ProConnect (au lieu de `/mon-espace` systématiquement).

## Détail

- **`middleware.ts`** — étend `config.matcher` à `/mon-espace/:path*`, `/declaration-remuneration/:path*`, `/avis-cse/:path*`. Nouveau `sessionMiddleware` (decode JWT, redirect si pas de token, sans gating `isAdmin`). Helper partagé `redirectToLogin(request)` qui construit `/login?callbackUrl=<pathname+search>` — utilisé aussi par `adminMiddleware` (préserve la querystring, ce qui n'était pas le cas avant). Le branche `/api/v1/*` reste inchangée.
- **`sanitizeCallbackUrl.ts`** (nouveau) — helper pur anti open-redirect : accepte uniquement un chemin relatif same-origin (`/...` non `//...` ni `/\\...`). Defense-in-depth par-dessus le callback `redirect` de NextAuth.
- **`app/login/page.tsx`** — lit `searchParams.callbackUrl`, sanitise, transmet à `LoginPage`. Si session existante → `redirect(safe ?? "/mon-espace")`.
- **`LoginPage` → `LoginForm` → `ProConnectButton`** — prop drilling `callbackUrl?: string`. `ProConnectButton` appelle `signIn("proconnect", { callbackUrl: callbackUrl ?? "/mon-espace" })`.
- Les gardes `auth()` server-side restent en place (defense-in-depth Node runtime).

## Test plan

- [x] `pnpm typecheck` — vert
- [x] `pnpm test` — 2683 + 83 tests verts (14 nouveaux tests, 100% coverage sur `sanitizeCallbackUrl` et `middleware`)
- [x] `pnpm lint:check` + `pnpm format:check` — verts
- [x] 4 quality gates (validator, structural, RGAA, security) — PASS sur les 4
- [ ] Scénario : non-connecté GET `/mon-espace/historique/123456789/2024` → 307 vers `/login?callbackUrl=%2Fmon-espace%2Fhistorique%2F123456789%2F2024`
- [ ] Scénario : `?callbackUrl=https://evil.com` → fallback `/mon-espace`
- [ ] Scénario : connexion ProConnect depuis `/declaration-remuneration` → redirection vers `/declaration-remuneration` (pas `/mon-espace`)