### PR TITLE
feat(admin): verrou déclaration — délai T configurable

### DIFF
--- a/packages/app/src/modules/admin/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/admin/__tests__/schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { impersonateSearchSchema, startImpersonateSchema } from "../schemas";
+import { updateLockTimeoutSchema } from "../settings/schemas";
 
 describe("admin schemas", () => {
 	it("accepts a valid 9-digit SIREN", () => {
@@ -30,5 +31,39 @@ describe("admin schemas", () => {
 		"abcdefghi",
 	])("rejects invalid SIREN %s", (siren) => {
 		expect(impersonateSearchSchema.safeParse({ siren }).success).toBe(false);
+	});
+});
+
+describe("updateLockTimeoutSchema", () => {
+	it.each([1, 30, 720, 1440])("accepts %d minutes within range", (minutes) => {
+		const result = updateLockTimeoutSchema.safeParse({
+			timeoutMinutes: minutes,
+		});
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.timeoutMinutes).toBe(minutes);
+		}
+	});
+
+	it.each([0, -1, 1441, 5000])("rejects %d minutes out of range", (minutes) => {
+		expect(
+			updateLockTimeoutSchema.safeParse({ timeoutMinutes: minutes }).success,
+		).toBe(false);
+	});
+
+	it("rejects a non-integer timeout", () => {
+		expect(
+			updateLockTimeoutSchema.safeParse({ timeoutMinutes: 30.5 }).success,
+		).toBe(false);
+	});
+
+	it("rejects a non-numeric timeout", () => {
+		expect(
+			updateLockTimeoutSchema.safeParse({ timeoutMinutes: "30" }).success,
+		).toBe(false);
+	});
+
+	it("rejects a missing timeout", () => {
+		expect(updateLockTimeoutSchema.safeParse({}).success).toBe(false);
 	});
 });

--- a/packages/app/src/modules/admin/settings/AdminSettingsPage.tsx
+++ b/packages/app/src/modules/admin/settings/AdminSettingsPage.tsx
@@ -2,15 +2,12 @@ import { getCurrentYear } from "~/modules/domain";
 import { api, HydrateClient } from "~/trpc/server";
 
 import { CampaignDeadlinesForm } from "./CampaignDeadlinesForm";
+import { LockTimeoutForm } from "./LockTimeoutForm";
 
-/**
- * Backoffice page to edit per-year campaign deadlines (GIP publication,
- * campaign start, CSE and declaration deadlines). The active campaign year is
- * now deduced from the `campaignStartDate` field and no longer edited here.
- */
 export async function AdminSettingsPage() {
 	const overview = await api.adminSettings.getOverview();
 	const initialYear = overview.configuredYears.at(-1) ?? getCurrentYear();
+	const lockTimeout = await api.adminSettings.getLockTimeout();
 
 	return (
 		<HydrateClient>
@@ -28,6 +25,13 @@ export async function AdminSettingsPage() {
 					configuredYears={overview.configuredYears}
 					initialYear={initialYear}
 				/>
+			</section>
+
+			<section aria-labelledby="lock-timeout-heading" className="fr-mt-4w">
+				<h2 className="fr-h3" id="lock-timeout-heading">
+					Verrou de déclaration
+				</h2>
+				<LockTimeoutForm initialTimeoutMinutes={lockTimeout.timeoutMinutes} />
 			</section>
 		</HydrateClient>
 	);

--- a/packages/app/src/modules/admin/settings/LockTimeoutForm.tsx
+++ b/packages/app/src/modules/admin/settings/LockTimeoutForm.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { useZodForm } from "~/modules/shared/useZodForm";
+import { api } from "~/trpc/react";
+import {
+	type UpdateLockTimeoutInput,
+	updateLockTimeoutSchema,
+} from "./schemas";
+
+type Props = {
+	initialTimeoutMinutes: number;
+};
+
+export function LockTimeoutForm({ initialTimeoutMinutes }: Props) {
+	const utils = api.useUtils();
+	const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+	const [serverError, setServerError] = useState<string | null>(null);
+
+	const form = useZodForm(updateLockTimeoutSchema, {
+		defaultValues: { timeoutMinutes: initialTimeoutMinutes },
+	});
+
+	const mutation = api.adminSettings.updateLockTimeout.useMutation({
+		onSuccess: async () => {
+			setStatus("success");
+			setServerError(null);
+			await utils.adminSettings.getLockTimeout.invalidate();
+		},
+		onError: (err) => {
+			setStatus("error");
+			setServerError(err.message);
+		},
+	});
+
+	const onSubmit = form.handleSubmit((values: UpdateLockTimeoutInput) => {
+		setStatus("idle");
+		mutation.mutate(values);
+	});
+
+	const error = form.formState.errors.timeoutMinutes?.message;
+
+	return (
+		<form autoComplete="off" noValidate onSubmit={onSubmit}>
+			<div
+				className={
+					error ? "fr-input-group fr-input-group--error" : "fr-input-group"
+				}
+			>
+				<label className="fr-label" htmlFor="lock-timeout-minutes">
+					Délai d'expiration du verrou de déclaration (minutes)
+					<span className="fr-hint-text">
+						Valeur entre 1 et 1440 minutes (24 heures maximum).
+					</span>
+				</label>
+				<input
+					aria-describedby={error ? "lock-timeout-minutes-error" : undefined}
+					aria-invalid={Boolean(error)}
+					className="fr-input"
+					id="lock-timeout-minutes"
+					max={1440}
+					min={1}
+					type="number"
+					{...form.register("timeoutMinutes", { valueAsNumber: true })}
+				/>
+				{error && (
+					<p className="fr-error-text" id="lock-timeout-minutes-error">
+						{error}
+					</p>
+				)}
+			</div>
+
+			{status === "success" && (
+				<div
+					aria-live="polite"
+					className="fr-alert fr-alert--success fr-alert--sm fr-mt-2w"
+				>
+					<p>Délai d'expiration enregistré.</p>
+				</div>
+			)}
+			{status === "error" && serverError && (
+				<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
+					<p>{serverError}</p>
+				</div>
+			)}
+
+			<ul className="fr-btns-group fr-btns-group--inline-sm fr-mt-2w">
+				<li>
+					<button
+						className="fr-btn"
+						disabled={mutation.isPending}
+						type="submit"
+					>
+						{mutation.isPending ? "Enregistrement…" : "Enregistrer"}
+					</button>
+				</li>
+			</ul>
+		</form>
+	);
+}

--- a/packages/app/src/modules/admin/settings/__tests__/AdminSettingsPage.test.tsx
+++ b/packages/app/src/modules/admin/settings/__tests__/AdminSettingsPage.test.tsx
@@ -2,13 +2,17 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
-const { getOverviewMock } = vi.hoisted(() => ({
+const { getOverviewMock, getLockTimeoutMock } = vi.hoisted(() => ({
 	getOverviewMock: vi.fn(),
+	getLockTimeoutMock: vi.fn(),
 }));
 
 vi.mock("~/trpc/server", () => ({
 	api: {
-		adminSettings: { getOverview: getOverviewMock },
+		adminSettings: {
+			getOverview: getOverviewMock,
+			getLockTimeout: getLockTimeoutMock,
+		},
 	},
 	HydrateClient: ({ children }: { children: React.ReactNode }) => children,
 }));
@@ -25,6 +29,14 @@ vi.mock("../CampaignDeadlinesForm", () => ({
 		}),
 }));
 
+vi.mock("../LockTimeoutForm", () => ({
+	LockTimeoutForm: (props: { initialTimeoutMinutes: number }) =>
+		React.createElement("div", {
+			"data-testid": "lock-timeout-form",
+			"data-initial-timeout": props.initialTimeoutMinutes,
+		}),
+}));
+
 import { AdminSettingsPage } from "../AdminSettingsPage";
 
 describe("AdminSettingsPage", () => {
@@ -32,6 +44,7 @@ describe("AdminSettingsPage", () => {
 		getOverviewMock.mockResolvedValue({
 			configuredYears: [2025, 2026, 2027],
 		});
+		getLockTimeoutMock.mockResolvedValue({ timeoutMinutes: 30 });
 		render(await AdminSettingsPage());
 		expect(
 			screen.getByRole("heading", {
@@ -54,10 +67,22 @@ describe("AdminSettingsPage", () => {
 		getOverviewMock.mockResolvedValue({
 			configuredYears: [],
 		});
+		getLockTimeoutMock.mockResolvedValue({ timeoutMinutes: 30 });
 		render(await AdminSettingsPage());
 		const deadlines = screen.getByTestId("campaign-deadlines-form");
 		expect(deadlines.getAttribute("data-initial-year")).toBe(
 			String(new Date().getFullYear()),
 		);
+	});
+
+	it("renders the lock timeout section seeded with the stored timeout", async () => {
+		getOverviewMock.mockResolvedValue({ configuredYears: [2026] });
+		getLockTimeoutMock.mockResolvedValue({ timeoutMinutes: 45 });
+		render(await AdminSettingsPage());
+		expect(
+			screen.getByRole("heading", { level: 2, name: /verrou de déclaration/i }),
+		).toBeInTheDocument();
+		const lockForm = screen.getByTestId("lock-timeout-form");
+		expect(lockForm.getAttribute("data-initial-timeout")).toBe("45");
 	});
 });

--- a/packages/app/src/modules/admin/settings/__tests__/LockTimeoutForm.test.tsx
+++ b/packages/app/src/modules/admin/settings/__tests__/LockTimeoutForm.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { lockMutate, lockState, invalidateLockTimeout } = vi.hoisted(() => ({
+	lockMutate: vi.fn(),
+	lockState: { isPending: false } as {
+		isPending: boolean;
+		onSuccess?: () => Promise<void> | void;
+		onError?: (err: { message: string }) => void;
+	},
+	invalidateLockTimeout: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		adminSettings: {
+			updateLockTimeout: {
+				useMutation: (opts: {
+					onSuccess?: () => Promise<void> | void;
+					onError?: (err: { message: string }) => void;
+				}) => {
+					lockState.onSuccess = opts.onSuccess;
+					lockState.onError = opts.onError;
+					return { mutate: lockMutate, isPending: lockState.isPending };
+				},
+			},
+		},
+		useUtils: () => ({
+			adminSettings: {
+				getLockTimeout: { invalidate: invalidateLockTimeout },
+			},
+		}),
+	},
+}));
+
+import { LockTimeoutForm } from "../LockTimeoutForm";
+
+describe("LockTimeoutForm", () => {
+	beforeEach(() => {
+		lockMutate.mockReset();
+		invalidateLockTimeout.mockClear();
+		lockState.isPending = false;
+	});
+
+	it("seeds the input with the initial timeout", () => {
+		render(<LockTimeoutForm initialTimeoutMinutes={30} />);
+		expect(screen.getByLabelText(/délai d'expiration du verrou/i)).toHaveValue(
+			30,
+		);
+	});
+
+	it("submits the entered timeout", async () => {
+		render(<LockTimeoutForm initialTimeoutMinutes={30} />);
+		const input = screen.getByLabelText(/délai d'expiration du verrou/i);
+		await userEvent.clear(input);
+		await userEvent.type(input, "60");
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+		await waitFor(() => expect(lockMutate).toHaveBeenCalled());
+		expect(lockMutate.mock.calls[0]?.[0]).toEqual({ timeoutMinutes: 60 });
+	});
+
+	it("blocks submission and shows an error for an out-of-range value", async () => {
+		render(<LockTimeoutForm initialTimeoutMinutes={30} />);
+		const input = screen.getByLabelText(/délai d'expiration du verrou/i);
+		await userEvent.clear(input);
+		await userEvent.type(input, "1441");
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+		await waitFor(() =>
+			expect(
+				screen.getByLabelText(/délai d'expiration du verrou/i),
+			).toHaveAttribute("aria-invalid", "true"),
+		);
+		expect(
+			document.getElementById("lock-timeout-minutes-error"),
+		).toBeInTheDocument();
+		expect(lockMutate).not.toHaveBeenCalled();
+	});
+
+	it("shows a success alert and invalidates the query on success", async () => {
+		render(<LockTimeoutForm initialTimeoutMinutes={30} />);
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+		await waitFor(() => expect(lockMutate).toHaveBeenCalled());
+		await lockState.onSuccess?.();
+		await waitFor(() =>
+			expect(
+				screen.getByText(/délai d'expiration enregistré/i),
+			).toBeInTheDocument(),
+		);
+		expect(invalidateLockTimeout).toHaveBeenCalled();
+	});
+
+	it("surfaces the server error when the mutation fails", async () => {
+		render(<LockTimeoutForm initialTimeoutMinutes={30} />);
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+		await waitFor(() => expect(lockMutate).toHaveBeenCalled());
+		lockState.onError?.({ message: "Réservé aux administrateurs" });
+		await waitFor(() =>
+			expect(screen.getByRole("alert")).toHaveTextContent(
+				"Réservé aux administrateurs",
+			),
+		);
+		expect(invalidateLockTimeout).not.toHaveBeenCalled();
+	});
+
+	it("disables the submit button while the mutation is pending", () => {
+		lockState.isPending = true;
+		render(<LockTimeoutForm initialTimeoutMinutes={30} />);
+		expect(
+			screen.getByRole("button", { name: /enregistrement/i }),
+		).toBeDisabled();
+	});
+});

--- a/packages/app/src/modules/admin/settings/schemas.ts
+++ b/packages/app/src/modules/admin/settings/schemas.ts
@@ -55,3 +55,9 @@ export type CampaignDeadlinesFormValues = z.output<
 export const getCampaignDeadlinesByYearSchema = z.object({
 	year: campaignYearSchema,
 });
+
+export const updateLockTimeoutSchema = z.object({
+	timeoutMinutes: z.number().int().min(1).max(1440),
+});
+
+export type UpdateLockTimeoutInput = z.infer<typeof updateLockTimeoutSchema>;

--- a/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
+++ b/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
@@ -18,6 +18,15 @@ describe("AUDIT_ACTIONS", () => {
 		const values = Object.values(AUDIT_ACTIONS);
 		expect(new Set(values).size).toBe(values.length);
 	});
+
+	it("maps the lock-timeout admin setting update to a mutation", () => {
+		expect(AUDIT_ACTIONS.ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT).toBe(
+			"admin_settings.update_lock_timeout",
+		);
+		expect(
+			AUDIT_ACTION_CATEGORIES[AUDIT_ACTIONS.ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT],
+		).toBe("mutation");
+	});
 });
 
 describe("retention constants", () => {

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -60,6 +60,7 @@ export const AUDIT_ACTIONS = {
 
 	// ── Admin settings mutations ──────────────────────────
 	ADMIN_SETTINGS_UPSERT_DEADLINES: "admin_settings.upsert_deadlines",
+	ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT: "admin_settings.update_lock_timeout",
 
 	// ── Admin stats reads ─────────────────────────────────
 	ADMIN_STATS_CAMPAIGN_PROGRESSION: "admin_stats.campaign_progression",
@@ -156,6 +157,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_DECLARATIONS_GET_RECAP]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES]: "mutation",
+	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_CAMPAIGN_STATS]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DURATIONS]: "read_sensitive",

--- a/packages/app/src/server/api/routers/adminSettings.ts
+++ b/packages/app/src/server/api/routers/adminSettings.ts
@@ -3,10 +3,14 @@ import { eq } from "drizzle-orm";
 import {
 	campaignDeadlinesFormSchema,
 	getCampaignDeadlinesByYearSchema,
+	updateLockTimeoutSchema,
 } from "~/modules/admin/settings/schemas";
-import { getDefaultCampaignDeadlines } from "~/modules/domain";
+import {
+	DEFAULT_LOCK_TIMEOUT_MINUTES,
+	getDefaultCampaignDeadlines,
+} from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
-import { campaignDeadlines } from "~/server/db/schema";
+import { campaignDeadlines, globalSettings } from "~/server/db/schema";
 
 /**
  * Admin / settings router — edits platform-wide global variables.
@@ -86,6 +90,37 @@ export const adminSettingsRouter = createTRPCRouter({
 					defaults.decl2JointEvaluationDeadline,
 				),
 			};
+		}),
+
+	getLockTimeout: adminProcedure.query(async ({ ctx }) => {
+		const [row] = await ctx.db
+			.select({
+				declarationLockTimeoutMinutes:
+					globalSettings.declarationLockTimeoutMinutes,
+			})
+			.from(globalSettings)
+			.where(eq(globalSettings.id, 1))
+			.limit(1);
+
+		return {
+			timeoutMinutes:
+				row?.declarationLockTimeoutMinutes ?? DEFAULT_LOCK_TIMEOUT_MINUTES,
+		};
+	}),
+
+	updateLockTimeout: adminProcedure
+		.input(updateLockTimeoutSchema)
+		.mutation(async ({ ctx, input }) => {
+			await ctx.db
+				.update(globalSettings)
+				.set({
+					declarationLockTimeoutMinutes: input.timeoutMinutes,
+					updatedAt: new Date(),
+					updatedBy: ctx.session.user.id,
+				})
+				.where(eq(globalSettings.id, 1));
+
+			return { success: true as const };
 		}),
 
 	/**

--- a/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
+++ b/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
@@ -69,6 +69,22 @@ describe("auditMiddleware", () => {
 		});
 	});
 
+	it("logs the admin lock-timeout update mutation", async () => {
+		const next = vi.fn(async () => ({ success: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "adminSettings.updateLockTimeout",
+			getRawInput: buildGetRawInput({ timeoutMinutes: 45 }),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "admin_settings.update_lock_timeout",
+			status: "success",
+			metadata: { timeoutMinutes: 45 },
+		});
+	});
+
 	it("logs a failed mutation with the error message and re-throws", async () => {
 		const error = new TRPCError({
 			code: "BAD_REQUEST",

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -65,6 +65,8 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	// ── admin settings mutations ──────────────────────────
 	"adminSettings.upsertCampaignDeadlines":
 		AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES,
+	"adminSettings.updateLockTimeout":
+		AUDIT_ACTIONS.ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT,
 
 	// ── admin stats sensitive reads ──────────────────────
 	"adminStats.getCampaignProgression":


### PR DESCRIPTION
Closes #3726

## Résumé

Rend le délai d'expiration T du verrou de déclaration configurable depuis la page admin paramètres (scénario S9 de l'epic #3556).

### Changements

- **`adminSettings` router** : procédures `getLockTimeout` (query) et `updateLockTimeout` (mutation) sur `globalSettings` (id=1), fallback `DEFAULT_LOCK_TIMEOUT_MINUTES`
- **`modules/admin/settings/schemas.ts`** : `updateLockTimeoutSchema` (entier, 1–1440 min)
- **`modules/admin/settings/LockTimeoutForm.tsx`** : composant client DSFR avec champ numérique, validation, feedback succès/erreur
- **`AdminSettingsPage.tsx`** : section « Verrou de déclaration » avec prefetch SSR du timeout courant
- **Audit** : `ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT` (catégorie `mutation`) câblé dans `actionKeys.ts` + `PROCEDURE_TO_ACTION`

## Plan de test

- [ ] Ouvrir la page admin `/admin/settings` — la section « Verrou de déclaration » affiche la valeur courante (30 min par défaut)
- [ ] Changer à 15 min, enregistrer → alerte succès, `global_setting.declaration_lock_timeout_minutes = 15` en DB
- [ ] Changer à 0 → champ refusé (validation Zod min=1)
- [ ] Changer à 1441 → champ refusé (validation Zod max=1440)
- [ ] Vérifier que les prochaines acquisitions de verrou utilisent le nouveau délai

## Critères d'acceptation

- [x] `getLockTimeout` / `updateLockTimeout` (`adminProcedure`) sur `global_setting`
- [x] Champ admin éditant T avec validation (1..1440)
- [x] Schéma Zod hors routeur ; audit câblé
- [x] Tests ajoutés et verts, typecheck, lint