### PR TITLE
feat(admin-stats): comptages engagement CSE + utilisateurs par entreprise

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -375,7 +375,7 @@ Routes publiques (aucune authentification, OpenAPI documentée) :
 | `/admin/liste-referents` | Annuaire admin (CRUD + import CSV) |
 | `/admin/impersonate` | Recherche d'entreprise pour impersonation |
 | `/admin/parametres` | Configuration des deadlines de campagne (par année) |
-| `/admin/stats/campagne` | Courbes de progression des soumissions par segment d'effectif |
+| `/admin/stats` | Tableau de bord statistiques en 3 sections : **Suivi de campagne** (courbes de progression par segment d'effectif, durées et décrochages par étape), **Comptes & engagement CSE** (utilisateurs par entreprise + confirmations de statut CSE), **Funnels de complétion** (Matomo) |
 
 **Modules** : `~/modules/admin/*`.
 
@@ -386,7 +386,7 @@ Routes publiques (aucune authentification, OpenAPI documentée) :
 - L'accès admin est gardé par le **middleware Edge** (`src/middleware.ts`) qui redirige vers `/login` si `isAdmin` est faux.
 - L'**impersonation** est tracée dans `adminImpersonationEvents` (audit trail dédié, lecture par `admin.getLastImpersonated`). Le callback JWT NextAuth injecte un `impersonation: { siren, startedAt }` dans la session active.
 - Les **deadlines** sont par année de campagne ; si aucune ligne n'existe en BDD pour l'année courante, des défauts viennent de `~/modules/domain` (`getDefaultCampaignDeadlines`).
-- Les **stats** segmentent les entreprises par effectif (`small / medium / large`, voir `COMPANY_SIZE_RANGES`).
+- Les **stats** segmentent les entreprises par effectif (`small / medium / large`, voir `COMPANY_SIZE_RANGES`). Deux métriques d'engagement complètent les courbes : les **utilisateurs par entreprise** (agrégat BDD sur `user_company` — répartition mono/multi-utilisateurs, sans PII) et le **volume de confirmations du statut CSE** (event Matomo anonymisé `oui`/`non`, donc un comptage d'actions, pas d'entreprises distinctes).
 - L'**import GIP-MDS** est déclenché manuellement depuis la home admin (pas de cron en V2).
 
 **Audit** : presque toutes les procédures admin sont auditées (`ADMIN_DECLARATIONS_SEARCH`, `ADMIN_SETTINGS_UPSERT_DEADLINES`, etc.).

--- a/docs/matomo-cnil-exemption.md
+++ b/docs/matomo-cnil-exemption.md
@@ -187,6 +187,14 @@ taxonomie (pages vues + 22 événements distincts) :
   (`setDoNotTrack(true)`).
 - ✅ **Opt-out** : l'iframe `action=optOut` répond et propose la désinscription.
 
+> Snapshot daté de la mise en place de l'exemption. La taxonomie s'est depuis
+> enrichie (liens d'aide, usage du modèle de l'indicateur par catégorie, et
+> l'action **`cse_status` / `cse_status_confirm`** — confirmation du statut CSE).
+> Chaque ajout respecte la même garantie : `cse_status_confirm` n'émet que le
+> label borné `oui`/`non` + l'année de campagne (slot 1), **jamais le SIREN ni
+> aucun identifiant**. La liste 1:1 avec le code est tenue dans
+> [`plan-de-tracking.md`](./plan-de-tracking.md).
+
 Conclusion : la configuration documentée tient les conditions d'exemption de
 consentement de la CNIL. Reste à appliquer ces réglages sur l'instance de
 production et à inscrire le traitement au registre RGPD.

--- a/docs/plan-de-tracking.md
+++ b/docs/plan-de-tracking.md
@@ -103,11 +103,15 @@ Clés d'étape : `step_1` Actions correctives et seconde déclaration · `step_2
 | `document` / `category_import_failure` | Échec de parsing d'un fichier de catégories importé | type d'erreur (`missing-columns` \| `invalid-value` \| `empty-file`) | — | `declaration-remuneration/steps/step5/CategoryImportExport.tsx` | K20 |
 | `auth` / `login_start` | Clic sur « S'identifier avec ProConnect » (avant la redirection OIDC) | — | — | `login/ProConnectButton.tsx` | K20 |
 | `dashboard` / `declaration_start` | Clic sur le lien de démarrage d'une déclaration rémunération depuis `mon-espace` | `remuneration` | — | `my-space/DeclarationLink.tsx` | K19, K20 |
+| `cse_status` / `cse_status_confirm` | Enregistrement du statut CSE d'une entreprise (succès de `company.updateHasCse`) | `oui` \| `non` (jamais de SIREN) | — | `my-space/useUpdateHasCse.ts` (`CompanyEditModal`, `MissingInfoModal`, `UpdateCseModal`) | Engagement CSE (`/admin/stats`) |
 
-> Dimension : `pdf_download` porte l'année quand elle est connue. Aucune autre
-> action ne porte de dimension. Les recherches n'émettent **que** les noms de
-> facettes, jamais leurs valeurs (la requête libre peut contenir un SIREN ou un
-> nom d'entreprise).
+> Dimension : `pdf_download` et `cse_status_confirm` portent l'année de campagne
+> (`cse_status_confirm` toujours, `pdf_download` quand elle est connue). Aucune
+> autre action ne porte de dimension. `cse_status_confirm` n'émet que le label
+> borné `oui`/`non` — jamais le SIREN, pour préserver l'exemption de consentement
+> CNIL : le comptage est donc un **volume de confirmations** (pas d'entreprises
+> distinctes). Les recherches n'émettent **que** les noms de facettes, jamais
+> leurs valeurs (la requête libre peut contenir un SIREN ou un nom d'entreprise).
 
 ## Dimensions personnalisées
 

--- a/docs/strategie-tracking.md
+++ b/docs/strategie-tracking.md
@@ -43,7 +43,8 @@ Deux natures de signaux :
    (où les gens décrochent) et les **actions ponctuelles** (recherche,
    téléchargement, upload, login, ouverture d'une section d'aide, clic sur un lien
    d'accompagnement, usage du modèle de l'indicateur par catégorie — durée de
-   remplissage et échecs d'import —, démarrage d'une déclaration).
+   remplissage et échecs d'import —, démarrage d'une déclaration, enregistrement
+   du statut CSE d'une entreprise — label borné `oui`/`non`, jamais le SIREN).
    Liste complète dans [`plan-de-tracking.md`](./plan-de-tracking.md).
 
 Le croisement « visiteurs » (pages vues) vs. « acteurs » (événements d'action)

--- a/packages/app/src/modules/admin/stats/CseStatusConfirmationsTile.tsx
+++ b/packages/app/src/modules/admin/stats/CseStatusConfirmationsTile.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "~/modules/shared";
+import { api } from "~/trpc/react";
+
+import { AdminKpiTile } from "./AdminKpiTile";
+import { formatCount } from "./formatters";
+
+type Props = {
+	year: number;
+};
+
+export function CseStatusConfirmationsTile({ year }: Props) {
+	const query = api.adminStats.getMatomoCseStatusConfirmations.useQuery(
+		{ year },
+		{ placeholderData: (prev) => prev },
+	);
+
+	if (query.isLoading && !query.data) return <CampaignRateTileLoading />;
+	if (query.isError) return <CampaignRateTileError />;
+
+	const data = query.data;
+	if (!data) return null;
+
+	return (
+		<AdminKpiTile
+			delta={null}
+			subtitle={`${formatCount(data.yes)} « oui » · ${formatCount(data.no)} « non »`}
+			title={`Confirmations de statut CSE (${year})`}
+			value={formatCount(data.total)}
+		/>
+	);
+}

--- a/packages/app/src/modules/admin/stats/StatsDashboard.tsx
+++ b/packages/app/src/modules/admin/stats/StatsDashboard.tsx
@@ -14,6 +14,7 @@ import { CampaignProgressionTable } from "./CampaignProgressionTable";
 import { CampaignRateTile } from "./CampaignRateTile";
 import { CompletionFunnelChart } from "./CompletionFunnelChart";
 import { CompletionFunnelTable } from "./CompletionFunnelTable";
+import { CseStatusConfirmationsTile } from "./CseStatusConfirmationsTile";
 import { StagnationDaysFilter } from "./StagnationDaysFilter";
 import { type BarSeries, StatsBarChart } from "./StatsBarChart";
 import { StatsBarTable, type StatsTableColumn } from "./StatsBarTable";
@@ -23,6 +24,7 @@ import { StepDropoffTable } from "./StepDropoffTable";
 import { StepDurationsChart } from "./StepDurationsChart";
 import { StepDurationsTable } from "./StepDurationsTable";
 import type { DeviceBreakdownRow, LabeledCount } from "./types";
+import { UsersPerCompanyTile } from "./UsersPerCompanyTile";
 import { useDebouncedValue } from "./useDebouncedValue";
 import { YearsFilter } from "./YearsFilter";
 
@@ -288,6 +290,28 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								</>
 							)}
 						</section>
+					</div>
+				</div>
+			</section>
+
+			<section className="fr-mt-6w" id="comptes">
+				<h2 className="fr-h2">Comptes &amp; engagement CSE</h2>
+				<p>
+					Confirmations du statut CSE mesurées côté navigateur (Matomo,
+					anonymisé — volume de confirmations sur l&apos;année, pas
+					d&apos;entreprises distinctes) et répartition des utilisateurs par
+					entreprise (lecture directe en base).
+				</p>
+				<div className="fr-grid-row fr-grid-row--gutters fr-mt-4w">
+					<div className="fr-col-12 fr-col-md-6">
+						<div className={styles.card}>
+							<UsersPerCompanyTile />
+						</div>
+					</div>
+					<div className="fr-col-12 fr-col-md-6">
+						<div className={styles.card}>
+							<CseStatusConfirmationsTile year={activeYear} />
+						</div>
 					</div>
 				</div>
 			</section>

--- a/packages/app/src/modules/admin/stats/UsersPerCompanyTile.tsx
+++ b/packages/app/src/modules/admin/stats/UsersPerCompanyTile.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import {
+	CampaignRateTileError,
+	CampaignRateTileLoading,
+} from "~/modules/shared";
+import { api } from "~/trpc/react";
+
+import { AdminKpiTile } from "./AdminKpiTile";
+import { formatCount, formatDecimal } from "./formatters";
+
+export function UsersPerCompanyTile() {
+	const query = api.adminStats.getUsersPerCompany.useQuery(undefined, {
+		placeholderData: (prev) => prev,
+	});
+
+	if (query.isLoading && !query.data) return <CampaignRateTileLoading />;
+	if (query.isError) return <CampaignRateTileError />;
+
+	const data = query.data;
+	if (!data) return null;
+
+	const avgLabel = formatDecimal(data.avgPerCompany);
+
+	return (
+		<AdminKpiTile
+			delta={null}
+			subtitle={`${formatCount(data.totalCompanies)} entreprises · ${formatCount(data.multi)} multi-utilisateurs · max ${formatCount(data.maxUsers)}`}
+			title="Utilisateurs par entreprise"
+			value={avgLabel}
+		/>
+	);
+}

--- a/packages/app/src/modules/admin/stats/__tests__/CseStatusConfirmationsTile.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/CseStatusConfirmationsTile.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CseStatusConfirmations } from "../types";
+
+const useQueryMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		adminStats: {
+			getMatomoCseStatusConfirmations: {
+				useQuery: (...args: unknown[]) => useQueryMock(...args),
+			},
+		},
+	},
+}));
+
+import { CseStatusConfirmationsTile } from "../CseStatusConfirmationsTile";
+
+function mockQuery({
+	data,
+	isLoading = false,
+	isError = false,
+}: {
+	data?: CseStatusConfirmations;
+	isLoading?: boolean;
+	isError?: boolean;
+}) {
+	useQueryMock.mockReturnValue({ data, isLoading, isError });
+}
+
+describe("CseStatusConfirmationsTile", () => {
+	beforeEach(() => useQueryMock.mockReset());
+
+	it("shows a loading message while the query is in flight and no data is cached", () => {
+		mockQuery({ isLoading: true });
+		render(<CseStatusConfirmationsTile year={2026} />);
+
+		expect(screen.getByText(/chargement/i)).toHaveAttribute(
+			"aria-live",
+			"polite",
+		);
+	});
+
+	it("shows an error alert when the query errors out", () => {
+		mockQuery({ isError: true });
+		render(<CseStatusConfirmationsTile year={2026} />);
+
+		expect(
+			screen.getByText(/erreur est survenue/i).closest(".fr-alert"),
+		).toHaveClass("fr-alert--error");
+	});
+
+	it("renders the total, the year in the title and the oui/non split", () => {
+		mockQuery({ data: { total: 1234, yes: 1000, no: 234 } });
+		render(<CseStatusConfirmationsTile year={2026} />);
+
+		expect(
+			screen.getByRole("heading", {
+				name: "Confirmations de statut CSE (2026)",
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText((content) => /^1\s?234$/.test(content)),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText((content) =>
+				/1\s?000\s*«\s*oui\s*».*234\s*«\s*non\s*»/.test(
+					content.replace(/\s/g, " "),
+				),
+			),
+		).toBeInTheDocument();
+	});
+
+	it("returns null when the query has neither data, loading nor error state", () => {
+		mockQuery({});
+		const { container } = render(<CseStatusConfirmationsTile year={2026} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("passes the year through and a placeholderData identity function to the query", () => {
+		mockQuery({ data: { total: 0, yes: 0, no: 0 } });
+		render(<CseStatusConfirmationsTile year={2025} />);
+
+		expect(useQueryMock.mock.calls[0]?.[0]).toEqual({ year: 2025 });
+		const options = useQueryMock.mock.calls[0]?.[1] as {
+			placeholderData: (prev: unknown) => unknown;
+		};
+		expect(options.placeholderData("prev")).toBe("prev");
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.campaign.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.campaign.test.tsx
@@ -9,6 +9,8 @@ const matomoFunnelUseQueryMock = vi.fn();
 const matomoCategoryModelUseQueryMock = vi.fn();
 const matomoHelpLinksUseQueryMock = vi.fn();
 const matomoDeviceUseQueryMock = vi.fn();
+const cseStatusConfirmationsUseQueryMock = vi.fn();
+const usersPerCompanyUseQueryMock = vi.fn();
 const statsUseQueryMock = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
@@ -41,6 +43,13 @@ vi.mock("~/trpc/react", () => ({
 			},
 			getMatomoDeviceBreakdown: {
 				useQuery: (...args: unknown[]) => matomoDeviceUseQueryMock(...args),
+			},
+			getMatomoCseStatusConfirmations: {
+				useQuery: (...args: unknown[]) =>
+					cseStatusConfirmationsUseQueryMock(...args),
+			},
+			getUsersPerCompany: {
+				useQuery: (...args: unknown[]) => usersPerCompanyUseQueryMock(...args),
 			},
 		},
 	},
@@ -88,6 +97,8 @@ const defaultMocks = () =>
 		matomoCategoryModelUseQueryMock,
 		matomoHelpLinksUseQueryMock,
 		matomoDeviceUseQueryMock,
+		cseStatusConfirmationsUseQueryMock,
+		usersPerCompanyUseQueryMock,
 	});
 
 describe("StatsDashboard — campaign section states", () => {

--- a/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/StatsDashboard.test.tsx
@@ -9,6 +9,8 @@ const matomoFunnelUseQueryMock = vi.fn();
 const matomoCategoryModelUseQueryMock = vi.fn();
 const matomoHelpLinksUseQueryMock = vi.fn();
 const matomoDeviceUseQueryMock = vi.fn();
+const cseStatusConfirmationsUseQueryMock = vi.fn();
+const usersPerCompanyUseQueryMock = vi.fn();
 const statsUseQueryMock = vi.fn();
 
 vi.mock("~/trpc/react", () => ({
@@ -41,6 +43,13 @@ vi.mock("~/trpc/react", () => ({
 			},
 			getMatomoDeviceBreakdown: {
 				useQuery: (...args: unknown[]) => matomoDeviceUseQueryMock(...args),
+			},
+			getMatomoCseStatusConfirmations: {
+				useQuery: (...args: unknown[]) =>
+					cseStatusConfirmationsUseQueryMock(...args),
+			},
+			getUsersPerCompany: {
+				useQuery: (...args: unknown[]) => usersPerCompanyUseQueryMock(...args),
 			},
 		},
 	},
@@ -91,6 +100,8 @@ const defaultMocks = () =>
 		matomoCategoryModelUseQueryMock,
 		matomoHelpLinksUseQueryMock,
 		matomoDeviceUseQueryMock,
+		cseStatusConfirmationsUseQueryMock,
+		usersPerCompanyUseQueryMock,
 	});
 
 describe("StatsDashboard — structure and filters", () => {

--- a/packages/app/src/modules/admin/stats/__tests__/UsersPerCompanyTile.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/UsersPerCompanyTile.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { UsersPerCompany } from "../types";
+
+const useQueryMock = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		adminStats: {
+			getUsersPerCompany: {
+				useQuery: (...args: unknown[]) => useQueryMock(...args),
+			},
+		},
+	},
+}));
+
+import { UsersPerCompanyTile } from "../UsersPerCompanyTile";
+
+function mockQuery({
+	data,
+	isLoading = false,
+	isError = false,
+}: {
+	data?: UsersPerCompany;
+	isLoading?: boolean;
+	isError?: boolean;
+}) {
+	useQueryMock.mockReturnValue({ data, isLoading, isError });
+}
+
+describe("UsersPerCompanyTile", () => {
+	beforeEach(() => useQueryMock.mockReset());
+
+	it("shows a loading message while the query is in flight and no data is cached", () => {
+		mockQuery({ isLoading: true });
+		render(<UsersPerCompanyTile />);
+
+		expect(screen.getByText(/chargement/i)).toHaveAttribute(
+			"aria-live",
+			"polite",
+		);
+	});
+
+	it("shows an error alert when the query errors out", () => {
+		mockQuery({ isError: true });
+		render(<UsersPerCompanyTile />);
+
+		expect(
+			screen.getByText(/erreur est survenue/i).closest(".fr-alert"),
+		).toHaveClass("fr-alert--error");
+	});
+
+	it("renders the average, the title and the companies/multi/max subtitle", () => {
+		mockQuery({
+			data: {
+				totalCompanies: 3,
+				mono: 1,
+				multi: 2,
+				avgPerCompany: 2.3333,
+				maxUsers: 4,
+			},
+		});
+		render(<UsersPerCompanyTile />);
+
+		expect(
+			screen.getByRole("heading", { name: "Utilisateurs par entreprise" }),
+		).toBeInTheDocument();
+		// average formatted to one decimal in fr-FR ("2,3")
+		expect(
+			screen.getByText((content) => /^2,3$/.test(content.trim())),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText((content) => {
+				const normalized = content.replace(/\s/g, " ");
+				return (
+					/3\s*entreprises/.test(normalized) &&
+					/2\s*multi-utilisateurs/.test(normalized) &&
+					/max\s*4/.test(normalized)
+				);
+			}),
+		).toBeInTheDocument();
+	});
+
+	it("returns null when the query has neither data, loading nor error state", () => {
+		mockQuery({});
+		const { container } = render(<UsersPerCompanyTile />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("passes no input and a placeholderData identity function to the query", () => {
+		mockQuery({
+			data: {
+				totalCompanies: 0,
+				mono: 0,
+				multi: 0,
+				avgPerCompany: 0,
+				maxUsers: 0,
+			},
+		});
+		render(<UsersPerCompanyTile />);
+
+		expect(useQueryMock.mock.calls[0]?.[0]).toBeUndefined();
+		const options = useQueryMock.mock.calls[0]?.[1] as {
+			placeholderData: (prev: unknown) => unknown;
+		};
+		expect(options.placeholderData("prev")).toBe("prev");
+	});
+});

--- a/packages/app/src/modules/admin/stats/__tests__/helpers/statsDashboardMocks.ts
+++ b/packages/app/src/modules/admin/stats/__tests__/helpers/statsDashboardMocks.ts
@@ -23,6 +23,8 @@ type QueryMocks = {
 	matomoCategoryModelUseQueryMock?: Mock;
 	matomoHelpLinksUseQueryMock?: Mock;
 	matomoDeviceUseQueryMock?: Mock;
+	cseStatusConfirmationsUseQueryMock?: Mock;
+	usersPerCompanyUseQueryMock?: Mock;
 };
 
 export function setDefaultMocks(mocks: QueryMocks) {
@@ -68,6 +70,22 @@ export function setDefaultMocks(mocks: QueryMocks) {
 	});
 	mocks.matomoDeviceUseQueryMock?.mockReturnValue({
 		data: undefined,
+		isLoading: false,
+		isError: false,
+	});
+	mocks.cseStatusConfirmationsUseQueryMock?.mockReturnValue({
+		data: { total: 0, yes: 0, no: 0 },
+		isLoading: false,
+		isError: false,
+	});
+	mocks.usersPerCompanyUseQueryMock?.mockReturnValue({
+		data: {
+			totalCompanies: 0,
+			mono: 0,
+			multi: 0,
+			avgPerCompany: 0,
+			maxUsers: 0,
+		},
 		isLoading: false,
 		isError: false,
 	});

--- a/packages/app/src/modules/admin/stats/formatters.ts
+++ b/packages/app/src/modules/admin/stats/formatters.ts
@@ -17,6 +17,10 @@ export function formatCount(value: number): string {
 	return value.toLocaleString("fr-FR");
 }
 
+export function formatDecimal(value: number): string {
+	return value.toLocaleString("fr-FR", { maximumFractionDigits: 1 });
+}
+
 export function formatDays(
 	value: number | null,
 	{ withUnit = false }: WithUnitOption = {},

--- a/packages/app/src/modules/admin/stats/index.ts
+++ b/packages/app/src/modules/admin/stats/index.ts
@@ -5,7 +5,13 @@ export { CampaignProgressionTable } from "./CampaignProgressionTable";
 export { CampaignRateTile } from "./CampaignRateTile";
 export { CompletionFunnelChart } from "./CompletionFunnelChart";
 export { CompletionFunnelTable } from "./CompletionFunnelTable";
-export { formatCount, formatDays, formatPercent } from "./formatters";
+export { CseStatusConfirmationsTile } from "./CseStatusConfirmationsTile";
+export {
+	formatCount,
+	formatDays,
+	formatDecimal,
+	formatPercent,
+} from "./formatters";
 export { StagnationDaysFilter } from "./StagnationDaysFilter";
 export { StatsBarChart } from "./StatsBarChart";
 export { StatsBarTable } from "./StatsBarTable";
@@ -36,6 +42,7 @@ export type {
 	CampaignStats,
 	CategoryModelUsage,
 	CompletionFunnelOutput,
+	CseStatusConfirmations,
 	DeviceBreakdown,
 	DeviceBreakdownRow,
 	FunnelRow,
@@ -44,6 +51,8 @@ export type {
 	MatomoFunnelOutput,
 	StepDropoffRow,
 	StepDurationRow,
+	UsersPerCompany,
 } from "./types";
+export { UsersPerCompanyTile } from "./UsersPerCompanyTile";
 export { useDebouncedValue } from "./useDebouncedValue";
 export { YearsFilter } from "./YearsFilter";

--- a/packages/app/src/modules/admin/stats/types.ts
+++ b/packages/app/src/modules/admin/stats/types.ts
@@ -181,3 +181,30 @@ export type DeviceBreakdownRow = {
 export type DeviceBreakdown = {
 	rows: DeviceBreakdownRow[];
 };
+
+/**
+ * Output of `adminStats.getMatomoCseStatusConfirmations` — volume of CSE-status
+ * confirmations (`cse_status / cse_status_confirm`) for one campaign year, split
+ * by the bounded oui/non label. Read from Matomo (anonymised, no SIREN): it
+ * counts confirmation *actions* (forward-only), not distinct companies. All zero
+ * when Matomo is not configured.
+ */
+export type CseStatusConfirmations = {
+	total: number;
+	yes: number;
+	no: number;
+};
+
+/**
+ * Output of `adminStats.getUsersPerCompany` — distribution of distinct users
+ * per company, read live from the existing `user_company` table. Aggregate only
+ * (no SIREN / email in the payload). `mono` = companies with exactly one user,
+ * `multi` = companies with two or more.
+ */
+export type UsersPerCompany = {
+	totalCompanies: number;
+	mono: number;
+	multi: number;
+	avgPerCompany: number;
+	maxUsers: number;
+};

--- a/packages/app/src/modules/analytics/shared/events.ts
+++ b/packages/app/src/modules/analytics/shared/events.ts
@@ -10,6 +10,7 @@ export const MATOMO_EVENT_CATEGORY = {
 	DOCUMENT: "document",
 	AUTH: "auth",
 	DASHBOARD: "dashboard",
+	CSE_STATUS: "cse_status",
 } as const;
 
 export const MATOMO_FUNNEL_ACTION = {
@@ -32,6 +33,7 @@ export const MATOMO_ACTION = {
 	CATEGORY_IMPORT_FAILURE: "category_import_failure",
 	CATEGORY_IMPORT_DURATION: "category_import_duration",
 	HELP_LINK_CLICK: "help_link_click",
+	CSE_STATUS_CONFIRM: "cse_status_confirm",
 } as const;
 
 // Slot IDs must match the Custom Dimension slots configured in the Matomo

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -68,6 +68,9 @@ export const AUDIT_ACTIONS = {
 	ADMIN_STATS_GET_MATOMO_HELP_LINKS: "admin_stats.get_matomo_help_links",
 	ADMIN_STATS_GET_MATOMO_DEVICE_BREAKDOWN:
 		"admin_stats.get_matomo_device_breakdown",
+	ADMIN_STATS_GET_CSE_STATUS_CONFIRMATIONS:
+		"admin_stats.get_cse_status_confirmations",
+	ADMIN_STATS_GET_USERS_PER_COMPANY: "admin_stats.get_users_per_company",
 
 	// ── Declaration draft ─────────────────────────────────
 	DRAFT_READ: "declaration_draft.read",
@@ -161,6 +164,8 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_CATEGORY_MODEL]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_HELP_LINKS]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_DEVICE_BREAKDOWN]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_STATS_GET_CSE_STATUS_CONFIRMATIONS]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_STATS_GET_USERS_PER_COMPANY]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_SAVE]: "mutation",
 	[AUDIT_ACTIONS.DRAFT_CLEAR]: "mutation",

--- a/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useRef, useState } from "react";
 import { useReadOnlyGuard } from "~/modules/auth";
+import { useUpdateHasCse } from "~/modules/my-space";
 import { getDsfrModal } from "~/modules/shared";
-import { api } from "~/trpc/react";
 import styles from "./UpdateCseModal.module.scss";
 
 const MODAL_ID = "update-cse-modal";
@@ -24,10 +24,8 @@ export function UpdateCseModal({ siren }: Props) {
 		}
 	}, []);
 
-	const mutation = api.company.updateHasCse.useMutation({
-		onSuccess: () => {
-			closeModal();
-		},
+	const mutation = useUpdateHasCse({
+		onSuccess: closeModal,
 	});
 
 	function handleSave() {

--- a/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/UpdateCseModal.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import { useReadOnlyGuard } from "~/modules/auth";
-import { useUpdateHasCse } from "~/modules/my-space";
+import { useUpdateHasCse } from "~/modules/my-space/useUpdateHasCse";
 import { getDsfrModal } from "~/modules/shared";
 import styles from "./UpdateCseModal.module.scss";
 

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -7,10 +7,10 @@ import { Controller } from "react-hook-form";
 import { getCurrentYear } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
-import { api } from "~/trpc/react";
 import styles from "./CompanyEditModal.module.scss";
 import { formatSiren } from "./formatSiren";
 import { updateHasCseSchema } from "./schemas";
+import { useUpdateHasCse } from "./useUpdateHasCse";
 
 export const MODAL_ID = "company-edit-modal";
 const MODAL_TITLE_ID = "company-edit-modal-title";
@@ -45,7 +45,7 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 		if (dialog) getDsfrModal(dialog)?.conceal();
 	}, []);
 
-	const updateHasCseMutation = api.company.updateHasCse.useMutation({
+	const updateHasCseMutation = useUpdateHasCse({
 		onSuccess: () => {
 			closeModal();
 			router.refresh();

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -12,6 +12,7 @@ import { api } from "~/trpc/react";
 import { DECLARATION_PROCESS_PANEL_ID } from "./DeclarationProcessPanel";
 import styles from "./DeclarationProcessPanel.module.scss";
 import { createMissingInfoSchema } from "./schemas";
+import { useUpdateHasCse } from "./useUpdateHasCse";
 
 export const MISSING_INFO_PANEL_ID = "missing-info-modal";
 const PANEL_TITLE_ID = "missing-info-modal-title";
@@ -54,7 +55,7 @@ export function MissingInfoModal({ siren, userPhone, hasCse }: Props) {
 	const cseError = form.formState.errors.hasCse?.message ?? null;
 
 	const updatePhoneMutation = api.profile.updatePhone.useMutation();
-	const updateHasCseMutation = api.company.updateHasCse.useMutation();
+	const updateHasCseMutation = useUpdateHasCse();
 
 	const closeModal = useCallback(() => {
 		const dialog = dialogRef.current;

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -3,14 +3,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockMutate = vi.fn();
 
+vi.mock("~/modules/analytics", () => ({
+	campaignYearDimension: () => ({ 1: "2026" }),
+	MATOMO_ACTION: { CSE_STATUS_CONFIRM: "cse_status_confirm" },
+	MATOMO_EVENT_CATEGORY: { CSE_STATUS: "cse_status" },
+	trackEvent: vi.fn(),
+}));
+
 vi.mock("~/trpc/react", () => ({
 	api: {
 		company: {
 			updateHasCse: {
 				useMutation: vi.fn().mockImplementation(({ onSuccess }) => ({
-					mutate: (...args: unknown[]) => {
-						mockMutate(...args);
-						onSuccess();
+					mutate: (variables: { siren: string; hasCse: boolean }) => {
+						mockMutate(variables);
+						// Mirror the real tRPC contract: onSuccess(data, variables).
+						onSuccess(undefined, variables);
 					},
 					isPending: false,
 				})),

--- a/packages/app/src/modules/my-space/__tests__/useUpdateHasCse.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/useUpdateHasCse.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { trackEventMock, useMutationMock } = vi.hoisted(() => ({
+	trackEventMock: vi.fn(),
+	useMutationMock: vi.fn(),
+}));
+
+vi.mock("~/modules/analytics", () => ({
+	campaignYearDimension: (year: number) => ({ 1: String(year) }),
+	MATOMO_ACTION: { CSE_STATUS_CONFIRM: "cse_status_confirm" },
+	MATOMO_EVENT_CATEGORY: { CSE_STATUS: "cse_status" },
+	trackEvent: trackEventMock,
+}));
+
+vi.mock("~/modules/domain", () => ({
+	getCurrentYear: () => 2026,
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		company: {
+			updateHasCse: {
+				useMutation: (...args: unknown[]) => useMutationMock(...args),
+			},
+		},
+	},
+}));
+
+import { useUpdateHasCse } from "../useUpdateHasCse";
+
+type MutationOptions = {
+	onSuccess: (
+		data: unknown,
+		variables: { siren: string; hasCse: boolean },
+	) => void;
+};
+
+// Capture the options the hook passes to `useMutation` so we can drive the
+// `onSuccess(data, variables)` callback exactly as tRPC would.
+function captureOptions(): MutationOptions {
+	const options = useMutationMock.mock.calls[0]?.[0] as MutationOptions;
+	return options;
+}
+
+const SIREN = "123456789";
+
+describe("useUpdateHasCse", () => {
+	beforeEach(() => {
+		trackEventMock.mockReset();
+		useMutationMock.mockReset();
+		useMutationMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
+	});
+
+	it("tracks a single oui event on success with hasCse:true", () => {
+		renderHook(() => useUpdateHasCse());
+
+		captureOptions().onSuccess(undefined, { siren: SIREN, hasCse: true });
+
+		expect(trackEventMock).toHaveBeenCalledTimes(1);
+		expect(trackEventMock).toHaveBeenCalledWith({
+			category: "cse_status",
+			action: "cse_status_confirm",
+			name: "oui",
+			dimensions: { 1: "2026" },
+		});
+	});
+
+	it("tracks a non event on success with hasCse:false", () => {
+		renderHook(() => useUpdateHasCse());
+
+		captureOptions().onSuccess(undefined, { siren: SIREN, hasCse: false });
+
+		expect(trackEventMock).toHaveBeenCalledTimes(1);
+		expect(trackEventMock.mock.calls[0]?.[0]).toMatchObject({ name: "non" });
+	});
+
+	it("never leaks the SIREN / SIRET / any PII into the tracked payload (CNIL anonymisation)", () => {
+		renderHook(() => useUpdateHasCse());
+
+		captureOptions().onSuccess(undefined, { siren: SIREN, hasCse: true });
+
+		const payload = trackEventMock.mock.calls[0]?.[0];
+		const serialized = JSON.stringify(payload);
+		expect(serialized).not.toContain(SIREN);
+		expect(serialized).not.toMatch(/siren/i);
+		expect(serialized).not.toMatch(/siret/i);
+	});
+
+	it("invokes the caller's onSuccess after tracking", () => {
+		const callerOnSuccess = vi.fn();
+		renderHook(() => useUpdateHasCse({ onSuccess: callerOnSuccess }));
+
+		captureOptions().onSuccess(undefined, { siren: SIREN, hasCse: true });
+
+		expect(callerOnSuccess).toHaveBeenCalledTimes(1);
+		// Tracking must fire before the caller's callback (which may navigate away
+		// and unmount the component mid-flush).
+		const trackOrder = trackEventMock.mock.invocationCallOrder[0] ?? Infinity;
+		const callerOrder =
+			callerOnSuccess.mock.invocationCallOrder[0] ?? -Infinity;
+		expect(trackOrder).toBeLessThan(callerOrder);
+	});
+
+	it("does not throw when no caller onSuccess is provided", () => {
+		renderHook(() => useUpdateHasCse());
+
+		expect(() =>
+			captureOptions().onSuccess(undefined, { siren: SIREN, hasCse: false }),
+		).not.toThrow();
+		expect(trackEventMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/app/src/modules/my-space/index.ts
+++ b/packages/app/src/modules/my-space/index.ts
@@ -7,3 +7,4 @@ export { extractSiren, formatSiren } from "./formatSiren";
 export { MonEspacePage } from "./MonEspacePage";
 export { MyCompaniesPage } from "./MyCompaniesPage";
 export { sirenInputSchema, updateHasCseSchema } from "./schemas";
+export { useUpdateHasCse } from "./useUpdateHasCse";

--- a/packages/app/src/modules/my-space/useUpdateHasCse.ts
+++ b/packages/app/src/modules/my-space/useUpdateHasCse.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import {
+	campaignYearDimension,
+	MATOMO_ACTION,
+	MATOMO_EVENT_CATEGORY,
+	trackEvent,
+} from "~/modules/analytics";
+import { getCurrentYear } from "~/modules/domain";
+import { api } from "~/trpc/react";
+
+type UseUpdateHasCseOptions = {
+	onSuccess?: () => void;
+};
+
+/**
+ * Shared mutation hook for the company CSE status.
+ *
+ * Wraps `company.updateHasCse` and emits a single anonymised Matomo event on
+ * success (`cse_status / cse_status_confirm`, name = "oui" | "non") so the
+ * `/admin/stats` confirmation-volume KPI is fed from one place rather than
+ * duplicated across the three modals that update the field.
+ *
+ * The SIREN is **never** sent to Matomo — only the bounded oui/non label — so
+ * the CNIL consent exemption (full anonymisation) stays intact. The event fires
+ * on success only, so an impersonation-blocked write never produces one.
+ */
+export function useUpdateHasCse(options?: UseUpdateHasCseOptions) {
+	return api.company.updateHasCse.useMutation({
+		onSuccess: (_data, variables) => {
+			trackEvent({
+				category: MATOMO_EVENT_CATEGORY.CSE_STATUS,
+				action: MATOMO_ACTION.CSE_STATUS_CONFIRM,
+				name: variables.hasCse ? "oui" : "non",
+				dimensions: campaignYearDimension(getCurrentYear()),
+			});
+			options?.onSuccess?.();
+		},
+	});
+}

--- a/packages/app/src/server/api/routers/__tests__/adminStats.getUsersPerCompany.integration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.getUsersPerCompany.integration.test.ts
@@ -1,0 +1,104 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+import { adminStatsRouter } from "~/server/api/routers/adminStats";
+import { db } from "~/server/db";
+
+describe("adminStatsRouter.getUsersPerCompany (real Postgres)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN_MONO = "111111111";
+	const SIREN_DUO = "222222222";
+	const SIREN_QUAD = "333333333";
+	const SIRENS = [SIREN_MONO, SIREN_DUO, SIREN_QUAD];
+	const USER_PREFIX = "upc-int-";
+
+	// mono: 1 user · duo: 2 users · quad: 4 users → 7 distinct users.
+	const SEED: Array<{ siren: string; users: string[] }> = [
+		{ siren: SIREN_MONO, users: [`${USER_PREFIX}a1`] },
+		{ siren: SIREN_DUO, users: [`${USER_PREFIX}b1`, `${USER_PREFIX}b2`] },
+		{
+			siren: SIREN_QUAD,
+			users: [
+				`${USER_PREFIX}c1`,
+				`${USER_PREFIX}c2`,
+				`${USER_PREFIX}c3`,
+				`${USER_PREFIX}c4`,
+			],
+		},
+	];
+
+	function createCaller() {
+		return adminStatsRouter.createCaller({
+			db,
+			session: {
+				user: {
+					id: `${USER_PREFIX}admin`,
+					email: "upc-int-admin@example.fr",
+					siret: `${SIREN_MONO}00015`,
+					isAdmin: true,
+					impersonation: null,
+				},
+				expires: "",
+			},
+			headers: new Headers(),
+		} as never);
+	}
+
+	// The KPI aggregates the whole `app_user_company` table, so the test must own
+	// it exclusively. The integration suite is serial (fileParallelism:false) and
+	// every other file re-seeds its own data in beforeEach.
+	async function cleanup() {
+		await sql`DELETE FROM app_user_company`;
+		await sql`DELETE FROM app_company WHERE siren IN ${sql(SIRENS)}`;
+		await sql`DELETE FROM app_user WHERE id LIKE ${`${USER_PREFIX}%`}`;
+	}
+
+	async function seed() {
+		for (const { siren, users } of SEED) {
+			await sql`INSERT INTO app_company (siren, name) VALUES (${siren}, ${`Company ${siren}`})`;
+			for (const userId of users) {
+				await sql`INSERT INTO app_user (id, email) VALUES (${userId}, ${`${userId}@example.fr`})`;
+				await sql`INSERT INTO app_user_company (user_id, siren) VALUES (${userId}, ${siren})`;
+			}
+		}
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(cleanup);
+
+	it("returns the mono/multi distribution, average and max from user_company", async () => {
+		await seed();
+
+		const result = await createCaller().getUsersPerCompany();
+
+		expect(result).toEqual({
+			totalCompanies: 3,
+			mono: 1,
+			multi: 2,
+			avgPerCompany: expect.closeTo(2.3333, 3),
+			maxUsers: 4,
+		});
+	});
+
+	it("returns all zeros when no user is linked to any company", async () => {
+		const result = await createCaller().getUsersPerCompany();
+
+		expect(result).toEqual({
+			totalCompanies: 0,
+			mono: 0,
+			multi: 0,
+			avgPerCompany: 0,
+			maxUsers: 0,
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -13,17 +13,20 @@ const {
 	fetchMatomoCategoryModelMock,
 	fetchMatomoHelpLinksMock,
 	fetchMatomoDeviceBreakdownMock,
+	fetchMatomoCseStatusConfirmationsMock,
 } = vi.hoisted(() => ({
 	fetchMatomoFunnelMock: vi.fn(),
 	fetchMatomoCategoryModelMock: vi.fn(),
 	fetchMatomoHelpLinksMock: vi.fn(),
 	fetchMatomoDeviceBreakdownMock: vi.fn(),
+	fetchMatomoCseStatusConfirmationsMock: vi.fn(),
 }));
 vi.mock("~/server/services/matomo", () => ({
 	fetchMatomoFunnel: fetchMatomoFunnelMock,
 	fetchMatomoCategoryModel: fetchMatomoCategoryModelMock,
 	fetchMatomoHelpLinks: fetchMatomoHelpLinksMock,
 	fetchMatomoDeviceBreakdown: fetchMatomoDeviceBreakdownMock,
+	fetchMatomoCseStatusConfirmations: fetchMatomoCseStatusConfirmationsMock,
 }));
 
 type SelectChain = {
@@ -2030,5 +2033,185 @@ describe("adminStatsRouter.getMatomoDeviceBreakdown", () => {
 		await expect(
 			caller.getMatomoDeviceBreakdown({ year: 2101 }),
 		).rejects.toThrow();
+	});
+});
+
+describe("adminStatsRouter.getMatomoCseStatusConfirmations", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("rejects non-admin callers", async () => {
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: buildDb(),
+			session: nonAdminSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(
+			caller.getMatomoCseStatusConfirmations({ year: 2026 }),
+		).rejects.toThrow(/administrateurs/i);
+	});
+
+	it("delegates to the Matomo service with the year only (sizeRange is ignored)", async () => {
+		const output = { total: 55, yes: 42, no: 13 };
+		fetchMatomoCseStatusConfirmationsMock.mockResolvedValue(output);
+
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: buildDb(),
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getMatomoCseStatusConfirmations({
+			year: 2026,
+			sizeRange: "50-99",
+		});
+
+		expect(fetchMatomoCseStatusConfirmationsMock).toHaveBeenCalledWith({
+			year: 2026,
+		});
+		expect(result).toBe(output);
+	});
+
+	it("validates the year bounds", async () => {
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: buildDb(),
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(
+			caller.getMatomoCseStatusConfirmations({ year: 1999 }),
+		).rejects.toThrow();
+		await expect(
+			caller.getMatomoCseStatusConfirmations({ year: 2101 }),
+		).rejects.toThrow();
+	});
+});
+
+type UsersPerCompanyRow = {
+	total_companies: number | string;
+	mono: number | string;
+	multi: number | string;
+	avg_per_company: number | string;
+	max_users: number | string;
+};
+
+function buildUsersPerCompanyDb(row?: UsersPerCompanyRow) {
+	const execute = vi.fn().mockResolvedValue(row ? [row] : []);
+	return { select: vi.fn(), execute };
+}
+
+describe("adminStatsRouter.getUsersPerCompany", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("rejects non-admin callers", async () => {
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db: buildUsersPerCompanyDb(),
+			session: nonAdminSession,
+			headers: new Headers(),
+		} as never);
+
+		await expect(caller.getUsersPerCompany()).rejects.toThrow(
+			/administrateurs/i,
+		);
+	});
+
+	it("maps the SQL aggregate row to the typed UsersPerCompany shape", async () => {
+		const db = buildUsersPerCompanyDb({
+			total_companies: 3,
+			mono: 1,
+			multi: 2,
+			avg_per_company: 2.3333333333333335,
+			max_users: 4,
+		});
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getUsersPerCompany();
+
+		expect(result).toEqual({
+			totalCompanies: 3,
+			mono: 1,
+			multi: 2,
+			avgPerCompany: 2.3333333333333335,
+			maxUsers: 4,
+		});
+	});
+
+	it("coerces SQL numeric strings to numbers (pg may serialise COUNT/AVG as text)", async () => {
+		const db = buildUsersPerCompanyDb({
+			total_companies: "10",
+			mono: "6",
+			multi: "4",
+			avg_per_company: "1.8",
+			max_users: "5",
+		});
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getUsersPerCompany();
+
+		expect(result).toEqual({
+			totalCompanies: 10,
+			mono: 6,
+			multi: 4,
+			avgPerCompany: 1.8,
+			maxUsers: 5,
+		});
+	});
+
+	it("defaults every field to 0 when the aggregate query returns no row", async () => {
+		const db = buildUsersPerCompanyDb();
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getUsersPerCompany();
+
+		expect(result).toEqual({
+			totalCompanies: 0,
+			mono: 0,
+			multi: 0,
+			avgPerCompany: 0,
+			maxUsers: 0,
+		});
+	});
+
+	it("counts distinct users per siren via a single grouped CTE", async () => {
+		const db = buildUsersPerCompanyDb({
+			total_companies: 0,
+			mono: 0,
+			multi: 0,
+			avg_per_company: 0,
+			max_users: 0,
+		});
+		const { adminStatsRouter } = await import("../adminStats");
+		const caller = adminStatsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		await caller.getUsersPerCompany();
+
+		expect(db.execute).toHaveBeenCalledTimes(1);
+		const sqlText = flattenSql(db.execute.mock.calls[0]?.[0]);
+		expect(sqlText).toContain("DISTINCT");
+		expect(sqlText).toMatch(/GROUP BY/i);
 	});
 });

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -14,12 +14,14 @@ import type {
 	CampaignStats,
 	CategoryModelUsage,
 	CompletionFunnelOutput,
+	CseStatusConfirmations,
 	DeviceBreakdown,
 	FunnelRow,
 	HelpLinkClicks,
 	MatomoFunnelOutput,
 	StepDropoffRow,
 	StepDurationRow,
+	UsersPerCompany,
 } from "~/modules/admin/stats/types";
 import {
 	COMPANY_SIZE_ANNUAL_MIN,
@@ -44,9 +46,11 @@ import {
 	declarationStatusHistory,
 	declarations,
 	gipMdsData,
+	userCompanies,
 } from "~/server/db/schema";
 import {
 	fetchMatomoCategoryModel,
+	fetchMatomoCseStatusConfirmations,
 	fetchMatomoDeviceBreakdown,
 	fetchMatomoFunnel,
 	fetchMatomoHelpLinks,
@@ -1044,6 +1048,53 @@ export const adminStatsRouter = createTRPCRouter({
 				sizeRange: input.sizeRange,
 			});
 		}),
+
+	// CSE-status confirmation volume (oui/non), read anonymously from Matomo —
+	// no SIREN is ever pushed, so this is a confirmation-action count, not a
+	// distinct-company count. `sizeRange` is ignored (the event carries only the
+	// campaign-year dimension).
+	getMatomoCseStatusConfirmations: adminProcedure
+		.input(getMatomoFunnelSchema)
+		.query(({ input }): Promise<CseStatusConfirmations> => {
+			return fetchMatomoCseStatusConfirmations({ year: input.year });
+		}),
+
+	// Distinct users per company, read from the existing `user_company` table.
+	// Aggregate output only (no SIREN / email). This structural "stock" metric
+	// cannot be produced by anonymised Matomo, hence the direct DB read.
+	getUsersPerCompany: adminProcedure.query(
+		async ({ ctx }): Promise<UsersPerCompany> => {
+			const rows = await ctx.db.execute<{
+				total_companies: number | string;
+				mono: number | string;
+				multi: number | string;
+				avg_per_company: number | string;
+				max_users: number | string;
+			}>(sql`
+				WITH per_company AS (
+					SELECT ${userCompanies.siren} AS siren,
+						COUNT(DISTINCT ${userCompanies.userId}) AS c
+					FROM ${userCompanies}
+					GROUP BY ${userCompanies.siren}
+				)
+				SELECT
+					COUNT(*)::int AS total_companies,
+					COUNT(*) FILTER (WHERE c = 1)::int AS mono,
+					COUNT(*) FILTER (WHERE c > 1)::int AS multi,
+					COALESCE(AVG(c), 0)::float AS avg_per_company,
+					COALESCE(MAX(c), 0)::int AS max_users
+				FROM per_company
+			`);
+			const row = rows[0];
+			return {
+				totalCompanies: Number(row?.total_companies ?? 0),
+				mono: Number(row?.mono ?? 0),
+				multi: Number(row?.multi ?? 0),
+				avgPerCompany: Number(row?.avg_per_company ?? 0),
+				maxUsers: Number(row?.max_users ?? 0),
+			};
+		},
+	),
 });
 function countDeclarationsWithEvent(opts: {
 	eventType: string | readonly string[];

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -82,6 +82,10 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 		AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_HELP_LINKS,
 	"adminStats.getMatomoDeviceBreakdown":
 		AUDIT_ACTIONS.ADMIN_STATS_GET_MATOMO_DEVICE_BREAKDOWN,
+	"adminStats.getMatomoCseStatusConfirmations":
+		AUDIT_ACTIONS.ADMIN_STATS_GET_CSE_STATUS_CONFIRMATIONS,
+	"adminStats.getUsersPerCompany":
+		AUDIT_ACTIONS.ADMIN_STATS_GET_USERS_PER_COMPANY,
 
 	// ── gip mds ────────────────────────────────────────────
 	"gipMds.importFromUrl": AUDIT_ACTIONS.GIP_MDS_IMPORT,

--- a/packages/app/src/server/services/__tests__/matomo.test.ts
+++ b/packages/app/src/server/services/__tests__/matomo.test.ts
@@ -13,6 +13,7 @@ vi.mock("~/env", () => ({ env: mockEnv }));
 
 import {
 	fetchMatomoCategoryModel,
+	fetchMatomoCseStatusConfirmations,
 	fetchMatomoDeviceBreakdown,
 	fetchMatomoFunnel,
 	fetchMatomoHelpLinks,
@@ -537,5 +538,66 @@ describe("fetchMatomoDeviceBreakdown", () => {
 		for (const row of rows) {
 			expect(row).toMatchObject({ desktop: 0, smartphone: 0, tablet: 0 });
 		}
+	});
+});
+
+// The confirmation volume comes from the event NAME report scoped by an
+// `eventCategory==cse_status;eventAction==cse_status_confirm` segment. The
+// segment is visit-scoped, so a co-occurring event name leaks into the rows and
+// must be dropped by the oui/non allow-list.
+function cseStatusApiResponder(init: { body: URLSearchParams }): Row[] {
+	if (init.body.get("method") !== "Events.getName") return [];
+	const segment = init.body.get("segment") ?? "";
+	if (!segment.includes("eventAction==cse_status_confirm")) return [];
+	return [
+		{ label: "oui", nb_events: 42 },
+		{ label: "non", nb_events: 13 },
+		// Leaked from a co-occurring event in the same visit — not oui/non, so
+		// it must be ignored (and never inflate `total`).
+		{ label: "step_1", nb_events: 999 },
+	];
+}
+
+describe("fetchMatomoCseStatusConfirmations", () => {
+	beforeEach(() => setMatomoEnv());
+	afterEach(() => vi.restoreAllMocks());
+
+	it("splits oui/non and drops leaked labels via the allow-list", async () => {
+		stubFetch(cseStatusApiResponder);
+
+		const result = await fetchMatomoCseStatusConfirmations({ year: 2024 });
+
+		expect(result).toEqual({ total: 55, yes: 42, no: 13 });
+	});
+
+	it("scopes the read by the cse_status / cse_status_confirm event segment", async () => {
+		const fetchSpy = stubFetch(cseStatusApiResponder);
+
+		await fetchMatomoCseStatusConfirmations({ year: 2024 });
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const segment = (fetchSpy.mock.calls[0]?.[1].body as URLSearchParams).get(
+			"segment",
+		);
+		expect(segment).toContain("eventCategory==cse_status");
+		expect(segment).toContain("eventAction==cse_status_confirm");
+	});
+
+	it("returns all-zero without a token (no fetch)", async () => {
+		mockEnv.MATOMO_API_TOKEN = undefined;
+		const fetchSpy = stubFetch(cseStatusApiResponder);
+
+		const result = await fetchMatomoCseStatusConfirmations({ year: 2024 });
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(result).toEqual({ total: 0, yes: 0, no: 0 });
+	});
+
+	it("returns all-zero when Matomo reports no confirmation names", async () => {
+		stubFetch(() => []);
+
+		const result = await fetchMatomoCseStatusConfirmations({ year: 2024 });
+
+		expect(result).toEqual({ total: 0, yes: 0, no: 0 });
 	});
 });

--- a/packages/app/src/server/services/matomo.ts
+++ b/packages/app/src/server/services/matomo.ts
@@ -7,6 +7,7 @@ import {
 } from "~/modules/admin/stats/schemas";
 import type {
 	CategoryModelUsage,
+	CseStatusConfirmations,
 	DeviceBreakdown,
 	DeviceBreakdownRow,
 	FunnelRow,
@@ -453,6 +454,33 @@ async function fetchHelpLinkClicks(
 	return { rows };
 }
 
+/**
+ * Volume of CSE-status confirmations for one year, split by the bounded oui/non
+ * label. Mirrors {@link fetchHelpLinkClicks}: `Events.getName` is visit-scoped,
+ * so the result is **allow-listed** to the two expected labels — a co-occurring
+ * event name in the same visit is dropped. Counts confirmation *actions* (a
+ * re-save or a second co-declarant counts again); Matomo carries no SIREN, so
+ * it cannot dedupe to distinct companies.
+ */
+async function fetchCseStatusConfirmationsData(
+	config: MatomoConfig,
+	year: number,
+): Promise<CseStatusConfirmations> {
+	const names = await getEventNames(
+		config,
+		MATOMO_EVENT_CATEGORY.CSE_STATUS,
+		MATOMO_ACTION.CSE_STATUS_CONFIRM,
+		year,
+	);
+	let yes = 0;
+	let no = 0;
+	for (const name of names) {
+		if (name.label === "oui") yes += toCount(name.nb_events);
+		else if (name.label === "non") no += toCount(name.nb_events);
+	}
+	return { total: yes + no, yes, no };
+}
+
 // Each behaviour is detected by its marker event. `DevicesDetection.getType`
 // returns device-type rows (`nb_visits`) for visits matching the segment.
 // ⚠️ Segment dimension names and `DevicesDetection.getType` must be validated
@@ -545,6 +573,18 @@ export async function fetchMatomoHelpLinks({
 	const config = readConfig();
 	if (!config) return { rows: [] };
 	return fetchHelpLinkClicks(config, year);
+}
+
+/** Volume of CSE-status confirmations for one year, split oui / non. */
+export async function fetchMatomoCseStatusConfirmations({
+	year,
+}: {
+	year: number;
+	sizeRange?: CompanySizeRange;
+}): Promise<CseStatusConfirmations> {
+	const config = readConfig();
+	if (!config) return { total: 0, yes: 0, no: 0 };
+	return fetchCseStatusConfirmationsData(config, year);
 }
 
 /** Device split (desktop / smartphone / tablet) for the 3 tracked behaviours. */


### PR DESCRIPTION
## Contexte

Deux nouveaux KPI sur le dashboard `/admin/stats` (sous-issue de l'epic stats admin #3514).

## Changements

### Carte « Confirmations de statut CSE » (Matomo, anonymisé)
- Nouvel event `cse_status` / `cse_status_confirm` (`oui` | `non`, **sans SIREN** → exemption de consentement CNIL préservée), émis via un hook partagé `useUpdateHasCse` branché dans les 3 modals de mise à jour du CSE.
- Lecture via `adminStats.getMatomoCseStatusConfirmations` (Reporting API, allow-list `oui`/`non`).
- Sémantique assumée : **volume de confirmations** (forward-only), pas un comptage d'entreprises distinctes — Matomo anonymisé ne porte pas le SIREN.

### Carte « Utilisateurs par entreprise » (lecture DB)
- `adminStats.getUsersPerCompany` : agrégat `COUNT(DISTINCT user_id) GROUP BY siren` sur la table **existante** `user_company`. Sortie agrégée (distribution mono/multi, moyenne, max), **aucune PII** exposée.

### Transverse
- 2 endpoints `adminProcedure` audités `read_sensitive`.
- 2 cartes `AdminKpiTile` dans une section « Comptes & engagement CSE » de `/admin/stats`.
- Plan de tracking documenté (`docs/plan-de-tracking.md`).
- **Aucune migration, aucune nouvelle table, aucune modification serveur de `updateHasCse`.**

## Tests & qualité
- Unitaires : Matomo (allow-list `oui`/`non`), hook `useUpdateHasCse` (**assertion : aucun SIREN/PII dans le payload de l'event**), les 2 endpoints, les 2 tuiles.
- Intégration DB réelle : `getUsersPerCompany` (3 entreprises à 1/2/4 utilisateurs → `mono` 1, `multi` 2, `max` 4).
- `typecheck` / `lint` / `format` verts ; audits RGAA (PASS) et sécurité (SECURE).

Closes #3695
