### PR TITLE
domain : helpers effectif/%/gap + source unique du seuil 100 (#3788)

### DIFF
--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -4,7 +4,22 @@ import {
 	computeDeclarationStatus,
 	getCurrentCompliancePath,
 	isCancelled,
+	isDeclarationSubmitted,
 } from "../shared/declarationStatus";
+
+describe("isDeclarationSubmitted", () => {
+	it("returns false when status is null", () => {
+		expect(isDeclarationSubmitted(null)).toBe(false);
+	});
+
+	it("returns false when status is draft", () => {
+		expect(isDeclarationSubmitted("draft")).toBe(false);
+	});
+
+	it("returns true for any non-draft, non-null status", () => {
+		expect(isDeclarationSubmitted("submitted")).toBe(true);
+	});
+});
 
 describe("isCancelled", () => {
 	it("returns false when cancelledAt is null", () => {

--- a/packages/app/src/modules/domain/__tests__/gap.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gap.test.ts
@@ -110,6 +110,14 @@ describe("computeTotal", () => {
 		expect(computeTotal("100", "50")).toBe(150);
 	});
 
+	it("treats an invalid base as zero when variable is valid", () => {
+		expect(computeTotal("", "50")).toBe(50);
+	});
+
+	it("treats an invalid variable as zero when base is valid", () => {
+		expect(computeTotal("100", "")).toBe(100);
+	});
+
 	it("returns null when both are NaN", () => {
 		expect(computeTotal("", "")).toBeNull();
 	});

--- a/packages/app/src/modules/domain/__tests__/gap.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	computeGap,
+	computeGapBetween,
 	computeGapRatio,
 	computeTotal,
 	gapLevel,
@@ -61,6 +62,24 @@ describe("computeGap", () => {
 
 	it("computes 100% gap when women earn 0", () => {
 		expect(computeGap("0", "100")).toBeCloseTo(100);
+	});
+});
+
+describe("computeGapBetween", () => {
+	it("computes the absolute gap as a percentage of the men value", () => {
+		expect(computeGapBetween(90, 100)).toBe(10);
+	});
+
+	it("returns a positive value when women earn more than men", () => {
+		expect(computeGapBetween(110, 100)).toBe(10);
+	});
+
+	it("returns 0 for equal values", () => {
+		expect(computeGapBetween(100, 100)).toBe(0);
+	});
+
+	it("returns null when the men value is zero (division by zero)", () => {
+		expect(computeGapBetween(1, 0)).toBeNull();
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/percentage.test.ts
+++ b/packages/app/src/modules/domain/__tests__/percentage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { percentageOf, proportionOf } from "../shared/percentage";
+
+describe("proportionOf", () => {
+	it("returns the raw ratio of count over total", () => {
+		expect(proportionOf(3, 8)).toBe(0.375);
+	});
+
+	it("stays stable under GIP 4-decimal rounding", () => {
+		expect(Math.round(proportionOf(3, 8) * 10_000) / 10_000).toBe(0.375);
+	});
+
+	it("returns 0 when total is zero (no division by zero)", () => {
+		expect(proportionOf(1, 0)).toBe(0);
+	});
+});
+
+describe("percentageOf", () => {
+	it("returns the ratio expressed as a percentage", () => {
+		expect(percentageOf(1, 4)).toBe(25);
+	});
+
+	it("returns 0 when total is zero (no NaN)", () => {
+		expect(percentageOf(1, 0)).toBe(0);
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/workforce.test.ts
+++ b/packages/app/src/modules/domain/__tests__/workforce.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	computeWorkforceTotal,
+	sumCategoryWorkforce,
+	sumQuartileWorkforce,
+} from "../shared/workforce";
+
+describe("sumQuartileWorkforce", () => {
+	it("sums women and men across quartiles and computes total", () => {
+		expect(
+			sumQuartileWorkforce([
+				{ women: 2, men: 3 },
+				{ women: null, men: 1 },
+			]),
+		).toEqual({ women: 2, men: 4, total: 6 });
+	});
+
+	it("treats missing women/men fields as zero", () => {
+		expect(sumQuartileWorkforce([{}, { women: 5 }, { men: 7 }])).toEqual({
+			women: 5,
+			men: 7,
+			total: 12,
+		});
+	});
+
+	it("returns zeros for an empty quartile list", () => {
+		expect(sumQuartileWorkforce([])).toEqual({ women: 0, men: 0, total: 0 });
+	});
+});
+
+describe("sumCategoryWorkforce", () => {
+	it("sums parsed women and men counts across categories", () => {
+		expect(
+			sumCategoryWorkforce([
+				{ womenCount: "2", menCount: "3" },
+				{ womenCount: "4", menCount: "1" },
+			]),
+		).toEqual({ women: 6, men: 4 });
+	});
+
+	it("treats empty and non-numeric counts as zero", () => {
+		expect(
+			sumCategoryWorkforce([
+				{ womenCount: "", menCount: "abc" },
+				{ womenCount: null, menCount: undefined },
+				{},
+			]),
+		).toEqual({ women: 0, men: 0 });
+	});
+
+	it("returns zeros for an empty category list", () => {
+		expect(sumCategoryWorkforce([])).toEqual({ women: 0, men: 0 });
+	});
+});
+
+describe("computeWorkforceTotal", () => {
+	it("adds women and men", () => {
+		expect(computeWorkforceTotal(12, 8)).toBe(20);
+	});
+
+	it("returns zero when both are zero", () => {
+		expect(computeWorkforceTotal(0, 0)).toBe(0);
+	});
+});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -62,6 +62,7 @@ export {
 	computeDeclarationStatus,
 	getCurrentCompliancePath,
 	isCancelled,
+	isDeclarationSubmitted,
 } from "./shared/declarationStatus";
 // Declaration steps labels (A–F stepper), post-submit milestones, K19 funnels
 export type {
@@ -123,6 +124,7 @@ export {
 // Gap business rules (calculations & threshold classification)
 export {
 	computeGap,
+	computeGapBetween,
 	computeGapRatio,
 	computeTotal,
 	gapLevel,
@@ -147,6 +149,8 @@ export {
 	padDecimalToTwo,
 	parseNumber,
 } from "./shared/number";
+// Percentage & proportion numeric cores
+export { percentageOf, proportionOf } from "./shared/percentage";
 // Quartile helpers
 export { computeQuartileMin, migrateLegacyThresholds } from "./shared/quartile";
 export type { CountyCode, RegionCode } from "./shared/regions";
@@ -174,6 +178,12 @@ export {
 	NARROW_NBSP,
 	roundOneDecimal,
 } from "./shared/submissionRate";
+// Workforce sums (quartiles, categories)
+export {
+	computeWorkforceTotal,
+	sumCategoryWorkforce,
+	sumQuartileWorkforce,
+} from "./shared/workforce";
 export type {
 	CampaignDeadlines,
 	CompanySize,

--- a/packages/app/src/modules/domain/shared/declarationFlags.ts
+++ b/packages/app/src/modules/domain/shared/declarationFlags.ts
@@ -1,10 +1,8 @@
-import { GAP_ALERT_THRESHOLD } from "./constants";
+import { COMPANY_SIZE_ANNUAL_MIN, GAP_ALERT_THRESHOLD } from "./constants";
 import {
 	type DeclarationStatusEvent,
 	hasSubmittedSecondDeclaration,
 } from "./declarationTrajectory";
-
-const COMPLIANCE_PROCESS_SIZE_MIN = 100;
 
 export type DeclarationForFlags = {
 	rulesVersion: string | null;
@@ -22,7 +20,7 @@ export function isComplianceProcessRequired(
 	if (input.workforce === null) return false;
 	if (input.gap === null) return false;
 	return (
-		input.workforce >= COMPLIANCE_PROCESS_SIZE_MIN &&
+		input.workforce >= COMPANY_SIZE_ANNUAL_MIN &&
 		input.hasIndicatorG &&
 		input.gap >= GAP_ALERT_THRESHOLD
 	);

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -2,6 +2,10 @@ import type { DeclarationStatus } from "../types";
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
+export function isDeclarationSubmitted(status: string | null): boolean {
+	return status !== null && status !== "draft";
+}
+
 export function getCurrentCompliancePath(declaration: {
 	firstDeclarationPathChoice: CompliancePath | null;
 	secondDeclarationPathChoice: CompliancePath | null;

--- a/packages/app/src/modules/domain/shared/gap.ts
+++ b/packages/app/src/modules/domain/shared/gap.ts
@@ -38,6 +38,10 @@ export function computeGap(womenVal: string, menVal: string): number | null {
 	return Math.abs(((m - w) / m) * 100);
 }
 
+export function computeGapBetween(women: number, men: number): number | null {
+	return men === 0 ? null : Math.abs(((men - women) / men) * 100);
+}
+
 /** Classify a gap value against the regulatory threshold (5% by default). */
 export function gapLevel(gap: number | null): GapLevel | null {
 	if (gap === null) return null;

--- a/packages/app/src/modules/domain/shared/percentage.ts
+++ b/packages/app/src/modules/domain/shared/percentage.ts
@@ -1,0 +1,7 @@
+export function proportionOf(count: number, total: number): number {
+	return total === 0 ? 0 : count / total;
+}
+
+export function percentageOf(count: number, total: number): number {
+	return total === 0 ? 0 : (count / total) * 100;
+}

--- a/packages/app/src/modules/domain/shared/workforce.ts
+++ b/packages/app/src/modules/domain/shared/workforce.ts
@@ -1,0 +1,27 @@
+export function sumQuartileWorkforce(
+	quartiles: { women?: number | null; men?: number | null }[],
+): { women: number; men: number; total: number } {
+	const women = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
+	const men = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
+	return { women, men, total: women + men };
+}
+
+export function sumCategoryWorkforce(
+	categories: { womenCount?: string | null; menCount?: string | null }[],
+): { women: number; men: number } {
+	const parse = (value?: string | null): number => {
+		const n = Number.parseInt(value ?? "", 10);
+		return Number.isNaN(n) ? 0 : n;
+	};
+	return categories.reduce(
+		(sum, category) => ({
+			women: sum.women + parse(category.womenCount),
+			men: sum.men + parse(category.menCount),
+		}),
+		{ women: 0, men: 0 },
+	);
+}
+
+export function computeWorkforceTotal(women: number, men: number): number {
+	return women + men;
+}


### PR DESCRIPTION
Closes #3788

## Résumé

Ticket **foundation** de l'epic #3676 : création dans `~/modules/domain` des fonctions pures manquantes (effectif / % / gap) et collapse du doublon de constante du seuil 100, **sans toucher aux call-sites** (branchés par T2–T5). Tout est **iso-comportement**.

- `shared/workforce.ts` (nouveau) — `sumQuartileWorkforce`, `sumCategoryWorkforce`, `computeWorkforceTotal`
- `shared/percentage.ts` (nouveau) — `proportionOf`, `percentageOf` (cœurs numériques bruts ; garde `total === 0 → 0`)
- `shared/gap.ts` — ajout `computeGapBetween(women, men)` (variante numérique de `computeGap`)
- `shared/declarationFlags.ts` — `isComplianceProcessRequired` réutilise `COMPANY_SIZE_ANNUAL_MIN` (const privé `COMPLIANCE_PROCESS_SIZE_MIN` supprimé → source unique du seuil 100)
- `shared/declarationStatus.ts` — ajout `isDeclarationSubmitted(status)`
- `index.ts` — barrel exporte les 7 nouveaux symboles

## Test plan

- Suite vitest complète verte (2997 tests, 0 régression) ; 20 tests unitaires ajoutés couvrant les scénarios imposés (sums null/vide/NaN→0, garde `total===0`, parité GIP 4 décimales, `computeGapBetween(1,0)→null`, `isDeclarationSubmitted` draft/null/submitted).
- Couverture 100 % (stmts/funcs/lines/branches) sur les fichiers du ticket.
- `pnpm typecheck` ✓ · `pnpm lint:check` ✓ · `pnpm format:check` ✓
- Structural audit ✓ · RGAA PASS (aucun `.tsx`) · Security SECURE (aucun fichier serveur)

Aucune UI → pas de capture d'écran (couche domaine pure).

## Note scope (structural-auditor)

`isDeclarationSubmitted` (domain) est volontairement un miroir de `cseOpinion/confirmationHelpers.ts`. La migration du call-site vers le helper domaine + suppression du doublon relèvent de **T5** (ce ticket foundation ne touche aucun call-site, par design). Les exports sans consommateur (`percentageOf`, `proportionOf`, `computeWorkforceTotal`, `computeGapBetween`) sont branchés par T2–T5.
