### PR TITLE
feat(mon-espace): état du verrou dans le side panel (#3730)

### DIFF
--- a/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
+++ b/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
@@ -27,6 +27,15 @@ describe("AUDIT_ACTIONS", () => {
 			AUDIT_ACTION_CATEGORIES[AUDIT_ACTIONS.ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT],
 		).toBe("mutation");
 	});
+
+	it("maps the declaration lock state read to a sensitive read (holder PII)", () => {
+		expect(AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ).toBe(
+			"declaration.lock_state_read",
+		);
+		expect(
+			AUDIT_ACTION_CATEGORIES[AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ],
+		).toBe("read_sensitive");
+	});
 });
 
 describe("retention constants", () => {

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -26,10 +26,11 @@ export const AUDIT_ACTIONS = {
 	DECLARATION_SAVE_COMPLIANCE_PATH: "declaration.save_compliance_path",
 	DECLARATION_SUBMIT_JOINT_EVALUATION: "declaration.submit_joint_evaluation",
 
-	// ── Declaration edit lock mutations ────────────────────
+	// ── Declaration edit lock mutations & reads ────────────
 	DECLARATION_LOCK_ACQUIRED: "declaration.lock_acquired",
 	DECLARATION_LOCK_RELEASED: "declaration.lock_released",
 	ADMIN_DECLARATION_RELEASE_LOCK: "admin_declaration.release_lock",
+	DECLARATION_LOCK_STATE_READ: "declaration.lock_state_read",
 
 	// ── CSE opinion mutations ──────────────────────────────
 	CSE_OPINION_SAVE: "cse_opinion.save",
@@ -142,6 +143,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.DECLARATION_LOCK_ACQUIRED]: "mutation",
 	[AUDIT_ACTIONS.DECLARATION_LOCK_RELEASED]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_DECLARATION_RELEASE_LOCK]: "mutation",
+	[AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ]: "read_sensitive",
 
 	[AUDIT_ACTIONS.CSE_OPINION_SAVE]: "mutation",
 	[AUDIT_ACTIONS.CSE_OPINION_UPLOAD_FILE]: "mutation",

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -8,7 +8,11 @@ import { DeclarationProcessPanel } from "./DeclarationProcessPanel";
 import { DeclarationsSection } from "./DeclarationsSection";
 import { computeCtaHref, computePanelVariant } from "./declarationProcessState";
 import { MissingInfoModal } from "./MissingInfoModal";
-import type { CompanyDetail, DeclarationItem } from "./types";
+import type {
+	CompanyDetail,
+	DeclarationItem,
+	LockHolderDisplay,
+} from "./types";
 import { WelcomeBanner } from "./WelcomeBanner";
 
 type Props = {
@@ -16,6 +20,8 @@ type Props = {
 	company: CompanyDetail;
 	declarations: DeclarationItem[];
 	hasNoSanction: boolean;
+	lockedByOther: boolean;
+	lockHolder: LockHolderDisplay | null;
 	userPhone: string | null;
 };
 
@@ -40,6 +46,8 @@ export function CompanyDeclarationsPage({
 	company,
 	declarations,
 	hasNoSanction,
+	lockedByOther,
+	lockHolder,
 	userPhone,
 }: Props) {
 	const currentYear = getCurrentYear();
@@ -83,6 +91,8 @@ export function CompanyDeclarationsPage({
 					currentDeclaration?.hasSubmittedSecondDeclaration ?? false
 				}
 				lastActionDate={lastActionDate}
+				lockedByOther={lockedByOther}
+				lockHolder={lockHolder}
 				siren={company.siren}
 				variant={panelVariant}
 				year={currentYear}

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -2,12 +2,13 @@
 
 import Link from "next/link";
 import { useRef } from "react";
-
+import { DeclarationLockAlert } from "~/modules/declaration-remuneration";
 import type {
 	CampaignDeadlines,
 	DeclarationDisplayContext,
 } from "~/modules/domain";
 import styles from "./DeclarationProcessPanel.module.scss";
+import type { LockHolderDisplay } from "./types";
 import { getStepStatuses, VerticalStepper } from "./VerticalStepper";
 
 export const DECLARATION_PROCESS_PANEL_ID = "declaration-process-panel";
@@ -30,6 +31,8 @@ type Props = {
 	hasSubmittedSecondDeclaration: boolean;
 	siren: string;
 	ctaHref: string;
+	lockedByOther: boolean;
+	lockHolder: LockHolderDisplay | null;
 };
 
 export function DeclarationProcessPanel({
@@ -41,6 +44,8 @@ export function DeclarationProcessPanel({
 	hasSubmittedSecondDeclaration,
 	siren,
 	ctaHref,
+	lockedByOther,
+	lockHolder,
 }: Props) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 
@@ -72,6 +77,9 @@ export function DeclarationProcessPanel({
 							siren={siren}
 							year={year}
 						/>
+						{lockedByOther && lockHolder && (
+							<DeclarationLockAlert holder={lockHolder} />
+						)}
 						{(variant === "start" || variant === "compliance_choice") && (
 							<StartAlert />
 						)}
@@ -92,7 +100,9 @@ export function DeclarationProcessPanel({
 						<HelpSection />
 						<div className={styles.footer}>
 							<a className="fr-btn" href={ctaHref}>
-								{getCtaLabel(variant)}
+								{lockedByOther
+									? "Consulter en lecture seule"
+									: getCtaLabel(variant)}
 							</a>
 						</div>
 					</div>

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRef } from "react";
-import { DeclarationLockAlert } from "~/modules/declaration-remuneration";
+import { DeclarationLockAlert } from "~/modules/declaration-remuneration/shared/lock/DeclarationLockAlert";
 import type {
 	CampaignDeadlines,
 	DeclarationDisplayContext,

--- a/packages/app/src/modules/my-space/MonEspacePage.tsx
+++ b/packages/app/src/modules/my-space/MonEspacePage.tsx
@@ -21,11 +21,13 @@ export async function MonEspacePage({ siret, userPhone }: Props) {
 	}
 
 	const siren = siret.slice(0, SIREN_LENGTH);
-	const [data, sanctionStatus, campaignDeadlines] = await Promise.all([
-		api.company.getWithDeclarations({ siren }),
-		api.company.getSanctionStatus({ siren }),
-		getCampaignDeadlines(getCurrentYear()),
-	]);
+	const [data, sanctionStatus, campaignDeadlines, lockState] =
+		await Promise.all([
+			api.company.getWithDeclarations({ siren }),
+			api.company.getSanctionStatus({ siren }),
+			getCampaignDeadlines(getCurrentYear()),
+			api.declarationLock.getActiveLockForCurrentDeclaration(),
+		]);
 
 	const hasNoSanction = sanctionStatus !== null && !sanctionStatus.hasSanction;
 
@@ -35,6 +37,8 @@ export async function MonEspacePage({ siret, userPhone }: Props) {
 			company={data.company}
 			declarations={data.declarations}
 			hasNoSanction={hasNoSanction}
+			lockedByOther={lockState.lockedByOther}
+			lockHolder={lockState.holder}
 			userPhone={userPhone}
 		/>
 	);

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -235,6 +235,8 @@ export function PanelPlayground() {
 				})}
 				hasSubmittedSecondDeclaration={secondDeclarationSubmitted}
 				lastActionDate="12 mars 2026"
+				lockedByOther={false}
+				lockHolder={null}
 				siren="000000000"
 				variant={variant}
 				year={2027}

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -78,101 +78,83 @@ const declarations: DeclarationItem[] = [
 	},
 ];
 
+type LockHolder = {
+	firstName: string | null;
+	lastName: string | null;
+	email: string | null;
+};
+
+const BASE_PROPS = {
+	campaignDeadlines,
+	company,
+	declarations,
+	hasNoSanction: false,
+	lockedByOther: false,
+	lockHolder: null as LockHolder | null,
+	userPhone: "0122334455" as string | null,
+};
+
+function renderPage(overrides: Partial<typeof BASE_PROPS> = {}) {
+	return render(<CompanyDeclarationsPage {...BASE_PROPS} {...overrides} />);
+}
+
 describe("CompanyDeclarationsPage", () => {
 	it("renders the main landmark with id 'content'", () => {
-		render(
-			<CompanyDeclarationsPage
-				campaignDeadlines={campaignDeadlines}
-				company={company}
-				declarations={declarations}
-				hasNoSanction={false}
-				userPhone="0122334455"
-			/>,
-		);
+		renderPage();
 		const main = screen.getByRole("main");
 		expect(main).toBeInTheDocument();
 		expect(main).toHaveAttribute("id", "content");
 	});
 
 	it("renders the company name", () => {
-		render(
-			<CompanyDeclarationsPage
-				campaignDeadlines={campaignDeadlines}
-				company={company}
-				declarations={declarations}
-				hasNoSanction={false}
-				userPhone="0122334455"
-			/>,
-		);
+		renderPage();
 		expect(
 			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 
 	it("renders the 'Démarche en cours' heading", () => {
-		render(
-			<CompanyDeclarationsPage
-				campaignDeadlines={campaignDeadlines}
-				company={company}
-				declarations={declarations}
-				hasNoSanction={false}
-				userPhone="0122334455"
-			/>,
-		);
+		renderPage();
 		expect(
 			screen.getByRole("heading", { level: 2, name: "Démarche en cours" }),
 		).toBeInTheDocument();
 	});
 
 	it("renders the 'Archives' section", () => {
-		render(
-			<CompanyDeclarationsPage
-				campaignDeadlines={campaignDeadlines}
-				company={company}
-				declarations={declarations}
-				hasNoSanction={false}
-				userPhone="0122334455"
-			/>,
-		);
+		renderPage();
 		expect(screen.getByText("Archives")).toBeInTheDocument();
 	});
 
 	it("always renders MissingInfoModal so DSFR conceal/disclose chain works", () => {
-		const { container } = render(
-			<CompanyDeclarationsPage
-				campaignDeadlines={campaignDeadlines}
-				company={{ ...company, hasCse: true }}
-				declarations={declarations}
-				hasNoSanction={false}
-				userPhone="0122334455"
-			/>,
-		);
+		const { container } = renderPage({ company: { ...company, hasCse: true } });
 		expect(container.querySelector("#missing-info-modal")).toBeInTheDocument();
 	});
 
 	it("renders MissingInfoModal when userPhone is null", () => {
-		const { container } = render(
-			<CompanyDeclarationsPage
-				campaignDeadlines={campaignDeadlines}
-				company={{ ...company, hasCse: true }}
-				declarations={declarations}
-				hasNoSanction={false}
-				userPhone={null}
-			/>,
-		);
+		const { container } = renderPage({
+			company: { ...company, hasCse: true },
+			userPhone: null,
+		});
 		expect(container.querySelector("#missing-info-modal")).toBeInTheDocument();
 	});
 
 	it("renders MissingInfoModal when hasCse is null", () => {
-		const { container } = render(
-			<CompanyDeclarationsPage
-				campaignDeadlines={campaignDeadlines}
-				company={{ ...company, hasCse: null }}
-				declarations={declarations}
-				hasNoSanction={false}
-				userPhone="0122334455"
-			/>,
-		);
+		const { container } = renderPage({ company: { ...company, hasCse: null } });
 		expect(container.querySelector("#missing-info-modal")).toBeInTheDocument();
+	});
+
+	it("forwards the lock alert when the declaration is locked by another user", () => {
+		const { container } = renderPage({
+			lockedByOther: true,
+			lockHolder: {
+				firstName: "Alice",
+				lastName: "Martin",
+				email: "alice.martin@example.fr",
+			},
+		});
+		const alert = container.querySelector('[role="alert"]');
+		expect(alert).toBeInTheDocument();
+		expect(alert).toHaveTextContent("Déclaration en cours de modification");
+		expect(alert).toHaveTextContent("Alice Martin");
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -39,6 +39,12 @@ function makeDisplayContextFromPaths(
 	};
 }
 
+type LockHolder = {
+	firstName: string | null;
+	lastName: string | null;
+	email: string | null;
+};
+
 const BASE_PROPS = {
 	campaignDeadlines: getDefaultCampaignDeadlines(FUTURE_YEAR),
 	year: FUTURE_YEAR,
@@ -47,6 +53,8 @@ const BASE_PROPS = {
 	hasSubmittedSecondDeclaration: false,
 	siren: "532847196",
 	ctaHref: "/declaration-remuneration?siren=532847196",
+	lockedByOther: false,
+	lockHolder: null as LockHolder | null,
 };
 
 function renderPanel(
@@ -318,6 +326,75 @@ describe("DeclarationProcessPanel", () => {
 			expect(
 				panel.getByText(/Modification close depuis le/),
 			).toBeInTheDocument();
+		});
+	});
+
+	describe("lock held by another co-declarant", () => {
+		const lockHolder = {
+			firstName: "Alice",
+			lastName: "Martin",
+			email: "alice.martin@example.fr",
+		};
+
+		it("renders the lock alert naming the current editor", () => {
+			const { dialog } = renderPanel("start", {
+				lockedByOther: true,
+				lockHolder,
+			});
+			const alert = dialog.querySelector('[role="alert"]');
+			expect(alert).toBeInTheDocument();
+			expect(alert).toHaveTextContent("Déclaration en cours de modification");
+			expect(alert).toHaveTextContent("Alice Martin");
+		});
+
+		it('replaces the CTA label with "Consulter en lecture seule"', () => {
+			const { dialog } = renderPanel("start", {
+				lockedByOther: true,
+				lockHolder,
+			});
+			const ctaLinks = dialog.querySelectorAll("a.fr-btn");
+			const cta = ctaLinks[ctaLinks.length - 1];
+			expect(cta).toHaveTextContent("Consulter en lecture seule");
+			expect(cta).not.toHaveTextContent("Commencer la déclaration");
+		});
+
+		it("keeps the CTA href pointing to the declaration for read-only access", () => {
+			const { dialog } = renderPanel("start", {
+				lockedByOther: true,
+				lockHolder,
+			});
+			const ctaLinks = dialog.querySelectorAll("a.fr-btn");
+			const cta = ctaLinks[ctaLinks.length - 1];
+			expect(cta).toHaveAttribute(
+				"href",
+				"/declaration-remuneration?siren=532847196",
+			);
+		});
+
+		it("does not render the alert when lockedByOther is true but no holder is resolved", () => {
+			const { dialog } = renderPanel("start", {
+				lockedByOther: true,
+				lockHolder: null,
+			});
+			expect(dialog.querySelector('[role="alert"]')).not.toBeInTheDocument();
+		});
+	});
+
+	describe("declaration not locked by another user", () => {
+		it("does not render the lock alert", () => {
+			const { dialog } = renderPanel("start", {
+				lockedByOther: false,
+				lockHolder: null,
+			});
+			expect(dialog.querySelector('[role="alert"]')).not.toBeInTheDocument();
+		});
+
+		it("keeps the regular CTA label", () => {
+			const { dialog } = renderPanel("start", { lockedByOther: false });
+			const ctaLinks = dialog.querySelectorAll("a.fr-btn");
+			const cta = ctaLinks[ctaLinks.length - 1];
+			expect(cta).toHaveTextContent("Commencer la déclaration");
+			expect(cta).not.toHaveTextContent("Consulter en lecture seule");
 		});
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockRedirect } = vi.hoisted(() => ({
+const { mockRedirect, mockGetActiveLock } = vi.hoisted(() => ({
 	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
 		throw new Error("NEXT_REDIRECT");
 	}),
+	mockGetActiveLock: vi
+		.fn()
+		.mockResolvedValue({ lockedByOther: false, holder: null }),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -84,6 +87,9 @@ vi.mock("~/trpc/server", () => ({
 				.fn()
 				.mockResolvedValue({ hasSanction: false, validityDate: null }),
 		},
+		declarationLock: {
+			getActiveLockForCurrentDeclaration: mockGetActiveLock,
+		},
 	},
 	HydrateClient: ({ children }: { children: React.ReactNode }) => (
 		<>{children}</>
@@ -93,6 +99,10 @@ vi.mock("~/trpc/server", () => ({
 import { MonEspacePage } from "../MonEspacePage";
 
 describe("MonEspacePage", () => {
+	beforeEach(() => {
+		mockGetActiveLock.mockResolvedValue({ lockedByOther: false, holder: null });
+	});
+
 	it("redirects to mes-entreprises when siret is null", async () => {
 		await expect(
 			MonEspacePage({ siret: null, userPhone: null }),
@@ -126,5 +136,34 @@ describe("MonEspacePage", () => {
 		});
 		render(page);
 		expect(screen.getByRole("main")).toHaveAttribute("id", "content");
+	});
+
+	it("does not render the lock alert when the declaration is unlocked", async () => {
+		const page = await MonEspacePage({
+			siret: "12345678901234",
+			userPhone: "0612345678",
+		});
+		const { container } = render(page);
+		expect(container.querySelector('[role="alert"]')).not.toBeInTheDocument();
+	});
+
+	it("forwards the lock state when another co-declarant holds the lock", async () => {
+		mockGetActiveLock.mockResolvedValueOnce({
+			lockedByOther: true,
+			holder: {
+				firstName: "Alice",
+				lastName: "Martin",
+				email: "alice.martin@example.fr",
+			},
+		});
+		const page = await MonEspacePage({
+			siret: "12345678901234",
+			userPhone: "0612345678",
+		});
+		const { container } = render(page);
+		const alert = container.querySelector('[role="alert"]');
+		expect(alert).toBeInTheDocument();
+		expect(alert).toHaveTextContent("Déclaration en cours de modification");
+		expect(alert).toHaveTextContent("Alice Martin");
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
@@ -34,6 +34,8 @@ const BASE_PROPS = {
 	hasSubmittedSecondDeclaration: false,
 	siren: "532847196",
 	ctaHref: "/declaration-remuneration?siren=532847196",
+	lockedByOther: false,
+	lockHolder: null,
 };
 
 function renderPanel(

--- a/packages/app/src/modules/my-space/types.ts
+++ b/packages/app/src/modules/my-space/types.ts
@@ -31,6 +31,12 @@ export type CompanyDetail = {
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
+export type LockHolderDisplay = {
+	firstName: string | null;
+	lastName: string | null;
+	email: string | null;
+};
+
 export type DeclarationItem = {
 	type: DeclarationType;
 	siren: string;

--- a/packages/app/src/server/api/routers/__tests__/declarationLock.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationLock.test.ts
@@ -74,6 +74,77 @@ afterEach(() => {
 });
 
 describe("declarationLockRouter", () => {
+	describe("getActiveLockForCurrentDeclaration", () => {
+		it("returns no lock when the caller has no current-year declaration", async () => {
+			const db = createSelectDb([[]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getActiveLockForCurrentDeclaration();
+
+			expect(result).toEqual({ lockedByOther: false, holder: null });
+			expect(mocks.getActiveLock).not.toHaveBeenCalled();
+		});
+
+		it("returns lockedByOther=false and a null holder when the declaration is unlocked", async () => {
+			mocks.getActiveLock.mockResolvedValue(null);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getActiveLockForCurrentDeclaration();
+
+			expect(result).toEqual({ lockedByOther: false, holder: null });
+			expect(mocks.getActiveLock).toHaveBeenCalledWith(db, DECLARATION_ID);
+		});
+
+		it("reports lockedByOther and exposes the holder identity when another co-declarant holds the lock", async () => {
+			const holder = buildLockHolder({ userId: OTHER_USER_ID });
+			mocks.getActiveLock.mockResolvedValue(holder);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getActiveLockForCurrentDeclaration();
+
+			expect(result).toEqual({
+				lockedByOther: true,
+				holder: {
+					firstName: holder.firstName,
+					lastName: holder.lastName,
+					email: holder.email,
+				},
+			});
+		});
+
+		it("reports lockedByOther=false for the caller's own lock while still exposing the holder", async () => {
+			const holder = buildLockHolder({ userId: USER_ID });
+			mocks.getActiveLock.mockResolvedValue(holder);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getActiveLockForCurrentDeclaration();
+
+			expect(result).toEqual({
+				lockedByOther: false,
+				holder: {
+					firstName: holder.firstName,
+					lastName: holder.lastName,
+					email: holder.email,
+				},
+			});
+		});
+
+		it("never excludes the lock service's expiresAt from the leaked payload", async () => {
+			const holder = buildLockHolder({ userId: OTHER_USER_ID });
+			mocks.getActiveLock.mockResolvedValue(holder);
+			const db = createSelectDb([[{ id: DECLARATION_ID }]]);
+			const caller = await createCaller(db);
+
+			const result = await caller.getActiveLockForCurrentDeclaration();
+
+			expect(result.holder).not.toHaveProperty("expiresAt");
+			expect(result.holder).not.toHaveProperty("userId");
+		});
+	});
+
 	describe("acquireLock", () => {
 		it("acquires the lock, returns the holder, and audits a single acquisition (S11)", async () => {
 			const holder = buildLockHolder({ userId: USER_ID });

--- a/packages/app/src/server/api/routers/declarationLock.ts
+++ b/packages/app/src/server/api/routers/declarationLock.ts
@@ -71,6 +71,32 @@ async function readLockTimeoutMinutes(db: DB): Promise<number> {
 }
 
 export const declarationLockRouter = createTRPCRouter({
+	getActiveLockForCurrentDeclaration: companyProcedure.query(
+		async ({ ctx }) => {
+			const [row] = await ctx.db
+				.select({ id: declarations.id })
+				.from(declarations)
+				.where(activeDeclarationFilter(ctx.siren, getCurrentYear()))
+				.limit(1);
+
+			if (!row) {
+				return { lockedByOther: false, holder: null };
+			}
+
+			const holder = await getActiveLock(ctx.db, row.id);
+			return {
+				lockedByOther: holder !== null && holder.userId !== ctx.session.user.id,
+				holder: holder
+					? {
+							firstName: holder.firstName,
+							lastName: holder.lastName,
+							email: holder.email,
+						}
+					: null,
+			};
+		},
+	),
+
 	acquireLock: companyWriteProcedure
 		.input(acquireLockSchema)
 		.mutation(async ({ ctx, input }) => {

--- a/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
+++ b/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
@@ -141,6 +141,21 @@ describe("auditMiddleware", () => {
 		});
 	});
 
+	it("logs the declaration lock state read (declarationLock.getActiveLockForCurrentDeclaration)", async () => {
+		const next = vi.fn(async () => ({ lockedByOther: true, holder: {} }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "declarationLock.getActiveLockForCurrentDeclaration",
+			getRawInput: buildGetRawInput(undefined),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "declaration.lock_state_read",
+			status: "success",
+		});
+	});
+
 	it("strips sensitive metadata keys (token, password, …)", async () => {
 		const next = vi.fn(async () => undefined);
 		await auditMiddleware({

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -33,6 +33,10 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"declaration.getOrCreate": AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA,
 	"declaration.getStatusHistory": AUDIT_ACTIONS.DECLARATION_HISTORY_READ,
 
+	// ── declaration lock sensitive read (exposes holder PII) ─
+	"declarationLock.getActiveLockForCurrentDeclaration":
+		AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ,
+
 	// ── cse opinion mutations ──────────────────────────────
 	"cseOpinion.saveOpinions": AUDIT_ACTIONS.CSE_OPINION_SAVE,
 	"cseOpinion.deleteFile": AUDIT_ACTIONS.CSE_OPINION_DELETE_FILE,

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -33,9 +33,10 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"declaration.getOrCreate": AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA,
 	"declaration.getStatusHistory": AUDIT_ACTIONS.DECLARATION_HISTORY_READ,
 
-	// ── declaration lock sensitive read (exposes holder PII) ─
+	// ── declaration lock sensitive reads (expose holder PII) ─
 	"declarationLock.getActiveLockForCurrentDeclaration":
 		AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ,
+	"declarationLock.getLockState": AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ,
 
 	// ── cse opinion mutations ──────────────────────────────
 	"cseOpinion.saveOpinions": AUDIT_ACTIONS.CSE_OPINION_SAVE,


### PR DESCRIPTION
Closes #3730

## Résumé

- `MonEspacePage` (server component) récupère l'état du verrou via `declarationLock.getActiveLockForCurrentDeclaration` et le passe en props au panel
- `DeclarationProcessPanel` affiche `<DeclarationLockAlert>` entre le header et le stepper quand `lockedByOther=true`, et remplace le CTA habituel par « Consulter en lecture seule »
- Nouvelle procédure tRPC `getActiveLockForCurrentDeclaration` (companyProcedure) : récupère la déclaration de l'année courante pour le SIREN en session, puis interroge `getActiveLock`
- Type `LockHolderDisplay` factorisé dans `my-space/types.ts`
- Audit `read_sensitive` câblé pour la nouvelle procédure (expose firstName/lastName/email du verrou)

## Plan de test

- [ ] Vérifier que le side panel affiche l'alerte + le bouton « Consulter en lecture seule » quand un autre utilisateur détient le verrou
- [ ] Vérifier que le CTA habituel (Commencer / Continuer) s'affiche quand aucun verrou tiers
- [ ] Vérifier que la ligne `declaration.lock_state_read` apparaît dans `audit.action_log`
- [ ] Tests unitaires verts (310 fichiers, 2885 tests)