### PR TITLE
fix(declaration-remuneration): #3722 — « Mettre à jour l'existence d'un CSE » en bouton secondaire

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.module.scss
@@ -41,26 +41,14 @@
 	height: 1px;
 }
 
-.linksRow {
+// Figma spec: the "Voir les modèles" link sits directly under the paragraph,
+// and the "Mettre à jour l'existence d'un CSE" secondary button stacks below
+// it on its own row. align-items keeps the button hugging its content width.
+.ctaGroup {
 	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	gap: 0.5rem;
-}
-
-// DSFR's `fr-link` applies the underline via the `[href]` selector,
-// which a <button> does not match. Replicate the same gradient-based
-// underline so the modal trigger button renders identically to an
-// adjacent <a class="fr-link">.
-.linkButton {
-	background:
-		linear-gradient(0deg, currentColor, currentColor) no-repeat 0
-			calc(100% - var(--underline-thickness, 0.0625em)) /
-			var(--underline-idle-width, 100%) var(--underline-thickness, 0.0625em);
-	border: 0;
-	padding: 0;
-	cursor: pointer;
-	font: inherit;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 1rem;
 }
 
 .alertHeader {

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -37,28 +37,26 @@ export function NextStepsBox({
 						.
 					</p>
 
-					<div>
+					<div className={styles.ctaGroup}>
 						<p className="fr-mb-0">
 							Le ou les avis du CSE devront être transmis sur le portail lors de
 							la dernière étape.
 						</p>
-						<div className={`fr-mt-1w ${styles.linksRow}`}>
-							<button
-								aria-controls="update-cse-modal"
-								className={`fr-link ${styles.linkButton}`}
-								data-fr-opened="false"
-								type="button"
-							>
-								Mettre à jour l&apos;existence d&apos;un CSE
-							</button>
-							<TrackedLink
-								className="fr-link"
-								href="/avis-cse"
-								trackingId="cse_models"
-							>
-								Voir les modèles d&apos;avis CSE
-							</TrackedLink>
-						</div>
+						<TrackedLink
+							className="fr-link"
+							href="/avis-cse"
+							trackingId="cse_models"
+						>
+							Voir les modèles d&apos;avis CSE
+						</TrackedLink>
+						<button
+							aria-controls="update-cse-modal"
+							className="fr-btn fr-btn--secondary"
+							data-fr-opened="false"
+							type="button"
+						>
+							Mettre à jour l&apos;existence d&apos;un CSE
+						</button>
 					</div>
 				</div>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -187,6 +187,22 @@ describe("SecondDeclarationStep3Review", () => {
 		expect(screen.getByText("Prochaines étapes")).toBeInTheDocument();
 	});
 
+	it("renders the CSE update trigger as a secondary button", () => {
+		render(
+			<SecondDeclarationStep3Review
+				declarationYear={2025}
+				hasCse={null}
+				secondDeclarationCategories={mockCategories}
+				siren="532847196"
+			/>,
+		);
+		const cseButton = screen.getByRole("button", {
+			name: "Mettre à jour l'existence d'un CSE",
+		});
+		expect(cseButton).toHaveClass("fr-btn", "fr-btn--secondary");
+		expect(cseButton).toHaveAttribute("aria-controls", "update-cse-modal");
+	});
+
 	it("renders Soumettre button", () => {
 		render(
 			<SecondDeclarationStep3Review


### PR DESCRIPTION
## Contexte

Découpé depuis #3679 (« Accessibilité – Ajustements UI »). Sur l'encart « Prochaines étapes » des pages **« Récapitulatif de votre déclaration »** (1ère et seconde déclaration), le déclencheur « Mettre à jour l'existence d'un CSE » était rendu comme un **lien** (un `<button>` stylé `fr-link` avec un faux soulignement). La maquette demande un **bouton secondaire DSFR** autonome, placé **sous** le lien « Voir les modèles d'avis CSE ».

Réf. Figma : node `9326-226111`.

## Changements

- **`NextStepsBox.tsx`** — le déclencheur de la modale CSE passe de `fr-link` à **`fr-btn fr-btn--secondary`** ; ré-ordonnancement conforme à la maquette (paragraphe → lien « Voir les modèles d'avis CSE » → bouton secondaire sur sa propre ligne). `aria-controls` / `data-fr-opened` / `type="button"` conservés.
- **`NextStepsBox.module.scss`** — suppression du hack `.linkButton` (faux soulignement de lien, devenu mort) et du flex inline `.linksRow` ; ajout d'un layout colonne `.ctaGroup`.
- **Test** — non-régression : le CTA rend bien `fr-btn fr-btn--secondary` + `aria-controls="update-cse-modal"`.

Le composant `NextStepsBox` est partagé, donc le correctif s'applique aux deux récapitulatifs (Step6Review + SecondDeclarationStep3Review).

## Vérifications

- ✅ Typecheck (`tsc --noEmit`)
- ✅ Tests — 39/39 sur les deux récapitulatifs, dont le nouveau
- ✅ Lint/format (Biome)
- ✅ Accessibilité — amélioration : vrai `<button>` DSFR (nom accessible + `aria-controls`) au lieu d'un lien simulé

Closes #3722