### PR TITLE
fix(declaration-remuneration): indicateur par catégories — repositionnement obligatoires, date Medium, libellé catégorie (#3721)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
@@ -61,6 +61,10 @@
 	text-align: right;
 }
 
+.tableGap {
+	margin-top: 2rem;
+}
+
 .readOnlyFieldset {
 	border: none;
 	margin: 0;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -243,7 +243,7 @@ export function Step1Workforce({
 						<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 					</div>
 
-					<div className={common.dataSection}>
+					<div className={`${common.dataSection} ${common.tableGap}`}>
 						<div className={common.flexColumnGapHalf}>
 							<div
 								className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.workforceTable}`}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -183,7 +183,7 @@ export function Step2PayGap({
 					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 				</div>
 
-				<div className={common.dataSection}>
+				<div className={`${common.dataSection} ${common.tableGap}`}>
 					<div className={common.flexColumnGapHalf}>
 						<PayGapTable
 							caption="Écart de rémunération"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -226,7 +226,7 @@ export function Step3VariablePay({
 					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 				</div>
 
-				<div className={common.dataSection}>
+				<div className={`${common.dataSection} ${common.tableGap}`}>
 					<div className={common.flexColumnGapHalf}>
 						<PayGapTable
 							caption="Écart de rémunération variable ou complémentaire"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -26,6 +26,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
+	margin-top: 2rem;
 }
 
 .quartileTable {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -87,6 +87,10 @@
 	font-weight: 500;
 }
 
+.periodDate {
+	font-weight: 500;
+}
+
 .instructionRow {
 	display: flex;
 	flex-direction: column;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -11,14 +11,6 @@
 	}
 }
 
-.obligatoiresRow {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	gap: 1rem;
-	flex-wrap: wrap;
-}
-
 .deleteRow {
 	display: flex;
 	justify-content: flex-end;

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -113,6 +113,22 @@ describe("Step5EmployeeCategories", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders the obligatoires mention immediately after the description text", () => {
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+		const descriptionParagraph = screen.getByText(
+			/mesurer l'écart de rémunération/,
+		);
+		const obligatoiresParagraph = screen.getByText(
+			"Tous les champs sont obligatoires.",
+		);
+		expect(descriptionParagraph.nextElementSibling).toBe(obligatoiresParagraph);
+	});
+
 	it("renders table headers for the category", () => {
 		render(
 			<Step5EmployeeCategories
@@ -152,6 +168,20 @@ describe("Step5EmployeeCategories", () => {
 		);
 		expect(document.getElementById("cat-0-name")).toBeInTheDocument();
 		expect(document.getElementById("cat-0-detail")).not.toBeInTheDocument();
+	});
+
+	it("labels the category name input with the full category emploi wording", () => {
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+		expect(
+			screen.getByLabelText("Libellé de la catégorie d'emploi", {
+				selector: "#cat-0-name",
+			}),
+		).toBeInTheDocument();
 	});
 
 	it("can add a new category", async () => {
@@ -340,9 +370,12 @@ describe("Step5EmployeeCategories", () => {
 			/>,
 		);
 
-		const nameInput = screen.getByLabelText("Libellé", {
-			selector: "#cat-0-name",
-		});
+		const nameInput = screen.getByLabelText(
+			"Libellé de la catégorie d'emploi",
+			{
+				selector: "#cat-0-name",
+			},
+		);
 		expect(nameInput).toHaveValue("Cadres");
 	});
 
@@ -355,9 +388,12 @@ describe("Step5EmployeeCategories", () => {
 			/>,
 		);
 
-		const nameInput = screen.getByLabelText("Libellé", {
-			selector: "#cat-0-name",
-		});
+		const nameInput = screen.getByLabelText(
+			"Libellé de la catégorie d'emploi",
+			{
+				selector: "#cat-0-name",
+			},
+		);
 		await user.type(nameInput, "Techniciens");
 
 		await user.selectOptions(
@@ -389,9 +425,12 @@ describe("Step5EmployeeCategories", () => {
 			/>,
 		);
 
-		const nameInput = screen.getByLabelText("Libellé", {
-			selector: "#cat-0-name",
-		});
+		const nameInput = screen.getByLabelText(
+			"Libellé de la catégorie d'emploi",
+			{
+				selector: "#cat-0-name",
+			},
+		);
 		await user.type(nameInput, "Techniciens");
 
 		await user.click(screen.getByRole("button", { name: /suivant/i }));

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.module.scss
@@ -1,0 +1,3 @@
+.periodLabel {
+	font-weight: 500;
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
@@ -1,4 +1,5 @@
 import { TooltipButton } from "~/modules/declaration-remuneration/shared/TooltipButton";
+import styles from "./ReferencePeriodPicker.module.scss";
 
 type Props = {
 	startDate: string;
@@ -19,7 +20,7 @@ export function ReferencePeriodPicker({
 		<div>
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-2w">
 				<div className="fr-col-auto">
-					<p className="fr-mb-0 fr-text--medium">
+					<p className={`fr-mb-0 ${styles.periodLabel}`}>
 						Quelle est la période de référence pour le calcul de
 						l&apos;indicateur ?
 					</p>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -77,14 +77,18 @@ describe("SecondDeclarationStep2Form", () => {
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		expect(screen.getByText("Libellé :")).toBeInTheDocument();
+		expect(
+			screen.getByText("Libellé de la catégorie d'emploi :"),
+		).toBeInTheDocument();
 		expect(
 			screen.getByRole("button", {
 				name: "Catégorie d'emplois n°1 : Ouvriers",
 			}),
 		).toBeInTheDocument();
 		expect(screen.getByText("Ouvriers")).toBeInTheDocument();
-		expect(screen.queryByLabelText("Libellé")).not.toBeInTheDocument();
+		expect(
+			screen.queryByLabelText("Libellé de la catégorie d'emploi"),
+		).not.toBeInTheDocument();
 	});
 
 	it("displays source as read-only text", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -367,12 +367,15 @@ export function CategoryForm({
 
 			<div className={stepStyles.categoryBlock}>
 				<p className="fr-mb-0">{descriptionText}</p>
+				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 
 				{referencePeriodPicker ?? (
 					<div className={stepStyles.categoryHeader}>
 						<p className="fr-mb-0">
-							Période de référence pour le calcul des indicateurs : 01/01/
-							{referenceYear} - 31/12/{referenceYear}.
+							Période de référence pour le calcul des indicateurs :{" "}
+							<span className={stepStyles.periodDate}>
+								01/01/{referenceYear} - 31/12/{referenceYear}.
+							</span>
 						</p>
 						<TooltipButton
 							id={`${tooltipPrefix}-period`}
@@ -440,15 +443,12 @@ export function CategoryForm({
 						label="Information sur la saisie"
 					/>
 				</div>
-				<div className={stepStyles.obligatoiresRow}>
-					<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
-					{!readOnlyLabel && (
-						<CategoryImportExport
-							disabled={disabled}
-							onImport={handleImportCategories}
-						/>
-					)}
-				</div>
+				{!readOnlyLabel && (
+					<CategoryImportExport
+						disabled={disabled}
+						onImport={handleImportCategories}
+					/>
+				)}
 			</div>
 
 			<div className="fr-accordions-group" data-fr-group="false">
@@ -493,13 +493,15 @@ export function CategoryForm({
 								<div className={stepStyles.categoryBlock}>
 									{readOnlyLabel ? (
 										<p className="fr-mb-0">
-											<span className="fr-text--bold">Libellé : </span>
+											<span className="fr-text--bold">
+												Libellé de la catégorie d'emploi :{" "}
+											</span>
 											{cat?.name}
 										</p>
 									) : (
 										<div className="fr-input-group fr-mb-0">
 											<label className="fr-label" htmlFor={`cat-${index}-name`}>
-												Libellé
+												Libellé de la catégorie d'emploi
 											</label>
 											<input
 												className="fr-input"


### PR DESCRIPTION
Closes #3721

## Résumé

3 ajustements visuels sur la page « Indicateur par catégories de salariés » (étape 5 du parcours déclaration rémunération, partagée entre déclaration initiale et seconde déclaration).

**Point 1 — Repositionnement « Tous les champs sont obligatoires. »**
La mention remonte juste sous le texte d'explication de la page (`descriptionText`), avant le picker de période de référence. Le bouton Import/Export reste à sa place dans le bloc instruction. Le wrapper `obligatoiresRow` (devenu vide) est supprimé.

**Point 2 — Date de la période de référence en Marianne Medium (font-weight 500)**
La classe DSFR `fr-text--medium` n'existe pas dans le CSS DSFR (silencieusement ignorée). Le segment date uniquement est enveloppé dans un `<span>` portant une classe SCSS locale `font-weight: 500` (pattern déjà présent dans le module : `.descriptionTitle`). Appliqué aussi dans `ReferencePeriodPicker.tsx` (seconde déclaration) via un nouveau module SCSS dédié.

**Point 3 — Libellé de champ**
`"Libellé"` → `"Libellé de la catégorie d'emploi"` sur les deux variantes : label éditable (`<label>`) et span lecture seule.

## Fichiers modifiés

- `steps/step5/CategoryForm.tsx` — points 1, 2, 3
- `steps/Step5EmployeeCategories.module.scss` — classe `.periodDate` (font-weight 500) + suppression `.obligatoiresRow` morte
- `steps/secondDeclaration/ReferencePeriodPicker.tsx` — remplacement `fr-text--medium` no-op
- `steps/secondDeclaration/ReferencePeriodPicker.module.scss` — nouveau fichier, classe `.periodLabel` (font-weight 500)

## Vérification Figma

Node `7548:75691` (période de référence) : Figma confirme `Marianne:Medium` sur le segment date uniquement, `Marianne:Regular` sur le préfixe → aligné avec l'implémentation.

Node `10631:12177` (mention obligatoires) : `Marianne Regular` 16px → rendu par défaut du corps de texte, pas de classe supplémentaire.

## Plan de test

- [ ] Naviguer vers l'étape 5 du parcours déclaration rémunération (déclaration initiale)
- [ ] Vérifier que « Tous les champs sont obligatoires. » apparaît juste sous le texte de description, avant la période de référence
- [ ] Vérifier que la date de la période de référence est en graisse 500 (visiblement plus épaisse que le préfixe)
- [ ] Vérifier que les labels des catégories affichent « Libellé de la catégorie d'emploi »
- [ ] Vérifier le même rendu côté seconde déclaration (ReferencePeriodPicker)