### PR TITLE
Centraliser compliance/CSE & % côté serveur (export, routers) (#3792)

### DIFF
--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -775,3 +775,130 @@ describe("assembleDeclaration", () => {
 		);
 	});
 });
+
+describe("assembleDeclaration — compliance flags", () => {
+	const indicatorG: IndicatorGEntry[] = [
+		{
+			categoryName: "Cadres",
+			declarationType: "initial",
+			womenCount: 50,
+			menCount: 60,
+			annualBaseWomen: "52000",
+			annualBaseMen: "56000",
+			annualVariableWomen: null,
+			annualVariableMen: null,
+			hourlyBaseWomen: null,
+			hourlyBaseMen: null,
+			hourlyVariableWomen: null,
+			hourlyVariableMen: null,
+		},
+	];
+
+	it("requires the compliance process for >= 100 employees with indicator G and a gap >= 5%", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(true);
+	});
+
+	it("does not require the compliance process when the gap is below 5%", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0455" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+
+	it("does not require the compliance process below 100 employees even with a gap", () => {
+		const row = { ...baseRow, workforce: 99, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+	});
+
+	it("does not require the compliance process without indicator G", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+	});
+
+	it("does not require the compliance process when the global gap is null", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: null };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+	});
+
+	it("treats a null workforce as 0 for the derived flags", () => {
+		const row = { ...baseRow, workforce: null, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Indicateur_G_requis).toBe(false);
+	});
+
+	it("requires the revision when a second declaration was submitted with a correction gap >= 5%", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: "0.0800",
+			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours_de_conformite_revision_requis).toBe(true);
+	});
+
+	it("does not require the revision without a submitted second declaration", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: "0.0800",
+			secondDeclarationSubmittedAt: null,
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+
+	it("does not require the revision when the correction gap is below 5%", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: "0.0400",
+			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+
+	it("does not require the revision when the correction gap is null", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: null,
+			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+});

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -1,6 +1,10 @@
 import { and, eq, isNotNull, ne, or } from "drizzle-orm";
 
-import { GAP_ALERT_THRESHOLD, isIndicatorGRequired } from "~/modules/domain";
+import {
+	isComplianceProcessRequired,
+	isComplianceProcessRevisionRequired,
+	isIndicatorGRequired,
+} from "~/modules/domain";
 import type { DB } from "~/server/db";
 import { companies, declarations, users } from "~/server/db/schema";
 import { mapCseOpinions } from "./mapIndicators";
@@ -11,21 +15,6 @@ import {
 	statusHistoryProjection,
 } from "./queries";
 import type { ExportRow } from "./types";
-
-const COMPLIANCE_PROCESS_SIZE_MIN = 100;
-
-function computeComplianceProcessRequired(
-	workforce: number | null,
-	hasIndicatorG: boolean,
-	globalAnnualMeanGap: number | null,
-): boolean {
-	if (workforce === null || globalAnnualMeanGap === null) return false;
-	return (
-		workforce >= COMPLIANCE_PROCESS_SIZE_MIN &&
-		hasIndicatorG &&
-		Math.abs(globalAnnualMeanGap) >= GAP_ALERT_THRESHOLD
-	);
-}
 
 export async function buildExportRows(
 	db: DB,
@@ -93,16 +82,33 @@ export async function buildExportRows(
 		const variableAnnualMeanGap = row.variableAnnualMeanGap
 			? Number(row.variableAnnualMeanGap) * 100
 			: null;
-		const complianceProcessRequired = computeComplianceProcessRequired(
-			row.workforce,
-			hasIndicatorGForThisDecl,
-			globalAnnualMeanGap,
-		);
+		const complianceInput = {
+			workforce: row.workforce,
+			hasIndicatorG: hasIndicatorGForThisDecl,
+			gap: globalAnnualMeanGap === null ? null : Math.abs(globalAnnualMeanGap),
+		};
+		const complianceProcessRequired =
+			isComplianceProcessRequired(complianceInput);
 		const complianceProcessRevisionRequired =
-			complianceProcessRequired &&
-			row.secondDeclarationSubmittedAt !== null &&
-			variableAnnualMeanGap !== null &&
-			Math.abs(variableAnnualMeanGap) >= GAP_ALERT_THRESHOLD;
+			isComplianceProcessRevisionRequired({
+				...complianceInput,
+				correctionGap:
+					variableAnnualMeanGap === null
+						? null
+						: Math.abs(variableAnnualMeanGap),
+				events:
+					row.secondDeclarationSubmittedAt === null
+						? []
+						: [
+								{
+									eventType: "second_declaration_submit",
+									value: null,
+									round: null,
+									createdAt: row.secondDeclarationSubmittedAt,
+									actorUserId: null,
+								},
+							],
+			});
 		const indicatorGRequired = isIndicatorGRequired(
 			row.workforce ?? 0,
 			row.year,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -13,7 +13,11 @@ export {
 	fetchSubmittedDeclarations,
 } from "./queries";
 
-import { GAP_ALERT_THRESHOLD, isIndicatorGRequired } from "~/modules/domain";
+import {
+	isComplianceProcessRequired,
+	isComplianceProcessRevisionRequired,
+	isIndicatorGRequired,
+} from "~/modules/domain";
 import type { DeclarationRow } from "./queries";
 import {
 	INDICATOR_A_GAP_LABELS,
@@ -38,8 +42,6 @@ import {
 	getStatusHistoryLabel,
 } from "./shared/statusHistoryLabels";
 
-const COMPLIANCE_PROCESS_SIZE_MIN = 100;
-
 function deriveExportFlags(
 	row: DeclarationRow,
 	indicatorGEntries: IndicatorGEntry[],
@@ -56,17 +58,32 @@ function deriveExportFlags(
 		? Number(row.variableAnnualMeanGap) * 100
 		: null;
 	const workforce = row.workforce;
+	const complianceInput = {
+		workforce,
+		hasIndicatorG,
+		gap: globalAnnualMeanGap === null ? null : Math.abs(globalAnnualMeanGap),
+	};
 	const complianceProcessRequired =
-		workforce !== null &&
-		workforce >= COMPLIANCE_PROCESS_SIZE_MIN &&
-		hasIndicatorG &&
-		globalAnnualMeanGap !== null &&
-		Math.abs(globalAnnualMeanGap) >= GAP_ALERT_THRESHOLD;
-	const complianceProcessRevisionRequired =
-		complianceProcessRequired &&
-		row.secondDeclarationSubmittedAt !== null &&
-		variableAnnualMeanGap !== null &&
-		Math.abs(variableAnnualMeanGap) >= GAP_ALERT_THRESHOLD;
+		isComplianceProcessRequired(complianceInput);
+	const complianceProcessRevisionRequired = isComplianceProcessRevisionRequired(
+		{
+			...complianceInput,
+			correctionGap:
+				variableAnnualMeanGap === null ? null : Math.abs(variableAnnualMeanGap),
+			events:
+				row.secondDeclarationSubmittedAt === null
+					? []
+					: [
+							{
+								eventType: "second_declaration_submit",
+								value: null,
+								round: null,
+								createdAt: row.secondDeclarationSubmittedAt,
+								actorUserId: null,
+							},
+						],
+		},
+	);
 	const indicatorGRequiredFlag = isIndicatorGRequired(workforce ?? 0, row.year);
 	return {
 		complianceProcessRequired,

--- a/packages/app/src/modules/export/shared/__tests__/apiLabels.test.ts
+++ b/packages/app/src/modules/export/shared/__tests__/apiLabels.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { quartileProportion } from "../apiLabels";
+
+describe("quartileProportion", () => {
+	it("returns null when count is null", () => {
+		expect(quartileProportion(null, 10)).toBeNull();
+	});
+
+	it("returns null when totalCount is null", () => {
+		expect(quartileProportion(5, null)).toBeNull();
+	});
+
+	it("returns null when totalCount is zero (no division by zero)", () => {
+		expect(quartileProportion(5, 0)).toBeNull();
+	});
+
+	it("returns the exact ratio when it fits within 4 decimals", () => {
+		expect(quartileProportion(1, 4)).toBe(0.25);
+		expect(quartileProportion(3, 5)).toBe(0.6);
+	});
+
+	it("rounds to 4 decimals for GIP CSV parity", () => {
+		expect(quartileProportion(1, 3)).toBe(0.3333);
+		expect(quartileProportion(2, 3)).toBe(0.6667);
+		expect(quartileProportion(5, 9)).toBe(0.5556);
+	});
+
+	it("returns 0 for a zero count over a non-zero total", () => {
+		expect(quartileProportion(0, 10)).toBe(0);
+	});
+
+	// GIP CSV parity guard: proportionOf must match the raw count/total arithmetic it replaced.
+	it("matches raw count/totalCount rounding across a value spread", () => {
+		const pairs: Array<[number, number]> = [
+			[1, 3],
+			[2, 3],
+			[7, 13],
+			[123, 456],
+			[9, 9],
+			[0, 5],
+		];
+		for (const [count, total] of pairs) {
+			const expected = Math.round((count / total) * 10_000) / 10_000;
+			expect(quartileProportion(count, total)).toBe(expected);
+		}
+	});
+});

--- a/packages/app/src/modules/export/shared/apiLabels.ts
+++ b/packages/app/src/modules/export/shared/apiLabels.ts
@@ -7,6 +7,8 @@
  * same underscore-separated French style to stay consistent.
  */
 
+import { proportionOf } from "~/modules/domain";
+
 /** Indicator A — mean global remuneration. */
 export const INDICATOR_A_LABELS = {
 	annualWomen: "Rem_globale_annuelle_moyenne_F",
@@ -126,5 +128,5 @@ export function quartileProportion(
 	totalCount: number | null,
 ): number | null {
 	if (count === null || totalCount === null || totalCount === 0) return null;
-	return Math.round((count / totalCount) * 10_000) / 10_000;
+	return Math.round(proportionOf(count, totalCount) * 10_000) / 10_000;
 }

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -683,6 +683,43 @@ describe("declarationRouter", () => {
 		});
 	});
 
+	describe("submit — cseRequired snapshot", () => {
+		async function submitAndReadSnapshot(
+			workforce: number | null,
+			hasCse: boolean | null,
+		): Promise<boolean> {
+			const declaration = buildDeclaration({ status: "draft" });
+			const company = buildCompany({ workforce, hasCse });
+			const ctx = createSubmitMockDb(declaration, company, []);
+			const caller = await createLockedCaller(ctx.db);
+			await caller.submit();
+			const projectionCall = ctx.set.mock.calls
+				.map((c) => c[0] as Record<string, unknown>)
+				.find((c) => "cseRequired" in c);
+			return projectionCall?.cseRequired as boolean;
+		}
+
+		it("snapshots true for >= 100 employees with a CSE", async () => {
+			expect(await submitAndReadSnapshot(100, true)).toBe(true);
+		});
+
+		it("snapshots false just below the 100-employee threshold", async () => {
+			expect(await submitAndReadSnapshot(99, true)).toBe(false);
+		});
+
+		it("snapshots false for >= 100 employees without a CSE", async () => {
+			expect(await submitAndReadSnapshot(120, false)).toBe(false);
+		});
+
+		it("snapshots false when hasCse is null", async () => {
+			expect(await submitAndReadSnapshot(250, null)).toBe(false);
+		});
+
+		it("snapshots false when workforce is null", async () => {
+			expect(await submitAndReadSnapshot(null, true)).toBe(false);
+		});
+	});
+
 	describe("submitSecondDeclaration (rules engine)", () => {
 		it("transitions corrective_actions_chosen → awaiting_revision_choice when gap persists (S15)", async () => {
 			const declaration = buildDeclaration({

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -39,6 +39,8 @@ import {
 	POST_SUBMIT_DROPOFF_PHASES,
 	POST_SUBMIT_MILESTONES,
 	type PostSubmitMilestoneKey,
+	percentageOf,
+	roundOneDecimal,
 } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import {
@@ -658,8 +660,7 @@ export const adminStatsRouter = createTRPCRouter({
 				const aggregate = byStep.get(step);
 				const total = aggregate?.total ?? 0;
 				const abandoned = aggregate?.abandoned ?? 0;
-				const dropoffRate =
-					total === 0 ? 0 : Math.round((abandoned / total) * 1000) / 10;
+				const dropoffRate = roundOneDecimal(percentageOf(abandoned, total));
 				return {
 					key: String(step),
 					phase: "wizard",
@@ -838,8 +839,7 @@ export const adminStatsRouter = createTRPCRouter({
 				({ key, label, status }) => {
 					const total = totalsByPhase.get(status) ?? 0;
 					const abandoned = abandonedByPhase.get(status) ?? 0;
-					const dropoffRate =
-						total === 0 ? 0 : Math.round((abandoned / total) * 1000) / 10;
+					const dropoffRate = roundOneDecimal(percentageOf(abandoned, total));
 					return {
 						key,
 						phase: "post_submit",
@@ -1145,12 +1145,11 @@ function buildFunnelRows(
 	const start = numbers[0] ?? 0;
 	return steps.map((step, idx) => {
 		const count = numbers[idx] ?? 0;
-		const pctOfStart = start === 0 ? 0 : Math.round((count / start) * 100);
+		const pctOfStart = Math.round(percentageOf(count, start));
 		let pctDropFromPrev: number | null = null;
 		if (idx > 0) {
 			const prev = numbers[idx - 1] ?? 0;
-			pctDropFromPrev =
-				prev === 0 ? 0 : Math.round(((prev - count) / prev) * 100);
+			pctDropFromPrev = Math.round(percentageOf(prev - count, prev));
 		}
 		return {
 			key: step.key,

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -14,9 +14,9 @@ import {
 } from "~/modules/declaration-remuneration/schemas";
 import { mapGipToFormData } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import {
-	COMPANY_SIZE_ANNUAL_MIN,
 	getCurrentYear,
 	hasGapsAboveThreshold,
+	isCseRequired,
 	isTriennialYear,
 } from "~/modules/domain";
 import {
@@ -692,8 +692,7 @@ export const declarationRouter = createTRPCRouter({
 		// que les transitions FSM aval (saveCompliancePath, submitJointEvaluation,
 		// cseOpinion.finalize) liront comme guard.
 		const cseRequiredSnapshot =
-			(company.workforce ?? 0) >= COMPANY_SIZE_ANNUAL_MIN &&
-			company.hasCse === true;
+			isCseRequired(company.workforce ?? 0) && company.hasCse === true;
 
 		await ctx.db.transaction(async (tx) => {
 			if (declaration.status === "draft" && historyInserts.length > 0) {

--- a/packages/app/src/server/services/__tests__/matomo.test.ts
+++ b/packages/app/src/server/services/__tests__/matomo.test.ts
@@ -12,6 +12,7 @@ const { mockEnv } = vi.hoisted(() => ({
 vi.mock("~/env", () => ({ env: mockEnv }));
 
 import {
+	buildFunnelRows,
 	fetchMatomoCategoryModel,
 	fetchMatomoCseStatusConfirmations,
 	fetchMatomoDeviceBreakdown,
@@ -599,5 +600,57 @@ describe("fetchMatomoCseStatusConfirmations", () => {
 		const result = await fetchMatomoCseStatusConfirmations({ year: 2024 });
 
 		expect(result).toEqual({ total: 0, yes: 0, no: 0 });
+	});
+});
+
+describe("buildFunnelRows", () => {
+	const jalons = [
+		{ key: "start", label: "Démarrage", kind: "start" as const },
+		{ key: "mid", label: "Milieu", kind: "step" as const, step: "mid" },
+		{ key: "complete", label: "Fin", kind: "complete" as const },
+	];
+
+	it("anchors pctOfStart to the first jalon and rounds to a whole number", () => {
+		const rows = buildFunnelRows(jalons, {
+			start: 200,
+			mid: 150,
+			complete: 50,
+		});
+
+		expect(rows.map((r) => [r.count, r.pctOfStart])).toEqual([
+			[200, 100],
+			[150, 75],
+			[50, 25],
+		]);
+	});
+
+	it("computes pctDropFromPrev as null on the first jalon and rounded thereafter", () => {
+		const rows = buildFunnelRows(jalons, {
+			start: 200,
+			mid: 150,
+			complete: 50,
+		});
+
+		expect(rows[0]?.pctDropFromPrev).toBeNull();
+		expect(rows[1]?.pctDropFromPrev).toBe(25);
+		expect(rows[2]?.pctDropFromPrev).toBe(67);
+	});
+
+	it("yields 0 percentages when the funnel start is empty (no division by zero)", () => {
+		const rows = buildFunnelRows(jalons, {});
+
+		expect(rows.map((r) => r.count)).toEqual([0, 0, 0]);
+		for (const row of rows) {
+			expect(row.pctOfStart).toBe(0);
+		}
+		expect(rows[0]?.pctDropFromPrev).toBeNull();
+		expect(rows[1]?.pctDropFromPrev).toBe(0);
+	});
+
+	it("yields pctDropFromPrev 0 when the previous jalon is empty mid-funnel", () => {
+		const rows = buildFunnelRows(jalons, { start: 100, mid: 0, complete: 0 });
+
+		expect(rows[1]?.pctDropFromPrev).toBe(100);
+		expect(rows[2]?.pctDropFromPrev).toBe(0);
 	});
 });

--- a/packages/app/src/server/services/matomo.ts
+++ b/packages/app/src/server/services/matomo.ts
@@ -20,7 +20,7 @@ import {
 	MATOMO_EVENT_CATEGORY,
 	MATOMO_FUNNEL_ACTION,
 } from "~/modules/analytics/shared/events";
-import type { CompanySizeRange } from "~/modules/domain";
+import { type CompanySizeRange, percentageOf } from "~/modules/domain";
 
 const ONE_HOUR = 3_600;
 
@@ -127,12 +127,11 @@ export function buildFunnelRows(
 	const start = numbers[0] ?? 0;
 	return jalons.map((jalon, index) => {
 		const count = numbers[index] ?? 0;
-		const pctOfStart = start === 0 ? 0 : Math.round((count / start) * 100);
+		const pctOfStart = Math.round(percentageOf(count, start));
 		let pctDropFromPrev: number | null = null;
 		if (index > 0) {
 			const prev = numbers[index - 1] ?? 0;
-			pctDropFromPrev =
-				prev === 0 ? 0 : Math.round(((prev - count) / prev) * 100);
+			pctDropFromPrev = Math.round(percentageOf(prev - count, prev));
 		}
 		return {
 			key: jalon.key,


### PR DESCRIPTION
Centralise les flags compliance/CSE et les pourcentages côté serveur via les helpers du domaine (export, routers adminStats/declaration, service matomo). Couverture de tests ajoutée.

Closes #3792