### PR TITLE
refactor: use isCancelled domain helper + re-export isDeclarationSubmitted

### DIFF
--- a/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { getCurrentYear } from "~/modules/domain";
+import { getCurrentYear, isCancelled } from "~/modules/domain";
 import { useDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 
@@ -26,7 +26,7 @@ export function CancelDeclarationButton({
 	year,
 	cancelledAt,
 }: Props) {
-	if (cancelledAt !== null || year !== getCurrentYear()) {
+	if (isCancelled({ cancelledAt }) || year !== getCurrentYear()) {
 		return null;
 	}
 

--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { formatShortDate } from "~/modules/domain";
+import { formatShortDate, isCancelled } from "~/modules/domain";
 import { DsfrTable } from "~/modules/shared/DsfrTable";
 import { Pagination } from "~/modules/shared/Pagination";
 import { useSortableTable } from "~/modules/shared/useSortableTable";
@@ -79,7 +79,7 @@ export function DeclarationTable({
 							</td>
 							<td>{row.year}</td>
 							<td>
-								{row.cancelledAt !== null ? (
+								{isCancelled(row) ? (
 									<span className="fr-badge fr-badge--warning">Annulée</span>
 								) : (
 									(STATUS_LABELS[row.status ?? ""] ?? row.status)

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatShortDateTime } from "~/modules/domain";
+import { formatShortDateTime, isCancelled } from "~/modules/domain";
 import { STATUS_LABELS } from "./shared/constants";
 
 type Sibling = {
@@ -31,7 +31,7 @@ export function SiblingDeclarationsSection({ siblings }: Props) {
 							{formatShortDateTime(sibling.updatedAt)}
 						</Link>
 						{" — "}
-						{sibling.cancelledAt !== null ? (
+						{isCancelled(sibling) ? (
 							<span className="fr-badge fr-badge--warning">Annulée</span>
 						) : (
 							(STATUS_LABELS[sibling.status] ?? sibling.status)

--- a/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
@@ -7,9 +7,13 @@ const { mockMutate, mockOpen, mockClose } = vi.hoisted(() => ({
 	mockClose: vi.fn(),
 }));
 
-vi.mock("~/modules/domain", () => ({
-	getCurrentYear: () => 2026,
-}));
+vi.mock("~/modules/domain", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/domain")>();
+	return {
+		...actual,
+		getCurrentYear: () => 2026,
+	};
+});
 
 vi.mock("~/modules/shared", () => ({
 	useDsfrModal: () => ({

--- a/packages/app/src/modules/cseOpinion/confirmationHelpers.ts
+++ b/packages/app/src/modules/cseOpinion/confirmationHelpers.ts
@@ -1,3 +1,1 @@
-export function isDeclarationSubmitted(status: string | null): boolean {
-	return status !== null && status !== "draft";
-}
+export { isDeclarationSubmitted } from "~/modules/domain";


### PR DESCRIPTION
Closes #3793

## Résumé

Branchement des derniers call-sites sur les helpers `domain` (iso-comportement strict) :

- **`CancelDeclarationButton.tsx`** : `cancelledAt !== null` → `isCancelled({ cancelledAt })` depuis `~/modules/domain`
- **`DeclarationTable.tsx`** : `row.cancelledAt !== null` → `isCancelled(row)` depuis `~/modules/domain`
- **`SiblingDeclarationsSection.tsx`** : `sibling.cancelledAt !== null` → `isCancelled(sibling)` depuis `~/modules/domain`
- **`confirmationHelpers.ts`** : suppression de la fonction locale `isDeclarationSubmitted`, remplacée par `export { isDeclarationSubmitted } from "~/modules/domain"`

## Test plan

- [ ] Typecheck : vert (0 erreurs)
- [ ] Tests vitest : 3037/3037 pass (mock `~/modules/domain` complété via `importOriginal` dans `CancelDeclarationButton.test.tsx`)
- [ ] Lint/format : vert (974 fichiers vérifiés)
- [ ] RGAA : PASS
- [ ] Security : SECURE
- [ ] Structural : PASS (les imports internes `DsfrTable`/`Pagination`/`useSortableTable` sont pré-existants et hors scope)

## Référence Figma

N/A (refactor iso-comportement, aucun changement UI).