### PR TITLE
feat(guardrails): extend anti-scattering hooks and auditor rules

### DIFF
--- a/.claude/agents/structural-auditor/AGENT.md
+++ b/.claude/agents/structural-auditor/AGENT.md
@@ -152,19 +152,31 @@ For changed files in `src/server/`:
 
 ```bash
 # Must return ZERO — no inline getFullYear outside domain/
-grep -rn "new Date()\.getFullYear()" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
+grep -rn "getFullYear()" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 
-# Must return ZERO — no inline slice(0, 9) outside domain/
-grep -rn "slice(0, 9)" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/"
+# Must return ZERO — no inline slice/substring/substr(0, 9) outside domain/
+grep -rn "slice(0, *9)\|substring(0, *9)\|substr(0, *9)" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
+
+# Must return ZERO — no inline date arithmetic outside domain/
+grep -rn "\.getMonth()\|\.getDate()" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 
 # Must return ZERO — no local function definitions duplicating domain
 grep -rn "function getCurrentYear\|function getCseYear\|function getSiren" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/"
+
+# Must return ZERO — no domain helpers reimplemented inline outside domain/
+grep -rn "cancelledAt !== null\|cancelledAt != null\|workforce >= 100\|effectifs >= 100\|workforce < 50\|effectifs < 50" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
+
+# Must return ZERO (or WARN) — toLocaleString("fr-FR") outside domain/ (likely duplicates formatCount/formatRate/formatCurrency)
+grep -rn 'toLocaleString.*fr-FR\|toLocaleString.*"fr"' src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 ```
 
-- Inline `new Date().getFullYear()` → **[ERROR]**
-- Inline `siret.slice(0, 9)` → **[ERROR]**
+- Inline `getFullYear()` → **[ERROR]**
+- Inline `slice/substring/substr(0, 9)` for SIREN extraction → **[ERROR]**
+- Inline `.getMonth()` / `.getDate()` for date calculations → **[ERROR]**
 - Local function duplicating domain → **[ERROR]**
-- Hardcoded regulatory thresholds (5%, 50, 100) → **[WARN]**
+- Hardcoded regulatory thresholds (5%, 50, 100) → **[ERROR]**
+- Inline condition reimplementing a domain helper (e.g. `cancelledAt !== null` instead of `isCancelled()`, `workforce >= 100 && hasCse` instead of `isCseRequired()`, `isComplianceProcessRequired()`, `isComplianceProcessRevisionRequired()`) → **[ERROR]**
+- `toLocaleString("fr-FR")` outside `domain/` — probable duplicate of `formatCount`/`formatRate`/`formatCurrency` → **[WARN]**
 
 #### 2.16 Accessibility (quick check)
 

--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -108,10 +108,21 @@ check_pattern '\.(ts|tsx)$' \
   'Inline getFullYear() is forbidden. Use getCurrentYear() or getCseYear() from ~/modules/domain.' \
   '(domain/|__tests__|\.test\.|\.spec\.)'
 
-# Domain layer — slice(0, 9) for SIREN extraction must come from ~/modules/domain
+# Domain layer — slice/substring/substr(0, 9) for SIREN extraction must come from ~/modules/domain
 check_pattern '\.(ts|tsx)$' \
   'slice\(0,[[:space:]]*9\)' \
   'Inline slice(0, 9) is forbidden. Use extractSiren() from ~/modules/domain.' \
+  '(domain/|__tests__|\.test\.|\.spec\.)'
+
+check_pattern '\.(ts|tsx)$' \
+  '(substring|substr)\(0,[[:space:]]*9\)' \
+  'Inline substring/substr(0, 9) is forbidden. Use extractSiren() from ~/modules/domain.' \
+  '(domain/|__tests__|\.test\.|\.spec\.)'
+
+# Domain layer — inline date arithmetic (getMonth/getDate) must use domain campaign helpers
+check_pattern '\.(ts|tsx)$' \
+  '\.(getMonth|getDate)\(\)' \
+  'Inline .getMonth()/.getDate() is forbidden. Use campaign date helpers from ~/modules/domain.' \
   '(domain/|__tests__|\.test\.|\.spec\.)'
 
 # Zod imports forbidden in router files — schemas must be in ~/modules/{domain}/schemas.ts

--- a/.claude/rules/automation.md
+++ b/.claude/rules/automation.md
@@ -34,7 +34,9 @@ Blocks edits containing forbidden patterns:
 | `dangerouslySetInnerHTML` | `.tsx/.jsx` | XSS risk — use safe rendering or DOMPurify |
 | `: any`, `as any` | `.ts/.tsx` (excl. test files) | Use `unknown` with type narrowing |
 | `getFullYear()` | `.ts/.tsx` (excl. `domain/`, tests) | Use `getCurrentYear()` / `getCseYear()` from `~/modules/domain` |
-| `slice(0, 9)` | `.ts/.tsx` (excl. `domain/`, tests) | Use `extractSiren()` from `~/modules/domain` |
+| `slice(0, 9)` / `slice(0,9)` | `.ts/.tsx` (excl. `domain/`, tests) | Use `extractSiren()` from `~/modules/domain` |
+| `substring(0, 9)` / `substring(0,9)` / `substr(0, 9)` / `substr(0,9)` | `.ts/.tsx` (excl. `domain/`, tests) | Use `extractSiren()` from `~/modules/domain` |
+| `.getMonth()` / `.getDate()` | `.ts/.tsx` (excl. `domain/`, tests) | Use campaign date helpers from `~/modules/domain` |
 | `from "zod"` | `routers/*.ts`, `.tsx` (excl. tests) | Import schemas from `~/modules/{domain}/schemas.ts` |
 | `#hex`, `rgb()`, `rgba()` | `.scss` | Use DSFR CSS custom properties |
 | Non-route `.tsx` in `src/app/` | `src/app/**/*.tsx` | Move to `src/modules/` and import from barrel |
@@ -105,9 +107,11 @@ Apply these rules **as you write code**, before any agent runs:
 **Domain layer:**
 
 - No `new Date().getFullYear()` → use `getCurrentYear()` or `getCseYear()` from `~/modules/domain`
-- No `siret.slice(0, 9)` → use `extractSiren(siret)` from `~/modules/domain`
+- No `siret.slice(0, 9)`, `substring(0, 9)`, or `substr(0, 9)` → use `extractSiren(siret)` from `~/modules/domain`
+- No `.getMonth()` / `.getDate()` in calculations → use campaign date helpers from `~/modules/domain`
 - No hardcoded thresholds (5%, 50, 100) → use named constants from `~/modules/domain`
 - No local `getCurrentYear`/`getCseYear`/`getSiren` function definitions → import from `~/modules/domain`
+- No inline reimplementation of domain helpers: `cancelledAt !== null` → `isCancelled()`, `workforce >= 100` → `isCseRequired()` / `isComplianceProcessRequired()` / `isComplianceProcessRevisionRequired()`
 - New business rules → add to `~/modules/domain` as pure functions with tests
 
 **Security:**


### PR DESCRIPTION
Closes #3789

## Résumé

Durcissement des guardrails Claude pour prévenir la réintroduction de règles métier hors `~/modules/domain`.

### Hook `block-bad-patterns.sh`

- Étend la règle SIREN à `substring(0, 9)` / `substring(0,9)` / `substr(0, 9)` / `substr(0,9)` (en plus du `slice` déjà bloqué)
- Ajoute le blocage de `.getMonth()` et `.getDate()` hors `domain/` / tests — arithmétique de date qui doit passer par les helpers campaign de `~/modules/domain`
- Exclusions préservées : `domain/`, `__tests__`, `.test.`, `.spec.`
- Les littéraux 5/50/100 ne sont PAS bloqués par le hook (laissé au structural-auditor)

### Structural auditor §2.15 Domain layer

- Seuils réglementaires hardcodés (5%, 50, 100) : `[WARN]` → `[ERROR]`
- Nouveau check anti-réimplémentation des helpers `domain` (`cancelledAt !== null`, `workforce >= 100`, etc.) → `[ERROR]`
- Nouveau check `toLocaleString("fr-FR")` hors `domain/` (doublon probable de `formatCount`/`formatRate`/`formatCurrency`) → `[WARN]`
- Greps étendus : SIREN (`substring`/`substr`), date (`getMonth`/`getDate`)

### `automation.md`

- Tableau PreToolUse mis à jour avec les nouvelles entrées (variantes SIREN + date)
- Section "Domain layer" inline renforcée (nouvelles règles + exemples de réimplémentation à éviter)

## Test plan

- [x] Hook : `siret.substring(0, 9)` hors `domain/` → bloqué (exit 2)
- [x] Hook : `slice(0, 9)` dans `domain/` → passe (exclusion préservée)
- [x] Hook : `substr(0,9)` hors `domain/` → bloqué (exit 2)
- [x] Hook : `.getMonth()` hors `domain/` → bloqué (exit 2)
- [x] Hook : `.getDate()` dans un `.test.ts` → passe (exclusion tests)
- [x] Hook : `.getDate()` dans `domain/` → passe (exclusion domain)
- [x] Hook : littéral `100` → non bloqué (laissé au structural-auditor)
- [x] `bash --norc -n block-bad-patterns.sh` → syntaxe OK
- [x] Suite vitest complète (2832 tests) : 0 régression
- [x] typecheck / lint / format : PASS