### PR TITLE
feat(cron): purge déclarations — CronJob Kontinuous de planification

### DIFF
--- a/.kontinuous/templates/declaration-cleanup-cron.yaml
+++ b/.kontinuous/templates/declaration-cleanup-cron.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: declaration-cleanup-daily
+  namespace: {{ .Values.global.namespace }}
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            app: declaration-cleanup-daily
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 1000
+            runAsNonRoot: true
+          containers:
+            - name: declaration-cleanup
+              image: "{{ .Values.global.registry }}/{{ .Values.global.imageProject }}/{{ .Values.global.imageRepository }}/app:{{ .Values.global.imageTag }}"
+              securityContext:
+                allowPrivilegeEscalation: false
+              env:
+                - name: POSTGRES_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGHOST
+                - name: POSTGRES_DB
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGDATABASE
+                - name: POSTGRES_PORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGPORT
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGUSER
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGPASSWORD
+                - name: POSTGRES_SSLMODE
+                  valueFrom:
+                    secretKeyRef:
+                      name: "{{ .Values.global.pgSecretName }}"
+                      key: PGSSLMODE
+              envFrom:
+                - configMapRef:
+                    name: "s3"
+                - secretRef:
+                    name: "s3"
+                - configMapRef:
+                    name: "declaration-retention"
+                    optional: true
+              command:
+                - node
+                - packages/app/scripts/declaration-cleanup.mjs
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 200m
+                  memory: 256Mi


### PR DESCRIPTION
Closes #3770

## Résumé

Ajoute le manifest CronJob Kontinuous `.kontinuous/templates/declaration-cleanup-cron.yaml` qui planifie l'exécution automatique du script de purge RGPD des déclarations (#3769).

**Points clés :**
- Schedule `0 3 * * *` (3h du matin, décalé d'1h de l'audit-cleanup à 4h pour éviter le chevauchement)
- `concurrencyPolicy: Forbid`, `backoffLimit: 0`, `restartPolicy: Never` (identique à `audit-cleanup-cron.yaml`)
- Variables `POSTGRES_*` via `secretKeyRef` sur `{{ .Values.global.pgSecretName }}`
- Variables S3 via `envFrom` : `configMapRef: s3` (endpoint/region/bucket) + `secretRef: s3` (credentials) — mêmes sources que le pod `app`
- ConfigMap `declaration-retention` (`optional: true`) pour surcharger `EGAPRO_DECLARATION_RETENTION_YEARS` si besoin

## Test plan

- [x] Manifest YAML créé et calqué sur `audit-cleanup-cron.yaml`
- [x] Schedule `0 3 * * *`, `concurrencyPolicy: Forbid`, `backoffLimit: 0`, `restartPolicy: Never` vérifiés
- [x] `command` pointe sur `packages/app/scripts/declaration-cleanup.mjs`
- [x] Variables `POSTGRES_*` câblées via `secretKeyRef` sur `pgSecretName`
- [x] Variables S3 câblées via `envFrom` (configmap `s3` + secret `s3`), aucune valeur en clair
- [x] ConfigMap `declaration-retention` optionnel présent
- [x] Structure YAML validée (parsing avec placeholders Helm)

## Screenshots

N/A — manifest infrastructure uniquement, pas d'UI.

## À confirmer

- Le script `packages/app/scripts/declaration-cleanup.mjs` sera créé par le ticket #3769 (dépendance). Le manifest référence correctement ce path.