### PR TITLE
feat(declaration-lock): table, service et constantes (fondation) (#3723)

### DIFF
--- a/packages/app/drizzle/0041_curvy_forgotten_one.sql
+++ b/packages/app/drizzle/0041_curvy_forgotten_one.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "app_declaration_lock" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"declaration_id" varchar(255) NOT NULL,
+	"locked_by_user_id" varchar(255) NOT NULL,
+	"locked_at" timestamp with time zone NOT NULL,
+	"last_heartbeat_at" timestamp with time zone NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "app_global_setting" ADD COLUMN "declaration_lock_timeout_minutes" integer DEFAULT 30 NOT NULL;--> statement-breakpoint
+ALTER TABLE "app_declaration_lock" ADD CONSTRAINT "app_declaration_lock_declaration_id_app_declaration_id_fk" FOREIGN KEY ("declaration_id") REFERENCES "public"."app_declaration"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_declaration_lock" ADD CONSTRAINT "app_declaration_lock_locked_by_user_id_app_user_id_fk" FOREIGN KEY ("locked_by_user_id") REFERENCES "public"."app_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "declaration_lock_declaration_id_unique" ON "app_declaration_lock" USING btree ("declaration_id");--> statement-breakpoint
+CREATE INDEX "declaration_lock_expires_at_idx" ON "app_declaration_lock" USING btree ("expires_at");

--- a/packages/app/drizzle/meta/0041_snapshot.json
+++ b/packages/app/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,2719 @@
+{
+  "id": "65ab047f-52a9-4742-8396-527a50de6014",
+  "prevId": "c555c3aa-ee77-4736-b11c-18316f18f0ec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_admin_impersonation_event": {
+      "name": "app_admin_impersonation_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_impersonation_event_admin_started_idx": {
+          "name": "admin_impersonation_event_admin_started_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_admin_impersonation_event_siren_app_company_siren_fk": {
+          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_campaign_deadline": {
+      "name": "app_campaign_deadline",
+      "schema": "",
+      "columns": {
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gip_publication_date": {
+          "name": "gip_publication_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_start_date": {
+          "name": "campaign_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decl1_modification_deadline": {
+          "name": "decl1_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_justification_deadline": {
+          "name": "decl1_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_joint_evaluation_deadline": {
+          "name": "decl1_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_modification_deadline": {
+          "name": "decl2_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_justification_deadline": {
+          "name": "decl2_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_joint_evaluation_deadline": {
+          "name": "decl2_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_company": {
+      "name": "app_company",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naf_code": {
+          "name": "naf_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naf_label": {
+          "name": "naf_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce": {
+          "name": "workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_cse": {
+          "name": "has_cse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion_file": {
+      "name": "app_cse_opinion_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_file_declaration_idx": {
+          "name": "cse_opinion_file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_cse_opinion_file_file_id_app_file_id_fk": {
+          "name": "app_cse_opinion_file_file_id_app_file_id_fk",
+          "tableFrom": "app_cse_opinion_file",
+          "tableTo": "app_file",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_file_decl_number_type_idx": {
+          "name": "cse_opinion_file_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion": {
+      "name": "app_cse_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gap_consulted": {
+          "name": "gap_consulted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_date": {
+          "name": "opinion_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_declaration_idx": {
+          "name": "cse_opinion_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_decl_number_type_idx": {
+          "name": "cse_opinion_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration_lock": {
+      "name": "app_declaration_lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by_user_id": {
+          "name": "locked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "declaration_lock_declaration_id_unique": {
+          "name": "declaration_lock_declaration_id_unique",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "declaration_lock_expires_at_idx": {
+          "name": "declaration_lock_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_lock_declaration_id_app_declaration_id_fk": {
+          "name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_declaration_lock",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_declaration_lock_locked_by_user_id_app_user_id_fk": {
+          "name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
+          "tableFrom": "app_declaration_lock",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "locked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration_status_history": {
+      "name": "app_declaration_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "declaration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "decl_status_history_declaration_idx": {
+          "name": "decl_status_history_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
+          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration": {
+      "name": "app_declaration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_women": {
+          "name": "total_women",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_men": {
+          "name": "total_men",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remuneration_score": {
+          "name": "remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_remuneration_score": {
+          "name": "variable_remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quartile_score": {
+          "name": "quartile_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_score": {
+          "name": "category_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_declaration_path_choice": {
+          "name": "first_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_declaration_path_choice": {
+          "name": "second_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_women": {
+          "name": "indicator_a_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_men": {
+          "name": "indicator_a_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_women": {
+          "name": "indicator_a_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_men": {
+          "name": "indicator_a_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_women": {
+          "name": "indicator_b_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_men": {
+          "name": "indicator_b_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_women": {
+          "name": "indicator_b_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_men": {
+          "name": "indicator_b_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_women": {
+          "name": "indicator_c_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_men": {
+          "name": "indicator_c_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_women": {
+          "name": "indicator_c_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_men": {
+          "name": "indicator_c_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_women": {
+          "name": "indicator_d_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_men": {
+          "name": "indicator_d_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_women": {
+          "name": "indicator_d_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_men": {
+          "name": "indicator_d_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_women": {
+          "name": "indicator_e_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_men": {
+          "name": "indicator_e_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold1": {
+          "name": "indicator_f_annual_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold2": {
+          "name": "indicator_f_annual_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold3": {
+          "name": "indicator_f_annual_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women1": {
+          "name": "indicator_f_annual_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women2": {
+          "name": "indicator_f_annual_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women3": {
+          "name": "indicator_f_annual_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women4": {
+          "name": "indicator_f_annual_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men1": {
+          "name": "indicator_f_annual_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men2": {
+          "name": "indicator_f_annual_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men3": {
+          "name": "indicator_f_annual_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men4": {
+          "name": "indicator_f_annual_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold1": {
+          "name": "indicator_f_hourly_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold2": {
+          "name": "indicator_f_hourly_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold3": {
+          "name": "indicator_f_hourly_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women1": {
+          "name": "indicator_f_hourly_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women2": {
+          "name": "indicator_f_hourly_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women3": {
+          "name": "indicator_f_hourly_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women4": {
+          "name": "indicator_f_hourly_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men1": {
+          "name": "indicator_f_hourly_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men2": {
+          "name": "indicator_f_hourly_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men3": {
+          "name": "indicator_f_hourly_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men4": {
+          "name": "indicator_f_hourly_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "declaration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "second_declaration_step": {
+          "name": "second_declaration_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_start": {
+          "name": "second_decl_reference_period_start",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_end": {
+          "name": "second_decl_reference_period_end",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cse_required": {
+          "name": "cse_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_version": {
+          "name": "rules_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2027.1'"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_updated_at": {
+          "name": "draft_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "declarations_siren_year_active_unique": {
+          "name": "declarations_siren_year_active_unique",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "cancelled_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "declaration_declarant_idx": {
+          "name": "declaration_declarant_idx",
+          "columns": [
+            {
+              "expression": "declarant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_siren_app_company_siren_fk": {
+          "name": "app_declaration_siren_app_company_siren_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_declaration_declarant_id_app_user_id_fk": {
+          "name": "app_declaration_declarant_id_app_user_id_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_employee_category": {
+      "name": "app_employee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_category_id": {
+          "name": "job_category_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_type": {
+          "name": "declaration_type",
+          "type": "declaration_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "women_count": {
+          "name": "women_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count": {
+          "name": "men_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_women": {
+          "name": "annual_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_men": {
+          "name": "annual_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_women": {
+          "name": "annual_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_men": {
+          "name": "annual_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_women": {
+          "name": "hourly_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_men": {
+          "name": "hourly_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_women": {
+          "name": "hourly_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_men": {
+          "name": "hourly_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_employee_category_job_category_id_app_job_category_id_fk": {
+          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
+          "tableFrom": "app_employee_category",
+          "tableTo": "app_job_category",
+          "columnsFrom": [
+            "job_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employee_category_job_type_idx": {
+          "name": "employee_category_job_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_category_id",
+            "declaration_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_export": {
+      "name": "app_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "export_year_version_idx": {
+          "name": "export_year_version_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_file": {
+      "name": "app_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "file_declaration_idx": {
+          "name": "file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_joint_eval_unique": {
+          "name": "file_joint_eval_unique",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"type\" = 'joint_evaluation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_gip_mds_data": {
+      "name": "app_gip_mds_data",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_ema": {
+          "name": "workforce_ema",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_global": {
+          "name": "men_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_global": {
+          "name": "women_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_hourly_global": {
+          "name": "men_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_hourly_global": {
+          "name": "women_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_variable": {
+          "name": "men_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_variable": {
+          "name": "women_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_women": {
+          "name": "global_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_men": {
+          "name": "global_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_women": {
+          "name": "global_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_men": {
+          "name": "global_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_women": {
+          "name": "variable_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_men": {
+          "name": "variable_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_women": {
+          "name": "variable_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_men": {
+          "name": "variable_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_women": {
+          "name": "global_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_men": {
+          "name": "global_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_women": {
+          "name": "global_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_men": {
+          "name": "global_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_women": {
+          "name": "variable_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_men": {
+          "name": "variable_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_women": {
+          "name": "variable_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_men": {
+          "name": "variable_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold1": {
+          "name": "annual_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold2": {
+          "name": "annual_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold3": {
+          "name": "annual_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold1": {
+          "name": "hourly_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold2": {
+          "name": "hourly_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold3": {
+          "name": "hourly_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_index": {
+          "name": "confidence_index",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_exotic_contracts": {
+          "name": "confidence_exotic_contracts",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_unit_measure": {
+          "name": "confidence_unit_measure",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_suspension_ratio": {
+          "name": "confidence_suspension_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_suspensions": {
+          "name": "confidence_long_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_end_suspensions": {
+          "name": "confidence_no_end_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_sick_leave_ratio": {
+          "name": "confidence_sick_leave_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_sick_leave": {
+          "name": "confidence_long_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_sick_leave": {
+          "name": "confidence_no_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota250": {
+          "name": "confidence_quota250",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota0": {
+          "name": "confidence_quota0",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_multi_year": {
+          "name": "confidence_multi_year",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_fp_ratio": {
+          "name": "confidence_fp_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_remuneration": {
+          "name": "confidence_extreme_remuneration",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_rate": {
+          "name": "confidence_extreme_rate",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gip_mds_data_siren_idx": {
+          "name": "gip_mds_data_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_gip_mds_data_siren_app_company_siren_fk": {
+          "name": "app_gip_mds_data_siren_app_company_siren_fk",
+          "tableFrom": "app_gip_mds_data",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_gip_mds_data_siren_year_pk": {
+          "name": "app_gip_mds_data_siren_year_pk",
+          "columns": [
+            "siren",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_global_setting": {
+      "name": "app_global_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "active_campaign_year": {
+          "name": "active_campaign_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declaration_lock_timeout_minutes": {
+          "name": "declaration_lock_timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_global_setting_updated_by_app_user_id_fk": {
+          "name": "app_global_setting_updated_by_app_user_id_fk",
+          "tableFrom": "app_global_setting",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_job_category": {
+      "name": "app_job_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_index": {
+          "name": "category_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_job_category_declaration_id_app_declaration_id_fk": {
+          "name": "app_job_category_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_job_category",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_category_declaration_index_idx": {
+          "name": "job_category_declaration_index_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "category_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_referent": {
+      "name": "app_referent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "referent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "substitute_name": {
+          "name": "substitute_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "substitute_email": {
+          "name": "substitute_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "referent_region_idx": {
+          "name": "referent_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user_company": {
+      "name": "app_user_company",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_company_user_id_idx": {
+          "name": "user_company_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_company_user_id_app_user_id_fk": {
+          "name": "app_user_company_user_id_app_user_id_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_company_siren_app_company_siren_fk": {
+          "name": "app_user_company_siren_app_company_siren_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_user_company_user_id_siren_pk": {
+          "name": "app_user_company_user_id_siren_pk",
+          "columns": [
+            "user_id",
+            "siren"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user": {
+      "name": "app_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "audit.action_log": {
+      "name": "action_log",
+      "schema": "audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_log_created_at_idx": {
+          "name": "action_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_user_idx": {
+          "name": "action_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_siren_idx": {
+          "name": "action_log_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_action_idx": {
+          "name": "action_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_category_created_at_idx": {
+          "name": "action_log_category_created_at_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.compliance_path": {
+      "name": "compliance_path",
+      "schema": "public",
+      "values": [
+        "justify",
+        "corrective_action",
+        "joint_evaluation"
+      ]
+    },
+    "public.declaration_event_type": {
+      "name": "declaration_event_type",
+      "schema": "public",
+      "values": [
+        "submit",
+        "path_choice",
+        "second_declaration_submit",
+        "joint_evaluation_submit",
+        "cse_opinion_submit",
+        "cancel",
+        "demarche_complete",
+        "step_change"
+      ]
+    },
+    "public.declaration_status": {
+      "name": "declaration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "awaiting_compliance_path_choice",
+        "corrective_actions_chosen",
+        "joint_evaluation_chosen",
+        "awaiting_revision_choice",
+        "revised_joint_evaluation_chosen",
+        "awaiting_cse_opinion",
+        "demarche_completed"
+      ]
+    },
+    "public.declaration_type": {
+      "name": "declaration_type",
+      "schema": "public",
+      "values": [
+        "initial",
+        "correction"
+      ]
+    },
+    "public.file_type": {
+      "name": "file_type",
+      "schema": "public",
+      "values": [
+        "cse_opinion",
+        "joint_evaluation"
+      ]
+    },
+    "public.referent_type": {
+      "name": "referent_type",
+      "schema": "public",
+      "values": [
+        "email",
+        "url"
+      ]
+    }
+  },
+  "schemas": {
+    "audit": "audit"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/app/drizzle/meta/0041_snapshot.json
+++ b/packages/app/drizzle/meta/0041_snapshot.json
@@ -1,2719 +1,2611 @@
 {
-  "id": "65ab047f-52a9-4742-8396-527a50de6014",
-  "prevId": "c555c3aa-ee77-4736-b11c-18316f18f0ec",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.app_admin_impersonation_event": {
-      "name": "app_admin_impersonation_event",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "admin_user_id": {
-          "name": "admin_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stopped_at": {
-          "name": "stopped_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "admin_impersonation_event_admin_started_idx": {
-          "name": "admin_impersonation_event_admin_started_idx",
-          "columns": [
-            {
-              "expression": "admin_user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "started_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
-          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "admin_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_admin_impersonation_event_siren_app_company_siren_fk": {
-          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_campaign_deadline": {
-      "name": "app_campaign_deadline",
-      "schema": "",
-      "columns": {
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "gip_publication_date": {
-          "name": "gip_publication_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "campaign_start_date": {
-          "name": "campaign_start_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decl1_modification_deadline": {
-          "name": "decl1_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_justification_deadline": {
-          "name": "decl1_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_joint_evaluation_deadline": {
-          "name": "decl1_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_modification_deadline": {
-          "name": "decl2_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_justification_deadline": {
-          "name": "decl2_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_joint_evaluation_deadline": {
-          "name": "decl2_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_company": {
-      "name": "app_company",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "address": {
-          "name": "address",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "naf_code": {
-          "name": "naf_code",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "naf_label": {
-          "name": "naf_label",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce": {
-          "name": "workforce",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "has_cse": {
-          "name": "has_cse",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion_file": {
-      "name": "app_cse_opinion_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_id": {
-          "name": "file_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_file_declaration_idx": {
-          "name": "cse_opinion_file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_cse_opinion_file_file_id_app_file_id_fk": {
-          "name": "app_cse_opinion_file_file_id_app_file_id_fk",
-          "tableFrom": "app_cse_opinion_file",
-          "tableTo": "app_file",
-          "columnsFrom": [
-            "file_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_file_decl_number_type_idx": {
-          "name": "cse_opinion_file_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion": {
-      "name": "app_cse_opinion",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "gap_consulted": {
-          "name": "gap_consulted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion": {
-          "name": "opinion",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion_date": {
-          "name": "opinion_date",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_declaration_idx": {
-          "name": "cse_opinion_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_decl_number_type_idx": {
-          "name": "cse_opinion_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration_lock": {
-      "name": "app_declaration_lock",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "locked_by_user_id": {
-          "name": "locked_by_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "locked_at": {
-          "name": "locked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_heartbeat_at": {
-          "name": "last_heartbeat_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "declaration_lock_declaration_id_unique": {
-          "name": "declaration_lock_declaration_id_unique",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "declaration_lock_expires_at_idx": {
-          "name": "declaration_lock_expires_at_idx",
-          "columns": [
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_lock_declaration_id_app_declaration_id_fk": {
-          "name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_declaration_lock",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "app_declaration_lock_locked_by_user_id_app_user_id_fk": {
-          "name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
-          "tableFrom": "app_declaration_lock",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "locked_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration_status_history": {
-      "name": "app_declaration_status_history",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "event_type": {
-          "name": "event_type",
-          "type": "declaration_event_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "round": {
-          "name": "round",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "actor_user_id": {
-          "name": "actor_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "decl_status_history_declaration_idx": {
-          "name": "decl_status_history_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": false,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
-          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
-          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "actor_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration": {
-      "name": "app_declaration",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declarant_id": {
-          "name": "declarant_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "total_women": {
-          "name": "total_women",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total_men": {
-          "name": "total_men",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "remuneration_score": {
-          "name": "remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_remuneration_score": {
-          "name": "variable_remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "quartile_score": {
-          "name": "quartile_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "category_score": {
-          "name": "category_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "first_declaration_path_choice": {
-          "name": "first_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_declaration_path_choice": {
-          "name": "second_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_women": {
-          "name": "indicator_a_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_men": {
-          "name": "indicator_a_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_women": {
-          "name": "indicator_a_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_men": {
-          "name": "indicator_a_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_women": {
-          "name": "indicator_b_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_men": {
-          "name": "indicator_b_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_women": {
-          "name": "indicator_b_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_men": {
-          "name": "indicator_b_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_women": {
-          "name": "indicator_c_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_men": {
-          "name": "indicator_c_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_women": {
-          "name": "indicator_c_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_men": {
-          "name": "indicator_c_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_women": {
-          "name": "indicator_d_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_men": {
-          "name": "indicator_d_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_women": {
-          "name": "indicator_d_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_men": {
-          "name": "indicator_d_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_women": {
-          "name": "indicator_e_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_men": {
-          "name": "indicator_e_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold1": {
-          "name": "indicator_f_annual_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold2": {
-          "name": "indicator_f_annual_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold3": {
-          "name": "indicator_f_annual_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women1": {
-          "name": "indicator_f_annual_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women2": {
-          "name": "indicator_f_annual_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women3": {
-          "name": "indicator_f_annual_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women4": {
-          "name": "indicator_f_annual_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men1": {
-          "name": "indicator_f_annual_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men2": {
-          "name": "indicator_f_annual_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men3": {
-          "name": "indicator_f_annual_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men4": {
-          "name": "indicator_f_annual_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold1": {
-          "name": "indicator_f_hourly_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold2": {
-          "name": "indicator_f_hourly_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold3": {
-          "name": "indicator_f_hourly_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women1": {
-          "name": "indicator_f_hourly_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women2": {
-          "name": "indicator_f_hourly_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women3": {
-          "name": "indicator_f_hourly_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women4": {
-          "name": "indicator_f_hourly_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men1": {
-          "name": "indicator_f_hourly_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men2": {
-          "name": "indicator_f_hourly_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men3": {
-          "name": "indicator_f_hourly_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men4": {
-          "name": "indicator_f_hourly_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "declaration_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'draft'"
-        },
-        "second_declaration_step": {
-          "name": "second_declaration_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_start": {
-          "name": "second_decl_reference_period_start",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_end": {
-          "name": "second_decl_reference_period_end",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cse_required": {
-          "name": "cse_required",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "rules_version": {
-          "name": "rules_version",
-          "type": "varchar",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2027.1'"
-        },
-        "cancelled_at": {
-          "name": "cancelled_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft": {
-          "name": "draft",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft_updated_at": {
-          "name": "draft_updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "declarations_siren_year_active_unique": {
-          "name": "declarations_siren_year_active_unique",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "year",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "cancelled_at IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "declaration_declarant_idx": {
-          "name": "declaration_declarant_idx",
-          "columns": [
-            {
-              "expression": "declarant_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_siren_app_company_siren_fk": {
-          "name": "app_declaration_siren_app_company_siren_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_declaration_declarant_id_app_user_id_fk": {
-          "name": "app_declaration_declarant_id_app_user_id_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "declarant_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_employee_category": {
-      "name": "app_employee_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "job_category_id": {
-          "name": "job_category_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_type": {
-          "name": "declaration_type",
-          "type": "declaration_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "women_count": {
-          "name": "women_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count": {
-          "name": "men_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_women": {
-          "name": "annual_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_men": {
-          "name": "annual_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_women": {
-          "name": "annual_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_men": {
-          "name": "annual_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_women": {
-          "name": "hourly_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_men": {
-          "name": "hourly_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_women": {
-          "name": "hourly_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_men": {
-          "name": "hourly_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_employee_category_job_category_id_app_job_category_id_fk": {
-          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
-          "tableFrom": "app_employee_category",
-          "tableTo": "app_job_category",
-          "columnsFrom": [
-            "job_category_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "employee_category_job_type_idx": {
-          "name": "employee_category_job_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "job_category_id",
-            "declaration_type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_export": {
-      "name": "app_export",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "version": {
-          "name": "version",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'v1'"
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "s3_key": {
-          "name": "s3_key",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "row_count": {
-          "name": "row_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "export_year_version_idx": {
-          "name": "export_year_version_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "year",
-            "version"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_file": {
-      "name": "app_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_path": {
-          "name": "file_path",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "uploaded_at": {
-          "name": "uploaded_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "file_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "file_declaration_idx": {
-          "name": "file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "file_joint_eval_unique": {
-          "name": "file_joint_eval_unique",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"type\" = 'joint_evaluation'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_gip_mds_data": {
-      "name": "app_gip_mds_data",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "imported_at": {
-          "name": "imported_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_start": {
-          "name": "period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_end": {
-          "name": "period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce_ema": {
-          "name": "workforce_ema",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_global": {
-          "name": "men_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_global": {
-          "name": "women_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_hourly_global": {
-          "name": "men_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_hourly_global": {
-          "name": "women_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_variable": {
-          "name": "men_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_variable": {
-          "name": "women_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_women": {
-          "name": "global_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_men": {
-          "name": "global_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_women": {
-          "name": "global_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_men": {
-          "name": "global_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_women": {
-          "name": "variable_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_men": {
-          "name": "variable_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_women": {
-          "name": "variable_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_men": {
-          "name": "variable_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_women": {
-          "name": "global_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_men": {
-          "name": "global_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_women": {
-          "name": "global_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_men": {
-          "name": "global_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_women": {
-          "name": "variable_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_men": {
-          "name": "variable_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_women": {
-          "name": "variable_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_men": {
-          "name": "variable_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold1": {
-          "name": "annual_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold2": {
-          "name": "annual_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold3": {
-          "name": "annual_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold1": {
-          "name": "hourly_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold2": {
-          "name": "hourly_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold3": {
-          "name": "hourly_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_index": {
-          "name": "confidence_index",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_exotic_contracts": {
-          "name": "confidence_exotic_contracts",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_unit_measure": {
-          "name": "confidence_unit_measure",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_suspension_ratio": {
-          "name": "confidence_suspension_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_suspensions": {
-          "name": "confidence_long_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_end_suspensions": {
-          "name": "confidence_no_end_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_sick_leave_ratio": {
-          "name": "confidence_sick_leave_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_sick_leave": {
-          "name": "confidence_long_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_sick_leave": {
-          "name": "confidence_no_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota250": {
-          "name": "confidence_quota250",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota0": {
-          "name": "confidence_quota0",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_multi_year": {
-          "name": "confidence_multi_year",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_fp_ratio": {
-          "name": "confidence_fp_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_remuneration": {
-          "name": "confidence_extreme_remuneration",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_rate": {
-          "name": "confidence_extreme_rate",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "gip_mds_data_siren_idx": {
-          "name": "gip_mds_data_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_gip_mds_data_siren_app_company_siren_fk": {
-          "name": "app_gip_mds_data_siren_app_company_siren_fk",
-          "tableFrom": "app_gip_mds_data",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_gip_mds_data_siren_year_pk": {
-          "name": "app_gip_mds_data_siren_year_pk",
-          "columns": [
-            "siren",
-            "year"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_global_setting": {
-      "name": "app_global_setting",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "default": 1
-        },
-        "active_campaign_year": {
-          "name": "active_campaign_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "declaration_lock_timeout_minutes": {
-          "name": "declaration_lock_timeout_minutes",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 30
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_global_setting_updated_by_app_user_id_fk": {
-          "name": "app_global_setting_updated_by_app_user_id_fk",
-          "tableFrom": "app_global_setting",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "updated_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_job_category": {
-      "name": "app_job_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category_index": {
-          "name": "category_index",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source": {
-          "name": "source",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_job_category_declaration_id_app_declaration_id_fk": {
-          "name": "app_job_category_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_job_category",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "job_category_declaration_index_idx": {
-          "name": "job_category_declaration_index_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "category_index"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_referent": {
-      "name": "app_referent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "region": {
-          "name": "region",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county": {
-          "name": "county",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "referent_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "principal": {
-          "name": "principal",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "substitute_name": {
-          "name": "substitute_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "substitute_email": {
-          "name": "substitute_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "referent_region_idx": {
-          "name": "referent_region_idx",
-          "columns": [
-            {
-              "expression": "region",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user_company": {
-      "name": "app_user_company",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "user_company_user_id_idx": {
-          "name": "user_company_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_user_company_user_id_app_user_id_fk": {
-          "name": "app_user_company_user_id_app_user_id_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_user_company_siren_app_company_siren_fk": {
-          "name": "app_user_company_siren_app_company_siren_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_user_company_user_id_siren_pk": {
-          "name": "app_user_company_user_id_siren_pk",
-          "columns": [
-            "user_id",
-            "siren"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user": {
-      "name": "app_user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "first_name": {
-          "name": "first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_name": {
-          "name": "last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "phone": {
-          "name": "phone",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_admin": {
-          "name": "is_admin",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "audit.action_log": {
-      "name": "action_log",
-      "schema": "audit",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_email": {
-          "name": "user_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "action": {
-          "name": "action",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category": {
-          "name": "category",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_type": {
-          "name": "resource_type",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "resource_id": {
-          "name": "resource_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "varchar(45)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration_ms": {
-          "name": "duration_ms",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "action_log_created_at_idx": {
-          "name": "action_log_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_user_idx": {
-          "name": "action_log_user_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_siren_idx": {
-          "name": "action_log_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_action_idx": {
-          "name": "action_log_action_idx",
-          "columns": [
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_category_created_at_idx": {
-          "name": "action_log_category_created_at_idx",
-          "columns": [
-            {
-              "expression": "category",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.compliance_path": {
-      "name": "compliance_path",
-      "schema": "public",
-      "values": [
-        "justify",
-        "corrective_action",
-        "joint_evaluation"
-      ]
-    },
-    "public.declaration_event_type": {
-      "name": "declaration_event_type",
-      "schema": "public",
-      "values": [
-        "submit",
-        "path_choice",
-        "second_declaration_submit",
-        "joint_evaluation_submit",
-        "cse_opinion_submit",
-        "cancel",
-        "demarche_complete",
-        "step_change"
-      ]
-    },
-    "public.declaration_status": {
-      "name": "declaration_status",
-      "schema": "public",
-      "values": [
-        "draft",
-        "awaiting_compliance_path_choice",
-        "corrective_actions_chosen",
-        "joint_evaluation_chosen",
-        "awaiting_revision_choice",
-        "revised_joint_evaluation_chosen",
-        "awaiting_cse_opinion",
-        "demarche_completed"
-      ]
-    },
-    "public.declaration_type": {
-      "name": "declaration_type",
-      "schema": "public",
-      "values": [
-        "initial",
-        "correction"
-      ]
-    },
-    "public.file_type": {
-      "name": "file_type",
-      "schema": "public",
-      "values": [
-        "cse_opinion",
-        "joint_evaluation"
-      ]
-    },
-    "public.referent_type": {
-      "name": "referent_type",
-      "schema": "public",
-      "values": [
-        "email",
-        "url"
-      ]
-    }
-  },
-  "schemas": {
-    "audit": "audit"
-  },
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "65ab047f-52a9-4742-8396-527a50de6014",
+	"prevId": "c555c3aa-ee77-4736-b11c-18316f18f0ec",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_label": {
+					"name": "naf_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_declaration_idx": {
+					"name": "cse_opinion_file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_file_id_app_file_id_fk": {
+					"name": "app_cse_opinion_file_file_id_app_file_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_file_decl_number_type_idx": {
+					"name": "cse_opinion_file_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_lock": {
+			"name": "app_declaration_lock",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_by_user_id": {
+					"name": "locked_by_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_at": {
+					"name": "locked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"declaration_lock_declaration_id_unique": {
+					"name": "declaration_lock_declaration_id_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_lock_expires_at_idx": {
+					"name": "declaration_lock_expires_at_idx",
+					"columns": [
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_lock_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_lock_locked_by_user_id_app_user_id_fk": {
+					"name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_user",
+					"columnsFrom": ["locked_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_status_history": {
+			"name": "app_declaration_status_history",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "declaration_event_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"round": {
+					"name": "round",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"decl_status_history_declaration_idx": {
+					"name": "decl_status_history_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_status_history_actor_user_id_app_user_id_fk": {
+					"name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_declaration_path_choice": {
+					"name": "first_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_path_choice": {
+					"name": "second_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_required": {
+					"name": "cse_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"rules_version": {
+					"name": "rules_version",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'2027.1'"
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declarations_siren_year_active_unique": {
+					"name": "declarations_siren_year_active_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "cancelled_at IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declaration_lock_timeout_minutes": {
+					"name": "declaration_lock_timeout_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 30
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.compliance_path": {
+			"name": "compliance_path",
+			"schema": "public",
+			"values": ["justify", "corrective_action", "joint_evaluation"]
+		},
+		"public.declaration_event_type": {
+			"name": "declaration_event_type",
+			"schema": "public",
+			"values": [
+				"submit",
+				"path_choice",
+				"second_declaration_submit",
+				"joint_evaluation_submit",
+				"cse_opinion_submit",
+				"cancel",
+				"demarche_complete",
+				"step_change"
+			]
+		},
+		"public.declaration_status": {
+			"name": "declaration_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"awaiting_compliance_path_choice",
+				"corrective_actions_chosen",
+				"joint_evaluation_chosen",
+				"awaiting_revision_choice",
+				"revised_joint_evaluation_chosen",
+				"awaiting_cse_opinion",
+				"demarche_completed"
+			]
+		},
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,293 +1,300 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1771922842861,
-			"tag": "0000_fuzzy_romulus",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1771928448125,
-			"tag": "0001_worthless_dragon_lord",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1772154191182,
-			"tag": "0002_lean_khan",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1772215461501,
-			"tag": "0003_absurd_komodo",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1772223004236,
-			"tag": "0004_next_jack_murdock",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1772611200000,
-			"tag": "0005_standardize_snake_case",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1772703893318,
-			"tag": "0006_lovely_korath",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1773158962249,
-			"tag": "0007_gigantic_doctor_faustus",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1773328599101,
-			"tag": "0008_powerful_omega_flight",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1773331852632,
-			"tag": "0009_hot_vector",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1773504000000,
-			"tag": "0010_gip_mds_data",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1773936000000,
-			"tag": "0011_add_export_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1774022400000,
-			"tag": "0012_export_date_to_year",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1774108800000,
-			"tag": "0013_add_gip_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1774195200000,
-			"tag": "0014_drop_session_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1774281600000,
-			"tag": "0015_drop_account_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1774368000000,
-			"tag": "0016_link_cse_joint_eval_to_declaration",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1774874768051,
-			"tag": "0017_flatten-indicator-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1774945983953,
-			"tag": "0018_rare_next_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1775050635448,
-			"tag": "0019_declaration_siren_fk",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1775200000000,
-			"tag": "0020_clean-user-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1775400000000,
-			"tag": "0021_add-campaign-deadlines",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1775450000000,
-			"tag": "0022_merge_file_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1775500000000,
-			"tag": "0023_add_audit_action_log",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1775600000000,
-			"tag": "0024_add_admin_impersonation_events",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1775700000000,
-			"tag": "0025_add_user_is_admin",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1775800000000,
-			"tag": "0026_add_referents_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1775900000000,
-			"tag": "0027_add_global_settings",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1776000000000,
-			"tag": "0028_add_cse_opinion_completed_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1776100000000,
-			"tag": "0029_add_declaration_submitted_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1777379362370,
-			"tag": "0030_drop_job_category_detail",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1777500000000,
-			"tag": "0031_drop_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1778071563871,
-			"tag": "0032_sparkling_monster_badoon",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1778489783883,
-			"tag": "0033_add_cancelled_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1778584824979,
-			"tag": "0034_tranquil_catseye",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1778682813792,
-			"tag": "0035_status_history",
-			"breakpoints": true
-		},
-		{
-			"idx": 36,
-			"version": "7",
-			"when": 1779271468703,
-			"tag": "0036_add_step_change_event_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 37,
-			"version": "7",
-			"when": 1779271468704,
-			"tag": "0037_pale_mikhail_rasputin",
-			"breakpoints": true
-		},
-		{
-			"idx": 38,
-			"version": "7",
-			"when": 1780580810342,
-			"tag": "0038_whole_unus",
-			"breakpoints": true
-		},
-		{
-			"idx": 39,
-			"version": "7",
-			"when": 1781107611122,
-			"tag": "0039_cse_opinion_file",
-			"breakpoints": true
-		},
-		{
-			"idx": 40,
-			"version": "7",
-			"when": 1781169333713,
-			"tag": "0040_reconcile_drifted_schema",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1771922842861,
+      "tag": "0000_fuzzy_romulus",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771928448125,
+      "tag": "0001_worthless_dragon_lord",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772154191182,
+      "tag": "0002_lean_khan",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772215461501,
+      "tag": "0003_absurd_komodo",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772223004236,
+      "tag": "0004_next_jack_murdock",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772611200000,
+      "tag": "0005_standardize_snake_case",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1772703893318,
+      "tag": "0006_lovely_korath",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1773158962249,
+      "tag": "0007_gigantic_doctor_faustus",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1773328599101,
+      "tag": "0008_powerful_omega_flight",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1773331852632,
+      "tag": "0009_hot_vector",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1773504000000,
+      "tag": "0010_gip_mds_data",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1773936000000,
+      "tag": "0011_add_export_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1774022400000,
+      "tag": "0012_export_date_to_year",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1774108800000,
+      "tag": "0013_add_gip_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1774195200000,
+      "tag": "0014_drop_session_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1774281600000,
+      "tag": "0015_drop_account_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1774368000000,
+      "tag": "0016_link_cse_joint_eval_to_declaration",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1774874768051,
+      "tag": "0017_flatten-indicator-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1774945983953,
+      "tag": "0018_rare_next_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1775050635448,
+      "tag": "0019_declaration_siren_fk",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0020_clean-user-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1775400000000,
+      "tag": "0021_add-campaign-deadlines",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1775450000000,
+      "tag": "0022_merge_file_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1775500000000,
+      "tag": "0023_add_audit_action_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1775600000000,
+      "tag": "0024_add_admin_impersonation_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1775700000000,
+      "tag": "0025_add_user_is_admin",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1775800000000,
+      "tag": "0026_add_referents_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1775900000000,
+      "tag": "0027_add_global_settings",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0028_add_cse_opinion_completed_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1776100000000,
+      "tag": "0029_add_declaration_submitted_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1777379362370,
+      "tag": "0030_drop_job_category_detail",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1777500000000,
+      "tag": "0031_drop_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1778071563871,
+      "tag": "0032_sparkling_monster_badoon",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778489783883,
+      "tag": "0033_add_cancelled_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778584824979,
+      "tag": "0034_tranquil_catseye",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1778682813792,
+      "tag": "0035_status_history",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1779271468703,
+      "tag": "0036_add_step_change_event_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1779271468704,
+      "tag": "0037_pale_mikhail_rasputin",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1780580810342,
+      "tag": "0038_whole_unus",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1781107611122,
+      "tag": "0039_cse_opinion_file",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1781169333713,
+      "tag": "0040_reconcile_drifted_schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1782202160639,
+      "tag": "0041_curvy_forgotten_one",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,300 +1,300 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1771922842861,
-      "tag": "0000_fuzzy_romulus",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1771928448125,
-      "tag": "0001_worthless_dragon_lord",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1772154191182,
-      "tag": "0002_lean_khan",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1772215461501,
-      "tag": "0003_absurd_komodo",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1772223004236,
-      "tag": "0004_next_jack_murdock",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1772611200000,
-      "tag": "0005_standardize_snake_case",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1772703893318,
-      "tag": "0006_lovely_korath",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1773158962249,
-      "tag": "0007_gigantic_doctor_faustus",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1773328599101,
-      "tag": "0008_powerful_omega_flight",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1773331852632,
-      "tag": "0009_hot_vector",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1773504000000,
-      "tag": "0010_gip_mds_data",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1773936000000,
-      "tag": "0011_add_export_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1774022400000,
-      "tag": "0012_export_date_to_year",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1774108800000,
-      "tag": "0013_add_gip_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1774195200000,
-      "tag": "0014_drop_session_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1774281600000,
-      "tag": "0015_drop_account_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1774368000000,
-      "tag": "0016_link_cse_joint_eval_to_declaration",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1774874768051,
-      "tag": "0017_flatten-indicator-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1774945983953,
-      "tag": "0018_rare_next_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1775050635448,
-      "tag": "0019_declaration_siren_fk",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1775200000000,
-      "tag": "0020_clean-user-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1775400000000,
-      "tag": "0021_add-campaign-deadlines",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1775450000000,
-      "tag": "0022_merge_file_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1775500000000,
-      "tag": "0023_add_audit_action_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1775600000000,
-      "tag": "0024_add_admin_impersonation_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1775700000000,
-      "tag": "0025_add_user_is_admin",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1775800000000,
-      "tag": "0026_add_referents_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1775900000000,
-      "tag": "0027_add_global_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1776000000000,
-      "tag": "0028_add_cse_opinion_completed_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1776100000000,
-      "tag": "0029_add_declaration_submitted_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1777379362370,
-      "tag": "0030_drop_job_category_detail",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1777500000000,
-      "tag": "0031_drop_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1778071563871,
-      "tag": "0032_sparkling_monster_badoon",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1778489783883,
-      "tag": "0033_add_cancelled_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1778584824979,
-      "tag": "0034_tranquil_catseye",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1778682813792,
-      "tag": "0035_status_history",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1779271468703,
-      "tag": "0036_add_step_change_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "7",
-      "when": 1779271468704,
-      "tag": "0037_pale_mikhail_rasputin",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "7",
-      "when": 1780580810342,
-      "tag": "0038_whole_unus",
-      "breakpoints": true
-    },
-    {
-      "idx": 39,
-      "version": "7",
-      "when": 1781107611122,
-      "tag": "0039_cse_opinion_file",
-      "breakpoints": true
-    },
-    {
-      "idx": 40,
-      "version": "7",
-      "when": 1781169333713,
-      "tag": "0040_reconcile_drifted_schema",
-      "breakpoints": true
-    },
-    {
-      "idx": 41,
-      "version": "7",
-      "when": 1782202160639,
-      "tag": "0041_curvy_forgotten_one",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1771922842861,
+			"tag": "0000_fuzzy_romulus",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1771928448125,
+			"tag": "0001_worthless_dragon_lord",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1772154191182,
+			"tag": "0002_lean_khan",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1772215461501,
+			"tag": "0003_absurd_komodo",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1772223004236,
+			"tag": "0004_next_jack_murdock",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1772611200000,
+			"tag": "0005_standardize_snake_case",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1772703893318,
+			"tag": "0006_lovely_korath",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1773158962249,
+			"tag": "0007_gigantic_doctor_faustus",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1773328599101,
+			"tag": "0008_powerful_omega_flight",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1773331852632,
+			"tag": "0009_hot_vector",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1773504000000,
+			"tag": "0010_gip_mds_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1773936000000,
+			"tag": "0011_add_export_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1774022400000,
+			"tag": "0012_export_date_to_year",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1774108800000,
+			"tag": "0013_add_gip_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1774195200000,
+			"tag": "0014_drop_session_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1774281600000,
+			"tag": "0015_drop_account_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1774368000000,
+			"tag": "0016_link_cse_joint_eval_to_declaration",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1774874768051,
+			"tag": "0017_flatten-indicator-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1774945983953,
+			"tag": "0018_rare_next_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1775050635448,
+			"tag": "0019_declaration_siren_fk",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1775200000000,
+			"tag": "0020_clean-user-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1775400000000,
+			"tag": "0021_add-campaign-deadlines",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1775450000000,
+			"tag": "0022_merge_file_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1775500000000,
+			"tag": "0023_add_audit_action_log",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1775600000000,
+			"tag": "0024_add_admin_impersonation_events",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1775700000000,
+			"tag": "0025_add_user_is_admin",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1775800000000,
+			"tag": "0026_add_referents_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1775900000000,
+			"tag": "0027_add_global_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1776000000000,
+			"tag": "0028_add_cse_opinion_completed_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1776100000000,
+			"tag": "0029_add_declaration_submitted_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1777379362370,
+			"tag": "0030_drop_job_category_detail",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1777500000000,
+			"tag": "0031_drop_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1778071563871,
+			"tag": "0032_sparkling_monster_badoon",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1778489783883,
+			"tag": "0033_add_cancelled_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1778584824979,
+			"tag": "0034_tranquil_catseye",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1778682813792,
+			"tag": "0035_status_history",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779271468703,
+			"tag": "0036_add_step_change_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 37,
+			"version": "7",
+			"when": 1779271468704,
+			"tag": "0037_pale_mikhail_rasputin",
+			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1780580810342,
+			"tag": "0038_whole_unus",
+			"breakpoints": true
+		},
+		{
+			"idx": 39,
+			"version": "7",
+			"when": 1781107611122,
+			"tag": "0039_cse_opinion_file",
+			"breakpoints": true
+		},
+		{
+			"idx": 40,
+			"version": "7",
+			"when": 1781169333713,
+			"tag": "0040_reconcile_drifted_schema",
+			"breakpoints": true
+		},
+		{
+			"idx": 41,
+			"version": "7",
+			"when": 1782202160639,
+			"tag": "0041_curvy_forgotten_one",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -26,6 +26,11 @@ export const AUDIT_ACTIONS = {
 	DECLARATION_SAVE_COMPLIANCE_PATH: "declaration.save_compliance_path",
 	DECLARATION_SUBMIT_JOINT_EVALUATION: "declaration.submit_joint_evaluation",
 
+	// ── Declaration edit lock mutations ────────────────────
+	DECLARATION_LOCK_ACQUIRED: "declaration.lock_acquired",
+	DECLARATION_LOCK_RELEASED: "declaration.lock_released",
+	ADMIN_DECLARATION_RELEASE_LOCK: "admin_declaration.release_lock",
+
 	// ── CSE opinion mutations ──────────────────────────────
 	CSE_OPINION_SAVE: "cse_opinion.save",
 	CSE_OPINION_UPLOAD_FILE: "cse_opinion.upload_file",
@@ -127,6 +132,10 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.DECLARATION_SUBMIT_SECOND]: "mutation",
 	[AUDIT_ACTIONS.DECLARATION_SAVE_COMPLIANCE_PATH]: "mutation",
 	[AUDIT_ACTIONS.DECLARATION_SUBMIT_JOINT_EVALUATION]: "mutation",
+
+	[AUDIT_ACTIONS.DECLARATION_LOCK_ACQUIRED]: "mutation",
+	[AUDIT_ACTIONS.DECLARATION_LOCK_RELEASED]: "mutation",
+	[AUDIT_ACTIONS.ADMIN_DECLARATION_RELEASE_LOCK]: "mutation",
 
 	[AUDIT_ACTIONS.CSE_OPINION_SAVE]: "mutation",
 	[AUDIT_ACTIONS.CSE_OPINION_UPLOAD_FILE]: "mutation",

--- a/packages/app/src/modules/declaration-remuneration/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/schemas.ts
@@ -129,3 +129,15 @@ export const categoryFormSchema = z.object({
 export const saveCompliancePathSchema = z.object({
 	path: z.enum(COMPLIANCE_PATHS),
 });
+
+export const acquireLockSchema = z.object({
+	declarationId: z.string(),
+});
+
+export const heartbeatSchema = z.object({
+	declarationId: z.string(),
+});
+
+export const releaseLockSchema = z.object({
+	declarationId: z.string(),
+});

--- a/packages/app/src/modules/domain/__tests__/declarationLock.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationLock.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_LOCK_TIMEOUT_MINUTES,
+	LOCK_HEARTBEAT_INTERVAL_MS,
+} from "~/modules/domain";
+import {
+	DEFAULT_LOCK_TIMEOUT_MINUTES as DEFAULT_FROM_SOURCE,
+	LOCK_HEARTBEAT_INTERVAL_MS as INTERVAL_FROM_SOURCE,
+} from "../shared/declarationLock";
+
+describe("declaration lock constants", () => {
+	it("defaults the lock timeout to 30 minutes", () => {
+		expect(DEFAULT_LOCK_TIMEOUT_MINUTES).toBe(30);
+	});
+
+	it("sets the heartbeat interval to 10 seconds", () => {
+		expect(LOCK_HEARTBEAT_INTERVAL_MS).toBe(10_000);
+	});
+
+	it("heartbeat interval is well below the lock timeout window", () => {
+		expect(LOCK_HEARTBEAT_INTERVAL_MS).toBeLessThan(
+			DEFAULT_LOCK_TIMEOUT_MINUTES * 60_000,
+		);
+	});
+
+	it("re-exports the same values through the domain barrel", () => {
+		expect(DEFAULT_LOCK_TIMEOUT_MINUTES).toBe(DEFAULT_FROM_SOURCE);
+		expect(LOCK_HEARTBEAT_INTERVAL_MS).toBe(INTERVAL_FROM_SOURCE);
+	});
+});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -48,6 +48,11 @@ export {
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 } from "./shared/declarationFlags";
+// Declaration edit lock constants
+export {
+	DEFAULT_LOCK_TIMEOUT_MINUTES,
+	LOCK_HEARTBEAT_INTERVAL_MS,
+} from "./shared/declarationLock";
 // Declaration prerequisites
 export { hasRequiredDeclarationInfo } from "./shared/declarationPrerequisites";
 // Declaration process step deadline

--- a/packages/app/src/modules/domain/shared/declarationLock.ts
+++ b/packages/app/src/modules/domain/shared/declarationLock.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_LOCK_TIMEOUT_MINUTES = 30;
+
+export const LOCK_HEARTBEAT_INTERVAL_MS = 10_000;

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -251,6 +251,54 @@ export const declarationsRelations = relations(
 	}),
 );
 
+// ── Declaration edit lock ──────────────────────────────────────────
+
+export const declarationLocks = createTable(
+	"declaration_lock",
+	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		declarationId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => declarations.id, { onDelete: "cascade" }),
+		lockedByUserId: d
+			.varchar({ length: 255 })
+			.notNull()
+			.references(() => users.id),
+		lockedAt: d
+			.timestamp({ withTimezone: true })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		lastHeartbeatAt: d
+			.timestamp({ withTimezone: true })
+			.notNull()
+			.$defaultFn(() => new Date()),
+		expiresAt: d.timestamp({ withTimezone: true }).notNull(),
+	}),
+	(t) => [
+		uniqueIndex("declaration_lock_declaration_id_unique").on(t.declarationId),
+		index("declaration_lock_expires_at_idx").on(t.expiresAt),
+	],
+);
+
+export const declarationLocksRelations = relations(
+	declarationLocks,
+	({ one }) => ({
+		declaration: one(declarations, {
+			fields: [declarationLocks.declarationId],
+			references: [declarations.id],
+		}),
+		lockedBy: one(users, {
+			fields: [declarationLocks.lockedByUserId],
+			references: [users.id],
+		}),
+	}),
+);
+
 // ── Employee category tables (indicator G) ─────────────────────────
 
 export const declarationTypeEnum = pgEnum("declaration_type", [
@@ -658,6 +706,7 @@ export const campaignDeadlines = createTable("campaign_deadline", (d) => ({
 export const globalSettings = createTable("global_setting", (d) => ({
 	id: d.integer().notNull().primaryKey().default(1),
 	activeCampaignYear: d.integer(),
+	declarationLockTimeoutMinutes: d.integer().notNull().default(30),
 	updatedAt: d
 		.timestamp({ withTimezone: true })
 		.notNull()

--- a/packages/app/src/server/services/__tests__/declarationLockService.integration.test.ts
+++ b/packages/app/src/server/services/__tests__/declarationLockService.integration.test.ts
@@ -1,0 +1,315 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+import { db } from "~/server/db";
+import {
+	acquireOrRefreshLock,
+	getActiveLock,
+	refreshLock,
+	releaseAllLocksForUser,
+	releaseLock,
+	releaseLockAsAdmin,
+} from "~/server/services/declarationLockService";
+
+describe("declarationLockService (real Postgres)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN = "123456789";
+	const OTHER_SIREN = "987654321";
+	const YEAR = 2025;
+	const TIMEOUT_MINUTES = 30;
+
+	const DECLARATION_ID = "lock-it-decl-1";
+	const OTHER_DECLARATION_ID = "lock-it-decl-2";
+
+	const UID1 = "lock-it-user-1";
+	const UID2 = "lock-it-user-2";
+	const EMAIL1 = "lock-it-user-1@example.fr";
+	const EMAIL2 = "lock-it-user-2@example.fr";
+
+	async function seedFixtures() {
+		await sql`
+			INSERT INTO app_user (id, email, first_name, last_name)
+			VALUES
+				(${UID1}, ${EMAIL1}, 'Alice', 'Martin'),
+				(${UID2}, ${EMAIL2}, 'Bob', 'Durand')
+		`;
+		await sql`
+			INSERT INTO app_company (siren, name)
+			VALUES (${SIREN}, 'Lock Test Company'), (${OTHER_SIREN}, 'Lock Test Company 2')
+		`;
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id)
+			VALUES
+				(${DECLARATION_ID}, ${SIREN}, ${YEAR}, ${UID1}),
+				(${OTHER_DECLARATION_ID}, ${OTHER_SIREN}, ${YEAR}, ${UID1})
+		`;
+	}
+
+	async function cleanup() {
+		await sql`DELETE FROM app_declaration_lock WHERE locked_by_user_id IN (${UID1}, ${UID2})`;
+		await sql`DELETE FROM app_declaration WHERE id IN (${DECLARATION_ID}, ${OTHER_DECLARATION_ID})`;
+		await sql`DELETE FROM app_company WHERE siren IN (${SIREN}, ${OTHER_SIREN})`;
+		await sql`DELETE FROM app_user WHERE id IN (${UID1}, ${UID2})`;
+	}
+
+	async function countLockRows(declarationId: string): Promise<number> {
+		const rows = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count
+			FROM app_declaration_lock
+			WHERE declaration_id = ${declarationId}
+		`;
+		return rows[0]?.count ?? 0;
+	}
+
+	async function forceExpiry(declarationId: string, expiresAt: Date) {
+		await sql`
+			UPDATE app_declaration_lock
+			SET expires_at = ${expiresAt}
+			WHERE declaration_id = ${declarationId}
+		`;
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+		await seedFixtures();
+	});
+
+	describe("acquireOrRefreshLock on a free declaration", () => {
+		it("acquires the lock, creates a row, and stamps expiry near now + timeout", async () => {
+			const before = Date.now();
+			const result = await acquireOrRefreshLock(
+				db,
+				DECLARATION_ID,
+				UID1,
+				TIMEOUT_MINUTES,
+			);
+			const after = Date.now();
+
+			expect(result.acquired).toBe(true);
+			expect(result.holder.userId).toBe(UID1);
+			expect(result.holder.email).toBe(EMAIL1);
+			expect(result.holder.firstName).toBe("Alice");
+			expect(result.holder.lastName).toBe("Martin");
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(1);
+
+			const expiry = result.holder.expiresAt.getTime();
+			expect(expiry).toBeGreaterThanOrEqual(before + TIMEOUT_MINUTES * 60_000);
+			expect(expiry).toBeLessThanOrEqual(
+				after + TIMEOUT_MINUTES * 60_000 + 1_000,
+			);
+		});
+	});
+
+	describe("acquireOrRefreshLock when another user holds an active lock", () => {
+		it("does not acquire and returns the original holder", async () => {
+			const first = await acquireOrRefreshLock(
+				db,
+				DECLARATION_ID,
+				UID1,
+				TIMEOUT_MINUTES,
+			);
+			expect(first.acquired).toBe(true);
+
+			const second = await acquireOrRefreshLock(
+				db,
+				DECLARATION_ID,
+				UID2,
+				TIMEOUT_MINUTES,
+			);
+
+			expect(second.acquired).toBe(false);
+			expect(second.holder.userId).toBe(UID1);
+			expect(second.holder.email).toBe(EMAIL1);
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(1);
+		});
+	});
+
+	describe("acquireOrRefreshLock on an expired lock held by another user", () => {
+		it("getActiveLock returns null and the new user can take over", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+			await forceExpiry(DECLARATION_ID, new Date(Date.now() - 60_000));
+
+			expect(await getActiveLock(db, DECLARATION_ID)).toBeNull();
+
+			const takeover = await acquireOrRefreshLock(
+				db,
+				DECLARATION_ID,
+				UID2,
+				TIMEOUT_MINUTES,
+			);
+
+			expect(takeover.acquired).toBe(true);
+			expect(takeover.holder.userId).toBe(UID2);
+			expect(takeover.holder.email).toBe(EMAIL2);
+			expect(takeover.holder.expiresAt.getTime()).toBeGreaterThan(Date.now());
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(1);
+		});
+	});
+
+	describe("acquireOrRefreshLock by the same holder", () => {
+		it("refreshes in place without creating a second row and extends expiry", async () => {
+			const first = await acquireOrRefreshLock(
+				db,
+				DECLARATION_ID,
+				UID1,
+				TIMEOUT_MINUTES,
+			);
+			await forceExpiry(DECLARATION_ID, new Date(Date.now() + 60_000));
+
+			const refreshed = await acquireOrRefreshLock(
+				db,
+				DECLARATION_ID,
+				UID1,
+				TIMEOUT_MINUTES,
+			);
+
+			expect(refreshed.acquired).toBe(true);
+			expect(refreshed.holder.userId).toBe(UID1);
+			expect(await countLockRows(DECLARATION_ID)).toBe(1);
+			expect(refreshed.holder.expiresAt.getTime()).toBeGreaterThan(
+				first.holder.expiresAt.getTime(),
+			);
+		});
+	});
+
+	describe("getActiveLock", () => {
+		it("returns the holder joined with the user details when active", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+
+			const holder = await getActiveLock(db, DECLARATION_ID);
+
+			expect(holder).not.toBeNull();
+			expect(holder?.userId).toBe(UID1);
+			expect(holder?.email).toBe(EMAIL1);
+			expect(holder?.firstName).toBe("Alice");
+			expect(holder?.lastName).toBe("Martin");
+			expect(holder?.expiresAt).toBeInstanceOf(Date);
+		});
+
+		it("returns null when no lock exists for the declaration", async () => {
+			expect(await getActiveLock(db, DECLARATION_ID)).toBeNull();
+		});
+
+		it("returns null on the exact expiry boundary (expiresAt <= now)", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+			await forceExpiry(DECLARATION_ID, new Date());
+
+			expect(await getActiveLock(db, DECLARATION_ID)).toBeNull();
+		});
+	});
+
+	describe("refreshLock", () => {
+		it("extends expiry and returns true when held by the user", async () => {
+			const acquired = await acquireOrRefreshLock(
+				db,
+				DECLARATION_ID,
+				UID1,
+				TIMEOUT_MINUTES,
+			);
+			await forceExpiry(DECLARATION_ID, new Date(Date.now() + 60_000));
+
+			const ok = await refreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+
+			expect(ok).toBe(true);
+			const holder = await getActiveLock(db, DECLARATION_ID);
+			expect(holder?.expiresAt.getTime()).toBeGreaterThan(
+				acquired.holder.expiresAt.getTime(),
+			);
+		});
+
+		it("returns false and does not touch the row when not held by the user", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+			const before = await getActiveLock(db, DECLARATION_ID);
+
+			const ok = await refreshLock(db, DECLARATION_ID, UID2, TIMEOUT_MINUTES);
+
+			expect(ok).toBe(false);
+			const after = await getActiveLock(db, DECLARATION_ID);
+			expect(after?.userId).toBe(UID1);
+			expect(after?.expiresAt.getTime()).toBe(before?.expiresAt.getTime());
+		});
+
+		it("returns false when no lock exists", async () => {
+			expect(await refreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES)).toBe(
+				false,
+			);
+		});
+	});
+
+	describe("releaseLock", () => {
+		it("removes the lock when held by the user", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+
+			await releaseLock(db, DECLARATION_ID, UID1);
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(0);
+		});
+
+		it("leaves another user's lock untouched", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+
+			await releaseLock(db, DECLARATION_ID, UID2);
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(1);
+			const holder = await getActiveLock(db, DECLARATION_ID);
+			expect(holder?.userId).toBe(UID1);
+		});
+	});
+
+	describe("releaseAllLocksForUser", () => {
+		it("removes every lock held by the user across declarations", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+			await acquireOrRefreshLock(
+				db,
+				OTHER_DECLARATION_ID,
+				UID1,
+				TIMEOUT_MINUTES,
+			);
+
+			await releaseAllLocksForUser(db, UID1);
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(0);
+			expect(await countLockRows(OTHER_DECLARATION_ID)).toBe(0);
+		});
+
+		it("does not remove locks held by other users", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+			await acquireOrRefreshLock(
+				db,
+				OTHER_DECLARATION_ID,
+				UID2,
+				TIMEOUT_MINUTES,
+			);
+
+			await releaseAllLocksForUser(db, UID1);
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(0);
+			expect(await countLockRows(OTHER_DECLARATION_ID)).toBe(1);
+		});
+	});
+
+	describe("releaseLockAsAdmin", () => {
+		it("removes the lock regardless of who holds it", async () => {
+			await acquireOrRefreshLock(db, DECLARATION_ID, UID1, TIMEOUT_MINUTES);
+
+			await releaseLockAsAdmin(db, DECLARATION_ID);
+
+			expect(await countLockRows(DECLARATION_ID)).toBe(0);
+			expect(await getActiveLock(db, DECLARATION_ID)).toBeNull();
+		});
+	});
+});

--- a/packages/app/src/server/services/__tests__/declarationLockService.test.ts
+++ b/packages/app/src/server/services/__tests__/declarationLockService.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/db", () => ({ db: {} }));
+
+vi.mock("~/server/db/schema", () => ({
+	declarationLocks: {
+		id: "id",
+		declarationId: "declarationId",
+		lockedByUserId: "lockedByUserId",
+		lockedAt: "lockedAt",
+		lastHeartbeatAt: "lastHeartbeatAt",
+		expiresAt: "expiresAt",
+	},
+	users: {
+		id: "id",
+		email: "email",
+		firstName: "firstName",
+		lastName: "lastName",
+	},
+}));
+
+const DECLARATION_ID = "decl-1";
+const USER_ID = "user-1";
+const TIMEOUT_MINUTES = 30;
+const NOW = new Date("2025-06-23T10:00:00.000Z");
+const EXPECTED_EXPIRY = new Date(NOW.getTime() + TIMEOUT_MINUTES * 60_000);
+
+const HOLDER = {
+	userId: USER_ID,
+	email: "user-1@example.fr",
+	firstName: "Alice",
+	lastName: "Martin",
+	expiresAt: EXPECTED_EXPIRY,
+};
+
+function selectChain(rows: unknown[]) {
+	const limit = vi.fn().mockResolvedValue(rows);
+	const where = vi.fn().mockReturnValue({ limit });
+	const innerJoin = vi.fn().mockReturnValue({ where });
+	const from = vi.fn().mockReturnValue({ innerJoin });
+	return { select: vi.fn().mockReturnValue({ from }), where, limit };
+}
+
+function insertChain(returnedRows: unknown[]) {
+	const returning = vi.fn().mockResolvedValue(returnedRows);
+	const onConflictDoUpdate = vi.fn().mockReturnValue({ returning });
+	const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+	return {
+		insert: vi.fn().mockReturnValue({ values }),
+		values,
+		onConflictDoUpdate,
+		returning,
+	};
+}
+
+function updateChain(returnedRows: unknown[]) {
+	const returning = vi.fn().mockResolvedValue(returnedRows);
+	const where = vi.fn().mockReturnValue({ returning });
+	const set = vi.fn().mockReturnValue({ where });
+	return { update: vi.fn().mockReturnValue({ set }), set, where, returning };
+}
+
+function deleteChain() {
+	const where = vi.fn().mockResolvedValue(undefined);
+	return { delete: vi.fn().mockReturnValue({ where }), where };
+}
+
+const service = () => import("~/server/services/declarationLockService");
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("getActiveLock", () => {
+	it("returns the holder row when the join yields an active lock", async () => {
+		const select = selectChain([HOLDER]);
+		const { getActiveLock } = await service();
+
+		const result = await getActiveLock(select as never, DECLARATION_ID);
+
+		expect(result).toEqual(HOLDER);
+	});
+
+	it("returns null when no active lock row is returned", async () => {
+		const select = selectChain([]);
+		const { getActiveLock } = await service();
+
+		expect(await getActiveLock(select as never, DECLARATION_ID)).toBeNull();
+	});
+});
+
+describe("acquireOrRefreshLock", () => {
+	it("acquired=true when the upsert returns a row, stamping now + timeout", async () => {
+		const insert = insertChain([{ id: "lock-1" }]);
+		const db = { ...insert, ...selectChain([HOLDER]) };
+		const { acquireOrRefreshLock } = await service();
+
+		const result = await acquireOrRefreshLock(
+			db as never,
+			DECLARATION_ID,
+			USER_ID,
+			TIMEOUT_MINUTES,
+		);
+
+		expect(result.acquired).toBe(true);
+		expect(result.holder).toEqual(HOLDER);
+		const insertedValues = insert.values.mock.calls[0]?.[0];
+		expect(insertedValues).toMatchObject({
+			declarationId: DECLARATION_ID,
+			lockedByUserId: USER_ID,
+			lockedAt: NOW,
+			lastHeartbeatAt: NOW,
+			expiresAt: EXPECTED_EXPIRY,
+		});
+	});
+
+	it("acquired=false when the conflict update touches no row", async () => {
+		const insert = insertChain([]);
+		const db = { ...insert, ...selectChain([HOLDER]) };
+		const { acquireOrRefreshLock } = await service();
+
+		const result = await acquireOrRefreshLock(
+			db as never,
+			DECLARATION_ID,
+			"other-user",
+			TIMEOUT_MINUTES,
+		);
+
+		expect(result.acquired).toBe(false);
+		expect(result.holder).toEqual(HOLDER);
+	});
+
+	it("throws when the lock row is missing right after the upsert", async () => {
+		const db = { ...insertChain([{ id: "lock-1" }]), ...selectChain([]) };
+		const { acquireOrRefreshLock } = await service();
+
+		await expect(
+			acquireOrRefreshLock(
+				db as never,
+				DECLARATION_ID,
+				USER_ID,
+				TIMEOUT_MINUTES,
+			),
+		).rejects.toThrow(DECLARATION_ID);
+	});
+});
+
+describe("refreshLock", () => {
+	it("returns true and stamps now + timeout when a row is updated", async () => {
+		const update = updateChain([{ id: "lock-1" }]);
+		const { refreshLock } = await service();
+
+		const ok = await refreshLock(
+			update as never,
+			DECLARATION_ID,
+			USER_ID,
+			TIMEOUT_MINUTES,
+		);
+
+		expect(ok).toBe(true);
+		expect(update.set.mock.calls[0]?.[0]).toMatchObject({
+			lastHeartbeatAt: NOW,
+			expiresAt: EXPECTED_EXPIRY,
+		});
+	});
+
+	it("returns false when no row is updated", async () => {
+		const update = updateChain([]);
+		const { refreshLock } = await service();
+
+		expect(
+			await refreshLock(
+				update as never,
+				DECLARATION_ID,
+				USER_ID,
+				TIMEOUT_MINUTES,
+			),
+		).toBe(false);
+	});
+});
+
+describe("release helpers issue a delete", () => {
+	it("releaseLock deletes scoped to the declaration and user", async () => {
+		const del = deleteChain();
+		const { releaseLock } = await service();
+
+		await releaseLock(del as never, DECLARATION_ID, USER_ID);
+
+		expect(del.delete).toHaveBeenCalledTimes(1);
+		expect(del.where).toHaveBeenCalledTimes(1);
+	});
+
+	it("releaseAllLocksForUser deletes scoped to the user", async () => {
+		const del = deleteChain();
+		const { releaseAllLocksForUser } = await service();
+
+		await releaseAllLocksForUser(del as never, USER_ID);
+
+		expect(del.delete).toHaveBeenCalledTimes(1);
+		expect(del.where).toHaveBeenCalledTimes(1);
+	});
+
+	it("releaseLockAsAdmin deletes scoped to the declaration", async () => {
+		const del = deleteChain();
+		const { releaseLockAsAdmin } = await service();
+
+		await releaseLockAsAdmin(del as never, DECLARATION_ID);
+
+		expect(del.delete).toHaveBeenCalledTimes(1);
+		expect(del.where).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/app/src/server/services/declarationLockService.ts
+++ b/packages/app/src/server/services/declarationLockService.ts
@@ -1,0 +1,166 @@
+import "server-only";
+
+import { and, eq, gt, sql } from "drizzle-orm";
+
+import type { DB } from "~/server/db";
+import { declarationLocks, users } from "~/server/db/schema";
+
+type Tx = Parameters<Parameters<DB["transaction"]>[0]>[0];
+
+export type DbClient = DB | Tx;
+
+export type LockHolder = {
+	userId: string;
+	email: string | null;
+	firstName: string | null;
+	lastName: string | null;
+	expiresAt: Date;
+};
+
+const MS_PER_MINUTE = 60_000;
+
+function computeExpiry(now: Date, timeoutMinutes: number): Date {
+	return new Date(now.getTime() + timeoutMinutes * MS_PER_MINUTE);
+}
+
+/**
+ * Return the active lock holder for a declaration, or `null` if there is no
+ * lock or the lock has expired. Expiry is lazy: an expired row is treated as a
+ * free declaration rather than being eagerly deleted.
+ */
+export async function getActiveLock(
+	db: DbClient,
+	declarationId: string,
+): Promise<LockHolder | null> {
+	const rows = await db
+		.select({
+			userId: declarationLocks.lockedByUserId,
+			email: users.email,
+			firstName: users.firstName,
+			lastName: users.lastName,
+			expiresAt: declarationLocks.expiresAt,
+		})
+		.from(declarationLocks)
+		.innerJoin(users, eq(declarationLocks.lockedByUserId, users.id))
+		.where(
+			and(
+				eq(declarationLocks.declarationId, declarationId),
+				gt(declarationLocks.expiresAt, new Date()),
+			),
+		)
+		.limit(1);
+
+	return rows[0] ?? null;
+}
+
+/**
+ * Atomically acquire or refresh the edit lock on a declaration.
+ *
+ * Uses `INSERT ... ON CONFLICT (declaration_id)` so concurrent callers cannot
+ * both win: the conflict update only fires when the existing lock is free to
+ * take (held by the same user, or expired). If an active lock is held by
+ * another user, the row is left untouched and `acquired` is `false`.
+ */
+export async function acquireOrRefreshLock(
+	db: DbClient,
+	declarationId: string,
+	userId: string,
+	timeoutMinutes: number,
+): Promise<{ acquired: boolean; holder: LockHolder }> {
+	const now = new Date();
+	const expiresAt = computeExpiry(now, timeoutMinutes);
+
+	const acquiredRows = await db
+		.insert(declarationLocks)
+		.values({
+			declarationId,
+			lockedByUserId: userId,
+			lockedAt: now,
+			lastHeartbeatAt: now,
+			expiresAt,
+		})
+		.onConflictDoUpdate({
+			target: declarationLocks.declarationId,
+			set: {
+				lockedByUserId: userId,
+				lastHeartbeatAt: now,
+				expiresAt,
+			},
+			setWhere: sql`${declarationLocks.lockedByUserId} = ${userId} or ${declarationLocks.expiresAt} <= ${now}`,
+		})
+		.returning({ id: declarationLocks.id });
+
+	const holder = await getActiveLock(db, declarationId);
+
+	if (!holder) {
+		throw new Error(
+			`Declaration lock row missing right after upsert for ${declarationId}`,
+		);
+	}
+
+	return { acquired: acquiredRows.length > 0, holder };
+}
+
+/**
+ * Extend the lock's expiry and heartbeat if it is held by `userId`. Returns
+ * `false` when the user does not currently hold the lock.
+ */
+export async function refreshLock(
+	db: DbClient,
+	declarationId: string,
+	userId: string,
+	timeoutMinutes: number,
+): Promise<boolean> {
+	const now = new Date();
+	const updated = await db
+		.update(declarationLocks)
+		.set({
+			lastHeartbeatAt: now,
+			expiresAt: computeExpiry(now, timeoutMinutes),
+		})
+		.where(
+			and(
+				eq(declarationLocks.declarationId, declarationId),
+				eq(declarationLocks.lockedByUserId, userId),
+			),
+		)
+		.returning({ id: declarationLocks.id });
+
+	return updated.length > 0;
+}
+
+/** Release the lock on a declaration if it is held by `userId`. */
+export async function releaseLock(
+	db: DbClient,
+	declarationId: string,
+	userId: string,
+): Promise<void> {
+	await db
+		.delete(declarationLocks)
+		.where(
+			and(
+				eq(declarationLocks.declarationId, declarationId),
+				eq(declarationLocks.lockedByUserId, userId),
+			),
+		);
+}
+
+/** Release every lock held by `userId` (e.g. on logout). */
+export async function releaseAllLocksForUser(
+	db: DbClient,
+	userId: string,
+): Promise<void> {
+	await db
+		.delete(declarationLocks)
+		.where(eq(declarationLocks.lockedByUserId, userId));
+}
+
+/** Release the lock on a declaration unconditionally (admin override). */
+export async function releaseLockAsAdmin(
+	db: DbClient,
+	declarationId: string,
+): Promise<void> {
+	await db
+		.delete(declarationLocks)
+		.where(eq(declarationLocks.declarationId, declarationId));
+}

--- a/packages/app/src/server/services/declarationLockService.ts
+++ b/packages/app/src/server/services/declarationLockService.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, eq, gt, sql } from "drizzle-orm";
+import { and, eq, gt, lte, or } from "drizzle-orm";
 
 import type { DB } from "~/server/db";
 import { declarationLocks, users } from "~/server/db/schema";
@@ -86,7 +86,10 @@ export async function acquireOrRefreshLock(
 				lastHeartbeatAt: now,
 				expiresAt,
 			},
-			setWhere: sql`${declarationLocks.lockedByUserId} = ${userId} or ${declarationLocks.expiresAt} <= ${now}`,
+			setWhere: or(
+				eq(declarationLocks.lockedByUserId, userId),
+				lte(declarationLocks.expiresAt, now),
+			),
 		})
 		.returning({ id: declarationLocks.id });
 

--- a/packages/app/src/server/services/declarationLockService.ts
+++ b/packages/app/src/server/services/declarationLockService.ts
@@ -104,10 +104,6 @@ export async function acquireOrRefreshLock(
 	return { acquired: acquiredRows.length > 0, holder };
 }
 
-/**
- * Extend the lock's expiry and heartbeat if it is held by `userId`. Returns
- * `false` when the user does not currently hold the lock.
- */
 export async function refreshLock(
 	db: DbClient,
 	declarationId: string,
@@ -132,7 +128,6 @@ export async function refreshLock(
 	return updated.length > 0;
 }
 
-/** Release the lock on a declaration if it is held by `userId`. */
 export async function releaseLock(
 	db: DbClient,
 	declarationId: string,
@@ -148,7 +143,6 @@ export async function releaseLock(
 		);
 }
 
-/** Release every lock held by `userId` (e.g. on logout). */
 export async function releaseAllLocksForUser(
 	db: DbClient,
 	userId: string,
@@ -158,7 +152,7 @@ export async function releaseAllLocksForUser(
 		.where(eq(declarationLocks.lockedByUserId, userId));
 }
 
-/** Release the lock on a declaration unconditionally (admin override). */
+// No ownership predicate: admin override, callers gate on the admin role.
 export async function releaseLockAsAdmin(
 	db: DbClient,
 	declarationId: string,


### PR DESCRIPTION
Closes #3723

## Résumé

Fondation technique du verrou d'édition de la démarche de déclaration (epic #3556) : persistance + service serveur + constantes. Aucun comportement UI ni procédure tRPC — le câblage se fait dans les sous-tickets suivants.

### Contenu
- **Table `declaration_lock`** (`createTable`, préfixe `app_`) : `id`, `declarationId` (FK → `declarations`, `onDelete: cascade`), `lockedByUserId` (FK → `users`), `lockedAt`, `lastHeartbeatAt`, `expiresAt` ; `uniqueIndex` sur `declarationId` (un verrou par démarche) + index sur `expiresAt`.
- **Colonne `declarationLockTimeoutMinutes`** (integer NOT NULL default 30) sur `global_setting`.
- **Migration** `0041_curvy_forgotten_one` générée par drizzle-kit (journal monotone respecté).
- **Service `declarationLockService.ts`** avec expiration paresseuse : `getActiveLock`, `acquireOrRefreshLock` (`INSERT … ON CONFLICT (declaration_id)` atomique avec `setWhere` same-user-or-expired), `refreshLock`, `releaseLock`, `releaseAllLocksForUser`, `releaseLockAsAdmin`.
- **Constantes domaine** `DEFAULT_LOCK_TIMEOUT_MINUTES`, `LOCK_HEARTBEAT_INTERVAL_MS` exportées depuis `~/modules/domain`.
- **Schémas Zod** `acquireLockSchema`, `heartbeatSchema`, `releaseLockSchema`.
- **Audit** : 3 actions (`DECLARATION_LOCK_ACQUIRED`, `DECLARATION_LOCK_RELEASED`, `ADMIN_DECLARATION_RELEASE_LOCK`) + catégories `mutation`.

## Test plan
- TU constantes domaine + TU service (contrats observables : `acquired` true/false, `expiresAt = now + T`, throw défensif, release deletes) — 100% sur les fichiers de logique.
- Tests d'intégration sur driver réel (`*.integration.test.ts`) couvrant les 3 scénarios S1/S10/S11 : acquisition libre, acquisition bloquée par un autre user, takeover après expiration paresseuse via `ON CONFLICT`.
- `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` verts.

Pas de changement UI → pas de screenshots.
