### PR TITLE
feat(declaration-remuneration): lecture seule du parcours de conformité (#3494)

### DIFF
--- a/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
+++ b/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
@@ -2,15 +2,13 @@ import { expect, test } from "@playwright/test";
 
 import { getCurrentYear } from "~/modules/domain";
 import {
+	pushCampaignDeadlinesFarFuture,
 	resetDeclarationToDraft,
 	setCompanyHasCse,
 	setDeclarationComplianceState,
 	setUserPhone,
 } from "./helpers/db";
-import {
-	deleteCampaignDeadlines,
-	setCampaignDeadlines,
-} from "./helpers/db-campaign";
+import { setCampaignDeadlines } from "./helpers/db-campaign";
 import { clickAndExpectDialogOpen, waitForDsfrModal } from "./helpers/dsfr";
 import { loginWithProConnect } from "./helpers/login";
 
@@ -61,7 +59,7 @@ test.describe("Campaign deadlines gating", () => {
 	}
 
 	test.afterAll(async () => {
-		await deleteCampaignDeadlines(testDeclarationYear);
+		await pushCampaignDeadlinesFarFuture();
 		await resetDeclarationToDraft();
 		await setCompanyHasCse(true);
 	});

--- a/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
+++ b/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
@@ -2,13 +2,15 @@ import { expect, test } from "@playwright/test";
 
 import { getCurrentYear } from "~/modules/domain";
 import {
-	pushCampaignDeadlinesFarFuture,
 	resetDeclarationToDraft,
 	setCompanyHasCse,
 	setDeclarationComplianceState,
 	setUserPhone,
 } from "./helpers/db";
-import { setCampaignDeadlines } from "./helpers/db-campaign";
+import {
+	deleteCampaignDeadlines,
+	setCampaignDeadlines,
+} from "./helpers/db-campaign";
 import { clickAndExpectDialogOpen, waitForDsfrModal } from "./helpers/dsfr";
 import { loginWithProConnect } from "./helpers/login";
 
@@ -59,7 +61,7 @@ test.describe("Campaign deadlines gating", () => {
 	}
 
 	test.afterAll(async () => {
-		await pushCampaignDeadlinesFarFuture();
+		await deleteCampaignDeadlines(testDeclarationYear);
 		await resetDeclarationToDraft();
 		await setCompanyHasCse(true);
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -24,7 +24,11 @@ import {
 	getCompliancePathHref,
 	SecondRoundOptions,
 } from "./compliancePath/CompliancePathOptions";
-import type { CompliancePathValue } from "./compliancePath/constants";
+import { CompliancePathReadOnlyAlert } from "./compliancePath/CompliancePathReadOnlyAlert";
+import type {
+	CompliancePathReadOnlyReason,
+	CompliancePathValue,
+} from "./compliancePath/constants";
 import { DeclarationSuccessBanner } from "./compliancePath/DeclarationSuccessBanner";
 
 type Props = {
@@ -36,6 +40,7 @@ type Props = {
 	initialPath?: CompliancePathValue;
 	isSecondRound?: boolean;
 	pdfDownloadHref?: string;
+	readOnlyReason?: CompliancePathReadOnlyReason;
 };
 
 export function CompliancePathChoice({
@@ -47,9 +52,11 @@ export function CompliancePathChoice({
 	initialPath,
 	isSecondRound = false,
 	pdfDownloadHref,
+	readOnlyReason,
 }: Props) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const isReadOnly = readOnlyReason !== undefined;
 
 	const dbValues = useMemo(() => ({ path: initialPath }), [initialPath]);
 
@@ -79,7 +86,7 @@ export function CompliancePathChoice({
 		}
 	});
 
-	useDraftAutoSave(form, draftHydrated, (values) =>
+	useDraftAutoSave(form, draftHydrated && !isReadOnly, (values) =>
 		setField(values as { path: CompliancePathValue | undefined }),
 	);
 
@@ -105,7 +112,7 @@ export function CompliancePathChoice({
 	if (!draftHydrated) return <DraftLoadingState />;
 
 	const onSubmit = form.handleSubmit((data) => {
-		if (!data.path) return;
+		if (isReadOnly || !data.path) return;
 		mutation.mutate({ path: data.path });
 	});
 
@@ -137,6 +144,10 @@ export function CompliancePathChoice({
 				pdfDownloadHref={pdfDownloadHref}
 				year={currentYear}
 			/>
+
+			{readOnlyReason ? (
+				<CompliancePathReadOnlyAlert reason={readOnlyReason} />
+			) : null}
 
 			<div className={common.flexColumnGap1}>
 				<p className={`fr-mb-0 ${styles.instructions}`}>
@@ -189,7 +200,7 @@ export function CompliancePathChoice({
 
 							{isSecondRound ? (
 								<SecondRoundOptions
-									disabled={isImpersonating}
+									disabled={isImpersonating || isReadOnly}
 									jointEvaluationDeadline={
 										campaignDeadlines.decl2JointEvaluationDeadline
 									}
@@ -204,7 +215,7 @@ export function CompliancePathChoice({
 									correctiveActionDeadline={
 										campaignDeadlines.decl2ModificationDeadline
 									}
-									disabled={isImpersonating}
+									disabled={isImpersonating || isReadOnly}
 									jointEvaluationDeadline={
 										campaignDeadlines.decl1JointEvaluationDeadline
 									}
@@ -225,7 +236,12 @@ export function CompliancePathChoice({
 				mimoquageNextHref={
 					initialPath ? getCompliancePathHref(initialPath) : undefined
 				}
-				nextDisabled={!selectedPath}
+				nextDisabled={!selectedPath || isReadOnly}
+				nextHref={
+					isReadOnly && initialPath
+						? getCompliancePathHref(initialPath)
+						: undefined
+				}
 				nextLabel="Suivant"
 				previousHref="/declaration-remuneration/etape/6"
 			/>

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -46,7 +46,7 @@ export function getCompliancePathReadOnlyReason(params: {
 	hasSubmittedSecondDeclaration: boolean;
 	hasSubmittedCseOpinion: boolean;
 	hasSubmittedJointEvaluation: boolean;
-	modificationDeadline: Date;
+	pathChoiceDeadline: Date;
 	now?: Date;
 }): CompliancePathReadOnlyReason | null {
 	const {
@@ -55,7 +55,7 @@ export function getCompliancePathReadOnlyReason(params: {
 		hasSubmittedSecondDeclaration,
 		hasSubmittedCseOpinion,
 		hasSubmittedJointEvaluation,
-		modificationDeadline,
+		pathChoiceDeadline,
 		now,
 	} = params;
 
@@ -66,8 +66,8 @@ export function getCompliancePathReadOnlyReason(params: {
 		return "second_declaration_submitted";
 	if (pathChoice === "joint_evaluation" && hasSubmittedJointEvaluation)
 		return "joint_evaluation_submitted";
-	if (isDeadlinePassed(modificationDeadline, now))
-		return "modification_deadline_passed";
+	if (isDeadlinePassed(pathChoiceDeadline, now))
+		return "path_choice_deadline_passed";
 	return null;
 }
 
@@ -124,9 +124,7 @@ export async function CompliancePathPage() {
 		hasSubmittedSecondDeclaration: data.hasSubmittedSecondDeclaration,
 		hasSubmittedCseOpinion: data.hasSubmittedCseOpinion,
 		hasSubmittedJointEvaluation: data.hasSubmittedJointEvaluation,
-		modificationDeadline: isSecondRound
-			? campaignDeadlines.decl2ModificationDeadline
-			: campaignDeadlines.decl1ModificationDeadline,
+		pathChoiceDeadline: campaignDeadlines.pathChoiceDeadline,
 	});
 
 	return (

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -1,10 +1,18 @@
 import { redirect } from "next/navigation";
-import { hasGapsAboveThreshold } from "~/modules/domain";
+import {
+	type DeclarationFsmStatus,
+	hasGapsAboveThreshold,
+	isDeadlinePassed,
+} from "~/modules/domain";
 import { auth } from "~/server/auth";
 import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { api, HydrateClient } from "~/trpc/server";
 import { getPostComplianceDestination } from "../shared/complianceNavigation";
 import { CompliancePathChoice } from "./CompliancePathChoice";
+import type {
+	CompliancePathReadOnlyReason,
+	CompliancePathValue,
+} from "./compliancePath/constants";
 
 type ComplianceState =
 	| { type: "no_gap" }
@@ -30,6 +38,37 @@ export function getComplianceState(
 	}
 
 	return { type: "first_round" };
+}
+
+export function getCompliancePathReadOnlyReason(params: {
+	status: DeclarationFsmStatus;
+	pathChoice: CompliancePathValue | null;
+	hasSubmittedSecondDeclaration: boolean;
+	hasSubmittedCseOpinion: boolean;
+	hasSubmittedJointEvaluation: boolean;
+	modificationDeadline: Date;
+	now?: Date;
+}): CompliancePathReadOnlyReason | null {
+	const {
+		status,
+		pathChoice,
+		hasSubmittedSecondDeclaration,
+		hasSubmittedCseOpinion,
+		hasSubmittedJointEvaluation,
+		modificationDeadline,
+		now,
+	} = params;
+
+	if (status === "demarche_completed") return "demarche_completed";
+	if (pathChoice === "justify" && hasSubmittedCseOpinion)
+		return "cse_opinion_submitted";
+	if (pathChoice === "corrective_action" && hasSubmittedSecondDeclaration)
+		return "second_declaration_submitted";
+	if (pathChoice === "joint_evaluation" && hasSubmittedJointEvaluation)
+		return "joint_evaluation_submitted";
+	if (isDeadlinePassed(modificationDeadline, now))
+		return "modification_deadline_passed";
+	return null;
 }
 
 export async function CompliancePathPage() {
@@ -75,6 +114,21 @@ export async function CompliancePathPage() {
 	const currentYear = data.declaration.year;
 	const campaignDeadlines = await getCampaignDeadlines(currentYear);
 
+	const isSecondRound = state.type === "second_round";
+	const pathChoice = isSecondRound
+		? data.declaration.secondDeclarationPathChoice
+		: data.declaration.firstDeclarationPathChoice;
+	const readOnlyReason = getCompliancePathReadOnlyReason({
+		status: data.declaration.status,
+		pathChoice,
+		hasSubmittedSecondDeclaration: data.hasSubmittedSecondDeclaration,
+		hasSubmittedCseOpinion: data.hasSubmittedCseOpinion,
+		hasSubmittedJointEvaluation: data.hasSubmittedJointEvaluation,
+		modificationDeadline: isSecondRound
+			? campaignDeadlines.decl2ModificationDeadline
+			: campaignDeadlines.decl1ModificationDeadline,
+	});
+
 	return (
 		<HydrateClient>
 			<CompliancePathChoice
@@ -83,13 +137,14 @@ export async function CompliancePathPage() {
 				declarationSiren={data.declaration.siren}
 				declarationYear={currentYear}
 				email={email}
-				initialPath={data.declaration.firstDeclarationPathChoice ?? undefined}
-				isSecondRound={state.type === "second_round"}
+				initialPath={pathChoice ?? undefined}
+				isSecondRound={isSecondRound}
 				pdfDownloadHref={
-					state.type === "second_round"
+					isSecondRound
 						? `/api/declaration-pdf?type=correction&year=${currentYear}`
 						: `/api/declaration-pdf?year=${currentYear}`
 				}
+				readOnlyReason={readOnlyReason ?? undefined}
 			/>
 		</HydrateClient>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getDefaultCampaignDeadlines } from "~/modules/domain";
@@ -176,6 +182,32 @@ describe("CompliancePathChoice", () => {
 		);
 	});
 
+	it("submits justify and navigates to the CSE opinion page", async () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+		const radio = screen.getByLabelText(
+			"Justifier les écarts de rémunération ≥ 5 %",
+		);
+		fireEvent.click(radio);
+
+		const form = screen
+			.getByRole("button", { name: /suivant/i })
+			.closest("form") as HTMLFormElement;
+		fireEvent.submit(form);
+
+		await waitFor(() => {
+			expect(mockMutate).toHaveBeenCalledWith({ path: "justify" });
+		});
+		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
+	});
+
 	it("pre-selects the initial path when provided", () => {
 		render(
 			<CompliancePathChoice
@@ -329,5 +361,69 @@ describe("CompliancePathChoice", () => {
 			/>,
 		);
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();
+	});
+});
+
+describe("CompliancePathChoice read-only mode", () => {
+	it("renders the read-only alert and disables the radios", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+				initialPath="justify"
+				readOnlyReason="cse_opinion_submitted"
+			/>,
+		);
+		expect(
+			screen.getByText(/L'avis du CSE a déjà été transmis/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByLabelText("Justifier les écarts de rémunération ≥ 5 %"),
+		).toBeDisabled();
+	});
+
+	it("renders Suivant as a navigation link instead of a submit button", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+				initialPath="justify"
+				readOnlyReason="cse_opinion_submitted"
+			/>,
+		);
+		expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
+			"href",
+			"/avis-cse",
+		);
+		expect(
+			screen.queryByRole("button", { name: /suivant/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not call the save mutation when the read-only form is submitted", async () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+				initialPath="justify"
+				readOnlyReason="cse_opinion_submitted"
+			/>,
+		);
+		const form = screen
+			.getByRole("link", { name: /suivant/i })
+			.closest("form") as HTMLFormElement;
+		await act(async () => {
+			fireEvent.submit(form);
+		});
+		expect(mockMutate).not.toHaveBeenCalled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getComplianceState } from "../CompliancePathPage";
+import {
+	getCompliancePathReadOnlyReason,
+	getComplianceState,
+} from "../CompliancePathPage";
 
 const noGapCategory = {
 	annualBaseWomen: "30000",
@@ -71,5 +74,153 @@ describe("getComplianceState", () => {
 	it("returns first_round when path is justify", () => {
 		const result = getComplianceState("justify", false, [highGapCategory], []);
 		expect(result).toEqual({ type: "first_round" });
+	});
+});
+
+describe("getCompliancePathReadOnlyReason", () => {
+	const baseParams = {
+		status: "awaiting_compliance_path_choice",
+		pathChoice: null,
+		hasSubmittedSecondDeclaration: false,
+		hasSubmittedCseOpinion: false,
+		hasSubmittedJointEvaluation: false,
+		modificationDeadline: new Date("2026-12-01T00:00:00"),
+		now: new Date("2026-06-15T00:00:00"),
+	} satisfies Parameters<typeof getCompliancePathReadOnlyReason>[0];
+
+	it("returns null when no condition is met", () => {
+		expect(getCompliancePathReadOnlyReason(baseParams)).toBeNull();
+	});
+
+	it("returns demarche_completed when the démarche is finalised", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				status: "demarche_completed",
+				pathChoice: "justify",
+			}),
+		).toBe("demarche_completed");
+	});
+
+	it("prioritises demarche_completed over a submitted next step", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				status: "demarche_completed",
+				pathChoice: "justify",
+				hasSubmittedCseOpinion: true,
+			}),
+		).toBe("demarche_completed");
+	});
+
+	it("returns cse_opinion_submitted for justify once the CSE opinion is submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: "justify",
+				hasSubmittedCseOpinion: true,
+			}),
+		).toBe("cse_opinion_submitted");
+	});
+
+	it("keeps justify editable while the CSE opinion is not submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({ ...baseParams, pathChoice: "justify" }),
+		).toBeNull();
+	});
+
+	it("returns second_declaration_submitted for corrective_action once the second declaration is submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: "corrective_action",
+				hasSubmittedSecondDeclaration: true,
+			}),
+		).toBe("second_declaration_submitted");
+	});
+
+	it("keeps corrective_action editable while the second declaration is not submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: "corrective_action",
+			}),
+		).toBeNull();
+	});
+
+	it("returns joint_evaluation_submitted for joint_evaluation once the report is submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: "joint_evaluation",
+				hasSubmittedJointEvaluation: true,
+			}),
+		).toBe("joint_evaluation_submitted");
+	});
+
+	it("keeps joint_evaluation editable while the report is not submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: "joint_evaluation",
+			}),
+		).toBeNull();
+	});
+
+	it("returns modification_deadline_passed once the deadline is in the past", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: "justify",
+				modificationDeadline: new Date("2026-06-01T00:00:00"),
+				now: new Date("2026-06-02T00:00:00"),
+			}),
+		).toBe("modification_deadline_passed");
+	});
+
+	it("prioritises a submitted next step over a passed deadline", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: "justify",
+				hasSubmittedCseOpinion: true,
+				modificationDeadline: new Date("2026-06-01T00:00:00"),
+				now: new Date("2026-06-02T00:00:00"),
+			}),
+		).toBe("cse_opinion_submitted");
+	});
+
+	it("returns modification_deadline_passed even without a chosen path", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoice: null,
+				modificationDeadline: new Date("2026-06-01T00:00:00"),
+				now: new Date("2026-06-02T00:00:00"),
+			}),
+		).toBe("modification_deadline_passed");
+	});
+
+	it("does not lock the second-round revision choice when only the first-round second declaration was submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				status: "awaiting_revision_choice",
+				pathChoice: "justify",
+				hasSubmittedSecondDeclaration: true,
+			}),
+		).toBeNull();
+	});
+
+	it("locks the second-round revision once its own joint evaluation is submitted", () => {
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				status: "revised_joint_evaluation_chosen",
+				pathChoice: "joint_evaluation",
+				hasSubmittedSecondDeclaration: true,
+				hasSubmittedJointEvaluation: true,
+			}),
+		).toBe("joint_evaluation_submitted");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
@@ -84,7 +84,7 @@ describe("getCompliancePathReadOnlyReason", () => {
 		hasSubmittedSecondDeclaration: false,
 		hasSubmittedCseOpinion: false,
 		hasSubmittedJointEvaluation: false,
-		modificationDeadline: new Date("2026-12-01T00:00:00"),
+		pathChoiceDeadline: new Date("2026-12-01T00:00:00"),
 		now: new Date("2026-06-15T00:00:00"),
 	} satisfies Parameters<typeof getCompliancePathReadOnlyReason>[0];
 
@@ -167,15 +167,15 @@ describe("getCompliancePathReadOnlyReason", () => {
 		).toBeNull();
 	});
 
-	it("returns modification_deadline_passed once the deadline is in the past", () => {
+	it("returns path_choice_deadline_passed once the deadline is in the past", () => {
 		expect(
 			getCompliancePathReadOnlyReason({
 				...baseParams,
 				pathChoice: "justify",
-				modificationDeadline: new Date("2026-06-01T00:00:00"),
+				pathChoiceDeadline: new Date("2026-06-01T00:00:00"),
 				now: new Date("2026-06-02T00:00:00"),
 			}),
-		).toBe("modification_deadline_passed");
+		).toBe("path_choice_deadline_passed");
 	});
 
 	it("prioritises a submitted next step over a passed deadline", () => {
@@ -184,21 +184,21 @@ describe("getCompliancePathReadOnlyReason", () => {
 				...baseParams,
 				pathChoice: "justify",
 				hasSubmittedCseOpinion: true,
-				modificationDeadline: new Date("2026-06-01T00:00:00"),
+				pathChoiceDeadline: new Date("2026-06-01T00:00:00"),
 				now: new Date("2026-06-02T00:00:00"),
 			}),
 		).toBe("cse_opinion_submitted");
 	});
 
-	it("returns modification_deadline_passed even without a chosen path", () => {
+	it("returns path_choice_deadline_passed even without a chosen path", () => {
 		expect(
 			getCompliancePathReadOnlyReason({
 				...baseParams,
 				pathChoice: null,
-				modificationDeadline: new Date("2026-06-01T00:00:00"),
+				pathChoiceDeadline: new Date("2026-06-01T00:00:00"),
 				now: new Date("2026-06-02T00:00:00"),
 			}),
-		).toBe("modification_deadline_passed");
+		).toBe("path_choice_deadline_passed");
 	});
 
 	it("does not lock the second-round revision choice when only the first-round second declaration was submitted", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathReadOnlyAlert.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathReadOnlyAlert.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CompliancePathReadOnlyAlert } from "../compliancePath/CompliancePathReadOnlyAlert";
+import type { CompliancePathReadOnlyReason } from "../compliancePath/constants";
+
+const CASES: Array<[CompliancePathReadOnlyReason, RegExp]> = [
+	["demarche_completed", /Votre démarche est finalisée/],
+	["cse_opinion_submitted", /L'avis du CSE a déjà été transmis/],
+	["second_declaration_submitted", /La seconde déclaration a déjà été soumise/],
+	[
+		"joint_evaluation_submitted",
+		/Le rapport d'évaluation conjointe a déjà été transmis/,
+	],
+	[
+		"modification_deadline_passed",
+		/La date limite de modification de votre déclaration est dépassée/,
+	],
+];
+
+describe("CompliancePathReadOnlyAlert", () => {
+	it.each(CASES)("renders the %s message", (reason, pattern) => {
+		render(<CompliancePathReadOnlyAlert reason={reason} />);
+		expect(screen.getByText(pattern)).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathReadOnlyAlert.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathReadOnlyAlert.test.tsx
@@ -13,8 +13,8 @@ const CASES: Array<[CompliancePathReadOnlyReason, RegExp]> = [
 		/Le rapport d'évaluation conjointe a déjà été transmis/,
 	],
 	[
-		"modification_deadline_passed",
-		/La date limite de modification de votre déclaration est dépassée/,
+		"path_choice_deadline_passed",
+		/La date limite pour choisir un parcours de mise en conformité est dépassée/,
 	],
 ];
 

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathReadOnlyAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathReadOnlyAlert.tsx
@@ -9,8 +9,8 @@ const READ_ONLY_MESSAGES: Record<CompliancePathReadOnlyReason, string> = {
 		"La seconde déclaration a déjà été soumise. Le choix du parcours ne peut plus être modifié.",
 	joint_evaluation_submitted:
 		"Le rapport d'évaluation conjointe a déjà été transmis. Le choix du parcours ne peut plus être modifié.",
-	modification_deadline_passed:
-		"La date limite de modification de votre déclaration est dépassée. Le choix du parcours ne peut plus être modifié.",
+	path_choice_deadline_passed:
+		"La date limite pour choisir un parcours de mise en conformité est dépassée. Le choix du parcours ne peut plus être modifié.",
 };
 
 export function CompliancePathReadOnlyAlert({

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathReadOnlyAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathReadOnlyAlert.tsx
@@ -1,0 +1,26 @@
+import type { CompliancePathReadOnlyReason } from "./constants";
+
+const READ_ONLY_MESSAGES: Record<CompliancePathReadOnlyReason, string> = {
+	demarche_completed:
+		"Votre démarche est finalisée. Le choix du parcours ne peut plus être modifié.",
+	cse_opinion_submitted:
+		"L'avis du CSE a déjà été transmis. Le choix du parcours ne peut plus être modifié.",
+	second_declaration_submitted:
+		"La seconde déclaration a déjà été soumise. Le choix du parcours ne peut plus être modifié.",
+	joint_evaluation_submitted:
+		"Le rapport d'évaluation conjointe a déjà été transmis. Le choix du parcours ne peut plus être modifié.",
+	modification_deadline_passed:
+		"La date limite de modification de votre déclaration est dépassée. Le choix du parcours ne peut plus être modifié.",
+};
+
+export function CompliancePathReadOnlyAlert({
+	reason,
+}: {
+	reason: CompliancePathReadOnlyReason;
+}) {
+	return (
+		<div className="fr-alert fr-alert--info fr-alert--sm">
+			<p>{READ_ONLY_MESSAGES[reason]}</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/constants.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/constants.ts
@@ -5,3 +5,10 @@ export const COMPLIANCE_PATHS = [
 ] as const;
 
 export type CompliancePathValue = (typeof COMPLIANCE_PATHS)[number];
+
+export type CompliancePathReadOnlyReason =
+	| "demarche_completed"
+	| "cse_opinion_submitted"
+	| "second_declaration_submitted"
+	| "joint_evaluation_submitted"
+	| "modification_deadline_passed";

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/constants.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/constants.ts
@@ -11,4 +11,4 @@ export type CompliancePathReadOnlyReason =
 	| "cse_opinion_submitted"
 	| "second_declaration_submitted"
 	| "joint_evaluation_submitted"
-	| "modification_deadline_passed";
+	| "path_choice_deadline_passed";

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -245,6 +245,7 @@ export const declarationRouter = createTRPCRouter({
 		const declarationId = result.declaration.id;
 		let hasSubmittedSecondDeclaration = false;
 		let hasSubmittedCseOpinion = false;
+		let hasSubmittedJointEvaluation = false;
 		if (declarationId !== "") {
 			const eventRows = await ctx.db
 				.select({ eventType: declarationStatusHistory.eventType })
@@ -256,6 +257,8 @@ export const declarationRouter = createTRPCRouter({
 						hasSubmittedSecondDeclaration = true;
 					} else if (row.eventType === "cse_opinion_submit") {
 						hasSubmittedCseOpinion = true;
+					} else if (row.eventType === "joint_evaluation_submit") {
+						hasSubmittedJointEvaluation = true;
 					}
 				}
 			}
@@ -267,6 +270,7 @@ export const declarationRouter = createTRPCRouter({
 			previousYearCategories,
 			hasSubmittedSecondDeclaration,
 			hasSubmittedCseOpinion,
+			hasSubmittedJointEvaluation,
 		};
 	}),
 


### PR DESCRIPTION
Closes #3494

## Résumé

Verrouille en lecture seule le choix du parcours de conformité (`/declaration-remuneration/parcours-conformite`) dès qu'une condition métier est remplie. La FSM (`server/rules/v2027.1.json`) rejetait déjà ces mutations, mais l'UI laissait croire que le choix restait modifiable → erreur silencieuse au clic sur « Suivant ».

Conditions de verrou, **évaluées par rapport au choix du tour courant** :
- démarche finalisée (`demarche_completed`)
- étape suivante du parcours choisi soumise : `justify` → avis CSE déposé · `corrective_action` → 2ᵉ déclaration soumise · `joint_evaluation` → évaluation conjointe transmise
- **date limite pour choisir un parcours dépassée** (`pathChoiceDeadline` — la date affichée sur la page, 1er janvier N+1)

En lecture seule : radios désactivés, autosave coupé, alerte DSFR `--info` explicite, et « Suivant » devient un lien de navigation (aucune écriture de donnée). Le 2ᵉ tour de révision reste modifiable tant que sa propre étape suivante n'est pas soumise.

## Changements

- `getOrCreate` expose `hasSubmittedJointEvaluation` (symétrique des flags CSE / 2ᵉ déclaration déjà dérivés du `declarationStatusHistory`)
- Fonction pure `getCompliancePathReadOnlyReason` (5 raisons + ordre de priorité + scoping par tour)
- Composant `CompliancePathReadOnlyAlert` (message FR par raison)
- `initialPath` corrigé pour utiliser le choix du tour courant au 2ᵉ tour (pré-sélection au revisit)

## Note sur l'échéance

Le verrou « date limite » utilise `pathChoiceDeadline` (date limite pour **choisir** un parcours, affichée sur la page), **pas** `decl1/decl2ModificationDeadline` (échéance de modification de la déclaration). Sinon un formulaire vierge se retrouverait verrouillé dès le 1er juin alors que rien n'a été choisi. `pathChoiceDeadline` étant calculée, le formulaire ne dépend pas de la table `app_campaign_deadline`.

## Tests

- Unitaires : `getCompliancePathReadOnlyReason` (toutes branches + scoping 2ᵉ tour), `CompliancePathReadOnlyAlert` (5 messages)
- Composant : alerte rendue, radios désactivés, « Suivant » rendu en lien, mutation jamais appelée en lecture seule
- typecheck + lint + format verts

---

> Implémentation indépendante sur `alpha` ; conflit de merge attendu avec #3753 (epic lock #3556, qui réécrit le même composant pour un verrou de concurrence) — à résoudre au merge.
> Les scénarios E2E bout-en-bout (parcours verrouillé / éditable) relèvent de `e2e-dev`.
