### PR TITLE
feat(infra): CronJob Kontinuous de purge quotidienne des déclarations (#3770)

### DIFF
--- a/.kontinuous/templates/declaration-cleanup-cron.yaml
+++ b/.kontinuous/templates/declaration-cleanup-cron.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: declaration-cleanup-daily
+  namespace: {{ .Values.global.namespace }}
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: declaration-cleanup-daily
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 1000
+            runAsNonRoot: true
+          containers:
+            - name: declaration-cleanup
+              image: "{{ .Values.global.registry }}/{{ .Values.global.imageProject }}/{{ .Values.global.imageRepository }}/app:{{ .Values.global.imageTag }}"
+              securityContext:
+                allowPrivilegeEscalation: false
+              env:
+                - name: POSTGRES_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGHOST
+                - name: POSTGRES_DB
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGDATABASE
+                - name: POSTGRES_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGPORT
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGUSER
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGPASSWORD
+                - name: POSTGRES_SSLMODE
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGSSLMODE
+              envFrom:
+                - configMapRef:
+                    name: "s3"
+                - secretRef:
+                    name: "s3"
+                - configMapRef:
+                    name: "declaration-retention"
+                    optional: true
+              command:
+                - node
+                - packages/app/scripts/declaration-cleanup.mjs
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 256Mi


### PR DESCRIPTION
## Résumé

Création de `.kontinuous/templates/declaration-cleanup-cron.yaml` : une CronJob Kontinuous qui planifie l'exécution quotidienne du script de purge RGPD des déclarations (`packages/app/scripts/declaration-cleanup.mjs`, implémenté dans #3769).

Calquée sur `audit-cleanup-cron.yaml` (#3268) avec les adaptations suivantes :
- `name: declaration-cleanup-daily`, schedule `0 3 * * *` (03:00 UTC, 1h avant l'audit-cleanup à 04:00 pour éviter le chevauchement)
- `command: node packages/app/scripts/declaration-cleanup.mjs`
- Vars `POSTGRES_*` via `secretKeyRef` sur `{{ .Values.global.pgSecretName }}` (copie exacte)
- Vars S3 (`S3_ENDPOINT`, `S3_REGION`, `S3_BUCKET_NAME` via configmap `s3` ; `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY` via secret `s3`) — réutilise les mêmes sources que le pod `app`, aucune valeur en clair
- Configmap `declaration-retention` optional pour surcharger `EGAPRO_DECLARATION_RETENTION_YEARS` (absent = défaut 6 ans dans le script)
- `concurrencyPolicy: Forbid`, `backoffLimit: 0`, `restartPolicy: Never`

## Plan de test

- [ ] Revue du manifest YAML : cohérence des références de secrets (pas de valeur en clair)
- [ ] `declaration-cleanup-cron.yaml` suit la même structure que `audit-cleanup-cron.yaml`
- [ ] Schedule `0 3 * * *` décalé d'1h de l'audit-cleanup (`0 4 * * *`)
- [ ] Toutes les variables S3 référencées par leur configmap/secret existants (`s3`)
- [ ] Configmap `declaration-retention` optionnel (absent = no-op)

## À confirmer

- Le typecheck échoue pré-existant sur `declarationCleanupScript.integration.test.ts` (test créé par #3769, non encore commité sur la branche epic) qui référence `#scripts/declaration-cleanup.mjs` (script de #3769, pas encore présent dans ce worktree). Non lié à ce ticket. Sera vert une fois #3769 squash-mergé dans `epic/3134`.
