### PR TITLE
API publique — projection publique d'une déclaration (exclusion G + masquage non-diffusible) + schémas

### DIFF
--- a/packages/app/src/modules/public-api/index.ts
+++ b/packages/app/src/modules/public-api/index.ts
@@ -1,0 +1,18 @@
+export type {
+	PublicCompanySource,
+	PublicDeclarationSource,
+} from "./projection";
+export {
+	isCompanyDiffusible,
+	toPublicDeclaration,
+} from "./projection";
+export type {
+	PublicDeclarationDTO,
+	PublicSearchInput,
+	PublicSearchResultDTO,
+} from "./schemas";
+export {
+	publicDeclarationDTOSchema,
+	publicSearchInputSchema,
+	publicSearchResultDTOSchema,
+} from "./schemas";

--- a/packages/app/src/modules/public-api/projection.test.ts
+++ b/packages/app/src/modules/public-api/projection.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import {
+	isCompanyDiffusible,
+	type PublicCompanySource,
+	type PublicDeclarationSource,
+	toPublicDeclaration,
+} from "./projection";
+import { publicDeclarationDTOSchema, publicSearchInputSchema } from "./schemas";
+
+const declarationFixture: PublicDeclarationSource = {
+	year: 2024,
+	totalWomen: 120,
+	totalMen: 80,
+	globalAnnualMeanGap: "12.3400",
+	globalAnnualMedianGap: "10.0000",
+	globalHourlyMeanGap: "8.5000",
+	globalHourlyMedianGap: "7.2500",
+	variableAnnualMeanGap: "5.5000",
+	variableAnnualMedianGap: "4.1000",
+	variableHourlyMeanGap: "3.3000",
+	variableHourlyMedianGap: "2.2000",
+	variableProportionWomen: "45.0000",
+	variableProportionMen: "55.0000",
+	annualQuartile1ProportionWomen: "60.0000",
+	annualQuartile2ProportionWomen: "55.0000",
+	annualQuartile3ProportionWomen: "50.0000",
+	annualQuartile4ProportionWomen: "40.0000",
+	annualQuartile1ProportionMen: "40.0000",
+	annualQuartile2ProportionMen: "45.0000",
+	annualQuartile3ProportionMen: "50.0000",
+	annualQuartile4ProportionMen: "60.0000",
+	hourlyQuartile1ProportionWomen: "61.0000",
+	hourlyQuartile2ProportionWomen: "56.0000",
+	hourlyQuartile3ProportionWomen: "51.0000",
+	hourlyQuartile4ProportionWomen: "41.0000",
+	hourlyQuartile1ProportionMen: "39.0000",
+	hourlyQuartile2ProportionMen: "44.0000",
+	hourlyQuartile3ProportionMen: "49.0000",
+	hourlyQuartile4ProportionMen: "59.0000",
+};
+
+const companyFixture: PublicCompanySource = {
+	siren: "123456789",
+	name: "Société Démo",
+	address: "1 rue de la Paix, 75002 Paris",
+	region: "Île-de-France",
+	departmentCode: "75",
+	departmentLabel: "Paris",
+	nafCode: "62.01Z",
+	nafLabel: "Programmation informatique",
+	statutDiffusion: "O",
+	workforceEma: "250.0000",
+};
+
+const EXPECTED_DTO_KEYS = Object.keys(publicDeclarationDTOSchema.shape).sort();
+
+const MASKED_COMPANY_FIELDS = [
+	"name",
+	"address",
+	"region",
+	"departmentCode",
+	"departmentLabel",
+	"nafCode",
+	"nafLabel",
+] as const;
+
+const FORBIDDEN_KEYS = [
+	"categoryScore",
+	"remunerationScore",
+	"variableRemunerationScore",
+	"quartileScore",
+	"globalScore",
+	"index",
+	"workforce",
+	"declarantId",
+	"status",
+	"draft",
+];
+
+describe("isCompanyDiffusible", () => {
+	it("returns false when the statut is 'N'", () => {
+		expect(isCompanyDiffusible("N")).toBe(false);
+	});
+
+	it("returns true when the statut is null", () => {
+		expect(isCompanyDiffusible(null)).toBe(true);
+	});
+
+	it("returns true when the statut is 'O'", () => {
+		expect(isCompanyDiffusible("O")).toBe(true);
+	});
+
+	it("returns true for any other statut value", () => {
+		expect(isCompanyDiffusible("P")).toBe(true);
+		expect(isCompanyDiffusible("")).toBe(true);
+	});
+});
+
+describe("toPublicDeclaration", () => {
+	it("exposes exactly the DTO whitelist and nothing else", () => {
+		const dto = toPublicDeclaration(declarationFixture, companyFixture);
+
+		expect(Object.keys(dto).sort()).toEqual(EXPECTED_DTO_KEYS);
+		expect(() => publicDeclarationDTOSchema.parse(dto)).not.toThrow();
+	});
+
+	it("never leaks scores, the global /100 index, or indicator G data", () => {
+		const dto = toPublicDeclaration(
+			{ ...declarationFixture },
+			{ ...companyFixture },
+		) as Record<string, unknown>;
+
+		for (const forbidden of FORBIDDEN_KEYS) {
+			expect(dto).not.toHaveProperty(forbidden);
+		}
+		expect(
+			Object.keys(dto).some((key) => /score|category|index/i.test(key)),
+		).toBe(false);
+	});
+
+	it("exposes the full company whitelist for a diffusible company", () => {
+		const dto = toPublicDeclaration(declarationFixture, companyFixture);
+
+		expect(dto.siren).toBe("123456789");
+		expect(dto.name).toBe("Société Démo");
+		expect(dto.address).toBe("1 rue de la Paix, 75002 Paris");
+		expect(dto.region).toBe("Île-de-France");
+		expect(dto.departmentCode).toBe("75");
+		expect(dto.departmentLabel).toBe("Paris");
+		expect(dto.nafCode).toBe("62.01Z");
+		expect(dto.nafLabel).toBe("Programmation informatique");
+	});
+
+	it("masks company identity fields when the company is non-diffusible", () => {
+		const dto = toPublicDeclaration(declarationFixture, {
+			...companyFixture,
+			statutDiffusion: "N",
+		});
+
+		for (const field of MASKED_COMPANY_FIELDS) {
+			expect(dto[field]).toBeNull();
+		}
+	});
+
+	it("keeps siren, year, workforceEma and every indicator for a non-diffusible company", () => {
+		const diffusible = toPublicDeclaration(declarationFixture, companyFixture);
+		const nonDiffusible = toPublicDeclaration(declarationFixture, {
+			...companyFixture,
+			statutDiffusion: "N",
+		});
+
+		expect(nonDiffusible.siren).toBe(companyFixture.siren);
+		expect(nonDiffusible.year).toBe(declarationFixture.year);
+		expect(nonDiffusible.workforceEma).toBe(250);
+
+		const indicatorKeys = EXPECTED_DTO_KEYS.filter(
+			(key) =>
+				key !== "siren" &&
+				key !== "year" &&
+				key !== "workforceEma" &&
+				!MASKED_COMPANY_FIELDS.includes(
+					key as (typeof MASKED_COMPANY_FIELDS)[number],
+				),
+		);
+		for (const key of indicatorKeys) {
+			expect(nonDiffusible[key as keyof typeof nonDiffusible]).toEqual(
+				diffusible[key as keyof typeof diffusible],
+			);
+		}
+	});
+
+	it("converts numeric string gaps to numbers and preserves year and counts", () => {
+		const dto = toPublicDeclaration(declarationFixture, companyFixture);
+
+		expect(dto.year).toBe(2024);
+		expect(dto.totalWomen).toBe(120);
+		expect(dto.totalMen).toBe(80);
+		expect(dto.globalAnnualMeanGap).toBe(12.34);
+		expect(dto.variableProportionWomen).toBe(45);
+		expect(dto.annualQuartile4ProportionMen).toBe(60);
+		expect(dto.hourlyQuartile1ProportionWomen).toBe(61);
+		expect(dto.workforceEma).toBe(250);
+	});
+
+	it("maps null numeric inputs to null", () => {
+		const dto = toPublicDeclaration(
+			{ ...declarationFixture, globalAnnualMeanGap: null },
+			{ ...companyFixture, workforceEma: null },
+		);
+
+		expect(dto.globalAnnualMeanGap).toBeNull();
+		expect(dto.workforceEma).toBeNull();
+	});
+
+	it("maps non-numeric strings to null", () => {
+		const dto = toPublicDeclaration(
+			{ ...declarationFixture, globalHourlyMeanGap: "NR" },
+			companyFixture,
+		);
+
+		expect(dto.globalHourlyMeanGap).toBeNull();
+	});
+
+	it("passes through null integer counts", () => {
+		const dto = toPublicDeclaration(
+			{ ...declarationFixture, totalWomen: null, totalMen: null },
+			companyFixture,
+		);
+
+		expect(dto.totalWomen).toBeNull();
+		expect(dto.totalMen).toBeNull();
+	});
+});
+
+describe("publicSearchInputSchema", () => {
+	it("applies default limit and offset", () => {
+		const parsed = publicSearchInputSchema.parse({});
+
+		expect(parsed.limit).toBe(10);
+		expect(parsed.offset).toBe(0);
+	});
+
+	it("accepts the optional filters", () => {
+		const parsed = publicSearchInputSchema.parse({
+			q: "acme",
+			region: "Île-de-France",
+			departement: "75",
+			naf: "62.01Z",
+			year: 2024,
+			limit: 50,
+			offset: 20,
+		});
+
+		expect(parsed).toEqual({
+			q: "acme",
+			region: "Île-de-France",
+			departement: "75",
+			naf: "62.01Z",
+			year: 2024,
+			limit: 50,
+			offset: 20,
+		});
+	});
+
+	it("rejects a limit above 100", () => {
+		expect(publicSearchInputSchema.safeParse({ limit: 101 }).success).toBe(
+			false,
+		);
+	});
+
+	it("rejects a limit below 1", () => {
+		expect(publicSearchInputSchema.safeParse({ limit: 0 }).success).toBe(false);
+	});
+
+	it("rejects a negative offset", () => {
+		expect(publicSearchInputSchema.safeParse({ offset: -1 }).success).toBe(
+			false,
+		);
+	});
+
+	it("rejects an empty q filter", () => {
+		expect(publicSearchInputSchema.safeParse({ q: "" }).success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/public-api/projection.ts
+++ b/packages/app/src/modules/public-api/projection.ts
@@ -1,0 +1,141 @@
+import type { companies, declarations } from "~/server/db/schema";
+import type { PublicDeclarationDTO } from "./schemas";
+
+export type PublicDeclarationSource = Pick<
+	typeof declarations.$inferSelect,
+	| "year"
+	| "totalWomen"
+	| "totalMen"
+	| "globalAnnualMeanGap"
+	| "globalAnnualMedianGap"
+	| "globalHourlyMeanGap"
+	| "globalHourlyMedianGap"
+	| "variableAnnualMeanGap"
+	| "variableAnnualMedianGap"
+	| "variableHourlyMeanGap"
+	| "variableHourlyMedianGap"
+	| "variableProportionWomen"
+	| "variableProportionMen"
+	| "annualQuartile1ProportionWomen"
+	| "annualQuartile2ProportionWomen"
+	| "annualQuartile3ProportionWomen"
+	| "annualQuartile4ProportionWomen"
+	| "annualQuartile1ProportionMen"
+	| "annualQuartile2ProportionMen"
+	| "annualQuartile3ProportionMen"
+	| "annualQuartile4ProportionMen"
+	| "hourlyQuartile1ProportionWomen"
+	| "hourlyQuartile2ProportionWomen"
+	| "hourlyQuartile3ProportionWomen"
+	| "hourlyQuartile4ProportionWomen"
+	| "hourlyQuartile1ProportionMen"
+	| "hourlyQuartile2ProportionMen"
+	| "hourlyQuartile3ProportionMen"
+	| "hourlyQuartile4ProportionMen"
+>;
+
+export type PublicCompanySource = Pick<
+	typeof companies.$inferSelect,
+	| "siren"
+	| "name"
+	| "address"
+	| "region"
+	| "departmentCode"
+	| "departmentLabel"
+	| "nafCode"
+	| "nafLabel"
+> & {
+	statutDiffusion: string | null;
+	// Année-1 average annual workforce, sourced from gipMdsData.workforceEma (not companies.workforce).
+	workforceEma: string | null;
+};
+
+export function isCompanyDiffusible(statutDiffusion: string | null): boolean {
+	return statutDiffusion !== "N";
+}
+
+function toNumber(value: string | null): number | null {
+	if (value === null) return null;
+	const parsed = Number(value);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
+export function toPublicDeclaration(
+	declaration: PublicDeclarationSource,
+	company: PublicCompanySource,
+): PublicDeclarationDTO {
+	const diffusible = isCompanyDiffusible(company.statutDiffusion);
+
+	return {
+		year: declaration.year,
+		siren: company.siren,
+		name: diffusible ? company.name : null,
+		address: diffusible ? company.address : null,
+		region: diffusible ? company.region : null,
+		departmentCode: diffusible ? company.departmentCode : null,
+		departmentLabel: diffusible ? company.departmentLabel : null,
+		nafCode: diffusible ? company.nafCode : null,
+		nafLabel: diffusible ? company.nafLabel : null,
+		workforceEma: toNumber(company.workforceEma),
+		totalWomen: declaration.totalWomen,
+		totalMen: declaration.totalMen,
+		globalAnnualMeanGap: toNumber(declaration.globalAnnualMeanGap),
+		globalAnnualMedianGap: toNumber(declaration.globalAnnualMedianGap),
+		globalHourlyMeanGap: toNumber(declaration.globalHourlyMeanGap),
+		globalHourlyMedianGap: toNumber(declaration.globalHourlyMedianGap),
+		variableAnnualMeanGap: toNumber(declaration.variableAnnualMeanGap),
+		variableAnnualMedianGap: toNumber(declaration.variableAnnualMedianGap),
+		variableHourlyMeanGap: toNumber(declaration.variableHourlyMeanGap),
+		variableHourlyMedianGap: toNumber(declaration.variableHourlyMedianGap),
+		variableProportionWomen: toNumber(declaration.variableProportionWomen),
+		variableProportionMen: toNumber(declaration.variableProportionMen),
+		annualQuartile1ProportionWomen: toNumber(
+			declaration.annualQuartile1ProportionWomen,
+		),
+		annualQuartile2ProportionWomen: toNumber(
+			declaration.annualQuartile2ProportionWomen,
+		),
+		annualQuartile3ProportionWomen: toNumber(
+			declaration.annualQuartile3ProportionWomen,
+		),
+		annualQuartile4ProportionWomen: toNumber(
+			declaration.annualQuartile4ProportionWomen,
+		),
+		annualQuartile1ProportionMen: toNumber(
+			declaration.annualQuartile1ProportionMen,
+		),
+		annualQuartile2ProportionMen: toNumber(
+			declaration.annualQuartile2ProportionMen,
+		),
+		annualQuartile3ProportionMen: toNumber(
+			declaration.annualQuartile3ProportionMen,
+		),
+		annualQuartile4ProportionMen: toNumber(
+			declaration.annualQuartile4ProportionMen,
+		),
+		hourlyQuartile1ProportionWomen: toNumber(
+			declaration.hourlyQuartile1ProportionWomen,
+		),
+		hourlyQuartile2ProportionWomen: toNumber(
+			declaration.hourlyQuartile2ProportionWomen,
+		),
+		hourlyQuartile3ProportionWomen: toNumber(
+			declaration.hourlyQuartile3ProportionWomen,
+		),
+		hourlyQuartile4ProportionWomen: toNumber(
+			declaration.hourlyQuartile4ProportionWomen,
+		),
+		hourlyQuartile1ProportionMen: toNumber(
+			declaration.hourlyQuartile1ProportionMen,
+		),
+		hourlyQuartile2ProportionMen: toNumber(
+			declaration.hourlyQuartile2ProportionMen,
+		),
+		hourlyQuartile3ProportionMen: toNumber(
+			declaration.hourlyQuartile3ProportionMen,
+		),
+		hourlyQuartile4ProportionMen: toNumber(
+			declaration.hourlyQuartile4ProportionMen,
+		),
+	};
+}

--- a/packages/app/src/modules/public-api/projection.ts
+++ b/packages/app/src/modules/public-api/projection.ts
@@ -46,7 +46,6 @@ export type PublicCompanySource = Pick<
 	| "nafLabel"
 > & {
 	statutDiffusion: string | null;
-	// Année-1 average annual workforce, sourced from gipMdsData.workforceEma (not companies.workforce).
 	workforceEma: string | null;
 };
 

--- a/packages/app/src/modules/public-api/schemas.ts
+++ b/packages/app/src/modules/public-api/schemas.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+
+export const publicSearchInputSchema = z.object({
+	q: z.string().trim().min(1).optional(),
+	region: z.string().trim().min(1).optional(),
+	departement: z.string().trim().min(1).optional(),
+	naf: z.string().trim().min(1).optional(),
+	year: z.number().int().optional(),
+	limit: z.number().int().min(1).max(100).default(10),
+	offset: z.number().int().min(0).default(0),
+});
+
+export type PublicSearchInput = z.infer<typeof publicSearchInputSchema>;
+
+export const publicDeclarationDTOSchema = z.object({
+	year: z.number().int(),
+	siren: z.string(),
+	name: z.string().nullable(),
+	address: z.string().nullable(),
+	region: z.string().nullable(),
+	departmentCode: z.string().nullable(),
+	departmentLabel: z.string().nullable(),
+	nafCode: z.string().nullable(),
+	nafLabel: z.string().nullable(),
+	workforceEma: z.number().nullable(),
+	totalWomen: z.number().int().nullable(),
+	totalMen: z.number().int().nullable(),
+	globalAnnualMeanGap: z.number().nullable(),
+	globalAnnualMedianGap: z.number().nullable(),
+	globalHourlyMeanGap: z.number().nullable(),
+	globalHourlyMedianGap: z.number().nullable(),
+	variableAnnualMeanGap: z.number().nullable(),
+	variableAnnualMedianGap: z.number().nullable(),
+	variableHourlyMeanGap: z.number().nullable(),
+	variableHourlyMedianGap: z.number().nullable(),
+	variableProportionWomen: z.number().nullable(),
+	variableProportionMen: z.number().nullable(),
+	annualQuartile1ProportionWomen: z.number().nullable(),
+	annualQuartile2ProportionWomen: z.number().nullable(),
+	annualQuartile3ProportionWomen: z.number().nullable(),
+	annualQuartile4ProportionWomen: z.number().nullable(),
+	annualQuartile1ProportionMen: z.number().nullable(),
+	annualQuartile2ProportionMen: z.number().nullable(),
+	annualQuartile3ProportionMen: z.number().nullable(),
+	annualQuartile4ProportionMen: z.number().nullable(),
+	hourlyQuartile1ProportionWomen: z.number().nullable(),
+	hourlyQuartile2ProportionWomen: z.number().nullable(),
+	hourlyQuartile3ProportionWomen: z.number().nullable(),
+	hourlyQuartile4ProportionWomen: z.number().nullable(),
+	hourlyQuartile1ProportionMen: z.number().nullable(),
+	hourlyQuartile2ProportionMen: z.number().nullable(),
+	hourlyQuartile3ProportionMen: z.number().nullable(),
+	hourlyQuartile4ProportionMen: z.number().nullable(),
+});
+
+export type PublicDeclarationDTO = z.infer<typeof publicDeclarationDTOSchema>;
+
+export const publicSearchResultDTOSchema = z.object({
+	data: z.array(publicDeclarationDTOSchema),
+	count: z.number().int(),
+});
+
+export type PublicSearchResultDTO = z.infer<typeof publicSearchResultDTOSchema>;

--- a/packages/app/src/server/services/weez.ts
+++ b/packages/app/src/server/services/weez.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import { env } from "~/env";
 import { getLocationFromPostalCode } from "~/modules/domain";
+import { isCompanyDiffusible } from "~/modules/public-api";
 
 const NON_DIFFUSIBLE_NAME = "Entreprise non diffusible";
 
@@ -87,10 +88,6 @@ function buildAddress(entity: WeezLegalEntity): string | null {
 	return null;
 }
 
-function isNonDiffusible(entity: WeezLegalEntity): boolean {
-	return entity.statutdiffusionunitelegale === "N";
-}
-
 export async function fetchCompanyBySiren(
 	siren: string,
 ): Promise<CompanyInfo | null> {
@@ -126,7 +123,7 @@ export async function fetchCompanyBySiren(
 	// when `address` becomes null.
 	const location = getLocationFromPostalCode(entity.codepostal);
 
-	if (isNonDiffusible(entity)) {
+	if (!isCompanyDiffusible(entity.statutdiffusionunitelegale)) {
 		return {
 			name:
 				entity.denominationunitelegale ||


### PR DESCRIPTION
Closes #3709

## Résumé

Fondation de l'**API publique** de la déclaration rémunération (index) V2 : ce ticket fournit la **projection publique** d'une déclaration — la seule source de vérité de ce qui est diffusable — consommée par les endpoints publics à venir (recherche #3711, détail #3712, export #3713).

Modèle de diffusion arbitré : on publie les **données brutes** (écarts, proportions, répartitions par quartile, effectifs), **jamais** les scores ni l'indice global /100. Trois règles : l'indicateur G n'est jamais diffusé ; aucun score/note n'est exposé ; l'identité des entreprises non diffusibles est masquée.

## Changements

- **`~/modules/public-api/schemas.ts`** (nouveau) — schémas Zod publics :
  - `publicSearchInputSchema` : `q?`, `region?`, `departement?`, `naf?`, `year?`, `limit` (défaut 10, max 100), `offset` (défaut 0) ;
  - `publicDeclarationDTOSchema` (whitelist de sortie) + `publicSearchResultDTOSchema` = `{ data, count }`.
- **`~/modules/public-api/projection.ts`** (nouveau) — fonctions pures :
  - `isCompanyDiffusible(statutDiffusion)` : `false` uniquement si `"N"`, `true` sinon (null inclus) ;
  - `toPublicDeclaration(declaration, company)` : construit le DTO par assignation explicite champ à champ (aucun spread des objets source → impossible de leaker un champ non-whitelisté). Masque `name`/`address`/`region`/`departmentCode`/`departmentLabel`/`nafCode`/`nafLabel` pour les unités non diffusibles ; conserve toujours `siren`, `year`, `workforceEma` et **tous** les indicateurs.
- **`~/modules/public-api/index.ts`** (nouveau) — barrel du module (exports consommés par #3711/#3712/#3713).
- **`~/server/services/weez.ts`** (modifié) — le prédicat local `isNonDiffusible` est extrait vers `isCompanyDiffusible` (importé du module). Comportement **inchangé** : `!isCompanyDiffusible(s)` ≡ `s === "N"`, null traité comme diffusible à l'identique.

## Source des valeurs (à confirmer au câblage)

- Les écarts/proportions du DTO proviennent de **`declarations`** (valeurs de la déclaration = source de vérité), et non de `gipMdsData`. Les types d'entrée `PublicDeclarationSource` sont un `Pick<typeof declarations.$inferSelect, …>` → alignement garanti avec la colonne DB.
- **`workforceEma`** provient de **`gipMdsData.workforceEma`** (effectif annuel moyen année-1), **pas** de `companies.workforce` (tranche). Le champ du DTO reprend le nom exact de la colonne source.
- Les champs entreprise (`region`, `departmentCode`, `departmentLabel`) restent alignés sur les colonnes ajoutées par #3710 (déjà mergé dans `epic/3172`).

## Décision produit (non-régression)

La V2 ne diffuse **aucune note** — ni scores d'indicateurs, ni indice global /100. L'absence du /100 est **volontaire**. Effet de bord : ne publiant aucun score, le risque historique « G déductible par soustraction » devient caduc.

## Note pour le câblage (#3711/#3712/#3713)

`PublicCompanySource.statutDiffusion` n'a pas encore de colonne dédiée sur `app_company`. Au câblage de la requête DB, il faut peupler `statutDiffusion` depuis une source fiable (re-fetch Weez, données GIP-MDS, ou nouvelle colonne). ⚠️ **Fail-safe** : si la valeur défaut est `null`, `isCompanyDiffusible(null)` renvoie `true` (diffusible) — une unité non diffusible verrait alors son identité exposée. À traiter explicitement dans le ticket de câblage.

## Tests

- `~/modules/public-api/projection.test.ts` (par `tu-dev`) — 19 tests, **100%** de couverture sur `projection.ts`.
- Scénarios épic **S4** (indicateur G jamais diffusé : aucune clé `score`/`category`/`index` dans le DTO) et **S5** (non diffusible : identité masquée, indicateurs + `siren`/`workforceEma` conservés) couverts, plus `isCompanyDiffusible`, la conversion numeric→number et `publicSearchInputSchema`.

## Gates

- Typecheck ✅ · Tests ✅ (3144/3144) · Lint ✅ · Format ✅
- Structural auditor : aucun ERROR · Security auditor : SECURE (whitelist vérifiée, aucun leak score/G, comportement `weez.ts` préservé)

_Pas de capture d'écran : ticket backend, aucune modification UI._
