### PR TITLE
Consolider admin-stats & publicStats sur les formatters/% domain

### DIFF
--- a/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
@@ -11,7 +11,7 @@ import {
 	YAxis,
 } from "recharts";
 
-import { formatMonthDay } from "~/modules/domain";
+import { formatCount, formatMonthDay, percentageOf } from "~/modules/domain";
 
 import styles from "./CampaignProgressionChart.module.scss";
 import type { CampaignProgressionSeries } from "./types";
@@ -102,11 +102,11 @@ function ProgressionTooltip({
 					if (entry.value == null) return null;
 					const year = Number(entry.name);
 					const total = totals[year] ?? 0;
-					const pct = total > 0 ? Math.round((entry.value / total) * 100) : 0;
+					const pct = Math.round(percentageOf(entry.value, total));
 					return (
 						<li className={styles.tooltipItem} key={entry.name}>
-							{year} : {entry.value.toLocaleString("fr-FR")} déclarations ({pct}{" "}
-							% du total)
+							{year} : {formatCount(entry.value)} déclarations ({pct} % du
+							total)
 						</li>
 					);
 				})}
@@ -146,9 +146,7 @@ export function CampaignProgressionChart({ series, currentYear }: Props) {
 						interval={6}
 						tickFormatter={(value: string) => formatMonthDay(value)}
 					/>
-					<YAxis
-						tickFormatter={(value: number) => value.toLocaleString("fr-FR")}
-					/>
+					<YAxis tickFormatter={(value: number) => formatCount(value)} />
 					<Tooltip content={<ProgressionTooltip totals={totals} />} />
 					<Legend />
 					{series.map(({ year }) => (

--- a/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
@@ -11,9 +11,10 @@ import {
 	YAxis,
 } from "recharts";
 
-import { formatCount, formatMonthDay, percentageOf } from "~/modules/domain";
+import { formatMonthDay, percentageOf } from "~/modules/domain";
 
 import styles from "./CampaignProgressionChart.module.scss";
+import { formatCount } from "./formatters";
 import type { CampaignProgressionSeries } from "./types";
 
 type TooltipEntry = {

--- a/packages/app/src/modules/admin/stats/CampaignProgressionTable.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionTable.tsx
@@ -1,4 +1,4 @@
-import { formatMonthDay } from "~/modules/domain";
+import { formatCount, formatMonthDay } from "~/modules/domain";
 
 import type { CampaignProgressionSeries } from "./types";
 
@@ -63,9 +63,7 @@ export function CampaignProgressionTable({ series }: Props) {
 												const value = byDayByYear.get(year)?.get(key);
 												return (
 													<td key={year}>
-														{value != null
-															? value.toLocaleString("fr-FR")
-															: "—"}
+														{value != null ? formatCount(value) : "—"}
 													</td>
 												);
 											})}

--- a/packages/app/src/modules/admin/stats/CampaignProgressionTable.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionTable.tsx
@@ -1,5 +1,6 @@
-import { formatCount, formatMonthDay } from "~/modules/domain";
+import { formatMonthDay } from "~/modules/domain";
 
+import { formatCount } from "./formatters";
 import type { CampaignProgressionSeries } from "./types";
 
 type Props = {

--- a/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
@@ -11,9 +11,8 @@ import { CanvasRenderer } from "echarts/renderers";
 import ReactECharts from "echarts-for-react/lib/core";
 import { useEffect, useState } from "react";
 
-import { formatCount } from "~/modules/domain";
-
 import styles from "./CompletionFunnelChart.module.scss";
+import { formatCount } from "./formatters";
 import type { FunnelRow } from "./types";
 
 echarts.use([

--- a/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
@@ -11,6 +11,8 @@ import { CanvasRenderer } from "echarts/renderers";
 import ReactECharts from "echarts-for-react/lib/core";
 import { useEffect, useState } from "react";
 
+import { formatCount } from "~/modules/domain";
+
 import styles from "./CompletionFunnelChart.module.scss";
 import type { FunnelRow } from "./types";
 
@@ -119,10 +121,6 @@ export function pickFunnelColor(
 	}
 	const colors = dsfrPalette.palette;
 	return colors[index % colors.length] as string;
-}
-
-function formatCount(value: number): string {
-	return value.toLocaleString("fr-FR");
 }
 
 export function isAboveThreshold(

--- a/packages/app/src/modules/admin/stats/CompletionFunnelTable.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelTable.tsx
@@ -1,5 +1,4 @@
-import { formatCount } from "~/modules/domain";
-
+import { formatCount } from "./formatters";
 import type { FunnelRow } from "./types";
 
 type Props = {

--- a/packages/app/src/modules/admin/stats/CompletionFunnelTable.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelTable.tsx
@@ -1,3 +1,5 @@
+import { formatCount } from "~/modules/domain";
+
 import type { FunnelRow } from "./types";
 
 type Props = {
@@ -41,7 +43,7 @@ export function CompletionFunnelTable({ rows, caption }: Props) {
 									{rows.map((row) => (
 										<tr key={row.key}>
 											<th scope="row">{row.label}</th>
-											<td>{row.count.toLocaleString("fr-FR")}</td>
+											<td>{formatCount(row.count)}</td>
 											<td>{row.pctOfStart} %</td>
 											<td>{formatDrop(row.pctDropFromPrev)}</td>
 										</tr>

--- a/packages/app/src/modules/admin/stats/StatsBarTable.tsx
+++ b/packages/app/src/modules/admin/stats/StatsBarTable.tsx
@@ -1,3 +1,5 @@
+import { formatCount } from "~/modules/domain";
+
 export type StatsTableColumn<Row> = {
 	key: Extract<keyof Row, string>;
 	label: string;
@@ -11,7 +13,7 @@ type Props<Row extends { key: string; label: string }> = {
 };
 
 function formatValue(value: unknown): string {
-	if (typeof value === "number") return value.toLocaleString("fr-FR");
+	if (typeof value === "number") return formatCount(value);
 	if (typeof value === "string") return value;
 	return "0";
 }

--- a/packages/app/src/modules/admin/stats/StatsBarTable.tsx
+++ b/packages/app/src/modules/admin/stats/StatsBarTable.tsx
@@ -1,4 +1,4 @@
-import { formatCount } from "~/modules/domain";
+import { formatCount } from "./formatters";
 
 export type StatsTableColumn<Row> = {
 	key: Extract<keyof Row, string>;

--- a/packages/app/src/modules/admin/stats/__tests__/CampaignProgressionChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/CampaignProgressionChart.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { cloneElement, isValidElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CampaignProgressionSeries } from "../types";
+
+type TooltipContentProps = {
+	active?: boolean;
+	label?: string | number;
+	payload?: Array<{ name?: string | number; value?: number }>;
+};
+
+// Recharts never mounts under jsdom (no layout), so drive the internals directly:
+// render the Tooltip `content` with a controlled active payload, invoke the
+// axis `tickFormatter`s and record each Line's stroke, mirroring how
+// ScoreDistributionChart is tested.
+let capturedYAxisTickFormatter: ((value: number) => string) | undefined;
+let capturedXAxisTickFormatter: ((value: string) => string) | undefined;
+const capturedLineStrokes: Record<string, string> = {};
+const tooltipProbe: TooltipContentProps = {};
+
+vi.mock("recharts", () => ({
+	ResponsiveContainer: ({ children }: { children: ReactElement }) => children,
+	LineChart: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="line-chart">{children}</div>
+	),
+	CartesianGrid: () => null,
+	Legend: () => null,
+	Line: ({ name, stroke }: { name: string; stroke: string }) => {
+		capturedLineStrokes[name] = stroke;
+		return null;
+	},
+	XAxis: ({ tickFormatter }: { tickFormatter?: (value: string) => string }) => {
+		capturedXAxisTickFormatter = tickFormatter;
+		return null;
+	},
+	YAxis: ({ tickFormatter }: { tickFormatter?: (value: number) => string }) => {
+		capturedYAxisTickFormatter = tickFormatter;
+		return null;
+	},
+	Tooltip: ({ content }: { content: ReactElement<TooltipContentProps> }) =>
+		isValidElement(content)
+			? cloneElement(content, {
+					active: tooltipProbe.active,
+					label: tooltipProbe.label,
+					payload: tooltipProbe.payload,
+				})
+			: null,
+}));
+
+const { CampaignProgressionChart } = await import(
+	"../CampaignProgressionChart"
+);
+
+const SERIES: CampaignProgressionSeries[] = [
+	{
+		year: 2025,
+		points: [
+			{ day: "2025-02-10", cumulative: 40 },
+			{ day: "2025-02-15", cumulative: 200 },
+		],
+	},
+	{
+		year: 2026,
+		points: [
+			{ day: "2026-02-12", cumulative: 30 },
+			{ day: "2026-02-15", cumulative: 7842 },
+		],
+	},
+];
+
+function renderWithTooltip(
+	probe: TooltipContentProps,
+	series: CampaignProgressionSeries[] = SERIES,
+) {
+	Object.assign(tooltipProbe, {
+		active: undefined,
+		label: undefined,
+		payload: undefined,
+		...probe,
+	});
+	return render(
+		<CampaignProgressionChart currentYear={2026} series={series} />,
+	);
+}
+
+describe("CampaignProgressionChart", () => {
+	it("shows an empty state when no series produce any day", () => {
+		render(<CampaignProgressionChart currentYear={2026} series={[]} />);
+		expect(screen.getByText(/Aucune donnée/)).toBeInTheDocument();
+	});
+
+	it("renders an accessible figcaption alongside the chart", () => {
+		const { container } = renderWithTooltip({});
+		expect(container.querySelector("figure")).not.toBeNull();
+		expect(container.querySelector("figcaption")?.textContent).toMatch(
+			/progression cumulative/i,
+		);
+	});
+});
+
+describe("CampaignProgressionChart Y axis", () => {
+	it("formats ticks identically to the French locale (iso-render)", () => {
+		renderWithTooltip({});
+		expect(capturedYAxisTickFormatter?.(7842)).toBe(
+			(7842).toLocaleString("fr-FR"),
+		);
+	});
+
+	it("formats zero as '0'", () => {
+		renderWithTooltip({});
+		expect(capturedYAxisTickFormatter?.(0)).toBe("0");
+	});
+});
+
+describe("CampaignProgressionChart X axis", () => {
+	it("formats MM-DD ticks as a day/month label", () => {
+		renderWithTooltip({});
+		expect(capturedXAxisTickFormatter?.("02-15")).toBe("15/02");
+	});
+});
+
+describe("CampaignProgressionChart line colors", () => {
+	it("draws the current year, the previous year and older years each with its own color", () => {
+		renderWithTooltip({}, [
+			{ year: 2024, points: [{ day: "2024-02-15", cumulative: 10 }] },
+			{ year: 2025, points: [{ day: "2025-02-15", cumulative: 20 }] },
+			{ year: 2026, points: [{ day: "2026-02-15", cumulative: 30 }] },
+		]);
+		expect(capturedLineStrokes["2026"]).not.toBe(capturedLineStrokes["2025"]);
+		expect(capturedLineStrokes["2025"]).not.toBe(capturedLineStrokes["2024"]);
+		expect(capturedLineStrokes["2026"]).not.toBe(capturedLineStrokes["2024"]);
+	});
+});
+
+describe("CampaignProgressionChart tooltip", () => {
+	it("renders nothing when inactive", () => {
+		renderWithTooltip({
+			active: false,
+			label: "02-15",
+			payload: [{ name: "2026", value: 7842 }],
+		});
+		expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+	});
+
+	it("renders nothing when the payload is empty", () => {
+		renderWithTooltip({ active: true, label: "02-15", payload: [] });
+		expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+	});
+
+	it("renders nothing when the label is not a string", () => {
+		renderWithTooltip({
+			active: true,
+			label: 42,
+			payload: [{ name: "2026", value: 7842 }],
+		});
+		expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+	});
+
+	it("formats the count and the rounded share of the year total", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-15",
+			payload: [
+				{ name: "2025", value: 200 },
+				{ name: "2026", value: 7842 },
+			],
+		});
+		expect(
+			screen.getByText(/7 842 déclarations \(100 % du total\)/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/2025 : 200 déclarations \(100 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("rounds the share to the nearest integer", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-12",
+			// 30 / 7842 total ≈ 0.38 % -> rounds to 0 %
+			payload: [{ name: "2026", value: 30 }],
+		});
+		expect(
+			screen.getByText(/30 déclarations \(0 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("falls back to 0 % when the year has no known total", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-15",
+			payload: [{ name: "2099", value: 5 }],
+		});
+		expect(
+			screen.getByText(/5 déclarations \(0 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("treats a year with no data points as a zero total", () => {
+		renderWithTooltip(
+			{
+				active: true,
+				label: "02-15",
+				payload: [{ name: "2025", value: 4 }],
+			},
+			[
+				{ year: 2025, points: [] },
+				{ year: 2026, points: [{ day: "2026-02-15", cumulative: 30 }] },
+			],
+		);
+		expect(
+			screen.getByText(/2025 : 4 déclarations \(0 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("skips entries whose value is null", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-15",
+			payload: [
+				{ name: "2025", value: undefined },
+				{ name: "2026", value: 7842 },
+			],
+		});
+		const items = screen.getAllByRole("listitem");
+		expect(items).toHaveLength(1);
+		// \s matches the U+202F narrow-no-break-space the fr-FR locale emits
+		expect(items[0]?.textContent).toMatch(/7\s842 déclarations/);
+	});
+});

--- a/packages/app/src/modules/admin/stats/formatters.ts
+++ b/packages/app/src/modules/admin/stats/formatters.ts
@@ -1,3 +1,5 @@
+export { formatCount } from "~/modules/domain";
+
 type WithUnitOption = {
 	withUnit?: boolean;
 };
@@ -11,10 +13,6 @@ export function formatPercent(
 		minimumFractionDigits: 1,
 	});
 	return withUnit ? `${formatted} %` : formatted;
-}
-
-export function formatCount(value: number): string {
-	return value.toLocaleString("fr-FR");
 }
 
 export function formatDecimal(value: number): string {

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
@@ -52,7 +52,7 @@ type ChartTooltipProps = {
 };
 
 export function formatYAxisTick(value: number): string {
-	return value.toLocaleString("fr-FR");
+	return formatCount(value);
 }
 
 export function ChartTooltip({ active, payload }: ChartTooltipProps) {


### PR DESCRIPTION
Closes #3791

## Résumé

Consolide les modules **admin-stats** et **publicStats** sur les formatters/cœurs de pourcentage du module `domain` (T3 de l'epic #3676, dépend de #3788). Refacto **iso-comportement strict** : aucune chaîne affichée n'est modifiée.

- `admin/stats/formatters.ts` : suppression du `formatCount` local (dupliquait exactement `domain`) → re-export depuis `~/modules/domain`. `formatPercent`/`formatDecimal`/`formatDays` conservés (admin-scoped, non réductibles strictement à `formatRate` sans changer le rendu — séparateur d'unité `%` et 1 décimale forcée).
- 5 composants/tables admin-stats + `publicStats/ScoreDistributionChart` : remplacement des `toLocaleString("fr-FR")` de comptage par `formatCount`.
- `CampaignProgressionChart` : `Math.round((v/total)*100)` → `Math.round(percentageOf(v, total))` (arrondi entier préservé).
- Import de `formatCount` routé via le barrel local `./formatters` dans admin-stats (cohérence intra-module avec les composants non modifiés).

## Iso-rendu vérifié

`formatCount(v)` = `v.toLocaleString("fr-FR").replace(/ /g, NARROW_NBSP)` produit une sortie **byte-identique** à l'ancien `toLocaleString("fr-FR")` (0, 5, 42, 1 234, 1 234 567 — séparateur U+202F inchangé). `percentageOf` iso à l'ancien calcul manuel pour tous les inputs réalistes (total ≥ 0).

## Test plan

- Tests unitaires (via `tu-dev`) : suite verte (3051 tests), +14 tests sur `CampaignProgressionChart` (tooltip `percentageOf`/`formatCount`, axes, edge cases) → 100% coverage du seul fichier de logique modifié.
- Typecheck, lint, format verts. Auditors structural / RGAA / security : PASS.

Refactor iso-comportement — aucune capture d'écran (rendu inchangé).