### PR TITLE
feat(release): #3736 — canal prerelease alpha avec déclenchement automatique

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: 🔖 Release
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - alpha
 
 permissions:
   contents: write
@@ -17,7 +20,7 @@ env:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/beta'
+    if: github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha'
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,8 @@
 {
   "branches": [
     "master",
-    { "name": "beta", "prerelease": true }
+    { "name": "beta", "prerelease": true },
+    { "name": "alpha", "prerelease": true }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",
@@ -12,7 +13,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
Closes #3736

## Résumé

Mise en place du système de release automatique pour la branche `alpha` (V2) via semantic-release.

**`.releaserc.json`** :
- Ajout du canal prerelease `{ "name": "alpha", "prerelease": true }` après `beta` dans la hiérarchie de maturité (`master` → `beta` → `alpha`)
- Suffixe `[skip ci]` sur le message de commit du plugin `@semantic-release/git` pour éviter la boucle infinie (le commit de release ne re-déclenche pas le workflow)

**`.github/workflows/release.yml`** :
- Ajout du trigger `push: branches: [alpha]` pour un déclenchement automatique à chaque push sur `alpha`
- Élargissement de la garde `if:` du job pour inclure `refs/heads/alpha`

## Résultat attendu

Un push de commit conventional sur `alpha` produit automatiquement un tag/Release prerelease `vX.Y.Z-alpha.N` (ex. `v3.18.0-alpha.1`), marqué GitHub Pre-release — distinct des tags V1 (`vX.Y.Z`) et beta (`vX.Y.Z-beta.N`). Le commit de release `[skip ci]` ne boucle pas.

## Non-régressions

- Déclenchement manuel `workflow_dispatch` depuis `beta` : comportement inchangé
- Tags master (`vX.Y.Z`) et beta (`vX.Y.Z-beta.N`) : non impactés

## Plan de test

- [ ] Vérifier que le JSON `.releaserc.json` est valide et contient `alpha` après `beta`
- [ ] Vérifier que `release.yml` a le trigger `push: branches: [alpha]` et la garde `|| github.ref == 'refs/heads/alpha'`
- [ ] Après merge sur `alpha` : confirmer qu'un push avec `feat:` ou `fix:` déclenche le workflow et crée un tag `-alpha.N`
- [ ] Confirmer que le commit de release `[skip ci]` ne re-déclenche pas le workflow