### PR TITLE
refactor(declaration-remuneration): branche le parcours déclaration/récap sur les helpers domain (#3790)

### DIFF
--- a/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { getCurrentYear } from "~/modules/domain";
+import { getCurrentYear, isCancelled } from "~/modules/domain";
 import { useDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 
@@ -26,7 +26,7 @@ export function CancelDeclarationButton({
 	year,
 	cancelledAt,
 }: Props) {
-	if (cancelledAt !== null || year !== getCurrentYear()) {
+	if (isCancelled({ cancelledAt }) || year !== getCurrentYear()) {
 		return null;
 	}
 

--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { formatShortDate } from "~/modules/domain";
+import { formatShortDate, isCancelled } from "~/modules/domain";
 import { DsfrTable } from "~/modules/shared/DsfrTable";
 import { Pagination } from "~/modules/shared/Pagination";
 import { useSortableTable } from "~/modules/shared/useSortableTable";
@@ -79,7 +79,7 @@ export function DeclarationTable({
 							</td>
 							<td>{row.year}</td>
 							<td>
-								{row.cancelledAt !== null ? (
+								{isCancelled(row) ? (
 									<span className="fr-badge fr-badge--warning">Annulée</span>
 								) : (
 									(STATUS_LABELS[row.status ?? ""] ?? row.status)

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatShortDateTime } from "~/modules/domain";
+import { formatShortDateTime, isCancelled } from "~/modules/domain";
 import { STATUS_LABELS } from "./shared/constants";
 
 type Sibling = {
@@ -31,7 +31,7 @@ export function SiblingDeclarationsSection({ siblings }: Props) {
 							{formatShortDateTime(sibling.updatedAt)}
 						</Link>
 						{" — "}
-						{sibling.cancelledAt !== null ? (
+						{isCancelled(sibling) ? (
 							<span className="fr-badge fr-badge--warning">Annulée</span>
 						) : (
 							(STATUS_LABELS[sibling.status] ?? sibling.status)

--- a/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
@@ -7,9 +7,13 @@ const { mockMutate, mockOpen, mockClose } = vi.hoisted(() => ({
 	mockClose: vi.fn(),
 }));
 
-vi.mock("~/modules/domain", () => ({
-	getCurrentYear: () => 2026,
-}));
+vi.mock("~/modules/domain", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/domain")>();
+	return {
+		...actual,
+		getCurrentYear: () => 2026,
+	};
+});
 
 vi.mock("~/modules/shared", () => ({
 	useDsfrModal: () => ({

--- a/packages/app/src/modules/cseOpinion/confirmationHelpers.ts
+++ b/packages/app/src/modules/cseOpinion/confirmationHelpers.ts
@@ -1,3 +1,1 @@
-export function isDeclarationSubmitted(status: string | null): boolean {
-	return status !== null && status !== "draft";
-}
+export { isDeclarationSubmitted } from "~/modules/domain";

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -1,7 +1,9 @@
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import {
 	computeGap,
+	computeGapBetween,
 	computeTotal,
+	computeWorkforceTotal,
 	formatCurrency,
 	formatGap,
 	formatTotal,
@@ -34,7 +36,7 @@ export function CategoryRecapTable({
 }: Props) {
 	const womenCount = category.womenCount ?? 0;
 	const menCount = category.menCount ?? 0;
-	const totalSalaries = womenCount + menCount;
+	const totalSalaries = computeWorkforceTotal(womenCount, menCount);
 
 	const annualWomenSum = computeTotal(
 		category.annualBaseWomen ?? "",
@@ -63,8 +65,8 @@ export function CategoryRecapTable({
 		category.annualVariableMen ?? "",
 	);
 	const annualTotalGap =
-		annualWomenSum !== null && annualMenSum !== null && annualMenSum !== 0
-			? Math.abs(((annualMenSum - annualWomenSum) / annualMenSum) * 100)
+		annualWomenSum !== null && annualMenSum !== null
+			? computeGapBetween(annualWomenSum, annualMenSum)
 			: null;
 
 	const hourlyBaseGap = computeGap(
@@ -76,8 +78,8 @@ export function CategoryRecapTable({
 		category.hourlyVariableMen ?? "",
 	);
 	const hourlyTotalGap =
-		hourlyWomenSum !== null && hourlyMenSum !== null && hourlyMenSum !== 0
-			? Math.abs(((hourlyMenSum - hourlyWomenSum) / hourlyMenSum) * 100)
+		hourlyWomenSum !== null && hourlyMenSum !== null
+			? computeGapBetween(hourlyWomenSum, hourlyMenSum)
 			: null;
 
 	const heading = `Catégorie d'emplois n°${index + 1}${category.name ? ` : ${category.name}` : ""}`;

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
@@ -6,9 +6,11 @@ import type {
 import {
 	computeGap,
 	computePercentage,
+	computeWorkforceTotal,
 	formatCurrency,
 	formatGap,
 	GAP_ALERT_THRESHOLD,
+	sumQuartileWorkforce,
 } from "~/modules/domain";
 import styles from "./IndicatorTables.module.scss";
 
@@ -114,7 +116,7 @@ function WorkforceTable({
 	totalWomen: number | null;
 	totalMen: number | null;
 }) {
-	const total = (totalWomen ?? 0) + (totalMen ?? 0);
+	const total = computeWorkforceTotal(totalWomen ?? 0, totalMen ?? 0);
 	return (
 		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
 			<div className="fr-table__wrapper">
@@ -165,7 +167,7 @@ function ProportionTable({
 	const eMen = Number.parseInt(indicatorEMen, 10);
 	const tWomen = totalWomen ?? 0;
 	const tMen = totalMen ?? 0;
-	const grandTotal = tWomen + tMen;
+	const grandTotal = computeWorkforceTotal(tWomen, tMen);
 	return (
 		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
 			<div className="fr-table__wrapper">
@@ -251,9 +253,11 @@ function QuartileDistributionTable({
 		(q) => q.threshold !== "" || q.women !== undefined || q.men !== undefined,
 	);
 	if (!hasData) return null;
-	const totalWomen = quartiles.reduce((s, q) => s + (q.women ?? 0), 0);
-	const totalMen = quartiles.reduce((s, q) => s + (q.men ?? 0), 0);
-	const total = totalWomen + totalMen;
+	const {
+		women: totalWomen,
+		men: totalMen,
+		total,
+	} = sumQuartileWorkforce(quartiles);
 
 	function fmt(value: string | undefined) {
 		if (!value) return "-";
@@ -309,7 +313,10 @@ function QuartileDistributionTable({
 											i === 0 ? "0" : (quartiles[i - 1]?.threshold ?? "");
 										const min = i === 0 ? `0 ${unit}` : fmt(prev);
 										const max = i === 3 ? "-" : fmt(q.threshold);
-										const lineTotal = (q.women ?? 0) + (q.men ?? 0);
+										const lineTotal = computeWorkforceTotal(
+											q.women ?? 0,
+											q.men ?? 0,
+										);
 										return (
 											<tr key={QUARTILE_LABELS[i]}>
 												<th scope="row">{QUARTILE_LABELS[i]}</th>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
@@ -28,6 +28,13 @@ function effectifCells() {
 	return within(row).getAllByRole("cell");
 }
 
+function totalRowGapCell() {
+	const rows = screen
+		.getAllByRole("rowheader", { name: "Total" })
+		.map((th) => th.parentElement as HTMLElement);
+	return rows.map((row) => within(row).getAllByRole("cell").at(-1));
+}
+
 describe("CategoryRecapTable", () => {
 	it("suffixes the 'Effectif physique' counts with 'nb'", () => {
 		render(
@@ -139,5 +146,22 @@ describe("CategoryRecapTable", () => {
 		// Hourly total gap: |((22 - 19) / 22) * 100| = 13,6 % → élevé.
 		expect(screen.getAllByText("élevé").length).toBeGreaterThanOrEqual(2);
 		expect(screen.getAllByRole("row").length).toBeGreaterThan(0);
+	});
+
+	it("renders '-' for the total gap when the men total is zero", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({
+					annualBaseWomen: "1000",
+					annualBaseMen: "0",
+				})}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		const [annualTotalGapCell, hourlyTotalGapCell] = totalRowGapCell();
+		expect(annualTotalGapCell).toHaveTextContent("-");
+		expect(annualTotalGapCell).not.toHaveTextContent("%");
+		expect(hourlyTotalGapCell).toHaveTextContent("-");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -235,6 +235,46 @@ describe("RecapitulatifPage", () => {
 		).toBeGreaterThanOrEqual(1);
 	});
 
+	it("locks the computed quartile percentages and grand totals (iso-behaviour)", () => {
+		render(
+			<RecapitulatifPage
+				{...defaultProps()}
+				step4Data={{
+					annual: [
+						{ threshold: "20700.35", women: 30, men: 60 },
+						{ threshold: "25750.99", women: 40, men: 30 },
+						{ threshold: "34900.99", women: 24, men: 31 },
+						{ threshold: "", women: 15, men: 26 },
+					],
+					hourly: [
+						{ threshold: "10", women: 30, men: 60 },
+						{ threshold: "15", women: 40, men: 30 },
+						{ threshold: "20", women: 24, men: 31 },
+						{ threshold: "", women: 15, men: 26 },
+					],
+				}}
+			/>,
+		);
+		// annual and hourly fixtures share the same counts, so each computed
+		// percentage renders twice (once per distribution table).
+		for (const pct of [
+			"33,3 %",
+			"66,7 %",
+			"57,1 %",
+			"42,9 %",
+			"43,6 %",
+			"56,4 %",
+			"36,6 %",
+			"63,4 %",
+			"42,6 %",
+			"57,4 %",
+		]) {
+			expect(screen.getAllByText(pct)).toHaveLength(2);
+		}
+		expect(screen.getAllByText("109")).toHaveLength(2);
+		expect(screen.getAllByText("147")).toHaveLength(2);
+	});
+
 	it("renders one category table per step5 category with matching heading", () => {
 		render(
 			<RecapitulatifPage

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -255,8 +255,6 @@ describe("RecapitulatifPage", () => {
 				}}
 			/>,
 		);
-		// annual and hourly fixtures share the same counts, so each computed
-		// percentage renders twice (once per distribution table).
 		for (const pct of [
 			"33,3 %",
 			"66,7 %",

--- a/packages/app/src/modules/declaration-remuneration/shared/computeIndicatorPercentages.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/computeIndicatorPercentages.ts
@@ -1,4 +1,8 @@
-import { computeGapRatio } from "~/modules/domain";
+import {
+	computeGapRatio,
+	computeWorkforceTotal,
+	proportionOf,
+} from "~/modules/domain";
 
 type DeclarationRowSubset = {
 	indicatorAAnnualWomen: string | null;
@@ -76,11 +80,11 @@ function proportionFromCounts(
 	men: number | null,
 ): { women: number | null; men: number | null } {
 	if (women === null || men === null) return { women: null, men: null };
-	const total = women + men;
+	const total = computeWorkforceTotal(women, men);
 	if (total === 0) return { women: null, men: null };
 	return {
-		women: Math.round((women / total) * 10_000) / 10_000,
-		men: Math.round((men / total) * 10_000) / 10_000,
+		women: Math.round(proportionOf(women, total) * 10_000) / 10_000,
+		men: Math.round(proportionOf(men, total) * 10_000) / 10_000,
 	};
 }
 
@@ -92,11 +96,11 @@ function proportionFromStrings(
 	const w = Number(women);
 	const m = Number(men);
 	if (Number.isNaN(w) || Number.isNaN(m)) return { women: null, men: null };
-	const total = w + m;
+	const total = computeWorkforceTotal(w, m);
 	if (total === 0) return { women: null, men: null };
 	return {
-		women: w / total,
-		men: m / total,
+		women: proportionOf(w, total),
+		men: proportionOf(m, total),
 	};
 }
 

--- a/packages/app/src/modules/declaration-remuneration/shared/gipMdsMapping.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/gipMdsMapping.ts
@@ -1,3 +1,4 @@
+import { computeWorkforceTotal, QUARTILE_COUNT } from "~/modules/domain";
 import type { gipMdsData } from "~/server/db/schema";
 
 /**
@@ -269,8 +270,8 @@ function buildQuartileData(
 	],
 	menProportions: [string | null, string | null, string | null, string | null],
 ): GipQuartileData {
-	const totalAll = (totalWomen ?? 0) + (totalMen ?? 0);
-	const quartileSize = totalAll > 0 ? Math.round(totalAll / 4) : 0;
+	const totalAll = computeWorkforceTotal(totalWomen ?? 0, totalMen ?? 0);
+	const quartileSize = totalAll > 0 ? Math.round(totalAll / QUARTILE_COUNT) : 0;
 
 	return {
 		thresholds,

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
+import { computeWorkforceTotal } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep1Schema } from "../schemas";
@@ -78,7 +79,7 @@ export function Step1Workforce({
 
 	const totalWomen = form.watch("totalWomen");
 	const totalMen = form.watch("totalMen");
-	const total = totalWomen + totalMen;
+	const total = computeWorkforceTotal(totalWomen, totalMen);
 
 	const [womenRaw, setWomenRaw] = useState(() =>
 		initialData.totalWomen > 0 ? String(initialData.totalWomen) : "",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -1,7 +1,10 @@
 import { notFound, redirect } from "next/navigation";
 
 import { campaignYearDimension, FunnelStepTracker } from "~/modules/analytics";
-import { shouldRedirectSubmittedToRecap } from "~/modules/domain";
+import {
+	formatShortDate,
+	shouldRedirectSubmittedToRecap,
+} from "~/modules/domain";
 import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
 import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { api, HydrateClient } from "~/trpc/server";
@@ -57,9 +60,11 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 
 	const initialSource = data.jobCategories[0]?.source;
 
-	const declarationDate = data.declaration.updatedAt
-		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
-		: new Date().toLocaleDateString("fr-FR");
+	const declarationDate = formatShortDate(
+		data.declaration.updatedAt
+			? new Date(data.declaration.updatedAt)
+			: new Date(),
+	);
 
 	const stepTracker = (
 		<FunnelStepTracker

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { QuartileTuple } from "~/modules/declaration-remuneration/types";
-import { computePercentage } from "~/modules/domain";
+import { computePercentage, sumQuartileWorkforce } from "~/modules/domain";
 import stepStyles from "../Step4QuartileDistribution.module.scss";
 import { QuartileTableRow } from "./QuartileTableRow";
 
@@ -42,9 +42,11 @@ export function QuartileTable({
 	onQuartileChange,
 	disabled = false,
 }: Props) {
-	const totalWomen = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
-	const totalMen = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
-	const totalAll = totalWomen + totalMen;
+	const {
+		women: totalWomen,
+		men: totalMen,
+		total: totalAll,
+	} = sumQuartileWorkforce(quartiles);
 	const trancheSuffix =
 		tableType === "annual" ? "annuelle brute" : "horaire brute";
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -4,6 +4,7 @@ import common from "~/modules/declaration-remuneration/shared/common.module.scss
 import {
 	computeGap,
 	computeTotal,
+	computeWorkforceTotal,
 	displayDecimal,
 	formatTotal,
 } from "~/modules/domain";
@@ -205,7 +206,9 @@ export function CategoryDataTable({
 	const womenInt = cat.womenCount ? Number.parseInt(cat.womenCount, 10) : NaN;
 	const menInt = cat.menCount ? Number.parseInt(cat.menCount, 10) : NaN;
 	const totalEmployees =
-		!Number.isNaN(womenInt) && !Number.isNaN(menInt) ? womenInt + menInt : null;
+		!Number.isNaN(womenInt) && !Number.isNaN(menInt)
+			? computeWorkforceTotal(womenInt, menInt)
+			: null;
 
 	const idPrefix = `cat-${catIndex}`;
 	return (

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -22,7 +22,11 @@ import type {
 	EmployeeCategoryRow,
 	EmployeeCategorySubmitData,
 } from "~/modules/declaration-remuneration/types";
-import { padDecimalOnBlur, padDecimalToTwo } from "~/modules/domain";
+import {
+	padDecimalOnBlur,
+	padDecimalToTwo,
+	sumCategoryWorkforce,
+} from "~/modules/domain";
 import { getDsfrCollapse } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import stepStyles from "../Step5EmployeeCategories.module.scss";
@@ -304,15 +308,8 @@ export function CategoryForm({
 		}
 
 		if (maxWomen !== undefined || maxMen !== undefined) {
-			const totalWomen = data.categories.reduce(
-				(sum, cat) =>
-					sum + (cat.womenCount ? Number.parseInt(cat.womenCount, 10) : 0),
-				0,
-			);
-			const totalMen = data.categories.reduce(
-				(sum, cat) =>
-					sum + (cat.menCount ? Number.parseInt(cat.menCount, 10) : 0),
-				0,
+			const { women: totalWomen, men: totalMen } = sumCategoryWorkforce(
+				data.categories,
 			);
 
 			const errors: string[] = [];

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/QuartileColumn.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/QuartileColumn.tsx
@@ -1,3 +1,4 @@
+import { computeWorkforceTotal, percentageOf } from "~/modules/domain";
 import stepStyles from "../Step6Review.module.scss";
 
 type Props = {
@@ -13,8 +14,8 @@ export function QuartileColumn({ title, quartiles }: Props) {
 			<p className="fr-text--sm fr-mb-0">Pourcentage de femmes</p>
 			<div className={stepStyles.subSection}>
 				{quartiles.map((q) => {
-					const total = q.womenCount + q.menCount || 1;
-					const pct = ((q.womenCount / total) * 100).toFixed(1);
+					const total = computeWorkforceTotal(q.womenCount, q.menCount) || 1;
+					const pct = percentageOf(q.womenCount, total).toFixed(1);
 					return (
 						<div className={stepStyles.flex1} key={`f-${q.label}`}>
 							<p className="fr-text--sm fr-mb-0">{q.label}</p>
@@ -27,8 +28,8 @@ export function QuartileColumn({ title, quartiles }: Props) {
 			<p className="fr-text--sm fr-mb-0 fr-mt-1w">Pourcentage d&apos;hommes</p>
 			<div className={stepStyles.subSection}>
 				{quartiles.map((q) => {
-					const total = q.womenCount + q.menCount || 1;
-					const pct = ((q.menCount / total) * 100).toFixed(1);
+					const total = computeWorkforceTotal(q.womenCount, q.menCount) || 1;
+					const pct = percentageOf(q.menCount, total).toFixed(1);
 					return (
 						<div className={stepStyles.flex1} key={`m-${q.label}`}>
 							<p className="fr-text--sm fr-mb-0">{q.label}</p>


### PR DESCRIPTION
Closes #3790

## Résumé

Refactor **iso-comportement** : branche le parcours *déclaration / récapitulatif* (module `declaration-remuneration`) sur les helpers `domain` créés en T1 (#3788). Aucune valeur affichée ni exportée ne change ; la parité octet-à-octet du CSV GIP (`computeIndicatorPercentages`, proportions à 4 décimales) est préservée.

### Substitutions (inline → helper `~/modules/domain`)

| Call-site | Avant | Après |
|---|---|---|
| Somme effectif quartile | `reduce(...women)` + `reduce(...men)` | `sumQuartileWorkforce(quartiles)` |
| Somme effectif catégories | double `reduce(parseInt)` | `sumCategoryWorkforce(categories)` |
| Addition `women + men` | inline | `computeWorkforceTotal(w, m)` |
| Gap composite | `Math.abs(((men-women)/men)*100)` | `computeGapBetween(womenSum, menSum)` |
| Proportion 4 déc. (parité GIP) | `w/total` / `Math.round(...*1e4)/1e4` | `proportionOf(...)` (arrondi conservé) |
| Pourcentage d'affichage | `((w/total)*100).toFixed(1)` | `percentageOf(w, total).toFixed(1)` |
| Division quartile en dur | `/ 4` | `/ QUARTILE_COUNT` |
| Date FR | `toLocaleDateString("fr-FR")` | `formatShortDate(...)` |

La null-safety existante est conservée à chaque call-site (`computeGapBetween` renvoie `null` si le total Hommes vaut 0 ; `proportionOf`/`percentageOf` renvoient 0 si total nul, sur des sites déjà gardés `total > 0`).

## Fichiers

- `recapitulatif/IndicatorTables.tsx`, `recapitulatif/CategoryRecapTable.tsx`
- `steps/step4/QuartileTable.tsx`, `steps/step5/CategoryForm.tsx`, `steps/step5/CategoryDataTable.tsx`, `steps/step6/QuartileColumn.tsx`, `steps/Step1Workforce.tsx`
- `steps/secondDeclaration/SecondDeclarationStepPage.tsx`
- `shared/computeIndicatorPercentages.ts`, `shared/gipMdsMapping.ts`

## Test plan

- Suite vitest **verte : 3038/3038** (via `tu-dev`), typecheck + lint + format verts.
- Nouveau test : lock du cas `computeGapBetween` (total-gap = `-` quand le total Hommes vaut 0), seule branche restructurée par le refactor.
- Parité GIP CSV verrouillée par `computeIndicatorPercentages.test.ts` (arrondi 4 décimales `.toBe`) et `gipMdsMapping.test.ts` (`QUARTILE_COUNT`/`computeWorkforceTotal` byte-for-byte).
- `formatShortDate` : parité runtime confirmée avec `.toLocaleDateString("fr-FR")` (format `JJ/MM/AAAA` identique).

_Refactor iso-comportement — aucun changement visuel (Référence Figma : N/A)._
