### PR TITLE
feat(rgpd): config rétention déclarations + action audit système (#3768)

### DIFF
--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -91,6 +91,11 @@ export const env = createEnv({
 			.int()
 			.positive()
 			.default(365),
+		EGAPRO_DECLARATION_RETENTION_YEARS: z.coerce
+			.number()
+			.int()
+			.positive()
+			.default(6),
 		// MAIL_*, SMTP_* are intentionally NOT declared here — they are consumed
 		// exclusively by the notifications worker (packages/notifications).
 		// See packages/notifications/README.md for the runtime config surface.
@@ -150,6 +155,8 @@ export const env = createEnv({
 			process.env.EGAPRO_AUDIT_RETENTION_SHORT_DAYS,
 		EGAPRO_AUDIT_RETENTION_LONG_DAYS:
 			process.env.EGAPRO_AUDIT_RETENTION_LONG_DAYS,
+		EGAPRO_DECLARATION_RETENTION_YEARS:
+			process.env.EGAPRO_DECLARATION_RETENTION_YEARS,
 		VALKEY_URL: process.env.VALKEY_URL,
 		NEXT_PUBLIC_EGAPRO_ENV: process.env.NEXT_PUBLIC_EGAPRO_ENV,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -118,6 +118,7 @@ export const AUDIT_ACTIONS = {
 
 	// ── System / cron-triggered ────────────────────────────
 	SYSTEM_AUDIT_CLEANUP: "system.audit_cleanup",
+	SYSTEM_DECLARATION_CLEANUP: "system.declaration_cleanup",
 } as const;
 
 export type AuditActionKey = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];
@@ -208,4 +209,5 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
 
 	[AUDIT_ACTIONS.SYSTEM_AUDIT_CLEANUP]: "system",
+	[AUDIT_ACTIONS.SYSTEM_DECLARATION_CLEANUP]: "system",
 };


### PR DESCRIPTION
Closes #3768

## Résumé

Pose les fondations de configuration pour la purge RGPD des déclarations (epic #3134) :

- **`env.js`** : ajout de `EGAPRO_DECLARATION_RETENTION_YEARS` (server + runtimeEnv), validé `positive int`, défaut 6 (durée légale retenue RGPD/CNIL).
- **`actionKeys.ts`** : ajout de `SYSTEM_DECLARATION_CLEANUP = "system.declaration_cleanup"` dans `AUDIT_ACTIONS` + catégorie `"system"` dans `AUDIT_ACTION_CATEGORIES`. Non câblé dans `PROCEDURE_TO_ACTION` (job cron, pas une procédure tRPC).

## Test plan

- [x] `pnpm typecheck` vert
- [x] `actionKeys.test.ts` : toutes les actions ont une catégorie déclarée (cohérence taxonomie garantie par le test existant qui itère `Object.values(AUDIT_ACTIONS)`)
- [ ] Vérifier que `EGAPRO_DECLARATION_RETENTION_YEARS` est bien exposé dans l'env de la review app (override via `.env.local` ou var K8s si besoin)

## Pas d'UI touchée

Ticket purement back-office / infrastructure — pas de capture d'écran.

## À confirmer

- La valeur par défaut de 6 ans est la durée légale retenue (CNIL / Code du travail) ; si l'équipe métier souhaite une valeur différente, modifier le `.default(6)`.