### PR TITLE
feat(auth): demande le niveau eidas2 (2FA) sur ProConnect

### DIFF
--- a/packages/app/src/server/auth/__tests__/config.providers.test.ts
+++ b/packages/app/src/server/auth/__tests__/config.providers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("~/server/db", () => ({ db: {} }));
+vi.mock("~/server/db/schema", () => ({
+	users: {},
+	companies: {},
+	userCompanies: {},
+}));
+vi.mock("~/server/services/weez", () => ({ fetchCompanyBySiren: vi.fn() }));
+
+import { authConfig } from "../config";
+
+type OAuthProviderConfig = {
+	id: string;
+	authorization?: { params?: Record<string, string> };
+};
+
+describe("auth config — ProConnect provider", () => {
+	it("requests the eidas2 substantial assurance level via acr_values", () => {
+		const proconnect = (
+			authConfig.providers as unknown as OAuthProviderConfig[]
+		).find((provider) => provider.id === "proconnect");
+
+		expect(proconnect).toBeDefined();
+		expect(proconnect?.authorization?.params?.acr_values).toBe("eidas2");
+	});
+});

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -177,6 +177,7 @@ function getProviders(): Provider[] {
 			authorization: {
 				params: {
 					scope: "openid email given_name usual_name siret",
+					acr_values: "eidas2",
 				},
 			},
 			idToken: true,


### PR DESCRIPTION
## Objectif

Mise en place du 2FA ProConnect au niveau de garantie **substantiel** (eidas2), demandé par l'issue #3565.

## Changement

- `packages/app/src/server/auth/config.ts` — ajoute `acr_values: "eidas2"` aux `authorization.params` OIDC du provider ProConnect. On demande le niveau eidas2 (MFA forte) ; le claim `acr` retourné n'est **pas** vérifié/bloqué côté egapro (choix minimal retenu dans l'analyse — durcissement possible plus tard).
- Test unitaire net-new : `config.providers.test.ts` asserte que le provider ProConnect demande bien `acr_values: eidas2`.

## Validation

- typecheck ✓ · suite unitaire (3016 + 83) ✓ · lint ✓ · format ✓
- Pas de `.tsx` modifié (RGAA N/A) ; le changement renforce l'auth (aucune nouvelle query/mutation/input).

## À valider avant merge (dépendances externes, cf. analyse #3565)

- [ ] Le client ProConnect egapro est habilité à demander eidas2 (portail partenaires).
- [ ] Le proxy de test `proconnecttest` (dev/preprod/prod) accepte une requête `acr_values=eidas2` (sinon le login casse) — **à confirmer via l'env de review de cette PR**.
- [ ] Le compte de test E2E supporte un 2ᵉ facteur (sinon la suite E2E login casse).

Closes #3565