### PR TITLE
feat(purge): script de purge atomique des déclarations RGPD (#3769)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,16 +1,1 @@
-{
-	"mcpServers": {
-		"next-devtools": {
-			"command": "npx",
-			"args": ["-y", "next-devtools-mcp@latest"]
-		},
-		"dsfr": {
-			"command": "npx",
-			"args": ["dsfr-mcp"]
-		},
-		"figma": {
-			"type": "http",
-			"url": "https://mcp.figma.com/mcp"
-		}
-	}
-}
+{"mcpServers":{}}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,1 +1,16 @@
-{"mcpServers":{}}
+{
+	"mcpServers": {
+		"next-devtools": {
+			"command": "npx",
+			"args": ["-y", "next-devtools-mcp@latest"]
+		},
+		"dsfr": {
+			"command": "npx",
+			"args": ["dsfr-mcp"]
+		},
+		"figma": {
+			"type": "http",
+			"url": "https://mcp.figma.com/mcp"
+		}
+	}
+}

--- a/packages/app/scripts/declaration-cleanup.mjs
+++ b/packages/app/scripts/declaration-cleanup.mjs
@@ -2,6 +2,8 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 
+/** @typedef {import("postgres").Sql} Sql */
+
 const DECLARATION_CLEANUP_ACTION = "system.declaration_cleanup";
 const DECLARATION_CLEANUP_CATEGORY = "system";
 const DEFAULT_RETENTION_YEARS = 6;
@@ -31,6 +33,11 @@ function getDatabaseUrl() {
 	throw new Error("DATABASE_URL or POSTGRES_HOST+POSTGRES_DB must be set");
 }
 
+/**
+ * @param {string | undefined} raw
+ * @param {number} fallback
+ * @returns {number}
+ */
 function toPositiveInt(raw, fallback) {
 	if (raw === undefined || raw === null || raw === "") return fallback;
 	const n = Number(raw);
@@ -42,6 +49,13 @@ function toPositiveInt(raw, fallback) {
 	return n;
 }
 
+/**
+ * @param {Object} args
+ * @param {Sql} args.sql
+ * @param {number} args.retentionYears
+ * @param {Date} [args.now]
+ * @param {(key: string) => Promise<unknown>} args.deleteObject
+ */
 export async function runDeclarationCleanup({
 	sql,
 	retentionYears,
@@ -105,7 +119,10 @@ export async function runDeclarationCleanup({
 			purgedS3Objects++;
 		} catch (s3Error) {
 			failedS3Objects++;
-			console.error(`[declaration-cleanup] S3 delete failed for key ${key}:`, s3Error);
+			console.error(
+				`[declaration-cleanup] S3 delete failed for key ${key}:`,
+				s3Error,
+			);
 		}
 	}
 
@@ -140,6 +157,10 @@ export async function runDeclarationCleanup({
 	return { purgedDeclarations, purgedFiles, purgedS3Objects, failedS3Objects };
 }
 
+/**
+ * @param {Sql} sql
+ * @param {unknown} error
+ */
 async function logFailure(sql, error) {
 	const message = error instanceof Error ? error.message : "Unknown error";
 	try {
@@ -174,9 +195,7 @@ const isMain = (() => {
 })();
 
 if (isMain) {
-	const { DeleteObjectCommand, S3Client } = await import(
-		"@aws-sdk/client-s3"
-	);
+	const { DeleteObjectCommand, S3Client } = await import("@aws-sdk/client-s3");
 
 	const retentionYears = toPositiveInt(
 		process.env.EGAPRO_DECLARATION_RETENTION_YEARS,
@@ -191,15 +210,26 @@ if (isMain) {
 		S3_BUCKET_NAME,
 	} = process.env;
 
-	if (!S3_ENDPOINT || !S3_REGION || !S3_ACCESS_KEY_ID || !S3_SECRET_ACCESS_KEY || !S3_BUCKET_NAME) {
-		console.error("[declaration-cleanup] Missing required S3 environment variables");
+	if (
+		!S3_ENDPOINT ||
+		!S3_REGION ||
+		!S3_ACCESS_KEY_ID ||
+		!S3_SECRET_ACCESS_KEY ||
+		!S3_BUCKET_NAME
+	) {
+		console.error(
+			"[declaration-cleanup] Missing required S3 environment variables",
+		);
 		process.exit(1);
 	}
 
 	const s3Client = new S3Client({
 		endpoint: S3_ENDPOINT,
 		region: S3_REGION,
-		credentials: { accessKeyId: S3_ACCESS_KEY_ID, secretAccessKey: S3_SECRET_ACCESS_KEY },
+		credentials: {
+			accessKeyId: S3_ACCESS_KEY_ID,
+			secretAccessKey: S3_SECRET_ACCESS_KEY,
+		},
 		forcePathStyle: true,
 	});
 
@@ -210,7 +240,9 @@ if (isMain) {
 			sql,
 			retentionYears,
 			deleteObject: (key) =>
-				s3Client.send(new DeleteObjectCommand({ Bucket: S3_BUCKET_NAME, Key: key })),
+				s3Client.send(
+					new DeleteObjectCommand({ Bucket: S3_BUCKET_NAME, Key: key }),
+				),
 		});
 		console.log(
 			`[declaration-cleanup] Success — purgedDeclarations=${result.purgedDeclarations} purgedFiles=${result.purgedFiles} purgedS3Objects=${result.purgedS3Objects} failedS3Objects=${result.failedS3Objects}`,

--- a/packages/app/scripts/declaration-cleanup.mjs
+++ b/packages/app/scripts/declaration-cleanup.mjs
@@ -1,0 +1,226 @@
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+const DECLARATION_CLEANUP_ACTION = "system.declaration_cleanup";
+const DECLARATION_CLEANUP_CATEGORY = "system";
+const DEFAULT_RETENTION_YEARS = 6;
+
+function getDatabaseUrl() {
+	if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+
+	const {
+		POSTGRES_USER,
+		POSTGRES_PASSWORD,
+		POSTGRES_HOST,
+		POSTGRES_PORT,
+		POSTGRES_DB,
+		POSTGRES_SSLMODE,
+	} = process.env;
+
+	if (POSTGRES_HOST && POSTGRES_DB) {
+		const user = encodeURIComponent(POSTGRES_USER ?? "postgres");
+		const password = POSTGRES_PASSWORD
+			? `:${encodeURIComponent(POSTGRES_PASSWORD)}`
+			: "";
+		const port = POSTGRES_PORT ?? "5432";
+		const sslmode = POSTGRES_SSLMODE ? `?sslmode=${POSTGRES_SSLMODE}` : "";
+		return `postgresql://${user}${password}@${POSTGRES_HOST}:${port}/${POSTGRES_DB}${sslmode}`;
+	}
+
+	throw new Error("DATABASE_URL or POSTGRES_HOST+POSTGRES_DB must be set");
+}
+
+function toPositiveInt(raw, fallback) {
+	if (raw === undefined || raw === null || raw === "") return fallback;
+	const n = Number(raw);
+	if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+		throw new Error(
+			`Invalid retention value: "${raw}". Expected a positive integer.`,
+		);
+	}
+	return n;
+}
+
+export async function runDeclarationCleanup({
+	sql,
+	retentionYears,
+	now = new Date(),
+	deleteObject,
+}) {
+	const cutoffYear = now.getUTCFullYear() - retentionYears;
+
+	const { s3Keys, purgedDeclarations, purgedFiles } = await sql.begin(
+		async (txRaw) => {
+			// postgres-js TransactionSql strips call signatures via Omit — cast back to Sql
+			const tx = /** @type {import("postgres").Sql} */ (
+				/** @type {unknown} */ (txRaw)
+			);
+
+			const eligibleRows = await tx`
+				SELECT id FROM app_declaration WHERE year < ${cutoffYear}
+			`;
+			const ids = eligibleRows.map((r) => r.id);
+
+			if (ids.length === 0) {
+				return { s3Keys: [], purgedDeclarations: 0, purgedFiles: 0 };
+			}
+
+			const fileRows = await tx`
+				SELECT file_path FROM app_file WHERE declaration_id = ANY(${ids})
+			`;
+			const collectedKeys = fileRows.map((r) => r.file_path);
+
+			await tx`
+				DELETE FROM app_employee_category
+				WHERE job_category_id IN (
+					SELECT id FROM app_job_category WHERE declaration_id = ANY(${ids})
+				)
+			`;
+			await tx`DELETE FROM app_job_category WHERE declaration_id = ANY(${ids})`;
+			await tx`DELETE FROM app_cse_opinion_file WHERE declaration_id = ANY(${ids})`;
+			await tx`DELETE FROM app_cse_opinion WHERE declaration_id = ANY(${ids})`;
+			const fileResult =
+				await tx`DELETE FROM app_file WHERE declaration_id = ANY(${ids})`;
+			// app_declaration_status_history and app_declaration_lock cascade on delete
+			const declResult =
+				await tx`DELETE FROM app_declaration WHERE id = ANY(${ids})`;
+
+			return {
+				s3Keys: collectedKeys,
+				purgedDeclarations: Number(declResult.count ?? 0),
+				purgedFiles: Number(fileResult.count ?? 0),
+			};
+		},
+	);
+
+	let purgedS3Objects = 0;
+	let failedS3Objects = 0;
+	// S3 deletion is outside the transaction — S3 is not rollbackable, and a
+	// failure deleting an object must not undo committed DB deletes (RGPD data
+	// is already gone). Best-effort: log each error but keep going.
+	for (const key of s3Keys) {
+		try {
+			await deleteObject(key);
+			purgedS3Objects++;
+		} catch (s3Error) {
+			failedS3Objects++;
+			console.error(`[declaration-cleanup] S3 delete failed for key ${key}:`, s3Error);
+		}
+	}
+
+	// Self-audit runs outside the transaction for the same reason: a failure to
+	// insert the audit row must not roll back completed deletions.
+	try {
+		await sql`
+			INSERT INTO audit.action_log (id, created_at, action, category, status, metadata)
+			VALUES (
+				${crypto.randomUUID()},
+				${new Date()},
+				${DECLARATION_CLEANUP_ACTION},
+				${DECLARATION_CLEANUP_CATEGORY},
+				'success',
+				${sql.json({
+					purgedDeclarations,
+					purgedFiles,
+					purgedS3Objects,
+					failedS3Objects,
+					retentionYears,
+					cutoffYear,
+				})}
+			)
+		`;
+	} catch (auditError) {
+		console.error(
+			"[declaration-cleanup] Cleanup succeeded but self-audit insert failed:",
+			auditError,
+		);
+	}
+
+	return { purgedDeclarations, purgedFiles, purgedS3Objects, failedS3Objects };
+}
+
+async function logFailure(sql, error) {
+	const message = error instanceof Error ? error.message : "Unknown error";
+	try {
+		await sql`
+			INSERT INTO audit.action_log (id, created_at, action, category, status, error_message)
+			VALUES (
+				${crypto.randomUUID()},
+				${new Date()},
+				${DECLARATION_CLEANUP_ACTION},
+				${DECLARATION_CLEANUP_CATEGORY},
+				'failure',
+				${message}
+			)
+		`;
+	} catch (auditError) {
+		console.error(
+			"[declaration-cleanup] Failed to record failure in audit log:",
+			auditError,
+		);
+	}
+}
+
+const isMain = (() => {
+	const entry = process.argv[1];
+	if (!entry) return false;
+	// realpathSync resolves symlinks from pnpm content-addressable store or Docker bind-mounts
+	try {
+		return fileURLToPath(import.meta.url) === realpathSync(entry);
+	} catch {
+		return false;
+	}
+})();
+
+if (isMain) {
+	const { DeleteObjectCommand, S3Client } = await import(
+		"@aws-sdk/client-s3"
+	);
+
+	const retentionYears = toPositiveInt(
+		process.env.EGAPRO_DECLARATION_RETENTION_YEARS,
+		DEFAULT_RETENTION_YEARS,
+	);
+
+	const {
+		S3_ENDPOINT,
+		S3_REGION,
+		S3_ACCESS_KEY_ID,
+		S3_SECRET_ACCESS_KEY,
+		S3_BUCKET_NAME,
+	} = process.env;
+
+	if (!S3_ENDPOINT || !S3_REGION || !S3_ACCESS_KEY_ID || !S3_SECRET_ACCESS_KEY || !S3_BUCKET_NAME) {
+		console.error("[declaration-cleanup] Missing required S3 environment variables");
+		process.exit(1);
+	}
+
+	const s3Client = new S3Client({
+		endpoint: S3_ENDPOINT,
+		region: S3_REGION,
+		credentials: { accessKeyId: S3_ACCESS_KEY_ID, secretAccessKey: S3_SECRET_ACCESS_KEY },
+		forcePathStyle: true,
+	});
+
+	const sql = postgres(getDatabaseUrl(), { max: 1 });
+
+	try {
+		const result = await runDeclarationCleanup({
+			sql,
+			retentionYears,
+			deleteObject: (key) =>
+				s3Client.send(new DeleteObjectCommand({ Bucket: S3_BUCKET_NAME, Key: key })),
+		});
+		console.log(
+			`[declaration-cleanup] Success — purgedDeclarations=${result.purgedDeclarations} purgedFiles=${result.purgedFiles} purgedS3Objects=${result.purgedS3Objects} failedS3Objects=${result.failedS3Objects}`,
+		);
+		await sql.end();
+		process.exit(0);
+	} catch (error) {
+		console.error("[declaration-cleanup] Failed:", error);
+		await logFailure(sql, error);
+		await sql.end();
+		process.exit(1);
+	}
+}

--- a/packages/app/src/server/audit/__tests__/declarationCleanupScript.integration.test.ts
+++ b/packages/app/src/server/audit/__tests__/declarationCleanupScript.integration.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Integration test for `scripts/declaration-cleanup.mjs` — runs against the
+ * real Postgres container booted by `src/test/integration-setup.ts`.
+ *
+ * Why this exists as an integration test (issue #3769):
+ *  The RGPD purge bypasses the drizzle schema and runs ordered raw DELETEs
+ *  inside a single `postgres` transaction across eight tables, plus a
+ *  best-effort S3 side-effect and a self-audit insert. Only a real database
+ *  proves the FK-safe ordering, the cascade of `status_history`/`lock`, and
+ *  the atomic rollback — a mocked driver would hide all of it.
+ *
+ * The `.mjs` script is a standalone CLI entry — we import its exported core
+ * routine and drive it with our own `sql` client (never spawning `node`) and a
+ * mocked `deleteObject` so no real S3 is touched. `logFailure` + the failure
+ * audit row live in the un-exported `isMain` CLI wrapper, so this test locks
+ * the testable contract: the atomic rollback and the success self-audit.
+ */
+
+import postgres from "postgres";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type Mock,
+} from "vitest";
+import { runDeclarationCleanup } from "#scripts/declaration-cleanup.mjs";
+import { env } from "~/env.js";
+
+const ACTION = "system.declaration_cleanup";
+const SIREN = "123456789";
+const USER_ID = "test-decl-cleanup-user";
+const USER_EMAIL = "test-decl-cleanup@example.fr";
+// 2026 − 6 (default retention) ⇒ cutoffYear 2020: year < 2020 is purged.
+const NOW = new Date("2026-06-15T00:00:00Z");
+const RETENTION = 6;
+
+describe("declaration-cleanup.mjs (integration)", () => {
+	let sql!: ReturnType<typeof postgres>;
+	let deleteObject: Mock<(key: string) => Promise<void>>;
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+		deleteObject = vi.fn<(key: string) => Promise<void>>(async () => undefined);
+	});
+
+	async function cleanup() {
+		// The S6 guard table holds a RESTRICT FK on app_declaration — drop it
+		// first so the declaration deletes below are not blocked.
+		await sql`DROP TABLE IF EXISTS _tu_decl_guard`;
+		await sql`
+			DELETE FROM app_employee_category
+			WHERE job_category_id IN (
+				SELECT id FROM app_job_category
+				WHERE declaration_id IN (SELECT id FROM app_declaration WHERE siren = ${SIREN})
+			)
+		`;
+		await sql`DELETE FROM app_job_category WHERE declaration_id IN (SELECT id FROM app_declaration WHERE siren = ${SIREN})`;
+		await sql`DELETE FROM app_cse_opinion_file WHERE declaration_id IN (SELECT id FROM app_declaration WHERE siren = ${SIREN})`;
+		await sql`DELETE FROM app_cse_opinion WHERE declaration_id IN (SELECT id FROM app_declaration WHERE siren = ${SIREN})`;
+		await sql`DELETE FROM app_file WHERE declaration_id IN (SELECT id FROM app_declaration WHERE siren = ${SIREN})`;
+		await sql`DELETE FROM app_declaration WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+		await sql`DELETE FROM audit.action_log WHERE action = ${ACTION}`;
+	}
+
+	async function seedCompanyAndUser() {
+		await sql`INSERT INTO app_user (id, email) VALUES (${USER_ID}, ${USER_EMAIL})`;
+		await sql`INSERT INTO app_company (siren, name) VALUES (${SIREN}, 'Société Démo')`;
+	}
+
+	async function seedDeclaration(year: number, suffix: string) {
+		const declId = `decl-${suffix}`;
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id)
+			VALUES (${declId}, ${SIREN}, ${year}, ${USER_ID})
+		`;
+		return declId;
+	}
+
+	// Seeds a declaration with one row in every declaration-scoped child table
+	// (job/employee category, cse_opinion, two files, cse_opinion_file,
+	// status_history, lock). Returns the declaration id and its two S3 keys.
+	async function seedDeclarationTree(year: number, suffix: string) {
+		const declId = await seedDeclaration(year, suffix);
+		const jobCategoryId = `jc-${suffix}`;
+		const cseFileId = `file-cse-${suffix}`;
+		const evalFileId = `file-eval-${suffix}`;
+		const cseKey = `${SIREN}/${year}/avis-cse-${suffix}.pdf`;
+		const evalKey = `${SIREN}/${year}/evaluation-${suffix}.pdf`;
+
+		await sql`
+			INSERT INTO app_job_category (id, declaration_id, category_index, name, source)
+			VALUES (${jobCategoryId}, ${declId}, 0, 'Cadres', 'manual')
+		`;
+		await sql`
+			INSERT INTO app_employee_category (id, job_category_id, declaration_type)
+			VALUES (${`ec-${suffix}`}, ${jobCategoryId}, 'initial')
+		`;
+		await sql`
+			INSERT INTO app_cse_opinion (id, declaration_id, declaration_number, type)
+			VALUES (${`co-${suffix}`}, ${declId}, 1, 'accuracy')
+		`;
+		await sql`
+			INSERT INTO app_file (id, declaration_id, file_name, file_path, type, uploaded_at)
+			VALUES (${cseFileId}, ${declId}, 'avis.pdf', ${cseKey}, 'cse_opinion', now())
+		`;
+		await sql`
+			INSERT INTO app_file (id, declaration_id, file_name, file_path, type, uploaded_at)
+			VALUES (${evalFileId}, ${declId}, 'evaluation.pdf', ${evalKey}, 'joint_evaluation', now())
+		`;
+		await sql`
+			INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id)
+			VALUES (${`cof-${suffix}`}, ${declId}, 1, 'accuracy', ${cseFileId})
+		`;
+		await sql`
+			INSERT INTO app_declaration_status_history (id, declaration_id, event_type, created_at)
+			VALUES (${`sh-${suffix}`}, ${declId}, 'submit', now())
+		`;
+		await sql`
+			INSERT INTO app_declaration_lock (id, declaration_id, locked_by_user_id, locked_at, last_heartbeat_at, expires_at)
+			VALUES (${`lk-${suffix}`}, ${declId}, ${USER_ID}, now(), now(), now() + interval '1 hour')
+		`;
+
+		return { declId, keys: [cseKey, evalKey] };
+	}
+
+	async function countDeclaration(declId: string): Promise<number> {
+		const rows = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count FROM app_declaration WHERE id = ${declId}
+		`;
+		return rows[0]?.count ?? 0;
+	}
+
+	async function countByDeclaration(
+		table: string,
+		declId: string,
+	): Promise<number> {
+		const rows = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count FROM ${sql(table)} WHERE declaration_id = ${declId}
+		`;
+		return rows[0]?.count ?? 0;
+	}
+
+	async function countEmployeeCategories(declId: string): Promise<number> {
+		const rows = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count FROM app_employee_category
+			WHERE job_category_id IN (
+				SELECT id FROM app_job_category WHERE declaration_id = ${declId}
+			)
+		`;
+		return rows[0]?.count ?? 0;
+	}
+
+	async function getSelfAudit() {
+		const rows = await sql<
+			[{ status: string; metadata: Record<string, unknown> }]
+		>`
+			SELECT status, metadata FROM audit.action_log
+			WHERE action = ${ACTION}
+			ORDER BY created_at DESC
+			LIMIT 1
+		`;
+		return rows[0];
+	}
+
+	async function countAuditByStatus(status: string): Promise<number> {
+		const rows = await sql<{ count: number }[]>`
+			SELECT count(*)::int AS count FROM audit.action_log
+			WHERE action = ${ACTION} AND status = ${status}
+		`;
+		return rows[0]?.count ?? 0;
+	}
+
+	it("purges a declaration whose year is beyond retention, with its S3 objects (S1)", async () => {
+		await seedCompanyAndUser();
+		const { declId, keys } = await seedDeclarationTree(2015, "s1");
+
+		const result = await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(result).toEqual({
+			purgedDeclarations: 1,
+			purgedFiles: 2,
+			purgedS3Objects: 2,
+			failedS3Objects: 0,
+		});
+		expect(await countDeclaration(declId)).toBe(0);
+		expect(deleteObject).toHaveBeenCalledTimes(2);
+		expect(deleteObject).toHaveBeenCalledWith(keys[0]);
+		expect(deleteObject).toHaveBeenCalledWith(keys[1]);
+	});
+
+	it("keeps a declaration whose year is still within retention (S2)", async () => {
+		await seedCompanyAndUser();
+		const { declId } = await seedDeclarationTree(2024, "s2");
+
+		const result = await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(result.purgedDeclarations).toBe(0);
+		expect(result.purgedFiles).toBe(0);
+		expect(await countDeclaration(declId)).toBe(1);
+		expect(await countByDeclaration("app_file", declId)).toBe(2);
+		expect(deleteObject).not.toHaveBeenCalled();
+	});
+
+	it("leaves no orphan in any attached table after a purge (S3)", async () => {
+		await seedCompanyAndUser();
+		const { declId } = await seedDeclarationTree(2015, "s3");
+
+		await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(await countDeclaration(declId)).toBe(0);
+		expect(await countByDeclaration("app_file", declId)).toBe(0);
+		expect(await countByDeclaration("app_job_category", declId)).toBe(0);
+		expect(await countEmployeeCategories(declId)).toBe(0);
+		expect(await countByDeclaration("app_cse_opinion", declId)).toBe(0);
+		expect(await countByDeclaration("app_cse_opinion_file", declId)).toBe(0);
+		// status_history and lock are removed by FK cascade, not an explicit DELETE.
+		expect(
+			await countByDeclaration("app_declaration_status_history", declId),
+		).toBe(0);
+		expect(await countByDeclaration("app_declaration_lock", declId)).toBe(0);
+	});
+
+	it("is a no-op and idempotent when nothing is eligible (S5)", async () => {
+		await seedCompanyAndUser();
+		const { declId } = await seedDeclarationTree(2025, "s5");
+
+		const first = await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+		const second = await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(first).toEqual({
+			purgedDeclarations: 0,
+			purgedFiles: 0,
+			purgedS3Objects: 0,
+			failedS3Objects: 0,
+		});
+		expect(second).toEqual(first);
+		expect(await countDeclaration(declId)).toBe(1);
+		expect(deleteObject).not.toHaveBeenCalled();
+		// Each run still records its success self-audit.
+		expect(await countAuditByStatus("success")).toBe(2);
+	});
+
+	it("purges year = cutoff − 1 but keeps year = cutoff at the exact boundary (S7)", async () => {
+		await seedCompanyAndUser();
+		const keptId = await seedDeclaration(2020, "s7-kept");
+		const purgedId = await seedDeclaration(2019, "s7-purged");
+
+		const result = await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(result.purgedDeclarations).toBe(1);
+		expect(await countDeclaration(keptId)).toBe(1);
+		expect(await countDeclaration(purgedId)).toBe(0);
+	});
+
+	it("rolls back the whole purge atomically when a delete fails mid-transaction (S6)", async () => {
+		await seedCompanyAndUser();
+		const { declId } = await seedDeclarationTree(2015, "s6");
+		// Force a real mid-transaction failure: a RESTRICT FK on the parent makes
+		// the final `DELETE FROM app_declaration` throw, exercising the rollback.
+		await sql`
+			CREATE TABLE _tu_decl_guard (
+				decl_id varchar(255) NOT NULL REFERENCES app_declaration(id) ON DELETE RESTRICT
+			)
+		`;
+		await sql`INSERT INTO _tu_decl_guard (decl_id) VALUES (${declId})`;
+
+		try {
+			await expect(
+				runDeclarationCleanup({
+					sql,
+					retentionYears: RETENTION,
+					now: NOW,
+					deleteObject,
+				}),
+			).rejects.toThrow();
+
+			// Nothing partially deleted — declaration and every child remain.
+			expect(await countDeclaration(declId)).toBe(1);
+			expect(await countByDeclaration("app_file", declId)).toBe(2);
+			expect(await countByDeclaration("app_job_category", declId)).toBe(1);
+			expect(await countEmployeeCategories(declId)).toBe(1);
+			expect(await countByDeclaration("app_cse_opinion", declId)).toBe(1);
+			expect(await countByDeclaration("app_cse_opinion_file", declId)).toBe(1);
+			// No success self-audit is written when the transaction aborts.
+			expect(await countAuditByStatus("success")).toBe(0);
+			// S3 deletion only runs after a successful commit.
+			expect(deleteObject).not.toHaveBeenCalled();
+		} finally {
+			await sql`DROP TABLE IF EXISTS _tu_decl_guard`;
+		}
+	});
+
+	it("still purges the database when an S3 object delete fails (non-fatal)", async () => {
+		await seedCompanyAndUser();
+		const { declId } = await seedDeclarationTree(2015, "s3fail");
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => {});
+		deleteObject
+			.mockRejectedValueOnce(new Error("S3 unavailable"))
+			.mockResolvedValueOnce(undefined);
+
+		const result = await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(result.purgedDeclarations).toBe(1);
+		expect(result.purgedS3Objects).toBe(1);
+		expect(result.failedS3Objects).toBe(1);
+		expect(deleteObject).toHaveBeenCalledTimes(2);
+		// DB purge is committed regardless of the S3 outcome.
+		expect(await countDeclaration(declId)).toBe(0);
+		expect(consoleError).toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+
+	it("writes a success self-audit row holding only counter metadata, no PII (S6 trace + RGPD)", async () => {
+		await seedCompanyAndUser();
+		await seedDeclarationTree(2015, "audit");
+
+		await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		const selfAudit = await getSelfAudit();
+		expect(selfAudit?.status).toBe("success");
+		expect(selfAudit?.metadata).toEqual({
+			purgedDeclarations: 1,
+			purgedFiles: 2,
+			purgedS3Objects: 2,
+			failedS3Objects: 0,
+			retentionYears: RETENTION,
+			cutoffYear: 2020,
+		});
+	});
+
+	it("records a success self-audit even when the database is empty", async () => {
+		const result = await runDeclarationCleanup({
+			sql,
+			retentionYears: RETENTION,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(result).toEqual({
+			purgedDeclarations: 0,
+			purgedFiles: 0,
+			purgedS3Objects: 0,
+			failedS3Objects: 0,
+		});
+		expect(await countAuditByStatus("success")).toBe(1);
+	});
+
+	it("respects a custom retention window when computing the cutoff", async () => {
+		await seedCompanyAndUser();
+		// retentionYears 3 ⇒ cutoffYear 2023: 2022 purged, 2023 kept.
+		const purgedId = await seedDeclaration(2022, "ret-purged");
+		const keptId = await seedDeclaration(2023, "ret-kept");
+
+		const result = await runDeclarationCleanup({
+			sql,
+			retentionYears: 3,
+			now: NOW,
+			deleteObject,
+		});
+
+		expect(result.purgedDeclarations).toBe(1);
+		expect(await countDeclaration(purgedId)).toBe(0);
+		expect(await countDeclaration(keptId)).toBe(1);
+	});
+});


### PR DESCRIPTION
Closes #3769

## Résumé

Script de purge RGPD autonome `packages/app/scripts/declaration-cleanup.mjs` pour les déclarations dont l'année de campagne dépasse la fenêtre de rétention (défaut 6 ans). Calqué sur `audit-cleanup.mjs` (#3268).

### Comportement

- **Seuil** : `year < currentYear - retentionYears` (env `EGAPRO_DECLARATION_RETENTION_YEARS`, défaut 6). En 2026 → purge `year ≤ 2019`.
- **Transaction atomique** `sql.begin()` avec suppression dans l'ordre FK :
  1. `app_employee_category` (via job_category)
  2. `app_job_category`
  3. `app_cse_opinion_file`
  4. `app_cse_opinion`
  5. `app_file` (clés S3 collectées *avant* la transaction)
  6. `app_declaration` (cascade : status_history + lock)
- **S3 best-effort** après commit : chaque clé collectée est supprimée via `deleteObject(key)` injecté ; un échec S3 est loggé mais non fatal.
- **Self-audit** hors transaction : INSERT `system.declaration_cleanup` dans `audit.action_log` (`metadata` = compteurs uniquement, zéro PII).
- **logFailure** hors transaction : INSERT `failure` sur exception, puis `process.exit(1)`.
- **Idempotence** : 0 déclaration éligible → no-op, 0 purgé, sans erreur.

### Export testable

`export async function runDeclarationCleanup({ sql, retentionYears, now, deleteObject })` — `deleteObject` injecté pour mocker S3 dans le test d'intégration sans spawner de processus.

### CLI (isMain)

S3Client créé directement depuis les env vars (`S3_ENDPOINT`, `S3_REGION`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `S3_BUCKET_NAME`) — pas d'import depuis le code TS source (même pattern que `audit-cleanup.mjs`).

## Test plan

- [ ] `pnpm typecheck` vert ✓
- [ ] Test d'intégration (à écrire par `tu-dev`) couvrant S1 (purge year < cutoff), S2 (conservation year ≥ cutoff), S3 (cascade multi-tables sans orphelins), S5 (0 éligible = no-op), S6 (rollback sur erreur tx), S7 (borne exacte)
- [ ] Vérifier que `deleteObject` mocké est appelé pour chaque `file_path` collecté
- [ ] Vérifier l'INSERT audit success/failure dans `audit.action_log`

## Référence Figma

N/A — pas d'UI touchée.