### PR TITLE
fix(prod/pg): corrige la clé d'override du storage CNPG (storage → persistence)

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -86,7 +86,7 @@ nginx:
 
 pg:
   cnpg-cluster:
-    storage:
+    persistence:
       size: 20Gi
 
 redis:


### PR DESCRIPTION
## Contexte

Le déploiement prod de `v3.18.0` échoue à l'apply du `Cluster/egapro/pg` :

> `The Cluster "pg" is invalid: spec.storage: ... can't shrink existing storage from 20Gi to 8Gi`

## Cause racine

La bump de storage introduite en v3.18.0 (#3511) écrivait la valeur sous la **mauvaise clé** :

```yaml
pg:
  cnpg-cluster:
    storage:      # ← clé non lue par le chart
      size: 20Gi
```

Le sous-chart `cnpg-cluster` (`socialgouv/helm-charts/charts/cnpg-cluster@v1`) lit la taille du PVC depuis **`persistence.size`** (défaut `8Gi`), qu'il template ensuite dans `spec.storage.size`. La clé `storage.size` était donc **silencieusement ignorée** → le manifeste rendait `8Gi`.

Le PVC live étant déjà à `20Gi` (agrandi hors chart lors de l'incident #3511), CloudNativePG **refuse le shrink** `20Gi → 8Gi` et fait échouer chaque déploiement.

## Fix

Renommage de la clé `storage` → `persistence`. Le manifeste rendra `spec.storage.size: 20Gi`, alignant le desired state sur le PVC live.

```diff
 pg:
   cnpg-cluster:
-    storage:
+    persistence:
       size: 20Gi
```

## Validation

- Confirmé sur le chart : `cluster.cnpg.yaml` → `storage.size: {{ .Values.persistence.size | quote }}`, défaut `persistence.size: 8Gi`.
- `20Gi` reste ≥ taille live (un PVC CNPG ne peut pas rétrécir).
- Nécessite un nouveau tag de release pour atteindre la prod.