### PR TITLE
feat(audit): config rétention déclarations + action audit système (#3768)

### DIFF
--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -91,6 +91,12 @@ export const env = createEnv({
 			.int()
 			.positive()
 			.default(365),
+		// retention (years) for declaration data, consumed by the declaration-cleanup CronJob (#3134), default 6 (legal retention period)
+		EGAPRO_DECLARATION_RETENTION_YEARS: z.coerce
+			.number()
+			.int()
+			.positive()
+			.default(6),
 		// MAIL_*, SMTP_* are intentionally NOT declared here — they are consumed
 		// exclusively by the notifications worker (packages/notifications).
 		// See packages/notifications/README.md for the runtime config surface.
@@ -150,6 +156,8 @@ export const env = createEnv({
 			process.env.EGAPRO_AUDIT_RETENTION_SHORT_DAYS,
 		EGAPRO_AUDIT_RETENTION_LONG_DAYS:
 			process.env.EGAPRO_AUDIT_RETENTION_LONG_DAYS,
+		EGAPRO_DECLARATION_RETENTION_YEARS:
+			process.env.EGAPRO_DECLARATION_RETENTION_YEARS,
 		VALKEY_URL: process.env.VALKEY_URL,
 		NEXT_PUBLIC_EGAPRO_ENV: process.env.NEXT_PUBLIC_EGAPRO_ENV,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -118,6 +118,7 @@ export const AUDIT_ACTIONS = {
 
 	// ── System / cron-triggered ────────────────────────────
 	SYSTEM_AUDIT_CLEANUP: "system.audit_cleanup",
+	SYSTEM_DECLARATION_CLEANUP: "system.declaration_cleanup",
 } as const;
 
 export type AuditActionKey = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];
@@ -208,4 +209,5 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
 
 	[AUDIT_ACTIONS.SYSTEM_AUDIT_CLEANUP]: "system",
+	[AUDIT_ACTIONS.SYSTEM_DECLARATION_CLEANUP]: "system",
 };


### PR DESCRIPTION
Closes #3768

## Résumé

Pose les fondations de configuration pour la purge RGPD des déclarations (epic #3134) :

- **`EGAPRO_DECLARATION_RETENTION_YEARS`** — nouvelle variable d'environnement serveur dans `env.js`, validée `coerce.number().int().positive()`, défaut 6 (durée légale de rétention). Ajoutée dans le schéma `server` et dans `runtimeEnv`.
- **`AUDIT_ACTIONS.SYSTEM_DECLARATION_CLEANUP`** — nouvelle constante d'action `"system.declaration_cleanup"` dans `actionKeys.ts`, catégorie `"system"` (rétention 365 jours, hors `read_sensitive`). Non câblée dans `PROCEDURE_TO_ACTION` : c'est un job cron qui écrira directement dans `audit.action_log`.

## Plan de test

- [ ] `pnpm typecheck` vert — vérifié localement
- [ ] `pnpm biome check` vert — vérifié localement
- [ ] `actionKeys.test.ts` : la nouvelle action `SYSTEM_DECLARATION_CLEANUP` doit avoir une catégorie déclarée (test de taxonomie existant itère `AUDIT_ACTIONS`)

## À confirmer

- Le nom de la variable `EGAPRO_DECLARATION_RETENTION_YEARS` (en années, contrairement aux `*_DAYS` existantes) est intentionnel selon la spec (#3768) — à valider si une cohérence en jours est préférée.