### PR TITLE
feat(declaration-lock): release all locks for user on logout (#3725)

### DIFF
--- a/packages/app/src/app/api/auth/logout/route.ts
+++ b/packages/app/src/app/api/auth/logout/route.ts
@@ -7,6 +7,8 @@ import { parseSiren } from "~/modules/domain";
 import { logAction } from "~/server/audit/log";
 import { buildRequestContext } from "~/server/audit/requestContext";
 import { fetchEndSessionEndpoint } from "~/server/auth/proconnect-logout";
+import { db } from "~/server/db";
+import { releaseAllLocksForUser } from "~/server/services/declarationLockService";
 
 export async function GET(request: NextRequest) {
 	const token = await getToken({ req: request });
@@ -27,6 +29,14 @@ export async function GET(request: NextRequest) {
 			ipAddress: requestContext.ipAddress,
 			userAgent: requestContext.userAgent,
 		});
+
+		if (token.id) {
+			try {
+				await releaseAllLocksForUser(db, token.id);
+			} catch {
+				// best-effort: lock release failure must not block logout
+			}
+		}
 	}
 
 	const redirectTarget = await buildLogoutRedirectUrl(token?.id_token, baseUrl);

--- a/packages/app/src/server/auth/__tests__/logout-route.test.ts
+++ b/packages/app/src/server/auth/__tests__/logout-route.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGetToken = vi.fn();
 const mockLogAction = vi.fn();
+const mockReleaseAllLocksForUser = vi.fn();
+
+const fakeDb = { __brand: "db" };
 
 vi.mock("next-auth/jwt", () => ({
 	getToken: (...args: unknown[]) => mockGetToken(...args),
@@ -14,6 +17,13 @@ vi.mock("~/server/auth/proconnect-logout", () => ({
 
 vi.mock("~/server/audit/log", () => ({
 	logAction: (...args: unknown[]) => mockLogAction(...args),
+}));
+
+vi.mock("~/server/db", () => ({ db: fakeDb }));
+
+vi.mock("~/server/services/declarationLockService", () => ({
+	releaseAllLocksForUser: (...args: unknown[]) =>
+		mockReleaseAllLocksForUser(...args),
 }));
 
 import { fetchEndSessionEndpoint } from "~/server/auth/proconnect-logout";
@@ -33,6 +43,7 @@ describe("GET /api/auth/logout", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockFetchEndSession.mockResolvedValue(null);
+		mockReleaseAllLocksForUser.mockResolvedValue(undefined);
 	});
 
 	it("redirects to the home page when no session is active", async () => {
@@ -126,5 +137,44 @@ describe("GET /api/auth/logout", () => {
 			userEmail: "user@example.com",
 			siren: "123456789",
 		});
+	});
+
+	it("releases all locks held by the user with the db client and user id", async () => {
+		mockGetToken.mockResolvedValue({ id: "user-123" });
+
+		await GET(buildRequest());
+
+		expect(mockReleaseAllLocksForUser).toHaveBeenCalledOnce();
+		expect(mockReleaseAllLocksForUser).toHaveBeenCalledWith(fakeDb, "user-123");
+	});
+
+	it("does not release any lock when the request is unauthenticated", async () => {
+		mockGetToken.mockResolvedValue(null);
+
+		await GET(buildRequest());
+
+		expect(mockReleaseAllLocksForUser).not.toHaveBeenCalled();
+	});
+
+	it("does not release any lock when the session token carries no user id", async () => {
+		mockGetToken.mockResolvedValue({ email: "user@example.com" });
+
+		await GET(buildRequest());
+
+		expect(mockReleaseAllLocksForUser).not.toHaveBeenCalled();
+	});
+
+	it("still completes the logout redirect when releasing locks throws", async () => {
+		mockGetToken.mockResolvedValue({ id: "user-123" });
+		mockReleaseAllLocksForUser.mockRejectedValue(new Error("DB unavailable"));
+
+		const response = await GET(buildRequest());
+
+		expect(mockReleaseAllLocksForUser).toHaveBeenCalledOnce();
+		expect(response.status).toBe(307);
+		expect(response.headers.get("Location")).toBe("http://localhost:3000/");
+		expect(response.headers.get("set-cookie")).toContain(
+			"next-auth.session-token=",
+		);
 	});
 });


### PR DESCRIPTION
Closes #3725

## Résumé

Au logout, appel best-effort de `releaseAllLocksForUser(db, token.id)` dans le route handler `GET /api/auth/logout`, après `logAction(AUTH_LOGOUT)` et uniquement si `token.id` est présent. Un échec de la libération (DB indisponible, etc.) est silencieusement ignoré via try/catch — la déconnexion et la redirection ProConnect ne sont pas affectées.

## Plan de test

- [x] `releaseAllLocksForUser` appelé avec `(db, token.id)` quand `token.id` présent
- [x] Pas d'appel si non authentifié
- [x] Pas d'appel si token sans `id`
- [x] Logout aboutit (redirect 307 + cookie purgé) même si `releaseAllLocksForUser` throw
- [x] Typecheck, tests, lint, format — tous verts
- [x] Structural audit (17 règles) — PASS
- [x] Security audit (OWASP) — SECURE

## Référence Figma

N/A