### PR TITLE
feat(epic): #3676 — Vérifier que les même règles métiers sont utilisés partout dans l'app

### DIFF
--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: Architecte technique : lit le codebase et produit des specs exécutables (modes epic-create / epic-enrich / task).
-model: opus
+model: fable
 ---
 
 # Architect Agent
@@ -10,7 +10,7 @@ You are the technical architect for the egapro project. You read the codebase an
 
 ## Model & Tools
 
-- **Model:** opus (architectural decisions)
+- **Model:** fable (architectural decisions)
 - **Tools:** Bash (gh CLI), Read, Grep, Glob, figma-dev MCP (read-only — never modify code)
 
 ## Modes

--- a/.claude/agents/architect/AGENT.md
+++ b/.claude/agents/architect/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: architect
+description: Architecte technique : lit le codebase et produit des specs exécutables (modes epic-create / epic-enrich / task).
+model: opus
+---
+
 # Architect Agent
 
 You are the technical architect for the egapro project. You read the codebase and produce **executable specs** (format `rules/ticket-spec-format.md`) that a Sonnet `code-dev` can run without further decisions.

--- a/.claude/agents/bug-analyst/AGENT.md
+++ b/.claude/agents/bug-analyst/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: bug-analyst
+description: Analyse un bug end-to-end : reproduit le dysfonctionnement, identifie la cause racine, propose un correctif ciblé. Poste ## Analyse du bug.
+model: opus
+---
+
 # Bug Analyst Agent
 
 You analyze a single bug issue end-to-end: reproduce the malfunction, identify the root cause, and post a structured analysis comment that lets `code-dev` apply the fix without re-doing the diagnostic work.

--- a/.claude/agents/code-dev/AGENT.md
+++ b/.claude/agents/code-dev/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: code-dev
+description: Implémente un ticket end-to-end — édite le code, délègue tous les tests (TU + intégration) à tu-dev, ouvre une PR draft, déclenche les validators. N'écrit aucun test E2E (détenus par e2e-dev). Sonnet par défaut, Opus si le ticket porte le label complexe.
+model: sonnet
+---
+
 # Code Dev Agent
 
 You execute one pre-specified ticket end-to-end : edit code, delegate all unit/integration tests to `tu-dev`, open a PR, post screenshots, trigger validators. You do **not** write any test — unit/integration tests are owned by `tu-dev` (step 5.5) and **all E2E Playwright tests are owned by `e2e-dev`**, which runs at the end of the pipeline (epic-end for a Feature, or after your `validated` verdict for a Task/Bug). You never touch `src/e2e/**`.

--- a/.claude/agents/design-validator/AGENT.md
+++ b/.claude/agents/design-validator/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: design-validator
+description: Gate de fidélité visuelle indépendant : compare le rendu d'un ticket UI au node Figma de référence (mesure DOM + overlay onion-skin + vision). Read-only.
+model: sonnet
+---
+
 # Design Validator Agent
 
 You are the **independent visual-fidelity gate**. You compare the *rendered* UI of a ticket against its **Figma reference** and return a blocking verdict. You are spawned by `code-dev` at the end of its run (step 9, alongside `functional-validator`) — you are a separate pair of eyes, never the agent that wrote the code.

--- a/.claude/agents/designer/AGENT.md
+++ b/.claude/agents/designer/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: designer
+description: Designer UX/UI : propose des flux d'écrans et produit des maquettes DSFR statiques.
+model: sonnet
+---
+
 # Designer Agent
 
 You are the UX/UI designer for the egapro project. You propose screen flows and produce **static DSFR HTML mockups** that serve as visual references for `code-dev` and `design-validator`.

--- a/.claude/agents/doc-writer/AGENT.md
+++ b/.claude/agents/doc-writer/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: doc-writer
+description: Régénère la documentation utilisateur du repo (docs/*.md) à partir de l'état courant du code.
+model: sonnet
+---
+
 # Doc Writer Agent
 
 Tu régénères la documentation utilisateur du repo (`docs/*.md`) à partir de l'état courant du code. Tu es invoqué soit par la pipeline d'orchestration `epic_loop.sh` (en fin d'epic, avant l'ouverture de la PR finale), soit par le skill `/doc` (humain, hors pipeline).

--- a/.claude/agents/functional-validator/AGENT.md
+++ b/.claude/agents/functional-validator/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: functional-validator
+description: Rejoue les scénarios PO du ticket sur l'app en cours via Playwright MCP et vérifie le comportement visible par l'utilisateur. Read-only.
+model: sonnet
+---
+
 # Functional Validator Agent
 
 You replay the ticket's scenarios on the running app via Playwright MCP. You verify that user-visible behavior matches what the PO specified.

--- a/.claude/agents/product-owner/AGENT.md
+++ b/.claude/agents/product-owner/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: product-owner
+description: Product owner : affine les demandes de fonctionnalités en specs exécutables et rédige les scénarios PO sur l'epic.
+model: opus
+---
+
 # Product Owner Agent
 
 You are the product owner for the egapro project. You refine feature requests into executable specs with test scenarios, **before** any design or code work.

--- a/.claude/agents/review-fixer/AGENT.md
+++ b/.claude/agents/review-fixer/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: review-fixer
+description: Adresse les commentaires de revue (humain + bots) sur une ou plusieurs PR : lit les threads non résolus, applique les fixes, pousse, prépare les réponses. Tourne en worktree dédié.
+model: sonnet
+---
+
 # Review Fixer Agent
 
 You address review feedback on one or more PRs : read the unresolved comments, apply the necessary code fixes, run validators, push, and reply to each thread.

--- a/.claude/agents/rgaa-auditor/AGENT.md
+++ b/.claude/agents/rgaa-auditor/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: rgaa-auditor
+description: Auditeur d'accessibilité : audite les composants React modifiés contre le RGAA (WCAG). Read-only.
+model: sonnet
+---
+
 # RGAA Auditor Agent
 
 You are an accessibility auditor for the egapro project. You audit React components against RGAA (WCAG 2.1 AA) criteria specific to the DSFR design system.

--- a/.claude/agents/security-auditor/AGENT.md
+++ b/.claude/agents/security-auditor/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: security-auditor
+description: Auditeur sécurité : revue OWASP Top 10 + RGS sur les fichiers serveur modifiés (routers, tRPC, server). Read-only.
+model: sonnet
+---
+
 # Security Auditor Agent
 
 You are a security auditor for the egapro project. You review code against OWASP Top 10 and French government security standards (RGS).

--- a/.claude/agents/structural-auditor/AGENT.md
+++ b/.claude/agents/structural-auditor/AGENT.md
@@ -152,19 +152,31 @@ For changed files in `src/server/`:
 
 ```bash
 # Must return ZERO — no inline getFullYear outside domain/
-grep -rn "new Date()\.getFullYear()" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
+grep -rn "getFullYear()" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 
-# Must return ZERO — no inline slice(0, 9) outside domain/
-grep -rn "slice(0, 9)" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/"
+# Must return ZERO — no inline slice/substring/substr(0, 9) outside domain/
+grep -rn "slice(0, *9)\|substring(0, *9)\|substr(0, *9)" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
+
+# Must return ZERO — no inline date arithmetic outside domain/
+grep -rn "\.getMonth()\|\.getDate()" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 
 # Must return ZERO — no local function definitions duplicating domain
 grep -rn "function getCurrentYear\|function getCseYear\|function getSiren" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/"
+
+# Must return ZERO — no domain helpers reimplemented inline outside domain/
+grep -rn "cancelledAt !== null\|cancelledAt != null\|workforce >= 100\|effectifs >= 100\|workforce < 50\|effectifs < 50" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
+
+# Must return ZERO (or WARN) — toLocaleString("fr-FR") outside domain/ (likely duplicates formatCount/formatRate/formatCurrency)
+grep -rn 'toLocaleString.*fr-FR\|toLocaleString.*"fr"' src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 ```
 
-- Inline `new Date().getFullYear()` → **[ERROR]**
-- Inline `siret.slice(0, 9)` → **[ERROR]**
+- Inline `getFullYear()` → **[ERROR]**
+- Inline `slice/substring/substr(0, 9)` for SIREN extraction → **[ERROR]**
+- Inline `.getMonth()` / `.getDate()` for date calculations → **[ERROR]**
 - Local function duplicating domain → **[ERROR]**
-- Hardcoded regulatory thresholds (5%, 50, 100) → **[WARN]**
+- Hardcoded regulatory thresholds (5%, 50, 100) → **[ERROR]**
+- Inline condition reimplementing a domain helper (e.g. `cancelledAt !== null` instead of `isCancelled()`, `workforce >= 100 && hasCse` instead of `isCseRequired()`, `isComplianceProcessRequired()`, `isComplianceProcessRevisionRequired()`) → **[ERROR]**
+- `toLocaleString("fr-FR")` outside `domain/` — probable duplicate of `formatCount`/`formatRate`/`formatCurrency` → **[WARN]**
 
 #### 2.16 Accessibility (quick check)
 

--- a/.claude/agents/structural-auditor/AGENT.md
+++ b/.claude/agents/structural-auditor/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: structural-auditor
+description: Auditeur structurel : vérifie les fichiers modifiés contre les règles projet (qualité du code, forms, schemas, DRY, imports, no-comments…). Read-only.
+model: sonnet
+---
+
 # Structural Auditor Agent
 
 You are a structural code auditor for the egapro project. You check changed files against all project conventions and report violations. This agent merges code review and structural audit into a single comprehensive checklist.

--- a/.claude/agents/structural-auditor/AGENT.md
+++ b/.claude/agents/structural-auditor/AGENT.md
@@ -172,7 +172,7 @@ grep -rn "function getCurrentYear\|function getCseYear\|function getSiren" src/ 
 # Must return ZERO — no domain helpers reimplemented inline outside domain/
 grep -rn "cancelledAt !== null\|cancelledAt != null\|workforce >= 100\|effectifs >= 100\|workforce < 50\|effectifs < 50" src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 
-# Must return ZERO (or WARN) — toLocaleString("fr-FR") outside domain/ (likely duplicates formatCount/formatRate/formatCurrency)
+# WARN on matches — toLocaleString("fr-FR") outside domain/ (likely duplicates formatCount/formatRate/formatCurrency)
 grep -rn 'toLocaleString.*fr-FR\|toLocaleString.*"fr"' src/ --include="*.ts" --include="*.tsx" | grep -v "domain/" | grep -v "__tests__" | grep -v "\.test\."
 ```
 

--- a/.claude/agents/validator/AGENT.md
+++ b/.claude/agents/validator/AGENT.md
@@ -1,3 +1,9 @@
+---
+name: validator
+description: Runner de validation : lance tous les checks qualité équivalents CI (typecheck, test, lint, format) en parallèle et rapporte les résultats. Read-only, ne modifie aucun fichier.
+model: sonnet
+---
+
 # Validator Agent
 
 You are a validation runner for the egapro project. You run all CI-equivalent quality checks and report results.

--- a/.claude/hooks/block-bad-patterns.sh
+++ b/.claude/hooks/block-bad-patterns.sh
@@ -108,10 +108,21 @@ check_pattern '\.(ts|tsx)$' \
   'Inline getFullYear() is forbidden. Use getCurrentYear() or getCseYear() from ~/modules/domain.' \
   '(domain/|__tests__|\.test\.|\.spec\.)'
 
-# Domain layer — slice(0, 9) for SIREN extraction must come from ~/modules/domain
+# Domain layer — slice/substring/substr(0, 9) for SIREN extraction must come from ~/modules/domain
 check_pattern '\.(ts|tsx)$' \
   'slice\(0,[[:space:]]*9\)' \
   'Inline slice(0, 9) is forbidden. Use extractSiren() from ~/modules/domain.' \
+  '(domain/|__tests__|\.test\.|\.spec\.)'
+
+check_pattern '\.(ts|tsx)$' \
+  '(substring|substr)\(0,[[:space:]]*9\)' \
+  'Inline substring/substr(0, 9) is forbidden. Use extractSiren() from ~/modules/domain.' \
+  '(domain/|__tests__|\.test\.|\.spec\.)'
+
+# Domain layer — inline date arithmetic (getMonth/getDate) must use domain campaign helpers
+check_pattern '\.(ts|tsx)$' \
+  '\.(getMonth|getDate)\(\)' \
+  'Inline .getMonth()/.getDate() is forbidden. Use campaign date helpers from ~/modules/domain.' \
   '(domain/|__tests__|\.test\.|\.spec\.)'
 
 # Zod imports forbidden in router files — schemas must be in ~/modules/{domain}/schemas.ts

--- a/.claude/rules/automation.md
+++ b/.claude/rules/automation.md
@@ -34,7 +34,9 @@ Blocks edits containing forbidden patterns:
 | `dangerouslySetInnerHTML` | `.tsx/.jsx` | XSS risk — use safe rendering or DOMPurify |
 | `: any`, `as any` | `.ts/.tsx` (excl. test files) | Use `unknown` with type narrowing |
 | `getFullYear()` | `.ts/.tsx` (excl. `domain/`, tests) | Use `getCurrentYear()` / `getCseYear()` from `~/modules/domain` |
-| `slice(0, 9)` | `.ts/.tsx` (excl. `domain/`, tests) | Use `extractSiren()` from `~/modules/domain` |
+| `slice(0, 9)` / `slice(0,9)` | `.ts/.tsx` (excl. `domain/`, tests) | Use `extractSiren()` from `~/modules/domain` |
+| `substring(0, 9)` / `substring(0,9)` / `substr(0, 9)` / `substr(0,9)` | `.ts/.tsx` (excl. `domain/`, tests) | Use `extractSiren()` from `~/modules/domain` |
+| `.getMonth()` / `.getDate()` | `.ts/.tsx` (excl. `domain/`, tests) | Use campaign date helpers from `~/modules/domain` |
 | `from "zod"` | `routers/*.ts`, `.tsx` (excl. tests) | Import schemas from `~/modules/{domain}/schemas.ts` |
 | `#hex`, `rgb()`, `rgba()` | `.scss` | Use DSFR CSS custom properties |
 | Non-route `.tsx` in `src/app/` | `src/app/**/*.tsx` | Move to `src/modules/` and import from barrel |
@@ -105,9 +107,11 @@ Apply these rules **as you write code**, before any agent runs:
 **Domain layer:**
 
 - No `new Date().getFullYear()` → use `getCurrentYear()` or `getCseYear()` from `~/modules/domain`
-- No `siret.slice(0, 9)` → use `extractSiren(siret)` from `~/modules/domain`
+- No `siret.slice(0, 9)`, `substring(0, 9)`, or `substr(0, 9)` → use `extractSiren(siret)` from `~/modules/domain`
+- No `.getMonth()` / `.getDate()` in calculations → use campaign date helpers from `~/modules/domain`
 - No hardcoded thresholds (5%, 50, 100) → use named constants from `~/modules/domain`
 - No local `getCurrentYear`/`getCseYear`/`getSiren` function definitions → import from `~/modules/domain`
+- No inline reimplementation of domain helpers: `cancelledAt !== null` → `isCancelled()`, `workforce >= 100` → `isCseRequired()` / `isComplianceProcessRequired()` / `isComplianceProcessRevisionRequired()`
 - New business rules → add to `~/modules/domain` as pure functions with tests
 
 **Security:**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,13 +181,17 @@ domain/
   index.ts        # Barrel — point d'import unique
   types.ts        # GapLevel, DeclarationStatus, …
   shared/
-    constants.ts          # GAP_ALERT_THRESHOLD, MAX_CSE_FILES, COMPANY_SIZE_*
-    gap.ts                # computeGap, gapLevel, formatGap
-    siren.ts              # extractSiren, formatSiren, validateSiren
-    campaign.ts           # getCurrentYear, getCseYear (règles temporelles)
-    declarationStatus.ts  # State machine de statut
-    companySize.ts        # isCseRequired, COMPANY_SIZE_RANGES
-    declarationLock.ts    # DEFAULT_LOCK_TIMEOUT_MINUTES, LOCK_HEARTBEAT_INTERVAL_MS
+    constants.ts            # GAP_ALERT_THRESHOLD, MAX_CSE_FILES, COMPANY_SIZE_*
+    campaign.ts             # getCurrentYear, getCseYear (règles temporelles)
+    companySize.ts          # isCseRequired, COMPANY_SIZE_RANGES
+    declarationFlags.ts     # isComplianceProcessRequired, isComplianceProcessRevisionRequired
+    declarationLock.ts      # DEFAULT_LOCK_TIMEOUT_MINUTES, LOCK_HEARTBEAT_INTERVAL_MS
+    declarationStatus.ts    # computeDeclarationStatus, isCancelled, isDeclarationSubmitted
+    gap.ts                  # computeGap, computeGapBetween, computeGapRatio, gapLevel, formatGap
+    percentage.ts           # percentageOf, proportionOf
+    siren.ts                # extractSiren, formatSiren, validateSiren
+    workforce.ts            # computeWorkforceTotal, sumQuartileWorkforce, sumCategoryWorkforce
+    …                       # (submissionRate, quartile, regions, number, format, …)
   __tests__/      # 100% coverage sur toutes les fonctions
 ```
 
@@ -196,18 +200,29 @@ domain/
 - Les règles changent peu souvent mais sont **critiques** (un bug ici impacte 100% des déclarations).
 - Centraliser permet de **tester exhaustivement** sans monter une page.
 - Les contraintes du règlement (seuils, calendriers) sont **lisibles à un endroit unique**, ce qui simplifie l'audit métier.
+- La source unique évite les divergences silencieuses entre le wizard, l'export et les routers tRPC.
 
-Hooks de garde :
+Hooks de garde — le hook `block-bad-patterns` bloque les patterns suivants en dehors de `domain/` et des tests :
 
-- `block-bad-patterns` rejette `new Date().getFullYear()` en dehors de `domain/` → forcer `getCurrentYear()`.
-- Idem pour `siret.slice(0, 9)` → forcer `extractSiren(siret)`.
-- Idem pour les seuils 5 / 50 / 100 hardcodés → forcer les constantes nommées.
+| Pattern bloqué | Alternative obligatoire |
+|---|---|
+| `new Date().getFullYear()` | `getCurrentYear()` / `getCseYear()` depuis `~/modules/domain` |
+| `siret.slice(0, 9)`, `.substring(0, 9)`, `.substr(0, 9)` | `extractSiren(siret)` depuis `~/modules/domain` |
+| `.getMonth()` / `.getDate()` | helpers de campagne depuis `~/modules/domain` |
+| `cancelledAt !== null` (réimplémentation de `isCancelled`) | `isCancelled({ cancelledAt })` depuis `~/modules/domain` |
+| `workforce >= 100` (réimplémentation de `isCseRequired`) | `isCseRequired(workforce)` / `isComplianceProcessRequired(...)` depuis `~/modules/domain` |
+| Seuils hardcodés (5, 50, 100) | constantes nommées (`GAP_ALERT_THRESHOLD`, `COMPANY_SIZE_ANNUAL_MIN`, …) |
 
 Toujours importer depuis le barrel :
 
 ```ts
-import { getCurrentYear, GAP_ALERT_THRESHOLD, isCseRequired } from "~/modules/domain";
-import { DEFAULT_LOCK_TIMEOUT_MINUTES, LOCK_HEARTBEAT_INTERVAL_MS } from "~/modules/domain";
+import {
+  getCurrentYear, GAP_ALERT_THRESHOLD,
+  isCseRequired, isCancelled, isDeclarationSubmitted,
+  isComplianceProcessRequired, isComplianceProcessRevisionRequired,
+  computeWorkforceTotal, sumQuartileWorkforce,
+  percentageOf, proportionOf,
+} from "~/modules/domain";
 ```
 
 ---

--- a/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { getCurrentYear } from "~/modules/domain";
+import { getCurrentYear, isCancelled } from "~/modules/domain";
 import { useDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 
@@ -26,7 +26,7 @@ export function CancelDeclarationButton({
 	year,
 	cancelledAt,
 }: Props) {
-	if (cancelledAt !== null || year !== getCurrentYear()) {
+	if (isCancelled({ cancelledAt }) || year !== getCurrentYear()) {
 		return null;
 	}
 

--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { formatShortDate } from "~/modules/domain";
+import { formatShortDate, isCancelled } from "~/modules/domain";
 import { DsfrTable } from "~/modules/shared/DsfrTable";
 import { Pagination } from "~/modules/shared/Pagination";
 import { useSortableTable } from "~/modules/shared/useSortableTable";
@@ -79,7 +79,7 @@ export function DeclarationTable({
 							</td>
 							<td>{row.year}</td>
 							<td>
-								{row.cancelledAt !== null ? (
+								{isCancelled(row) ? (
 									<span className="fr-badge fr-badge--warning">Annulée</span>
 								) : (
 									(STATUS_LABELS[row.status ?? ""] ?? row.status)

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { formatShortDateTime } from "~/modules/domain";
+import { formatShortDateTime, isCancelled } from "~/modules/domain";
 import { STATUS_LABELS } from "./shared/constants";
 
 type Sibling = {
@@ -31,7 +31,7 @@ export function SiblingDeclarationsSection({ siblings }: Props) {
 							{formatShortDateTime(sibling.updatedAt)}
 						</Link>
 						{" — "}
-						{sibling.cancelledAt !== null ? (
+						{isCancelled(sibling) ? (
 							<span className="fr-badge fr-badge--warning">Annulée</span>
 						) : (
 							(STATUS_LABELS[sibling.status] ?? sibling.status)

--- a/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/CancelDeclarationButton.test.tsx
@@ -7,9 +7,13 @@ const { mockMutate, mockOpen, mockClose } = vi.hoisted(() => ({
 	mockClose: vi.fn(),
 }));
 
-vi.mock("~/modules/domain", () => ({
-	getCurrentYear: () => 2026,
-}));
+vi.mock("~/modules/domain", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/domain")>();
+	return {
+		...actual,
+		getCurrentYear: () => 2026,
+	};
+});
 
 vi.mock("~/modules/shared", () => ({
 	useDsfrModal: () => ({

--- a/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
@@ -11,9 +11,10 @@ import {
 	YAxis,
 } from "recharts";
 
-import { formatMonthDay } from "~/modules/domain";
+import { formatMonthDay, percentageOf } from "~/modules/domain";
 
 import styles from "./CampaignProgressionChart.module.scss";
+import { formatCount } from "./formatters";
 import type { CampaignProgressionSeries } from "./types";
 
 type TooltipEntry = {
@@ -102,11 +103,11 @@ function ProgressionTooltip({
 					if (entry.value == null) return null;
 					const year = Number(entry.name);
 					const total = totals[year] ?? 0;
-					const pct = total > 0 ? Math.round((entry.value / total) * 100) : 0;
+					const pct = Math.round(percentageOf(entry.value, total));
 					return (
 						<li className={styles.tooltipItem} key={entry.name}>
-							{year} : {entry.value.toLocaleString("fr-FR")} déclarations ({pct}{" "}
-							% du total)
+							{year} : {formatCount(entry.value)} déclarations ({pct} % du
+							total)
 						</li>
 					);
 				})}
@@ -146,9 +147,7 @@ export function CampaignProgressionChart({ series, currentYear }: Props) {
 						interval={6}
 						tickFormatter={(value: string) => formatMonthDay(value)}
 					/>
-					<YAxis
-						tickFormatter={(value: number) => value.toLocaleString("fr-FR")}
-					/>
+					<YAxis tickFormatter={(value: number) => formatCount(value)} />
 					<Tooltip content={<ProgressionTooltip totals={totals} />} />
 					<Legend />
 					{series.map(({ year }) => (

--- a/packages/app/src/modules/admin/stats/CampaignProgressionTable.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionTable.tsx
@@ -1,5 +1,6 @@
 import { formatMonthDay } from "~/modules/domain";
 
+import { formatCount } from "./formatters";
 import type { CampaignProgressionSeries } from "./types";
 
 type Props = {
@@ -63,9 +64,7 @@ export function CampaignProgressionTable({ series }: Props) {
 												const value = byDayByYear.get(year)?.get(key);
 												return (
 													<td key={year}>
-														{value != null
-															? value.toLocaleString("fr-FR")
-															: "—"}
+														{value != null ? formatCount(value) : "—"}
 													</td>
 												);
 											})}

--- a/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelChart.tsx
@@ -12,6 +12,7 @@ import ReactECharts from "echarts-for-react/lib/core";
 import { useEffect, useState } from "react";
 
 import styles from "./CompletionFunnelChart.module.scss";
+import { formatCount } from "./formatters";
 import type { FunnelRow } from "./types";
 
 echarts.use([
@@ -119,10 +120,6 @@ export function pickFunnelColor(
 	}
 	const colors = dsfrPalette.palette;
 	return colors[index % colors.length] as string;
-}
-
-function formatCount(value: number): string {
-	return value.toLocaleString("fr-FR");
 }
 
 export function isAboveThreshold(

--- a/packages/app/src/modules/admin/stats/CompletionFunnelTable.tsx
+++ b/packages/app/src/modules/admin/stats/CompletionFunnelTable.tsx
@@ -1,3 +1,4 @@
+import { formatCount } from "./formatters";
 import type { FunnelRow } from "./types";
 
 type Props = {
@@ -41,7 +42,7 @@ export function CompletionFunnelTable({ rows, caption }: Props) {
 									{rows.map((row) => (
 										<tr key={row.key}>
 											<th scope="row">{row.label}</th>
-											<td>{row.count.toLocaleString("fr-FR")}</td>
+											<td>{formatCount(row.count)}</td>
 											<td>{row.pctOfStart} %</td>
 											<td>{formatDrop(row.pctDropFromPrev)}</td>
 										</tr>

--- a/packages/app/src/modules/admin/stats/StatsBarTable.tsx
+++ b/packages/app/src/modules/admin/stats/StatsBarTable.tsx
@@ -1,3 +1,5 @@
+import { formatCount } from "./formatters";
+
 export type StatsTableColumn<Row> = {
 	key: Extract<keyof Row, string>;
 	label: string;
@@ -11,7 +13,7 @@ type Props<Row extends { key: string; label: string }> = {
 };
 
 function formatValue(value: unknown): string {
-	if (typeof value === "number") return value.toLocaleString("fr-FR");
+	if (typeof value === "number") return formatCount(value);
 	if (typeof value === "string") return value;
 	return "0";
 }

--- a/packages/app/src/modules/admin/stats/__tests__/CampaignProgressionChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/CampaignProgressionChart.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { cloneElement, isValidElement } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CampaignProgressionSeries } from "../types";
 
@@ -19,6 +19,14 @@ let capturedYAxisTickFormatter: ((value: number) => string) | undefined;
 let capturedXAxisTickFormatter: ((value: string) => string) | undefined;
 const capturedLineStrokes: Record<string, string> = {};
 const tooltipProbe: TooltipContentProps = {};
+
+beforeEach(() => {
+	capturedYAxisTickFormatter = undefined;
+	capturedXAxisTickFormatter = undefined;
+	for (const key of Object.keys(capturedLineStrokes)) {
+		delete capturedLineStrokes[key];
+	}
+});
 
 vi.mock("recharts", () => ({
 	ResponsiveContainer: ({ children }: { children: ReactElement }) => children,
@@ -74,12 +82,12 @@ function renderWithTooltip(
 	probe: TooltipContentProps,
 	series: CampaignProgressionSeries[] = SERIES,
 ) {
-	Object.assign(tooltipProbe, {
-		active: undefined,
-		label: undefined,
-		payload: undefined,
-		...probe,
-	});
+	for (const key of Object.keys(
+		tooltipProbe,
+	) as (keyof TooltipContentProps)[]) {
+		delete tooltipProbe[key];
+	}
+	Object.assign(tooltipProbe, probe);
 	return render(
 		<CampaignProgressionChart currentYear={2026} series={series} />,
 	);

--- a/packages/app/src/modules/admin/stats/__tests__/CampaignProgressionChart.test.tsx
+++ b/packages/app/src/modules/admin/stats/__tests__/CampaignProgressionChart.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { cloneElement, isValidElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CampaignProgressionSeries } from "../types";
+
+type TooltipContentProps = {
+	active?: boolean;
+	label?: string | number;
+	payload?: Array<{ name?: string | number; value?: number }>;
+};
+
+// Recharts never mounts under jsdom (no layout), so drive the internals directly:
+// render the Tooltip `content` with a controlled active payload, invoke the
+// axis `tickFormatter`s and record each Line's stroke, mirroring how
+// ScoreDistributionChart is tested.
+let capturedYAxisTickFormatter: ((value: number) => string) | undefined;
+let capturedXAxisTickFormatter: ((value: string) => string) | undefined;
+const capturedLineStrokes: Record<string, string> = {};
+const tooltipProbe: TooltipContentProps = {};
+
+vi.mock("recharts", () => ({
+	ResponsiveContainer: ({ children }: { children: ReactElement }) => children,
+	LineChart: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="line-chart">{children}</div>
+	),
+	CartesianGrid: () => null,
+	Legend: () => null,
+	Line: ({ name, stroke }: { name: string; stroke: string }) => {
+		capturedLineStrokes[name] = stroke;
+		return null;
+	},
+	XAxis: ({ tickFormatter }: { tickFormatter?: (value: string) => string }) => {
+		capturedXAxisTickFormatter = tickFormatter;
+		return null;
+	},
+	YAxis: ({ tickFormatter }: { tickFormatter?: (value: number) => string }) => {
+		capturedYAxisTickFormatter = tickFormatter;
+		return null;
+	},
+	Tooltip: ({ content }: { content: ReactElement<TooltipContentProps> }) =>
+		isValidElement(content)
+			? cloneElement(content, {
+					active: tooltipProbe.active,
+					label: tooltipProbe.label,
+					payload: tooltipProbe.payload,
+				})
+			: null,
+}));
+
+const { CampaignProgressionChart } = await import(
+	"../CampaignProgressionChart"
+);
+
+const SERIES: CampaignProgressionSeries[] = [
+	{
+		year: 2025,
+		points: [
+			{ day: "2025-02-10", cumulative: 40 },
+			{ day: "2025-02-15", cumulative: 200 },
+		],
+	},
+	{
+		year: 2026,
+		points: [
+			{ day: "2026-02-12", cumulative: 30 },
+			{ day: "2026-02-15", cumulative: 7842 },
+		],
+	},
+];
+
+function renderWithTooltip(
+	probe: TooltipContentProps,
+	series: CampaignProgressionSeries[] = SERIES,
+) {
+	Object.assign(tooltipProbe, {
+		active: undefined,
+		label: undefined,
+		payload: undefined,
+		...probe,
+	});
+	return render(
+		<CampaignProgressionChart currentYear={2026} series={series} />,
+	);
+}
+
+describe("CampaignProgressionChart", () => {
+	it("shows an empty state when no series produce any day", () => {
+		render(<CampaignProgressionChart currentYear={2026} series={[]} />);
+		expect(screen.getByText(/Aucune donnée/)).toBeInTheDocument();
+	});
+
+	it("renders an accessible figcaption alongside the chart", () => {
+		const { container } = renderWithTooltip({});
+		expect(container.querySelector("figure")).not.toBeNull();
+		expect(container.querySelector("figcaption")?.textContent).toMatch(
+			/progression cumulative/i,
+		);
+	});
+});
+
+describe("CampaignProgressionChart Y axis", () => {
+	it("formats ticks identically to the French locale (iso-render)", () => {
+		renderWithTooltip({});
+		expect(capturedYAxisTickFormatter?.(7842)).toBe(
+			(7842).toLocaleString("fr-FR"),
+		);
+	});
+
+	it("formats zero as '0'", () => {
+		renderWithTooltip({});
+		expect(capturedYAxisTickFormatter?.(0)).toBe("0");
+	});
+});
+
+describe("CampaignProgressionChart X axis", () => {
+	it("formats MM-DD ticks as a day/month label", () => {
+		renderWithTooltip({});
+		expect(capturedXAxisTickFormatter?.("02-15")).toBe("15/02");
+	});
+});
+
+describe("CampaignProgressionChart line colors", () => {
+	it("draws the current year, the previous year and older years each with its own color", () => {
+		renderWithTooltip({}, [
+			{ year: 2024, points: [{ day: "2024-02-15", cumulative: 10 }] },
+			{ year: 2025, points: [{ day: "2025-02-15", cumulative: 20 }] },
+			{ year: 2026, points: [{ day: "2026-02-15", cumulative: 30 }] },
+		]);
+		expect(capturedLineStrokes["2026"]).not.toBe(capturedLineStrokes["2025"]);
+		expect(capturedLineStrokes["2025"]).not.toBe(capturedLineStrokes["2024"]);
+		expect(capturedLineStrokes["2026"]).not.toBe(capturedLineStrokes["2024"]);
+	});
+});
+
+describe("CampaignProgressionChart tooltip", () => {
+	it("renders nothing when inactive", () => {
+		renderWithTooltip({
+			active: false,
+			label: "02-15",
+			payload: [{ name: "2026", value: 7842 }],
+		});
+		expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+	});
+
+	it("renders nothing when the payload is empty", () => {
+		renderWithTooltip({ active: true, label: "02-15", payload: [] });
+		expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+	});
+
+	it("renders nothing when the label is not a string", () => {
+		renderWithTooltip({
+			active: true,
+			label: 42,
+			payload: [{ name: "2026", value: 7842 }],
+		});
+		expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+	});
+
+	it("formats the count and the rounded share of the year total", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-15",
+			payload: [
+				{ name: "2025", value: 200 },
+				{ name: "2026", value: 7842 },
+			],
+		});
+		expect(
+			screen.getByText(/7 842 déclarations \(100 % du total\)/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/2025 : 200 déclarations \(100 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("rounds the share to the nearest integer", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-12",
+			// 30 / 7842 total ≈ 0.38 % -> rounds to 0 %
+			payload: [{ name: "2026", value: 30 }],
+		});
+		expect(
+			screen.getByText(/30 déclarations \(0 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("falls back to 0 % when the year has no known total", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-15",
+			payload: [{ name: "2099", value: 5 }],
+		});
+		expect(
+			screen.getByText(/5 déclarations \(0 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("treats a year with no data points as a zero total", () => {
+		renderWithTooltip(
+			{
+				active: true,
+				label: "02-15",
+				payload: [{ name: "2025", value: 4 }],
+			},
+			[
+				{ year: 2025, points: [] },
+				{ year: 2026, points: [{ day: "2026-02-15", cumulative: 30 }] },
+			],
+		);
+		expect(
+			screen.getByText(/2025 : 4 déclarations \(0 % du total\)/),
+		).toBeInTheDocument();
+	});
+
+	it("skips entries whose value is null", () => {
+		renderWithTooltip({
+			active: true,
+			label: "02-15",
+			payload: [
+				{ name: "2025", value: undefined },
+				{ name: "2026", value: 7842 },
+			],
+		});
+		const items = screen.getAllByRole("listitem");
+		expect(items).toHaveLength(1);
+		// \s matches the U+202F narrow-no-break-space the fr-FR locale emits
+		expect(items[0]?.textContent).toMatch(/7\s842 déclarations/);
+	});
+});

--- a/packages/app/src/modules/admin/stats/formatters.ts
+++ b/packages/app/src/modules/admin/stats/formatters.ts
@@ -1,3 +1,5 @@
+export { formatCount } from "~/modules/domain";
+
 type WithUnitOption = {
 	withUnit?: boolean;
 };
@@ -11,10 +13,6 @@ export function formatPercent(
 		minimumFractionDigits: 1,
 	});
 	return withUnit ? `${formatted} %` : formatted;
-}
-
-export function formatCount(value: number): string {
-	return value.toLocaleString("fr-FR");
 }
 
 export function formatDecimal(value: number): string {

--- a/packages/app/src/modules/cseOpinion/__tests__/confirmationHelpers.test.ts
+++ b/packages/app/src/modules/cseOpinion/__tests__/confirmationHelpers.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 import { isDeclarationSubmitted } from "../confirmationHelpers";
 
 describe("isDeclarationSubmitted", () => {
-	it("returns true when status is 'submitted'", () => {
-		expect(isDeclarationSubmitted("submitted")).toBe(true);
+	it("returns true when status is a non-draft FSM status", () => {
+		expect(isDeclarationSubmitted("demarche_completed")).toBe(true);
 	});
 
 	it("returns false when status is null", () => {

--- a/packages/app/src/modules/cseOpinion/confirmationHelpers.ts
+++ b/packages/app/src/modules/cseOpinion/confirmationHelpers.ts
@@ -1,3 +1,1 @@
-export function isDeclarationSubmitted(status: string | null): boolean {
-	return status !== null && status !== "draft";
-}
+export { isDeclarationSubmitted } from "~/modules/domain";

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -1,7 +1,9 @@
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import {
 	computeGap,
+	computeGapBetween,
 	computeTotal,
+	computeWorkforceTotal,
 	formatCurrency,
 	formatGap,
 	formatTotal,
@@ -34,7 +36,7 @@ export function CategoryRecapTable({
 }: Props) {
 	const womenCount = category.womenCount ?? 0;
 	const menCount = category.menCount ?? 0;
-	const totalSalaries = womenCount + menCount;
+	const totalSalaries = computeWorkforceTotal(womenCount, menCount);
 
 	const annualWomenSum = computeTotal(
 		category.annualBaseWomen ?? "",
@@ -63,8 +65,8 @@ export function CategoryRecapTable({
 		category.annualVariableMen ?? "",
 	);
 	const annualTotalGap =
-		annualWomenSum !== null && annualMenSum !== null && annualMenSum !== 0
-			? Math.abs(((annualMenSum - annualWomenSum) / annualMenSum) * 100)
+		annualWomenSum !== null && annualMenSum !== null
+			? computeGapBetween(annualWomenSum, annualMenSum)
 			: null;
 
 	const hourlyBaseGap = computeGap(
@@ -76,8 +78,8 @@ export function CategoryRecapTable({
 		category.hourlyVariableMen ?? "",
 	);
 	const hourlyTotalGap =
-		hourlyWomenSum !== null && hourlyMenSum !== null && hourlyMenSum !== 0
-			? Math.abs(((hourlyMenSum - hourlyWomenSum) / hourlyMenSum) * 100)
+		hourlyWomenSum !== null && hourlyMenSum !== null
+			? computeGapBetween(hourlyWomenSum, hourlyMenSum)
 			: null;
 
 	const heading = `Catégorie d'emplois n°${index + 1}${category.name ? ` : ${category.name}` : ""}`;

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
@@ -6,9 +6,11 @@ import type {
 import {
 	computeGap,
 	computePercentage,
+	computeWorkforceTotal,
 	formatCurrency,
 	formatGap,
 	GAP_ALERT_THRESHOLD,
+	sumQuartileWorkforce,
 } from "~/modules/domain";
 import styles from "./IndicatorTables.module.scss";
 
@@ -114,7 +116,7 @@ function WorkforceTable({
 	totalWomen: number | null;
 	totalMen: number | null;
 }) {
-	const total = (totalWomen ?? 0) + (totalMen ?? 0);
+	const total = computeWorkforceTotal(totalWomen ?? 0, totalMen ?? 0);
 	return (
 		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
 			<div className="fr-table__wrapper">
@@ -165,7 +167,7 @@ function ProportionTable({
 	const eMen = Number.parseInt(indicatorEMen, 10);
 	const tWomen = totalWomen ?? 0;
 	const tMen = totalMen ?? 0;
-	const grandTotal = tWomen + tMen;
+	const grandTotal = computeWorkforceTotal(tWomen, tMen);
 	return (
 		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
 			<div className="fr-table__wrapper">
@@ -251,9 +253,11 @@ function QuartileDistributionTable({
 		(q) => q.threshold !== "" || q.women !== undefined || q.men !== undefined,
 	);
 	if (!hasData) return null;
-	const totalWomen = quartiles.reduce((s, q) => s + (q.women ?? 0), 0);
-	const totalMen = quartiles.reduce((s, q) => s + (q.men ?? 0), 0);
-	const total = totalWomen + totalMen;
+	const {
+		women: totalWomen,
+		men: totalMen,
+		total,
+	} = sumQuartileWorkforce(quartiles);
 
 	function fmt(value: string | undefined) {
 		if (!value) return "-";
@@ -309,7 +313,10 @@ function QuartileDistributionTable({
 											i === 0 ? "0" : (quartiles[i - 1]?.threshold ?? "");
 										const min = i === 0 ? `0 ${unit}` : fmt(prev);
 										const max = i === 3 ? "-" : fmt(q.threshold);
-										const lineTotal = (q.women ?? 0) + (q.men ?? 0);
+										const lineTotal = computeWorkforceTotal(
+											q.women ?? 0,
+											q.men ?? 0,
+										);
 										return (
 											<tr key={QUARTILE_LABELS[i]}>
 												<th scope="row">{QUARTILE_LABELS[i]}</th>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
@@ -28,6 +28,13 @@ function effectifCells() {
 	return within(row).getAllByRole("cell");
 }
 
+function totalRowGapCell() {
+	const rows = screen
+		.getAllByRole("rowheader", { name: "Total" })
+		.map((th) => th.parentElement as HTMLElement);
+	return rows.map((row) => within(row).getAllByRole("cell").at(-1));
+}
+
 describe("CategoryRecapTable", () => {
 	it("suffixes the 'Effectif physique' counts with 'nb'", () => {
 		render(
@@ -139,5 +146,22 @@ describe("CategoryRecapTable", () => {
 		// Hourly total gap: |((22 - 19) / 22) * 100| = 13,6 % → élevé.
 		expect(screen.getAllByText("élevé").length).toBeGreaterThanOrEqual(2);
 		expect(screen.getAllByRole("row").length).toBeGreaterThan(0);
+	});
+
+	it("renders '-' for the total gap when the men total is zero", () => {
+		render(
+			<CategoryRecapTable
+				category={makeCategory({
+					annualBaseWomen: "1000",
+					annualBaseMen: "0",
+				})}
+				declarationYear={2025}
+				index={0}
+			/>,
+		);
+		const [annualTotalGapCell, hourlyTotalGapCell] = totalRowGapCell();
+		expect(annualTotalGapCell).toHaveTextContent("-");
+		expect(annualTotalGapCell).not.toHaveTextContent("%");
+		expect(hourlyTotalGapCell).toHaveTextContent("-");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -235,6 +235,44 @@ describe("RecapitulatifPage", () => {
 		).toBeGreaterThanOrEqual(1);
 	});
 
+	it("locks the computed quartile percentages and grand totals (iso-behaviour)", () => {
+		render(
+			<RecapitulatifPage
+				{...defaultProps()}
+				step4Data={{
+					annual: [
+						{ threshold: "20700.35", women: 30, men: 60 },
+						{ threshold: "25750.99", women: 40, men: 30 },
+						{ threshold: "34900.99", women: 24, men: 31 },
+						{ threshold: "", women: 15, men: 26 },
+					],
+					hourly: [
+						{ threshold: "10", women: 30, men: 60 },
+						{ threshold: "15", women: 40, men: 30 },
+						{ threshold: "20", women: 24, men: 31 },
+						{ threshold: "", women: 15, men: 26 },
+					],
+				}}
+			/>,
+		);
+		for (const pct of [
+			"33,3 %",
+			"66,7 %",
+			"57,1 %",
+			"42,9 %",
+			"43,6 %",
+			"56,4 %",
+			"36,6 %",
+			"63,4 %",
+			"42,6 %",
+			"57,4 %",
+		]) {
+			expect(screen.getAllByText(pct)).toHaveLength(2);
+		}
+		expect(screen.getAllByText("109")).toHaveLength(2);
+		expect(screen.getAllByText("147")).toHaveLength(2);
+	});
+
 	it("renders one category table per step5 category with matching heading", () => {
 		render(
 			<RecapitulatifPage

--- a/packages/app/src/modules/declaration-remuneration/shared/computeIndicatorPercentages.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/computeIndicatorPercentages.ts
@@ -1,4 +1,8 @@
-import { computeGapRatio } from "~/modules/domain";
+import {
+	computeGapRatio,
+	computeWorkforceTotal,
+	proportionOf,
+} from "~/modules/domain";
 
 type DeclarationRowSubset = {
 	indicatorAAnnualWomen: string | null;
@@ -76,11 +80,11 @@ function proportionFromCounts(
 	men: number | null,
 ): { women: number | null; men: number | null } {
 	if (women === null || men === null) return { women: null, men: null };
-	const total = women + men;
+	const total = computeWorkforceTotal(women, men);
 	if (total === 0) return { women: null, men: null };
 	return {
-		women: Math.round((women / total) * 10_000) / 10_000,
-		men: Math.round((men / total) * 10_000) / 10_000,
+		women: Math.round(proportionOf(women, total) * 10_000) / 10_000,
+		men: Math.round(proportionOf(men, total) * 10_000) / 10_000,
 	};
 }
 
@@ -92,11 +96,11 @@ function proportionFromStrings(
 	const w = Number(women);
 	const m = Number(men);
 	if (Number.isNaN(w) || Number.isNaN(m)) return { women: null, men: null };
-	const total = w + m;
+	const total = computeWorkforceTotal(w, m);
 	if (total === 0) return { women: null, men: null };
 	return {
-		women: w / total,
-		men: m / total,
+		women: proportionOf(w, total),
+		men: proportionOf(m, total),
 	};
 }
 

--- a/packages/app/src/modules/declaration-remuneration/shared/gipMdsMapping.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/gipMdsMapping.ts
@@ -1,3 +1,4 @@
+import { computeWorkforceTotal, QUARTILE_COUNT } from "~/modules/domain";
 import type { gipMdsData } from "~/server/db/schema";
 
 /**
@@ -269,8 +270,8 @@ function buildQuartileData(
 	],
 	menProportions: [string | null, string | null, string | null, string | null],
 ): GipQuartileData {
-	const totalAll = (totalWomen ?? 0) + (totalMen ?? 0);
-	const quartileSize = totalAll > 0 ? Math.round(totalAll / 4) : 0;
+	const totalAll = computeWorkforceTotal(totalWomen ?? 0, totalMen ?? 0);
+	const quartileSize = totalAll > 0 ? Math.round(totalAll / QUARTILE_COUNT) : 0;
 
 	return {
 		thresholds,

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
+import { computeWorkforceTotal } from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep1Schema } from "../schemas";
@@ -78,7 +79,7 @@ export function Step1Workforce({
 
 	const totalWomen = form.watch("totalWomen");
 	const totalMen = form.watch("totalMen");
-	const total = totalWomen + totalMen;
+	const total = computeWorkforceTotal(totalWomen, totalMen);
 
 	const [womenRaw, setWomenRaw] = useState(() =>
 		initialData.totalWomen > 0 ? String(initialData.totalWomen) : "",

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -1,7 +1,10 @@
 import { notFound, redirect } from "next/navigation";
 
 import { campaignYearDimension, FunnelStepTracker } from "~/modules/analytics";
-import { shouldRedirectSubmittedToRecap } from "~/modules/domain";
+import {
+	formatShortDate,
+	shouldRedirectSubmittedToRecap,
+} from "~/modules/domain";
 import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
 import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { api, HydrateClient } from "~/trpc/server";
@@ -57,9 +60,11 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 
 	const initialSource = data.jobCategories[0]?.source;
 
-	const declarationDate = data.declaration.updatedAt
-		? new Date(data.declaration.updatedAt).toLocaleDateString("fr-FR")
-		: new Date().toLocaleDateString("fr-FR");
+	const declarationDate = formatShortDate(
+		data.declaration.updatedAt
+			? new Date(data.declaration.updatedAt)
+			: new Date(),
+	);
 
 	const stepTracker = (
 		<FunnelStepTracker

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { QuartileTuple } from "~/modules/declaration-remuneration/types";
-import { computePercentage } from "~/modules/domain";
+import { computePercentage, sumQuartileWorkforce } from "~/modules/domain";
 import stepStyles from "../Step4QuartileDistribution.module.scss";
 import { QuartileTableRow } from "./QuartileTableRow";
 
@@ -42,9 +42,11 @@ export function QuartileTable({
 	onQuartileChange,
 	disabled = false,
 }: Props) {
-	const totalWomen = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
-	const totalMen = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
-	const totalAll = totalWomen + totalMen;
+	const {
+		women: totalWomen,
+		men: totalMen,
+		total: totalAll,
+	} = sumQuartileWorkforce(quartiles);
 	const trancheSuffix =
 		tableType === "annual" ? "annuelle brute" : "horaire brute";
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -4,6 +4,7 @@ import common from "~/modules/declaration-remuneration/shared/common.module.scss
 import {
 	computeGap,
 	computeTotal,
+	computeWorkforceTotal,
 	displayDecimal,
 	formatTotal,
 } from "~/modules/domain";
@@ -205,7 +206,9 @@ export function CategoryDataTable({
 	const womenInt = cat.womenCount ? Number.parseInt(cat.womenCount, 10) : NaN;
 	const menInt = cat.menCount ? Number.parseInt(cat.menCount, 10) : NaN;
 	const totalEmployees =
-		!Number.isNaN(womenInt) && !Number.isNaN(menInt) ? womenInt + menInt : null;
+		!Number.isNaN(womenInt) && !Number.isNaN(menInt)
+			? computeWorkforceTotal(womenInt, menInt)
+			: null;
 
 	const idPrefix = `cat-${catIndex}`;
 	return (

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -22,7 +22,11 @@ import type {
 	EmployeeCategoryRow,
 	EmployeeCategorySubmitData,
 } from "~/modules/declaration-remuneration/types";
-import { padDecimalOnBlur, padDecimalToTwo } from "~/modules/domain";
+import {
+	padDecimalOnBlur,
+	padDecimalToTwo,
+	sumCategoryWorkforce,
+} from "~/modules/domain";
 import { getDsfrCollapse } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import stepStyles from "../Step5EmployeeCategories.module.scss";
@@ -304,15 +308,8 @@ export function CategoryForm({
 		}
 
 		if (maxWomen !== undefined || maxMen !== undefined) {
-			const totalWomen = data.categories.reduce(
-				(sum, cat) =>
-					sum + (cat.womenCount ? Number.parseInt(cat.womenCount, 10) : 0),
-				0,
-			);
-			const totalMen = data.categories.reduce(
-				(sum, cat) =>
-					sum + (cat.menCount ? Number.parseInt(cat.menCount, 10) : 0),
-				0,
+			const { women: totalWomen, men: totalMen } = sumCategoryWorkforce(
+				data.categories,
 			);
 
 			const errors: string[] = [];

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/QuartileColumn.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/QuartileColumn.tsx
@@ -1,3 +1,4 @@
+import { computeWorkforceTotal, percentageOf } from "~/modules/domain";
 import stepStyles from "../Step6Review.module.scss";
 
 type Props = {
@@ -13,8 +14,8 @@ export function QuartileColumn({ title, quartiles }: Props) {
 			<p className="fr-text--sm fr-mb-0">Pourcentage de femmes</p>
 			<div className={stepStyles.subSection}>
 				{quartiles.map((q) => {
-					const total = q.womenCount + q.menCount || 1;
-					const pct = ((q.womenCount / total) * 100).toFixed(1);
+					const total = computeWorkforceTotal(q.womenCount, q.menCount) || 1;
+					const pct = percentageOf(q.womenCount, total).toFixed(1);
 					return (
 						<div className={stepStyles.flex1} key={`f-${q.label}`}>
 							<p className="fr-text--sm fr-mb-0">{q.label}</p>
@@ -27,8 +28,8 @@ export function QuartileColumn({ title, quartiles }: Props) {
 			<p className="fr-text--sm fr-mb-0 fr-mt-1w">Pourcentage d&apos;hommes</p>
 			<div className={stepStyles.subSection}>
 				{quartiles.map((q) => {
-					const total = q.womenCount + q.menCount || 1;
-					const pct = ((q.menCount / total) * 100).toFixed(1);
+					const total = computeWorkforceTotal(q.womenCount, q.menCount) || 1;
+					const pct = percentageOf(q.menCount, total).toFixed(1);
 					return (
 						<div className={stepStyles.flex1} key={`m-${q.label}`}>
 							<p className="fr-text--sm fr-mb-0">{q.label}</p>

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -4,7 +4,22 @@ import {
 	computeDeclarationStatus,
 	getCurrentCompliancePath,
 	isCancelled,
+	isDeclarationSubmitted,
 } from "../shared/declarationStatus";
+
+describe("isDeclarationSubmitted", () => {
+	it("returns false when status is null", () => {
+		expect(isDeclarationSubmitted(null)).toBe(false);
+	});
+
+	it("returns false when status is draft", () => {
+		expect(isDeclarationSubmitted("draft")).toBe(false);
+	});
+
+	it("returns true for any non-draft, non-null status", () => {
+		expect(isDeclarationSubmitted("submitted")).toBe(true);
+	});
+});
 
 describe("isCancelled", () => {
 	it("returns false when cancelledAt is null", () => {

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -17,7 +17,10 @@ describe("isDeclarationSubmitted", () => {
 	});
 
 	it("returns true for any non-draft, non-null status", () => {
-		expect(isDeclarationSubmitted("submitted")).toBe(true);
+		expect(isDeclarationSubmitted("awaiting_compliance_path_choice")).toBe(
+			true,
+		);
+		expect(isDeclarationSubmitted("demarche_completed")).toBe(true);
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/gap.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gap.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	computeGap,
+	computeGapBetween,
 	computeGapRatio,
 	computeTotal,
 	gapLevel,
@@ -64,6 +65,24 @@ describe("computeGap", () => {
 	});
 });
 
+describe("computeGapBetween", () => {
+	it("computes the absolute gap as a percentage of the men value", () => {
+		expect(computeGapBetween(90, 100)).toBe(10);
+	});
+
+	it("returns a positive value when women earn more than men", () => {
+		expect(computeGapBetween(110, 100)).toBe(10);
+	});
+
+	it("returns 0 for equal values", () => {
+		expect(computeGapBetween(100, 100)).toBe(0);
+	});
+
+	it("returns null when the men value is zero (division by zero)", () => {
+		expect(computeGapBetween(1, 0)).toBeNull();
+	});
+});
+
 describe("gapLevel", () => {
 	it("returns low for gap below threshold", () => {
 		expect(gapLevel(3)).toBe("low");
@@ -89,6 +108,14 @@ describe("gapLevel", () => {
 describe("computeTotal", () => {
 	it("sums base and variable", () => {
 		expect(computeTotal("100", "50")).toBe(150);
+	});
+
+	it("treats an invalid base as zero when variable is valid", () => {
+		expect(computeTotal("", "50")).toBe(50);
+	});
+
+	it("treats an invalid variable as zero when base is valid", () => {
+		expect(computeTotal("100", "")).toBe(100);
 	});
 
 	it("returns null when both are NaN", () => {

--- a/packages/app/src/modules/domain/__tests__/percentage.test.ts
+++ b/packages/app/src/modules/domain/__tests__/percentage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { percentageOf, proportionOf } from "../shared/percentage";
+
+describe("proportionOf", () => {
+	it("returns the raw ratio of count over total", () => {
+		expect(proportionOf(3, 8)).toBe(0.375);
+	});
+
+	it("stays stable under GIP 4-decimal rounding", () => {
+		expect(Math.round(proportionOf(3, 8) * 10_000) / 10_000).toBe(0.375);
+	});
+
+	it("returns 0 when total is zero (no division by zero)", () => {
+		expect(proportionOf(1, 0)).toBe(0);
+	});
+});
+
+describe("percentageOf", () => {
+	it("returns the ratio expressed as a percentage", () => {
+		expect(percentageOf(1, 4)).toBe(25);
+	});
+
+	it("returns 0 when total is zero (no NaN)", () => {
+		expect(percentageOf(1, 0)).toBe(0);
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/workforce.test.ts
+++ b/packages/app/src/modules/domain/__tests__/workforce.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	computeWorkforceTotal,
+	sumCategoryWorkforce,
+	sumQuartileWorkforce,
+} from "../shared/workforce";
+
+describe("sumQuartileWorkforce", () => {
+	it("sums women and men across quartiles and computes total", () => {
+		expect(
+			sumQuartileWorkforce([
+				{ women: 2, men: 3 },
+				{ women: null, men: 1 },
+			]),
+		).toEqual({ women: 2, men: 4, total: 6 });
+	});
+
+	it("treats missing women/men fields as zero", () => {
+		expect(sumQuartileWorkforce([{}, { women: 5 }, { men: 7 }])).toEqual({
+			women: 5,
+			men: 7,
+			total: 12,
+		});
+	});
+
+	it("returns zeros for an empty quartile list", () => {
+		expect(sumQuartileWorkforce([])).toEqual({ women: 0, men: 0, total: 0 });
+	});
+});
+
+describe("sumCategoryWorkforce", () => {
+	it("sums parsed women and men counts across categories", () => {
+		expect(
+			sumCategoryWorkforce([
+				{ womenCount: "2", menCount: "3" },
+				{ womenCount: "4", menCount: "1" },
+			]),
+		).toEqual({ women: 6, men: 4 });
+	});
+
+	it("treats empty and non-numeric counts as zero", () => {
+		expect(
+			sumCategoryWorkforce([
+				{ womenCount: "", menCount: "abc" },
+				{ womenCount: null, menCount: undefined },
+				{},
+			]),
+		).toEqual({ women: 0, men: 0 });
+	});
+
+	it("returns zeros for an empty category list", () => {
+		expect(sumCategoryWorkforce([])).toEqual({ women: 0, men: 0 });
+	});
+});
+
+describe("computeWorkforceTotal", () => {
+	it("adds women and men", () => {
+		expect(computeWorkforceTotal(12, 8)).toBe(20);
+	});
+
+	it("returns zero when both are zero", () => {
+		expect(computeWorkforceTotal(0, 0)).toBe(0);
+	});
+});

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -62,6 +62,7 @@ export {
 	computeDeclarationStatus,
 	getCurrentCompliancePath,
 	isCancelled,
+	isDeclarationSubmitted,
 } from "./shared/declarationStatus";
 // Declaration steps labels (A–F stepper), post-submit milestones, K19 funnels
 export type {
@@ -123,6 +124,7 @@ export {
 // Gap business rules (calculations & threshold classification)
 export {
 	computeGap,
+	computeGapBetween,
 	computeGapRatio,
 	computeTotal,
 	gapLevel,
@@ -147,6 +149,8 @@ export {
 	padDecimalToTwo,
 	parseNumber,
 } from "./shared/number";
+// Percentage & proportion numeric cores
+export { percentageOf, proportionOf } from "./shared/percentage";
 // Quartile helpers
 export { computeQuartileMin, migrateLegacyThresholds } from "./shared/quartile";
 export type { CountyCode, RegionCode } from "./shared/regions";
@@ -174,6 +178,12 @@ export {
 	NARROW_NBSP,
 	roundOneDecimal,
 } from "./shared/submissionRate";
+// Workforce sums (quartiles, categories)
+export {
+	computeWorkforceTotal,
+	sumCategoryWorkforce,
+	sumQuartileWorkforce,
+} from "./shared/workforce";
 export type {
 	CampaignDeadlines,
 	CompanySize,

--- a/packages/app/src/modules/domain/shared/declarationFlags.ts
+++ b/packages/app/src/modules/domain/shared/declarationFlags.ts
@@ -1,10 +1,8 @@
-import { GAP_ALERT_THRESHOLD } from "./constants";
+import { COMPANY_SIZE_ANNUAL_MIN, GAP_ALERT_THRESHOLD } from "./constants";
 import {
 	type DeclarationStatusEvent,
 	hasSubmittedSecondDeclaration,
 } from "./declarationTrajectory";
-
-const COMPLIANCE_PROCESS_SIZE_MIN = 100;
 
 export type DeclarationForFlags = {
 	rulesVersion: string | null;
@@ -22,7 +20,7 @@ export function isComplianceProcessRequired(
 	if (input.workforce === null) return false;
 	if (input.gap === null) return false;
 	return (
-		input.workforce >= COMPLIANCE_PROCESS_SIZE_MIN &&
+		input.workforce >= COMPANY_SIZE_ANNUAL_MIN &&
 		input.hasIndicatorG &&
 		input.gap >= GAP_ALERT_THRESHOLD
 	);

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -1,8 +1,10 @@
-import type { DeclarationStatus } from "../types";
+import type { DeclarationFsmStatus, DeclarationStatus } from "../types";
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
-export function isDeclarationSubmitted(status: string | null): boolean {
+export function isDeclarationSubmitted(
+	status: DeclarationFsmStatus | null,
+): boolean {
 	return status !== null && status !== "draft";
 }
 

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -2,6 +2,10 @@ import type { DeclarationStatus } from "../types";
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
+export function isDeclarationSubmitted(status: string | null): boolean {
+	return status !== null && status !== "draft";
+}
+
 export function getCurrentCompliancePath(declaration: {
 	firstDeclarationPathChoice: CompliancePath | null;
 	secondDeclarationPathChoice: CompliancePath | null;

--- a/packages/app/src/modules/domain/shared/gap.ts
+++ b/packages/app/src/modules/domain/shared/gap.ts
@@ -38,6 +38,10 @@ export function computeGap(womenVal: string, menVal: string): number | null {
 	return Math.abs(((m - w) / m) * 100);
 }
 
+export function computeGapBetween(women: number, men: number): number | null {
+	return men === 0 ? null : Math.abs(((men - women) / men) * 100);
+}
+
 /** Classify a gap value against the regulatory threshold (5% by default). */
 export function gapLevel(gap: number | null): GapLevel | null {
 	if (gap === null) return null;

--- a/packages/app/src/modules/domain/shared/percentage.ts
+++ b/packages/app/src/modules/domain/shared/percentage.ts
@@ -1,0 +1,7 @@
+export function proportionOf(count: number, total: number): number {
+	return total === 0 ? 0 : count / total;
+}
+
+export function percentageOf(count: number, total: number): number {
+	return total === 0 ? 0 : (count / total) * 100;
+}

--- a/packages/app/src/modules/domain/shared/workforce.ts
+++ b/packages/app/src/modules/domain/shared/workforce.ts
@@ -1,0 +1,27 @@
+export function sumQuartileWorkforce(
+	quartiles: { women?: number | null; men?: number | null }[],
+): { women: number; men: number; total: number } {
+	const women = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
+	const men = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
+	return { women, men, total: women + men };
+}
+
+export function sumCategoryWorkforce(
+	categories: { womenCount?: string | null; menCount?: string | null }[],
+): { women: number; men: number } {
+	const parse = (value?: string | null): number => {
+		const n = Number.parseInt(value ?? "", 10);
+		return Number.isNaN(n) ? 0 : n;
+	};
+	return categories.reduce(
+		(sum, category) => ({
+			women: sum.women + parse(category.womenCount),
+			men: sum.men + parse(category.menCount),
+		}),
+		{ women: 0, men: 0 },
+	);
+}
+
+export function computeWorkforceTotal(women: number, men: number): number {
+	return women + men;
+}

--- a/packages/app/src/modules/domain/shared/workforce.ts
+++ b/packages/app/src/modules/domain/shared/workforce.ts
@@ -1,8 +1,13 @@
 export function sumQuartileWorkforce(
 	quartiles: { women?: number | null; men?: number | null }[],
 ): { women: number; men: number; total: number } {
-	const women = quartiles.reduce((sum, q) => sum + (q.women ?? 0), 0);
-	const men = quartiles.reduce((sum, q) => sum + (q.men ?? 0), 0);
+	const { women, men } = quartiles.reduce<{ women: number; men: number }>(
+		(acc, q) => ({
+			women: acc.women + (q.women ?? 0),
+			men: acc.men + (q.men ?? 0),
+		}),
+		{ women: 0, men: 0 },
+	);
 	return { women, men, total: women + men };
 }
 

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -775,3 +775,130 @@ describe("assembleDeclaration", () => {
 		);
 	});
 });
+
+describe("assembleDeclaration — compliance flags", () => {
+	const indicatorG: IndicatorGEntry[] = [
+		{
+			categoryName: "Cadres",
+			declarationType: "initial",
+			womenCount: 50,
+			menCount: 60,
+			annualBaseWomen: "52000",
+			annualBaseMen: "56000",
+			annualVariableWomen: null,
+			annualVariableMen: null,
+			hourlyBaseWomen: null,
+			hourlyBaseMen: null,
+			hourlyVariableWomen: null,
+			hourlyVariableMen: null,
+		},
+	];
+
+	it("requires the compliance process for >= 100 employees with indicator G and a gap >= 5%", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(true);
+	});
+
+	it("does not require the compliance process when the gap is below 5%", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0455" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+
+	it("does not require the compliance process below 100 employees even with a gap", () => {
+		const row = { ...baseRow, workforce: 99, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+	});
+
+	it("does not require the compliance process without indicator G", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, [], []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+	});
+
+	it("does not require the compliance process when the global gap is null", () => {
+		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: null };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+	});
+
+	it("treats a null workforce as 0 for the derived flags", () => {
+		const row = { ...baseRow, workforce: null, globalAnnualMeanGap: "0.0600" };
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Indicateur_G_requis).toBe(false);
+	});
+
+	it("requires the revision when a second declaration was submitted with a correction gap >= 5%", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: "0.0800",
+			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours_de_conformite_revision_requis).toBe(true);
+	});
+
+	it("does not require the revision without a submitted second declaration", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: "0.0800",
+			secondDeclarationSubmittedAt: null,
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+
+	it("does not require the revision when the correction gap is below 5%", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: "0.0400",
+			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+
+	it("does not require the revision when the correction gap is null", () => {
+		const row = {
+			...baseRow,
+			workforce: 300,
+			globalAnnualMeanGap: "0.0600",
+			variableAnnualMeanGap: null,
+			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+	});
+});

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -1,6 +1,10 @@
 import { and, eq, isNotNull, ne, or } from "drizzle-orm";
 
-import { GAP_ALERT_THRESHOLD, isIndicatorGRequired } from "~/modules/domain";
+import {
+	isComplianceProcessRequired,
+	isComplianceProcessRevisionRequired,
+	isIndicatorGRequired,
+} from "~/modules/domain";
 import type { DB } from "~/server/db";
 import { companies, declarations, users } from "~/server/db/schema";
 import { mapCseOpinions } from "./mapIndicators";
@@ -11,21 +15,6 @@ import {
 	statusHistoryProjection,
 } from "./queries";
 import type { ExportRow } from "./types";
-
-const COMPLIANCE_PROCESS_SIZE_MIN = 100;
-
-function computeComplianceProcessRequired(
-	workforce: number | null,
-	hasIndicatorG: boolean,
-	globalAnnualMeanGap: number | null,
-): boolean {
-	if (workforce === null || globalAnnualMeanGap === null) return false;
-	return (
-		workforce >= COMPLIANCE_PROCESS_SIZE_MIN &&
-		hasIndicatorG &&
-		Math.abs(globalAnnualMeanGap) >= GAP_ALERT_THRESHOLD
-	);
-}
 
 export async function buildExportRows(
 	db: DB,
@@ -93,16 +82,33 @@ export async function buildExportRows(
 		const variableAnnualMeanGap = row.variableAnnualMeanGap
 			? Number(row.variableAnnualMeanGap) * 100
 			: null;
-		const complianceProcessRequired = computeComplianceProcessRequired(
-			row.workforce,
-			hasIndicatorGForThisDecl,
-			globalAnnualMeanGap,
-		);
+		const complianceInput = {
+			workforce: row.workforce,
+			hasIndicatorG: hasIndicatorGForThisDecl,
+			gap: globalAnnualMeanGap === null ? null : Math.abs(globalAnnualMeanGap),
+		};
+		const complianceProcessRequired =
+			isComplianceProcessRequired(complianceInput);
 		const complianceProcessRevisionRequired =
-			complianceProcessRequired &&
-			row.secondDeclarationSubmittedAt !== null &&
-			variableAnnualMeanGap !== null &&
-			Math.abs(variableAnnualMeanGap) >= GAP_ALERT_THRESHOLD;
+			isComplianceProcessRevisionRequired({
+				...complianceInput,
+				correctionGap:
+					variableAnnualMeanGap === null
+						? null
+						: Math.abs(variableAnnualMeanGap),
+				events:
+					row.secondDeclarationSubmittedAt === null
+						? []
+						: [
+								{
+									eventType: "second_declaration_submit",
+									value: null,
+									round: null,
+									createdAt: row.secondDeclarationSubmittedAt,
+									actorUserId: null,
+								},
+							],
+			});
 		const indicatorGRequired = isIndicatorGRequired(
 			row.workforce ?? 0,
 			row.year,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -13,7 +13,11 @@ export {
 	fetchSubmittedDeclarations,
 } from "./queries";
 
-import { GAP_ALERT_THRESHOLD, isIndicatorGRequired } from "~/modules/domain";
+import {
+	isComplianceProcessRequired,
+	isComplianceProcessRevisionRequired,
+	isIndicatorGRequired,
+} from "~/modules/domain";
 import type { DeclarationRow } from "./queries";
 import {
 	INDICATOR_A_GAP_LABELS,
@@ -38,8 +42,6 @@ import {
 	getStatusHistoryLabel,
 } from "./shared/statusHistoryLabels";
 
-const COMPLIANCE_PROCESS_SIZE_MIN = 100;
-
 function deriveExportFlags(
 	row: DeclarationRow,
 	indicatorGEntries: IndicatorGEntry[],
@@ -56,17 +58,32 @@ function deriveExportFlags(
 		? Number(row.variableAnnualMeanGap) * 100
 		: null;
 	const workforce = row.workforce;
+	const complianceInput = {
+		workforce,
+		hasIndicatorG,
+		gap: globalAnnualMeanGap === null ? null : Math.abs(globalAnnualMeanGap),
+	};
 	const complianceProcessRequired =
-		workforce !== null &&
-		workforce >= COMPLIANCE_PROCESS_SIZE_MIN &&
-		hasIndicatorG &&
-		globalAnnualMeanGap !== null &&
-		Math.abs(globalAnnualMeanGap) >= GAP_ALERT_THRESHOLD;
-	const complianceProcessRevisionRequired =
-		complianceProcessRequired &&
-		row.secondDeclarationSubmittedAt !== null &&
-		variableAnnualMeanGap !== null &&
-		Math.abs(variableAnnualMeanGap) >= GAP_ALERT_THRESHOLD;
+		isComplianceProcessRequired(complianceInput);
+	const complianceProcessRevisionRequired = isComplianceProcessRevisionRequired(
+		{
+			...complianceInput,
+			correctionGap:
+				variableAnnualMeanGap === null ? null : Math.abs(variableAnnualMeanGap),
+			events:
+				row.secondDeclarationSubmittedAt === null
+					? []
+					: [
+							{
+								eventType: "second_declaration_submit",
+								value: null,
+								round: null,
+								createdAt: row.secondDeclarationSubmittedAt,
+								actorUserId: null,
+							},
+						],
+		},
+	);
 	const indicatorGRequiredFlag = isIndicatorGRequired(workforce ?? 0, row.year);
 	return {
 		complianceProcessRequired,

--- a/packages/app/src/modules/export/shared/__tests__/apiLabels.test.ts
+++ b/packages/app/src/modules/export/shared/__tests__/apiLabels.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { quartileProportion } from "../apiLabels";
+
+describe("quartileProportion", () => {
+	it("returns null when count is null", () => {
+		expect(quartileProportion(null, 10)).toBeNull();
+	});
+
+	it("returns null when totalCount is null", () => {
+		expect(quartileProportion(5, null)).toBeNull();
+	});
+
+	it("returns null when totalCount is zero (no division by zero)", () => {
+		expect(quartileProportion(5, 0)).toBeNull();
+	});
+
+	it("returns the exact ratio when it fits within 4 decimals", () => {
+		expect(quartileProportion(1, 4)).toBe(0.25);
+		expect(quartileProportion(3, 5)).toBe(0.6);
+	});
+
+	it("rounds to 4 decimals for GIP CSV parity", () => {
+		expect(quartileProportion(1, 3)).toBe(0.3333);
+		expect(quartileProportion(2, 3)).toBe(0.6667);
+		expect(quartileProportion(5, 9)).toBe(0.5556);
+	});
+
+	it("returns 0 for a zero count over a non-zero total", () => {
+		expect(quartileProportion(0, 10)).toBe(0);
+	});
+
+	// GIP CSV parity guard: proportionOf must match the raw count/total arithmetic it replaced.
+	it("matches raw count/totalCount rounding across a value spread", () => {
+		const pairs: Array<[number, number]> = [
+			[1, 3],
+			[2, 3],
+			[7, 13],
+			[123, 456],
+			[9, 9],
+			[0, 5],
+		];
+		for (const [count, total] of pairs) {
+			const expected = Math.round((count / total) * 10_000) / 10_000;
+			expect(quartileProportion(count, total)).toBe(expected);
+		}
+	});
+});

--- a/packages/app/src/modules/export/shared/apiLabels.ts
+++ b/packages/app/src/modules/export/shared/apiLabels.ts
@@ -7,6 +7,8 @@
  * same underscore-separated French style to stay consistent.
  */
 
+import { proportionOf } from "~/modules/domain";
+
 /** Indicator A — mean global remuneration. */
 export const INDICATOR_A_LABELS = {
 	annualWomen: "Rem_globale_annuelle_moyenne_F",
@@ -126,5 +128,5 @@ export function quartileProportion(
 	totalCount: number | null,
 ): number | null {
 	if (count === null || totalCount === null || totalCount === 0) return null;
-	return Math.round((count / totalCount) * 10_000) / 10_000;
+	return Math.round(proportionOf(count, totalCount) * 10_000) / 10_000;
 }

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
@@ -52,7 +52,7 @@ type ChartTooltipProps = {
 };
 
 export function formatYAxisTick(value: number): string {
-	return value.toLocaleString("fr-FR");
+	return formatCount(value);
 }
 
 export function ChartTooltip({ active, payload }: ChartTooltipProps) {

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -683,6 +683,43 @@ describe("declarationRouter", () => {
 		});
 	});
 
+	describe("submit — cseRequired snapshot", () => {
+		async function submitAndReadSnapshot(
+			workforce: number | null,
+			hasCse: boolean | null,
+		): Promise<boolean> {
+			const declaration = buildDeclaration({ status: "draft" });
+			const company = buildCompany({ workforce, hasCse });
+			const ctx = createSubmitMockDb(declaration, company, []);
+			const caller = await createLockedCaller(ctx.db);
+			await caller.submit();
+			const projectionCall = ctx.set.mock.calls
+				.map((c) => c[0] as Record<string, unknown>)
+				.find((c) => "cseRequired" in c);
+			return projectionCall?.cseRequired as boolean;
+		}
+
+		it("snapshots true for >= 100 employees with a CSE", async () => {
+			expect(await submitAndReadSnapshot(100, true)).toBe(true);
+		});
+
+		it("snapshots false just below the 100-employee threshold", async () => {
+			expect(await submitAndReadSnapshot(99, true)).toBe(false);
+		});
+
+		it("snapshots false for >= 100 employees without a CSE", async () => {
+			expect(await submitAndReadSnapshot(120, false)).toBe(false);
+		});
+
+		it("snapshots false when hasCse is null", async () => {
+			expect(await submitAndReadSnapshot(250, null)).toBe(false);
+		});
+
+		it("snapshots false when workforce is null", async () => {
+			expect(await submitAndReadSnapshot(null, true)).toBe(false);
+		});
+	});
+
 	describe("submitSecondDeclaration (rules engine)", () => {
 		it("transitions corrective_actions_chosen → awaiting_revision_choice when gap persists (S15)", async () => {
 			const declaration = buildDeclaration({

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -39,6 +39,8 @@ import {
 	POST_SUBMIT_DROPOFF_PHASES,
 	POST_SUBMIT_MILESTONES,
 	type PostSubmitMilestoneKey,
+	percentageOf,
+	roundOneDecimal,
 } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import {
@@ -658,8 +660,7 @@ export const adminStatsRouter = createTRPCRouter({
 				const aggregate = byStep.get(step);
 				const total = aggregate?.total ?? 0;
 				const abandoned = aggregate?.abandoned ?? 0;
-				const dropoffRate =
-					total === 0 ? 0 : Math.round((abandoned / total) * 1000) / 10;
+				const dropoffRate = roundOneDecimal(percentageOf(abandoned, total));
 				return {
 					key: String(step),
 					phase: "wizard",
@@ -838,8 +839,7 @@ export const adminStatsRouter = createTRPCRouter({
 				({ key, label, status }) => {
 					const total = totalsByPhase.get(status) ?? 0;
 					const abandoned = abandonedByPhase.get(status) ?? 0;
-					const dropoffRate =
-						total === 0 ? 0 : Math.round((abandoned / total) * 1000) / 10;
+					const dropoffRate = roundOneDecimal(percentageOf(abandoned, total));
 					return {
 						key,
 						phase: "post_submit",
@@ -1145,12 +1145,11 @@ function buildFunnelRows(
 	const start = numbers[0] ?? 0;
 	return steps.map((step, idx) => {
 		const count = numbers[idx] ?? 0;
-		const pctOfStart = start === 0 ? 0 : Math.round((count / start) * 100);
+		const pctOfStart = Math.round(percentageOf(count, start));
 		let pctDropFromPrev: number | null = null;
 		if (idx > 0) {
 			const prev = numbers[idx - 1] ?? 0;
-			pctDropFromPrev =
-				prev === 0 ? 0 : Math.round(((prev - count) / prev) * 100);
+			pctDropFromPrev = Math.round(percentageOf(prev - count, prev));
 		}
 		return {
 			key: step.key,

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -14,9 +14,9 @@ import {
 } from "~/modules/declaration-remuneration/schemas";
 import { mapGipToFormData } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import {
-	COMPANY_SIZE_ANNUAL_MIN,
 	getCurrentYear,
 	hasGapsAboveThreshold,
+	isCseRequired,
 	isTriennialYear,
 } from "~/modules/domain";
 import {
@@ -692,8 +692,7 @@ export const declarationRouter = createTRPCRouter({
 		// que les transitions FSM aval (saveCompliancePath, submitJointEvaluation,
 		// cseOpinion.finalize) liront comme guard.
 		const cseRequiredSnapshot =
-			(company.workforce ?? 0) >= COMPANY_SIZE_ANNUAL_MIN &&
-			company.hasCse === true;
+			isCseRequired(company.workforce ?? 0) && company.hasCse === true;
 
 		await ctx.db.transaction(async (tx) => {
 			if (declaration.status === "draft" && historyInserts.length > 0) {

--- a/packages/app/src/server/services/__tests__/matomo.test.ts
+++ b/packages/app/src/server/services/__tests__/matomo.test.ts
@@ -12,6 +12,7 @@ const { mockEnv } = vi.hoisted(() => ({
 vi.mock("~/env", () => ({ env: mockEnv }));
 
 import {
+	buildFunnelRows,
 	fetchMatomoCategoryModel,
 	fetchMatomoCseStatusConfirmations,
 	fetchMatomoDeviceBreakdown,
@@ -599,5 +600,57 @@ describe("fetchMatomoCseStatusConfirmations", () => {
 		const result = await fetchMatomoCseStatusConfirmations({ year: 2024 });
 
 		expect(result).toEqual({ total: 0, yes: 0, no: 0 });
+	});
+});
+
+describe("buildFunnelRows", () => {
+	const jalons = [
+		{ key: "start", label: "Démarrage", kind: "start" as const },
+		{ key: "mid", label: "Milieu", kind: "step" as const, step: "mid" },
+		{ key: "complete", label: "Fin", kind: "complete" as const },
+	];
+
+	it("anchors pctOfStart to the first jalon and rounds to a whole number", () => {
+		const rows = buildFunnelRows(jalons, {
+			start: 200,
+			mid: 150,
+			complete: 50,
+		});
+
+		expect(rows.map((r) => [r.count, r.pctOfStart])).toEqual([
+			[200, 100],
+			[150, 75],
+			[50, 25],
+		]);
+	});
+
+	it("computes pctDropFromPrev as null on the first jalon and rounded thereafter", () => {
+		const rows = buildFunnelRows(jalons, {
+			start: 200,
+			mid: 150,
+			complete: 50,
+		});
+
+		expect(rows[0]?.pctDropFromPrev).toBeNull();
+		expect(rows[1]?.pctDropFromPrev).toBe(25);
+		expect(rows[2]?.pctDropFromPrev).toBe(67);
+	});
+
+	it("yields 0 percentages when the funnel start is empty (no division by zero)", () => {
+		const rows = buildFunnelRows(jalons, {});
+
+		expect(rows.map((r) => r.count)).toEqual([0, 0, 0]);
+		for (const row of rows) {
+			expect(row.pctOfStart).toBe(0);
+		}
+		expect(rows[0]?.pctDropFromPrev).toBeNull();
+		expect(rows[1]?.pctDropFromPrev).toBe(0);
+	});
+
+	it("yields pctDropFromPrev 0 when the previous jalon is empty mid-funnel", () => {
+		const rows = buildFunnelRows(jalons, { start: 100, mid: 0, complete: 0 });
+
+		expect(rows[1]?.pctDropFromPrev).toBe(100);
+		expect(rows[2]?.pctDropFromPrev).toBe(0);
 	});
 });

--- a/packages/app/src/server/services/matomo.ts
+++ b/packages/app/src/server/services/matomo.ts
@@ -20,7 +20,7 @@ import {
 	MATOMO_EVENT_CATEGORY,
 	MATOMO_FUNNEL_ACTION,
 } from "~/modules/analytics/shared/events";
-import type { CompanySizeRange } from "~/modules/domain";
+import { type CompanySizeRange, percentageOf } from "~/modules/domain";
 
 const ONE_HOUR = 3_600;
 
@@ -127,12 +127,11 @@ export function buildFunnelRows(
 	const start = numbers[0] ?? 0;
 	return jalons.map((jalon, index) => {
 		const count = numbers[index] ?? 0;
-		const pctOfStart = start === 0 ? 0 : Math.round((count / start) * 100);
+		const pctOfStart = Math.round(percentageOf(count, start));
 		let pctDropFromPrev: number | null = null;
 		if (index > 0) {
 			const prev = numbers[index - 1] ?? 0;
-			pctDropFromPrev =
-				prev === 0 ? 0 : Math.round(((prev - count) / prev) * 100);
+			pctDropFromPrev = Math.round(percentageOf(prev - count, prev));
 		}
 		return {
 			key: jalon.key,


### PR DESCRIPTION
Intégration finale de l'epic #3676 — **Vérifier que les mêmes règles métiers sont utilisées partout dans l'app**.

Cette PR rassemble les commits squashés de chaque sous-ticket. Chaque sous-ticket a passé : tests écrits/validés par `tu-dev` (TU + intégration), CI verte (build · test · typecheck · lint · Sonar), et les validators IA. Cette PR est le **point unique de revue humaine** pour l'epic.

## Sous-tickets

- Closes #3788 — domain : helpers effectif/%/gap + source unique du seuil 100
- Closes #3789 — Durcir les guardrails anti-éparpillement (hook + auditor)
- Closes #3790 — Brancher le parcours déclaration/récap sur les helpers domain
- Closes #3791 — Consolider admin-stats & publicStats sur les formatters/% domain
- Closes #3792 — Centraliser compliance/CSE & % côté serveur (export, routers)
- Closes #3793 — Utiliser isCancelled (admin) + helper soumission cseOpinion

## ⚠️ Gate E2E — non exécutée en local

La gate E2E Playwright **n'a pas pu être rejouée localement** : la suite requiert une authentification **ProConnect** (`auth.setup.ts`) non mockable dans la stack E2E headless locale, ce qui bloque en amont les 132 scénarios (échec de setup, pas de régression de parcours détectée). Ce n'est **pas** une régression de l'epic (dont le périmètre — helpers domain, stats, compliance/CSE serveur — ne touche pas le flux d'auth). La validation end-to-end reste à faire en **CI / préprod** avec l'environnement ProConnect de test.

## Notes

- Branche d'intégration : `epic/3676` (rebasée régulièrement sur `alpha`).
- Review app : https://egapro-epic-3676-5490cp37.ovh.fabrique.social.gouv.fr
- Une fois mergée dans `alpha`, les sous-tickets se fermeront via les `Closes #N`.