### PR TITLE
refactor(declaration): unifier impersonation et verrou collaboratif dans LockContext

### DIFF
--- a/packages/app/src/e2e/admin-impersonation-read-only.e2e.ts
+++ b/packages/app/src/e2e/admin-impersonation-read-only.e2e.ts
@@ -4,6 +4,7 @@ import {
 	ensureCurrentYearDeclaration,
 	resetDeclarationToDraft,
 } from "./helpers/db";
+import { startImpersonation, stopImpersonation } from "./helpers/impersonation";
 
 const TEST_SIREN = "130025265";
 
@@ -18,24 +19,13 @@ test.describe("admin impersonation — read-only guards", () => {
 	});
 
 	test.afterEach(async ({ page }) => {
-		// Best-effort stop of any impersonation left over so the next test
-		// (or the next describe block) starts from a clean session.
-		await page.goto("/admin/impersonate");
-		const stopBtn = page.getByRole("button", { name: /arrêter le mimoquage/i });
-		if (await stopBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-			await stopBtn.click();
-		}
+		await stopImpersonation(page);
 	});
 
 	test("form submit is disabled with a read-only tooltip during mimoquage", async ({
 		page,
 	}) => {
-		await page.goto("/admin/impersonate");
-		await page.getByLabel("SIREN de l'entreprise").fill(TEST_SIREN);
-		await page.getByRole("button", { name: "Rechercher" }).click();
-		await page.getByRole("button", { name: /valider et mimoquer/i }).click();
-
-		await page.waitForURL("**/mon-espace");
+		await startImpersonation(page, TEST_SIREN);
 		await expect(page.getByText(/vous mimoquez l'entreprise/i)).toBeVisible();
 
 		await page.goto("/declaration-remuneration/etape/1");
@@ -48,14 +38,31 @@ test.describe("admin impersonation — read-only guards", () => {
 		await expect(page.locator(`#${tooltipId}`)).toContainText(/mimoquage/i);
 	});
 
+	// `/avis-cse/etape/1` renders under the layout's StaticLockProvider (fed by
+	// `getLockReadState`, which is lock-only and stays false during mimoquage).
+	// After unifying impersonation + lock into LockContext (#3765), the static
+	// path must still disable writes during impersonation — exactly the surface
+	// that regressed before the StaticLockProvider folded `useIsImpersonating`
+	// in. The dynamic path (declaration step 1) is covered above.
+	test("CSE opinion submit is disabled with a read-only tooltip during mimoquage", async ({
+		page,
+	}) => {
+		await startImpersonation(page, TEST_SIREN);
+
+		await page.goto("/avis-cse/etape/1");
+
+		const submitButton = page.getByRole("button", { name: /suivant/i });
+		await expect(submitButton).toBeVisible();
+		await expect(submitButton).toBeDisabled();
+		const tooltipId = await submitButton.getAttribute("aria-describedby");
+		expect(tooltipId).not.toBeNull();
+		await expect(page.locator(`#${tooltipId}`)).toContainText(/mimoquage/i);
+	});
+
 	test("file upload endpoint returns 403 during impersonation", async ({
 		page,
 	}) => {
-		await page.goto("/admin/impersonate");
-		await page.getByLabel("SIREN de l'entreprise").fill(TEST_SIREN);
-		await page.getByRole("button", { name: "Rechercher" }).click();
-		await page.getByRole("button", { name: /valider et mimoquer/i }).click();
-		await page.waitForURL("**/mon-espace");
+		await startImpersonation(page, TEST_SIREN);
 
 		const response = await page.request.post("/api/upload", {
 			headers: {

--- a/packages/app/src/e2e/helpers/impersonation.ts
+++ b/packages/app/src/e2e/helpers/impersonation.ts
@@ -1,0 +1,19 @@
+import type { Page } from "@playwright/test";
+
+/** Start admin impersonation ("mimoquage") of a company by SIREN. */
+export async function startImpersonation(page: Page, siren: string) {
+	await page.goto("/admin/impersonate");
+	await page.getByLabel("SIREN de l'entreprise").fill(siren);
+	await page.getByRole("button", { name: "Rechercher" }).click();
+	await page.getByRole("button", { name: /valider et mimoquer/i }).click();
+	await page.waitForURL("**/mon-espace");
+}
+
+/** Best-effort stop of any active impersonation so the next test starts clean. */
+export async function stopImpersonation(page: Page) {
+	await page.goto("/admin/impersonate");
+	const stopBtn = page.getByRole("button", { name: /arrêter le mimoquage/i });
+	if (await stopBtn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+		await stopBtn.click();
+	}
+}

--- a/packages/app/src/e2e/public-referents.e2e.ts
+++ b/packages/app/src/e2e/public-referents.e2e.ts
@@ -149,11 +149,15 @@ test.describe("public referents search", () => {
 		const anonCtx = await browser.newContext({ storageState: undefined });
 		try {
 			const page = await anonCtx.newPage();
-			await page.goto("/referents");
-			await page.getByLabel("Région").selectOption("11");
-			await page.getByRole("button", { name: /^rechercher$/i }).click();
+			// Drive the search through the URL — the form only pushes these query
+			// params and the results are fetched from them — so this exercises the
+			// same code path without the flakiness of the client-side submit race.
+			await page.goto("/referents?region=11&page=1");
 
-			const row = page.locator("li", { hasText: "E2E Référent Paris" });
+			const list = page.getByTestId("public-referents-list");
+			await expect(list).toBeVisible({ timeout: 30_000 });
+
+			const row = list.locator("li", { hasText: "E2E Référent Paris" });
 			await expect(row).toBeVisible({ timeout: 30_000 });
 			await row.getByRole("link", { name: /voir le contact/i }).click();
 

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -56,7 +56,7 @@ export function Step1Opinions({
 	const isJointEvaluation = firstDeclarationPathChoice === "joint_evaluation";
 	const router = useRouter();
 	const readOnlyGuard = useReadOnlyGuard();
-	const { isReadOnly: isLocked } = useLockContext();
+	const { isReadOnly } = useLockContext();
 
 	const dbValues = useMemo(
 		() => ({
@@ -147,13 +147,13 @@ export function Step1Opinions({
 	}, [isLoadingDraft, draft, form, hasSecondDeclaration]);
 
 	const triggerDraftSave = useCallback(() => {
-		if (isLocked) return;
+		if (isReadOnly) return;
 		const values = form.getValues();
 		setField({
 			firstDeclaration: values.firstDeclaration,
 			secondDeclaration: values.secondDeclaration,
 		});
-	}, [form, isLocked, setField]);
+	}, [form, isReadOnly, setField]);
 
 	const mutation = api.cseOpinion.saveOpinions.useMutation({
 		onSuccess: () => router.push("/avis-cse/etape/2"),
@@ -200,7 +200,7 @@ export function Step1Opinions({
 
 	return (
 		<form autoComplete="off" onSubmit={onSubmit}>
-			<fieldset className={styles.readOnlyFieldset} disabled={isLocked}>
+			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
 						<div className="fr-col">
@@ -364,9 +364,7 @@ export function Step1Opinions({
 						<button
 							{...readOnlyGuard.buttonProps}
 							className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-							disabled={
-								mutation.isPending || readOnlyGuard.isReadOnly || isLocked
-							}
+							disabled={mutation.isPending || isReadOnly}
 							type="submit"
 						>
 							{mutation.isPending ? "Enregistrement…" : "Suivant"}

--- a/packages/app/src/modules/cseOpinion/Step2Upload.tsx
+++ b/packages/app/src/modules/cseOpinion/Step2Upload.tsx
@@ -54,7 +54,7 @@ export function Step2Upload({
 		buildAssociationMap(columns, initialAssociations),
 	);
 	const readOnlyGuard = useReadOnlyGuard();
-	const { isReadOnly: isLocked } = useLockContext();
+	const { isReadOnly } = useLockContext();
 
 	const emptyDbValues = useMemo(() => ({}), []);
 	useDeclarationDraft({
@@ -210,7 +210,7 @@ export function Step2Upload({
 						accept=".pdf"
 						acceptLabel="pdf"
 						allowedMimeTypes={["application/pdf"]}
-						disabled={readOnlyGuard.isReadOnly || isLocked || isUploadingFiles}
+						disabled={isReadOnly || isUploadingFiles}
 						error={uploadError}
 						inputId="cse-file-upload"
 						maxFileCount={remainingSlots}
@@ -233,7 +233,7 @@ export function Step2Upload({
 							associations={associations}
 							columns={columns}
 							deletingFileId={deletingFileId}
-							disabled={readOnlyGuard.isReadOnly || isLocked}
+							disabled={isReadOnly}
 							files={existingFiles}
 							onDelete={(fileId) => {
 								setDeletingFileId(fileId);
@@ -295,7 +295,7 @@ export function Step2Upload({
 						<button
 							{...readOnlyGuard.buttonProps}
 							className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-							disabled={readOnlyGuard.isReadOnly || isLocked}
+							disabled={isReadOnly}
 							type="submit"
 						>
 							Soumettre

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -1,8 +1,24 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSession } from "next-auth/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { Step1Opinions } from "../Step1Opinions";
+
+const mockedUseSession = vi.mocked(useSession);
+
+function mockImpersonating() {
+	mockedUseSession.mockReturnValue({
+		data: {
+			user: {
+				id: "admin-1",
+				impersonation: { siren: "123456789", name: "Acme" },
+			},
+			expires: "2099-01-01",
+		},
+		status: "authenticated",
+	} as unknown as ReturnType<typeof useSession>);
+}
 
 const { mockSetField, mockClearDraft, mockUseDeclarationDraft } = vi.hoisted(
 	() => {
@@ -726,6 +742,50 @@ describe("Step1Opinions", () => {
 			expect(
 				screen.getByRole("button", { name: /Suivant/ }),
 			).not.toBeDisabled();
+		});
+	});
+
+	describe("admin impersonation", () => {
+		afterEach(() => {
+			mockedUseSession.mockReset();
+		});
+
+		it("disables the fieldset and next button under the static provider when impersonating", () => {
+			mockImpersonating();
+
+			// The static provider receives `isReadOnly={false}` from the layout but
+			// must still disable writes when an admin is impersonating.
+			const { container } = render(
+				<LockProvider isReadOnly={false}>
+					<Step1Opinions
+						cseDeadline={cseDeadline}
+						siren="123456789"
+						year={2026}
+					/>
+				</LockProvider>,
+			);
+
+			expect(container.querySelector("fieldset")).toBeDisabled();
+			expect(screen.getByRole("button", { name: /Suivant/ })).toBeDisabled();
+		});
+
+		it("does not save a draft while impersonating", async () => {
+			mockImpersonating();
+			const user = userEvent.setup();
+
+			render(
+				<LockProvider isReadOnly={false}>
+					<Step1Opinions
+						cseDeadline={cseDeadline}
+						siren="123456789"
+						year={2026}
+					/>
+				</LockProvider>,
+			);
+
+			await user.click(screen.getAllByLabelText("Favorable")[0] as HTMLElement);
+
+			expect(mockSetField).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step2Upload.test.tsx
@@ -6,6 +6,7 @@ import {
 	waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useSession } from "next-auth/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { FILENAME_ERROR_MESSAGES } from "~/modules/shared";
@@ -744,6 +745,39 @@ describe("Step2Upload", () => {
 				screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
 			).toBeEnabled();
 			expect(screen.getByRole("button", { name: "Soumettre" })).toBeEnabled();
+		});
+	});
+
+	describe("admin impersonation", () => {
+		afterEach(() => {
+			vi.mocked(useSession).mockReset();
+		});
+
+		it("disables the upload and submit controls under the static provider when impersonating", () => {
+			vi.mocked(useSession).mockReturnValue({
+				data: {
+					user: {
+						id: "admin-1",
+						impersonation: { siren: "123456789", name: "Acme" },
+					},
+					expires: "2099-01-01",
+				},
+				status: "authenticated",
+			} as unknown as ReturnType<typeof useSession>);
+
+			// The layout feeds `isReadOnly={false}` but impersonation must still
+			// disable writes through the unified context.
+			renderStep({
+				columns: SINGLE_COLUMN,
+				existingFiles: [makeFile("avis-1.pdf", "file-1")],
+				isReadOnly: false,
+			});
+
+			expect(
+				screen.getByRole("button", { name: /Sélectionner des fichiers/ }),
+			).toBeDisabled();
+			expect(screen.getByRole("button", { name: "Soumettre" })).toBeDisabled();
+			expect(screen.getByRole("button", { name: /Supprimer/ })).toBeDisabled();
 		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -34,10 +34,15 @@ export type {
 export { CSV_TO_SCHEMA_MAP, mapGipToFormData } from "./shared/gipMdsMapping";
 export { getEffectiveGipPrefillData } from "./shared/gipToStepData";
 export { DeclarationLockAlert } from "./shared/lock/DeclarationLockAlert";
-export { LockProvider, useLockContext } from "./shared/lock/LockContext";
+export {
+	LockProvider,
+	useLockContext,
+	useReadOnlyContext,
+} from "./shared/lock/LockContext";
 export type {
 	DeclarationLockState,
 	LockHolder,
+	ReadOnlyReason,
 } from "./shared/lock/useDeclarationLock";
 export { useDeclarationLock } from "./shared/lock/useDeclarationLock";
 export { ComplianceConfirmation } from "./steps/ComplianceConfirmation";

--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.tsx
@@ -32,8 +32,8 @@ export function FormActions({
 	className,
 	mimoquageNextHref,
 }: FormActionsProps) {
-	const { isReadOnly, buttonProps, tooltip } = useReadOnlyGuard();
-	const { isReadOnly: isLocked, isLoading: isLockLoading } = useLockContext();
+	const { buttonProps, tooltip } = useReadOnlyGuard();
+	const { isReadOnly, isLoading: isLockLoading } = useLockContext();
 
 	return (
 		<div className={`${styles.actions} ${className ?? ""}`}>
@@ -54,7 +54,7 @@ export function FormActions({
 				>
 					{nextLabel}
 				</Link>
-			) : (isReadOnly || isLocked) && mimoquageNextHref ? (
+			) : isReadOnly && mimoquageNextHref ? (
 				<span>
 					<Link
 						aria-describedby={buttonProps["aria-describedby"]}
@@ -71,11 +71,7 @@ export function FormActions({
 						{...buttonProps}
 						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
 						disabled={
-							isReadOnly ||
-							isLocked ||
-							isLockLoading ||
-							isSubmitting ||
-							nextDisabled
+							isReadOnly || isLockLoading || isSubmitting || nextDisabled
 						}
 						type="submit"
 					>

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/FormActions.test.tsx
@@ -74,7 +74,14 @@ describe("FormActions", () => {
 		it("disables the submit button and renders a tooltip when impersonating without a saved record", () => {
 			mockImpersonating();
 
-			render(<FormActions />);
+			// The static provider folds impersonation into the unified context the
+			// same way the layouts do in production; FormActions reads `isReadOnly`
+			// from there.
+			render(
+				<LockProvider>
+					<FormActions />
+				</LockProvider>,
+			);
 
 			const button = screen.getByRole("button", { name: /suivant/i });
 			expect(button).toBeDisabled();
@@ -87,7 +94,9 @@ describe("FormActions", () => {
 			mockImpersonating();
 
 			render(
-				<FormActions mimoquageNextHref="/declaration-remuneration/etape/2" />,
+				<LockProvider>
+					<FormActions mimoquageNextHref="/declaration-remuneration/etape/2" />
+				</LockProvider>,
 			);
 
 			expect(
@@ -142,6 +151,7 @@ describe("FormActions", () => {
 		it("disables the submit button while the lock is still being acquired", () => {
 			vi.mocked(useLockContext).mockReturnValueOnce({
 				isReadOnly: false,
+				reason: null,
 				holder: null,
 				isLoading: true,
 			});

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
@@ -3,6 +3,8 @@
 import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
+import { useIsImpersonating } from "~/modules/auth";
+import type { ReadOnlyReason } from "./useDeclarationLock";
 import { useDeclarationLock } from "./useDeclarationLock";
 
 export type LockHolder = {
@@ -13,18 +15,21 @@ export type LockHolder = {
 
 type LockState = {
 	isReadOnly: boolean;
+	reason: ReadOnlyReason | null;
 	holder: LockHolder | null;
 	isLoading?: boolean;
 };
 
 const LockContext = createContext<LockState>({
 	isReadOnly: false,
+	reason: null,
 	holder: null,
 });
 
 type StaticLockProviderProps = {
 	children: ReactNode;
 	isReadOnly?: boolean;
+	reason?: ReadOnlyReason | null;
 	holder?: LockHolder | null;
 };
 
@@ -38,10 +43,26 @@ type LockProviderProps = StaticLockProviderProps | DynamicLockProviderProps;
 function StaticLockProvider({
 	children,
 	isReadOnly = false,
+	reason,
 	holder = null,
 }: StaticLockProviderProps) {
+	// Impersonation is read-only too, but the layouts feed this provider from
+	// `getLockReadState` (lock only, no impersonation). Fold it in here so the
+	// unified context disables writes on the static path the same way the
+	// dynamic provider does — without re-wiring each consumer or touching the
+	// back (the lock stays server-disabled during impersonation).
+	const isImpersonating = useIsImpersonating();
+	const resolvedReason: ReadOnlyReason | null = isImpersonating
+		? "impersonation"
+		: (reason ?? (holder != null ? "lock" : null));
 	return (
-		<LockContext.Provider value={{ isReadOnly, holder }}>
+		<LockContext.Provider
+			value={{
+				isReadOnly: isReadOnly || isImpersonating,
+				reason: resolvedReason,
+				holder: isImpersonating ? null : holder,
+			}}
+		>
 			{children}
 		</LockContext.Provider>
 	);
@@ -51,11 +72,11 @@ function DynamicLockProvider({
 	children,
 	declarationId,
 }: DynamicLockProviderProps) {
-	const { isReadOnly, holder, isLoading } = useDeclarationLock({
+	const { isReadOnly, reason, holder, isLoading } = useDeclarationLock({
 		declarationId,
 	});
 	return (
-		<LockContext.Provider value={{ isReadOnly, holder, isLoading }}>
+		<LockContext.Provider value={{ isReadOnly, reason, holder, isLoading }}>
 			{children}
 		</LockContext.Provider>
 	);
@@ -68,6 +89,8 @@ export function LockProvider(props: LockProviderProps) {
 	return <StaticLockProvider {...props} />;
 }
 
-export function useLockContext(): LockState {
+export function useReadOnlyContext(): LockState {
 	return useContext(LockContext);
 }
+
+export const useLockContext = useReadOnlyContext;

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/LockContext.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { useSession } from "next-auth/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { DeclarationLockState } from "../useDeclarationLock";
 
 const dynamicState: DeclarationLockState = {
 	isReadOnly: true,
+	reason: "lock",
 	holder: null,
 	isLoading: false,
 };
@@ -14,13 +16,20 @@ vi.mock("../useDeclarationLock", () => ({
 }));
 
 import type { LockHolder } from "../LockContext";
-import { LockProvider, useLockContext } from "../LockContext";
+import {
+	LockProvider,
+	useLockContext,
+	useReadOnlyContext,
+} from "../LockContext";
+
+const mockedUseSession = vi.mocked(useSession);
 
 function ContextProbe() {
-	const { isReadOnly, holder } = useLockContext();
+	const { isReadOnly, reason, holder } = useReadOnlyContext();
 	return (
 		<div>
 			<span data-testid="read-only">{String(isReadOnly)}</span>
+			<span data-testid="reason">{reason ?? "none"}</span>
 			<span data-testid="holder">{holder ? holder.email : "none"}</span>
 		</div>
 	);
@@ -32,15 +41,33 @@ const holder: LockHolder = {
 	email: "camille.martin@example.fr",
 };
 
+function mockImpersonating() {
+	mockedUseSession.mockReturnValue({
+		data: {
+			user: {
+				id: "admin-1",
+				impersonation: { siren: "123456789", name: "Acme" },
+			},
+			expires: "2099-01-01",
+		},
+		status: "authenticated",
+	} as unknown as ReturnType<typeof useSession>);
+}
+
 describe("LockContext — static provider", () => {
+	afterEach(() => {
+		mockedUseSession.mockReset();
+	});
+
 	it("exposes a default non-readonly state without a provider", () => {
 		render(<ContextProbe />);
 
 		expect(screen.getByTestId("read-only")).toHaveTextContent("false");
+		expect(screen.getByTestId("reason")).toHaveTextContent("none");
 		expect(screen.getByTestId("holder")).toHaveTextContent("none");
 	});
 
-	it("defaults to non-readonly with no holder when no props are passed", () => {
+	it("defaults to non-readonly with no reason or holder when no props are passed", () => {
 		render(
 			<LockProvider>
 				<ContextProbe />
@@ -48,10 +75,11 @@ describe("LockContext — static provider", () => {
 		);
 
 		expect(screen.getByTestId("read-only")).toHaveTextContent("false");
+		expect(screen.getByTestId("reason")).toHaveTextContent("none");
 		expect(screen.getByTestId("holder")).toHaveTextContent("none");
 	});
 
-	it("propagates isReadOnly and holder when provided", () => {
+	it("derives reason 'lock' from a holder when read-only without an explicit reason", () => {
 		render(
 			<LockProvider holder={holder} isReadOnly>
 				<ContextProbe />
@@ -59,25 +87,70 @@ describe("LockContext — static provider", () => {
 		);
 
 		expect(screen.getByTestId("read-only")).toHaveTextContent("true");
+		expect(screen.getByTestId("reason")).toHaveTextContent("lock");
 		expect(screen.getByTestId("holder")).toHaveTextContent(
 			"camille.martin@example.fr",
 		);
 	});
-});
 
-describe("LockContext — dynamic provider", () => {
-	it("exposes the lock state returned by useDeclarationLock", () => {
-		function Consumer() {
-			const state = useLockContext();
-			return <span>{state.isReadOnly ? "read-only" : "editable"}</span>;
-		}
-
+	it("keeps an explicit reason prop over the holder-derived default", () => {
 		render(
-			<LockProvider declarationId="decl-1">
-				<Consumer />
+			<LockProvider holder={holder} isReadOnly reason="impersonation">
+				<ContextProbe />
 			</LockProvider>,
 		);
 
-		expect(screen.getByText("read-only")).toBeInTheDocument();
+		expect(screen.getByTestId("reason")).toHaveTextContent("impersonation");
+	});
+
+	it("folds impersonation into the unified context, overriding the props", () => {
+		mockImpersonating();
+
+		render(
+			<LockProvider holder={holder} isReadOnly={false}>
+				<ContextProbe />
+			</LockProvider>,
+		);
+
+		expect(screen.getByTestId("read-only")).toHaveTextContent("true");
+		expect(screen.getByTestId("reason")).toHaveTextContent("impersonation");
+		// The lock holder is hidden during impersonation: the read-only reason is
+		// the mimoquage, not another user holding the lock.
+		expect(screen.getByTestId("holder")).toHaveTextContent("none");
+	});
+});
+
+describe("LockContext — dynamic provider", () => {
+	it("relays the lock state returned by useDeclarationLock", () => {
+		render(
+			<LockProvider declarationId="decl-1">
+				<ContextProbe />
+			</LockProvider>,
+		);
+
+		expect(screen.getByTestId("read-only")).toHaveTextContent("true");
+		expect(screen.getByTestId("reason")).toHaveTextContent("lock");
+	});
+});
+
+describe("LockContext — hook aliases", () => {
+	it("useLockContext and useReadOnlyContext return the same context", () => {
+		function AliasProbe() {
+			const fromLock = useLockContext();
+			const fromReadOnly = useReadOnlyContext();
+			return (
+				<span data-testid="same">
+					{String(fromLock.isReadOnly === fromReadOnly.isReadOnly)}
+				</span>
+			);
+		}
+
+		render(
+			<LockProvider isReadOnly reason="lock">
+				<AliasProbe />
+			</LockProvider>,
+		);
+
+		expect(screen.getByTestId("same")).toHaveTextContent("true");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/useDeclarationLock.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/useDeclarationLock.test.tsx
@@ -285,12 +285,32 @@ describe("useDeclarationLock", () => {
 		expect(result.current.isLoading).toBe(true);
 	});
 
-	it("is disabled while impersonating: never acquires the lock", () => {
+	it("is read-only while impersonating with reason 'impersonation', without acquiring the lock", () => {
 		setSession({ impersonating: true });
 		const { result } = renderLockHook();
 
 		expect(acquireMutateAsync).not.toHaveBeenCalled();
+		expect(result.current.isReadOnly).toBe(true);
+		expect(result.current.reason).toBe("impersonation");
+		expect(result.current.holder).toBeNull();
+	});
+
+	it("reports reason 'lock' when the declaration is held by another user", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: false, holder: HOLDER });
+		const { result } = renderLockHook();
+		await flush();
+
+		expect(result.current.isReadOnly).toBe(true);
+		expect(result.current.reason).toBe("lock");
+	});
+
+	it("reports a null reason for a normal editor that holds the lock", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+		const { result } = renderLockHook();
+		await flush();
+
 		expect(result.current.isReadOnly).toBe(false);
+		expect(result.current.reason).toBeNull();
 	});
 
 	it("swallows heartbeat rejections without re-reading ownership", async () => {

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
@@ -10,8 +10,11 @@ export type LockHolder = NonNullable<
 	RouterOutputs["declarationLock"]["getLockState"]["holder"]
 >;
 
+export type ReadOnlyReason = "impersonation" | "lock";
+
 export type DeclarationLockState = {
 	isReadOnly: boolean;
+	reason: ReadOnlyReason | null;
 	holder: LockHolder | null;
 	isLoading: boolean;
 };
@@ -48,7 +51,10 @@ export function useDeclarationLock({
 	useEffect(() => {
 		if (!isEnabled) {
 			isHolderRef.current = false;
-			setIsReadOnly(false);
+			// Impersonation is a read-only reason too: surface it through the same
+			// state so the shared context exposes a single read-only flag. The lock
+			// itself stays disabled (no acquire/heartbeat) during impersonation.
+			setIsReadOnly(isImpersonating);
 			setHolder(null);
 			// Stay "loading" while the session is still resolving so consumers do
 			// not flash an editable state before ownership is known.
@@ -130,7 +136,13 @@ export function useDeclarationLock({
 			// (tab close), logout, the inactivity timeout, and admin override.
 			isHolderRef.current = false;
 		};
-	}, [declarationId, isEnabled, session.status]);
+	}, [declarationId, isEnabled, isImpersonating, session.status]);
 
-	return { isReadOnly, holder, isLoading };
+	const reason: ReadOnlyReason | null = isImpersonating
+		? "impersonation"
+		: isReadOnly
+			? "lock"
+			: null;
+
+	return { isReadOnly, reason, holder, isLoading };
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -36,7 +36,7 @@ export function JointEvaluationForm({
 }: Props) {
 	const router = useRouter();
 	const readOnlyGuard = useReadOnlyGuard();
-	const { isReadOnly: isLocked } = useLockContext();
+	const { isReadOnly } = useLockContext();
 
 	const { clearDraft } = useDeclarationDraft({
 		siren: declarationSiren,
@@ -84,7 +84,7 @@ export function JointEvaluationForm({
 				className={common.flexColumnGap2}
 				onSubmit={handleSubmit}
 			>
-				<fieldset className={common.readOnlyFieldset} disabled={isLocked}>
+				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
 					<div className={common.flexBetween}>
 						<h1 className="fr-h4 fr-mb-0">
 							Parcours de mise en conformité pour l&apos;indicateur par
@@ -143,7 +143,7 @@ export function JointEvaluationForm({
 						accept=".pdf"
 						acceptLabel="pdf"
 						allowedMimeTypes={["application/pdf"]}
-						disabled={readOnlyGuard.isReadOnly || isLocked}
+						disabled={isReadOnly}
 						error={uploadError}
 						inputId="joint-evaluation-file-upload"
 						onFilesChange={handleFilesChange}
@@ -200,7 +200,7 @@ export function JointEvaluationForm({
 							<button
 								{...readOnlyGuard.buttonProps}
 								className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-								disabled={isPending || readOnlyGuard.isReadOnly || isLocked}
+								disabled={isPending || isReadOnly}
 								type="submit"
 							>
 								Transmettre

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useSession } from "next-auth/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { JointEvaluationForm } from "../JointEvaluationForm";
 
 const mockPush = vi.fn();
@@ -194,6 +196,38 @@ describe("JointEvaluationForm", () => {
 		});
 		await waitFor(() => {
 			expect(mockPush).toHaveBeenCalledWith(expectedRedirect);
+		});
+	});
+
+	describe("admin impersonation", () => {
+		afterEach(() => {
+			vi.mocked(useSession).mockReset();
+		});
+
+		it("disables the fieldset and submit button under the static provider when impersonating", () => {
+			vi.mocked(useSession).mockReturnValue({
+				data: {
+					user: {
+						id: "admin-1",
+						impersonation: { siren: "123456789", name: "Acme" },
+					},
+					expires: "2099-01-01",
+				},
+				status: "authenticated",
+			} as unknown as ReturnType<typeof useSession>);
+
+			// The layout feeds `isReadOnly={false}` but impersonation must still
+			// disable writes through the unified context.
+			const { container } = render(
+				<LockProvider isReadOnly={false}>
+					<JointEvaluationForm {...defaultProps} />
+				</LockProvider>,
+			);
+
+			expect(container.querySelector("fieldset")).toBeDisabled();
+			expect(
+				screen.getByRole("button", { name: /transmettre/i }),
+			).toBeDisabled();
 		});
 	});
 });


### PR DESCRIPTION
Closes #3765

## Contexte

Issu de la revue de la PR #3753 (epic #3556). Le parcours déclaration possédait **deux** mécanismes de lecture seule avec deux couches de présentation distinctes : l'impersonation admin (« mimoquage ») et le verrou collaboratif. Chaque surface d'écriture câblait et combinait les deux à la main.

## Changement

Refacto de présentation : `LockContext` devient la **source unique** de l'état read-only du parcours. L'impersonation y entre comme une *raison* parmi deux ; le verrou reste inchangé. **Aucune règle métier back modifiée** (le verrou reste désactivé en impersonation, pas d'`acquireLock`/`heartbeat`), **aucun changement UX visible**.

- `useDeclarationLock.ts` — expose un état unifié `{ isReadOnly, reason, holder, isLoading }` (`reason: "impersonation" | "lock" | null`).
- `LockContext.tsx` — `LockState` porte `reason` ; `StaticLockProvider` (chemin SSR des layouts) plie `useIsImpersonating()` dans le flag unifié, pour que le chemin statique désactive aussi les écritures en mimoquage. Sélecteur `useReadOnlyContext()` exporté (alias `useLockContext` conservé pour ne pas casser les imports).
- 4 consommateurs (`FormActions`, `JointEvaluationForm`, `cseOpinion/Step1Opinions`, `cseOpinion/Step2Upload`) — suppression du double câblage : un **seul** flag `isReadOnly` pilote le `disabled`. Le tooltip d'impersonation reste rendu uniquement quand l'utilisateur mimoque (via `useReadOnlyGuard`, qui se gate sur l'impersonation) ; le bandeau verrou reste rendu par les layouts pour le verrou.

## Rendus inchangés (zéro régression UX)

- **Verrou** (`reason === "lock"`) → bandeau nominatif `DeclarationLockAlert` + champs désactivés.
- **Impersonation** (`reason === "impersonation"`) → tooltip DSFR `ReadOnlyTooltip` sur le bouton désactivé, pas de bandeau, pas de holder, pas d'appel verrou.
- **Éditeur normal** → `isReadOnly = false`, tout actif.

## Test plan

- `pnpm typecheck` · `pnpm lint:check` · `pnpm format:check` verts.
- `pnpm test` — 3077 tests verts (couverture complète des 3 scénarios + de la régression de présentation : consommateur statique en impersonation → `disabled` + tooltip). Revert-verify exécuté sur le fold-in impersonation : 7 tests passent RED sans le fix, GREEN avec.
- Pas de fichier `src/e2e/**` touché.
