### PR TITLE
fix(a11y): contraste tag « élevé » et encarts d'avertissement (#3720)

### DIFF
--- a/packages/app/src/modules/aide/AideCallout.module.scss
+++ b/packages/app/src/modules/aide/AideCallout.module.scss
@@ -1,0 +1,7 @@
+.callout:global(.fr-callout--orange-terre-battue) {
+	background-image: linear-gradient(
+		0deg,
+		var(--text-default-warning),
+		var(--text-default-warning)
+	);
+}

--- a/packages/app/src/modules/aide/AideCallout.tsx
+++ b/packages/app/src/modules/aide/AideCallout.tsx
@@ -1,4 +1,5 @@
 import { formatLongDate } from "~/modules/domain";
+import styles from "./AideCallout.module.scss";
 
 type Props = {
 	year: number;
@@ -8,7 +9,9 @@ type Props = {
 /** Callout displaying the declaration deadline for the active campaign year. */
 export function AideCallout({ year, deadline }: Props) {
 	return (
-		<div className="fr-callout fr-callout--orange-terre-battue">
+		<div
+			className={`fr-callout fr-callout--orange-terre-battue ${styles.callout}`}
+		>
 			<h2 className="fr-callout__title">Date limite de déclaration</h2>
 			<p className="fr-callout__text">
 				La date limite de déclaration pour l'année {year} est fixée au{" "}

--- a/packages/app/src/modules/declaration-remuneration/shared/InterpretationCallout.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/InterpretationCallout.module.scss
@@ -2,4 +2,12 @@
 	:global(.fr-callout__text) {
 		font-size: 1rem;
 	}
+
+	&:global(.fr-callout--orange-terre-battue) {
+		background-image: linear-gradient(
+			0deg,
+			var(--text-default-warning),
+			var(--text-default-warning)
+		);
+	}
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
@@ -73,10 +73,3 @@
 .alertBadge {
 	text-transform: uppercase;
 }
-
-// Figma spec: the warning badge uses orange-terre-battue, matching the
-// "élevé" gap badges, rather than DSFR's default warning brown. Double class
-// for specificity over `.fr-badge--warning`.
-.alertBadge.alertBadge {
-	color: var(--orange-terre-battue-main-645);
-}

--- a/packages/app/src/modules/declaration-remuneration/shared/gapBadge.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/gapBadge.module.scss
@@ -1,3 +1,0 @@
-.high.high {
-	color: var(--orange-terre-battue-main-645);
-}

--- a/packages/app/src/modules/declaration-remuneration/shared/gapBadge.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/gapBadge.ts
@@ -6,7 +6,6 @@
  */
 
 import type { GapLevel } from "~/modules/domain";
-import styles from "./gapBadge.module.scss";
 
 /** French labels for gap severity levels. */
 export const GAP_LEVEL_LABELS: Record<GapLevel, string> = {
@@ -19,5 +18,5 @@ export function gapBadgeClass(level: GapLevel): string {
 	const base = "fr-badge fr-badge--sm fr-badge--no-icon";
 	return level === "low"
 		? `${base} fr-badge--info`
-		: `${base} fr-badge--warning ${styles.high}`;
+		: `${base} fr-badge--warning`;
 }


### PR DESCRIPTION

## Contexte

Bug d'accessibilité (contraste) découpé depuis #3679. Le tag « ÉLEVÉ » et le liseré des encarts d'avertissement utilisaient `--orange-terre-battue-main-645` (**#e4794a**), dont le contraste sur fond clair passe sous le seuil WCAG AA 4.5:1. La maquette de référence cible **#b34000**, qui est exactement le token de décision DSFR `--text-default-warning`.

## Changements

Remplacement de l'orange illustratif par le token sémantique `--text-default-warning` (jamais de hex en dur — interdit par le hook `block-bad-patterns`) :

| Fichier | Changement |
|---|---|
| `shared/gapBadge.ts` + suppression de `shared/gapBadge.module.scss` | Retrait de l'override `.high` → la couleur native DSFR `fr-badge--warning` (= `--text-default-warning`) reprend la main sur le tag « élevé » (`PayGapTable`, `step6/GapBadge`) |
| `shared/NextStepsBox.module.scss` | Retrait de l'override couleur du badge « Écarts détectés » → idem couleur native warning |
| `shared/InterpretationCallout.module.scss` | Override scoped du liseré gauche (`background-image`) → `--text-default-warning`, **sans toucher au fond orange** (couvre les callouts Gap + Quartile) |
| `aide/AideCallout.tsx` + nouveau `aide/AideCallout.module.scss` | Même override de liseré sur le callout de la page d'aide |

Le fond orange clair des encarts (`--background-contrast-orange-terre-battue`) et le fond des badges (`--background-contrast-warning`) sont **préservés** : seule la couleur du texte des badges et la couleur du liseré des callouts changent.

## Vérification visuelle (Figma + mesure DOM)

Lecture structurelle du node Figma de référence (`7548:74759`) :
- tag « élevé » → `fills = $text-default-warning` (**#B34000**), fond `$background-contrast-warning` ;
- liseré callout (« 🎨 Bordure », 4px) → `fills = $text-default-warning` (**#B34000**), fond inchangé.

Couleurs résolues mesurées au `getComputedStyle` (CSS DSFR réelle, thème clair) :

| Élément | Avant | Après | Cible |
|---|---|---|---|
| Tag « élevé » (texte) | `rgb(228,121,74)` #e4794a | **`rgb(179,64,0)` #B34000** | #B34000 |
| Badge « Écarts détectés » | `rgb(228,121,74)` | **`rgb(179,64,0)`** | #B34000 |
| Liseré callout | gradient #e4794a | **gradient #B34000** | #B34000 |
| Fond du callout | `rgb(254,233,229)` | `rgb(254,233,229)` *(inchangé)* | — |

### Avant / Après — desktop (1280×800)
![Avant/Après desktop](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-3720/egapro-3720-desktop.png)

### Avant / Après — mobile (375×667)
![Avant/Après mobile](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-3720/egapro-3720-mobile.png)

> Captures rendues via un harnais isolé chargeant la feuille DSFR réelle (composants sans auth/donnée), avec données fictives. La fidélité au design est vérifiée structurellement (tokens) ; ces captures sont l'artefact de revue.

## Test plan

- `pnpm typecheck` ✅
- `pnpm lint:check` ✅
- `pnpm format:check` ✅
- Couleurs résolues vérifiées au DOM (tableau ci-dessus) ✅
- Tests unitaires/E2E : hors périmètre de cette PR (pris en charge par les nœuds dédiés de la pipeline ; `gapBadge.test.ts` n'asserte que `fr-badge--warning`, inchangé)

## À confirmer

- **Périmètre du badge « Écarts détectés » (NextStepsBox)** : inclus ici car il porte le même token fautif et le même défaut de contraste, et le code le rattache explicitement aux badges « élevé ». Le ticket ne nomme littéralement que le tag « ÉLEVÉ » — à exclure si un fix strictement minimal est préféré.
- **Mutualisation de l'override de liseré** : choix de co-localiser l'override (module partagé `InterpretationCallout` pour Gap+Quartile + petit module pour `AideCallout`) plutôt que d'extraire un module unique, pour rester aligné sur la convention « un module SCSS co-localisé par composant » et éviter un fichier partagé inter-modules au domicile ambigu (`aide` ↔ `declaration-remuneration`).

