### PR TITLE
feat(declaration-lock): lecture seule et bandeau sur le parcours déclaration

### DIFF
--- a/packages/app/src/app/avis-cse/layout.tsx
+++ b/packages/app/src/app/avis-cse/layout.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import { CseOpinionLayout } from "~/modules/cseOpinion";
 import { auth } from "~/server/auth";
 import { getEffectiveSiren } from "~/server/auth/companyAccess";
+import { db } from "~/server/db";
+import { getActiveLock } from "~/server/services/declarationLockService";
 import { api } from "~/trpc/server";
 
 export default async function CseOpinionRootLayout({
@@ -25,10 +27,24 @@ export default async function CseOpinionRootLayout({
 		api.declaration.getOrCreate(),
 	]);
 
+	const declaration = declarationData.declaration;
+	const activeLock = await getActiveLock(db, declaration.id);
+	const isReadOnly =
+		activeLock !== null && activeLock.userId !== session.user.id;
+	const lockHolder = isReadOnly
+		? {
+				firstName: activeLock.firstName,
+				lastName: activeLock.lastName,
+				email: activeLock.email,
+			}
+		: null;
+
 	return (
 		<CseOpinionLayout
 			company={company}
-			declarationYear={declarationData.declaration.year}
+			declarationYear={declaration.year}
+			isReadOnly={isReadOnly}
+			lockHolder={lockHolder}
 		>
 			{children}
 		</CseOpinionLayout>

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/layout.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/layout.tsx
@@ -5,6 +5,8 @@ import {
 } from "~/modules/declaration-remuneration";
 import { auth } from "~/server/auth";
 import { getEffectiveSiren } from "~/server/auth/companyAccess";
+import { db } from "~/server/db";
+import { getActiveLock } from "~/server/services/declarationLockService";
 import { api } from "~/trpc/server";
 
 /**
@@ -33,10 +35,24 @@ export default async function WithBannerLayout({
 		api.declaration.getOrCreate(),
 	]);
 
+	const declaration = declarationData.declaration;
+	const activeLock = await getActiveLock(db, declaration.id);
+	const isReadOnly =
+		activeLock !== null && activeLock.userId !== session.user.id;
+	const lockHolder = isReadOnly
+		? {
+				firstName: activeLock.firstName,
+				lastName: activeLock.lastName,
+				email: activeLock.email,
+			}
+		: null;
+
 	return (
 		<DeclarationLayout
 			company={company}
-			declarationYear={declarationData.declaration.year}
+			declarationYear={declaration.year}
+			isReadOnly={isReadOnly}
+			lockHolder={lockHolder}
 		>
 			{children}
 		</DeclarationLayout>

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
@@ -1,7 +1,7 @@
 import { FunnelCompleteTracker } from "~/modules/analytics";
 import {
-	ComplianceConfirmation,
 	COMPLIANCE_FUNNEL,
+	ComplianceConfirmation,
 } from "~/modules/declaration-remuneration";
 
 export default function ComplianceConfirmationPage() {

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -1,3 +1,6 @@
+import { DeclarationLockAlert } from "~/modules/declaration-remuneration/shared/lock/DeclarationLockAlert";
+import type { LockHolder } from "~/modules/declaration-remuneration/shared/lock/LockContext";
+import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { getWorkforceYear } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
@@ -15,12 +18,16 @@ type Props = {
 	company: CompanyData;
 	declarationYear: number;
 	children: React.ReactNode;
+	isReadOnly?: boolean;
+	lockHolder?: LockHolder | null;
 };
 
 export function CseOpinionLayout({
 	company,
 	declarationYear,
 	children,
+	isReadOnly = false,
+	lockHolder = null,
 }: Props) {
 	return (
 		<>
@@ -72,9 +79,16 @@ export function CseOpinionLayout({
 				</div>
 			</div>
 			<main className="fr-container fr-py-7w" id="content">
-				<div className="fr-grid-row fr-grid-row--center">
-					<div className="fr-col-12 fr-col-lg-8">{children}</div>
-				</div>
+				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
+					<div className="fr-grid-row fr-grid-row--center">
+						<div className="fr-col-12 fr-col-lg-8">
+							{isReadOnly && lockHolder && (
+								<DeclarationLockAlert holder={lockHolder} />
+							)}
+							{children}
+						</div>
+					</div>
+				</LockProvider>
 			</main>
 		</>
 	);

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
@@ -3,3 +3,10 @@
 	flex-direction: column;
 	gap: 1.5rem;
 }
+
+.readOnlyFieldset {
+	border: none;
+	margin: 0;
+	padding: 0;
+	min-width: 0;
+}

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -239,7 +239,11 @@ export function Step1Opinions({
 				</p>
 				<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
 
-				<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
+				{isJointEvaluation ? (
+					<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
+				) : (
+					<h2 className="fr-h6 fr-mb-3w">Première déclaration</h2>
+				)}
 
 				<div className={styles.cardStack}>
 					<AccuracyOpinionCard
@@ -285,7 +289,11 @@ export function Step1Opinions({
 
 				{hasSecondDeclaration && (
 					<>
-						<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
+						{isJointEvaluation ? (
+							<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
+						) : (
+							<h2 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h2>
+						)}
 
 						<div className={styles.cardStack}>
 							<AccuracyOpinionCard

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -7,6 +7,7 @@ import { Controller } from "react-hook-form";
 
 import { useReadOnlyGuard } from "~/modules/auth";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
+import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { getCurrentYear } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
@@ -55,6 +56,7 @@ export function Step1Opinions({
 	const isJointEvaluation = firstDeclarationPathChoice === "joint_evaluation";
 	const router = useRouter();
 	const readOnlyGuard = useReadOnlyGuard();
+	const { isReadOnly: isLocked } = useLockContext();
 
 	const dbValues = useMemo(
 		() => ({
@@ -145,12 +147,13 @@ export function Step1Opinions({
 	}, [isLoadingDraft, draft, form, hasSecondDeclaration]);
 
 	const triggerDraftSave = useCallback(() => {
+		if (isLocked) return;
 		const values = form.getValues();
 		setField({
 			firstDeclaration: values.firstDeclaration,
 			secondDeclaration: values.secondDeclaration,
 		});
-	}, [form, setField]);
+	}, [form, isLocked, setField]);
 
 	const mutation = api.cseOpinion.saveOpinions.useMutation({
 		onSuccess: () => router.push("/avis-cse/etape/2"),
@@ -197,168 +200,173 @@ export function Step1Opinions({
 
 	return (
 		<form autoComplete="off" onSubmit={onSubmit}>
-			{isJointEvaluation && (
-				<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
-					<div className="fr-col">
-						<h1 className="fr-h4 fr-mb-0">
-							Parcours de mise en conformité pour l'indicateur par catégorie de
-							salariés
-						</h1>
+			<fieldset className={styles.readOnlyFieldset} disabled={isLocked}>
+				{isJointEvaluation && (
+					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
+						<div className="fr-col">
+							<h1 className="fr-h4 fr-mb-0">
+								Parcours de mise en conformité pour l'indicateur par catégorie
+								de salariés
+							</h1>
+						</div>
 					</div>
+				)}
+
+				{isJointEvaluation && (
+					<SubmissionBanner
+						deadline={cseDeadline}
+						email={email ?? "adresse@exemple.fr"}
+						year={getCurrentYear()}
+					/>
+				)}
+
+				{isJointEvaluation ? (
+					<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
+						Transmettre l'avis ou les avis du CSE
+					</h2>
+				) : (
+					<h1 className="fr-h4 fr-mb-3w">
+						Transmettre l'avis ou les avis du CSE
+					</h1>
+				)}
+
+				<CseStepIndicator currentStep={1} />
+
+				<p className="fr-text--md fr-mb-2w">
+					Indiquez si le CSE a été consulté et précisez les avis émis avant de
+					soumettre votre déclaration aux services du ministère chargé du
+					Travail.
+				</p>
+				<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
+
+				<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
+
+				<div className={styles.cardStack}>
+					<AccuracyOpinionCard
+						date={firstDeclDate ?? ""}
+						id="first-decl-accuracy"
+						onDateChange={(v) => {
+							form.setValue("firstDeclaration.accuracyDate", v);
+							triggerDraftSave();
+						}}
+						onOpinionChange={(v) => {
+							form.setValue("firstDeclaration.accuracyOpinion", v);
+							triggerDraftSave();
+						}}
+						opinion={firstDeclOpinion ?? null}
+						title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
+					/>
+
+					<Controller
+						control={form.control}
+						name="firstDeclaration.gapConsulted"
+						render={({ field }) => (
+							<GapConsultationCard
+								consulted={field.value ?? null}
+								date={firstDeclGapDate ?? ""}
+								id="first-decl-gap"
+								onConsultedChange={(v) => {
+									field.onChange(v);
+									triggerDraftSave();
+								}}
+								onDateChange={(v) => {
+									form.setValue("firstDeclaration.gapDate", v);
+									triggerDraftSave();
+								}}
+								onOpinionChange={(v) => {
+									form.setValue("firstDeclaration.gapOpinion", v);
+									triggerDraftSave();
+								}}
+								opinion={firstDeclGapOpinion ?? null}
+							/>
+						)}
+					/>
 				</div>
-			)}
 
-			{isJointEvaluation && (
-				<SubmissionBanner
-					deadline={cseDeadline}
-					email={email ?? "adresse@exemple.fr"}
-					year={getCurrentYear()}
-				/>
-			)}
+				{hasSecondDeclaration && (
+					<>
+						<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
 
-			{isJointEvaluation ? (
-				<h2 className="fr-h4 fr-mt-5w fr-mb-3w">
-					Transmettre l'avis ou les avis du CSE
-				</h2>
-			) : (
-				<h1 className="fr-h4 fr-mb-3w">
-					Transmettre l'avis ou les avis du CSE
-				</h1>
-			)}
+						<div className={styles.cardStack}>
+							<AccuracyOpinionCard
+								date={secondDeclDate ?? ""}
+								id="second-decl-accuracy"
+								onDateChange={(v) => {
+									form.setValue("secondDeclaration.accuracyDate", v);
+									triggerDraftSave();
+								}}
+								onOpinionChange={(v) => {
+									form.setValue("secondDeclaration.accuracyOpinion", v);
+									triggerDraftSave();
+								}}
+								opinion={secondDeclOpinion ?? null}
+								title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
+							/>
 
-			<CseStepIndicator currentStep={1} />
+							<Controller
+								control={form.control}
+								name="secondDeclaration.gapConsulted"
+								render={({ field }) => (
+									<GapConsultationCard
+										consulted={field.value ?? null}
+										date={secondDeclGapDate ?? ""}
+										id="second-decl-gap"
+										onConsultedChange={(v) => {
+											field.onChange(v);
+											triggerDraftSave();
+										}}
+										onDateChange={(v) => {
+											form.setValue("secondDeclaration.gapDate", v);
+											triggerDraftSave();
+										}}
+										onOpinionChange={(v) => {
+											form.setValue("secondDeclaration.gapOpinion", v);
+											triggerDraftSave();
+										}}
+										opinion={secondDeclGapOpinion ?? null}
+									/>
+								)}
+							/>
+						</div>
+					</>
+				)}
 
-			<p className="fr-text--md fr-mb-2w">
-				Indiquez si le CSE a été consulté et précisez les avis émis avant de
-				soumettre votre déclaration aux services du ministère chargé du Travail.
-			</p>
-			<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
-
-			<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
-
-			<div className={styles.cardStack}>
-				<AccuracyOpinionCard
-					date={firstDeclDate ?? ""}
-					id="first-decl-accuracy"
-					onDateChange={(v) => {
-						form.setValue("firstDeclaration.accuracyDate", v);
-						triggerDraftSave();
-					}}
-					onOpinionChange={(v) => {
-						form.setValue("firstDeclaration.accuracyOpinion", v);
-						triggerDraftSave();
-					}}
-					opinion={firstDeclOpinion ?? null}
-					title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
-				/>
-
-				<Controller
-					control={form.control}
-					name="firstDeclaration.gapConsulted"
-					render={({ field }) => (
-						<GapConsultationCard
-							consulted={field.value ?? null}
-							date={firstDeclGapDate ?? ""}
-							id="first-decl-gap"
-							onConsultedChange={(v) => {
-								field.onChange(v);
-								triggerDraftSave();
-							}}
-							onDateChange={(v) => {
-								form.setValue("firstDeclaration.gapDate", v);
-								triggerDraftSave();
-							}}
-							onOpinionChange={(v) => {
-								form.setValue("firstDeclaration.gapOpinion", v);
-								triggerDraftSave();
-							}}
-							opinion={firstDeclGapOpinion ?? null}
-						/>
+				<div aria-live="polite">
+					{(form.formState.errors.firstDeclaration ||
+						form.formState.errors.secondDeclaration) && (
+						<div className="fr-alert fr-alert--error fr-mt-3w">
+							<p>Veuillez remplir tous les champs obligatoires.</p>
+						</div>
 					)}
-				/>
-			</div>
+					{mutation.error && (
+						<div className="fr-alert fr-alert--error fr-mt-3w">
+							<p>{mutation.error.message}</p>
+						</div>
+					)}
+				</div>
 
-			{hasSecondDeclaration && (
-				<>
-					<h3 className="fr-h6 fr-mt-5w fr-mb-3w">Deuxième déclaration</h3>
-
-					<div className={styles.cardStack}>
-						<AccuracyOpinionCard
-							date={secondDeclDate ?? ""}
-							id="second-decl-accuracy"
-							onDateChange={(v) => {
-								form.setValue("secondDeclaration.accuracyDate", v);
-								triggerDraftSave();
-							}}
-							onOpinionChange={(v) => {
-								form.setValue("secondDeclaration.accuracyOpinion", v);
-								triggerDraftSave();
-							}}
-							opinion={secondDeclOpinion ?? null}
-							title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
-						/>
-
-						<Controller
-							control={form.control}
-							name="secondDeclaration.gapConsulted"
-							render={({ field }) => (
-								<GapConsultationCard
-									consulted={field.value ?? null}
-									date={secondDeclGapDate ?? ""}
-									id="second-decl-gap"
-									onConsultedChange={(v) => {
-										field.onChange(v);
-										triggerDraftSave();
-									}}
-									onDateChange={(v) => {
-										form.setValue("secondDeclaration.gapDate", v);
-										triggerDraftSave();
-									}}
-									onOpinionChange={(v) => {
-										form.setValue("secondDeclaration.gapOpinion", v);
-										triggerDraftSave();
-									}}
-									opinion={secondDeclGapOpinion ?? null}
-								/>
-							)}
-						/>
-					</div>
-				</>
-			)}
-
-			<div aria-live="polite">
-				{(form.formState.errors.firstDeclaration ||
-					form.formState.errors.secondDeclaration) && (
-					<div className="fr-alert fr-alert--error fr-mt-3w">
-						<p>Veuillez remplir tous les champs obligatoires.</p>
-					</div>
-				)}
-				{mutation.error && (
-					<div className="fr-alert fr-alert--error fr-mt-3w">
-						<p>{mutation.error.message}</p>
-					</div>
-				)}
-			</div>
-
-			<div className={`fr-mt-4w ${formStyles.actions}`}>
-				<Link
-					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
-					href={previousHref}
-				>
-					Précédent
-				</Link>
-				<span>
-					<button
-						{...readOnlyGuard.buttonProps}
-						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-						disabled={mutation.isPending || readOnlyGuard.isReadOnly}
-						type="submit"
+				<div className={`fr-mt-4w ${formStyles.actions}`}>
+					<Link
+						className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+						href={previousHref}
 					>
-						{mutation.isPending ? "Enregistrement…" : "Suivant"}
-					</button>
-					{readOnlyGuard.tooltip}
-				</span>
-			</div>
+						Précédent
+					</Link>
+					<span>
+						<button
+							{...readOnlyGuard.buttonProps}
+							className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+							disabled={
+								mutation.isPending || readOnlyGuard.isReadOnly || isLocked
+							}
+							type="submit"
+						>
+							{mutation.isPending ? "Enregistrement…" : "Suivant"}
+						</button>
+						{readOnlyGuard.tooltip}
+					</span>
+				</div>
+			</fieldset>
 		</form>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -6,6 +6,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import { useReadOnlyGuard } from "~/modules/auth";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
+import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { FileUpload, getDsfrModal, useFileUploadForm } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import { ContentTypeMatrix } from "./components/ContentTypeMatrix";
@@ -53,6 +54,7 @@ export function Step2Upload({
 		buildAssociationMap(columns, initialAssociations),
 	);
 	const readOnlyGuard = useReadOnlyGuard();
+	const { isReadOnly: isLocked } = useLockContext();
 
 	const emptyDbValues = useMemo(() => ({}), []);
 	useDeclarationDraft({
@@ -208,7 +210,7 @@ export function Step2Upload({
 						accept=".pdf"
 						acceptLabel="pdf"
 						allowedMimeTypes={["application/pdf"]}
-						disabled={readOnlyGuard.isReadOnly || isUploadingFiles}
+						disabled={readOnlyGuard.isReadOnly || isLocked || isUploadingFiles}
 						error={uploadError}
 						inputId="cse-file-upload"
 						maxFileCount={remainingSlots}
@@ -231,7 +233,7 @@ export function Step2Upload({
 							associations={associations}
 							columns={columns}
 							deletingFileId={deletingFileId}
-							disabled={readOnlyGuard.isReadOnly}
+							disabled={readOnlyGuard.isReadOnly || isLocked}
 							files={existingFiles}
 							onDelete={(fileId) => {
 								setDeletingFileId(fileId);
@@ -293,7 +295,7 @@ export function Step2Upload({
 						<button
 							{...readOnlyGuard.buttonProps}
 							className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-							disabled={readOnlyGuard.isReadOnly}
+							disabled={readOnlyGuard.isReadOnly || isLocked}
 							type="submit"
 						>
 							Soumettre

--- a/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
@@ -106,4 +106,43 @@ describe("CseOpinionLayout", () => {
 
 		expect(screen.getByTestId("lock-probe")).toHaveTextContent("false:none");
 	});
+
+	it("renders 'Non' when the company has no CSE", () => {
+		render(
+			<CseOpinionLayout
+				company={{ ...company, hasCse: false }}
+				declarationYear={2024}
+			>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.getByText("Non")).toBeInTheDocument();
+	});
+
+	it("renders 'Non renseigné' when the CSE existence is unknown", () => {
+		render(
+			<CseOpinionLayout
+				company={{ ...company, hasCse: null }}
+				declarationYear={2024}
+			>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.getByText("Non renseigné")).toBeInTheDocument();
+	});
+
+	it("omits the workforce line when the workforce is unknown", () => {
+		render(
+			<CseOpinionLayout
+				company={{ ...company, workforce: null }}
+				declarationYear={2024}
+			>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.queryByText(/Effectif annuel moyen/)).not.toBeInTheDocument();
+	});
 });

--- a/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
+import { CseOpinionLayout } from "../CseOpinionLayout";
+
+const company = {
+	name: "Alpha Solutions",
+	siren: "123456789",
+	workforce: 256,
+	hasCse: true,
+};
+
+const lockHolder = {
+	firstName: "Camille",
+	lastName: "Martin",
+	email: "camille.martin@example.fr",
+};
+
+function LockProbe() {
+	const { isReadOnly, holder } = useLockContext();
+	return (
+		<span data-testid="lock-probe">{`${isReadOnly}:${holder?.email ?? "none"}`}</span>
+	);
+}
+
+describe("CseOpinionLayout", () => {
+	it("renders the children inside the banner layout", () => {
+		render(
+			<CseOpinionLayout company={company} declarationYear={2024}>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.getByText("Step content")).toBeInTheDocument();
+	});
+
+	it("shows the lock alert when read-only and a holder is provided", () => {
+		render(
+			<CseOpinionLayout
+				company={company}
+				declarationYear={2024}
+				isReadOnly
+				lockHolder={lockHolder}
+			>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"Déclaration en cours de modification",
+		);
+		expect(
+			screen.getByText(/Camille Martin \(camille\.martin@example\.fr\)/),
+		).toBeInTheDocument();
+	});
+
+	it("does not show the lock alert by default", () => {
+		render(
+			<CseOpinionLayout company={company} declarationYear={2024}>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("does not show the lock alert when read-only but no holder is resolved", () => {
+		render(
+			<CseOpinionLayout
+				company={company}
+				declarationYear={2024}
+				isReadOnly
+				lockHolder={null}
+			>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("provides the lock state to descendant consumers when read-only", () => {
+		render(
+			<CseOpinionLayout
+				company={company}
+				declarationYear={2024}
+				isReadOnly
+				lockHolder={lockHolder}
+			>
+				<LockProbe />
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.getByTestId("lock-probe")).toHaveTextContent(
+			"true:camille.martin@example.fr",
+		);
+	});
+
+	it("provides a non-readonly lock state to descendants by default", () => {
+		render(
+			<CseOpinionLayout company={company} declarationYear={2024}>
+				<LockProbe />
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.getByTestId("lock-probe")).toHaveTextContent("false:none");
+	});
+});

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { Step1Opinions } from "../Step1Opinions";
 
 const { mockSetField, mockClearDraft, mockUseDeclarationDraft } = vi.hoisted(
@@ -59,6 +60,31 @@ vi.mock("~/trpc/react", () => ({
 		},
 	},
 }));
+
+type DeclarationDraft = {
+	accuracyOpinion?: string;
+	accuracyDate?: string;
+	gapConsulted?: boolean;
+	gapOpinion?: string;
+	gapDate?: string;
+};
+
+type SavedDraft = {
+	firstDeclaration?: DeclarationDraft;
+	secondDeclaration?: DeclarationDraft;
+};
+
+function lastSavedDraft(): SavedDraft | undefined {
+	return mockSetField.mock.calls.at(-1)?.[0] as SavedDraft | undefined;
+}
+
+function lastFirstDeclaration() {
+	return lastSavedDraft()?.firstDeclaration;
+}
+
+function lastSecondDeclaration() {
+	return lastSavedDraft()?.secondDeclaration;
+}
 
 beforeEach(() => {
 	mockPush.mockClear();
@@ -375,6 +401,70 @@ describe("Step1Opinions", () => {
 		expect(screen.getByText("adresse@exemple.fr")).toBeInTheDocument();
 	});
 
+	describe("gap consultation validation", () => {
+		it("blocks submission when the first-declaration gap is consulted but incomplete", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={false}
+					initialData={{
+						firstDeclAccuracyOpinion: "favorable",
+						firstDeclAccuracyDate: "2026-01-15",
+						firstDeclGapConsulted: true,
+						firstDeclGapOpinion: null,
+						firstDeclGapDate: null,
+						secondDeclAccuracyOpinion: null,
+						secondDeclAccuracyDate: "",
+						secondDeclGapConsulted: null,
+						secondDeclGapOpinion: null,
+						secondDeclGapDate: null,
+					}}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+			expect(
+				screen.getByText("Veuillez remplir tous les champs obligatoires."),
+			).toBeInTheDocument();
+			expect(mockMutate).not.toHaveBeenCalled();
+		});
+
+		it("blocks submission when the second-declaration gap is consulted but incomplete", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={true}
+					initialData={{
+						firstDeclAccuracyOpinion: "favorable",
+						firstDeclAccuracyDate: "2026-01-15",
+						firstDeclGapConsulted: false,
+						firstDeclGapOpinion: null,
+						firstDeclGapDate: null,
+						secondDeclAccuracyOpinion: "favorable",
+						secondDeclAccuracyDate: "2026-02-01",
+						secondDeclGapConsulted: true,
+						secondDeclGapOpinion: null,
+						secondDeclGapDate: null,
+					}}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /Suivant/ }));
+
+			expect(
+				screen.getByText("Veuillez remplir tous les champs obligatoires."),
+			).toBeInTheDocument();
+			expect(mockMutate).not.toHaveBeenCalled();
+		});
+	});
+
 	describe("draft integration", () => {
 		it("hydrates form from draft when available", () => {
 			mockUseDeclarationDraft.mockReturnValue({
@@ -403,6 +493,43 @@ describe("Step1Opinions", () => {
 
 			const favorableRadios = screen.getAllByLabelText("Favorable");
 			expect(favorableRadios[0]).toBeChecked();
+		});
+
+		it("hydrates both declarations from a draft with second-declaration data", () => {
+			mockUseDeclarationDraft.mockReturnValue({
+				draft: {
+					firstDeclaration: {
+						accuracyOpinion: "favorable",
+						accuracyDate: "2026-01-10",
+						gapConsulted: false,
+						gapOpinion: null,
+						gapDate: null,
+					},
+					secondDeclaration: {
+						accuracyOpinion: "unfavorable",
+						accuracyDate: "2026-02-10",
+						gapConsulted: true,
+						gapOpinion: "favorable",
+						gapDate: "2026-02-15",
+					},
+				},
+				setField: mockSetField,
+				clearDraft: mockClearDraft,
+				hasDraft: true,
+				isLoadingDraft: false,
+			});
+
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={true}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			expect(screen.getAllByLabelText("Favorable")[0]).toBeChecked();
+			expect(screen.getAllByLabelText("Défavorable")[1]).toBeChecked();
 		});
 
 		it("shows loading state while draft is loading", () => {
@@ -441,10 +568,164 @@ describe("Step1Opinions", () => {
 			await user.click(screen.getAllByLabelText("Favorable")[0] as HTMLElement);
 
 			expect(mockSetField).toHaveBeenCalled();
-			const callArg = mockSetField.mock.calls[
-				mockSetField.mock.calls.length - 1
-			]?.[0] as { firstDeclaration?: { accuracyOpinion?: string } } | undefined;
-			expect(callArg?.firstDeclaration?.accuracyOpinion).toBe("favorable");
+			expect(lastFirstDeclaration()?.accuracyOpinion).toBe("favorable");
+		});
+
+		it("saves a draft when the accuracy date changes", async () => {
+			const user = userEvent.setup();
+			render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={false}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			const dateInput = screen.getByLabelText(
+				/Date de l'avis rendu par le CSE/,
+			);
+			await user.type(dateInput, "2026-03-10");
+
+			expect(lastFirstDeclaration()?.accuracyDate).toBe("2026-03-10");
+		});
+
+		it("saves a draft for the gap opinion and date once consultation is confirmed", async () => {
+			const user = userEvent.setup();
+			const { container } = render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={false}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			// Answering "Oui" on the gap card reveals its opinion + date sub-fields and
+			// triggers an autosave through onConsultedChange.
+			await user.click(screen.getByLabelText("Oui"));
+
+			const gapOpinion = container.querySelector(
+				"#first-decl-gap-unfavorable",
+			) as HTMLElement;
+			await user.click(gapOpinion);
+			expect(lastFirstDeclaration()?.gapOpinion).toBe("unfavorable");
+
+			const gapDate = container.querySelector(
+				"#first-decl-gap-date",
+			) as HTMLElement;
+			await user.type(gapDate, "2026-04-01");
+			expect(lastFirstDeclaration()?.gapDate).toBe("2026-04-01");
+		});
+
+		it("saves a draft for the second-declaration accuracy fields", async () => {
+			const user = userEvent.setup();
+			const { container } = render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={true}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			const secondAccuracy = container.querySelector(
+				"#second-decl-accuracy-favorable",
+			) as HTMLElement;
+			await user.click(secondAccuracy);
+			expect(lastSecondDeclaration()?.accuracyOpinion).toBe("favorable");
+
+			const secondAccuracyDate = container.querySelector(
+				"#second-decl-accuracy-date",
+			) as HTMLElement;
+			await user.type(secondAccuracyDate, "2026-05-02");
+			expect(lastSecondDeclaration()?.accuracyDate).toBe("2026-05-02");
+		});
+
+		it("saves a draft for the second-declaration gap fields", async () => {
+			const user = userEvent.setup();
+			const { container } = render(
+				<Step1Opinions
+					cseDeadline={cseDeadline}
+					hasSecondDeclaration={true}
+					siren="123456789"
+					year={2026}
+				/>,
+			);
+
+			// The second gap card is the second "Oui" radio on the page.
+			await user.click(screen.getAllByLabelText("Oui")[1] as HTMLElement);
+			expect(lastSecondDeclaration()?.gapConsulted).toBe(true);
+
+			const gapOpinion = container.querySelector(
+				"#second-decl-gap-favorable",
+			) as HTMLElement;
+			await user.click(gapOpinion);
+			expect(lastSecondDeclaration()?.gapOpinion).toBe("favorable");
+
+			const gapDate = container.querySelector(
+				"#second-decl-gap-date",
+			) as HTMLElement;
+			await user.type(gapDate, "2026-05-20");
+			expect(lastSecondDeclaration()?.gapDate).toBe("2026-05-20");
+		});
+	});
+
+	describe("declaration lock", () => {
+		function renderLocked() {
+			return render(
+				<LockProvider isReadOnly>
+					<Step1Opinions
+						cseDeadline={cseDeadline}
+						siren="123456789"
+						year={2026}
+					/>
+				</LockProvider>,
+			);
+		}
+
+		it("disables the whole fieldset when the declaration is locked", () => {
+			const { container } = renderLocked();
+
+			const fieldset = container.querySelector("fieldset");
+			expect(fieldset).toBeDisabled();
+		});
+
+		it("disables every input and the next button when locked", () => {
+			renderLocked();
+
+			for (const radio of screen.getAllByRole("radio")) {
+				expect(radio).toBeDisabled();
+			}
+			expect(screen.getByRole("button", { name: /Suivant/ })).toBeDisabled();
+		});
+
+		it("does not save a draft when an opinion is changed while locked", async () => {
+			const user = userEvent.setup();
+			renderLocked();
+
+			const favorable = screen.getAllByLabelText("Favorable")[0] as HTMLElement;
+			// A disabled fieldset still lets us fire the handler imperatively; the
+			// click is a no-op but we assert no draft write occurs regardless.
+			await user.click(favorable);
+
+			expect(mockSetField).not.toHaveBeenCalled();
+		});
+
+		it("keeps inputs enabled when the lock is inactive", () => {
+			render(
+				<LockProvider isReadOnly={false}>
+					<Step1Opinions
+						cseDeadline={cseDeadline}
+						siren="123456789"
+						year={2026}
+					/>
+				</LockProvider>,
+			);
+
+			expect(
+				screen.getByRole("button", { name: /Suivant/ }),
+			).not.toBeDisabled();
 		});
 	});
 });

--- a/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { FILENAME_ERROR_MESSAGES } from "~/modules/shared";
 import { computeContentTypeColumns } from "../contentTypeColumns";
 import { Step2Upload } from "../Step2Upload";
@@ -116,16 +117,19 @@ function renderStep(
 		existingFiles?: UploadedFile[];
 		columns?: ContentTypeColumn[];
 		initialAssociations?: StoredFileContentType[];
+		isReadOnly?: boolean;
 	} = {},
 ) {
 	return render(
-		<Step2Upload
-			columns={props.columns ?? SINGLE_COLUMN}
-			declarationYear={2026}
-			existingFiles={props.existingFiles}
-			initialAssociations={props.initialAssociations}
-			siren="123456789"
-		/>,
+		<LockProvider isReadOnly={props.isReadOnly ?? false}>
+			<Step2Upload
+				columns={props.columns ?? SINGLE_COLUMN}
+				declarationYear={2026}
+				existingFiles={props.existingFiles}
+				initialAssociations={props.initialAssociations}
+				siren="123456789"
+			/>
+		</LockProvider>,
 	);
 }
 
@@ -703,5 +707,43 @@ describe("Step2Upload", () => {
 				deleteMutationOptions.onError?.();
 			});
 		}).not.toThrow();
+	});
+
+	describe("declaration lock", () => {
+		it("disables the file upload select button when locked", () => {
+			renderStep({ isReadOnly: true });
+
+			expect(
+				screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
+			).toBeDisabled();
+		});
+
+		it("disables the submit button when locked", () => {
+			renderStep({ isReadOnly: true });
+
+			expect(screen.getByRole("button", { name: "Soumettre" })).toBeDisabled();
+		});
+
+		it("disables the matrix delete and checkbox controls when locked", () => {
+			renderStep({
+				columns: SINGLE_COLUMN,
+				existingFiles: [makeFile("avis-1.pdf", "file-1")],
+				isReadOnly: true,
+			});
+
+			expect(
+				screen.getByRole("checkbox", { name: "Exactitude — avis-1.pdf" }),
+			).toBeDisabled();
+			expect(screen.getByRole("button", { name: /Supprimer/ })).toBeDisabled();
+		});
+
+		it("keeps the controls enabled when the lock is inactive", () => {
+			renderStep({ isReadOnly: false });
+
+			expect(
+				screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
+			).toBeEnabled();
+			expect(screen.getByRole("button", { name: "Soumettre" })).toBeEnabled();
+		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -1,4 +1,7 @@
 import { CompanyBanner } from "./shared/CompanyBanner";
+import { DeclarationLockAlert } from "./shared/lock/DeclarationLockAlert";
+import type { LockHolder } from "./shared/lock/LockContext";
+import { LockProvider } from "./shared/lock/LockContext";
 
 type CompanyData = {
 	name: string;
@@ -13,12 +16,16 @@ type DeclarationLayoutProps = {
 	company: CompanyData;
 	declarationYear: number;
 	children: React.ReactNode;
+	isReadOnly?: boolean;
+	lockHolder?: LockHolder | null;
 };
 
 export function DeclarationLayout({
 	company,
 	declarationYear,
 	children,
+	isReadOnly = false,
+	lockHolder = null,
 }: DeclarationLayoutProps) {
 	return (
 		<>
@@ -27,9 +34,16 @@ export function DeclarationLayout({
 				currentPageLabel={`Démarche des indicateurs de rémunération ${declarationYear}`}
 			/>
 			<main className="fr-container fr-py-7w" id="content">
-				<div className="fr-grid-row fr-grid-row--center">
-					<div className="fr-col-12 fr-col-lg-8">{children}</div>
-				</div>
+				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
+					<div className="fr-grid-row fr-grid-row--center">
+						<div className="fr-col-12 fr-col-lg-8">
+							{isReadOnly && lockHolder && (
+								<DeclarationLockAlert holder={lockHolder} />
+							)}
+							{children}
+						</div>
+					</div>
+				</LockProvider>
 			</main>
 		</>
 	);

--- a/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DeclarationLayout } from "../DeclarationLayout";
+import { useLockContext } from "../shared/lock/LockContext";
+
+const company = {
+	name: "Alpha Solutions",
+	siren: "123456789",
+	nafCode: "62.01Z",
+	nafLabel: "Programmation informatique",
+	workforce: 256,
+	hasCse: true,
+};
+
+const lockHolder = {
+	firstName: "Camille",
+	lastName: "Martin",
+	email: "camille.martin@example.fr",
+};
+
+function LockProbe() {
+	const { isReadOnly, holder } = useLockContext();
+	return (
+		<span data-testid="lock-probe">{`${isReadOnly}:${holder?.email ?? "none"}`}</span>
+	);
+}
+
+describe("DeclarationLayout", () => {
+	it("renders the children inside the banner layout", () => {
+		render(
+			<DeclarationLayout company={company} declarationYear={2024}>
+				<p>Step content</p>
+			</DeclarationLayout>,
+		);
+
+		expect(screen.getByText("Step content")).toBeInTheDocument();
+	});
+
+	it("shows the lock alert when read-only and a holder is provided", () => {
+		render(
+			<DeclarationLayout
+				company={company}
+				declarationYear={2024}
+				isReadOnly
+				lockHolder={lockHolder}
+			>
+				<p>Step content</p>
+			</DeclarationLayout>,
+		);
+
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"Déclaration en cours de modification",
+		);
+		expect(
+			screen.getByText(/Camille Martin \(camille\.martin@example\.fr\)/),
+		).toBeInTheDocument();
+	});
+
+	it("does not show the lock alert by default", () => {
+		render(
+			<DeclarationLayout company={company} declarationYear={2024}>
+				<p>Step content</p>
+			</DeclarationLayout>,
+		);
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("does not show the lock alert when read-only but no holder is resolved", () => {
+		render(
+			<DeclarationLayout
+				company={company}
+				declarationYear={2024}
+				isReadOnly
+				lockHolder={null}
+			>
+				<p>Step content</p>
+			</DeclarationLayout>,
+		);
+
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("provides the lock state to descendant consumers", () => {
+		render(
+			<DeclarationLayout
+				company={company}
+				declarationYear={2024}
+				isReadOnly
+				lockHolder={lockHolder}
+			>
+				<LockProbe />
+			</DeclarationLayout>,
+		);
+
+		expect(screen.getByTestId("lock-probe")).toHaveTextContent(
+			"true:camille.martin@example.fr",
+		);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
@@ -2,8 +2,8 @@
 
 import Link from "next/link";
 import { useReadOnlyGuard } from "~/modules/auth";
-
 import styles from "./FormActions.module.scss";
+import { useLockContext } from "./lock/LockContext";
 
 type FormActionsProps = {
 	previousHref?: string;
@@ -33,6 +33,7 @@ export function FormActions({
 	mimoquageNextHref,
 }: FormActionsProps) {
 	const { isReadOnly, buttonProps, tooltip } = useReadOnlyGuard();
+	const { isReadOnly: isLocked } = useLockContext();
 
 	return (
 		<div className={`${styles.actions} ${className ?? ""}`}>
@@ -53,7 +54,7 @@ export function FormActions({
 				>
 					{nextLabel}
 				</Link>
-			) : isReadOnly && mimoquageNextHref ? (
+			) : (isReadOnly || isLocked) && mimoquageNextHref ? (
 				<span>
 					<Link
 						aria-describedby={buttonProps["aria-describedby"]}
@@ -69,7 +70,7 @@ export function FormActions({
 					<button
 						{...buttonProps}
 						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-						disabled={isReadOnly || isSubmitting || nextDisabled}
+						disabled={isReadOnly || isLocked || isSubmitting || nextDisabled}
 						type="submit"
 					>
 						{isSubmitting ? "Enregistrement…" : nextLabel}

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
@@ -3,6 +3,7 @@ import { useSession } from "next-auth/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { FormActions } from "../FormActions";
+import { LockProvider } from "../lock/LockContext";
 
 const mockedUseSession = vi.mocked(useSession);
 
@@ -107,6 +108,46 @@ describe("FormActions", () => {
 			render(<FormActions />);
 
 			expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("declaration lock", () => {
+		it("disables the submit button when the declaration is locked by another user", () => {
+			render(
+				<LockProvider isReadOnly>
+					<FormActions />
+				</LockProvider>,
+			);
+
+			expect(screen.getByRole("button", { name: /suivant/i })).toBeDisabled();
+		});
+
+		it("keeps the submit button enabled when the lock is inactive", () => {
+			render(
+				<LockProvider isReadOnly={false}>
+					<FormActions />
+				</LockProvider>,
+			);
+
+			expect(
+				screen.getByRole("button", { name: /suivant/i }),
+			).not.toBeDisabled();
+		});
+
+		it("renders a Link instead of the submit button when locked with mimoquageNextHref", () => {
+			render(
+				<LockProvider isReadOnly>
+					<FormActions mimoquageNextHref="/declaration-remuneration/etape/2" />
+				</LockProvider>,
+			);
+
+			expect(
+				screen.queryByRole("button", { name: /suivant/i }),
+			).not.toBeInTheDocument();
+			expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
+				"href",
+				"/declaration-remuneration/etape/2",
+			);
 		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
@@ -60,3 +60,10 @@
 .numericInput {
 	text-align: right;
 }
+
+.readOnlyFieldset {
+	border: none;
+	margin: 0;
+	padding: 0;
+	min-width: 0;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -9,17 +9,16 @@ export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {
 		.filter(Boolean)
 		.join(" ")
 		.trim();
-	const hasEmailSuffix = Boolean(fullName) && Boolean(holder.email);
-	const editor = fullName || holder.email || "Un autre utilisateur";
-	const emailSuffix = hasEmailSuffix ? ` (${holder.email})` : "";
+	const identity = fullName
+		? `${fullName}${holder.email ? ` (${holder.email})` : ""}`
+		: (holder.email ?? "Un autre utilisateur");
 
 	return (
-		<div className="fr-alert fr-alert--warning fr-alert--sm" role="alert">
+		<div className="fr-alert fr-alert--warning fr-mb-3w" role="alert">
+			<h3 className="fr-alert__title">Déclaration en cours de modification</h3>
 			<p>
-				<span className="fr-sr-only">Attention : </span>
-				<strong>Déclaration en cours de modification</strong> — {editor}
-				{emailSuffix} modifie actuellement cette déclaration. Vous pouvez la
-				consulter en lecture seule jusqu'à la fin de sa modification.
+				{identity} modifie actuellement cette déclaration. Vous pouvez la
+				consulter en lecture seule jusqu&apos;à la fin de sa modification.
 			</p>
 		</div>
 	);

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
@@ -3,6 +3,8 @@
 import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
+import { useDeclarationLock } from "./useDeclarationLock";
+
 export type LockHolder = {
 	firstName: string | null;
 	lastName: string | null;
@@ -12,6 +14,7 @@ export type LockHolder = {
 type LockState = {
 	isReadOnly: boolean;
 	holder: LockHolder | null;
+	isLoading?: boolean;
 };
 
 const LockContext = createContext<LockState>({
@@ -19,22 +22,50 @@ const LockContext = createContext<LockState>({
 	holder: null,
 });
 
-type LockProviderProps = {
+type StaticLockProviderProps = {
 	children: ReactNode;
 	isReadOnly?: boolean;
 	holder?: LockHolder | null;
 };
 
-export function LockProvider({
+type DynamicLockProviderProps = {
+	children: ReactNode;
+	declarationId: string;
+};
+
+type LockProviderProps = StaticLockProviderProps | DynamicLockProviderProps;
+
+function StaticLockProvider({
 	children,
 	isReadOnly = false,
 	holder = null,
-}: LockProviderProps) {
+}: StaticLockProviderProps) {
 	return (
 		<LockContext.Provider value={{ isReadOnly, holder }}>
 			{children}
 		</LockContext.Provider>
 	);
+}
+
+function DynamicLockProvider({
+	children,
+	declarationId,
+}: DynamicLockProviderProps) {
+	const { isReadOnly, holder, isLoading } = useDeclarationLock({
+		declarationId,
+	});
+	return (
+		<LockContext.Provider value={{ isReadOnly, holder, isLoading }}>
+			{children}
+		</LockContext.Provider>
+	);
+}
+
+export function LockProvider(props: LockProviderProps) {
+	if ("declarationId" in props) {
+		return <DynamicLockProvider {...props} />;
+	}
+	return <StaticLockProvider {...props} />;
 }
 
 export function useLockContext(): LockState {

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
@@ -1,28 +1,42 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
-import {
-	type DeclarationLockState,
-	useDeclarationLock,
-} from "./useDeclarationLock";
-
-const LockContext = createContext<DeclarationLockState | null>(null);
-
-type LockProviderProps = {
-	declarationId: string;
-	children: React.ReactNode;
+export type LockHolder = {
+	firstName: string | null;
+	lastName: string | null;
+	email: string | null;
 };
 
-export function LockProvider({ declarationId, children }: LockProviderProps) {
-	const state = useDeclarationLock({ declarationId });
-	return <LockContext.Provider value={state}>{children}</LockContext.Provider>;
+type LockState = {
+	isReadOnly: boolean;
+	holder: LockHolder | null;
+};
+
+const LockContext = createContext<LockState>({
+	isReadOnly: false,
+	holder: null,
+});
+
+type LockProviderProps = {
+	children: ReactNode;
+	isReadOnly?: boolean;
+	holder?: LockHolder | null;
+};
+
+export function LockProvider({
+	children,
+	isReadOnly = false,
+	holder = null,
+}: LockProviderProps) {
+	return (
+		<LockContext.Provider value={{ isReadOnly, holder }}>
+			{children}
+		</LockContext.Provider>
+	);
 }
 
-export function useLockContext(): DeclarationLockState {
-	const context = useContext(LockContext);
-	if (context === null) {
-		throw new Error("useLockContext must be used within a LockProvider");
-	}
-	return context;
+export function useLockContext(): LockState {
+	return useContext(LockContext);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/DeclarationLockAlert.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/DeclarationLockAlert.test.tsx
@@ -4,29 +4,63 @@ import { describe, expect, it } from "vitest";
 import { DeclarationLockAlert } from "../DeclarationLockAlert";
 
 describe("DeclarationLockAlert", () => {
-	it("renders the full name followed by the email in parentheses", () => {
+	it("renders a DSFR warning alert with the lock title", () => {
 		render(
 			<DeclarationLockAlert
 				holder={{
-					firstName: "Alice",
+					firstName: "Camille",
 					lastName: "Martin",
-					email: "alice@example.fr",
+					email: "camille.martin@example.fr",
 				}}
 			/>,
 		);
 
-		expect(
-			screen.getByText(/Alice Martin \(alice@example\.fr\)/),
-		).toBeInTheDocument();
+		const alert = screen.getByRole("alert");
+		expect(alert).toHaveClass("fr-alert", "fr-alert--warning");
 		expect(
 			screen.getByText("Déclaration en cours de modification"),
 		).toBeInTheDocument();
 	});
 
-	it("falls back to the email alone when the name is missing", () => {
+	it("shows the full name and email when both are present", () => {
 		render(
 			<DeclarationLockAlert
-				holder={{ firstName: null, lastName: null, email: "owner@example.fr" }}
+				holder={{
+					firstName: "Camille",
+					lastName: "Martin",
+					email: "camille.martin@example.fr",
+				}}
+			/>,
+		);
+
+		expect(
+			screen.getByText(
+				/Camille Martin \(camille\.martin@example\.fr\) modifie actuellement/,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("shows the name without parentheses when the email is null", () => {
+		render(
+			<DeclarationLockAlert
+				holder={{ firstName: "Camille", lastName: "Martin", email: null }}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/^Camille Martin modifie actuellement/),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/\(/)).not.toBeInTheDocument();
+	});
+
+	it("falls back to the email alone when no name is provided", () => {
+		render(
+			<DeclarationLockAlert
+				holder={{
+					firstName: null,
+					lastName: null,
+					email: "owner@example.fr",
+				}}
 			/>,
 		);
 
@@ -37,7 +71,7 @@ describe("DeclarationLockAlert", () => {
 		expect(paragraph).not.toHaveTextContent("(owner@example.fr)");
 	});
 
-	it("falls back to a generic label when neither name nor email is known", () => {
+	it("falls back to a generic label when neither name nor email is available", () => {
 		render(
 			<DeclarationLockAlert
 				holder={{ firstName: null, lastName: null, email: null }}
@@ -45,7 +79,7 @@ describe("DeclarationLockAlert", () => {
 		);
 
 		expect(
-			screen.getByText(/Un autre utilisateur modifie actuellement/),
+			screen.getByText(/^Un autre utilisateur modifie actuellement/),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
@@ -1,22 +1,72 @@
-import { render, renderHook, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DeclarationLockState } from "../useDeclarationLock";
 
-const lockState: DeclarationLockState = {
+const dynamicState: DeclarationLockState = {
 	isReadOnly: true,
 	holder: null,
 	isLoading: false,
 };
 
 vi.mock("../useDeclarationLock", () => ({
-	useDeclarationLock: vi.fn(() => lockState),
+	useDeclarationLock: vi.fn(() => dynamicState),
 }));
 
+import type { LockHolder } from "../LockContext";
 import { LockProvider, useLockContext } from "../LockContext";
 
-describe("LockContext", () => {
-	it("exposes the lock state computed by the hook to consumers", () => {
+function ContextProbe() {
+	const { isReadOnly, holder } = useLockContext();
+	return (
+		<div>
+			<span data-testid="read-only">{String(isReadOnly)}</span>
+			<span data-testid="holder">{holder ? holder.email : "none"}</span>
+		</div>
+	);
+}
+
+const holder: LockHolder = {
+	firstName: "Camille",
+	lastName: "Martin",
+	email: "camille.martin@example.fr",
+};
+
+describe("LockContext — static provider", () => {
+	it("exposes a default non-readonly state without a provider", () => {
+		render(<ContextProbe />);
+
+		expect(screen.getByTestId("read-only")).toHaveTextContent("false");
+		expect(screen.getByTestId("holder")).toHaveTextContent("none");
+	});
+
+	it("defaults to non-readonly with no holder when no props are passed", () => {
+		render(
+			<LockProvider>
+				<ContextProbe />
+			</LockProvider>,
+		);
+
+		expect(screen.getByTestId("read-only")).toHaveTextContent("false");
+		expect(screen.getByTestId("holder")).toHaveTextContent("none");
+	});
+
+	it("propagates isReadOnly and holder when provided", () => {
+		render(
+			<LockProvider holder={holder} isReadOnly>
+				<ContextProbe />
+			</LockProvider>,
+		);
+
+		expect(screen.getByTestId("read-only")).toHaveTextContent("true");
+		expect(screen.getByTestId("holder")).toHaveTextContent(
+			"camille.martin@example.fr",
+		);
+	});
+});
+
+describe("LockContext — dynamic provider", () => {
+	it("exposes the lock state returned by useDeclarationLock", () => {
 		function Consumer() {
 			const state = useLockContext();
 			return <span>{state.isReadOnly ? "read-only" : "editable"}</span>;
@@ -29,11 +79,5 @@ describe("LockContext", () => {
 		);
 
 		expect(screen.getByText("read-only")).toBeInTheDocument();
-	});
-
-	it("throws when useLockContext is used outside a LockProvider", () => {
-		expect(() => renderHook(() => useLockContext())).toThrow(
-			"useLockContext must be used within a LockProvider",
-		);
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -81,7 +81,7 @@ export function CompliancePathChoice({
 		}
 	});
 
-	useDraftAutoSave(form, draftHydrated, (values) =>
+	useDraftAutoSave(form, draftHydrated && !isReadOnly, (values) =>
 		setField(values as { path: CompliancePathValue | undefined }),
 	);
 

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -10,6 +10,7 @@ import { DraftLoadingState } from "~/modules/declaration-remuneration/shared/dra
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { useDraftAutoSave } from "~/modules/declaration-remuneration/shared/draft/useDraftAutoSave";
 import { useDraftHydration } from "~/modules/declaration-remuneration/shared/draft/useDraftHydration";
+import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { type CampaignDeadlines, formatLongDate } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -50,6 +51,7 @@ export function CompliancePathChoice({
 }: Props) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const { isReadOnly } = useLockContext();
 
 	const dbValues = useMemo(() => ({ path: initialPath }), [initialPath]);
 
@@ -115,120 +117,122 @@ export function CompliancePathChoice({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			<div className={common.flexBetween}>
-				<h1 className="fr-h4 fr-mb-0">
-					Déclaration des indicateurs de rémunération {currentYear}
-				</h1>
-				<SavedIndicator
-					hasData={hasData}
-					isPendingSave={isPendingSave}
-					isSaving={isSaving}
-				/>
-			</div>
-
-			<DeclarationSuccessBanner
-				email={email}
-				isSecondDeclaration={isSecondRound}
-				modificationDeadline={
-					isSecondRound
-						? campaignDeadlines.decl2ModificationDeadline
-						: campaignDeadlines.decl1ModificationDeadline
-				}
-				pdfDownloadHref={pdfDownloadHref}
-				year={currentYear}
-			/>
-
-			<div className={common.flexColumnGap1}>
-				<p className={`fr-mb-0 ${styles.instructions}`}>
-					{isSecondRound
-						? "Des écarts ≥ 5 % ont de nouveau été détectés, vous devez engager l'un des parcours suivants."
-						: "Des écarts ≥ 5 % ont été constatés, vous devez engager l'un des parcours suivants."}
-				</p>
-
-				<div className="fr-highlight fr-mb-0">
-					<p className="fr-mb-1w">
-						Date limite pour choisir un parcours de mise en conformité
-					</p>
-					<p className="fr-text--lg fr-text--bold fr-mb-0">
-						{formatLongDate(campaignDeadlines.pathChoiceDeadline)}
-					</p>
-				</div>
-			</div>
-
-			<div className={common.dataSection}>
-				<div className={common.flexColumnGapHalf}>
-					<h2 className="fr-h6 fr-mb-0">
-						La justification est possible par des critères objectifs et non
-						sexistes
-					</h2>
-					<p className="fr-mb-0">
-						<TrackedLink
-							className="fr-link"
-							href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-							rel="noopener noreferrer"
-							target="_blank"
-							trackingId="objective_criteria"
-						>
-							Qu&apos;entend-on par critères objectifs et non sexistes ?
-							<NewTabNotice />
-						</TrackedLink>
-					</p>
+			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<div className={common.flexBetween}>
+					<h1 className="fr-h4 fr-mb-0">
+						Déclaration des indicateurs de rémunération {currentYear}
+					</h1>
+					<SavedIndicator
+						hasData={hasData}
+						isPendingSave={isPendingSave}
+						isSaving={isSaving}
+					/>
 				</div>
 
-				<Controller
-					control={form.control}
-					name="path"
-					render={({ field }) => (
-						<fieldset
-							aria-labelledby="compliance-path-legend"
-							className="fr-fieldset"
-						>
-							<legend className="fr-sr-only" id="compliance-path-legend">
-								Choix du parcours de mise en conformité
-							</legend>
-
-							{isSecondRound ? (
-								<SecondRoundOptions
-									disabled={isImpersonating}
-									jointEvaluationDeadline={
-										campaignDeadlines.decl2JointEvaluationDeadline
-									}
-									justificationDeadline={
-										campaignDeadlines.decl2JustificationDeadline
-									}
-									selectedPath={field.value}
-									setSelectedPath={field.onChange}
-								/>
-							) : (
-								<FirstRoundOptions
-									correctiveActionDeadline={
-										campaignDeadlines.decl2ModificationDeadline
-									}
-									disabled={isImpersonating}
-									jointEvaluationDeadline={
-										campaignDeadlines.decl1JointEvaluationDeadline
-									}
-									justificationDeadline={
-										campaignDeadlines.decl1JustificationDeadline
-									}
-									selectedPath={field.value}
-									setSelectedPath={field.onChange}
-								/>
-							)}
-						</fieldset>
-					)}
+				<DeclarationSuccessBanner
+					email={email}
+					isSecondDeclaration={isSecondRound}
+					modificationDeadline={
+						isSecondRound
+							? campaignDeadlines.decl2ModificationDeadline
+							: campaignDeadlines.decl1ModificationDeadline
+					}
+					pdfDownloadHref={pdfDownloadHref}
+					year={currentYear}
 				/>
-			</div>
 
-			<FormActions
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					initialPath ? getCompliancePathHref(initialPath) : undefined
-				}
-				nextDisabled={!selectedPath}
-				nextLabel="Suivant"
-				previousHref="/declaration-remuneration/etape/6"
-			/>
+				<div className={common.flexColumnGap1}>
+					<p className={`fr-mb-0 ${styles.instructions}`}>
+						{isSecondRound
+							? "Des écarts ≥ 5 % ont de nouveau été détectés, vous devez engager l'un des parcours suivants."
+							: "Des écarts ≥ 5 % ont été constatés, vous devez engager l'un des parcours suivants."}
+					</p>
+
+					<div className="fr-highlight fr-mb-0">
+						<p className="fr-mb-1w">
+							Date limite pour choisir un parcours de mise en conformité
+						</p>
+						<p className="fr-text--lg fr-text--bold fr-mb-0">
+							{formatLongDate(campaignDeadlines.pathChoiceDeadline)}
+						</p>
+					</div>
+				</div>
+
+				<div className={common.dataSection}>
+					<div className={common.flexColumnGapHalf}>
+						<h2 className="fr-h6 fr-mb-0">
+							La justification est possible par des critères objectifs et non
+							sexistes
+						</h2>
+						<p className="fr-mb-0">
+							<TrackedLink
+								className="fr-link"
+								href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+								rel="noopener noreferrer"
+								target="_blank"
+								trackingId="objective_criteria"
+							>
+								Qu&apos;entend-on par critères objectifs et non sexistes ?
+								<NewTabNotice />
+							</TrackedLink>
+						</p>
+					</div>
+
+					<Controller
+						control={form.control}
+						name="path"
+						render={({ field }) => (
+							<fieldset
+								aria-labelledby="compliance-path-legend"
+								className="fr-fieldset"
+							>
+								<legend className="fr-sr-only" id="compliance-path-legend">
+									Choix du parcours de mise en conformité
+								</legend>
+
+								{isSecondRound ? (
+									<SecondRoundOptions
+										disabled={isImpersonating}
+										jointEvaluationDeadline={
+											campaignDeadlines.decl2JointEvaluationDeadline
+										}
+										justificationDeadline={
+											campaignDeadlines.decl2JustificationDeadline
+										}
+										selectedPath={field.value}
+										setSelectedPath={field.onChange}
+									/>
+								) : (
+									<FirstRoundOptions
+										correctiveActionDeadline={
+											campaignDeadlines.decl2ModificationDeadline
+										}
+										disabled={isImpersonating}
+										jointEvaluationDeadline={
+											campaignDeadlines.decl1JointEvaluationDeadline
+										}
+										justificationDeadline={
+											campaignDeadlines.decl1JustificationDeadline
+										}
+										selectedPath={field.value}
+										setSelectedPath={field.onChange}
+									/>
+								)}
+							</fieldset>
+						)}
+					/>
+				</div>
+
+				<FormActions
+					isSubmitting={mutation.isPending}
+					mimoquageNextHref={
+						initialPath ? getCompliancePathHref(initialPath) : undefined
+					}
+					nextDisabled={!selectedPath}
+					nextLabel="Suivant"
+					previousHref="/declaration-remuneration/etape/6"
+				/>
+			</fieldset>
 		</form>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -17,6 +17,7 @@ import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
+import { useLockContext } from "../shared/lock/LockContext";
 import { PrefillResetConfirmDialog } from "../shared/PrefillResetConfirmDialog";
 import { PrefillResetWarning } from "../shared/PrefillResetWarning";
 import { PrefillSource } from "../shared/PrefillSource";
@@ -41,6 +42,7 @@ export function Step1Workforce({
 }: Step1WorkforceProps) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const { isReadOnly } = useLockContext();
 	const isPrefilled = !!gipPrefillData;
 
 	const hasInitialData = initialData.totalWomen > 0 || initialData.totalMen > 0;
@@ -193,208 +195,210 @@ export function Step1Workforce({
 				className={common.flexColumnGap2}
 				onSubmit={onSubmit}
 			>
-				<StepTitleRow
-					hasData={hasData}
-					isPendingSave={isPendingSave}
-					isSaving={isSaving}
-					onDevFill={() => {
-						const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;
-						const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;
-						form.setValue("totalWomen", womenValue);
-						form.setValue("totalMen", menValue);
-						setWomenRaw(String(womenValue));
-						setMenRaw(String(menValue));
-						setField({ totalWomen: womenValue, totalMen: menValue });
-					}}
-					title={
-						<h1 className="fr-h4 fr-mb-0">
-							Déclaration des indicateurs de rémunération {declarationYear}
-						</h1>
-					}
-				/>
+				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+					<StepTitleRow
+						hasData={hasData}
+						isPendingSave={isPendingSave}
+						isSaving={isSaving}
+						onDevFill={() => {
+							const womenValue = DEV_STEP1_CATEGORIES[0]?.women ?? 50;
+							const menValue = DEV_STEP1_CATEGORIES[0]?.men ?? 50;
+							form.setValue("totalWomen", womenValue);
+							form.setValue("totalMen", menValue);
+							setWomenRaw(String(womenValue));
+							setMenRaw(String(menValue));
+							setField({ totalWomen: womenValue, totalMen: menValue });
+						}}
+						title={
+							<h1 className="fr-h4 fr-mb-0">
+								Déclaration des indicateurs de rémunération {declarationYear}
+							</h1>
+						}
+					/>
 
-				<StepIndicator currentStep={1} />
+					<StepIndicator currentStep={1} />
 
-				<div className={common.flexColumnGap1}>
-					<p className="fr-mb-0">
-						Période de référence pour le calcul des indicateurs : 01/01/2026 -
-						31/12/2026.
-						<TooltipButton
-							id="tooltip-period"
-							label="Information sur la période de référence"
-							text="Pour les entreprises créées en cours d'année, cette période correspond à la durée d'activité effective depuis la date de création jusqu'au 31/12/2026."
-						/>
-					</p>
+					<div className={common.flexColumnGap1}>
+						<p className="fr-mb-0">
+							Période de référence pour le calcul des indicateurs : 01/01/2026 -
+							31/12/2026.
+							<TooltipButton
+								id="tooltip-period"
+								label="Information sur la période de référence"
+								text="Pour les entreprises créées en cours d'année, cette période correspond à la durée d'activité effective depuis la date de création jusqu'au 31/12/2026."
+							/>
+						</p>
 
-					<p className={`fr-mb-0 ${common.fontMedium}`}>
-						{isPrefilled
-							? "Vérifiez les informations préremplies à partir de vos données DSN et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
-							: "Renseignez l'effectif physique de votre entreprise."}
-						<TooltipButton
-							id="tooltip-workforce"
-							label="Information sur les effectifs"
-							text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
-						/>
-					</p>
+						<p className={`fr-mb-0 ${common.fontMedium}`}>
+							{isPrefilled
+								? "Vérifiez les informations préremplies à partir de vos données DSN et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
+								: "Renseignez l'effectif physique de votre entreprise."}
+							<TooltipButton
+								id="tooltip-workforce"
+								label="Information sur les effectifs"
+								text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
+							/>
+						</p>
 
-					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
-				</div>
+						<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
+					</div>
 
-				<div className={common.dataSection}>
-					<div className={common.flexColumnGapHalf}>
-						<div
-							className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.workforceTable}`}
-						>
-							<div className="fr-table__wrapper">
-								<div className="fr-table__container">
-									<div className="fr-table__content">
-										<table>
-											<caption>
-												Effectifs physiques pris en compte pour le calcul des
-												indicateurs
-											</caption>
-											<colgroup>
-												<col className={styles.labelCol} />
-												<col className={styles.inputCol} />
-												<col className={styles.inputCol} />
-												<col className={styles.totalCol} />
-											</colgroup>
-											<thead>
-												<tr>
-													<th scope="col">{/* vide */}</th>
-													<th scope="col">Femmes</th>
-													<th scope="col">Hommes</th>
-													<th scope="col">Total</th>
-												</tr>
-											</thead>
-											<tbody>
-												<tr>
-													<td>
-														<strong>Nombre de salariés</strong>
-													</td>
-													<td>
-														<div
-															className={
-																womenError
-																	? "fr-input-group fr-input-group--error"
-																	: "fr-input-group"
-															}
-														>
-															<input
-																aria-describedby={
-																	womenError ? "women-error" : undefined
+					<div className={common.dataSection}>
+						<div className={common.flexColumnGapHalf}>
+							<div
+								className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.workforceTable}`}
+							>
+								<div className="fr-table__wrapper">
+									<div className="fr-table__container">
+										<div className="fr-table__content">
+											<table>
+												<caption>
+													Effectifs physiques pris en compte pour le calcul des
+													indicateurs
+												</caption>
+												<colgroup>
+													<col className={styles.labelCol} />
+													<col className={styles.inputCol} />
+													<col className={styles.inputCol} />
+													<col className={styles.totalCol} />
+												</colgroup>
+												<thead>
+													<tr>
+														<th scope="col">{/* vide */}</th>
+														<th scope="col">Femmes</th>
+														<th scope="col">Hommes</th>
+														<th scope="col">Total</th>
+													</tr>
+												</thead>
+												<tbody>
+													<tr>
+														<td>
+															<strong>Nombre de salariés</strong>
+														</td>
+														<td>
+															<div
+																className={
+																	womenError
+																		? "fr-input-group fr-input-group--error"
+																		: "fr-input-group"
 																}
-																aria-invalid={womenError ? true : undefined}
-																aria-label="Nombre de femmes"
-																className={`fr-input ${common.numericInput}${womenError ? "fr-input--error" : ""}`}
-																disabled={isImpersonating}
-																inputMode="numeric"
-																onChange={handleWomenChange}
-																pattern="[0-9]*"
-																type="text"
-																value={womenRaw}
-															/>
-															{womenError && (
-																<p className="fr-error-text" id="women-error">
-																	{womenError}
-																</p>
-															)}
-														</div>
-													</td>
-													<td>
-														<div
-															className={
-																menError
-																	? "fr-input-group fr-input-group--error"
-																	: "fr-input-group"
-															}
-														>
-															<input
-																aria-describedby={
-																	menError ? "men-error" : undefined
+															>
+																<input
+																	aria-describedby={
+																		womenError ? "women-error" : undefined
+																	}
+																	aria-invalid={womenError ? true : undefined}
+																	aria-label="Nombre de femmes"
+																	className={`fr-input ${common.numericInput}${womenError ? "fr-input--error" : ""}`}
+																	disabled={isImpersonating}
+																	inputMode="numeric"
+																	onChange={handleWomenChange}
+																	pattern="[0-9]*"
+																	type="text"
+																	value={womenRaw}
+																/>
+																{womenError && (
+																	<p className="fr-error-text" id="women-error">
+																		{womenError}
+																	</p>
+																)}
+															</div>
+														</td>
+														<td>
+															<div
+																className={
+																	menError
+																		? "fr-input-group fr-input-group--error"
+																		: "fr-input-group"
 																}
-																aria-invalid={menError ? true : undefined}
-																aria-label="Nombre d'hommes"
-																className={`fr-input ${common.numericInput}${menError ? "fr-input--error" : ""}`}
-																disabled={isImpersonating}
-																inputMode="numeric"
-																onChange={handleMenChange}
-																pattern="[0-9]*"
-																type="text"
-																value={menRaw}
-															/>
-															{menError && (
-																<p className="fr-error-text" id="men-error">
-																	{menError}
-																</p>
-															)}
-														</div>
-													</td>
-													<td>
-														<strong>{total}</strong>
-													</td>
-												</tr>
-											</tbody>
-										</table>
+															>
+																<input
+																	aria-describedby={
+																		menError ? "men-error" : undefined
+																	}
+																	aria-invalid={menError ? true : undefined}
+																	aria-label="Nombre d'hommes"
+																	className={`fr-input ${common.numericInput}${menError ? "fr-input--error" : ""}`}
+																	disabled={isImpersonating}
+																	inputMode="numeric"
+																	onChange={handleMenChange}
+																	pattern="[0-9]*"
+																	type="text"
+																	value={menRaw}
+																/>
+																{menError && (
+																	<p className="fr-error-text" id="men-error">
+																		{menError}
+																	</p>
+																)}
+															</div>
+														</td>
+														<td>
+															<strong>{total}</strong>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+										</div>
 									</div>
 								</div>
 							</div>
+
+							{isPrefilled && (
+								<PrefillSource periodEnd={gipPrefillData.periodEnd} />
+							)}
+
+							{showResetWarning && <PrefillResetWarning />}
 						</div>
 
-						{isPrefilled && (
-							<PrefillSource periodEnd={gipPrefillData.periodEnd} />
-						)}
-
-						{showResetWarning && <PrefillResetWarning />}
+						<DefinitionAccordion
+							id="accordion-step1"
+							title="Définitions et méthode de calcul"
+						>
+							<div className="fr-callout">
+								<p>Les informations affichées incluront notamment&nbsp;:</p>
+								<ul>
+									<li>Dernière situation connue&nbsp;?</li>
+									<li>Effectif physique moyen&nbsp;?</li>
+									<li>
+										Comment sont intégrés les salariés entrés et sortis&nbsp;?
+									</li>
+									<li>
+										Comment sont traités les changements de situation (ex.
+										passage du temps plein au temps partiel)&nbsp;?
+									</li>
+									<li>
+										Les absences de six mois ou plus, continues ou discontinues,
+										sont-elles exclues du calcul&nbsp;?
+									</li>
+									<li>
+										Comment sont prises en compte les absences de trois mois,
+										avec leur recalcul en équivalent temps plein (ETP)&nbsp;?
+									</li>
+									<li>
+										Le détail des règles de calcul, illustré par des exemples
+										concrets selon les types de salariés&nbsp;? (Salariés à
+										prendre en compte / Salariés à exclure)
+									</li>
+								</ul>
+							</div>
+						</DefinitionAccordion>
 					</div>
 
-					<DefinitionAccordion
-						id="accordion-step1"
-						title="Définitions et méthode de calcul"
-					>
-						<div className="fr-callout">
-							<p>Les informations affichées incluront notamment&nbsp;:</p>
-							<ul>
-								<li>Dernière situation connue&nbsp;?</li>
-								<li>Effectif physique moyen&nbsp;?</li>
-								<li>
-									Comment sont intégrés les salariés entrés et sortis&nbsp;?
-								</li>
-								<li>
-									Comment sont traités les changements de situation (ex. passage
-									du temps plein au temps partiel)&nbsp;?
-								</li>
-								<li>
-									Les absences de six mois ou plus, continues ou discontinues,
-									sont-elles exclues du calcul&nbsp;?
-								</li>
-								<li>
-									Comment sont prises en compte les absences de trois mois, avec
-									leur recalcul en équivalent temps plein (ETP)&nbsp;?
-								</li>
-								<li>
-									Le détail des règles de calcul, illustré par des exemples
-									concrets selon les types de salariés&nbsp;? (Salariés à
-									prendre en compte / Salariés à exclure)
-								</li>
-							</ul>
-						</div>
-					</DefinitionAccordion>
-				</div>
+					<FormErrors
+						mutationError={mutation.error?.message}
+						validationError={validationError}
+					/>
 
-				<FormErrors
-					mutationError={mutation.error?.message}
-					validationError={validationError}
-				/>
-
-				<FormActions
-					className="fr-mt-0"
-					isSubmitting={mutation.isPending}
-					mimoquageNextHref={
-						hasInitialData ? "/declaration-remuneration/etape/2" : undefined
-					}
-					previousHref="/"
-				/>
+					<FormActions
+						className="fr-mt-0"
+						isSubmitting={mutation.isPending}
+						mimoquageNextHref={
+							hasInitialData ? "/declaration-remuneration/etape/2" : undefined
+						}
+						previousHref="/"
+					/>
+				</fieldset>
 			</form>
 			<PrefillResetConfirmDialog
 				dialogRef={dialogRef}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -26,6 +26,7 @@ import { StepTitleRow } from "../shared/StepTitleRow";
 import { TooltipButton } from "../shared/TooltipButton";
 import type { Step1Data } from "../types";
 import styles from "./Step1Workforce.module.scss";
+import { Step1WorkforceDefinition } from "./Step1WorkforceDefinition";
 
 type Step1WorkforceProps = {
 	declarationSiren: string;
@@ -355,33 +356,7 @@ export function Step1Workforce({
 							id="accordion-step1"
 							title="Définitions et méthode de calcul"
 						>
-							<div className="fr-callout">
-								<p>Les informations affichées incluront notamment&nbsp;:</p>
-								<ul>
-									<li>Dernière situation connue&nbsp;?</li>
-									<li>Effectif physique moyen&nbsp;?</li>
-									<li>
-										Comment sont intégrés les salariés entrés et sortis&nbsp;?
-									</li>
-									<li>
-										Comment sont traités les changements de situation (ex.
-										passage du temps plein au temps partiel)&nbsp;?
-									</li>
-									<li>
-										Les absences de six mois ou plus, continues ou discontinues,
-										sont-elles exclues du calcul&nbsp;?
-									</li>
-									<li>
-										Comment sont prises en compte les absences de trois mois,
-										avec leur recalcul en équivalent temps plein (ETP)&nbsp;?
-									</li>
-									<li>
-										Le détail des règles de calcul, illustré par des exemples
-										concrets selon les types de salariés&nbsp;? (Salariés à
-										prendre en compte / Salariés à exclure)
-									</li>
-								</ul>
-							</div>
+							<Step1WorkforceDefinition />
 						</DefinitionAccordion>
 					</div>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1WorkforceDefinition.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1WorkforceDefinition.tsx
@@ -1,0 +1,29 @@
+export function Step1WorkforceDefinition() {
+	return (
+		<div className="fr-callout">
+			<p>Les informations affichées incluront notamment&nbsp;:</p>
+			<ul>
+				<li>Dernière situation connue&nbsp;?</li>
+				<li>Effectif physique moyen&nbsp;?</li>
+				<li>Comment sont intégrés les salariés entrés et sortis&nbsp;?</li>
+				<li>
+					Comment sont traités les changements de situation (ex. passage du
+					temps plein au temps partiel)&nbsp;?
+				</li>
+				<li>
+					Les absences de six mois ou plus, continues ou discontinues,
+					sont-elles exclues du calcul&nbsp;?
+				</li>
+				<li>
+					Comment sont prises en compte les absences de trois mois, avec leur
+					recalcul en équivalent temps plein (ETP)&nbsp;?
+				</li>
+				<li>
+					Le détail des règles de calcul, illustré par des exemples concrets
+					selon les types de salariés&nbsp;? (Salariés à prendre en compte /
+					Salariés à exclure)
+				</li>
+			</ul>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -21,6 +21,7 @@ import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
 import { gipToStep2 } from "../shared/gipToStepData";
 import { getStep2FieldName, step2ToRows } from "../shared/indicatorRowMapping";
+import { useLockContext } from "../shared/lock/LockContext";
 import { PayGapTable } from "../shared/PayGapTable";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
@@ -43,6 +44,7 @@ export function Step2PayGap({
 }: Step2PayGapProps) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const { isReadOnly } = useLockContext();
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
 	const rawDefaults = hasSavedData
@@ -89,7 +91,7 @@ export function Step2PayGap({
 		});
 	});
 
-	useDraftAutoSave(form, draftHydrated, (values) =>
+	useDraftAutoSave(form, draftHydrated && !isReadOnly, (values) =>
 		setField(values as Step2Data),
 	);
 
@@ -134,121 +136,124 @@ export function Step2PayGap({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			<StepTitleRow
-				hasData={hasData}
-				isPendingSave={isPendingSave}
-				isSaving={isSaving}
-				onDevFill={() => {
-					DEV_STEP2_ROWS.forEach((row, i) => {
-						const womenField = getStep2FieldName(i, "womenValue");
-						const menField = getStep2FieldName(i, "menValue");
-						form.setValue(womenField, padDecimalToTwo(row.womenValue));
-						form.setValue(menField, padDecimalToTwo(row.menValue));
-					});
-				}}
-				title={
-					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {declarationYear}
-					</h1>
-				}
-			/>
+			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<StepTitleRow
+					hasData={hasData}
+					isPendingSave={isPendingSave}
+					isSaving={isSaving}
+					onDevFill={() => {
+						DEV_STEP2_ROWS.forEach((row, i) => {
+							const womenField = getStep2FieldName(i, "womenValue");
+							const menField = getStep2FieldName(i, "menValue");
+							form.setValue(womenField, padDecimalToTwo(row.womenValue));
+							form.setValue(menField, padDecimalToTwo(row.menValue));
+						});
+					}}
+					title={
+						<h1 className="fr-h4 fr-mb-0">
+							Déclaration des indicateurs de rémunération {declarationYear}
+						</h1>
+					}
+				/>
 
-			<StepIndicator currentStep={2} />
+				<StepIndicator currentStep={2} />
 
-			<div className={common.flexColumnGap1}>
-				<p className="fr-mb-0">
-					Ces indicateurs mesurent la différence de rémunération, moyenne et
-					médiane, entre les femmes et les hommes, exprimée en pourcentage du
-					salaire masculin correspondant. Ils couvrent l&apos;ensemble de la
-					rémunération : la partie fixe ainsi que les composantes variables ou
-					complémentaires.
-				</p>
+				<div className={common.flexColumnGap1}>
+					<p className="fr-mb-0">
+						Ces indicateurs mesurent la différence de rémunération, moyenne et
+						médiane, entre les femmes et les hommes, exprimée en pourcentage du
+						salaire masculin correspondant. Ils couvrent l&apos;ensemble de la
+						rémunération : la partie fixe ainsi que les composantes variables ou
+						complémentaires.
+					</p>
 
-				<p className={`fr-mb-0 ${common.fontMedium}`}>
-					{gipPrefillData
-						? "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
-						: "Renseignez les informations avant de valider vos indicateurs."}
-					{!gipPrefillData && (
-						<TooltipButton
-							id="tooltip-step2-info"
-							label="Information sur la confidentialité des données"
-							text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
-						/>
-					)}
-				</p>
+					<p className={`fr-mb-0 ${common.fontMedium}`}>
+						{gipPrefillData
+							? "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs (en cas d'erreur, pensez à corriger votre DSN)."
+							: "Renseignez les informations avant de valider vos indicateurs."}
+						{!gipPrefillData && (
+							<TooltipButton
+								id="tooltip-step2-info"
+								label="Information sur la confidentialité des données"
+								text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
+							/>
+						)}
+					</p>
 
-				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
-			</div>
-
-			<div className={common.dataSection}>
-				<div className={common.flexColumnGapHalf}>
-					<PayGapTable
-						caption="Écart de rémunération"
-						columnHeader="Rémunération"
-						disabled={isImpersonating}
-						onRowChange={handleRowChange}
-						rows={rows}
-					/>
-
-					{gipPrefillData && (
-						<PrefillSource
-							periodEnd={gipPrefillData.periodEnd}
-							tooltipId="tooltip-source-step2"
-						/>
-					)}
+					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 				</div>
 
-				<DefinitionAccordion
-					id="accordion-step2"
-					title="Définitions et méthode de calcul"
-				>
-					<div className="fr-callout">
-						<ul>
-							<li>
-								Quelles composantes variables ou complémentaires sont incluses
-								dans le calcul (ex. prime de cooptation, prime d&apos;astreinte,
-								prime d&apos;avancement) et avec quel niveau de détail&nbsp;?
-							</li>
-							<li>
-								Comment les rémunérations sont-elles reconstituées à partir des
-								données disponibles&nbsp;?
-							</li>
-							<li>
-								Comment expliquer l&apos;écart entre les pourcentages annuels et
-								horaires (ex. ×12 = annuel)&nbsp;?
-							</li>
-							<li>
-								Les données seraient-elles plus pertinentes en mensuel
-								brut&nbsp;?
-							</li>
-							<li>
-								Comment sont traitées les spécificités des UES, notamment
-								lorsque&nbsp;:
-							</li>
-							<li>
-								les salariés n&apos;ont pas tous le même nombre d&apos;heures
-								pour un équivalent temps plein, certains salariés sont au
-								forfait jours&nbsp;?
-							</li>
-						</ul>
+				<div className={common.dataSection}>
+					<div className={common.flexColumnGapHalf}>
+						<PayGapTable
+							caption="Écart de rémunération"
+							columnHeader="Rémunération"
+							disabled={isImpersonating}
+							onRowChange={handleRowChange}
+							rows={rows}
+						/>
+
+						{gipPrefillData && (
+							<PrefillSource
+								periodEnd={gipPrefillData.periodEnd}
+								tooltipId="tooltip-source-step2"
+							/>
+						)}
 					</div>
-				</DefinitionAccordion>
-			</div>
 
-			<GapInterpretationCallout rows={rows} />
+					<DefinitionAccordion
+						id="accordion-step2"
+						title="Définitions et méthode de calcul"
+					>
+						<div className="fr-callout">
+							<ul>
+								<li>
+									Quelles composantes variables ou complémentaires sont incluses
+									dans le calcul (ex. prime de cooptation, prime
+									d&apos;astreinte, prime d&apos;avancement) et avec quel niveau
+									de détail&nbsp;?
+								</li>
+								<li>
+									Comment les rémunérations sont-elles reconstituées à partir
+									des données disponibles&nbsp;?
+								</li>
+								<li>
+									Comment expliquer l&apos;écart entre les pourcentages annuels
+									et horaires (ex. ×12 = annuel)&nbsp;?
+								</li>
+								<li>
+									Les données seraient-elles plus pertinentes en mensuel
+									brut&nbsp;?
+								</li>
+								<li>
+									Comment sont traitées les spécificités des UES, notamment
+									lorsque&nbsp;:
+								</li>
+								<li>
+									les salariés n&apos;ont pas tous le même nombre d&apos;heures
+									pour un équivalent temps plein, certains salariés sont au
+									forfait jours&nbsp;?
+								</li>
+							</ul>
+						</div>
+					</DefinitionAccordion>
+				</div>
 
-			<FormErrors
-				mutationError={mutation.error?.message}
-				validationError={validationError}
-			/>
+				<GapInterpretationCallout rows={rows} />
 
-			<FormActions
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					hasSavedData ? "/declaration-remuneration/etape/3" : undefined
-				}
-				previousHref="/declaration-remuneration/etape/1"
-			/>
+				<FormErrors
+					mutationError={mutation.error?.message}
+					validationError={validationError}
+				/>
+
+				<FormActions
+					isSubmitting={mutation.isPending}
+					mimoquageNextHref={
+						hasSavedData ? "/declaration-remuneration/etape/3" : undefined
+					}
+					previousHref="/declaration-remuneration/etape/1"
+				/>
+			</fieldset>
 		</form>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -28,6 +28,7 @@ import { GapInterpretationCallout } from "../shared/GapInterpretationCallout";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
 import { gipToStep3 } from "../shared/gipToStepData";
 import { getStep3FieldName, step3ToRows } from "../shared/indicatorRowMapping";
+import { useLockContext } from "../shared/lock/LockContext";
 import { PayGapTable } from "../shared/PayGapTable";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
@@ -65,6 +66,7 @@ export function Step3VariablePay({
 }: Step3VariablePayProps) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const { isReadOnly } = useLockContext();
 
 	const hasSavedData = Object.values(initialData).some((v) => v !== "");
 
@@ -101,7 +103,7 @@ export function Step3VariablePay({
 		});
 	});
 
-	useDraftAutoSave(form, draftHydrated, (values) =>
+	useDraftAutoSave(form, draftHydrated && !isReadOnly, (values) =>
 		setField(values as Step3Data),
 	);
 
@@ -175,245 +177,248 @@ export function Step3VariablePay({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			<StepTitleRow
-				hasData={hasData}
-				isPendingSave={isPendingSave}
-				isSaving={isSaving}
-				onDevFill={() => {
-					DEV_STEP3_ROWS.forEach((row, i) => {
-						const womenField = getStep3FieldName(i, "womenValue");
-						const menField = getStep3FieldName(i, "menValue");
-						form.setValue(womenField, padDecimalToTwo(row.womenValue));
-						form.setValue(menField, padDecimalToTwo(row.menValue));
-					});
-					form.setValue("indicatorEWomen", DEV_STEP3_BENEFICIARY_WOMEN);
-					form.setValue("indicatorEMen", DEV_STEP3_BENEFICIARY_MEN);
-				}}
-				title={
-					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {declarationYear}
-					</h1>
-				}
-			/>
+			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<StepTitleRow
+					hasData={hasData}
+					isPendingSave={isPendingSave}
+					isSaving={isSaving}
+					onDevFill={() => {
+						DEV_STEP3_ROWS.forEach((row, i) => {
+							const womenField = getStep3FieldName(i, "womenValue");
+							const menField = getStep3FieldName(i, "menValue");
+							form.setValue(womenField, padDecimalToTwo(row.womenValue));
+							form.setValue(menField, padDecimalToTwo(row.menValue));
+						});
+						form.setValue("indicatorEWomen", DEV_STEP3_BENEFICIARY_WOMEN);
+						form.setValue("indicatorEMen", DEV_STEP3_BENEFICIARY_MEN);
+					}}
+					title={
+						<h1 className="fr-h4 fr-mb-0">
+							Déclaration des indicateurs de rémunération {declarationYear}
+						</h1>
+					}
+				/>
 
-			<StepIndicator currentStep={3} />
+				<StepIndicator currentStep={3} />
 
-			<div className={common.flexColumnGap1}>
-				<p className="fr-mb-0">
-					Ces indicateurs évaluent et comparent les rémunérations variables
-					(primes, bonus, avantages…) entre les femmes et les hommes. Ils
-					mesurent à la fois l&apos;écart moyen et médian des montants perçus
-					ainsi que la proportion de femmes et d&apos;hommes bénéficiant de ces
-					rémunérations.
-				</p>
+				<div className={common.flexColumnGap1}>
+					<p className="fr-mb-0">
+						Ces indicateurs évaluent et comparent les rémunérations variables
+						(primes, bonus, avantages…) entre les femmes et les hommes. Ils
+						mesurent à la fois l&apos;écart moyen et médian des montants perçus
+						ainsi que la proportion de femmes et d&apos;hommes bénéficiant de
+						ces rémunérations.
+					</p>
 
-				<p className={`fr-mb-0 ${common.fontMedium}`}>
-					{gipPrefillData
-						? "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs."
-						: "Renseignez les informations avant de valider vos indicateurs."}
-					{!gipPrefillData && (
-						<TooltipButton
-							id="tooltip-step3-info"
-							label="Information sur la confidentialité des données"
-							text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
-						/>
-					)}
-				</p>
+					<p className={`fr-mb-0 ${common.fontMedium}`}>
+						{gipPrefillData
+							? "Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs."
+							: "Renseignez les informations avant de valider vos indicateurs."}
+						{!gipPrefillData && (
+							<TooltipButton
+								id="tooltip-step3-info"
+								label="Information sur la confidentialité des données"
+								text="Les informations saisies sont confidentielles et utilisées uniquement pour le calcul des indicateurs d'égalité professionnelle."
+							/>
+						)}
+					</p>
 
-				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
-			</div>
-
-			<div className={common.dataSection}>
-				<div className={common.flexColumnGapHalf}>
-					<PayGapTable
-						caption="Écart de rémunération variable ou complémentaire"
-						className={stepStyles.payGapTable}
-						columnHeader={
-							<>
-								Rémunération variable
-								<br />
-								ou complémentaire
-							</>
-						}
-						disabled={isImpersonating}
-						onRowChange={handleRowChange}
-						rows={rows}
-					/>
-
-					{gipPrefillData && (
-						<PrefillSource
-							periodEnd={gipPrefillData.periodEnd}
-							tooltipId="tooltip-source-step3-paygap"
-						/>
-					)}
+					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 				</div>
 
-				<div className={common.flexColumnGapHalf}>
-					<div
-						className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}
-					>
-						<div className="fr-table__wrapper">
-							<div className="fr-table__container">
-								<div className="fr-table__content">
-									<table>
-										<caption>
-											Bénéficiaires de composantes variables ou complémentaires
-										</caption>
-										<colgroup>
-											<col className={stepStyles.colSex} />
-											<col className={stepStyles.colCount} />
-											<col className={stepStyles.colCount} />
-											<col />
-										</colgroup>
-										<thead>
-											<tr>
-												<th scope="col">Sexe</th>
-												<th scope="col">
-													Total de salariés
-													{maxWomen !== undefined && maxMen !== undefined
-														? ` : ${maxWomen + maxMen}`
-														: ""}
-												</th>
-												<th scope="col">
-													Bénéficiaires de composantes
-													<br />
-													variables ou complémentaires
-												</th>
-												<th scope="col">Proportion</th>
-											</tr>
-										</thead>
-										<tbody>
-											<tr>
-												<td>
-													<strong>Femmes</strong>
-												</td>
-												<td className="fr-cell--right">
-													<strong>{maxWomen ?? "-"}</strong>
-												</td>
-												<td>
-													<input
-														aria-label="Bénéficiaires femmes"
-														className={`fr-input ${common.numericInput}`}
-														disabled={isImpersonating}
-														inputMode="numeric"
-														onChange={(e) =>
-															handleBenefChange(
-																"indicatorEWomen",
-																maxWomen,
-																e.target.value,
-															)
-														}
-														pattern="[0-9]*"
-														type="text"
-														value={beneficiaryWomen}
-													/>
-												</td>
-												<td className="fr-cell--right">
-													<strong>
-														{computeProportion(beneficiaryWomen, maxWomen)}
-													</strong>
-												</td>
-											</tr>
-											<tr>
-												<td>
-													<strong>Hommes</strong>
-												</td>
-												<td className="fr-cell--right">
-													<strong>{maxMen ?? "-"}</strong>
-												</td>
-												<td>
-													<input
-														aria-label="Bénéficiaires hommes"
-														className={`fr-input ${common.numericInput}`}
-														disabled={isImpersonating}
-														inputMode="numeric"
-														onChange={(e) =>
-															handleBenefChange(
-																"indicatorEMen",
-																maxMen,
-																e.target.value,
-															)
-														}
-														pattern="[0-9]*"
-														type="text"
-														value={beneficiaryMen}
-													/>
-												</td>
-												<td className="fr-cell--right">
-													<strong>
-														{computeProportion(beneficiaryMen, maxMen)}
-													</strong>
-												</td>
-											</tr>
-										</tbody>
-									</table>
+				<div className={common.dataSection}>
+					<div className={common.flexColumnGapHalf}>
+						<PayGapTable
+							caption="Écart de rémunération variable ou complémentaire"
+							className={stepStyles.payGapTable}
+							columnHeader={
+								<>
+									Rémunération variable
+									<br />
+									ou complémentaire
+								</>
+							}
+							disabled={isImpersonating}
+							onRowChange={handleRowChange}
+							rows={rows}
+						/>
+
+						{gipPrefillData && (
+							<PrefillSource
+								periodEnd={gipPrefillData.periodEnd}
+								tooltipId="tooltip-source-step3-paygap"
+							/>
+						)}
+					</div>
+
+					<div className={common.flexColumnGapHalf}>
+						<div
+							className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}
+						>
+							<div className="fr-table__wrapper">
+								<div className="fr-table__container">
+									<div className="fr-table__content">
+										<table>
+											<caption>
+												Bénéficiaires de composantes variables ou
+												complémentaires
+											</caption>
+											<colgroup>
+												<col className={stepStyles.colSex} />
+												<col className={stepStyles.colCount} />
+												<col className={stepStyles.colCount} />
+												<col />
+											</colgroup>
+											<thead>
+												<tr>
+													<th scope="col">Sexe</th>
+													<th scope="col">
+														Total de salariés
+														{maxWomen !== undefined && maxMen !== undefined
+															? ` : ${maxWomen + maxMen}`
+															: ""}
+													</th>
+													<th scope="col">
+														Bénéficiaires de composantes
+														<br />
+														variables ou complémentaires
+													</th>
+													<th scope="col">Proportion</th>
+												</tr>
+											</thead>
+											<tbody>
+												<tr>
+													<td>
+														<strong>Femmes</strong>
+													</td>
+													<td className="fr-cell--right">
+														<strong>{maxWomen ?? "-"}</strong>
+													</td>
+													<td>
+														<input
+															aria-label="Bénéficiaires femmes"
+															className={`fr-input ${common.numericInput}`}
+															disabled={isImpersonating}
+															inputMode="numeric"
+															onChange={(e) =>
+																handleBenefChange(
+																	"indicatorEWomen",
+																	maxWomen,
+																	e.target.value,
+																)
+															}
+															pattern="[0-9]*"
+															type="text"
+															value={beneficiaryWomen}
+														/>
+													</td>
+													<td className="fr-cell--right">
+														<strong>
+															{computeProportion(beneficiaryWomen, maxWomen)}
+														</strong>
+													</td>
+												</tr>
+												<tr>
+													<td>
+														<strong>Hommes</strong>
+													</td>
+													<td className="fr-cell--right">
+														<strong>{maxMen ?? "-"}</strong>
+													</td>
+													<td>
+														<input
+															aria-label="Bénéficiaires hommes"
+															className={`fr-input ${common.numericInput}`}
+															disabled={isImpersonating}
+															inputMode="numeric"
+															onChange={(e) =>
+																handleBenefChange(
+																	"indicatorEMen",
+																	maxMen,
+																	e.target.value,
+																)
+															}
+															pattern="[0-9]*"
+															type="text"
+															value={beneficiaryMen}
+														/>
+													</td>
+													<td className="fr-cell--right">
+														<strong>
+															{computeProportion(beneficiaryMen, maxMen)}
+														</strong>
+													</td>
+												</tr>
+											</tbody>
+										</table>
+									</div>
 								</div>
 							</div>
 						</div>
+
+						{benefValidationError && (
+							<div
+								aria-live="polite"
+								className="fr-alert fr-alert--error fr-alert--sm"
+							>
+								<p>{benefValidationError}</p>
+							</div>
+						)}
+
+						{gipPrefillData && (
+							<PrefillSource
+								periodEnd={gipPrefillData.periodEnd}
+								tooltipId="tooltip-source-step3"
+							/>
+						)}
 					</div>
 
-					{benefValidationError && (
-						<div
-							aria-live="polite"
-							className="fr-alert fr-alert--error fr-alert--sm"
-						>
-							<p>{benefValidationError}</p>
+					<DefinitionAccordion
+						id="accordion-step3"
+						title="Définitions et méthode de calcul"
+					>
+						<div className="fr-callout">
+							<ul>
+								<li>
+									Quelles composantes de la rémunération sont incluses dans le
+									calcul (ex. véhicule de fonction, repas, prime de
+									participation, etc.)&nbsp;?
+								</li>
+								<li>
+									Les bons codes rubrique DSN sont-ils bien utilisés pour
+									chacune de ces composantes&nbsp;?
+								</li>
+								<li>
+									Comment vérifier ou identifier les codes DSN associés aux
+									éléments de rémunération pris en compte&nbsp;?
+								</li>
+							</ul>
 						</div>
-					)}
-
-					{gipPrefillData && (
-						<PrefillSource
-							periodEnd={gipPrefillData.periodEnd}
-							tooltipId="tooltip-source-step3"
-						/>
-					)}
+					</DefinitionAccordion>
 				</div>
 
-				<DefinitionAccordion
-					id="accordion-step3"
-					title="Définitions et méthode de calcul"
-				>
-					<div className="fr-callout">
-						<ul>
-							<li>
-								Quelles composantes de la rémunération sont incluses dans le
-								calcul (ex. véhicule de fonction, repas, prime de participation,
-								etc.)&nbsp;?
-							</li>
-							<li>
-								Les bons codes rubrique DSN sont-ils bien utilisés pour chacune
-								de ces composantes&nbsp;?
-							</li>
-							<li>
-								Comment vérifier ou identifier les codes DSN associés aux
-								éléments de rémunération pris en compte&nbsp;?
-							</li>
-						</ul>
-					</div>
-				</DefinitionAccordion>
-			</div>
+				<GapInterpretationCallout
+					beneficiaryMen={beneficiaryMen}
+					beneficiaryWomen={beneficiaryWomen}
+					maxMen={maxMen}
+					maxWomen={maxWomen}
+					rows={rows}
+					variant="variablePay"
+				/>
 
-			<GapInterpretationCallout
-				beneficiaryMen={beneficiaryMen}
-				beneficiaryWomen={beneficiaryWomen}
-				maxMen={maxMen}
-				maxWomen={maxWomen}
-				rows={rows}
-				variant="variablePay"
-			/>
+				<FormErrors
+					mutationError={mutation.error?.message}
+					validationError={validationError}
+				/>
 
-			<FormErrors
-				mutationError={mutation.error?.message}
-				validationError={validationError}
-			/>
-
-			<FormActions
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					hasSavedData ? "/declaration-remuneration/etape/4" : undefined
-				}
-				previousHref="/declaration-remuneration/etape/2"
-			/>
+				<FormActions
+					isSubmitting={mutation.isPending}
+					mimoquageNextHref={
+						hasSavedData ? "/declaration-remuneration/etape/4" : undefined
+					}
+					previousHref="/declaration-remuneration/etape/2"
+				/>
+			</fieldset>
 		</form>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -7,6 +7,7 @@ import { normalizeDecimalInput, padDecimalToTwo } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import { updateStep4Schema } from "../schemas";
+import common from "../shared/common.module.scss";
 import { DefinitionAccordion } from "../shared/DefinitionAccordion";
 import { DEV_STEP4_ANNUAL, DEV_STEP4_HOURLY } from "../shared/devFillData";
 import { DraftLoadingState } from "../shared/draft/DraftLoadingState";
@@ -16,6 +17,7 @@ import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
+import { useLockContext } from "../shared/lock/LockContext";
 import { PrefillSource } from "../shared/PrefillSource";
 import { StepIndicator } from "../shared/StepIndicator";
 import { StepTitleRow } from "../shared/StepTitleRow";
@@ -66,6 +68,7 @@ export function Step4QuartileDistribution({
 }: Step4QuartileDistributionProps) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const { isReadOnly } = useLockContext();
 	const alertRef = useRef<HTMLDivElement | null>(null);
 
 	const hasSavedData =
@@ -132,7 +135,7 @@ export function Step4QuartileDistribution({
 		if (d.hourly) form.setValue("hourly", d.hourly);
 	});
 
-	useDraftAutoSave(form, draftHydrated, (values) =>
+	useDraftAutoSave(form, draftHydrated && !isReadOnly, (values) =>
 		setField({
 			annual: values.annual as QuartileTuple,
 			hourly: values.hourly as QuartileTuple,
@@ -258,157 +261,159 @@ export function Step4QuartileDistribution({
 			noValidate
 			onSubmit={onSubmit}
 		>
-			<StepTitleRow
-				hasData={hasData}
-				isPendingSave={isPendingSave}
-				isSaving={isSaving}
-				onDevFill={() => {
-					form.setValue(
-						"annual",
-						padThresholds(
-							DEV_STEP4_ANNUAL.map(toQuartileData) as QuartileTuple,
-						),
-					);
-					form.setValue(
-						"hourly",
-						padThresholds(
-							DEV_STEP4_HOURLY.map(toQuartileData) as QuartileTuple,
-						),
-					);
-					setFieldErrors(emptyErrorMap());
-					setShowRecap(false);
-				}}
-				title={
-					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {declarationYear}
-					</h1>
-				}
-			/>
+			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<StepTitleRow
+					hasData={hasData}
+					isPendingSave={isPendingSave}
+					isSaving={isSaving}
+					onDevFill={() => {
+						form.setValue(
+							"annual",
+							padThresholds(
+								DEV_STEP4_ANNUAL.map(toQuartileData) as QuartileTuple,
+							),
+						);
+						form.setValue(
+							"hourly",
+							padThresholds(
+								DEV_STEP4_HOURLY.map(toQuartileData) as QuartileTuple,
+							),
+						);
+						setFieldErrors(emptyErrorMap());
+						setShowRecap(false);
+					}}
+					title={
+						<h1 className="fr-h4 fr-mb-0">
+							Déclaration des indicateurs de rémunération {declarationYear}
+						</h1>
+					}
+				/>
 
-			<StepIndicator currentStep={4} />
+				<StepIndicator currentStep={4} />
 
-			<div className={stepStyles.instructions}>
-				<p className="fr-mb-0">
-					Cet indicateur répartit l&apos;ensemble des salariés en quatre groupes
-					de rémunération appelés quartiles&nbsp;: du quartile inférieur qui
-					regroupe les salariés les moins rémunérés, au quartile supérieur qui
-					rassemble les salariés les mieux rémunérés.
-				</p>
+				<div className={stepStyles.instructions}>
+					<p className="fr-mb-0">
+						Cet indicateur répartit l&apos;ensemble des salariés en quatre
+						groupes de rémunération appelés quartiles&nbsp;: du quartile
+						inférieur qui regroupe les salariés les moins rémunérés, au quartile
+						supérieur qui rassemble les salariés les mieux rémunérés.
+					</p>
 
-				<p className="fr-mb-0">
-					<strong>
-						Vérifiez les informations préremplies et modifiez-les si nécessaire
-						avant de valider vos indicateurs.
-					</strong>
-				</p>
+					<p className="fr-mb-0">
+						<strong>
+							Vérifiez les informations préremplies et modifiez-les si
+							nécessaire avant de valider vos indicateurs.
+						</strong>
+					</p>
 
-				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
-			</div>
-
-			{showAlert && (
-				<div
-					aria-labelledby="step4-error-summary-title"
-					className="fr-alert fr-alert--error"
-					ref={alertRef}
-					role="alert"
-					tabIndex={-1}
-				>
-					<h3 className="fr-alert__title" id="step4-error-summary-title">
-						Le formulaire contient des erreurs
-					</h3>
-					<ul>
-						{recap.map((entry) => (
-							<li key={entry.id}>
-								<a href={`#${entry.id}`}>{entry.label}</a>
-							</li>
-						))}
-					</ul>
+					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 				</div>
-			)}
 
-			<div className={stepStyles.dataContainer}>
-				<QuartileTable
-					disabled={isImpersonating}
-					errors={fieldErrors.annual}
-					mins={annualMins}
-					onQuartileChange={(index, field, value) =>
-						handleQuartileChange("annual", index, field, value)
-					}
-					quartiles={annual}
-					sourceNote={
-						<PrefillSource periodEnd={gipPrefillData?.periodEnd ?? null} />
-					}
-					tableType="annual"
-					title="Rémunération annuelle brute moyenne"
-				/>
-
-				<QuartileTable
-					disabled={isImpersonating}
-					errors={fieldErrors.hourly}
-					mins={hourlyMins}
-					onQuartileChange={(index, field, value) =>
-						handleQuartileChange("hourly", index, field, value)
-					}
-					quartiles={hourly}
-					sourceNote={
-						<PrefillSource periodEnd={gipPrefillData?.periodEnd ?? null} />
-					}
-					tableType="hourly"
-					title="Rémunération horaire brute moyenne"
-				/>
-
-				<DefinitionAccordion
-					id="accordion-step4"
-					title="Définitions et méthode de calcul"
-				>
-					<div className="fr-callout">
+				{showAlert && (
+					<div
+						aria-labelledby="step4-error-summary-title"
+						className="fr-alert fr-alert--error"
+						ref={alertRef}
+						role="alert"
+						tabIndex={-1}
+					>
+						<h3 className="fr-alert__title" id="step4-error-summary-title">
+							Le formulaire contient des erreurs
+						</h3>
 						<ul>
-							<li>
-								Quelles données sont prises en compte dans les calculs&nbsp;?
-							</li>
-							<li>
-								Les calculs incluent-ils uniquement le salaire de base ou
-								également les primes&nbsp;?
-							</li>
-							<li>
-								Sont-ils réalisés en équivalent temps plein, en salaire brut
-								horaire ou selon une autre modalité&nbsp;?
-							</li>
-							<li>
-								Que signifie la notion de «&nbsp;quartile&nbsp;» dans ce
-								contexte&nbsp;? Définir simplement un quartile pour permettre à
-								l&apos;utilisateur de s&apos;assurer qu&apos;il comprend bien
-								cette notion.
-							</li>
-							<li>
-								À quoi servent les quartiles présentés&nbsp;? Quelle est la
-								finalité des quartiles lorsqu&apos;ils sont affichés sans
-								échelle ou référence comparative&nbsp;?
-							</li>
+							{recap.map((entry) => (
+								<li key={entry.id}>
+									<a href={`#${entry.id}`}>{entry.label}</a>
+								</li>
+							))}
 						</ul>
 					</div>
-				</DefinitionAccordion>
-			</div>
+				)}
 
-			{gipPrefillData && (
-				<QuartileInterpretationCallout
-					annualCategories={annual}
-					hourlyCategories={hourly}
+				<div className={stepStyles.dataContainer}>
+					<QuartileTable
+						disabled={isImpersonating}
+						errors={fieldErrors.annual}
+						mins={annualMins}
+						onQuartileChange={(index, field, value) =>
+							handleQuartileChange("annual", index, field, value)
+						}
+						quartiles={annual}
+						sourceNote={
+							<PrefillSource periodEnd={gipPrefillData?.periodEnd ?? null} />
+						}
+						tableType="annual"
+						title="Rémunération annuelle brute moyenne"
+					/>
+
+					<QuartileTable
+						disabled={isImpersonating}
+						errors={fieldErrors.hourly}
+						mins={hourlyMins}
+						onQuartileChange={(index, field, value) =>
+							handleQuartileChange("hourly", index, field, value)
+						}
+						quartiles={hourly}
+						sourceNote={
+							<PrefillSource periodEnd={gipPrefillData?.periodEnd ?? null} />
+						}
+						tableType="hourly"
+						title="Rémunération horaire brute moyenne"
+					/>
+
+					<DefinitionAccordion
+						id="accordion-step4"
+						title="Définitions et méthode de calcul"
+					>
+						<div className="fr-callout">
+							<ul>
+								<li>
+									Quelles données sont prises en compte dans les calculs&nbsp;?
+								</li>
+								<li>
+									Les calculs incluent-ils uniquement le salaire de base ou
+									également les primes&nbsp;?
+								</li>
+								<li>
+									Sont-ils réalisés en équivalent temps plein, en salaire brut
+									horaire ou selon une autre modalité&nbsp;?
+								</li>
+								<li>
+									Que signifie la notion de «&nbsp;quartile&nbsp;» dans ce
+									contexte&nbsp;? Définir simplement un quartile pour permettre
+									à l&apos;utilisateur de s&apos;assurer qu&apos;il comprend
+									bien cette notion.
+								</li>
+								<li>
+									À quoi servent les quartiles présentés&nbsp;? Quelle est la
+									finalité des quartiles lorsqu&apos;ils sont affichés sans
+									échelle ou référence comparative&nbsp;?
+								</li>
+							</ul>
+						</div>
+					</DefinitionAccordion>
+				</div>
+
+				{gipPrefillData && (
+					<QuartileInterpretationCallout
+						annualCategories={annual}
+						hourlyCategories={hourly}
+					/>
+				)}
+
+				<FormErrors
+					mutationError={mutation.error?.message}
+					validationError={maxError}
 				/>
-			)}
 
-			<FormErrors
-				mutationError={mutation.error?.message}
-				validationError={maxError}
-			/>
-
-			<FormActions
-				isSubmitting={mutation.isPending}
-				mimoquageNextHref={
-					hasSavedData ? "/declaration-remuneration/etape/5" : undefined
-				}
-				previousHref="/declaration-remuneration/etape/3"
-			/>
+				<FormActions
+					isSubmitting={mutation.isPending}
+					mimoquageNextHref={
+						hasSavedData ? "/declaration-remuneration/etape/5" : undefined
+					}
+					previousHref="/declaration-remuneration/etape/3"
+				/>
+			</fieldset>
 		</form>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -8,6 +8,7 @@ import { padDecimalToTwo } from "~/modules/domain";
 import { api } from "~/trpc/react";
 import { DraftLoadingState } from "../shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "../shared/draft/useDeclarationDraft";
+import { useLockContext } from "../shared/lock/LockContext";
 import { StepIndicator } from "../shared/StepIndicator";
 import type { EmployeeCategoryRow } from "../types";
 import { CategoryForm } from "./step5/CategoryForm";
@@ -48,6 +49,7 @@ export function Step5EmployeeCategories({
 }: Props) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const { isReadOnly: isLocked } = useLockContext();
 	const hasInitialData = (initialCategories?.length ?? 0) > 0;
 
 	const dbValues = useMemo<Step5FormValues>(
@@ -108,7 +110,7 @@ export function Step5EmployeeCategories({
 		<CategoryForm
 			accordionId="accordion-step5"
 			defaultValuesOverride={categoryFormDefaultOverride}
-			disabled={isImpersonating}
+			disabled={isImpersonating || isLocked}
 			hasDataOverride={hasInitialData || hasDraft}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -168,7 +168,6 @@ export function Step6Review({
 			onSubmit={handleSubmit}
 		>
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
-				{/* Title + save status */}
 				<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">
@@ -196,7 +195,6 @@ export function Step6Review({
 					withTooltips
 				/>
 
-				{/* Next steps callout when high gap detected */}
 				{highGap && declaration.siren && (
 					<NextStepsBox
 						hasGapsAboveThreshold={highGap}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -10,12 +10,14 @@ import {
 } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
+import common from "../shared/common.module.scss";
 import { getCurrentStageHref } from "../shared/complianceNavigation";
 import { FormActions } from "../shared/FormActions";
 import {
 	DECLARATION_FUNNEL,
 	declarationFunnelDimensions,
 } from "../shared/funnelConfig";
+import { useLockContext } from "../shared/lock/LockContext";
 import { NextStepsBox } from "../shared/NextStepsBox";
 import { SavedIndicator } from "../shared/SavedIndicator";
 import { StepIndicator } from "../shared/StepIndicator";
@@ -64,6 +66,7 @@ export function Step6Review({
 	hasCse = null,
 }: Props) {
 	const router = useRouter();
+	const { isReadOnly } = useLockContext();
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const submitMutation = api.declaration.submit.useMutation({
 		onSuccess: () => {
@@ -164,60 +167,63 @@ export function Step6Review({
 			className={stepStyles.formColumn}
 			onSubmit={handleSubmit}
 		>
-			{/* Title + save status */}
-			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
-				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
-						Déclaration des indicateurs de rémunération {declarationYear}
-					</h1>
+			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				{/* Title + save status */}
+				<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+					<div className="fr-col">
+						<h1 className="fr-h4 fr-mb-0">
+							Déclaration des indicateurs de rémunération {declarationYear}
+						</h1>
+					</div>
+					<div className="fr-col-auto">
+						<SavedIndicator hasData={true} />
+					</div>
 				</div>
-				<div className="fr-col-auto">
-					<SavedIndicator hasData={true} />
-				</div>
-			</div>
 
-			<StepIndicator currentStep={6} />
+				<StepIndicator currentStep={6} />
 
-			<p className={`fr-mb-0 ${stepStyles.intro}`}>
-				Vérifiez que toutes les informations ont été complétées avant de
-				soumettre votre déclaration aux services du ministère chargé du travail.
-			</p>
+				<p className={`fr-mb-0 ${stepStyles.intro}`}>
+					Vérifiez que toutes les informations ont été complétées avant de
+					soumettre votre déclaration aux services du ministère chargé du
+					travail.
+				</p>
 
-			<IndicatorSections
-				step2Data={step2Data}
-				step3Data={step3Data}
-				step4Data={step4Data}
-				step5Categories={step5Categories}
-				withTooltips
-			/>
-
-			{/* Next steps callout when high gap detected */}
-			{highGap && declaration.siren && (
-				<NextStepsBox
-					hasGapsAboveThreshold={highGap}
-					siren={declaration.siren}
+				<IndicatorSections
+					step2Data={step2Data}
+					step3Data={step3Data}
+					step4Data={step4Data}
+					step5Categories={step5Categories}
+					withTooltips
 				/>
-			)}
 
-			<FormActions
-				nextHref={
-					isSubmitted
-						? getCurrentStageHref(declaration.status, hasCse)
-						: undefined
-				}
-				nextLabel="Suivant"
-				previousHref="/declaration-remuneration/etape/5"
-			/>
+				{/* Next steps callout when high gap detected */}
+				{highGap && declaration.siren && (
+					<NextStepsBox
+						hasGapsAboveThreshold={highGap}
+						siren={declaration.siren}
+					/>
+				)}
 
-			{!isSubmitted && (
-				<SubmitDeclarationModal
-					isPending={submitMutation.isPending}
-					modalRef={modalRef}
-					onClose={closeModal}
-					onSubmit={() => submitMutation.mutate()}
-					year={declarationYear}
+				<FormActions
+					nextHref={
+						isSubmitted
+							? getCurrentStageHref(declaration.status, hasCse)
+							: undefined
+					}
+					nextLabel="Suivant"
+					previousHref="/declaration-remuneration/etape/5"
 				/>
-			)}
+
+				{!isSubmitted && (
+					<SubmitDeclarationModal
+						isPending={submitMutation.isPending}
+						modalRef={modalRef}
+						onClose={closeModal}
+						onSubmit={() => submitMutation.mutate()}
+						year={declarationYear}
+					/>
+				)}
+			</fieldset>
 		</form>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { getDefaultCampaignDeadlines } from "~/modules/domain";
 import { CompliancePathChoice } from "../CompliancePathChoice";
 
@@ -11,6 +12,26 @@ const DECLARATION_YEAR = 2026;
 
 const mockMutate = vi.fn();
 const mockPush = vi.fn();
+
+const { mockSetField, draftRef } = vi.hoisted(() => ({
+	mockSetField: vi.fn(),
+	draftRef: { current: {} as Record<string, unknown> },
+}));
+
+vi.mock(
+	"~/modules/declaration-remuneration/shared/draft/useDeclarationDraft",
+	() => ({
+		useDeclarationDraft: () => ({
+			draft: draftRef.current,
+			setField: mockSetField,
+			clearDraft: vi.fn(),
+			hasDraft: false,
+			isLoadingDraft: false,
+			isSaving: false,
+			isPendingSave: false,
+		}),
+	}),
+);
 
 vi.mock("next/navigation", () => ({
 	useRouter: () => ({ push: mockPush }),
@@ -44,6 +65,8 @@ vi.mock("~/trpc/react", () => ({
 beforeEach(() => {
 	mockMutate.mockClear();
 	mockPush.mockClear();
+	mockSetField.mockClear();
+	draftRef.current = {};
 });
 
 describe("CompliancePathChoice", () => {
@@ -174,6 +197,52 @@ describe("CompliancePathChoice", () => {
 		expect(mockPush).toHaveBeenCalledWith(
 			"/declaration-remuneration/parcours-conformite/etape/1",
 		);
+	});
+
+	it("does not submit when no path is selected", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+
+		const form = screen
+			.getByRole("button", { name: /suivant/i })
+			.closest("form") as HTMLFormElement;
+		fireEvent.submit(form);
+
+		expect(mockMutate).not.toHaveBeenCalled();
+		expect(mockPush).not.toHaveBeenCalled();
+	});
+
+	it("navigates to the CSE opinion funnel when justify is selected", async () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+		const radio = screen.getByLabelText(
+			"Justifier les écarts de rémunération ≥ 5 %",
+		);
+		fireEvent.click(radio);
+
+		const form = screen
+			.getByRole("button", { name: /suivant/i })
+			.closest("form") as HTMLFormElement;
+		fireEvent.submit(form);
+
+		await waitFor(() => {
+			expect(mockMutate).toHaveBeenCalledWith({ path: "justify" });
+		});
+		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
 	});
 
 	it("pre-selects the initial path when provided", () => {
@@ -329,5 +398,88 @@ describe("CompliancePathChoice", () => {
 			/>,
 		);
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();
+	});
+
+	describe("draft autosave", () => {
+		it("hydrates the selected path from a persisted draft", () => {
+			draftRef.current = { path: "joint_evaluation" };
+
+			render(
+				<CompliancePathChoice
+					campaignDeadlines={campaignDeadlines}
+					currentYear={2026}
+					declarationSiren={DECLARATION_SIREN}
+					declarationYear={DECLARATION_YEAR}
+					email="test@example.fr"
+				/>,
+			);
+
+			const radio = screen.getByLabelText(
+				"Mettre en place une évaluation conjointe des rémunérations",
+			) as HTMLInputElement;
+			expect(radio.checked).toBe(true);
+		});
+
+		it("saves a draft when a path is selected and the lock is inactive", async () => {
+			render(
+				<CompliancePathChoice
+					campaignDeadlines={campaignDeadlines}
+					currentYear={2026}
+					declarationSiren={DECLARATION_SIREN}
+					declarationYear={DECLARATION_YEAR}
+					email="test@example.fr"
+				/>,
+			);
+
+			fireEvent.click(
+				screen.getByLabelText("Actions correctives et seconde déclaration"),
+			);
+
+			await waitFor(() => {
+				expect(mockSetField).toHaveBeenCalledWith({
+					path: "corrective_action",
+				});
+			});
+		});
+
+		it("does not save a draft when the declaration is locked read-only", async () => {
+			render(
+				<LockProvider isReadOnly>
+					<CompliancePathChoice
+						campaignDeadlines={campaignDeadlines}
+						currentYear={2026}
+						declarationSiren={DECLARATION_SIREN}
+						declarationYear={DECLARATION_YEAR}
+						email="test@example.fr"
+					/>
+				</LockProvider>,
+			);
+
+			const radio = screen.getByLabelText(
+				"Actions correctives et seconde déclaration",
+			);
+			fireEvent.click(radio);
+			fireEvent.change(radio, { target: { checked: true } });
+
+			expect(mockSetField).not.toHaveBeenCalled();
+		});
+
+		it("disables the path fieldset when the declaration is locked read-only", () => {
+			const { container } = render(
+				<LockProvider isReadOnly>
+					<CompliancePathChoice
+						campaignDeadlines={campaignDeadlines}
+						currentYear={2026}
+						declarationSiren={DECLARATION_SIREN}
+						declarationYear={DECLARATION_YEAR}
+						email="test@example.fr"
+					/>
+				</LockProvider>,
+			);
+
+			// The outermost fieldset wraps the entire form in read-only mode.
+			expect(container.querySelector("fieldset")).toBeDisabled();
+			expect(screen.getByRole("button", { name: /suivant/i })).toBeDisabled();
+		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -8,6 +8,7 @@ import { useReadOnlyGuard } from "~/modules/auth";
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
 import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
+import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { formatLongDate } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { FileUpload, useFileUploadForm } from "~/modules/shared";
@@ -35,6 +36,7 @@ export function JointEvaluationForm({
 }: Props) {
 	const router = useRouter();
 	const readOnlyGuard = useReadOnlyGuard();
+	const { isReadOnly: isLocked } = useLockContext();
 
 	const { clearDraft } = useDeclarationDraft({
 		siren: declarationSiren,
@@ -82,128 +84,131 @@ export function JointEvaluationForm({
 				className={common.flexColumnGap2}
 				onSubmit={handleSubmit}
 			>
-				<div className={common.flexBetween}>
-					<h1 className="fr-h4 fr-mb-0">
-						Parcours de mise en conformité pour l&apos;indicateur par catégorie
-						de salariés
-					</h1>
-				</div>
-
-				<div className={common.flexColumnGapHalf}>
-					<h2 className="fr-h5 fr-mb-0">
-						Évaluation conjointe des rémunérations
-					</h2>
-					<p className="fr-mb-0">
-						<TrackedLink
-							className="fr-link"
-							href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
-							rel="noopener noreferrer"
-							target="_blank"
-							trackingId="joint_evaluation"
-						>
-							En savoir plus sur évaluation conjointe des rémunérations
-							<NewTabNotice />
-						</TrackedLink>
-					</p>
-				</div>
-
-				<p className="fr-mb-0">
-					Vous devez{" "}
-					<strong>
-						déposer le rapport de l&apos;évaluation conjointe, ci-dessous.
-					</strong>{" "}
-					L&apos;accord ou le plan d&apos;action conclu doit être déposé sur
-					TéléAccord.
-				</p>
-
-				<div className="fr-highlight">
-					<p className="fr-mb-1v fr-text--md">Date limite</p>
-					<p className="fr-h6 fr-mb-1v">
-						{formatLongDate(jointEvaluationDeadline)}
-					</p>
-					<p className="fr-mb-0 fr-text--sm fr-text--mention-grey">
-						Déclaration effectuée le {declarationDate}
-					</p>
-				</div>
-
-				<div>
-					<label className="fr-label" htmlFor="joint-evaluation-file-upload">
-						Veuillez importer/déposer le rapport de l&apos;évaluation conjointe.
-						<span className="fr-hint-text">
-							Taille maximale : 10 Mo. Format supporté : pdf.
-						</span>
-					</label>
-				</div>
-
-				<FileUpload
-					accept=".pdf"
-					acceptLabel="pdf"
-					allowedMimeTypes={["application/pdf"]}
-					disabled={readOnlyGuard.isReadOnly}
-					error={uploadError}
-					inputId="joint-evaluation-file-upload"
-					onFilesChange={handleFilesChange}
-					selectedFiles={selectedFiles}
-				/>
-
-				<div>
-					<div className={styles.panelBlue}>
-						<h3 className="fr-h6">
-							Ce que vous devez faire dans un délai de 2 mois
-						</h3>
-						<ul className="fr-mb-0">
-							<li>Élaboration du rapport</li>
-							<li>
-								Déposez le rapport dans la zone de dépôt prévue sur cette page
-							</li>
-						</ul>
+				<fieldset className={common.readOnlyFieldset} disabled={isLocked}>
+					<div className={common.flexBetween}>
+						<h1 className="fr-h4 fr-mb-0">
+							Parcours de mise en conformité pour l&apos;indicateur par
+							catégorie de salariés
+						</h1>
 					</div>
-					<div className={styles.panelWhite}>
-						<h3 className="fr-h6">Après dépôt du rapport</h3>
-						<ul className="fr-mb-2w">
-							<li>
-								Réaliser l&apos;analyse conjointe et définir des actions
-								correctrices
-							</li>
-							<li>
-								Mettre en place l&apos;accord collectif (ou à défaut un plan
-								d&apos;action)
-							</li>
-						</ul>
+
+					<div className={common.flexColumnGapHalf}>
+						<h2 className="fr-h5 fr-mb-0">
+							Évaluation conjointe des rémunérations
+						</h2>
 						<p className="fr-mb-0">
-							Les accords conclus devront être déposés sur{" "}
-							<a
+							<TrackedLink
 								className="fr-link"
-								href="https://www.teleaccord.travail.gouv.fr"
+								href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
 								rel="noopener noreferrer"
 								target="_blank"
+								trackingId="joint_evaluation"
 							>
-								TéléAccord
+								En savoir plus sur évaluation conjointe des rémunérations
 								<NewTabNotice />
-							</a>
+							</TrackedLink>
 						</p>
 					</div>
-				</div>
 
-				<div className={`fr-mt-4w ${common.flexBetween}`}>
-					<Link
-						className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
-						href="/declaration-remuneration/parcours-conformite"
-					>
-						Précédent
-					</Link>
-					<span>
-						<button
-							{...readOnlyGuard.buttonProps}
-							className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-							disabled={isPending || readOnlyGuard.isReadOnly}
-							type="submit"
+					<p className="fr-mb-0">
+						Vous devez{" "}
+						<strong>
+							déposer le rapport de l&apos;évaluation conjointe, ci-dessous.
+						</strong>{" "}
+						L&apos;accord ou le plan d&apos;action conclu doit être déposé sur
+						TéléAccord.
+					</p>
+
+					<div className="fr-highlight">
+						<p className="fr-mb-1v fr-text--md">Date limite</p>
+						<p className="fr-h6 fr-mb-1v">
+							{formatLongDate(jointEvaluationDeadline)}
+						</p>
+						<p className="fr-mb-0 fr-text--sm fr-text--mention-grey">
+							Déclaration effectuée le {declarationDate}
+						</p>
+					</div>
+
+					<div>
+						<label className="fr-label" htmlFor="joint-evaluation-file-upload">
+							Veuillez importer/déposer le rapport de l&apos;évaluation
+							conjointe.
+							<span className="fr-hint-text">
+								Taille maximale : 10 Mo. Format supporté : pdf.
+							</span>
+						</label>
+					</div>
+
+					<FileUpload
+						accept=".pdf"
+						acceptLabel="pdf"
+						allowedMimeTypes={["application/pdf"]}
+						disabled={readOnlyGuard.isReadOnly || isLocked}
+						error={uploadError}
+						inputId="joint-evaluation-file-upload"
+						onFilesChange={handleFilesChange}
+						selectedFiles={selectedFiles}
+					/>
+
+					<div>
+						<div className={styles.panelBlue}>
+							<h3 className="fr-h6">
+								Ce que vous devez faire dans un délai de 2 mois
+							</h3>
+							<ul className="fr-mb-0">
+								<li>Élaboration du rapport</li>
+								<li>
+									Déposez le rapport dans la zone de dépôt prévue sur cette page
+								</li>
+							</ul>
+						</div>
+						<div className={styles.panelWhite}>
+							<h3 className="fr-h6">Après dépôt du rapport</h3>
+							<ul className="fr-mb-2w">
+								<li>
+									Réaliser l&apos;analyse conjointe et définir des actions
+									correctrices
+								</li>
+								<li>
+									Mettre en place l&apos;accord collectif (ou à défaut un plan
+									d&apos;action)
+								</li>
+							</ul>
+							<p className="fr-mb-0">
+								Les accords conclus devront être déposés sur{" "}
+								<a
+									className="fr-link"
+									href="https://www.teleaccord.travail.gouv.fr"
+									rel="noopener noreferrer"
+									target="_blank"
+								>
+									TéléAccord
+									<NewTabNotice />
+								</a>
+							</p>
+						</div>
+					</div>
+
+					<div className={`fr-mt-4w ${common.flexBetween}`}>
+						<Link
+							className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+							href="/declaration-remuneration/parcours-conformite"
 						>
-							Transmettre
-						</button>
-						{readOnlyGuard.tooltip}
-					</span>
-				</div>
+							Précédent
+						</Link>
+						<span>
+							<button
+								{...readOnlyGuard.buttonProps}
+								className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+								disabled={isPending || readOnlyGuard.isReadOnly || isLocked}
+								type="submit"
+							>
+								Transmettre
+							</button>
+							{readOnlyGuard.tooltip}
+						</span>
+					</div>
+				</fieldset>
 			</form>
 
 			<JointEvaluationSubmitModal

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
@@ -2,8 +2,8 @@ import { getTableName } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-	declarations,
 	declarationStatusHistory,
+	declarations,
 	employeeCategories,
 	jobCategories,
 } from "~/server/db/schema";


### PR DESCRIPTION
Closes #3729

## Changes

- Add `LockContext` (client context) with `LockProvider` / `useLockContext` for read-only state propagation
- Add `DeclarationLockAlert` DSFR warning banner shown when another user holds the lock
- Server-side lock check in `WithBannerLayout` via `getActiveLock()` — no dependency on unmerged tRPC router (#3724)
- `DeclarationLayout` accepts `isReadOnly` + `lockHolder` props, wraps children in `LockProvider`, renders alert above content
- Steps 1–6 and `CompliancePathChoice`, `JointEvaluationForm`, `FormActions` all wrapped in `<fieldset disabled={isReadOnly}>` with SCSS reset class
- `useDraftAutoSave` gated with `draftHydrated && !isReadOnly` to cut autosave for viewers

## Tests

16 new unit tests (LockContext, DeclarationLockAlert, DeclarationLayout, FormActions read-only behaviour). 2809 total — all green.