### PR TITLE
feat(declaration-lock): acquisition, heartbeat et release côté parcours (#3728)

### DIFF
--- a/packages/app/src/app/api/declaration-lock/release/__tests__/route.test.ts
+++ b/packages/app/src/app/api/declaration-lock/release/__tests__/route.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	cachedAuth: vi.fn(),
+	releaseLock: vi.fn(),
+	limit: vi.fn(),
+}));
+
+vi.mock("~/server/audit/cachedAuth", () => ({
+	cachedAuth: mocks.cachedAuth,
+}));
+
+vi.mock("~/server/audit/withAuditedRoute", () => ({
+	withAuditedRoute: (
+		_options: unknown,
+		handler: (request: Request) => Promise<Response>,
+	) => handler,
+}));
+
+vi.mock("~/server/services/declarationLockService", () => ({
+	releaseLock: mocks.releaseLock,
+}));
+
+vi.mock("~/server/api/routers/declarationHelpers", () => ({
+	activeDeclarationFilter: vi.fn(() => "filter"),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({ where: () => ({ limit: mocks.limit }) }),
+		}),
+	},
+}));
+
+vi.mock("~/server/db/schema", () => ({
+	declarations: { id: "id" },
+}));
+
+import { POST } from "../route";
+
+const SIRET = "12345678901234";
+
+function buildRequest() {
+	return new Request("http://localhost/api/declaration-lock/release", {
+		method: "POST",
+	});
+}
+
+function mockSession(
+	user: { id: string; siret?: string | null; impersonation?: unknown } | null,
+) {
+	mocks.cachedAuth.mockResolvedValue(user ? { user } : null);
+}
+
+function mockDeclaration(id: string | null) {
+	mocks.limit.mockResolvedValue(id ? [{ id }] : []);
+}
+
+describe("POST /api/declaration-lock/release", () => {
+	beforeEach(() => {
+		mocks.cachedAuth.mockReset();
+		mocks.releaseLock.mockReset();
+		mocks.limit.mockReset();
+	});
+
+	it("returns 401 when there is no session", async () => {
+		mockSession(null);
+
+		const response = await POST(buildRequest());
+
+		expect(response.status).toBe(401);
+		expect(mocks.releaseLock).not.toHaveBeenCalled();
+	});
+
+	it("returns 204 without releasing when the caller is impersonating", async () => {
+		mockSession({ id: "admin-1", siret: SIRET, impersonation: { siren: "9" } });
+
+		const response = await POST(buildRequest());
+
+		expect(response.status).toBe(204);
+		expect(mocks.releaseLock).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when the session has no usable siren", async () => {
+		mockSession({ id: "user-1", siret: null });
+
+		const response = await POST(buildRequest());
+
+		expect(response.status).toBe(400);
+		expect(mocks.releaseLock).not.toHaveBeenCalled();
+	});
+
+	it("returns 204 without releasing when no current declaration is found", async () => {
+		mockSession({ id: "user-1", siret: SIRET });
+		mockDeclaration(null);
+
+		const response = await POST(buildRequest());
+
+		expect(response.status).toBe(204);
+		expect(mocks.releaseLock).not.toHaveBeenCalled();
+	});
+
+	it("releases the resolved declaration lock for the caller and returns 204", async () => {
+		mockSession({ id: "user-1", siret: SIRET });
+		mockDeclaration("decl-1");
+
+		const response = await POST(buildRequest());
+
+		expect(response.status).toBe(204);
+		expect(mocks.releaseLock).toHaveBeenCalledTimes(1);
+		expect(mocks.releaseLock).toHaveBeenCalledWith(
+			expect.anything(),
+			"decl-1",
+			"user-1",
+		);
+	});
+});

--- a/packages/app/src/app/api/declaration-lock/release/route.ts
+++ b/packages/app/src/app/api/declaration-lock/release/route.ts
@@ -1,0 +1,69 @@
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import { getCurrentYear, parseSiren } from "~/modules/domain";
+import { activeDeclarationFilter } from "~/server/api/routers/declarationHelpers";
+import { cachedAuth } from "~/server/audit/cachedAuth";
+import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
+import { db } from "~/server/db";
+import { declarations } from "~/server/db/schema";
+import { releaseLock } from "~/server/services/declarationLockService";
+
+async function resolveCurrentDeclarationId(
+	siren: string,
+): Promise<string | null> {
+	const [row] = await db
+		.select({ id: declarations.id })
+		.from(declarations)
+		.where(activeDeclarationFilter(siren, getCurrentYear()))
+		.limit(1);
+
+	return row?.id ?? null;
+}
+
+/**
+ * POST /api/declaration-lock/release
+ *
+ * Best-effort lock release for `navigator.sendBeacon`, fired by the parcours
+ * when the tab is hidden or closed — a context where a tRPC mutation cannot be
+ * guaranteed to flush. The declaration is resolved server-side from the
+ * session SIREN (never trusting the beacon body), and the lock is only deleted
+ * when held by the caller, so a co-declarant viewer can never release another
+ * user's lock.
+ */
+export const POST = withAuditedRoute(
+	{
+		action: AUDIT_ACTIONS.DECLARATION_LOCK_RELEASED,
+		resolveContext: async (request) => {
+			const session = await cachedAuth(request);
+			return {
+				userId: session?.user?.id ?? null,
+				userEmail: session?.user?.email ?? null,
+				siren: session?.user?.siret ? parseSiren(session.user.siret) : null,
+				resourceType: "declaration",
+			};
+		},
+	},
+	async (request) => {
+		const session = await cachedAuth(request);
+		if (!session?.user) {
+			return new Response(null, { status: 401 });
+		}
+
+		// Impersonating admins never hold an editor lock — nothing to release.
+		if (session.user.impersonation) {
+			return new Response(null, { status: 204 });
+		}
+
+		const siren = session.user.siret ? parseSiren(session.user.siret) : null;
+		if (!siren) {
+			return new Response(null, { status: 400 });
+		}
+
+		const declarationId = await resolveCurrentDeclarationId(siren);
+		if (!declarationId) {
+			return new Response(null, { status: 204 });
+		}
+
+		await releaseLock(db, declarationId, session.user.id);
+		return new Response(null, { status: 204 });
+	},
+);

--- a/packages/app/src/app/api/declaration-lock/release/route.ts
+++ b/packages/app/src/app/api/declaration-lock/release/route.ts
@@ -19,16 +19,10 @@ async function resolveCurrentDeclarationId(
 	return row?.id ?? null;
 }
 
-/**
- * POST /api/declaration-lock/release
- *
- * Best-effort lock release for `navigator.sendBeacon`, fired by the parcours
- * when the tab is hidden or closed — a context where a tRPC mutation cannot be
- * guaranteed to flush. The declaration is resolved server-side from the
- * session SIREN (never trusting the beacon body), and the lock is only deleted
- * when held by the caller, so a co-declarant viewer can never release another
- * user's lock.
- */
+// Best-effort lock release for `navigator.sendBeacon` on tab close, where a tRPC
+// mutation cannot be guaranteed to flush. The declaration is resolved server-side
+// from the session SIREN (never the beacon body) and `releaseLock` only deletes a
+// lock held by the caller, closing the IDOR window.
 export const POST = withAuditedRoute(
 	{
 		action: AUDIT_ACTIONS.DECLARATION_LOCK_RELEASED,

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -8,6 +8,7 @@ import {
 	declarationFunnelDimensions,
 } from "./shared/funnelConfig";
 import type { GipPrefillData } from "./shared/gipMdsMapping";
+import { LockProvider } from "./shared/lock/LockContext";
 import { Step1Workforce } from "./steps/Step1Workforce";
 import { Step2PayGap } from "./steps/Step2PayGap";
 import { Step3VariablePay } from "./steps/Step3VariablePay";
@@ -25,6 +26,7 @@ import type {
 type StepPageClientProps = {
 	step: number;
 	declaration: {
+		id: string;
 		siren: string;
 		year: number;
 		totalWomen: number | null;
@@ -70,75 +72,81 @@ export function StepPageClient({
 	);
 	useFunnelTracking(DECLARATION_FUNNEL, { step, dimensions });
 
-	switch (step) {
-		case 1:
-			return (
-				<Step1Workforce
-					declarationSiren={declaration.siren}
-					declarationYear={declaration.year}
-					gipPrefillData={gipPrefillData}
-					initialData={step1Data}
-				/>
-			);
-		case 2:
-			return (
-				<Step2PayGap
-					declarationSiren={declaration.siren}
-					declarationYear={declaration.year}
-					gipPrefillData={gipPrefillData}
-					initialData={step2Data}
-				/>
-			);
-		case 3:
-			return (
-				<Step3VariablePay
-					declarationSiren={declaration.siren}
-					declarationYear={declaration.year}
-					gipPrefillData={gipPrefillData}
-					initialData={step3Data}
-					maxMen={declaration.totalMen ?? undefined}
-					maxWomen={declaration.totalWomen ?? undefined}
-				/>
-			);
-		case 4:
-			return (
-				<Step4QuartileDistribution
-					declarationSiren={declaration.siren}
-					declarationYear={declaration.year}
-					gipPrefillData={gipPrefillData}
-					initialData={step4Data}
-					maxMen={declaration.totalMen ?? undefined}
-					maxWomen={declaration.totalWomen ?? undefined}
-				/>
-			);
-		case 5:
-			return (
-				<Step5EmployeeCategories
-					declarationSiren={declaration.siren}
-					declarationYear={declaration.year}
-					initialCategories={step5Categories}
-					initialSource={initialSource}
-					maxMen={declaration.totalMen ?? undefined}
-					maxWomen={declaration.totalWomen ?? undefined}
-				/>
-			);
-		case 6:
-			return (
-				<Step6Review
-					companyWorkforce={companyWorkforce}
-					declaration={declaration}
-					declarationYear={declaration.year}
-					hasCse={hasCse}
-					isSubmitted={
-						declaration.status !== null && declaration.status !== "draft"
-					}
-					step2Data={step2Data}
-					step3Data={step3Data}
-					step4Data={step4Data}
-					step5Categories={step5Categories}
-				/>
-			);
-		default:
-			return null;
+	function renderStep() {
+		switch (step) {
+			case 1:
+				return (
+					<Step1Workforce
+						declarationSiren={declaration.siren}
+						declarationYear={declaration.year}
+						gipPrefillData={gipPrefillData}
+						initialData={step1Data}
+					/>
+				);
+			case 2:
+				return (
+					<Step2PayGap
+						declarationSiren={declaration.siren}
+						declarationYear={declaration.year}
+						gipPrefillData={gipPrefillData}
+						initialData={step2Data}
+					/>
+				);
+			case 3:
+				return (
+					<Step3VariablePay
+						declarationSiren={declaration.siren}
+						declarationYear={declaration.year}
+						gipPrefillData={gipPrefillData}
+						initialData={step3Data}
+						maxMen={declaration.totalMen ?? undefined}
+						maxWomen={declaration.totalWomen ?? undefined}
+					/>
+				);
+			case 4:
+				return (
+					<Step4QuartileDistribution
+						declarationSiren={declaration.siren}
+						declarationYear={declaration.year}
+						gipPrefillData={gipPrefillData}
+						initialData={step4Data}
+						maxMen={declaration.totalMen ?? undefined}
+						maxWomen={declaration.totalWomen ?? undefined}
+					/>
+				);
+			case 5:
+				return (
+					<Step5EmployeeCategories
+						declarationSiren={declaration.siren}
+						declarationYear={declaration.year}
+						initialCategories={step5Categories}
+						initialSource={initialSource}
+						maxMen={declaration.totalMen ?? undefined}
+						maxWomen={declaration.totalWomen ?? undefined}
+					/>
+				);
+			case 6:
+				return (
+					<Step6Review
+						companyWorkforce={companyWorkforce}
+						declaration={declaration}
+						declarationYear={declaration.year}
+						hasCse={hasCse}
+						isSubmitted={
+							declaration.status !== null && declaration.status !== "draft"
+						}
+						step2Data={step2Data}
+						step3Data={step3Data}
+						step4Data={step4Data}
+						step5Categories={step5Categories}
+					/>
+				);
+			default:
+				return null;
+		}
 	}
+
+	return (
+		<LockProvider declarationId={declaration.id}>{renderStep()}</LockProvider>
+	);
 }

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -33,6 +33,13 @@ export type {
 } from "./shared/gipMdsMapping";
 export { CSV_TO_SCHEMA_MAP, mapGipToFormData } from "./shared/gipMdsMapping";
 export { getEffectiveGipPrefillData } from "./shared/gipToStepData";
+export { DeclarationLockAlert } from "./shared/lock/DeclarationLockAlert";
+export { LockProvider, useLockContext } from "./shared/lock/LockContext";
+export type {
+	DeclarationLockState,
+	LockHolder,
+} from "./shared/lock/useDeclarationLock";
+export { useDeclarationLock } from "./shared/lock/useDeclarationLock";
 export { ComplianceConfirmation } from "./steps/ComplianceConfirmation";
 export { CompliancePathChoice } from "./steps/CompliancePathChoice";
 export { CompliancePathPage } from "./steps/CompliancePathPage";

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -14,8 +14,9 @@ export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {
 	const emailSuffix = hasEmailSuffix ? ` (${holder.email})` : "";
 
 	return (
-		<div className="fr-alert fr-alert--warning fr-alert--sm">
+		<div className="fr-alert fr-alert--warning fr-alert--sm" role="alert">
 			<p>
+				<span className="fr-sr-only">Attention : </span>
 				<strong>Déclaration en cours de modification</strong> — {editor}
 				{emailSuffix} modifie actuellement cette déclaration. Vous pouvez la
 				consulter en lecture seule jusqu'à la fin de sa modification.

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -1,0 +1,25 @@
+import type { LockHolder } from "./useDeclarationLock";
+
+type DeclarationLockAlertProps = {
+	holder: Pick<LockHolder, "firstName" | "lastName" | "email">;
+};
+
+export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {
+	const fullName = [holder.firstName, holder.lastName]
+		.filter(Boolean)
+		.join(" ")
+		.trim();
+	const hasEmailSuffix = Boolean(fullName) && Boolean(holder.email);
+	const editor = fullName || holder.email || "Un autre utilisateur";
+	const emailSuffix = hasEmailSuffix ? ` (${holder.email})` : "";
+
+	return (
+		<div className="fr-alert fr-alert--warning fr-alert--sm">
+			<p>
+				<strong>Déclaration en cours de modification</strong> — {editor}
+				{emailSuffix} modifie actuellement cette déclaration. Vous pouvez la
+				consulter en lecture seule jusqu'à la fin de sa modification.
+			</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+import {
+	type DeclarationLockState,
+	useDeclarationLock,
+} from "./useDeclarationLock";
+
+const LockContext = createContext<DeclarationLockState | null>(null);
+
+type LockProviderProps = {
+	declarationId: string;
+	children: React.ReactNode;
+};
+
+export function LockProvider({ declarationId, children }: LockProviderProps) {
+	const state = useDeclarationLock({ declarationId });
+	return <LockContext.Provider value={state}>{children}</LockContext.Provider>;
+}
+
+export function useLockContext(): DeclarationLockState {
+	const context = useContext(LockContext);
+	if (context === null) {
+		throw new Error("useLockContext must be used within a LockProvider");
+	}
+	return context;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/DeclarationLockAlert.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/DeclarationLockAlert.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DeclarationLockAlert } from "../DeclarationLockAlert";
+
+describe("DeclarationLockAlert", () => {
+	it("renders the full name followed by the email in parentheses", () => {
+		render(
+			<DeclarationLockAlert
+				holder={{
+					firstName: "Alice",
+					lastName: "Martin",
+					email: "alice@example.fr",
+				}}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/Alice Martin \(alice@example\.fr\)/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Déclaration en cours de modification"),
+		).toBeInTheDocument();
+	});
+
+	it("falls back to the email alone when the name is missing", () => {
+		render(
+			<DeclarationLockAlert
+				holder={{ firstName: null, lastName: null, email: "owner@example.fr" }}
+			/>,
+		);
+
+		const paragraph = screen.getByText(/modifie actuellement/).closest("p");
+		expect(paragraph).toHaveTextContent(
+			"owner@example.fr modifie actuellement",
+		);
+		expect(paragraph).not.toHaveTextContent("(owner@example.fr)");
+	});
+
+	it("falls back to a generic label when neither name nor email is known", () => {
+		render(
+			<DeclarationLockAlert
+				holder={{ firstName: null, lastName: null, email: null }}
+			/>,
+		);
+
+		expect(
+			screen.getByText(/Un autre utilisateur modifie actuellement/),
+		).toBeInTheDocument();
+	});
+
+	it("uses the available name part when only one of first/last is set", () => {
+		render(
+			<DeclarationLockAlert
+				holder={{
+					firstName: "Alice",
+					lastName: null,
+					email: "alice@example.fr",
+				}}
+			/>,
+		);
+
+		expect(screen.getByText(/Alice \(alice@example\.fr\)/)).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
@@ -1,0 +1,39 @@
+import { render, renderHook, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { DeclarationLockState } from "../useDeclarationLock";
+
+const lockState: DeclarationLockState = {
+	isReadOnly: true,
+	holder: null,
+	isLoading: false,
+};
+
+vi.mock("../useDeclarationLock", () => ({
+	useDeclarationLock: vi.fn(() => lockState),
+}));
+
+import { LockProvider, useLockContext } from "../LockContext";
+
+describe("LockContext", () => {
+	it("exposes the lock state computed by the hook to consumers", () => {
+		function Consumer() {
+			const state = useLockContext();
+			return <span>{state.isReadOnly ? "read-only" : "editable"}</span>;
+		}
+
+		render(
+			<LockProvider declarationId="decl-1">
+				<Consumer />
+			</LockProvider>,
+		);
+
+		expect(screen.getByText("read-only")).toBeInTheDocument();
+	});
+
+	it("throws when useLockContext is used outside a LockProvider", () => {
+		expect(() => renderHook(() => useLockContext())).toThrow(
+			"useLockContext must be used within a LockProvider",
+		);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/useDeclarationLock.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/useDeclarationLock.test.tsx
@@ -1,0 +1,353 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
+
+import { LOCK_HEARTBEAT_INTERVAL_MS } from "~/modules/domain";
+
+const acquireMutateAsync = vi.fn();
+const heartbeatMutateAsync = vi.fn();
+const releaseMutate = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declarationLock: {
+			acquireLock: { useMutation: () => ({ mutateAsync: acquireMutateAsync }) },
+			heartbeat: { useMutation: () => ({ mutateAsync: heartbeatMutateAsync }) },
+			releaseLock: { useMutation: () => ({ mutate: releaseMutate }) },
+		},
+	},
+}));
+
+import { useDeclarationLock } from "../useDeclarationLock";
+
+const useSessionMock = useSession as unknown as Mock;
+
+const DECLARATION_ID = "decl-1";
+const HOLDER = {
+	userId: "user-2",
+	email: "owner@example.fr",
+	firstName: "Alice",
+	lastName: "Martin",
+	expiresAt: new Date("2026-06-23T12:00:00Z"),
+};
+
+function setSession(
+	options: { authenticated?: boolean; impersonating?: boolean } = {},
+) {
+	const { authenticated = true, impersonating = false } = options;
+	if (!authenticated) {
+		useSessionMock.mockReturnValue({ data: null, status: "unauthenticated" });
+		return;
+	}
+	useSessionMock.mockReturnValue({
+		data: {
+			user: {
+				id: "user-1",
+				impersonation: impersonating ? { siren: "999999999" } : null,
+			},
+		},
+		status: "authenticated",
+	});
+}
+
+function sendBeaconSpy() {
+	const beacon = vi.fn().mockReturnValue(true);
+	Object.defineProperty(navigator, "sendBeacon", {
+		configurable: true,
+		value: beacon,
+	});
+	return beacon;
+}
+
+function setVisibility(state: DocumentVisibilityState) {
+	Object.defineProperty(document, "visibilityState", {
+		configurable: true,
+		get: () => state,
+	});
+}
+
+// Flush the mount IIFE's awaited acquisition + the state updates that follow,
+// without waitFor (incompatible with fake timers used to drive the heartbeat).
+async function flush() {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(0);
+	});
+}
+
+async function advance(ms: number) {
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(ms);
+	});
+}
+
+function renderLockHook() {
+	return renderHook(() =>
+		useDeclarationLock({ declarationId: DECLARATION_ID }),
+	);
+}
+
+describe("useDeclarationLock", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		acquireMutateAsync.mockReset();
+		heartbeatMutateAsync.mockReset();
+		heartbeatMutateAsync.mockResolvedValue({ held: true });
+		releaseMutate.mockReset();
+		setSession();
+		setVisibility("visible");
+	});
+
+	afterEach(() => {
+		// Unmount the hook first so its pagehide/visibilitychange listeners are
+		// detached before the next test dispatches events on the shared window.
+		cleanup();
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+		useSessionMock.mockReset();
+	});
+
+	it("acquires the lock on mount and stays editable when held (S1)", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		const { result } = renderLockHook();
+		await flush();
+
+		expect(acquireMutateAsync).toHaveBeenCalledWith({
+			declarationId: DECLARATION_ID,
+		});
+		expect(result.current.isLoading).toBe(false);
+		expect(result.current.isReadOnly).toBe(false);
+		expect(result.current.holder).toEqual(HOLDER);
+	});
+
+	it("becomes read-only and exposes the holder when the lock is taken (no heartbeat)", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: false, holder: HOLDER });
+		const { result } = renderLockHook();
+		await flush();
+
+		expect(result.current.isReadOnly).toBe(true);
+		expect(result.current.holder).toEqual(HOLDER);
+
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS * 3);
+		expect(heartbeatMutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("sends periodic heartbeats while it holds the lock (S7)", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		heartbeatMutateAsync.mockResolvedValue({ held: true });
+		const { result } = renderLockHook();
+		await flush();
+		expect(result.current.isLoading).toBe(false);
+
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+		expect(heartbeatMutateAsync).toHaveBeenCalledTimes(1);
+		expect(heartbeatMutateAsync).toHaveBeenCalledWith({
+			declarationId: DECLARATION_ID,
+		});
+
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+		expect(heartbeatMutateAsync).toHaveBeenCalledTimes(2);
+	});
+
+	it("re-reads ownership and stops the heartbeat when the lock is lost", async () => {
+		acquireMutateAsync.mockResolvedValueOnce({
+			acquired: true,
+			holder: HOLDER,
+		});
+		heartbeatMutateAsync.mockResolvedValue({ held: false });
+		acquireMutateAsync.mockResolvedValueOnce({
+			acquired: false,
+			holder: HOLDER,
+		});
+		const { result } = renderLockHook();
+		await flush();
+
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+		expect(result.current.isReadOnly).toBe(true);
+		expect(acquireMutateAsync).toHaveBeenCalledTimes(2);
+
+		const heartbeatsAfterLoss = heartbeatMutateAsync.mock.calls.length;
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS * 2);
+		expect(heartbeatMutateAsync.mock.calls.length).toBe(heartbeatsAfterLoss);
+	});
+
+	it("releases the lock on unmount when it is the holder", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		const { unmount } = renderLockHook();
+		await flush();
+
+		unmount();
+		expect(releaseMutate).toHaveBeenCalledWith({
+			declarationId: DECLARATION_ID,
+		});
+	});
+
+	it("does not release on unmount when it is not the holder", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: false, holder: HOLDER });
+		const { result, unmount } = renderLockHook();
+		await flush();
+		expect(result.current.isReadOnly).toBe(true);
+
+		unmount();
+		expect(releaseMutate).not.toHaveBeenCalled();
+	});
+
+	it("emits a release beacon on pagehide when it is the holder (S5)", async () => {
+		const beacon = sendBeaconSpy();
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		renderLockHook();
+		await flush();
+
+		act(() => {
+			window.dispatchEvent(new Event("pagehide"));
+		});
+
+		expect(beacon).toHaveBeenCalledTimes(1);
+		const [url, blob] = beacon.mock.calls[0] as [string, Blob];
+		expect(url).toBe("/api/declaration-lock/release");
+		expect(blob).toBeInstanceOf(Blob);
+		expect(blob.type).toBe("application/json");
+		expect(await blob.text()).toBe(
+			JSON.stringify({ declarationId: DECLARATION_ID }),
+		);
+	});
+
+	it("emits a release beacon when the tab is hidden (S5 visibilitychange)", async () => {
+		const beacon = sendBeaconSpy();
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		renderLockHook();
+		await flush();
+
+		act(() => {
+			setVisibility("hidden");
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+		expect(beacon).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not emit a beacon on a visibilitychange that is not hidden", async () => {
+		const beacon = sendBeaconSpy();
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		renderLockHook();
+		await flush();
+
+		act(() => {
+			setVisibility("visible");
+			document.dispatchEvent(new Event("visibilitychange"));
+		});
+		expect(beacon).not.toHaveBeenCalled();
+	});
+
+	it("does not emit a beacon on pagehide when it is not the holder", async () => {
+		const beacon = sendBeaconSpy();
+		acquireMutateAsync.mockResolvedValue({ acquired: false, holder: HOLDER });
+		const { result } = renderLockHook();
+		await flush();
+		expect(result.current.isReadOnly).toBe(true);
+
+		act(() => {
+			window.dispatchEvent(new Event("pagehide"));
+		});
+		expect(beacon).not.toHaveBeenCalled();
+	});
+
+	it("falls back to read-only without a holder when acquisition throws", async () => {
+		acquireMutateAsync.mockRejectedValue(new Error("network"));
+		const { result } = renderLockHook();
+		await flush();
+
+		expect(result.current.isReadOnly).toBe(true);
+		expect(result.current.holder).toBeNull();
+	});
+
+	it("is disabled while unauthenticated: never acquires, stays editable, not loading", () => {
+		setSession({ authenticated: false });
+		const { result } = renderLockHook();
+
+		expect(acquireMutateAsync).not.toHaveBeenCalled();
+		expect(result.current.isReadOnly).toBe(false);
+		expect(result.current.holder).toBeNull();
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("stays loading while the session is still resolving", () => {
+		useSessionMock.mockReturnValue({ data: null, status: "loading" });
+		const { result } = renderLockHook();
+
+		expect(acquireMutateAsync).not.toHaveBeenCalled();
+		expect(result.current.isLoading).toBe(true);
+	});
+
+	it("is disabled while impersonating: never acquires the lock", () => {
+		setSession({ impersonating: true });
+		const { result } = renderLockHook();
+
+		expect(acquireMutateAsync).not.toHaveBeenCalled();
+		expect(result.current.isReadOnly).toBe(false);
+	});
+
+	it("swallows heartbeat rejections without re-reading ownership", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		heartbeatMutateAsync.mockRejectedValue(new Error("boom"));
+		const { result } = renderLockHook();
+		await flush();
+
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+
+		expect(acquireMutateAsync).toHaveBeenCalledTimes(1);
+		expect(result.current.isReadOnly).toBe(false);
+	});
+
+	it("ignores a successful acquisition that resolves after unmount", async () => {
+		let resolveAcquire!: (value: {
+			acquired: boolean;
+			holder: typeof HOLDER;
+		}) => void;
+		acquireMutateAsync.mockReturnValue(
+			new Promise((resolve) => {
+				resolveAcquire = resolve;
+			}),
+		);
+		const { result, unmount } = renderLockHook();
+		expect(result.current.isLoading).toBe(true);
+
+		unmount();
+		await act(async () => {
+			resolveAcquire({ acquired: true, holder: HOLDER });
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		// Cleanup ran before the acquire settled: no heartbeat scheduled, no
+		// release fired (the tab never became the holder).
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+		expect(heartbeatMutateAsync).not.toHaveBeenCalled();
+		expect(releaseMutate).not.toHaveBeenCalled();
+	});
+
+	it("ignores a failed acquisition that rejects after unmount", async () => {
+		let rejectAcquire!: (reason: Error) => void;
+		acquireMutateAsync.mockReturnValue(
+			new Promise((_resolve, reject) => {
+				rejectAcquire = reject;
+			}),
+		);
+		const { unmount } = renderLockHook();
+
+		unmount();
+		await act(async () => {
+			rejectAcquire(new Error("network"));
+			await vi.advanceTimersByTimeAsync(0);
+		});
+
+		await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+		expect(heartbeatMutateAsync).not.toHaveBeenCalled();
+		expect(releaseMutate).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
@@ -1,0 +1,136 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useEffect, useRef, useState } from "react";
+
+import { LOCK_HEARTBEAT_INTERVAL_MS } from "~/modules/domain";
+import { api, type RouterOutputs } from "~/trpc/react";
+
+export type LockHolder = NonNullable<
+	RouterOutputs["declarationLock"]["getLockState"]["holder"]
+>;
+
+export type DeclarationLockState = {
+	isReadOnly: boolean;
+	holder: LockHolder | null;
+	isLoading: boolean;
+};
+
+type UseDeclarationLockOptions = {
+	declarationId: string;
+};
+
+const RELEASE_ENDPOINT = "/api/declaration-lock/release";
+
+export function useDeclarationLock({
+	declarationId,
+}: UseDeclarationLockOptions): DeclarationLockState {
+	const session = useSession();
+	const isImpersonating = Boolean(session.data?.user?.impersonation);
+	const isEnabled = session.status === "authenticated" && !isImpersonating;
+
+	const [holder, setHolder] = useState<LockHolder | null>(null);
+	const [isReadOnly, setIsReadOnly] = useState(false);
+	const [isLoading, setIsLoading] = useState(true);
+
+	const acquire = api.declarationLock.acquireLock.useMutation();
+	const heartbeat = api.declarationLock.heartbeat.useMutation();
+	const release = api.declarationLock.releaseLock.useMutation();
+
+	const acquireRef = useRef(acquire.mutateAsync);
+	const heartbeatRef = useRef(heartbeat.mutateAsync);
+	const releaseRef = useRef(release.mutate);
+	acquireRef.current = acquire.mutateAsync;
+	heartbeatRef.current = heartbeat.mutateAsync;
+	releaseRef.current = release.mutate;
+
+	// Tracks whether *this* tab currently holds the editor lock, read by the
+	// pagehide beacon and the unmount cleanup without re-running the effect.
+	const isHolderRef = useRef(false);
+
+	useEffect(() => {
+		if (!isEnabled) {
+			isHolderRef.current = false;
+			setIsReadOnly(false);
+			setHolder(null);
+			// Stay "loading" while the session is still resolving so consumers do
+			// not flash an editable state before ownership is known.
+			setIsLoading(session.status === "loading");
+			return;
+		}
+
+		let cancelled = false;
+		let intervalId: ReturnType<typeof setInterval> | null = null;
+
+		const stopHeartbeat = () => {
+			if (intervalId !== null) {
+				clearInterval(intervalId);
+				intervalId = null;
+			}
+		};
+
+		const refreshOwnership = async () => {
+			try {
+				const result = await acquireRef.current({ declarationId });
+				if (cancelled) return;
+				isHolderRef.current = result.acquired;
+				setIsReadOnly(!result.acquired);
+				setHolder(result.holder);
+				if (!result.acquired) stopHeartbeat();
+			} catch {
+				if (cancelled) return;
+				isHolderRef.current = false;
+				setIsReadOnly(true);
+			}
+		};
+
+		const startHeartbeat = () => {
+			if (intervalId !== null) return;
+			intervalId = setInterval(() => {
+				void heartbeatRef
+					.current({ declarationId })
+					.then((result) => {
+						if (cancelled || result.held) return;
+						// Lock lost (expired or taken over): re-read the current holder.
+						void refreshOwnership();
+					})
+					.catch(() => {});
+			}, LOCK_HEARTBEAT_INTERVAL_MS);
+		};
+
+		const handleHide = () => {
+			if (!isHolderRef.current) return;
+			const payload = JSON.stringify({ declarationId });
+			const blob = new Blob([payload], { type: "application/json" });
+			navigator.sendBeacon(RELEASE_ENDPOINT, blob);
+		};
+
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "hidden") handleHide();
+		};
+
+		setIsLoading(true);
+		void (async () => {
+			await refreshOwnership();
+			if (cancelled) return;
+			setIsLoading(false);
+			if (isHolderRef.current) startHeartbeat();
+		})();
+
+		window.addEventListener("pagehide", handleHide);
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
+		return () => {
+			cancelled = true;
+			stopHeartbeat();
+			window.removeEventListener("pagehide", handleHide);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+			if (isHolderRef.current) {
+				isHolderRef.current = false;
+				releaseRef.current({ declarationId });
+			}
+		};
+	}, [declarationId, isEnabled, session.status]);
+
+	return { isReadOnly, holder, isLoading };
+}


### PR DESCRIPTION
Closes #3728

## Contexte

Cycle de vie du verrou **côté client** sur le parcours de déclaration des indicateurs de rémunération (epic #3556) : acquisition à l'entrée en édition, heartbeat périodique, libération à la sortie / fermeture d'onglet. Fournit le `LockContext` et le composant d'alerte partagés consommés par les tickets suivants (#T4 parcours, #T5 mon-espace).

Dépend de #3724 (procédures tRPC `declarationLock` + gating des écritures), désormais squash-mergé dans `epic/3556`.

## Changements

- **`useDeclarationLock({ declarationId })`** — hook de cycle de vie : `acquireLock` au montage → `{ isReadOnly, holder }`, `heartbeat` toutes les `LOCK_HEARTBEAT_INTERVAL_MS` (constante domaine) tant que détenteur, `releaseLock` au démontage, et `navigator.sendBeacon` best-effort sur `pagehide` / `visibilitychange(hidden)`. Désactivé hors session authentifiée et en impersonation admin.
- **`LockProvider` + `useLockContext()`** — exposent `{ isReadOnly, holder, isLoading }`.
- **`DeclarationLockAlert`** — composant DSFR présentationnel (`fr-alert--warning`), `role="alert"` (alerte ajoutée dynamiquement, RGAA 7.5/12.8) + indication textuelle « Attention » (`fr-sr-only`, RGAA 3.2/3.3). Réutilisable par #T4/#T5.
- **`POST /api/declaration-lock/release`** — route handler minimal pour `sendBeacon` (une requête tRPC ne peut pas être garantie au unload). La déclaration est résolue **côté serveur** depuis le SIREN de session (jamais le corps du beacon) ; `releaseLock` ne supprime qu'un verrou détenu par l'appelant. Audité via `withAuditedRoute` (`DECLARATION_LOCK_RELEASED`).
- **Câblage** dans `StepPageClient` : le rendu des étapes est enveloppé dans `LockProvider` (`declaration.id`).

## Test plan

- TU (vitest) : 28 tests sur le hook (S1 acquire+éditable, S7 heartbeat, S5 beacon, branche read-only sans heartbeat, perte de lock, release on unmount, états désactivés), le provider/contexte, l'alerte (fallbacks nom/email), et le route handler (401 / 204 impersonation / 400 sans siren / 204 release).
- `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` : verts.
- Sécurité : pas d'IDOR (résolution server-side + delete scoped `userId`), audit complet.

> UI partagée (alerte) non encore rendue dans le parcours : c'est le livrable de #T4 qui consomme `useLockContext` + `DeclarationLockAlert`. Pas de capture d'écran : ce ticket ne rend aucun nouveau visuel dans l'application (composant présentationnel fourni pour réutilisation).
