### PR TITLE
fix(infra): aligne archive/http.yaml sur la prod (files priority → 1000000)

### DIFF
--- a/.kontinuous/env/prod/archive/http.yaml
+++ b/.kontinuous/env/prod/archive/http.yaml
@@ -204,7 +204,7 @@ spec:
   routes:
   - kind: Rule
     match: Host(`egapro.travail.gouv.fr`) && (Path(`/index-egalite-fh.xlsx`) || Path(`/dgt-export-representation.xlsx`))
-    priority: 100
+    priority: 1000000
     services:
     - name: files
       port: 80
@@ -222,7 +222,7 @@ spec:
   routes:
   - kind: Rule
     match: Host(`egapro.travail.gouv.fr`) && (Path(`/dgt.xlsx`) || Path(`/dgt-representation.xlsx`) || Path(`/full.ndjson`) || Path(`/indexes.csv`))
-    priority: 100
+    priority: 1000000
     services:
     - name: files
       port: 80


### PR DESCRIPTION
## Contexte

En traitant la demande de la team produit (appliquer manuellement le traefik `archive/http.yaml` sur la prod egapro — la route `/apiv2/public/referents_egalite_professionnelle` de #3708), j'ai constaté que le fichier avait **dérivé de la prod**.

Depuis #3097, `.kontinuous/env/prod/archive/http.yaml` n'est **plus déployé par kontinuous** (dossier `archive/`, pas `templates/`) : il est appliqué **à la main** sur le cluster `ovh-prod` (ns `egapro`). C'est donc une source de vérité qu'il faut garder fidèle à la prod.

## Drift constaté (`kubectl diff` du fichier vs live prod)

Seules **2 routes** divergeaient — `priority` dans le fichier vs en prod :

| IngressRoute | fichier | prod (live) |
|---|---|---|
| `files-public` | `100` | `1000000` |
| `files-restricted` | `100` | `1000000` |

Un `kubectl apply -f archive/http.yaml` complet aurait donc **régressé** la précédence de ces routes de téléchargement (`.xlsx`, `.ndjson`, `.csv`).

## Fix

Aligne les deux `priority` sur l'état live (`1000000`). Le reste du fichier (api, app-redirect, nginx + la route référents de #3708, middlewares, certs) correspond déjà à la prod.

## Note de déploiement

La route référents de #3708 a déjà été **appliquée manuellement** en prod (uniquement l'IngressRoute `nginx`, sans le reste du fichier stale) :

```
curl -I https://egapro.travail.gouv.fr/apiv2/public/referents_egalite_professionnelle.xlsx
→ 200 + application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
```

Cette PR ne change rien en prod par elle-même — elle remet le fichier d'archive en cohérence pour les prochains `apply` manuels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)