### PR TITLE
feat(admin): déverrouillage manuel de déclaration (#3727)

### DIFF
--- a/packages/app/src/modules/admin/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/admin/__tests__/schemas.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { impersonateSearchSchema, startImpersonateSchema } from "../schemas";
+import {
+	impersonateSearchSchema,
+	releaseLockSchema,
+	startImpersonateSchema,
+} from "../schemas";
 import { updateLockTimeoutSchema } from "../settings/schemas";
 
 describe("admin schemas", () => {
@@ -65,5 +69,22 @@ describe("updateLockTimeoutSchema", () => {
 
 	it("rejects a missing timeout", () => {
 		expect(updateLockTimeoutSchema.safeParse({}).success).toBe(false);
+	});
+});
+
+describe("releaseLockSchema", () => {
+	it("accepts a valid UUID declarationId", () => {
+		const result = releaseLockSchema.safeParse({
+			declarationId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it.each([
+		"",
+		"not-a-uuid",
+		"123456789",
+	])("rejects a non-UUID declarationId %s", (declarationId) => {
+		expect(releaseLockSchema.safeParse({ declarationId }).success).toBe(false);
 	});
 });

--- a/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
@@ -15,6 +15,7 @@ import {
 	FilesSection,
 } from "./DetailSections";
 import { SiblingDeclarationsSection } from "./SiblingDeclarationsSection";
+import { UnlockDeclarationButton } from "./UnlockDeclarationButton";
 
 type Props = {
 	declarationId: string;
@@ -66,6 +67,10 @@ export function AdminDeclarationDetailPage({ declarationId }: Props) {
 				cancelledAt={data.cancelledAt}
 				declarationId={data.id}
 				year={data.year}
+			/>
+			<UnlockDeclarationButton
+				declarationId={data.id}
+				isLocked={data.lock !== null}
 			/>
 			<DeclarationSummary declaration={data} />
 			<CompanySection declaration={data} />

--- a/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
@@ -92,7 +92,6 @@ function UnlockDeclarationButtonInner({
 										<div
 											aria-live="polite"
 											className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
-											role="alert"
 										>
 											<p>{error}</p>
 										</div>

--- a/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+
+import { useDsfrModal } from "~/modules/shared";
+import { api } from "~/trpc/react";
+
+import {
+	UNLOCK_DECLARATION_BUTTON_LABEL,
+	UNLOCK_DECLARATION_CONFIRM_LABEL,
+	UNLOCK_DECLARATION_MODAL_BODY,
+	UNLOCK_DECLARATION_MODAL_TITLE,
+} from "./shared/constants";
+
+const MODAL_ID = "unlock-declaration-modal";
+
+type Props = {
+	declarationId: string;
+	isLocked: boolean;
+};
+
+export function UnlockDeclarationButton({ declarationId, isLocked }: Props) {
+	if (!isLocked) {
+		return null;
+	}
+
+	return <UnlockDeclarationButtonInner declarationId={declarationId} />;
+}
+
+function UnlockDeclarationButtonInner({
+	declarationId,
+}: {
+	declarationId: string;
+}) {
+	const [error, setError] = useState<string | null>(null);
+	const { modalRef, open, close } = useDsfrModal();
+	const utils = api.useUtils();
+
+	const mutation = api.adminDeclarations.releaseLock.useMutation({
+		onSuccess: async () => {
+			close();
+			await utils.adminDeclarations.getById.invalidate({ id: declarationId });
+		},
+		onError: (err) => {
+			setError(err.message);
+		},
+	});
+
+	const handleConfirm = () => {
+		setError(null);
+		mutation.mutate({ declarationId });
+	};
+
+	const handleClose = () => {
+		setError(null);
+		close();
+	};
+
+	return (
+		<>
+			<button className="fr-btn fr-btn--secondary" onClick={open} type="button">
+				{UNLOCK_DECLARATION_BUTTON_LABEL}
+			</button>
+			<dialog
+				aria-labelledby={`${MODAL_ID}-title`}
+				aria-modal="true"
+				className="fr-modal"
+				id={MODAL_ID}
+				ref={modalRef}
+			>
+				<div className="fr-container fr-container--fluid fr-container-md">
+					<div className="fr-grid-row fr-grid-row--center">
+						<div className="fr-col-12 fr-col-md-8 fr-col-lg-6">
+							<div className="fr-modal__body">
+								<div className="fr-modal__header">
+									<button
+										aria-controls={MODAL_ID}
+										className="fr-btn--close fr-btn"
+										onClick={handleClose}
+										title="Fermer"
+										type="button"
+									>
+										Fermer
+									</button>
+								</div>
+								<div className="fr-modal__content">
+									<h2 className="fr-modal__title" id={`${MODAL_ID}-title`}>
+										{UNLOCK_DECLARATION_MODAL_TITLE}
+									</h2>
+									<p>{UNLOCK_DECLARATION_MODAL_BODY}</p>
+									{error && (
+										<div
+											aria-live="polite"
+											className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
+											role="alert"
+										>
+											<p>{error}</p>
+										</div>
+									)}
+								</div>
+								<div className="fr-modal__footer">
+									<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+										<li>
+											<button
+												className="fr-btn fr-btn--primary"
+												disabled={mutation.isPending}
+												onClick={handleConfirm}
+												type="button"
+											>
+												{UNLOCK_DECLARATION_CONFIRM_LABEL}
+											</button>
+										</li>
+										<li>
+											<button
+												className="fr-btn fr-btn--secondary"
+												onClick={handleClose}
+												type="button"
+											>
+												Annuler
+											</button>
+										</li>
+									</ul>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</dialog>
+		</>
+	);
+}

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -48,6 +48,7 @@ vi.mock("~/trpc/react", () => ({
 							},
 						],
 						siblings: [],
+						lock: null,
 					},
 					isLoading: false,
 				}),
@@ -55,7 +56,18 @@ vi.mock("~/trpc/react", () => ({
 			getRecap: {
 				useQuery: vi.fn().mockReturnValue({ data: undefined }),
 			},
+			releaseLock: {
+				useMutation: vi
+					.fn()
+					.mockReturnValue({ mutate: vi.fn(), isPending: false }),
+			},
 		},
+		useUtils: vi.fn().mockReturnValue({
+			adminDeclarations: {
+				getById: { invalidate: vi.fn() },
+				search: { invalidate: vi.fn() },
+			},
+		}),
 	},
 }));
 
@@ -112,5 +124,13 @@ describe("AdminDeclarationDetailPage", () => {
 		expect(
 			screen.getByRole("link", { name: /Retour à la liste/ }),
 		).toHaveAttribute("href", "/admin/declarations");
+	});
+
+	it("does not display the unlock button when the declaration is not locked", () => {
+		render(<AdminDeclarationDetailPage declarationId="decl-1" />);
+
+		expect(
+			screen.queryByRole("button", { name: "Déverrouiller la déclaration" }),
+		).toBeNull();
 	});
 });

--- a/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
@@ -55,6 +55,7 @@ const declaration: DeclarationDetail = {
 		},
 	],
 	siblings: [],
+	lock: null,
 };
 
 describe("DeclarationSummary", () => {

--- a/packages/app/src/modules/admin/declarations/__tests__/UnlockDeclarationButton.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/UnlockDeclarationButton.test.tsx
@@ -1,0 +1,107 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockMutate, mockOpen, mockClose, mockInvalidate, mutationOptions } =
+	vi.hoisted(() => ({
+		mockMutate: vi.fn(),
+		mockOpen: vi.fn(),
+		mockClose: vi.fn(),
+		mockInvalidate: vi.fn(),
+		mutationOptions: { onSuccess: undefined, onError: undefined } as {
+			onSuccess?: () => Promise<void> | void;
+			onError?: (err: { message: string }) => void;
+		},
+	}));
+
+vi.mock("~/modules/shared", () => ({
+	useDsfrModal: () => ({
+		modalRef: { current: null },
+		open: mockOpen,
+		close: mockClose,
+	}),
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		adminDeclarations: {
+			releaseLock: {
+				useMutation: vi.fn().mockImplementation((options) => {
+					mutationOptions.onSuccess = options?.onSuccess;
+					mutationOptions.onError = options?.onError;
+					return { mutate: mockMutate, isPending: false };
+				}),
+			},
+		},
+		useUtils: vi.fn().mockReturnValue({
+			adminDeclarations: {
+				getById: { invalidate: mockInvalidate },
+			},
+		}),
+	},
+}));
+
+import { UnlockDeclarationButton } from "../UnlockDeclarationButton";
+
+describe("UnlockDeclarationButton", () => {
+	it("renders nothing when the declaration is not locked", () => {
+		render(<UnlockDeclarationButton declarationId="decl-1" isLocked={false} />);
+
+		expect(
+			screen.queryByRole("button", { name: "Déverrouiller la déclaration" }),
+		).toBeNull();
+	});
+
+	it("renders the button when the declaration is locked", () => {
+		render(<UnlockDeclarationButton declarationId="decl-1" isLocked />);
+
+		expect(
+			screen.getByRole("button", { name: "Déverrouiller la déclaration" }),
+		).toBeInTheDocument();
+	});
+
+	it("triggers the release mutation on confirmation", () => {
+		render(<UnlockDeclarationButton declarationId="decl-1" isLocked />);
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Confirmer le déverrouillage",
+				hidden: true,
+			}),
+		);
+
+		expect(mockMutate).toHaveBeenCalledWith({ declarationId: "decl-1" });
+	});
+
+	it("closes the modal when the cancel button is clicked", () => {
+		render(<UnlockDeclarationButton declarationId="decl-1" isLocked />);
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Annuler", hidden: true }),
+		);
+
+		expect(mockClose).toHaveBeenCalled();
+	});
+
+	it("closes the modal and invalidates the detail query on success", async () => {
+		render(<UnlockDeclarationButton declarationId="decl-1" isLocked />);
+
+		await act(async () => {
+			await mutationOptions.onSuccess?.();
+		});
+
+		expect(mockClose).toHaveBeenCalled();
+		expect(mockInvalidate).toHaveBeenCalledWith({ id: "decl-1" });
+	});
+
+	it("displays the error message returned by the mutation", () => {
+		render(<UnlockDeclarationButton declarationId="decl-1" isLocked />);
+
+		act(() => {
+			mutationOptions.onError?.({ message: "aucun verrou actif" });
+		});
+
+		expect(screen.getByRole("alert", { hidden: true })).toHaveTextContent(
+			"aucun verrou actif",
+		);
+	});
+});

--- a/packages/app/src/modules/admin/declarations/__tests__/UnlockDeclarationButton.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/UnlockDeclarationButton.test.tsx
@@ -100,8 +100,6 @@ describe("UnlockDeclarationButton", () => {
 			mutationOptions.onError?.({ message: "aucun verrou actif" });
 		});
 
-		expect(screen.getByRole("alert", { hidden: true })).toHaveTextContent(
-			"aucun verrou actif",
-		);
+		expect(screen.getByText("aucun verrou actif")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/declarations/shared/constants.ts
+++ b/packages/app/src/modules/admin/declarations/shared/constants.ts
@@ -15,3 +15,9 @@ export const CANCEL_DECLARATION_MODAL_TITLE = "Confirmer l'annulation";
 export const CANCEL_DECLARATION_MODAL_BODY =
 	"Cette action ne peut être annulée. La déclaration sera transmise à l'API SUIT comme annulée et l'entreprise pourra redéposer une nouvelle déclaration pour cette année.";
 export const CANCEL_DECLARATION_CONFIRM_LABEL = "Confirmer l'annulation";
+
+export const UNLOCK_DECLARATION_BUTTON_LABEL = "Déverrouiller la déclaration";
+export const UNLOCK_DECLARATION_MODAL_TITLE = "Confirmer le déverrouillage";
+export const UNLOCK_DECLARATION_MODAL_BODY =
+	"Le verrou d'édition sera supprimé immédiatement. L'utilisateur qui édite actuellement la déclaration pourra perdre ses modifications non sauvegardées.";
+export const UNLOCK_DECLARATION_CONFIRM_LABEL = "Confirmer le déverrouillage";

--- a/packages/app/src/modules/admin/index.ts
+++ b/packages/app/src/modules/admin/index.ts
@@ -10,5 +10,7 @@ export { AdminReferentsPage } from "./referents";
 export {
 	type ImpersonateSearchInput,
 	impersonateSearchSchema,
+	type ReleaseLockInput,
+	releaseLockSchema,
 	sirenSchema,
 } from "./schemas";

--- a/packages/app/src/modules/admin/schemas.ts
+++ b/packages/app/src/modules/admin/schemas.ts
@@ -29,3 +29,9 @@ export const startImpersonateSchema = z.object({
 });
 
 export type StartImpersonateInput = z.infer<typeof startImpersonateSchema>;
+
+export const releaseLockSchema = z.object({
+	declarationId: z.string().uuid(),
+});
+
+export type ReleaseLockInput = z.infer<typeof releaseLockSchema>;

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
@@ -44,6 +44,14 @@ const baseDeclaration = {
 	declarantPhone: null,
 };
 
+type LockRow = {
+	userId: string;
+	email: string | null;
+	firstName: string | null;
+	lastName: string | null;
+	expiresAt: Date;
+};
+
 function buildDb(options: {
 	declaration: typeof baseDeclaration | null;
 	siblings?: {
@@ -52,8 +60,9 @@ function buildDb(options: {
 		cancelledAt: Date | null;
 		updatedAt: Date;
 	}[];
+	lock?: LockRow | null;
 }) {
-	const { declaration, siblings = [] } = options;
+	const { declaration, siblings = [], lock = null } = options;
 
 	let selectCallCount = 0;
 	return {
@@ -67,7 +76,7 @@ function buildDb(options: {
 				limit: vi.fn().mockImplementation(() => {
 					if (callIndex === 1)
 						return Promise.resolve(declaration ? [declaration] : []);
-					return chain;
+					return Promise.resolve(lock ? [lock] : []);
 				}),
 				orderBy: vi.fn().mockResolvedValue(callIndex === 4 ? siblings : []),
 			};
@@ -158,5 +167,46 @@ describe("adminDeclarationsRouter — getById", () => {
 
 		expect(result?.siblings[0]?.status).toBe("submitted");
 		expect(result?.siblings[0]?.cancelledAt).toBeNull();
+	});
+
+	it("exposes lock as null when the declaration is not locked", async () => {
+		const db = buildDb({ declaration: baseDeclaration, lock: null });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getById({ id: DECL_ID_1 });
+
+		expect(result?.lock).toBeNull();
+	});
+
+	it("exposes the lock holder and expiry when the declaration is locked", async () => {
+		const expiresAt = new Date("2026-03-20T10:00:00Z");
+		const db = buildDb({
+			declaration: baseDeclaration,
+			lock: {
+				userId: "user-9",
+				email: "editor@example.fr",
+				firstName: "Bob",
+				lastName: "Martin",
+				expiresAt,
+			},
+		});
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getById({ id: DECL_ID_1 });
+
+		expect(result?.lock).toEqual({
+			holder: "editor@example.fr",
+			expiresAt,
+		});
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.releaseLock.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.releaseLock.test.ts
@@ -1,0 +1,122 @@
+import { TRPCError } from "@trpc/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const DECL_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+const adminSession = {
+	user: { id: "admin-1", email: "admin@example.fr", isAdmin: true },
+	expires: "",
+};
+
+const userSession = {
+	user: { id: "user-1", email: "user@example.fr", isAdmin: false },
+	expires: "",
+};
+
+type LockRow = {
+	userId: string;
+	email: string | null;
+	firstName: string | null;
+	lastName: string | null;
+	expiresAt: Date;
+};
+
+function buildDb(lock: LockRow | null) {
+	const deleteChain = {
+		where: vi.fn().mockResolvedValue(undefined),
+	};
+	const select = vi.fn().mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			innerJoin: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					limit: vi.fn().mockResolvedValue(lock ? [lock] : []),
+				}),
+			}),
+		}),
+	});
+	const del = vi.fn().mockReturnValue(deleteChain);
+	return { select, delete: del, __deleteChain: deleteChain };
+}
+
+const activeLock: LockRow = {
+	userId: "user-9",
+	email: "editor@example.fr",
+	firstName: "Bob",
+	lastName: "Martin",
+	expiresAt: new Date("2026-03-20T10:00:00Z"),
+};
+
+describe("adminDeclarationsRouter — releaseLock", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("releases the lock of a locked declaration", async () => {
+		const db = buildDb(activeLock);
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.releaseLock({ declarationId: DECL_ID });
+
+		expect(result).toEqual({ declarationId: DECL_ID });
+		expect(db.delete).toHaveBeenCalledTimes(1);
+		expect(db.__deleteChain.where).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects with BAD_REQUEST when no active lock exists", async () => {
+		const db = buildDb(null);
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const error = await caller
+			.releaseLock({ declarationId: DECL_ID })
+			.catch((e) => e);
+		expect(error).toBeInstanceOf(TRPCError);
+		expect((error as TRPCError).code).toBe("BAD_REQUEST");
+		expect((error as TRPCError).message).toMatch(/aucun verrou actif/);
+		expect(db.delete).not.toHaveBeenCalled();
+	});
+
+	it("rejects with UNAUTHORIZED when the caller is not an admin", async () => {
+		const db = buildDb(activeLock);
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: userSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(
+			caller.releaseLock({ declarationId: DECL_ID }),
+		).rejects.toThrow(/administrateurs/i);
+		expect(db.delete).not.toHaveBeenCalled();
+	});
+});
+
+describe("adminDeclarationsRouter — releaseLock audit wiring", () => {
+	it("AUDIT_ACTIONS.ADMIN_DECLARATION_RELEASE_LOCK is wired with category mutation", async () => {
+		const { AUDIT_ACTIONS, AUDIT_ACTION_CATEGORIES } = await import(
+			"~/modules/audit/shared/actionKeys"
+		);
+		expect(AUDIT_ACTIONS.ADMIN_DECLARATION_RELEASE_LOCK).toBe(
+			"admin_declaration.release_lock",
+		);
+		expect(
+			AUDIT_ACTION_CATEGORIES[AUDIT_ACTIONS.ADMIN_DECLARATION_RELEASE_LOCK],
+		).toBe("mutation");
+	});
+});

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -22,6 +22,7 @@ import {
 	getRecapSchema,
 	searchDeclarationsSchema,
 } from "~/modules/admin/declarations/schemas";
+import { releaseLockSchema } from "~/modules/admin/schemas";
 import { getCurrentYear } from "~/modules/domain";
 import {
 	mapToEmployeeCategoryRows,
@@ -38,6 +39,10 @@ import {
 	jobCategories,
 	users,
 } from "~/server/db/schema";
+import {
+	getActiveLock,
+	releaseLockAsAdmin,
+} from "~/server/services/declarationLockService";
 
 const sortColumnMap = {
 	siren: declarations.siren,
@@ -177,7 +182,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				return null;
 			}
 
-			const [declarationFiles, opinions, siblingRows, historyRows] =
+			const [declarationFiles, opinions, siblingRows, historyRows, activeLock] =
 				await Promise.all([
 					ctx.db
 						.select({
@@ -221,6 +226,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 						.from(declarationStatusHistory)
 						.where(eq(declarationStatusHistory.declarationId, input.id))
 						.orderBy(desc(declarationStatusHistory.createdAt)),
+					getActiveLock(ctx.db, input.id),
 				]);
 
 			const siblings = siblingRows.map((s) => ({
@@ -240,6 +246,9 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				files: declarationFiles,
 				cseOpinions: opinions,
 				siblings,
+				lock: activeLock
+					? { holder: activeLock.email, expiresAt: activeLock.expiresAt }
+					: null,
 				demarcheCompletedAt: findLatest("demarche_complete"),
 				secondDeclarationSubmittedAt: findLatest("second_declaration_submit"),
 			};
@@ -291,6 +300,22 @@ export const adminDeclarationsRouter = createTRPCRouter({
 			});
 
 			return { id: input.id, cancelledAt };
+		}),
+
+	releaseLock: adminProcedure
+		.input(releaseLockSchema)
+		.mutation(async ({ input, ctx }) => {
+			const lock = await getActiveLock(ctx.db, input.declarationId);
+			if (!lock) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "aucun verrou actif sur cette déclaration",
+				});
+			}
+
+			await releaseLockAsAdmin(ctx.db, input.declarationId);
+
+			return { declarationId: input.declarationId };
 		}),
 
 	getRecap: adminProcedure

--- a/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
+++ b/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
@@ -110,6 +110,22 @@ describe("auditMiddleware", () => {
 		});
 	});
 
+	it("logs the admin lock release mutation (adminDeclarations.releaseLock)", async () => {
+		const next = vi.fn(async () => ({ declarationId: "decl-1" }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "adminDeclarations.releaseLock",
+			getRawInput: buildGetRawInput({ declarationId: "decl-1" }),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "admin_declaration.release_lock",
+			status: "success",
+			metadata: { declarationId: "decl-1" },
+		});
+	});
+
 	it("logs sensitive query reads (declaration.getOrCreate)", async () => {
 		const next = vi.fn(async () => ({ declaration: {} }));
 		await auditMiddleware({

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -53,6 +53,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 
 	// ── admin declaration mutations ───────────────────────
 	"adminDeclarations.cancel": AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL,
+	"adminDeclarations.releaseLock": AUDIT_ACTIONS.ADMIN_DECLARATION_RELEASE_LOCK,
 
 	// ── public searches ────────────────────────────────────
 	"publicReferents.search": AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH,


### PR DESCRIPTION
## Résumé

- Mutation `adminDeclarations.releaseLock` : supprime le verrou actif via `releaseLockAsAdmin` (erreur `BAD_REQUEST` si aucun verrou)
- `adminDeclarations.getById` : expose `lock: { holder, expiresAt } | null` via `getActiveLock`
- `UnlockDeclarationButton` : bouton DSFR secondaire (calque de `CancelDeclarationButton`) avec modale de confirmation — visible uniquement si la déclaration est verrouillée
- Audit `ADMIN_DECLARATION_RELEASE_LOCK` câblé dans `trpcMiddleware.ts` (constante et catégorie déjà présentes dans `actionKeys.ts`)
- `releaseLockSchema` ajouté dans `~/modules/admin/schemas.ts`

## Closes

Closes #3727