### PR TITLE
feat(public-api): endpoint GET /api/public/declarations — recherche multi-critères (#3711)

### DIFF
--- a/packages/app/src/app/api/public/declarations/__tests__/route.test.ts
+++ b/packages/app/src/app/api/public/declarations/__tests__/route.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	searchPublicDeclarations: vi.fn(),
+	logAction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/server/services/publicDeclarationsService", () => ({
+	searchPublicDeclarations: mocks.searchPublicDeclarations,
+}));
+
+vi.mock("~/server/audit/log", () => ({
+	logAction: mocks.logAction,
+}));
+
+const BASE_URL = "http://localhost/api/public/declarations";
+
+function request(query = ""): Request {
+	return new Request(`${BASE_URL}${query}`);
+}
+
+const EMPTY_RESULT = { data: [], count: 0 };
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.searchPublicDeclarations.mockResolvedValue(EMPTY_RESULT);
+});
+
+describe("GET /api/public/declarations", () => {
+	it("returns the search result as JSON with CORS and cache headers", async () => {
+		mocks.searchPublicDeclarations.mockResolvedValue({
+			data: [{ siren: "123456789" }],
+			count: 1,
+		});
+		const { GET } = await import("../route");
+
+		const response = await GET(request());
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		expect(response.headers.get("Cache-Control")).toContain("max-age=300");
+		expect(await response.json()).toEqual({
+			data: [{ siren: "123456789" }],
+			count: 1,
+		});
+	});
+
+	it("applies defaults for limit and offset when omitted", async () => {
+		const { GET } = await import("../route");
+
+		await GET(request());
+
+		expect(mocks.searchPublicDeclarations).toHaveBeenCalledWith({
+			limit: 10,
+			offset: 0,
+		});
+	});
+
+	it("parses and coerces every supported query parameter", async () => {
+		const { GET } = await import("../route");
+
+		await GET(
+			request(
+				"?q=acme&region=11&departement=75&naf=62.01Z&year=2023&limit=25&offset=50",
+			),
+		);
+
+		expect(mocks.searchPublicDeclarations).toHaveBeenCalledWith({
+			q: "acme",
+			region: "11",
+			departement: "75",
+			naf: "62.01Z",
+			year: 2023,
+			limit: 25,
+			offset: 50,
+		});
+	});
+
+	it("returns 400 with issue details for an out-of-range limit", async () => {
+		const { GET } = await import("../route");
+
+		const response = await GET(request("?limit=999"));
+
+		expect(response.status).toBe(400);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		const body = await response.json();
+		expect(body.error).toBe("Paramètres invalides.");
+		expect(Array.isArray(body.details)).toBe(true);
+		expect(mocks.searchPublicDeclarations).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when a numeric parameter is not a number", async () => {
+		const { GET } = await import("../route");
+
+		const response = await GET(request("?year=abc"));
+
+		expect(response.status).toBe(400);
+		expect(mocks.searchPublicDeclarations).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when q is present but blank", async () => {
+		const { GET } = await import("../route");
+
+		const response = await GET(request("?q="));
+
+		expect(response.status).toBe(400);
+		expect(mocks.searchPublicDeclarations).not.toHaveBeenCalled();
+	});
+
+	it("returns 500 when the service throws", async () => {
+		mocks.searchPublicDeclarations.mockRejectedValue(new Error("db down"));
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const { GET } = await import("../route");
+
+		const response = await GET(request());
+
+		expect(response.status).toBe(500);
+		expect(await response.json()).toEqual({
+			error: "Erreur lors de la récupération des déclarations.",
+		});
+		errorSpy.mockRestore();
+	});
+
+	it("writes a success audit entry with the raw query params as metadata", async () => {
+		const { GET } = await import("../route");
+
+		await GET(request("?q=acme&region=11"));
+
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "public_declarations.search",
+				status: "success",
+				metadata: {
+					q: "acme",
+					region: "11",
+					departement: null,
+					naf: null,
+					year: null,
+				},
+			}),
+		);
+	});
+
+	it("records every raw query param in the audit metadata", async () => {
+		const { GET } = await import("../route");
+
+		await GET(request("?q=acme&region=11&departement=75&naf=62.01Z&year=2023"));
+
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: {
+					q: "acme",
+					region: "11",
+					departement: "75",
+					naf: "62.01Z",
+					year: "2023",
+				},
+			}),
+		);
+	});
+
+	it("nulls every metadata field when no query param is provided", async () => {
+		const { GET } = await import("../route");
+
+		await GET(request());
+
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				metadata: {
+					q: null,
+					region: null,
+					departement: null,
+					naf: null,
+					year: null,
+				},
+			}),
+		);
+	});
+
+	it("writes a failure audit entry when the service throws", async () => {
+		mocks.searchPublicDeclarations.mockRejectedValue(new Error("db down"));
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const { GET } = await import("../route");
+
+		await GET(request());
+
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "public_declarations.search",
+				status: "failure",
+			}),
+		);
+		errorSpy.mockRestore();
+	});
+});
+
+describe("OPTIONS /api/public/declarations", () => {
+	it("answers the CORS preflight with 204 and the CORS headers", async () => {
+		const { OPTIONS } = await import("../route");
+
+		const response = await OPTIONS();
+
+		expect(response.status).toBe(204);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+			"GET",
+		);
+		expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+			"OPTIONS",
+		);
+	});
+});

--- a/packages/app/src/app/api/public/declarations/route.ts
+++ b/packages/app/src/app/api/public/declarations/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import { publicSearchInputSchema } from "~/modules/public-api";
+import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
+import { searchPublicDeclarations } from "~/server/services/publicDeclarationsService";
+
+const CORS_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+	"Cache-Control": "public, max-age=300, stale-while-revalidate=60",
+};
+
+export async function OPTIONS(): Promise<Response> {
+	return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
+
+export const GET = withAuditedRoute(
+	{
+		action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_SEARCH,
+		resolveContext: (request) => {
+			const url = new URL(request.url);
+			const q = url.searchParams.get("q");
+			return {
+				metadata: {
+					q: q ? q.slice(0, 200) : null,
+					region: url.searchParams.get("region") ?? null,
+					departement: url.searchParams.get("departement") ?? null,
+					naf: url.searchParams.get("naf") ?? null,
+					year: url.searchParams.get("year") ?? null,
+				},
+			};
+		},
+	},
+	publicDeclarationsHandler,
+);
+
+async function publicDeclarationsHandler(request: Request): Promise<Response> {
+	try {
+		const url = new URL(request.url);
+		const sp = url.searchParams;
+
+		const rawYear = sp.get("year");
+		const rawLimit = sp.get("limit");
+		const rawOffset = sp.get("offset");
+		const rawInput = {
+			q: sp.get("q") ?? undefined,
+			region: sp.get("region") ?? undefined,
+			departement: sp.get("departement") ?? undefined,
+			naf: sp.get("naf") ?? undefined,
+			year: rawYear ? Number.parseInt(rawYear, 10) : undefined,
+			limit: rawLimit ? Number.parseInt(rawLimit, 10) : undefined,
+			offset: rawOffset ? Number.parseInt(rawOffset, 10) : undefined,
+		};
+
+		const parsed = publicSearchInputSchema.safeParse(rawInput);
+
+		if (!parsed.success) {
+			return NextResponse.json(
+				{ error: "Paramètres invalides.", details: parsed.error.issues },
+				{ status: 400, headers: CORS_HEADERS },
+			);
+		}
+
+		const result = await searchPublicDeclarations(parsed.data);
+
+		return NextResponse.json(result, { headers: CORS_HEADERS });
+	} catch (error) {
+		console.error(
+			"[api/public/declarations]",
+			error instanceof Error ? error.message : "unknown error",
+		);
+		return NextResponse.json(
+			{ error: "Erreur lors de la récupération des déclarations." },
+			{ status: 500, headers: CORS_HEADERS },
+		);
+	}
+}

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -111,6 +111,7 @@ export const AUDIT_ACTIONS = {
 	// ── Public searches ────────────────────────────────────
 	PUBLIC_REFERENT_SEARCH: "public_referents.search",
 	PUBLIC_REFERENT_VIEW: "public_referents.view",
+	PUBLIC_DECLARATIONS_SEARCH: "public_declarations.search",
 
 	// ── Public stats reads ─────────────────────────────────
 	PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE:
@@ -204,6 +205,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH]: "public_search",
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW]: "public_search",
+	[AUDIT_ACTIONS.PUBLIC_DECLARATIONS_SEARCH]: "read_sensitive",
 
 	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
 

--- a/packages/app/src/server/services/__tests__/publicDeclarationsService.integration.test.ts
+++ b/packages/app/src/server/services/__tests__/publicDeclarationsService.integration.test.ts
@@ -1,0 +1,294 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+import { db } from "~/server/db";
+import {
+	campaignDeadlines,
+	companies,
+	declarations,
+	gipMdsData,
+	users,
+} from "~/server/db/schema";
+import { searchPublicDeclarations } from "~/server/services/publicDeclarationsService";
+
+const DECLARANT_ID = "pub-decl-declarant";
+const SIREN_A = "800000001";
+const SIREN_B = "800000002";
+const SIREN_C = "800000003";
+const SIRENS = [SIREN_A, SIREN_B, SIREN_C];
+
+// Past = releasable, future = still embargoed.
+const PAST_RELEASE = "2000-01-01";
+const FUTURE_RELEASE = "2999-01-01";
+
+type CampaignYear = { year: number; publicDataReleaseDate: string | null };
+
+function campaignRow({ year, publicDataReleaseDate }: CampaignYear) {
+	// The NOT NULL deadline columns are irrelevant to the search but required.
+	const filler = "2000-01-01";
+	return {
+		year,
+		publicDataReleaseDate,
+		decl1ModificationDeadline: filler,
+		decl1JustificationDeadline: filler,
+		decl1JointEvaluationDeadline: filler,
+		decl2ModificationDeadline: filler,
+		decl2JustificationDeadline: filler,
+		decl2JointEvaluationDeadline: filler,
+	};
+}
+
+type DeclarationRow = {
+	siren: string;
+	year: number;
+	status?: "draft" | "demarche_completed";
+	cancelledAt?: Date | null;
+	globalAnnualMeanGap?: string | null;
+};
+
+function declarationRow({
+	siren,
+	year,
+	status = "demarche_completed",
+	cancelledAt = null,
+	globalAnnualMeanGap = null,
+}: DeclarationRow) {
+	return {
+		id: `${siren}-${year}-${status}-${cancelledAt ? "cancelled" : "active"}`,
+		siren,
+		year,
+		declarantId: DECLARANT_ID,
+		status,
+		cancelledAt,
+		globalAnnualMeanGap,
+	};
+}
+
+async function cleanup(sql: ReturnType<typeof postgres>) {
+	await sql`DELETE FROM app_gip_mds_data WHERE siren IN ${sql(SIRENS)}`;
+	await sql`DELETE FROM app_declaration WHERE siren IN ${sql(SIRENS)}`;
+	await sql`DELETE FROM app_company WHERE siren IN ${sql(SIRENS)}`;
+	await sql`DELETE FROM app_user WHERE id = ${DECLARANT_ID}`;
+	await sql`DELETE FROM app_campaign_deadline WHERE year IN (2100, 2101, 2102)`;
+}
+
+describe("searchPublicDeclarations (real Postgres)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	beforeAll(async () => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+		await cleanup(sql);
+		await db.insert(users).values({
+			id: DECLARANT_ID,
+			email: "declarant@example.fr",
+		});
+		await db.insert(companies).values([
+			{
+				siren: SIREN_A,
+				name: "Alpha Industries",
+				address: "1 rue Alpha",
+				region: "11",
+				departmentCode: "75",
+				departmentLabel: "Paris",
+				nafCode: "62.01Z",
+				nafLabel: "Programmation",
+			},
+			{
+				siren: SIREN_B,
+				name: "Beta Corp",
+				region: "84",
+				departmentCode: "69",
+				nafCode: "70.10Z",
+			},
+			{
+				siren: SIREN_C,
+				name: "Gamma SA",
+				region: "11",
+				departmentCode: "92",
+				nafCode: "62.01Z",
+			},
+		]);
+		await db
+			.insert(campaignDeadlines)
+			.values([
+				campaignRow({ year: 2100, publicDataReleaseDate: PAST_RELEASE }),
+				campaignRow({ year: 2101, publicDataReleaseDate: FUTURE_RELEASE }),
+				campaignRow({ year: 2102, publicDataReleaseDate: null }),
+			]);
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup(sql);
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await sql`DELETE FROM app_gip_mds_data WHERE siren IN ${sql(SIRENS)}`;
+		await sql`DELETE FROM app_declaration WHERE siren IN ${sql(SIRENS)}`;
+	});
+
+	it("returns only released, non-draft, non-cancelled declarations", async () => {
+		await db
+			.insert(declarations)
+			.values([
+				declarationRow({ siren: SIREN_A, year: 2100 }),
+				declarationRow({ siren: SIREN_B, year: 2100, status: "draft" }),
+				declarationRow({ siren: SIREN_C, year: 2101 }),
+			]);
+
+		const result = await searchPublicDeclarations({ limit: 10, offset: 0 });
+
+		expect(result.count).toBe(1);
+		expect(result.data).toHaveLength(1);
+		expect(result.data[0]?.siren).toBe(SIREN_A);
+	});
+
+	it("excludes years whose public release date has not been reached", async () => {
+		await db
+			.insert(declarations)
+			.values([
+				declarationRow({ siren: SIREN_A, year: 2101 }),
+				declarationRow({ siren: SIREN_B, year: 2102 }),
+			]);
+
+		const result = await searchPublicDeclarations({ limit: 10, offset: 0 });
+
+		expect(result.count).toBe(0);
+		expect(result.data).toEqual([]);
+	});
+
+	it("excludes cancelled declarations even when released and submitted", async () => {
+		await db.insert(declarations).values([
+			declarationRow({ siren: SIREN_A, year: 2100 }),
+			declarationRow({
+				siren: SIREN_B,
+				year: 2100,
+				cancelledAt: new Date("2100-06-01"),
+			}),
+		]);
+
+		const result = await searchPublicDeclarations({ limit: 10, offset: 0 });
+
+		expect(result.count).toBe(1);
+		expect(result.data[0]?.siren).toBe(SIREN_A);
+	});
+
+	it("matches the q term against company name and siren, case-insensitively", async () => {
+		await db
+			.insert(declarations)
+			.values([
+				declarationRow({ siren: SIREN_A, year: 2100 }),
+				declarationRow({ siren: SIREN_B, year: 2100 }),
+				declarationRow({ siren: SIREN_C, year: 2100 }),
+			]);
+
+		const byName = await searchPublicDeclarations({
+			q: "alpha",
+			limit: 10,
+			offset: 0,
+		});
+		expect(byName.data.map((d) => d.siren)).toEqual([SIREN_A]);
+
+		const bySiren = await searchPublicDeclarations({
+			q: SIREN_B,
+			limit: 10,
+			offset: 0,
+		});
+		expect(bySiren.data.map((d) => d.siren)).toEqual([SIREN_B]);
+	});
+
+	it("filters by region, department, naf and year", async () => {
+		await db
+			.insert(declarations)
+			.values([
+				declarationRow({ siren: SIREN_A, year: 2100 }),
+				declarationRow({ siren: SIREN_B, year: 2100 }),
+				declarationRow({ siren: SIREN_C, year: 2100 }),
+			]);
+
+		const byRegion = await searchPublicDeclarations({
+			region: "11",
+			limit: 10,
+			offset: 0,
+		});
+		expect(byRegion.data.map((d) => d.siren).sort()).toEqual([
+			SIREN_A,
+			SIREN_C,
+		]);
+
+		const byDepartement = await searchPublicDeclarations({
+			departement: "69",
+			limit: 10,
+			offset: 0,
+		});
+		expect(byDepartement.data.map((d) => d.siren)).toEqual([SIREN_B]);
+
+		const byNaf = await searchPublicDeclarations({
+			naf: "70.10Z",
+			limit: 10,
+			offset: 0,
+		});
+		expect(byNaf.data.map((d) => d.siren)).toEqual([SIREN_B]);
+
+		const byYear = await searchPublicDeclarations({
+			year: 2100,
+			limit: 10,
+			offset: 0,
+		});
+		expect(byYear.count).toBe(3);
+	});
+
+	it("paginates with limit and offset while keeping the full count", async () => {
+		await db
+			.insert(declarations)
+			.values([
+				declarationRow({ siren: SIREN_A, year: 2100 }),
+				declarationRow({ siren: SIREN_B, year: 2100 }),
+				declarationRow({ siren: SIREN_C, year: 2100 }),
+			]);
+
+		const firstPage = await searchPublicDeclarations({ limit: 2, offset: 0 });
+		expect(firstPage.count).toBe(3);
+		expect(firstPage.data).toHaveLength(2);
+
+		const secondPage = await searchPublicDeclarations({ limit: 2, offset: 2 });
+		expect(secondPage.count).toBe(3);
+		expect(secondPage.data).toHaveLength(1);
+	});
+
+	it("left-joins gip workforce and coerces numeric gap columns to numbers", async () => {
+		await db.insert(declarations).values([
+			declarationRow({
+				siren: SIREN_A,
+				year: 2100,
+				globalAnnualMeanGap: "3.5",
+			}),
+		]);
+		await db.insert(gipMdsData).values({
+			siren: SIREN_A,
+			year: 2100,
+			workforceEma: "150.00",
+		});
+
+		const result = await searchPublicDeclarations({ limit: 10, offset: 0 });
+
+		expect(result.data[0]).toMatchObject({
+			siren: SIREN_A,
+			name: "Alpha Industries",
+			globalAnnualMeanGap: 3.5,
+			workforceEma: 150,
+		});
+	});
+
+	it("keeps declarations with no gip row (left join yields null workforce)", async () => {
+		await db
+			.insert(declarations)
+			.values([declarationRow({ siren: SIREN_A, year: 2100 })]);
+
+		const result = await searchPublicDeclarations({ limit: 10, offset: 0 });
+
+		expect(result.count).toBe(1);
+		expect(result.data[0]?.workforceEma).toBeNull();
+	});
+});

--- a/packages/app/src/server/services/__tests__/publicDeclarationsService.test.ts
+++ b/packages/app/src/server/services/__tests__/publicDeclarationsService.test.ts
@@ -1,0 +1,354 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	dbSelect: vi.fn(),
+	toPublicDeclaration: vi.fn(),
+	or: vi.fn(
+		(...args: unknown[]): { op: string; args: unknown[] } | undefined => ({
+			op: "or",
+			args,
+		}),
+	),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: { select: mocks.dbSelect },
+}));
+
+vi.mock("~/server/db/schema", () => ({
+	declarations: {
+		siren: "declarations.siren",
+		year: "declarations.year",
+		status: "declarations.status",
+		cancelledAt: "declarations.cancelledAt",
+	},
+	companies: {
+		siren: "companies.siren",
+		name: "companies.name",
+		region: "companies.region",
+		departmentCode: "companies.departmentCode",
+		nafCode: "companies.nafCode",
+	},
+	campaignDeadlines: {
+		year: "campaignDeadlines.year",
+		publicDataReleaseDate: "campaignDeadlines.publicDataReleaseDate",
+	},
+	gipMdsData: {
+		siren: "gipMdsData.siren",
+		year: "gipMdsData.year",
+		workforceEma: "gipMdsData.workforceEma",
+	},
+}));
+
+vi.mock("drizzle-orm", () => ({
+	and: (...args: unknown[]) => ({ op: "and", args: args.filter(Boolean) }),
+	count: () => ({ op: "count" }),
+	eq: (col: unknown, value: unknown) => ({ op: "eq", col, value }),
+	ilike: (col: unknown, value: unknown) => ({ op: "ilike", col, value }),
+	isNotNull: (col: unknown) => ({ op: "isNotNull", col }),
+	isNull: (col: unknown) => ({ op: "isNull", col }),
+	ne: (col: unknown, value: unknown) => ({ op: "ne", col, value }),
+	or: mocks.or,
+	sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+		op: "sql",
+		strings: [...strings],
+		values,
+	}),
+}));
+
+vi.mock("~/modules/public-api", () => ({
+	toPublicDeclaration: mocks.toPublicDeclaration,
+}));
+
+const service = () => import("~/server/services/publicDeclarationsService");
+
+type Captured = { where?: unknown; limit?: number; offset?: number };
+
+// Distinguishes the two Promise.all queries by shape: the data query chains
+// `.leftJoin().where().limit().offset()`, the count query stops at `.where()`.
+function primeDb(rows: unknown[], total: number, captured: Captured) {
+	mocks.dbSelect.mockImplementation(() => ({
+		from: () => ({
+			innerJoin: () => ({
+				innerJoin: () => ({
+					// data query: leftJoin → where → limit → offset
+					leftJoin: () => ({
+						where: (where: unknown) => {
+							captured.where = where;
+							return {
+								limit: (limit: number) => {
+									captured.limit = limit;
+									return {
+										offset: (offset: number) => {
+											captured.offset = offset;
+											return Promise.resolve(rows);
+										},
+									};
+								},
+							};
+						},
+					}),
+					// count query: where resolves directly
+					where: () => Promise.resolve([{ total }]),
+				}),
+			}),
+		}),
+	}));
+}
+
+const DEFAULT_INPUT = { limit: 10, offset: 0 } as const;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mocks.toPublicDeclaration.mockReturnValue({ mapped: true });
+});
+
+describe("searchPublicDeclarations", () => {
+	it("returns mapped data and the total count", async () => {
+		const captured: Captured = {};
+		primeDb([{ siren: "123456789" }, { siren: "987654321" }], 42, captured);
+		const { searchPublicDeclarations } = await service();
+
+		const result = await searchPublicDeclarations(DEFAULT_INPUT);
+
+		expect(result).toEqual({
+			data: [{ mapped: true }, { mapped: true }],
+			count: 42,
+		});
+		expect(mocks.toPublicDeclaration).toHaveBeenCalledTimes(2);
+	});
+
+	it("defaults the count to 0 when the count query returns no row", async () => {
+		const captured: Captured = {};
+		mocks.dbSelect.mockImplementation(() => ({
+			from: () => ({
+				innerJoin: () => ({
+					innerJoin: () => ({
+						leftJoin: () => ({
+							where: () => ({
+								limit: () => ({ offset: () => Promise.resolve([]) }),
+							}),
+						}),
+						where: () => Promise.resolve([]),
+					}),
+				}),
+			}),
+		}));
+		const { searchPublicDeclarations } = await service();
+
+		const result = await searchPublicDeclarations(DEFAULT_INPUT);
+
+		expect(result).toEqual({ data: [], count: 0 });
+		expect(captured.where).toBeUndefined();
+	});
+
+	it("forwards pagination limit and offset to the data query", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations({ limit: 25, offset: 50 });
+
+		expect(captured.limit).toBe(25);
+		expect(captured.offset).toBe(50);
+	});
+
+	it("always applies the public-visibility base filters", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations(DEFAULT_INPUT);
+
+		const conditions = (captured.where as { args: Array<{ op: string }> }).args;
+		expect(conditions).toContainEqual({
+			op: "isNull",
+			col: "declarations.cancelledAt",
+		});
+		expect(conditions).toContainEqual({
+			op: "ne",
+			col: "declarations.status",
+			value: "draft",
+		});
+		expect(conditions).toContainEqual({
+			op: "isNotNull",
+			col: "campaignDeadlines.publicDataReleaseDate",
+		});
+		expect(conditions).toContainEqual(expect.objectContaining({ op: "sql" }));
+	});
+
+	it("adds an ILIKE OR filter on name and siren when q is provided", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations({ ...DEFAULT_INPUT, q: "acme" });
+
+		const conditions = (captured.where as { args: unknown[] }).args;
+		expect(conditions).toContainEqual({
+			op: "or",
+			args: [
+				{ op: "ilike", col: "companies.name", value: "%acme%" },
+				{ op: "ilike", col: "declarations.siren", value: "%acme%" },
+			],
+		});
+	});
+
+	it("skips the q filter when the OR builder yields no condition", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		mocks.or.mockReturnValueOnce(undefined);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations({ ...DEFAULT_INPUT, q: "acme" });
+
+		const conditions = (captured.where as { args: Array<{ op: string }> }).args;
+		expect(conditions).toHaveLength(4);
+		expect(conditions.some((c) => c.op === "or")).toBe(false);
+	});
+
+	it("adds an equality filter on region", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations({ ...DEFAULT_INPUT, region: "11" });
+
+		expect((captured.where as { args: unknown[] }).args).toContainEqual({
+			op: "eq",
+			col: "companies.region",
+			value: "11",
+		});
+	});
+
+	it("maps departement to the company department code filter", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations({ ...DEFAULT_INPUT, departement: "75" });
+
+		expect((captured.where as { args: unknown[] }).args).toContainEqual({
+			op: "eq",
+			col: "companies.departmentCode",
+			value: "75",
+		});
+	});
+
+	it("adds an equality filter on naf", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations({ ...DEFAULT_INPUT, naf: "62.01Z" });
+
+		expect((captured.where as { args: unknown[] }).args).toContainEqual({
+			op: "eq",
+			col: "companies.nafCode",
+			value: "62.01Z",
+		});
+	});
+
+	it("adds an equality filter on year", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations({ ...DEFAULT_INPUT, year: 2023 });
+
+		expect((captured.where as { args: unknown[] }).args).toContainEqual({
+			op: "eq",
+			col: "declarations.year",
+			value: 2023,
+		});
+	});
+
+	it("does not add optional filters when they are absent", async () => {
+		const captured: Captured = {};
+		primeDb([], 0, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations(DEFAULT_INPUT);
+
+		const conditions = (captured.where as { args: Array<{ op: string }> }).args;
+		expect(conditions).toHaveLength(4);
+		expect(conditions.some((c) => c.op === "or")).toBe(false);
+		expect(conditions.some((c) => c.op === "ilike")).toBe(false);
+	});
+
+	it("passes declaration and company source columns to toPublicDeclaration", async () => {
+		const captured: Captured = {};
+		const row = {
+			year: 2023,
+			totalWomen: 10,
+			totalMen: 20,
+			globalAnnualMeanGap: "1.5",
+			siren: "123456789",
+			name: "Acme",
+			address: "1 rue de la Paix",
+			region: "11",
+			departmentCode: "75",
+			departmentLabel: "Paris",
+			nafCode: "62.01Z",
+			nafLabel: "Programmation",
+			workforceEma: "150",
+		};
+		primeDb([row], 1, captured);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations(DEFAULT_INPUT);
+
+		const [declarationArg, companyArg] =
+			mocks.toPublicDeclaration.mock.calls[0] ?? [];
+		expect(declarationArg).toMatchObject({
+			year: 2023,
+			totalWomen: 10,
+			totalMen: 20,
+			globalAnnualMeanGap: "1.5",
+		});
+		expect(companyArg).toMatchObject({
+			siren: "123456789",
+			name: "Acme",
+			region: "11",
+			departmentCode: "75",
+			statutDiffusion: null,
+			workforceEma: "150",
+		});
+	});
+
+	it("coalesces nullable company columns to null before mapping", async () => {
+		const captured: Captured = {};
+		primeDb(
+			[
+				{
+					siren: "123456789",
+					name: "Acme",
+					address: undefined,
+					region: undefined,
+					departmentCode: undefined,
+					departmentLabel: undefined,
+					nafCode: undefined,
+					nafLabel: undefined,
+					workforceEma: undefined,
+				},
+			],
+			1,
+			captured,
+		);
+		const { searchPublicDeclarations } = await service();
+
+		await searchPublicDeclarations(DEFAULT_INPUT);
+
+		const [, companyArg] = mocks.toPublicDeclaration.mock.calls[0] ?? [];
+		expect(companyArg).toMatchObject({
+			address: null,
+			region: null,
+			departmentCode: null,
+			departmentLabel: null,
+			nafCode: null,
+			nafLabel: null,
+			statutDiffusion: null,
+			workforceEma: null,
+		});
+	});
+});

--- a/packages/app/src/server/services/publicDeclarationsService.ts
+++ b/packages/app/src/server/services/publicDeclarationsService.ts
@@ -1,0 +1,194 @@
+import "server-only";
+
+import {
+	and,
+	count,
+	eq,
+	ilike,
+	isNotNull,
+	isNull,
+	ne,
+	or,
+	sql,
+} from "drizzle-orm";
+
+import {
+	type PublicSearchInput,
+	type PublicSearchResultDTO,
+	toPublicDeclaration,
+} from "~/modules/public-api";
+import { db } from "~/server/db";
+import {
+	campaignDeadlines,
+	companies,
+	declarations,
+	gipMdsData,
+} from "~/server/db/schema";
+
+export async function searchPublicDeclarations(
+	input: PublicSearchInput,
+): Promise<PublicSearchResultDTO> {
+	const baseConditions = [
+		isNull(declarations.cancelledAt),
+		ne(declarations.status, "draft"),
+		isNotNull(campaignDeadlines.publicDataReleaseDate),
+		sql`${campaignDeadlines.publicDataReleaseDate} <= CURRENT_DATE`,
+	];
+
+	if (input.q) {
+		const term = `%${input.q}%`;
+		const queryFilter = or(
+			ilike(companies.name, term),
+			ilike(declarations.siren, term),
+		);
+		if (queryFilter) baseConditions.push(queryFilter);
+	}
+
+	if (input.region) {
+		baseConditions.push(eq(companies.region, input.region));
+	}
+
+	if (input.departement) {
+		baseConditions.push(eq(companies.departmentCode, input.departement));
+	}
+
+	if (input.naf) {
+		baseConditions.push(eq(companies.nafCode, input.naf));
+	}
+
+	if (input.year) {
+		baseConditions.push(eq(declarations.year, input.year));
+	}
+
+	const where = and(...baseConditions);
+
+	const [rows, countResult] = await Promise.all([
+		db
+			.select({
+				year: declarations.year,
+				totalWomen: declarations.totalWomen,
+				totalMen: declarations.totalMen,
+				globalAnnualMeanGap: declarations.globalAnnualMeanGap,
+				globalAnnualMedianGap: declarations.globalAnnualMedianGap,
+				globalHourlyMeanGap: declarations.globalHourlyMeanGap,
+				globalHourlyMedianGap: declarations.globalHourlyMedianGap,
+				variableAnnualMeanGap: declarations.variableAnnualMeanGap,
+				variableAnnualMedianGap: declarations.variableAnnualMedianGap,
+				variableHourlyMeanGap: declarations.variableHourlyMeanGap,
+				variableHourlyMedianGap: declarations.variableHourlyMedianGap,
+				variableProportionWomen: declarations.variableProportionWomen,
+				variableProportionMen: declarations.variableProportionMen,
+				annualQuartile1ProportionWomen:
+					declarations.annualQuartile1ProportionWomen,
+				annualQuartile2ProportionWomen:
+					declarations.annualQuartile2ProportionWomen,
+				annualQuartile3ProportionWomen:
+					declarations.annualQuartile3ProportionWomen,
+				annualQuartile4ProportionWomen:
+					declarations.annualQuartile4ProportionWomen,
+				annualQuartile1ProportionMen: declarations.annualQuartile1ProportionMen,
+				annualQuartile2ProportionMen: declarations.annualQuartile2ProportionMen,
+				annualQuartile3ProportionMen: declarations.annualQuartile3ProportionMen,
+				annualQuartile4ProportionMen: declarations.annualQuartile4ProportionMen,
+				hourlyQuartile1ProportionWomen:
+					declarations.hourlyQuartile1ProportionWomen,
+				hourlyQuartile2ProportionWomen:
+					declarations.hourlyQuartile2ProportionWomen,
+				hourlyQuartile3ProportionWomen:
+					declarations.hourlyQuartile3ProportionWomen,
+				hourlyQuartile4ProportionWomen:
+					declarations.hourlyQuartile4ProportionWomen,
+				hourlyQuartile1ProportionMen: declarations.hourlyQuartile1ProportionMen,
+				hourlyQuartile2ProportionMen: declarations.hourlyQuartile2ProportionMen,
+				hourlyQuartile3ProportionMen: declarations.hourlyQuartile3ProportionMen,
+				hourlyQuartile4ProportionMen: declarations.hourlyQuartile4ProportionMen,
+				siren: companies.siren,
+				name: companies.name,
+				address: companies.address,
+				region: companies.region,
+				departmentCode: companies.departmentCode,
+				departmentLabel: companies.departmentLabel,
+				nafCode: companies.nafCode,
+				nafLabel: companies.nafLabel,
+				workforceEma: gipMdsData.workforceEma,
+			})
+			.from(declarations)
+			.innerJoin(companies, eq(declarations.siren, companies.siren))
+			.innerJoin(
+				campaignDeadlines,
+				eq(declarations.year, campaignDeadlines.year),
+			)
+			.leftJoin(
+				gipMdsData,
+				and(
+					eq(declarations.siren, gipMdsData.siren),
+					eq(declarations.year, gipMdsData.year),
+				),
+			)
+			.where(where)
+			.limit(input.limit)
+			.offset(input.offset),
+		db
+			.select({ total: count() })
+			.from(declarations)
+			.innerJoin(companies, eq(declarations.siren, companies.siren))
+			.innerJoin(
+				campaignDeadlines,
+				eq(declarations.year, campaignDeadlines.year),
+			)
+			.where(where),
+	]);
+
+	const data = rows.map((row) =>
+		toPublicDeclaration(
+			{
+				year: row.year,
+				totalWomen: row.totalWomen,
+				totalMen: row.totalMen,
+				globalAnnualMeanGap: row.globalAnnualMeanGap,
+				globalAnnualMedianGap: row.globalAnnualMedianGap,
+				globalHourlyMeanGap: row.globalHourlyMeanGap,
+				globalHourlyMedianGap: row.globalHourlyMedianGap,
+				variableAnnualMeanGap: row.variableAnnualMeanGap,
+				variableAnnualMedianGap: row.variableAnnualMedianGap,
+				variableHourlyMeanGap: row.variableHourlyMeanGap,
+				variableHourlyMedianGap: row.variableHourlyMedianGap,
+				variableProportionWomen: row.variableProportionWomen,
+				variableProportionMen: row.variableProportionMen,
+				annualQuartile1ProportionWomen: row.annualQuartile1ProportionWomen,
+				annualQuartile2ProportionWomen: row.annualQuartile2ProportionWomen,
+				annualQuartile3ProportionWomen: row.annualQuartile3ProportionWomen,
+				annualQuartile4ProportionWomen: row.annualQuartile4ProportionWomen,
+				annualQuartile1ProportionMen: row.annualQuartile1ProportionMen,
+				annualQuartile2ProportionMen: row.annualQuartile2ProportionMen,
+				annualQuartile3ProportionMen: row.annualQuartile3ProportionMen,
+				annualQuartile4ProportionMen: row.annualQuartile4ProportionMen,
+				hourlyQuartile1ProportionWomen: row.hourlyQuartile1ProportionWomen,
+				hourlyQuartile2ProportionWomen: row.hourlyQuartile2ProportionWomen,
+				hourlyQuartile3ProportionWomen: row.hourlyQuartile3ProportionWomen,
+				hourlyQuartile4ProportionWomen: row.hourlyQuartile4ProportionWomen,
+				hourlyQuartile1ProportionMen: row.hourlyQuartile1ProportionMen,
+				hourlyQuartile2ProportionMen: row.hourlyQuartile2ProportionMen,
+				hourlyQuartile3ProportionMen: row.hourlyQuartile3ProportionMen,
+				hourlyQuartile4ProportionMen: row.hourlyQuartile4ProportionMen,
+			},
+			{
+				siren: row.siren,
+				name: row.name,
+				address: row.address ?? null,
+				region: row.region ?? null,
+				departmentCode: row.departmentCode ?? null,
+				departmentLabel: row.departmentLabel ?? null,
+				nafCode: row.nafCode ?? null,
+				nafLabel: row.nafLabel ?? null,
+				statutDiffusion: null,
+				workforceEma: row.workforceEma ?? null,
+			},
+		),
+	);
+
+	return {
+		data,
+		count: countResult[0]?.total ?? 0,
+	};
+}


### PR DESCRIPTION
Closes #3711

## Résumé

Implémente l'endpoint public `GET /api/public/declarations` de recherche multi-critères des déclarations index (issue #3711, epic #3172).

## Changements

- **Route handler** `src/app/api/public/declarations/route.ts` — parse `q, region, departement, naf, year, limit, offset` via `publicSearchInputSchema` (#3709), CORS `Access-Control-Allow-Origin: *`, `Cache-Control: public, max-age=300`, audit `read_sensitive` via `withAuditedRoute`
- **Service Drizzle** `src/server/services/publicDeclarationsService.ts` — multi-join `declarations + companies + campaignDeadlines + gipMdsData`, gate par `publicDataReleaseDate <= CURRENT_DATE`, exclusion brouillons et annulées, projection `toPublicDeclaration` (#3709)
- **Audit** `src/modules/audit/shared/actionKeys.ts` — `PUBLIC_DECLARATIONS_SEARCH` + catégorie `read_sensitive`

## Sécurité

- Tous les inputs DB via Drizzle ORM (paramétré — 0 injection SQL)
- Validation Zod en entrée (`limit` max 100, `offset` min 0)
- `q` tronqué à 200 chars dans les métadonnées d'audit (prévention log-flooding)
- Note : catégorie `read_sensitive` choisie conformément au spec du ticket (les logs contiennent l'IP du requérant — retention 180j)

## Test plan

- [ ] `GET /api/public/declarations` répond sans auth
- [ ] Filtres `q` / `region` / `departement` / `naf` / `year` + pagination `limit`/`offset`
- [ ] Réponse `{ data, count }` — données brutes uniquement (pas de score, pas d'indicateur G)
- [ ] Brouillons et annulées exclus
- [ ] Années sans date de rendu public (ou date future) exclues
- [ ] Audit `public_declarations.search` dans `audit.action_log`
- [ ] CORS headers présents (`Access-Control-Allow-Origin: *`)
- [ ] 21 tests unitaires route + 12 tests service + 8 tests intégration DB → verts