### PR TITLE
feat(declaration-lock): procédures tRPC et gating des écritures (#3724)

### DIFF
--- a/packages/app/src/app/api/upload/__tests__/route.test.ts
+++ b/packages/app/src/app/api/upload/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
 	auth: vi.fn(),
 	runUploadPipeline: vi.fn(),
 	logAction: vi.fn().mockResolvedValue(undefined),
+	getActiveLock: vi.fn(),
 }));
 
 vi.mock("~/server/auth", () => ({
@@ -16,6 +17,30 @@ vi.mock("~/server/services/uploadPipeline", () => ({
 
 vi.mock("~/server/audit/log", () => ({
 	logAction: mocks.logAction,
+}));
+
+// The route resolves the current-year declaration before streaming the body so
+// it can refuse a target locked by another co-declarant (epic #3556). Mock the
+// db lookup to return one declaration and the lock service to a configurable
+// holder.
+vi.mock("~/server/db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: async () => [{ id: "decl-1" }],
+				}),
+			}),
+		}),
+	},
+}));
+
+vi.mock("~/server/db/schema", () => ({
+	declarations: { id: "id", siren: "siren", year: "year" },
+}));
+
+vi.mock("~/server/services/declarationLockService", () => ({
+	getActiveLock: mocks.getActiveLock,
 }));
 
 function validSession() {
@@ -73,6 +98,8 @@ function buildRequestWithRawFilename(
 describe("POST /api/upload", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Default: declaration free of any active lock, so the upload proceeds.
+		mocks.getActiveLock.mockResolvedValue(null);
 	});
 
 	it("returns 400 when X-Flow-Type is missing", async () => {
@@ -564,5 +591,66 @@ describe("POST /api/upload", () => {
 		);
 
 		consoleSpy.mockRestore();
+	});
+
+	it("returns 409 and audits a failure row when another co-declarant holds the lock", async () => {
+		validSession();
+		mocks.getActiveLock.mockResolvedValue({
+			userId: "user-2",
+			email: "other@example.com",
+			firstName: "Bob",
+			lastName: "Durand",
+			expiresAt: new Date(Date.now() + 30 * 60_000),
+		});
+
+		const { POST } = await import("../route");
+		const response = await POST(
+			buildRequest({
+				"Content-Type": "application/pdf",
+				"X-Filename": "avis-cse.pdf",
+				"X-Flow-Type": "cse_opinion",
+			}),
+		);
+
+		expect(response.status).toBe(409);
+		const body = await response.json();
+		expect(body.error).toContain("verrouillée");
+		expect(mocks.runUploadPipeline).not.toHaveBeenCalled();
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "cse_opinion.upload_file",
+				status: "failure",
+				errorMessage: "HTTP 409 locked_by_other",
+			}),
+		);
+	});
+
+	it("proceeds when the session user holds the lock", async () => {
+		validSession();
+		mocks.getActiveLock.mockResolvedValue({
+			userId: "user-1",
+			email: "user@example.com",
+			firstName: "Alice",
+			lastName: "Martin",
+			expiresAt: new Date(Date.now() + 30 * 60_000),
+		});
+		mocks.runUploadPipeline.mockResolvedValue({
+			ok: true,
+			fileId: "file-uuid",
+			fileName: "avis-cse.pdf",
+			filePath: "123456789/2027/file-uuid.pdf",
+		});
+
+		const { POST } = await import("../route");
+		const response = await POST(
+			buildRequest({
+				"Content-Type": "application/pdf",
+				"X-Filename": "avis-cse.pdf",
+				"X-Flow-Type": "cse_opinion",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.runUploadPipeline).toHaveBeenCalled();
 	});
 });

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -1,3 +1,4 @@
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { AUDIT_ACTIONS, type AuditActionKey } from "~/modules/audit";
 import { getCurrentYear } from "~/modules/domain";
@@ -13,6 +14,9 @@ import {
 	type RequestContext,
 } from "~/server/audit/requestContext";
 import { auth } from "~/server/auth";
+import { db } from "~/server/db";
+import { declarations } from "~/server/db/schema";
+import { getActiveLock } from "~/server/services/declarationLockService";
 import {
 	type PipelineFailureReason,
 	runUploadPipeline,
@@ -210,6 +214,40 @@ export async function POST(request: Request): Promise<Response> {
 	// Persist the normalised (trimmed) name; validation already ran on it.
 	const safeFileName = fileName.trim();
 	const year = getCurrentYear();
+
+	// Collaborative edit lock (epic #3556). This route is not tRPC, so the lock
+	// is enforced inline against the service rather than via the
+	// `declarationLockedWriteProcedure` middleware. The upload is refused when
+	// another co-declarant holds an active lock on the same declaration; a free
+	// lock (or one held by this user) lets the upload proceed. The check runs
+	// before the body is streamed so no bandwidth is wasted on a locked target.
+	const declarationRows = await db
+		.select({ id: declarations.id })
+		.from(declarations)
+		.where(and(eq(declarations.siren, siren), eq(declarations.year, year)))
+		.limit(1);
+	const lockedDeclarationId = declarationRows[0]?.id;
+	if (lockedDeclarationId) {
+		const lock = await getActiveLock(db, lockedDeclarationId);
+		if (lock && lock.userId !== userId) {
+			writeFailure({
+				action,
+				flowType,
+				fileName,
+				fileId: null,
+				errorMessage: "HTTP 409 locked_by_other",
+				userId,
+				userEmail,
+				siren,
+				requestContext,
+				startedAt,
+			});
+			return Response.json(
+				{ error: "Déclaration verrouillée par un autre utilisateur." },
+				{ status: 409 },
+			);
+		}
+	}
 
 	let result: UploadPipelineResult;
 	try {

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -215,7 +215,7 @@ export async function POST(request: Request): Promise<Response> {
 	const safeFileName = fileName.trim();
 	const year = getCurrentYear();
 
-	// Collaborative edit lock (epic #3556). This route is not tRPC, so the lock
+	// Collaborative edit lock. This route is not tRPC, so the lock
 	// is enforced inline against the service rather than via the
 	// `declarationLockedWriteProcedure` middleware. The upload is refused when
 	// another co-declarant holds an active lock on the same declaration; a free

--- a/packages/app/src/server/api/__tests__/declarationLockedWriteProcedure.test.ts
+++ b/packages/app/src/server/api/__tests__/declarationLockedWriteProcedure.test.ts
@@ -1,0 +1,107 @@
+import { TRPCError } from "@trpc/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildLockHolder } from "~/server/api/routers/__tests__/helpers/lockTestHelpers";
+
+vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
+vi.mock("~/server/db", () => ({ db: {} }));
+
+const mockGetActiveLock = vi.fn();
+vi.mock("~/server/services/declarationLockService", () => ({
+	getActiveLock: (...args: unknown[]) => mockGetActiveLock(...args),
+}));
+
+import { createTRPCRouter, declarationLockedWriteProcedure } from "../trpc";
+
+const USER_ID = "user-1";
+const OTHER_USER_ID = "user-2";
+const USER_SIRET = "33978727700015";
+const DECLARATION_ID = "decl-1";
+
+const router = createTRPCRouter({
+	write: declarationLockedWriteProcedure.mutation(({ ctx }) => ({
+		ok: true,
+		declarationId: ctx.declarationId,
+	})),
+});
+
+// fetchCurrentDeclarationId (inherited from declarationWriteProcedure) resolves
+// the current-year declaration id off ctx.db before the lock check runs.
+function createDb() {
+	const limit = vi.fn().mockResolvedValue([{ id: DECLARATION_ID }]);
+	const where = vi.fn().mockReturnValue({ limit });
+	const from = vi.fn().mockReturnValue({ where });
+	const select = vi.fn().mockReturnValue({ from });
+	return { select } as unknown;
+}
+
+function createCaller(db: unknown) {
+	return router.createCaller({
+		db,
+		session: {
+			user: {
+				id: USER_ID,
+				email: "user@example.com",
+				siret: USER_SIRET,
+				isAdmin: false,
+				impersonation: null,
+			},
+			expires: "",
+		},
+		headers: new Headers(),
+	} as never);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("declarationLockedWriteProcedure", () => {
+	it("passes when the current user holds an active lock", async () => {
+		mockGetActiveLock.mockResolvedValue(buildLockHolder({ userId: USER_ID }));
+
+		await expect(createCaller(createDb()).write()).resolves.toEqual({
+			ok: true,
+			declarationId: DECLARATION_ID,
+		});
+		expect(mockGetActiveLock).toHaveBeenCalledWith(
+			expect.anything(),
+			DECLARATION_ID,
+		);
+	});
+
+	it("throws CONFLICT when there is no lock at all", async () => {
+		mockGetActiveLock.mockResolvedValue(null);
+
+		await expect(createCaller(createDb()).write()).rejects.toMatchObject({
+			code: "CONFLICT",
+		});
+	});
+
+	it("throws CONFLICT when the active lock is held by another co-declarant (S2)", async () => {
+		mockGetActiveLock.mockResolvedValue(
+			buildLockHolder({ userId: OTHER_USER_ID }),
+		);
+
+		await expect(createCaller(createDb()).write()).rejects.toBeInstanceOf(
+			TRPCError,
+		);
+		await expect(createCaller(createDb()).write()).rejects.toMatchObject({
+			code: "CONFLICT",
+			message: "Déclaration verrouillée par un autre utilisateur.",
+		});
+	});
+
+	it("throws CONFLICT when the lock has expired (getActiveLock returns null on lazy expiry)", async () => {
+		// getActiveLock already filters out expired rows, so an expired lock is
+		// indistinguishable from no lock at the middleware boundary.
+		mockGetActiveLock.mockResolvedValue(null);
+
+		await expect(createCaller(createDb()).write()).rejects.toMatchObject({
+			code: "CONFLICT",
+		});
+	});
+});

--- a/packages/app/src/server/api/root.ts
+++ b/packages/app/src/server/api/root.ts
@@ -7,6 +7,7 @@ import { companyRouter } from "~/server/api/routers/company";
 import { cseOpinionRouter } from "~/server/api/routers/cseOpinion";
 import { declarationRouter } from "~/server/api/routers/declaration";
 import { declarationDraftRouter } from "~/server/api/routers/declarationDraft";
+import { declarationLockRouter } from "~/server/api/routers/declarationLock";
 import { gipMdsRouter } from "~/server/api/routers/gipMds";
 import { jointEvaluationRouter } from "~/server/api/routers/jointEvaluation";
 import { mailRouter } from "~/server/api/routers/mail";
@@ -30,6 +31,7 @@ export const appRouter = createTRPCRouter({
 	cseOpinion: cseOpinionRouter,
 	declaration: declarationRouter,
 	declarationDraft: declarationDraftRouter,
+	declarationLock: declarationLockRouter,
 	gipMds: gipMdsRouter,
 	jointEvaluation: jointEvaluationRouter,
 	mail: mailRouter,

--- a/packages/app/src/server/api/routers/__tests__/declaration.cancellation-flow.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.cancellation-flow.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCaller } from "./helpers/declarationTestHelpers";
+import { withLockMiddleware } from "./helpers/lockTestHelpers";
+
+// submit and updateStep1 run through `declarationLockedWriteProcedure`: the
+// lock middleware issues two `ctx.db.select` calls (declaration resolution +
+// active-lock lookup) before the handler. `withLockMiddleware` answers both
+// with the current user holding the lock; getOrCreate stays on `createCaller`.
+function createLockedCaller(db: unknown) {
+	return createCaller(withLockMiddleware(db));
+}
 
 vi.mock("~/server/auth", () => ({
 	auth: vi.fn(),
@@ -313,7 +322,7 @@ describe("declaration cancellation redeposit flow", () => {
 		buildActiveStore([cancelledRow, activeRow]);
 
 		const db = buildDb();
-		const caller = await createCaller(db);
+		const caller = await createLockedCaller(db);
 
 		const result = await caller.submit();
 
@@ -352,7 +361,7 @@ describe("declaration cancellation redeposit flow", () => {
 		buildActiveStore([cancelledRow, activeRow]);
 
 		const db = buildDb();
-		const caller = await createCaller(db);
+		const caller = await createLockedCaller(db);
 
 		await caller.updateStep1({ totalWomen: 70, totalMen: 80 });
 
@@ -390,7 +399,7 @@ describe("declaration cancellation redeposit flow", () => {
 		buildActiveStore([cancelledRow, activeRow]);
 
 		const db = buildDb();
-		const caller = await createCaller(db);
+		const caller = await createLockedCaller(db);
 
 		await caller.submit();
 

--- a/packages/app/src/server/api/routers/__tests__/declaration.employeeCategories.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.employeeCategories.test.ts
@@ -3,6 +3,14 @@ import {
 	createCaller,
 	mockDeclaration,
 } from "./helpers/declarationTestHelpers";
+import { withLockMiddleware } from "./helpers/lockTestHelpers";
+
+// updateEmployeeCategories runs through `declarationLockedWriteProcedure`, so
+// the lock middleware issues two `ctx.db.select` calls before the handler;
+// `withLockMiddleware` answers both with the current user holding the lock.
+function createLockedCaller(mockDb: unknown) {
+	return createCaller(withLockMiddleware(mockDb));
+}
 
 vi.mock("~/server/auth", () => ({
 	auth: vi.fn(),
@@ -105,7 +113,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateEmployeeCategories(employeeInput);
 
@@ -124,7 +132,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const correctionInput = {
 				declarationType: "correction" as const,
@@ -158,7 +166,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await expect(
 				caller.updateEmployeeCategories(employeeInput),

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -3,6 +3,19 @@ import {
 	createCaller,
 	mockDeclaration,
 } from "./helpers/declarationTestHelpers";
+import { withLockMiddleware } from "./helpers/lockTestHelpers";
+
+// The 9 write mutations run through `declarationLockedWriteProcedure`, whose
+// middleware issues two extra `ctx.db.select` calls (declaration resolution +
+// active-lock lookup) before the handler. `withLockMiddleware` answers both
+// with the current user holding the lock so the handler logic under test runs.
+function createLockedCaller(
+	mockDb: unknown,
+	siret?: string | null,
+	impersonation?: { siren: string; name: string } | null,
+) {
+	return createCaller(withLockMiddleware(mockDb), siret, impersonation);
+}
 
 vi.mock("~/server/auth", () => ({
 	auth: vi.fn(),
@@ -495,7 +508,7 @@ describe("declarationRouter", () => {
 			const declaration = buildDeclaration({ status: "draft" });
 			const company = buildCompany({ workforce: 80, hasCse: false });
 			const ctx = createSubmitMockDb(declaration, company, []);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			const result = await caller.submit();
 
@@ -522,7 +535,7 @@ describe("declarationRouter", () => {
 				{ annualBaseWomen: "100", annualBaseMen: "100" },
 			];
 			const ctx = createSubmitMockDb(declaration, company, employeeCategories);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
 
@@ -541,7 +554,7 @@ describe("declarationRouter", () => {
 				{ annualBaseWomen: "85", annualBaseMen: "100" },
 			];
 			const ctx = createSubmitMockDb(declaration, company, employeeCategories);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
 
@@ -557,7 +570,7 @@ describe("declarationRouter", () => {
 			const declaration = buildDeclaration({ status: "awaiting_cse_opinion" });
 			const company = buildCompany();
 			const ctx = createSubmitMockDb(declaration, company, []);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 			await expect(caller.submit()).rejects.toThrow(/No matching transition/);
 		});
 
@@ -565,7 +578,7 @@ describe("declarationRouter", () => {
 			const declaration = buildDeclaration({ status: "draft" });
 			const company = buildCompany();
 			const ctx = createSubmitMockDb(declaration, company, []);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
 
@@ -587,7 +600,7 @@ describe("declarationRouter", () => {
 				select: selectQueue.select,
 				update,
 			} as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await expect(caller.submit()).rejects.toThrow();
 		});
@@ -600,14 +613,14 @@ describe("declarationRouter", () => {
 				select: selectQueue.select,
 				update,
 			} as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await expect(caller.submit()).rejects.toThrow("Entreprise introuvable");
 		});
 
 		it("throws when siret is missing", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb, null as never);
+			const caller = await createLockedCaller(mockDb, null as never);
 
 			await expect(caller.submit()).rejects.toThrow(
 				"SIRET manquant ou invalide dans la session",
@@ -621,7 +634,7 @@ describe("declarationRouter", () => {
 			});
 			const company = buildCompany();
 			const ctx = createSubmitMockDb(declaration, company, []);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
 
@@ -641,7 +654,7 @@ describe("declarationRouter", () => {
 			});
 			const company = buildCompany();
 			const ctx = createSubmitMockDb(declaration, company, []);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
 
@@ -658,7 +671,7 @@ describe("declarationRouter", () => {
 			const declaration = buildDeclaration({ status: "draft", draft: null });
 			const company = buildCompany();
 			const ctx = createSubmitMockDb(declaration, company, []);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
 
@@ -680,7 +693,7 @@ describe("declarationRouter", () => {
 				{ annualBaseWomen: "80", annualBaseMen: "100" },
 			];
 			const ctx = createOneRowSelectDb(declaration, employeeCategories);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			const result = await caller.submitSecondDeclaration();
 
@@ -708,7 +721,7 @@ describe("declarationRouter", () => {
 				{ annualBaseWomen: "100", annualBaseMen: "100" },
 			];
 			const ctx = createOneRowSelectDb(declaration, employeeCategories);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submitSecondDeclaration();
 
@@ -732,7 +745,7 @@ describe("declarationRouter", () => {
 				{ annualBaseWomen: "100", annualBaseMen: "100" },
 			];
 			const ctx = createOneRowSelectDb(declaration, employeeCategories);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submitSecondDeclaration();
 
@@ -746,7 +759,7 @@ describe("declarationRouter", () => {
 				select: selectQueue.select,
 				update: vi.fn(),
 			} as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await expect(caller.submitSecondDeclaration()).rejects.toThrow();
 		});
@@ -758,7 +771,7 @@ describe("declarationRouter", () => {
 				draft: { second: { step1: { foo: "bar" } }, main: { step1: {} } },
 			});
 			const ctx = createOneRowSelectDb(declaration, [], [declaration]);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submitSecondDeclaration();
 
@@ -778,7 +791,7 @@ describe("declarationRouter", () => {
 				draft: { second: { step1: { foo: "bar" } } },
 			});
 			const ctx = createOneRowSelectDb(declaration, [], [declaration]);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submitSecondDeclaration();
 
@@ -799,7 +812,7 @@ describe("declarationRouter", () => {
 				cseRequired: true,
 			});
 			const ctx = createSimpleSelectDb(declaration);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			const result = await caller.saveCompliancePath({
 				path: "corrective_action",
@@ -829,7 +842,7 @@ describe("declarationRouter", () => {
 				cseRequired: true,
 			});
 			const ctx = createSimpleSelectDb(declaration);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.saveCompliancePath({ path: "justify" });
 
@@ -844,7 +857,7 @@ describe("declarationRouter", () => {
 				cseRequired: false,
 			});
 			const ctx = createSimpleSelectDb(declaration);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.saveCompliancePath({ path: "justify" });
 
@@ -870,7 +883,7 @@ describe("declarationRouter", () => {
 				[{ eventType: "second_declaration_submit" }],
 				[],
 			);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.saveCompliancePath({ path: "justify" });
 
@@ -900,7 +913,7 @@ describe("declarationRouter", () => {
 				[{ eventType: "second_declaration_submit" }],
 				[],
 			);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await expect(
 				caller.saveCompliancePath({ path: "corrective_action" }),
@@ -918,7 +931,7 @@ describe("declarationRouter", () => {
 				[],
 				[{ eventType: "joint_evaluation_submit", round: 1 }],
 			);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await expect(
 				caller.saveCompliancePath({ path: "corrective_action" }),
@@ -937,7 +950,7 @@ describe("declarationRouter", () => {
 				[{ eventType: "second_declaration_submit" }],
 				[{ eventType: "cse_opinion_submit", round: null }],
 			);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await expect(
 				caller.saveCompliancePath({ path: "joint_evaluation" }),
@@ -950,7 +963,7 @@ describe("declarationRouter", () => {
 				cseRequired: true,
 			});
 			const ctx = createSimpleSelectDb(declaration);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await expect(
 				caller.saveCompliancePath({ path: "invalid_path" as never }),
@@ -967,7 +980,7 @@ describe("declarationRouter", () => {
 				},
 			});
 			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.saveCompliancePath({ path: "justify" });
 
@@ -987,7 +1000,7 @@ describe("declarationRouter", () => {
 				draft: { compliance: { step1: { path: "justify" } } },
 			});
 			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.saveCompliancePath({ path: "justify" });
 
@@ -1009,7 +1022,7 @@ describe("declarationRouter", () => {
 				firstDeclarationPathChoice: "joint_evaluation",
 			});
 			const ctx = createSimpleSelectDb(declaration);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			const result = await caller.submitJointEvaluation();
 
@@ -1036,7 +1049,7 @@ describe("declarationRouter", () => {
 				secondDeclarationPathChoice: "joint_evaluation",
 			});
 			const ctx = createSimpleSelectDb(declaration);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submitJointEvaluation();
 
@@ -1057,7 +1070,7 @@ describe("declarationRouter", () => {
 				select: selectQueue.select,
 				update: vi.fn(),
 			} as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await expect(caller.submitJointEvaluation()).rejects.toThrow();
 		});
@@ -1073,7 +1086,7 @@ describe("declarationRouter", () => {
 				},
 			});
 			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submitJointEvaluation();
 
@@ -1094,7 +1107,7 @@ describe("declarationRouter", () => {
 				draft: { joint: { step1: { foo: "bar" } } },
 			});
 			const ctx = createSimpleSelectDb(declaration, [], [], [declaration]);
-			const caller = await createCaller(ctx.db);
+			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submitJointEvaluation();
 
@@ -1115,7 +1128,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep1({
 				totalWomen: 30,
@@ -1137,7 +1150,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep1({
 				totalWomen: 30,
@@ -1156,7 +1169,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep1({
 				totalWomen: 50,
@@ -1174,7 +1187,7 @@ describe("declarationRouter", () => {
 
 		it("throws when siret is missing", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb, null as never);
+			const caller = await createLockedCaller(mockDb, null as never);
 
 			await expect(
 				caller.updateStep1({ totalWomen: 10, totalMen: 20 }),
@@ -1223,7 +1236,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep1({ totalWomen: 50, totalMen: 60 });
 
@@ -1241,7 +1254,7 @@ describe("declarationRouter", () => {
 	describe("updateStep2", () => {
 		it("saves indicator A and C values", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep2({
 				indicatorAAnnualWomen: "30000",
@@ -1262,7 +1275,7 @@ describe("declarationRouter", () => {
 
 		it("saves with all optional fields undefined", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep2({});
 
@@ -1271,7 +1284,7 @@ describe("declarationRouter", () => {
 
 		it("throws when siret is missing", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb, null as never);
+			const caller = await createLockedCaller(mockDb, null as never);
 
 			await expect(caller.updateStep2({})).rejects.toThrow(
 				"SIRET manquant ou invalide dans la session",
@@ -1291,7 +1304,7 @@ describe("declarationRouter", () => {
 				update: mockUpdate,
 				transaction: mockTransaction,
 			} as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep2({
 				indicatorAAnnualWomen: "200",
@@ -1318,7 +1331,7 @@ describe("declarationRouter", () => {
 	describe("updateStep3", () => {
 		it("saves indicator B, D and E values", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep3({
 				indicatorBAnnualWomen: "31000",
@@ -1341,7 +1354,7 @@ describe("declarationRouter", () => {
 
 		it("saves with all optional fields undefined", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep3({});
 
@@ -1350,7 +1363,7 @@ describe("declarationRouter", () => {
 
 		it("throws when siret is missing", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb, null as never);
+			const caller = await createLockedCaller(mockDb, null as never);
 
 			await expect(caller.updateStep3({})).rejects.toThrow(
 				"SIRET manquant ou invalide dans la session",
@@ -1370,7 +1383,7 @@ describe("declarationRouter", () => {
 				update: mockUpdate,
 				transaction: mockTransaction,
 			} as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep3({
 				indicatorBAnnualWomen: "100",
@@ -1419,7 +1432,7 @@ describe("declarationRouter", () => {
 
 		it("saves indicator F annual and hourly thresholds", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			const result = await caller.updateStep4(step4Input);
 
@@ -1431,7 +1444,7 @@ describe("declarationRouter", () => {
 
 		it("maps 3 thresholds + 4 counts per table with no *Threshold4 column", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep4(step4Input);
 
@@ -1450,7 +1463,7 @@ describe("declarationRouter", () => {
 
 		it("stores null for Q4 threshold when it is an empty string", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep4({
 				annual: [
@@ -1480,7 +1493,7 @@ describe("declarationRouter", () => {
 
 		it("throws when siret is missing", async () => {
 			const mockDb = createMockDb();
-			const caller = await createCaller(mockDb, null as never);
+			const caller = await createLockedCaller(mockDb, null as never);
 
 			await expect(caller.updateStep4(step4Input)).rejects.toThrow(
 				"SIRET manquant ou invalide dans la session",
@@ -1500,7 +1513,7 @@ describe("declarationRouter", () => {
 				update: mockUpdate,
 				transaction: mockTransaction,
 			} as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep4(step4Input);
 
@@ -1525,7 +1538,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep1({ totalWomen: 30, totalMen: 40 });
 
@@ -1552,7 +1565,7 @@ describe("declarationRouter", () => {
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
-			const caller = await createCaller(mockDb);
+			const caller = await createLockedCaller(mockDb);
 
 			await caller.updateStep2({
 				indicatorAAnnualWomen: "30000",

--- a/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildLockHolder } from "./helpers/lockTestHelpers";
 
 vi.mock("~/server/auth", () => ({
 	auth: vi.fn(),
@@ -10,6 +11,7 @@ vi.mock("~/server/db", () => ({
 
 vi.mock("~/server/db/schema", () => ({
 	declarations: {
+		id: "id",
 		siren: "siren",
 		year: "year",
 		draft: "draft",
@@ -20,6 +22,18 @@ vi.mock("~/server/db/schema", () => ({
 	userCompanies: {
 		siren: "siren",
 		userId: "userId",
+	},
+	declarationLocks: {
+		id: "id",
+		declarationId: "declarationId",
+		lockedByUserId: "lockedByUserId",
+		expiresAt: "expiresAt",
+	},
+	users: {
+		id: "id",
+		email: "email",
+		firstName: "firstName",
+		lastName: "lastName",
 	},
 }));
 
@@ -32,6 +46,12 @@ const SIREN = "123456789";
 const YEAR = 2024;
 const USER_SIRET = "12345678900015";
 const FORBIDDEN_MSG = "Accès refusé à ce SIREN.";
+const DECLARATION_ID = "decl-1";
+
+// The session in createCaller is "user-1"; an own-lock holder must match it,
+// a foreign holder must not.
+const ownLockHolder = () => buildLockHolder({ userId: "user-1" });
+const foreignLockHolder = () => buildLockHolder({ userId: "user-2" });
 
 type SelectResponse = unknown[];
 
@@ -45,7 +65,10 @@ function createMockDb(responses: SelectResponse[] = []) {
 	});
 
 	const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-	const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+	const mockInnerJoin = vi.fn().mockReturnValue({ where: mockWhere });
+	const mockFrom = vi
+		.fn()
+		.mockReturnValue({ where: mockWhere, innerJoin: mockInnerJoin });
 	const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
 	const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
@@ -209,7 +232,8 @@ describe("declarationDraftRouter", () => {
 			const existingDraft = { main: { step1: { workforce: 40 } } };
 			const { db, mocks } = createMockDb([
 				[{ siren: SIREN }],
-				[{ draft: existingDraft }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[ownLockHolder()],
 			]);
 			const caller = await createCaller(db);
 
@@ -228,7 +252,8 @@ describe("declarationDraftRouter", () => {
 			const existingDraft = { main: { step1: { workforce: 50 } } };
 			const { db, mocks } = createMockDb([
 				[{ siren: SIREN }],
-				[{ draft: existingDraft }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[ownLockHolder()],
 			]);
 			const caller = await createCaller(db);
 
@@ -246,6 +271,59 @@ describe("declarationDraftRouter", () => {
 					},
 				}),
 			);
+		});
+
+		it("allows the autosave when no declaration row exists yet (create path)", async () => {
+			const { db, mocks } = createMockDb([[{ siren: SIREN }], []]);
+			const caller = await createCaller(db);
+
+			const result = await caller.save({
+				siren: SIREN,
+				year: YEAR,
+				slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.insert).toHaveBeenCalled();
+		});
+
+		it("allows the autosave when the lock is free (no active holder)", async () => {
+			const existingDraft = { main: { step1: { workforce: 40 } } };
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[],
+			]);
+			const caller = await createCaller(db);
+
+			const result = await caller.save({
+				siren: SIREN,
+				year: YEAR,
+				slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+			});
+
+			expect(result).toEqual({ ok: true });
+			expect(mocks.update).toHaveBeenCalled();
+		});
+
+		it("throws CONFLICT when another co-declarant holds the lock", async () => {
+			const existingDraft = { main: { step1: { workforce: 40 } } };
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[foreignLockHolder()],
+			]);
+			const caller = await createCaller(db);
+
+			await expect(
+				caller.save({
+					siren: SIREN,
+					year: YEAR,
+					slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+				}),
+			).rejects.toThrow("Déclaration verrouillée par un autre utilisateur.");
+			expect(mocks.update).not.toHaveBeenCalled();
+			expect(mocks.insert).not.toHaveBeenCalled();
 		});
 
 		it("throws FORBIDDEN when user does not own the siren", async () => {

--- a/packages/app/src/server/api/routers/__tests__/declarationLock.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationLock.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildLockHolder } from "./helpers/lockTestHelpers";
+
+vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
+vi.mock("~/server/db", () => ({ db: {} }));
+
+const mockLogAction = vi.fn();
+vi.mock("~/server/audit/log", () => ({
+	logAction: (...args: unknown[]) => mockLogAction(...args),
+}));
+
+const mocks = vi.hoisted(() => ({
+	acquireOrRefreshLock: vi.fn(),
+	getActiveLock: vi.fn(),
+	refreshLock: vi.fn(),
+	releaseLock: vi.fn(),
+}));
+vi.mock("~/server/services/declarationLockService", () => ({
+	acquireOrRefreshLock: mocks.acquireOrRefreshLock,
+	getActiveLock: mocks.getActiveLock,
+	refreshLock: mocks.refreshLock,
+	releaseLock: mocks.releaseLock,
+}));
+
+const USER_ID = "user-1";
+const OTHER_USER_ID = "user-2";
+const USER_EMAIL = "user@example.com";
+const USER_SIRET = "33978727700015";
+const DECLARATION_ID = "decl-1";
+const FOREIGN_DECLARATION_ID = "decl-foreign";
+
+// Successive select chains: each `select()` resolves the next queued row set.
+// resolveOwnDeclarationId is always first; readLockTimeoutMinutes (when the
+// procedure reads it) is second.
+function createSelectDb(responses: unknown[][]) {
+	let index = 0;
+	const select = vi.fn().mockImplementation(() => {
+		const rows = responses[index] ?? [];
+		index++;
+		const limit = vi.fn().mockResolvedValue(rows);
+		const where = vi.fn().mockReturnValue({ limit });
+		const from = vi.fn().mockReturnValue({ where });
+		return { from };
+	});
+	return { select } as unknown;
+}
+
+function createCaller(db: unknown, siret: string | null = USER_SIRET) {
+	return import("~/server/api/routers/declarationLock").then(
+		({ declarationLockRouter }) =>
+			declarationLockRouter.createCaller({
+				db,
+				session: {
+					user: {
+						id: USER_ID,
+						email: USER_EMAIL,
+						siret,
+						isAdmin: false,
+						impersonation: null,
+					},
+					expires: "",
+				},
+				headers: new Headers(),
+			} as never),
+	);
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("declarationLockRouter", () => {
+	describe("acquireLock", () => {
+		it("acquires the lock, returns the holder, and audits a single acquisition (S11)", async () => {
+			const holder = buildLockHolder({ userId: USER_ID });
+			mocks.acquireOrRefreshLock.mockResolvedValue({ acquired: true, holder });
+			const db = createSelectDb([[{ id: DECLARATION_ID }], [{ minutes: 45 }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.acquireLock({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ acquired: true, holder });
+			expect(mocks.acquireOrRefreshLock).toHaveBeenCalledWith(
+				db,
+				DECLARATION_ID,
+				USER_ID,
+				45,
+			);
+			expect(mockLogAction).toHaveBeenCalledTimes(1);
+			expect(mockLogAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "declaration.lock_acquired",
+					status: "success",
+					userId: USER_ID,
+					resourceType: "declaration",
+					resourceId: DECLARATION_ID,
+				}),
+			);
+		});
+
+		it("does not audit when the lock is already held by another user", async () => {
+			const holder = buildLockHolder({ userId: OTHER_USER_ID });
+			mocks.acquireOrRefreshLock.mockResolvedValue({ acquired: false, holder });
+			const db = createSelectDb([[{ id: DECLARATION_ID }], [{ minutes: 30 }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.acquireLock({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ acquired: false, holder });
+			expect(mockLogAction).not.toHaveBeenCalled();
+		});
+
+		it("falls back to the default timeout when no global setting row exists", async () => {
+			const holder = buildLockHolder({ userId: USER_ID });
+			mocks.acquireOrRefreshLock.mockResolvedValue({ acquired: true, holder });
+			const db = createSelectDb([[{ id: DECLARATION_ID }], []]);
+			const caller = await createCaller(db);
+
+			await caller.acquireLock({ declarationId: DECLARATION_ID });
+
+			expect(mocks.acquireOrRefreshLock).toHaveBeenCalledWith(
+				db,
+				DECLARATION_ID,
+				USER_ID,
+				30,
+			);
+		});
+
+		it("throws FORBIDDEN when the claimed declarationId is not the caller's (IDOR guard)", async () => {
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			await expect(
+				caller.acquireLock({ declarationId: FOREIGN_DECLARATION_ID }),
+			).rejects.toMatchObject({ code: "FORBIDDEN" });
+			expect(mocks.acquireOrRefreshLock).not.toHaveBeenCalled();
+			expect(mockLogAction).not.toHaveBeenCalled();
+		});
+
+		it("throws NOT_FOUND when the caller has no current-year declaration", async () => {
+			const db = createSelectDb([[]]);
+			const caller = await createCaller(db);
+
+			await expect(
+				caller.acquireLock({ declarationId: DECLARATION_ID }),
+			).rejects.toMatchObject({ code: "NOT_FOUND" });
+			expect(mocks.acquireOrRefreshLock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("heartbeat", () => {
+		it("refreshes the lock and returns held=true, without auditing (S6)", async () => {
+			mocks.refreshLock.mockResolvedValue(true);
+			const db = createSelectDb([[{ id: DECLARATION_ID }], [{ minutes: 20 }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.heartbeat({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ held: true });
+			expect(mocks.refreshLock).toHaveBeenCalledWith(
+				db,
+				DECLARATION_ID,
+				USER_ID,
+				20,
+			);
+			expect(mockLogAction).not.toHaveBeenCalled();
+		});
+
+		it("returns held=false when the lock can no longer be refreshed (S7 lazy expiry)", async () => {
+			mocks.refreshLock.mockResolvedValue(false);
+			const db = createSelectDb([[{ id: DECLARATION_ID }], [{ minutes: 30 }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.heartbeat({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ held: false });
+		});
+	});
+
+	describe("releaseLock", () => {
+		it("releases an own active lock, returns released=true, and audits it", async () => {
+			mocks.getActiveLock.mockResolvedValue(
+				buildLockHolder({ userId: USER_ID }),
+			);
+			mocks.releaseLock.mockResolvedValue(undefined);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.releaseLock({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ released: true });
+			expect(mocks.releaseLock).toHaveBeenCalledWith(
+				db,
+				DECLARATION_ID,
+				USER_ID,
+			);
+			expect(mockLogAction).toHaveBeenCalledTimes(1);
+			expect(mockLogAction).toHaveBeenCalledWith(
+				expect.objectContaining({
+					action: "declaration.lock_released",
+					status: "success",
+					resourceId: DECLARATION_ID,
+				}),
+			);
+		});
+
+		it("returns released=false and does not audit when the active lock is held by another user", async () => {
+			mocks.getActiveLock.mockResolvedValue(
+				buildLockHolder({ userId: OTHER_USER_ID }),
+			);
+			mocks.releaseLock.mockResolvedValue(undefined);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.releaseLock({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ released: false });
+			expect(mockLogAction).not.toHaveBeenCalled();
+		});
+
+		it("returns released=false and does not audit when there is no active lock", async () => {
+			mocks.getActiveLock.mockResolvedValue(null);
+			mocks.releaseLock.mockResolvedValue(undefined);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.releaseLock({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ released: false });
+			expect(mocks.releaseLock).toHaveBeenCalled();
+			expect(mockLogAction).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("getLockState", () => {
+		it("reports locked + isOwnLock when the caller holds the lock", async () => {
+			const holder = buildLockHolder({ userId: USER_ID });
+			mocks.getActiveLock.mockResolvedValue(holder);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getLockState({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ locked: true, isOwnLock: true, holder });
+		});
+
+		it("reports locked but not isOwnLock when another co-declarant holds it", async () => {
+			const holder = buildLockHolder({ userId: OTHER_USER_ID });
+			mocks.getActiveLock.mockResolvedValue(holder);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getLockState({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ locked: true, isOwnLock: false, holder });
+		});
+
+		it("reports an unlocked declaration when no active lock exists (S7)", async () => {
+			mocks.getActiveLock.mockResolvedValue(null);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getLockState({
+				declarationId: DECLARATION_ID,
+			});
+
+			expect(result).toEqual({ locked: false, isOwnLock: false, holder: null });
+		});
+
+		it("never acquires a lock (read-only poll)", async () => {
+			mocks.getActiveLock.mockResolvedValue(null);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			await caller.getLockState({ declarationId: DECLARATION_ID });
+
+			expect(mocks.acquireOrRefreshLock).not.toHaveBeenCalled();
+			expect(mocks.refreshLock).not.toHaveBeenCalled();
+		});
+
+		it("throws FORBIDDEN on a foreign declarationId (IDOR guard)", async () => {
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			await expect(
+				caller.getLockState({ declarationId: FOREIGN_DECLARATION_ID }),
+			).rejects.toMatchObject({ code: "FORBIDDEN" });
+			expect(mocks.getActiveLock).not.toHaveBeenCalled();
+		});
+	});
+
+	it("rejects every procedure when the SIRET is missing from the session", async () => {
+		const db = createSelectDb([]);
+		const caller = await createCaller(db, null);
+
+		await expect(
+			caller.acquireLock({ declarationId: DECLARATION_ID }),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/helpers/lockTestHelpers.ts
+++ b/packages/app/src/server/api/routers/__tests__/helpers/lockTestHelpers.ts
@@ -1,0 +1,84 @@
+import { vi } from "vitest";
+
+export const LOCK_HOLDER_USER_ID = "user-1";
+
+export const LOCK_DECLARATION_ID = "decl-1";
+
+export type LockHolderOverrides = {
+	userId?: string;
+	expiresAt?: Date;
+};
+
+export function buildLockHolder(overrides: LockHolderOverrides = {}) {
+	return {
+		userId: overrides.userId ?? LOCK_HOLDER_USER_ID,
+		email: "user-1@example.fr",
+		firstName: "Alice",
+		lastName: "Martin",
+		expiresAt: overrides.expiresAt ?? new Date(Date.now() + 30 * 60_000),
+	};
+}
+
+type LockOptions = {
+	declarationId?: string;
+	holder?: ReturnType<typeof buildLockHolder> | null;
+};
+
+/**
+ * Wrap a test's bespoke mock db so the two middleware selects that
+ * `declarationLockedWriteProcedure` runs on `ctx.db` are answered before the
+ * handler's own queries. The middleware always issues, in order: the
+ * current-year declaration lookup (`fetchCurrentDeclarationId`, a plain
+ * select) followed by the active-lock lookup (`getActiveLock`, the only select
+ * that calls `.innerJoin`). Both are served here; every other call — the
+ * handler's `transaction`, `update`, `insert`, `delete`, and any later
+ * top-level `select` — is delegated to the inner db untouched.
+ */
+export function withLockMiddleware(
+	innerDb: unknown,
+	options: LockOptions = {},
+) {
+	const declarationId = options.declarationId ?? LOCK_DECLARATION_ID;
+	const holder =
+		options.holder === undefined ? buildLockHolder() : options.holder;
+	const inner = innerDb as Record<string, unknown>;
+
+	let middlewareSelectIndex = 0;
+
+	const select = vi.fn().mockImplementation((...args: unknown[]) => {
+		const callIndex = middlewareSelectIndex;
+		middlewareSelectIndex++;
+
+		if (callIndex === 0) {
+			// fetchCurrentDeclarationId: plain select → limit(1)
+			const limit = vi.fn().mockResolvedValue([{ id: declarationId }]);
+			const where = vi.fn().mockReturnValue({ limit });
+			const from = vi.fn().mockReturnValue({ where });
+			return { from };
+		}
+
+		if (callIndex === 1) {
+			// getActiveLock: innerJoin → where → limit(1)
+			const limit = vi.fn().mockResolvedValue(holder ? [holder] : []);
+			const where = vi.fn().mockReturnValue({ limit });
+			const innerJoin = vi.fn().mockReturnValue({ where });
+			const from = vi.fn().mockReturnValue({ innerJoin });
+			return { from };
+		}
+
+		const innerSelect = inner.select as
+			| ((...a: unknown[]) => unknown)
+			| undefined;
+		if (!innerSelect) {
+			throw new Error("withLockMiddleware: inner db has no select()");
+		}
+		return innerSelect(...args);
+	});
+
+	return new Proxy(inner, {
+		get(target, prop, receiver) {
+			if (prop === "select") return select;
+			return Reflect.get(target, prop, receiver);
+		},
+	});
+}

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -21,8 +21,8 @@ import {
 } from "~/modules/domain";
 import {
 	companyProcedure,
-	companyWriteProcedure,
 	createTRPCRouter,
+	declarationLockedWriteProcedure,
 	protectedProcedure,
 } from "~/server/api/trpc";
 import {
@@ -270,7 +270,7 @@ export const declarationRouter = createTRPCRouter({
 		};
 	}),
 
-	updateStep1: companyWriteProcedure
+	updateStep1: declarationLockedWriteProcedure
 		.input(updateStep1Schema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = ctx.siren;
@@ -372,7 +372,7 @@ export const declarationRouter = createTRPCRouter({
 			return { success: true };
 		}),
 
-	updateStep2: companyWriteProcedure
+	updateStep2: declarationLockedWriteProcedure
 		.input(updateStep2Schema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = ctx.siren;
@@ -421,7 +421,7 @@ export const declarationRouter = createTRPCRouter({
 			return { success: true };
 		}),
 
-	updateStep3: companyWriteProcedure
+	updateStep3: declarationLockedWriteProcedure
 		.input(updateStep3Schema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = ctx.siren;
@@ -472,7 +472,7 @@ export const declarationRouter = createTRPCRouter({
 			return { success: true };
 		}),
 
-	updateStep4: companyWriteProcedure
+	updateStep4: declarationLockedWriteProcedure
 		.input(updateStep4Schema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = ctx.siren;
@@ -535,7 +535,7 @@ export const declarationRouter = createTRPCRouter({
 			return { success: true };
 		}),
 
-	updateEmployeeCategories: companyWriteProcedure
+	updateEmployeeCategories: declarationLockedWriteProcedure
 		.input(updateEmployeeCategoriesSchema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = ctx.siren;
@@ -633,7 +633,7 @@ export const declarationRouter = createTRPCRouter({
 			return { success: true };
 		}),
 
-	submit: companyWriteProcedure.mutation(async ({ ctx }) => {
+	submit: declarationLockedWriteProcedure.mutation(async ({ ctx }) => {
 		const siren = ctx.siren;
 		const year = getCurrentYear();
 
@@ -735,7 +735,7 @@ export const declarationRouter = createTRPCRouter({
 		return { success: true };
 	}),
 
-	saveCompliancePath: companyWriteProcedure
+	saveCompliancePath: declarationLockedWriteProcedure
 		.input(saveCompliancePathInputSchema)
 		.mutation(async ({ ctx, input }) => {
 			const siren = ctx.siren;
@@ -813,70 +813,72 @@ export const declarationRouter = createTRPCRouter({
 			return { success: true };
 		}),
 
-	submitSecondDeclaration: companyWriteProcedure.mutation(async ({ ctx }) => {
-		const siren = ctx.siren;
-		const year = getCurrentYear();
+	submitSecondDeclaration: declarationLockedWriteProcedure.mutation(
+		async ({ ctx }) => {
+			const siren = ctx.siren;
+			const year = getCurrentYear();
 
-		const [declaration] = await ctx.db
-			.select()
-			.from(declarations)
-			.where(activeDeclarationFilter(siren, year))
-			.limit(1);
+			const [declaration] = await ctx.db
+				.select()
+				.from(declarations)
+				.where(activeDeclarationFilter(siren, year))
+				.limit(1);
 
-		if (!declaration) throw new TRPCError({ code: "NOT_FOUND" });
+			if (!declaration) throw new TRPCError({ code: "NOT_FOUND" });
 
-		const correctionCategories = await loadEmployeeCategoriesForDeclaration(
-			ctx.db,
-			declaration.id,
-			"correction",
-		);
-		const stillHasGap = hasGapsAboveThreshold(correctionCategories);
+			const correctionCategories = await loadEmployeeCategoriesForDeclaration(
+				ctx.db,
+				declaration.id,
+				"correction",
+			);
+			const stillHasGap = hasGapsAboveThreshold(correctionCategories);
 
-		const rules = loadRules(declaration.rulesVersion);
-		const facts = buildSecondDeclarationFacts(declaration, stillHasGap);
-		const { nextStatus, events } = applyAction(
-			facts,
-			"submit_second_declaration",
-			rules,
-		);
+			const rules = loadRules(declaration.rulesVersion);
+			const facts = buildSecondDeclarationFacts(declaration, stillHasGap);
+			const { nextStatus, events } = applyAction(
+				facts,
+				"submit_second_declaration",
+				rules,
+			);
 
-		const projection = computeProjectionUpdates(events, nextStatus);
-		const historyInserts = buildHistoryInserts(
-			declaration.id,
-			events,
-			ctx.session.user.id,
-		);
+			const projection = computeProjectionUpdates(events, nextStatus);
+			const historyInserts = buildHistoryInserts(
+				declaration.id,
+				events,
+				ctx.session.user.id,
+			);
 
-		await ctx.db.transaction(async (tx) => {
-			await tx.insert(declarationStatusHistory).values(historyInserts);
-			await tx
-				.update(declarations)
-				.set({
-					...projection,
-					secondDeclarationStep: 3,
-					updatedAt: new Date(),
-				})
-				.where(activeDeclarationFilter(siren, year));
-			await purgeDraftSlice(tx, siren, year, "second");
-		});
-
-		const email = ctx.session.user.email;
-		if (email) {
-			const { enqueueReceipt } = await import("~/modules/mail/server");
-			await enqueueReceipt({
-				kind: "secondDeclaration",
-				to: email,
-				siren,
-				year,
-				userId: ctx.session.user.id,
-				isResend: false,
+			await ctx.db.transaction(async (tx) => {
+				await tx.insert(declarationStatusHistory).values(historyInserts);
+				await tx
+					.update(declarations)
+					.set({
+						...projection,
+						secondDeclarationStep: 3,
+						updatedAt: new Date(),
+					})
+					.where(activeDeclarationFilter(siren, year));
+				await purgeDraftSlice(tx, siren, year, "second");
 			});
-		}
 
-		return { success: true };
-	}),
+			const email = ctx.session.user.email;
+			if (email) {
+				const { enqueueReceipt } = await import("~/modules/mail/server");
+				await enqueueReceipt({
+					kind: "secondDeclaration",
+					to: email,
+					siren,
+					year,
+					userId: ctx.session.user.id,
+					isResend: false,
+				});
+			}
 
-	submitJointEvaluation: companyWriteProcedure
+			return { success: true };
+		},
+	),
+
+	submitJointEvaluation: declarationLockedWriteProcedure
 		.input(submitJointEvaluationSchema)
 		.mutation(async ({ ctx }) => {
 			const siren = ctx.siren;

--- a/packages/app/src/server/api/routers/declarationDraft.ts
+++ b/packages/app/src/server/api/routers/declarationDraft.ts
@@ -11,6 +11,7 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { isImpersonatingSiren } from "~/server/auth/companyAccess";
 import type { DB } from "~/server/db";
 import { declarations, userCompanies } from "~/server/db/schema";
+import { getActiveLock } from "~/server/services/declarationLockService";
 
 const DRAFT_TTL_MS = 30 * 24 * 3600 * 1000;
 
@@ -87,7 +88,7 @@ export const declarationDraftRouter = createTRPCRouter({
 			await assertOwnership(ctx.db, ctx.session, siren);
 
 			const rows = await ctx.db
-				.select({ draft: declarations.draft })
+				.select({ id: declarations.id, draft: declarations.draft })
 				.from(declarations)
 				.where(
 					and(
@@ -99,6 +100,22 @@ export const declarationDraftRouter = createTRPCRouter({
 				.limit(1);
 
 			const existing = rows[0];
+
+			// Block the autosave only when another co-declarant currently holds the
+			// edit lock. When no declaration exists yet (first save creates it) or
+			// the lock is free / held by this same user, the draft is allowed
+			// through — the strict "must own the lock" rule lives on the explicit
+			// step mutations, not on background draft persistence (epic #3556).
+			if (existing) {
+				const lock = await getActiveLock(ctx.db, existing.id);
+				if (lock && lock.userId !== ctx.session.user.id) {
+					throw new TRPCError({
+						code: "CONFLICT",
+						message: "Déclaration verrouillée par un autre utilisateur.",
+					});
+				}
+			}
+
 			const currentDraft = (existing?.draft ?? {}) as DraftBlob;
 			const kindData = (currentDraft[slice.kind] ?? {}) as Record<
 				string,

--- a/packages/app/src/server/api/routers/declarationDraft.ts
+++ b/packages/app/src/server/api/routers/declarationDraft.ts
@@ -105,7 +105,7 @@ export const declarationDraftRouter = createTRPCRouter({
 			// edit lock. When no declaration exists yet (first save creates it) or
 			// the lock is free / held by this same user, the draft is allowed
 			// through — the strict "must own the lock" rule lives on the explicit
-			// step mutations, not on background draft persistence (epic #3556).
+			// step mutations, not on background draft persistence.
 			if (existing) {
 				const lock = await getActiveLock(ctx.db, existing.id);
 				if (lock && lock.userId !== ctx.session.user.id) {

--- a/packages/app/src/server/api/routers/declarationLock.ts
+++ b/packages/app/src/server/api/routers/declarationLock.ts
@@ -1,0 +1,183 @@
+import { TRPCError } from "@trpc/server";
+import { eq } from "drizzle-orm";
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import {
+	acquireLockSchema,
+	heartbeatSchema,
+	releaseLockSchema,
+} from "~/modules/declaration-remuneration/schemas";
+import { DEFAULT_LOCK_TIMEOUT_MINUTES, getCurrentYear } from "~/modules/domain";
+import {
+	companyProcedure,
+	companyWriteProcedure,
+	createTRPCRouter,
+} from "~/server/api/trpc";
+import { logAction } from "~/server/audit/log";
+import { buildRequestContext } from "~/server/audit/requestContext";
+import type { DB } from "~/server/db";
+import { GLOBAL_SETTINGS_ID } from "~/server/db/getGlobalSettings";
+import { declarations, globalSettings } from "~/server/db/schema";
+import {
+	acquireOrRefreshLock,
+	getActiveLock,
+	refreshLock,
+	releaseLock,
+} from "~/server/services/declarationLockService";
+import { activeDeclarationFilter } from "./declarationHelpers";
+
+/**
+ * Resolve the current-year declaration for `siren` and assert it matches the
+ * `declarationId` the client claims to operate on. Resolving server-side from
+ * the session SIREN (never trusting the raw input) closes the IDOR window: a
+ * co-declarant cannot lock or release a declaration belonging to another
+ * company by forging an arbitrary id.
+ */
+async function resolveOwnDeclarationId(
+	db: DB,
+	siren: string,
+	claimedDeclarationId: string,
+): Promise<string> {
+	const [row] = await db
+		.select({ id: declarations.id })
+		.from(declarations)
+		.where(activeDeclarationFilter(siren, getCurrentYear()))
+		.limit(1);
+
+	if (!row) {
+		throw new TRPCError({
+			code: "NOT_FOUND",
+			message: "Déclaration introuvable pour l'année en cours",
+		});
+	}
+
+	if (row.id !== claimedDeclarationId) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: "Déclaration non autorisée.",
+		});
+	}
+
+	return row.id;
+}
+
+async function readLockTimeoutMinutes(db: DB): Promise<number> {
+	const [settings] = await db
+		.select({ minutes: globalSettings.declarationLockTimeoutMinutes })
+		.from(globalSettings)
+		.where(eq(globalSettings.id, GLOBAL_SETTINGS_ID))
+		.limit(1);
+
+	return settings?.minutes ?? DEFAULT_LOCK_TIMEOUT_MINUTES;
+}
+
+export const declarationLockRouter = createTRPCRouter({
+	acquireLock: companyWriteProcedure
+		.input(acquireLockSchema)
+		.mutation(async ({ ctx, input }) => {
+			const declarationId = await resolveOwnDeclarationId(
+				ctx.db,
+				ctx.siren,
+				input.declarationId,
+			);
+			const timeoutMinutes = await readLockTimeoutMinutes(ctx.db);
+			const userId = ctx.session.user.id;
+
+			const { acquired, holder } = await acquireOrRefreshLock(
+				ctx.db,
+				declarationId,
+				userId,
+				timeoutMinutes,
+			);
+
+			// Audit only a real takeover: `acquired` is false when another user
+			// already holds an active lock (the row is left untouched), so logging
+			// every poll would pollute the trail with phantom "lock_acquired" rows.
+			if (acquired) {
+				const requestContext = buildRequestContext(ctx.headers);
+				void logAction({
+					action: AUDIT_ACTIONS.DECLARATION_LOCK_ACQUIRED,
+					status: "success",
+					userId,
+					userEmail: ctx.session.user.email,
+					siren: ctx.siren,
+					resourceType: "declaration",
+					resourceId: declarationId,
+					ipAddress: requestContext.ipAddress,
+					userAgent: requestContext.userAgent,
+				});
+			}
+
+			return { acquired, holder };
+		}),
+
+	heartbeat: companyWriteProcedure
+		.input(heartbeatSchema)
+		.mutation(async ({ ctx, input }) => {
+			const declarationId = await resolveOwnDeclarationId(
+				ctx.db,
+				ctx.siren,
+				input.declarationId,
+			);
+			const timeoutMinutes = await readLockTimeoutMinutes(ctx.db);
+
+			const held = await refreshLock(
+				ctx.db,
+				declarationId,
+				ctx.session.user.id,
+				timeoutMinutes,
+			);
+
+			return { held };
+		}),
+
+	releaseLock: companyWriteProcedure
+		.input(releaseLockSchema)
+		.mutation(async ({ ctx, input }) => {
+			const declarationId = await resolveOwnDeclarationId(
+				ctx.db,
+				ctx.siren,
+				input.declarationId,
+			);
+			const userId = ctx.session.user.id;
+
+			const active = await getActiveLock(ctx.db, declarationId);
+			const released = active?.userId === userId;
+
+			await releaseLock(ctx.db, declarationId, userId);
+
+			if (released) {
+				const requestContext = buildRequestContext(ctx.headers);
+				void logAction({
+					action: AUDIT_ACTIONS.DECLARATION_LOCK_RELEASED,
+					status: "success",
+					userId,
+					userEmail: ctx.session.user.email,
+					siren: ctx.siren,
+					resourceType: "declaration",
+					resourceId: declarationId,
+					ipAddress: requestContext.ipAddress,
+					userAgent: requestContext.userAgent,
+				});
+			}
+
+			return { released };
+		}),
+
+	getLockState: companyProcedure
+		.input(acquireLockSchema)
+		.query(async ({ ctx, input }) => {
+			const declarationId = await resolveOwnDeclarationId(
+				ctx.db,
+				ctx.siren,
+				input.declarationId,
+			);
+
+			const holder = await getActiveLock(ctx.db, declarationId);
+
+			return {
+				locked: holder !== null,
+				isOwnLock: holder?.userId === ctx.session.user.id,
+				holder,
+			};
+		}),
+});

--- a/packages/app/src/server/api/trpc.ts
+++ b/packages/app/src/server/api/trpc.ts
@@ -18,6 +18,7 @@ import { auth } from "~/server/auth";
 import { assertNotImpersonating } from "~/server/auth/companyAccess";
 import { db } from "~/server/db";
 import { declarations } from "~/server/db/schema";
+import { getActiveLock } from "~/server/services/declarationLockService";
 
 /**
  * 1. CONTEXT
@@ -252,5 +253,29 @@ export const declarationWriteProcedure = companyWriteProcedure.use(
 	async ({ ctx, next }) => {
 		const declarationId = await fetchCurrentDeclarationId(ctx.db, ctx.siren);
 		return next({ ctx: { ...ctx, declarationId } });
+	},
+);
+
+/**
+ * Declaration-scoped write procedure guarded by the collaborative edit lock.
+ *
+ * Same as {@link declarationWriteProcedure} plus the `enforceLock` middleware:
+ * the request only proceeds when an **active** lock on `ctx.declarationId` is
+ * held by the current user. Any other case — no lock, an expired lock, or a
+ * lock held by another co-declarant — is rejected with `CONFLICT` so two
+ * co-declarants can never write to the same declaration concurrently
+ * (epic #3556). The editing UI is responsible for acquiring the lock via
+ * `declarationLock.acquireLock` before enabling writes.
+ */
+export const declarationLockedWriteProcedure = declarationWriteProcedure.use(
+	async ({ ctx, next }) => {
+		const lock = await getActiveLock(ctx.db, ctx.declarationId);
+		if (!lock || lock.userId !== ctx.session.user.id) {
+			throw new TRPCError({
+				code: "CONFLICT",
+				message: "Déclaration verrouillée par un autre utilisateur.",
+			});
+		}
+		return next();
 	},
 );

--- a/packages/app/src/server/api/trpc.ts
+++ b/packages/app/src/server/api/trpc.ts
@@ -263,8 +263,8 @@ export const declarationWriteProcedure = companyWriteProcedure.use(
  * the request only proceeds when an **active** lock on `ctx.declarationId` is
  * held by the current user. Any other case — no lock, an expired lock, or a
  * lock held by another co-declarant — is rejected with `CONFLICT` so two
- * co-declarants can never write to the same declaration concurrently
- * (epic #3556). The editing UI is responsible for acquiring the lock via
+ * co-declarants can never write to the same declaration concurrently.
+ * The editing UI is responsible for acquiring the lock via
  * `declarationLock.acquireLock` before enabling writes.
  */
 export const declarationLockedWriteProcedure = declarationWriteProcedure.use(


### PR DESCRIPTION
Closes #3724

## Résumé

Procédures tRPC du verrou de déclaration + **gating de toutes les écritures** de la démarche de déclaration des indicateurs de rémunération (epic #3556). S'appuie sur le service + table + constantes de #3723.

### Router `declarationLock` (`src/server/api/routers/declarationLock.ts`)
- `acquireLock` (`companyWriteProcedure`) → `acquireOrRefreshLock` avec `T = global_setting.declarationLockTimeoutMinutes` (fallback `DEFAULT_LOCK_TIMEOUT_MINUTES`). Retour `{ acquired, holder }`.
- `heartbeat` (`companyWriteProcedure`) → `refreshLock`. Retour `{ held }`.
- `releaseLock` (`companyWriteProcedure`) → `releaseLock`. Retour `{ released }`.
- `getLockState` (`companyProcedure`, query) → `getActiveLock`, retour `{ locked, isOwnLock, holder }` (lecture seule, n'acquiert jamais).
- Enregistré dans `root.ts` (`declarationLock`).
- **IDOR guard** : `declarationId` est résolu côté serveur depuis `(ctx.siren, getCurrentYear())` et le `declarationId` du client doit correspondre (sinon `FORBIDDEN`) — un co-déclarant ne peut pas viser la déclaration d'une autre entreprise.

### Middleware `enforceLock` (`trpc.ts`)
- `declarationLockedWriteProcedure` (dérive de `declarationWriteProcedure`) : `CONFLICT` si aucun verrou actif détenu par `ctx.session.user.id` sur `ctx.declarationId` (pas de verrou / expiré / détenu par un tiers).

### Gating des écritures
- **`declaration.ts`** : les 9 mutations d'écriture passent de `companyWriteProcedure` à `declarationLockedWriteProcedure` (updateStep1-4, updateEmployeeCategories, submit, saveCompliancePath, submitSecondDeclaration, submitJointEvaluation) — interprétation de « toutes les écritures de la démarche » (point 3), cohérente avec le swap uniforme de la procédure d'écriture.
- **`declarationDraft.save`** : check inline (la procédure reste `protectedProcedure`, siren/year viennent de l'input et la déclaration peut être créée). Bloque l'autosave **seulement** si un verrou actif est détenu par un **autre** utilisateur ; déclaration absente / verrou libre / verrou propre → autorisé (préserve la création et la fenêtre avant acquisition).
- **`api/upload/route.ts`** : gating CSE / éval commune. Check inline via `getActiveLock` (route non-tRPC) avant le streaming → `409` si verrou tiers actif.

### Audit
- `DECLARATION_LOCK_ACQUIRED` / `DECLARATION_LOCK_RELEASED` (clés créées en #3723) via `logAction` **direct et conditionnel** : loggé **uniquement sur acquisition / libération réelle** (point 1 « sur acquisition réelle »), pas sur les polls. `heartbeat` n'est volontairement **pas** audité (keepalive ~10 s → flooding sans valeur forensique) ; `getLockState` est une lecture de poll. Choix assumé vs `PROCEDURE_TO_ACTION` (le middleware ne peut pas exprimer le conditionnel « acquired »).

## Notes pour la revue
- ⚠️ **Chemin du route handler d'upload** : le ticket listait `api/v1/files` mais c'est l'endpoint export/gateway (GET, sans session). Le vrai handler d'upload CSE/éval est **`api/upload/route.ts`** — c'est lui qui est gated.
- **Front non encore livré** : l'acquisition du verrou côté UI (`acquireLock` à l'entrée du parcours, heartbeat, message side-panel Figma) relève d'un autre sous-ticket de l'epic. Le gating backend est donc inerte tant que l'UI n'acquiert pas le verrou — c'est le flux incrémental normal de l'epic, validé end-to-end par la gate E2E de fin d'epic.

## Plan de test
- Scénarios ticket couverts (TU) : **S2** (verrou tiers → `CONFLICT` sur `updateStep2`), **S6/S7** (heartbeat prolonge `expiresAt` ; expiry paresseuse → plus actif), **S11** (verrou libéré → `acquireLock` `{ acquired: true }`).
- + IDOR `FORBIDDEN`, shapes `getLockState`, `releaseLock` true/false, middleware (no-lock/expired/foreign → CONFLICT, own → pass), draft foreign vs own/free, upload 409, audit conditionnel.
- Suite complète verte : **2759 tests** ; `declarationLock.ts` 100% coverage ; typecheck + lint + format clean.

## Audit checklist
- [x] `AUDIT_ACTIONS.DECLARATION_LOCK_ACQUIRED/RELEASED` (créés en #3723) + catégories `mutation`.
- [x] Câblage : `logAction` direct conditionnel (acquisition/libération réelles uniquement). heartbeat/getLockState non audités (justifié : flooding / lecture poll).
- [x] `metadata` sans secret / PII (resourceId = declarationId, pas d'IP en metadata).
