### PR TITLE
fix(quartile): design — colonnes min/max, inputs pleine largeur, intro/source conditionnels

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -33,8 +33,19 @@
 	:global(.fr-table__content),
 	:global(.fr-table__wrapper) {
 		overflow: visible;
-		padding-top: 0;
-		padding-bottom: 0;
+	}
+
+	// DSFR's --no-scroll variant sets the wrapper to fit-content and the table
+	// to width:auto, letting cell content drive column widths. Re-anchor both to
+	// 100% (specificity above the DSFR rules) so table-layout:fixed + colgroup
+	// fully control column sizing, independent of input content.
+	&:global(.fr-table.fr-table--no-scroll) :global(.fr-table__wrapper) {
+		width: 100%;
+	}
+
+	&:global(.fr-table.fr-table--no-scroll) :global(.fr-table__content) table {
+		width: 100%;
+		table-layout: fixed;
 	}
 
 	table {
@@ -44,24 +55,28 @@
 		border-collapse: collapse;
 	}
 
+	// Percentage column widths summing to exactly 100%. With table-layout:fixed
+	// on a width-anchored table, this leaves no deficit for the browser to
+	// redistribute, so columns never shift based on cell content (e.g. a long
+	// "1 000 000,00 €" threshold or a large effectif).
 	.colRowLabel {
-		width: 9rem;
+		width: 18%;
 	}
 
 	.colMin {
-		width: 8rem;
+		width: 17%;
 	}
 
 	.colMax {
-		width: 9.5rem;
+		width: 17%;
 	}
 
 	.colCount {
-		width: 7rem;
+		width: 12%;
 	}
 
 	.colPercent {
-		width: 7rem;
+		width: 12%;
 	}
 
 	th,
@@ -94,6 +109,16 @@
 	.numericCell {
 		text-align: right;
 		font-variant-numeric: tabular-nums;
+	}
+
+	// Neutralize each data cell's intrinsic content width so it can never nudge
+	// the fixed-layout column (long amounts use a non-breaking thousands
+	// separator; counts can reach 6 digits). Content fits within its column, so
+	// nothing is actually clipped — column widths stay strictly content-independent.
+	.minCell,
+	.maxCell,
+	.numericCell {
+		max-width: 0;
 	}
 
 	tbody td input:global(.fr-input) {
@@ -165,6 +190,9 @@
 		.maxCell,
 		.numericCell {
 			text-align: left;
+			// On mobile the table is block-displayed; cells are full width, so the
+			// desktop fixed-layout neutralizer must not collapse them.
+			max-width: none;
 		}
 
 		tbody td input:global(.fr-input) {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -33,6 +33,8 @@
 	:global(.fr-table__content),
 	:global(.fr-table__wrapper) {
 		overflow: visible;
+		padding-top: 0;
+		padding-bottom: 0;
 	}
 
 	table {
@@ -47,11 +49,11 @@
 	}
 
 	.colMin {
-		width: 7rem;
+		width: 8rem;
 	}
 
 	.colMax {
-		width: 7.5rem;
+		width: 9.5rem;
 	}
 
 	.colCount {
@@ -96,16 +98,14 @@
 
 	tbody td input:global(.fr-input) {
 		text-align: right;
-		width: 4.5rem;
-		margin-left: auto;
+		width: 100%;
 		padding-left: 8px;
 		padding-right: 8px;
 	}
 
 	tbody td .inputWithUnit input:global(.fr-input) {
-		width: 5.5rem;
-		min-width: 5.5rem;
-		max-width: 5.5rem;
+		flex: 1;
+		min-width: 0;
 		margin-left: 0;
 		padding-left: 0.25rem;
 		padding-right: 0.25rem;
@@ -207,6 +207,10 @@
 		margin-left: 0.25rem;
 		vertical-align: middle;
 	}
+}
+
+.introMedium {
+	font-weight: 500;
 }
 
 .readonlyCell {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -295,12 +295,18 @@ export function Step4QuartileDistribution({
 					rassemble les salariés les mieux rémunérés.
 				</p>
 
-				<p className="fr-mb-0">
-					<strong>
-						Vérifiez les informations préremplies et modifiez-les si nécessaire
-						avant de valider vos indicateurs.
-					</strong>
-				</p>
+				{gipPrefillData ? (
+					<p className="fr-mb-0">
+						<strong>
+							Vérifiez les informations préremplies et modifiez-les si
+							nécessaire avant de valider vos indicateurs.
+						</strong>
+					</p>
+				) : (
+					<p className={`fr-mb-0 ${stepStyles.introMedium}`}>
+						Renseignez les informations avant de valider vos indicateurs.
+					</p>
+				)}
 
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 			</div>
@@ -336,7 +342,9 @@ export function Step4QuartileDistribution({
 					}
 					quartiles={annual}
 					sourceNote={
-						<PrefillSource periodEnd={gipPrefillData?.periodEnd ?? null} />
+						gipPrefillData ? (
+							<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />
+						) : undefined
 					}
 					tableType="annual"
 					title="Rémunération annuelle brute moyenne"
@@ -351,7 +359,9 @@ export function Step4QuartileDistribution({
 					}
 					quartiles={hourly}
 					sourceNote={
-						<PrefillSource periodEnd={gipPrefillData?.periodEnd ?? null} />
+						gipPrefillData ? (
+							<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />
+						) : undefined
 					}
 					tableType="hourly"
 					title="Rémunération horaire brute moyenne"

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -96,7 +96,7 @@ describe("Step4QuartileDistribution", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders instruction text and mandatory fields notice", () => {
+	it("renders the non-prefilled instruction text and mandatory fields notice without GIP prefill", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
@@ -106,9 +106,14 @@ describe("Step4QuartileDistribution", () => {
 		);
 		expect(
 			screen.getByText(
-				"Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs.",
+				"Renseignez les informations avant de valider vos indicateurs.",
 			),
 		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				"Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs.",
+			),
+		).not.toBeInTheDocument();
 		expect(
 			screen.getByText("Tous les champs sont obligatoires."),
 		).toBeInTheDocument();
@@ -236,7 +241,7 @@ describe("Step4QuartileDistribution", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders DSN source line on both tables even without GIP prefill", () => {
+	it("does not render the DSN source line without GIP prefill", () => {
 		render(
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
@@ -245,10 +250,10 @@ describe("Step4QuartileDistribution", () => {
 			/>,
 		);
 		expect(
-			screen.getAllByText(
+			screen.queryByText(
 				/Source\s*:\s*DSN \(Déclarations Sociales Nominatives\)/,
-			).length,
-		).toBe(2);
+			),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders accordion", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
@@ -195,4 +195,48 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 		const menTotalCells = totalCells.filter((cell) => cell.textContent === "0");
 		expect(menTotalCells.length).toBeGreaterThanOrEqual(1);
 	});
+
+	it("renders the prefilled intro text and DSN source line on both tables", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				gipPrefillData={{
+					step1: { totalWomen: 100, totalMen: 100 },
+					step2: nullStep2,
+					step3: nullStep3,
+					step4: {
+						annual: {
+							thresholds: ["25000", "32000", "40000"],
+							womenCounts: [30, 25, 20, 15],
+							menCounts: [20, 25, 30, 35],
+						},
+						hourly: {
+							thresholds: ["13.74", "17.58", "21.98"],
+							womenCounts: [28, 22, 18, 12],
+							menCounts: [22, 28, 32, 38],
+						},
+					},
+					confidenceIndex: "0.85",
+					periodEnd: "2026-12-31",
+				}}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+		expect(
+			screen.getByText(
+				"Vérifiez les informations préremplies et modifiez-les si nécessaire avant de valider vos indicateurs.",
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				"Renseignez les informations avant de valider vos indicateurs.",
+			),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getAllByText(
+				/Source\s*:\s*DSN \(Déclarations Sociales Nominatives\)/,
+			).length,
+		).toBe(2);
+	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -54,13 +54,15 @@ export function QuartileTable({
 			<div className={stepStyles.tableSection}>
 				{readingNote}
 				<div
-					className={`fr-table fr-table--no-scroll fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
+					className={`fr-table fr-table--no-scroll fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
 				>
 					<div className="fr-table__wrapper">
 						<div className="fr-table__container">
 							<div className="fr-table__content">
 								<table>
-									<caption className="fr-sr-only">{title}</caption>
+									{/* fr-table--no-caption keeps the caption in the a11y tree (sr-only)
+									    without reserving the DSFR --table-offset top space. */}
+									<caption>{title}</caption>
 									<colgroup>
 										<col className={stepStyles.colRowLabel} />
 										<col className={stepStyles.colMin} />


### PR DESCRIPTION
Closes #3575

## Changements

**Step4QuartileDistribution.tsx**
- Texte d'intro conditionnel sur `gipPrefillData` : sans GIP → « Renseignez les informations avant de valider vos indicateurs. » (Marianne Medium) ; avec GIP → « Vérifiez les informations préremplies… » (bold, inchangé)
- `sourceNote` des deux `<QuartileTable>` conditionnel sur `gipPrefillData` : `<PrefillSource>` affiché uniquement si GIP présent

**Step4QuartileDistribution.module.scss**
- `.colMin` : 7rem → 8rem (tient les montants à 7 chiffres)
- `.colMax` : 7.5rem → 9.5rem (aligne sur Figma 152px)
- Inputs nombre femmes/hommes : `width: 100%` (remplissent la cellule), suppression de `margin-left: auto`
- Input seuil (`.inputWithUnit`) : `flex: 1` + `min-width: 0` (remplit l'espace disponible)
- Ajout `padding-top: 0; padding-bottom: 0` sur les wrappers DSFR `.fr-table__*` (supprime l'espace parasite entre h3 et tableau)
- Classe `.introMedium` : `font-weight: 500` (Marianne Medium pour le texte non-prérempli)