### PR TITLE
test(auth): couverture Jest du nouveau code ProConnect (#3647)

### DIFF
--- a/packages/app/src/api/core-domain/infra/auth/__tests__/ProConnectProvider.test.ts
+++ b/packages/app/src/api/core-domain/infra/auth/__tests__/ProConnectProvider.test.ts
@@ -1,0 +1,10 @@
+import { ProConnectProvider } from "../ProConnectProvider";
+
+describe("ProConnectProvider", () => {
+  it("requests acr_values=eidas0 and keeps the provider id", () => {
+    const provider = ProConnectProvider({ clientId: "id", clientSecret: "secret" });
+    expect(provider.id).toBe("moncomptepro");
+    const authorization = provider.authorization as { params: { acr_values?: string } };
+    expect(authorization.params.acr_values).toBe("eidas0");
+  });
+});

--- a/packages/app/src/api/core-domain/infra/auth/__tests__/proconnect-logout.test.ts
+++ b/packages/app/src/api/core-domain/infra/auth/__tests__/proconnect-logout.test.ts
@@ -1,0 +1,40 @@
+describe("fetchEndSessionEndpoint", () => {
+  const ORIGINAL = process.env.EGAPRO_PROCONNECT_DISCOVERY_URL;
+
+  afterEach(() => {
+    process.env.EGAPRO_PROCONNECT_DISCOVERY_URL = ORIGINAL;
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  const load = () => {
+    jest.resetModules();
+    return require("../proconnect-logout").fetchEndSessionEndpoint as () => Promise<string | null>;
+  };
+
+  it("returns the end_session_endpoint from the discovery document", async () => {
+    process.env.EGAPRO_PROCONNECT_DISCOVERY_URL = "https://issuer.test";
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ json: async () => ({ end_session_endpoint: "https://issuer.test/logout" }) }) as never;
+    await expect(load()()).resolves.toBe("https://issuer.test/logout");
+    expect(global.fetch).toHaveBeenCalledWith("https://issuer.test/.well-known/openid-configuration");
+  });
+
+  it("returns null when the discovery URL is unset", async () => {
+    delete process.env.EGAPRO_PROCONNECT_DISCOVERY_URL;
+    await expect(load()()).resolves.toBeNull();
+  });
+
+  it("returns null when end_session_endpoint is absent", async () => {
+    process.env.EGAPRO_PROCONNECT_DISCOVERY_URL = "https://issuer.test";
+    global.fetch = jest.fn().mockResolvedValue({ json: async () => ({}) }) as never;
+    await expect(load()()).resolves.toBeNull();
+  });
+
+  it("returns null on fetch error", async () => {
+    process.env.EGAPRO_PROCONNECT_DISCOVERY_URL = "https://issuer.test";
+    global.fetch = jest.fn().mockRejectedValue(new Error("network")) as never;
+    await expect(load()()).resolves.toBeNull();
+  });
+});

--- a/packages/app/src/app/(default)/mon-espace/mes-declarations/__tests__/SelectSiren.test.tsx
+++ b/packages/app/src/app/(default)/mon-espace/mes-declarations/__tests__/SelectSiren.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+
+import { SelectSiren } from "../SelectSiren";
+
+describe("mes-declarations SelectSiren (mono-entreprise)", () => {
+  it("shows the active siren and company name in read-only, without a dropdown or refresh button", () => {
+    render(
+      <SelectSiren
+        sirenListWithCompanyName={[{ siren: "123456789", companyName: "Société Démo" }]}
+        currentSiren="123456789"
+      />,
+    );
+    expect(screen.getByText("123456789")).toBeInTheDocument();
+    expect(screen.getByText("Société Démo")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Rafraichir/i })).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the user has no company", () => {
+    const { container } = render(<SelectSiren sirenListWithCompanyName={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/app/src/app/(default)/mon-espace/mes-entreprises/__tests__/SelectSiren.test.tsx
+++ b/packages/app/src/app/(default)/mon-espace/mes-entreprises/__tests__/SelectSiren.test.tsx
@@ -1,0 +1,24 @@
+import { getCompany } from "@globalActions/company";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { SelectSiren } from "../SelectSiren";
+
+jest.mock("@globalActions/company", () => ({ getCompany: jest.fn() }));
+
+describe("mes-entreprises SelectSiren (mono-entreprise)", () => {
+  beforeEach(() => {
+    (getCompany as jest.Mock).mockResolvedValue({ ok: true, data: { simpleLabel: "Société Démo" } });
+  });
+
+  it("shows the active siren and the fetched company name, without a dropdown", async () => {
+    render(<SelectSiren sirenList={["123456789"]} loadedSiren="123456789" />);
+    expect(screen.getByText("123456789")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Société Démo")).toBeInTheDocument());
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when there is no siren", () => {
+    const { container } = render(<SelectSiren sirenList={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/app/src/app/api/auth/logout/__tests__/route.test.ts
+++ b/packages/app/src/app/api/auth/logout/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+import { fetchEndSessionEndpoint } from "@api/core-domain/infra/auth/proconnect-logout";
+import { getToken } from "next-auth/jwt";
+
+import { GET } from "../route";
+
+jest.mock("next-auth/jwt", () => ({ getToken: jest.fn() }));
+jest.mock("@api/core-domain/infra/auth/proconnect-logout", () => ({ fetchEndSessionEndpoint: jest.fn() }));
+jest.mock("@common/config", () => ({ config: { api: { security: { auth: { secret: "test-secret" } } } } }));
+
+const mockedGetToken = getToken as jest.Mock;
+const mockedFetchEndSession = fetchEndSessionEndpoint as jest.Mock;
+
+const call = () => GET(new Request("https://app.test/api/auth/logout") as never);
+
+describe("logout route", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("redirects to end_session with id_token_hint and clears the session cookie", async () => {
+    mockedGetToken.mockResolvedValue({ id_token: "ID_TOKEN" });
+    mockedFetchEndSession.mockResolvedValue("https://issuer.test/session/end");
+
+    const res = await call();
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("https://issuer.test/session/end");
+    expect(location).toContain("id_token_hint=ID_TOKEN");
+    expect(location).toContain("post_logout_redirect_uri=");
+    expect(res.headers.get("set-cookie")).toContain("__Secure-next-auth.session-token=;");
+  });
+
+  it("falls back to home when there is no id_token", async () => {
+    mockedGetToken.mockResolvedValue(null);
+    const res = await call();
+    expect(res.headers.get("location")).toBe("https://app.test/");
+  });
+
+  it("falls back to home when the end_session_endpoint is unavailable", async () => {
+    mockedGetToken.mockResolvedValue({ id_token: "ID_TOKEN" });
+    mockedFetchEndSession.mockResolvedValue(null);
+    const res = await call();
+    expect(res.headers.get("location")).toBe("https://app.test/");
+  });
+});

--- a/packages/app/src/app/api/auth/logout/callback/__tests__/route.test.ts
+++ b/packages/app/src/app/api/auth/logout/callback/__tests__/route.test.ts
@@ -1,0 +1,12 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from "../route";
+
+describe("logout callback route", () => {
+  it("redirects to the home page", () => {
+    const res = GET(new Request("https://app.test/api/auth/logout/callback"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://app.test/");
+  });
+});


### PR DESCRIPTION
Tests unitaires sur le nouveau code de l'epic #3647 pour passer le quality gate Sonar (new code ≥ 60 %).

Couverture mesurée localement : proconnect-logout 100 %, logout route 83 % + callback 100 %, SelectSiren mono ×2 100 %, ProConnectProvider (acr_values eidas0). 13 tests, tous verts (`pnpm jest`).

Base : epic/3647. Refs #3647.