### PR TITLE
feat(#3712): API publique — GET /declarations/{siren}[/{year}]

### DIFF
--- a/packages/app/src/app/api/public/declarations/[siren]/[year]/__tests__/route.test.ts
+++ b/packages/app/src/app/api/public/declarations/[siren]/[year]/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getPublicDeclarationBySirenYear: vi.fn(),
+	logAction: vi.fn(),
+}));
+
+vi.mock("~/modules/public-api", () => ({
+	getPublicDeclarationBySirenYear: mocks.getPublicDeclarationBySirenYear,
+}));
+
+vi.mock("~/server/audit/log", () => ({
+	logAction: mocks.logAction,
+}));
+
+const VALID_SIREN = "123456789";
+
+function buildRequest(siren: string, year: string) {
+	return new Request(
+		`http://localhost/api/public/declarations/${siren}/${year}`,
+	);
+}
+
+async function callGet(rawSiren: string, rawYear: string) {
+	const { GET } = await import("../route");
+	return GET(buildRequest(rawSiren, rawYear), {
+		params: Promise.resolve({ siren: rawSiren, year: rawYear }),
+	});
+}
+
+describe("GET /api/public/declarations/[siren]/[year]", () => {
+	beforeEach(() => {
+		mocks.getPublicDeclarationBySirenYear.mockReset();
+		mocks.logAction.mockReset();
+	});
+
+	it("returns 400 and logs a failure for an invalid siren", async () => {
+		const response = await callGet("abc", "2024");
+
+		expect(response.status).toBe(400);
+		expect(mocks.getPublicDeclarationBySirenYear).not.toHaveBeenCalled();
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "failure", siren: null }),
+		);
+	});
+
+	it("returns 400 for a non-numeric year", async () => {
+		const response = await callGet(VALID_SIREN, "abcd");
+
+		expect(response.status).toBe(400);
+		expect(mocks.getPublicDeclarationBySirenYear).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 for a year before 2018", async () => {
+		const response = await callGet(VALID_SIREN, "2017");
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 for a year after 2100", async () => {
+		const response = await callGet(VALID_SIREN, "2101");
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 404 and logs a failure when the declaration is absent or unreleased", async () => {
+		mocks.getPublicDeclarationBySirenYear.mockResolvedValue(null);
+
+		const response = await callGet(VALID_SIREN, "2024");
+
+		expect(response.status).toBe(404);
+		expect(mocks.getPublicDeclarationBySirenYear).toHaveBeenCalledWith(
+			VALID_SIREN,
+			2024,
+		);
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "failure", errorMessage: "HTTP 404" }),
+		);
+	});
+
+	it("returns 200 with the declaration and CORS headers on success", async () => {
+		const data = { siren: VALID_SIREN, year: 2024 };
+		mocks.getPublicDeclarationBySirenYear.mockResolvedValue(data);
+
+		const response = await callGet(VALID_SIREN, "2024");
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		expect(await response.json()).toEqual(data);
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "success", siren: VALID_SIREN }),
+		);
+	});
+
+	it("returns 500 and logs a failure when the service throws", async () => {
+		mocks.getPublicDeclarationBySirenYear.mockRejectedValue(new Error("boom"));
+
+		const response = await callGet(VALID_SIREN, "2024");
+
+		expect(response.status).toBe(500);
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "failure", errorMessage: "boom" }),
+		);
+	});
+});

--- a/packages/app/src/app/api/public/declarations/[siren]/[year]/route.ts
+++ b/packages/app/src/app/api/public/declarations/[siren]/[year]/route.ts
@@ -1,0 +1,107 @@
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import { parseSiren } from "~/modules/domain";
+import { getPublicDeclarationBySirenYear } from "~/modules/public-api";
+import { logAction } from "~/server/audit/log";
+import { buildRequestContext } from "~/server/audit/requestContext";
+
+const PUBLIC_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Cache-Control": "public, max-age=300, s-maxage=300",
+};
+
+export async function GET(
+	request: Request,
+	{ params }: { params: Promise<{ siren: string; year: string }> },
+) {
+	const startedAt = Date.now();
+	const requestContext = buildRequestContext(request.headers);
+	const { siren: rawSiren, year: rawYear } = await params;
+
+	const siren = parseSiren(rawSiren);
+	if (!siren) {
+		void logAction({
+			action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN_YEAR,
+			status: "failure",
+			siren: null,
+			metadata: { rawSiren, rawYear },
+			errorMessage: "HTTP 400",
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+		return Response.json(
+			{ error: "SIREN invalide. Attendu : 9 chiffres." },
+			{ status: 400, headers: PUBLIC_HEADERS },
+		);
+	}
+
+	const year = Number.parseInt(rawYear, 10);
+	if (!Number.isInteger(year) || year < 2018 || year > 2100) {
+		void logAction({
+			action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN_YEAR,
+			status: "failure",
+			siren,
+			metadata: { rawYear },
+			errorMessage: "HTTP 400",
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+		return Response.json(
+			{ error: "Année invalide." },
+			{ status: 400, headers: PUBLIC_HEADERS },
+		);
+	}
+
+	try {
+		const data = await getPublicDeclarationBySirenYear(siren, year);
+
+		if (data === null) {
+			void logAction({
+				action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN_YEAR,
+				status: "failure",
+				siren,
+				metadata: { year },
+				errorMessage: "HTTP 404",
+				ipAddress: requestContext.ipAddress,
+				userAgent: requestContext.userAgent,
+				durationMs: Date.now() - startedAt,
+			});
+			return Response.json(
+				{ error: "Déclaration non trouvée ou non encore publiée." },
+				{ status: 404, headers: PUBLIC_HEADERS },
+			);
+		}
+
+		void logAction({
+			action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN_YEAR,
+			status: "success",
+			siren,
+			metadata: { year },
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+
+		return Response.json(data, { headers: PUBLIC_HEADERS });
+	} catch (error) {
+		console.error(
+			"[api/public/declarations/:siren/:year]",
+			error instanceof Error ? error.message : "unknown error",
+		);
+		void logAction({
+			action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN_YEAR,
+			status: "failure",
+			siren,
+			metadata: { year },
+			errorMessage: error instanceof Error ? error.message : "Unknown error",
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+		return Response.json(
+			{ error: "Erreur lors de la récupération de la déclaration." },
+			{ status: 500, headers: PUBLIC_HEADERS },
+		);
+	}
+}

--- a/packages/app/src/app/api/public/declarations/[siren]/__tests__/route.test.ts
+++ b/packages/app/src/app/api/public/declarations/[siren]/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getPublicDeclarationsBySiren: vi.fn(),
+	logAction: vi.fn(),
+}));
+
+vi.mock("~/modules/public-api", () => ({
+	getPublicDeclarationsBySiren: mocks.getPublicDeclarationsBySiren,
+}));
+
+vi.mock("~/server/audit/log", () => ({
+	logAction: mocks.logAction,
+}));
+
+const VALID_SIREN = "123456789";
+
+function buildRequest(path: string) {
+	return new Request(`http://localhost/api/public/declarations/${path}`);
+}
+
+async function callGet(rawSiren: string, query = "") {
+	const { GET } = await import("../route");
+	return GET(buildRequest(`${rawSiren}${query}`), {
+		params: Promise.resolve({ siren: rawSiren }),
+	});
+}
+
+describe("GET /api/public/declarations/[siren]", () => {
+	beforeEach(() => {
+		mocks.getPublicDeclarationsBySiren.mockReset();
+		mocks.logAction.mockReset();
+	});
+
+	it("returns 400 and logs a failure for an invalid siren", async () => {
+		const response = await callGet("abc");
+
+		expect(response.status).toBe(400);
+		expect(mocks.getPublicDeclarationsBySiren).not.toHaveBeenCalled();
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "failure", siren: null }),
+		);
+	});
+
+	it("returns 400 when the limit param is not an integer in [1, 100]", async () => {
+		const response = await callGet(VALID_SIREN, "?limit=0");
+
+		expect(response.status).toBe(400);
+		expect(mocks.getPublicDeclarationsBySiren).not.toHaveBeenCalled();
+	});
+
+	it("returns 400 when the limit param exceeds 100", async () => {
+		const response = await callGet(VALID_SIREN, "?limit=101");
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 400 when the limit param is not numeric", async () => {
+		const response = await callGet(VALID_SIREN, "?limit=abc");
+
+		expect(response.status).toBe(400);
+	});
+
+	it("returns 200 with the declarations and CORS headers on success", async () => {
+		const data = [{ siren: VALID_SIREN, year: 2024 }];
+		mocks.getPublicDeclarationsBySiren.mockResolvedValue(data);
+
+		const response = await callGet(VALID_SIREN);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		expect(response.headers.get("Cache-Control")).toContain("max-age=300");
+		expect(await response.json()).toEqual(data);
+		expect(mocks.getPublicDeclarationsBySiren).toHaveBeenCalledWith(
+			VALID_SIREN,
+			undefined,
+		);
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "success", siren: VALID_SIREN }),
+		);
+	});
+
+	it("forwards a valid limit param to the service", async () => {
+		mocks.getPublicDeclarationsBySiren.mockResolvedValue([]);
+
+		const response = await callGet(VALID_SIREN, "?limit=5");
+
+		expect(response.status).toBe(200);
+		expect(mocks.getPublicDeclarationsBySiren).toHaveBeenCalledWith(
+			VALID_SIREN,
+			5,
+		);
+	});
+
+	it("returns 500 and logs a failure when the service throws", async () => {
+		mocks.getPublicDeclarationsBySiren.mockRejectedValue(new Error("boom"));
+
+		const response = await callGet(VALID_SIREN);
+
+		expect(response.status).toBe(500);
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "failure", errorMessage: "boom" }),
+		);
+	});
+});

--- a/packages/app/src/app/api/public/declarations/[siren]/route.ts
+++ b/packages/app/src/app/api/public/declarations/[siren]/route.ts
@@ -1,0 +1,86 @@
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import { parseSiren } from "~/modules/domain";
+import { getPublicDeclarationsBySiren } from "~/modules/public-api";
+import { logAction } from "~/server/audit/log";
+import { buildRequestContext } from "~/server/audit/requestContext";
+
+const PUBLIC_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Cache-Control": "public, max-age=300, s-maxage=300",
+};
+
+export async function GET(
+	request: Request,
+	{ params }: { params: Promise<{ siren: string }> },
+) {
+	const startedAt = Date.now();
+	const requestContext = buildRequestContext(request.headers);
+	const { siren: rawSiren } = await params;
+
+	const siren = parseSiren(rawSiren);
+	if (!siren) {
+		void logAction({
+			action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN,
+			status: "failure",
+			siren: null,
+			metadata: { rawSiren },
+			errorMessage: "HTTP 400",
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+		return Response.json(
+			{ error: "SIREN invalide. Attendu : 9 chiffres." },
+			{ status: 400, headers: PUBLIC_HEADERS },
+		);
+	}
+
+	const url = new URL(request.url);
+	const limitParam = url.searchParams.get("limit");
+	let limit: number | undefined;
+	if (limitParam !== null) {
+		const parsed = Number.parseInt(limitParam, 10);
+		if (!Number.isInteger(parsed) || parsed < 1 || parsed > 100) {
+			return Response.json(
+				{ error: "Le paramètre 'limit' doit être un entier entre 1 et 100." },
+				{ status: 400, headers: PUBLIC_HEADERS },
+			);
+		}
+		limit = parsed;
+	}
+
+	try {
+		const data = await getPublicDeclarationsBySiren(siren, limit);
+
+		void logAction({
+			action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN,
+			status: "success",
+			siren,
+			metadata: { count: data.length, limit: limit ?? null },
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+
+		return Response.json(data, { headers: PUBLIC_HEADERS });
+	} catch (error) {
+		console.error(
+			"[api/public/declarations/:siren]",
+			error instanceof Error ? error.message : "unknown error",
+		);
+		void logAction({
+			action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN,
+			status: "failure",
+			siren,
+			metadata: null,
+			errorMessage: error instanceof Error ? error.message : "Unknown error",
+			ipAddress: requestContext.ipAddress,
+			userAgent: requestContext.userAgent,
+			durationMs: Date.now() - startedAt,
+		});
+		return Response.json(
+			{ error: "Erreur lors de la récupération des déclarations." },
+			{ status: 500, headers: PUBLIC_HEADERS },
+		);
+	}
+}

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -116,6 +116,10 @@ export const AUDIT_ACTIONS = {
 	PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE:
 		"public_stats.get_current_campaign_rate",
 
+	// ── Public declaration reads ───────────────────────────
+	PUBLIC_DECLARATIONS_BY_SIREN: "public_declarations.by_siren",
+	PUBLIC_DECLARATIONS_BY_SIREN_YEAR: "public_declarations.by_siren_year",
+
 	// ── System / cron-triggered ────────────────────────────
 	SYSTEM_AUDIT_CLEANUP: "system.audit_cleanup",
 } as const;
@@ -206,6 +210,9 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW]: "public_search",
 
 	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
+
+	[AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN]: "read_sensitive",
+	[AUDIT_ACTIONS.PUBLIC_DECLARATIONS_BY_SIREN_YEAR]: "read_sensitive",
 
 	[AUDIT_ACTIONS.SYSTEM_AUDIT_CLEANUP]: "system",
 };

--- a/packages/app/src/modules/public-api/declarationsBySirenService.test.ts
+++ b/packages/app/src/modules/public-api/declarationsBySirenService.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	dbSelect: vi.fn(),
+	orderBy: vi.fn(),
+	where: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: { select: mocks.dbSelect },
+}));
+
+vi.mock("~/server/db/schema", () => ({
+	campaignDeadlines: { year: "cd.year", publicDataReleaseDate: "cd.release" },
+	companies: { siren: "c.siren" },
+	declarations: {
+		siren: "d.siren",
+		year: "d.year",
+		status: "d.status",
+		cancelledAt: "d.cancelledAt",
+	},
+	gipMdsData: { siren: "g.siren", year: "g.year", workforceEma: "g.ema" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+	and: (...args: unknown[]) => ({ and: args }),
+	desc: (col: unknown) => ({ desc: col }),
+	eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+	isNull: (col: unknown) => ({ isNull: col }),
+	ne: (a: unknown, b: unknown) => ({ ne: [a, b] }),
+}));
+
+const NOW = new Date("2026-06-15T12:00:00Z");
+const RELEASED_DATE = "2026-03-01";
+const FUTURE_DATE = "2027-03-01";
+
+type RawRow = Record<string, unknown>;
+
+function makeRawRow(overrides: RawRow = {}): RawRow {
+	return {
+		year: 2024,
+		totalWomen: 120,
+		totalMen: 80,
+		globalAnnualMeanGap: "12.3400",
+		globalAnnualMedianGap: "10.0000",
+		globalHourlyMeanGap: "8.5000",
+		globalHourlyMedianGap: "7.2500",
+		variableAnnualMeanGap: "5.5000",
+		variableAnnualMedianGap: "4.1000",
+		variableHourlyMeanGap: "3.3000",
+		variableHourlyMedianGap: "2.2000",
+		variableProportionWomen: "45.0000",
+		variableProportionMen: "55.0000",
+		annualQuartile1ProportionWomen: "60.0000",
+		annualQuartile2ProportionWomen: "55.0000",
+		annualQuartile3ProportionWomen: "50.0000",
+		annualQuartile4ProportionWomen: "40.0000",
+		annualQuartile1ProportionMen: "40.0000",
+		annualQuartile2ProportionMen: "45.0000",
+		annualQuartile3ProportionMen: "50.0000",
+		annualQuartile4ProportionMen: "60.0000",
+		hourlyQuartile1ProportionWomen: "61.0000",
+		hourlyQuartile2ProportionWomen: "56.0000",
+		hourlyQuartile3ProportionWomen: "51.0000",
+		hourlyQuartile4ProportionWomen: "41.0000",
+		hourlyQuartile1ProportionMen: "39.0000",
+		hourlyQuartile2ProportionMen: "44.0000",
+		hourlyQuartile3ProportionMen: "49.0000",
+		hourlyQuartile4ProportionMen: "59.0000",
+		companySiren: "123456789",
+		companyName: "Société Démo",
+		companyAddress: "1 rue de la Paix, 75002 Paris",
+		companyRegion: "Île-de-France",
+		companyDepartmentCode: "75",
+		companyDepartmentLabel: "Paris",
+		companyNafCode: "62.01Z",
+		companyNafLabel: "Programmation informatique",
+		workforceEma: "250.0000",
+		publicDataReleaseDate: RELEASED_DATE,
+		...overrides,
+	};
+}
+
+function setRows(rows: RawRow[]) {
+	mocks.orderBy.mockResolvedValue(rows);
+}
+
+async function importService() {
+	return import("./declarationsBySirenService");
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.setSystemTime(NOW);
+	mocks.orderBy.mockReset();
+	mocks.where.mockReset();
+	mocks.where.mockReturnValue({ orderBy: mocks.orderBy });
+	mocks.dbSelect.mockReturnValue({
+		from: () => ({
+			innerJoin: () => ({
+				leftJoin: () => ({
+					leftJoin: () => ({ where: mocks.where }),
+				}),
+			}),
+		}),
+	});
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("getPublicDeclarationsBySiren", () => {
+	it("returns projected DTOs for released declarations", async () => {
+		setRows([makeRawRow()]);
+		const { getPublicDeclarationsBySiren } = await importService();
+
+		const result = await getPublicDeclarationsBySiren("123456789");
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			siren: "123456789",
+			year: 2024,
+			name: "Société Démo",
+			workforceEma: 250,
+			globalAnnualMeanGap: 12.34,
+		});
+	});
+
+	it("filters out declarations whose year is not yet publicly released", async () => {
+		setRows([
+			makeRawRow({ year: 2024, publicDataReleaseDate: RELEASED_DATE }),
+			makeRawRow({ year: 2025, publicDataReleaseDate: FUTURE_DATE }),
+			makeRawRow({ year: 2023, publicDataReleaseDate: null }),
+		]);
+		const { getPublicDeclarationsBySiren } = await importService();
+
+		const result = await getPublicDeclarationsBySiren("123456789");
+
+		expect(result.map((d) => d.year)).toEqual([2024]);
+	});
+
+	it("applies the limit after the release filter", async () => {
+		setRows([
+			makeRawRow({ year: 2024 }),
+			makeRawRow({ year: 2023 }),
+			makeRawRow({ year: 2022 }),
+		]);
+		const { getPublicDeclarationsBySiren } = await importService();
+
+		const result = await getPublicDeclarationsBySiren("123456789", 2);
+
+		expect(result.map((d) => d.year)).toEqual([2024, 2023]);
+	});
+
+	it("returns an empty array when no declaration exists for the siren", async () => {
+		setRows([]);
+		const { getPublicDeclarationsBySiren } = await importService();
+
+		const result = await getPublicDeclarationsBySiren("123456789");
+
+		expect(result).toEqual([]);
+	});
+
+	it("masks company identity when the address proxy is null (non-diffusible)", async () => {
+		setRows([makeRawRow({ companyAddress: null })]);
+		const { getPublicDeclarationsBySiren } = await importService();
+
+		const result = await getPublicDeclarationsBySiren("123456789");
+
+		expect(result[0]).toMatchObject({
+			siren: "123456789",
+			name: null,
+			address: null,
+			region: null,
+			nafCode: null,
+		});
+	});
+
+	it("coerces nullable join columns to null", async () => {
+		setRows([
+			makeRawRow({
+				companyRegion: null,
+				companyDepartmentCode: null,
+				companyDepartmentLabel: null,
+				companyNafCode: null,
+				companyNafLabel: null,
+				workforceEma: null,
+			}),
+		]);
+		const { getPublicDeclarationsBySiren } = await importService();
+
+		const result = await getPublicDeclarationsBySiren("123456789");
+
+		expect(result[0]).toMatchObject({
+			region: null,
+			departmentCode: null,
+			nafCode: null,
+			workforceEma: null,
+		});
+	});
+});
+
+describe("getPublicDeclarationBySirenYear", () => {
+	it("returns the projected DTO for a released declaration", async () => {
+		setRows([makeRawRow({ year: 2024 })]);
+		const { getPublicDeclarationBySirenYear } = await importService();
+
+		const result = await getPublicDeclarationBySirenYear("123456789", 2024);
+
+		expect(result).toMatchObject({ siren: "123456789", year: 2024 });
+	});
+
+	it("returns null when the declaration does not exist", async () => {
+		setRows([]);
+		const { getPublicDeclarationBySirenYear } = await importService();
+
+		const result = await getPublicDeclarationBySirenYear("123456789", 2024);
+
+		expect(result).toBeNull();
+	});
+
+	it("returns null when the declaration exists but is not yet released", async () => {
+		setRows([makeRawRow({ year: 2025, publicDataReleaseDate: FUTURE_DATE })]);
+		const { getPublicDeclarationBySirenYear } = await importService();
+
+		const result = await getPublicDeclarationBySirenYear("123456789", 2025);
+
+		expect(result).toBeNull();
+	});
+
+	it("returns null when the year has no release date set", async () => {
+		setRows([makeRawRow({ year: 2023, publicDataReleaseDate: null })]);
+		const { getPublicDeclarationBySirenYear } = await importService();
+
+		const result = await getPublicDeclarationBySirenYear("123456789", 2023);
+
+		expect(result).toBeNull();
+	});
+});

--- a/packages/app/src/modules/public-api/declarationsBySirenService.ts
+++ b/packages/app/src/modules/public-api/declarationsBySirenService.ts
@@ -1,0 +1,186 @@
+import "server-only";
+
+import { and, desc, eq, isNull, ne } from "drizzle-orm";
+import { isYearPubliclyReleased } from "~/modules/domain";
+import { db } from "~/server/db";
+import {
+	campaignDeadlines,
+	companies,
+	declarations,
+	gipMdsData,
+} from "~/server/db/schema";
+import type {
+	PublicCompanySource,
+	PublicDeclarationSource,
+} from "./projection";
+import { toPublicDeclaration } from "./projection";
+import type { PublicDeclarationDTO } from "./schemas";
+
+type DeclarationRow = {
+	declaration: PublicDeclarationSource;
+	company: PublicCompanySource;
+	publicDataReleaseDate: string | null;
+};
+
+async function fetchRows(
+	siren: string,
+	year?: number,
+): Promise<DeclarationRow[]> {
+	const yearFilter =
+		year !== undefined ? eq(declarations.year, year) : undefined;
+
+	const rows = await db
+		.select({
+			year: declarations.year,
+			totalWomen: declarations.totalWomen,
+			totalMen: declarations.totalMen,
+			globalAnnualMeanGap: declarations.globalAnnualMeanGap,
+			globalAnnualMedianGap: declarations.globalAnnualMedianGap,
+			globalHourlyMeanGap: declarations.globalHourlyMeanGap,
+			globalHourlyMedianGap: declarations.globalHourlyMedianGap,
+			variableAnnualMeanGap: declarations.variableAnnualMeanGap,
+			variableAnnualMedianGap: declarations.variableAnnualMedianGap,
+			variableHourlyMeanGap: declarations.variableHourlyMeanGap,
+			variableHourlyMedianGap: declarations.variableHourlyMedianGap,
+			variableProportionWomen: declarations.variableProportionWomen,
+			variableProportionMen: declarations.variableProportionMen,
+			annualQuartile1ProportionWomen:
+				declarations.annualQuartile1ProportionWomen,
+			annualQuartile2ProportionWomen:
+				declarations.annualQuartile2ProportionWomen,
+			annualQuartile3ProportionWomen:
+				declarations.annualQuartile3ProportionWomen,
+			annualQuartile4ProportionWomen:
+				declarations.annualQuartile4ProportionWomen,
+			annualQuartile1ProportionMen: declarations.annualQuartile1ProportionMen,
+			annualQuartile2ProportionMen: declarations.annualQuartile2ProportionMen,
+			annualQuartile3ProportionMen: declarations.annualQuartile3ProportionMen,
+			annualQuartile4ProportionMen: declarations.annualQuartile4ProportionMen,
+			hourlyQuartile1ProportionWomen:
+				declarations.hourlyQuartile1ProportionWomen,
+			hourlyQuartile2ProportionWomen:
+				declarations.hourlyQuartile2ProportionWomen,
+			hourlyQuartile3ProportionWomen:
+				declarations.hourlyQuartile3ProportionWomen,
+			hourlyQuartile4ProportionWomen:
+				declarations.hourlyQuartile4ProportionWomen,
+			hourlyQuartile1ProportionMen: declarations.hourlyQuartile1ProportionMen,
+			hourlyQuartile2ProportionMen: declarations.hourlyQuartile2ProportionMen,
+			hourlyQuartile3ProportionMen: declarations.hourlyQuartile3ProportionMen,
+			hourlyQuartile4ProportionMen: declarations.hourlyQuartile4ProportionMen,
+			companySiren: companies.siren,
+			companyName: companies.name,
+			companyAddress: companies.address,
+			companyRegion: companies.region,
+			companyDepartmentCode: companies.departmentCode,
+			companyDepartmentLabel: companies.departmentLabel,
+			companyNafCode: companies.nafCode,
+			companyNafLabel: companies.nafLabel,
+			workforceEma: gipMdsData.workforceEma,
+			publicDataReleaseDate: campaignDeadlines.publicDataReleaseDate,
+		})
+		.from(declarations)
+		.innerJoin(companies, eq(declarations.siren, companies.siren))
+		.leftJoin(
+			gipMdsData,
+			and(
+				eq(gipMdsData.siren, declarations.siren),
+				eq(gipMdsData.year, declarations.year),
+			),
+		)
+		.leftJoin(campaignDeadlines, eq(campaignDeadlines.year, declarations.year))
+		.where(
+			and(
+				eq(declarations.siren, siren),
+				isNull(declarations.cancelledAt),
+				ne(declarations.status, "draft"),
+				yearFilter,
+			),
+		)
+		.orderBy(desc(declarations.year));
+
+	return rows.map((row) => ({
+		declaration: {
+			year: row.year,
+			totalWomen: row.totalWomen,
+			totalMen: row.totalMen,
+			globalAnnualMeanGap: row.globalAnnualMeanGap,
+			globalAnnualMedianGap: row.globalAnnualMedianGap,
+			globalHourlyMeanGap: row.globalHourlyMeanGap,
+			globalHourlyMedianGap: row.globalHourlyMedianGap,
+			variableAnnualMeanGap: row.variableAnnualMeanGap,
+			variableAnnualMedianGap: row.variableAnnualMedianGap,
+			variableHourlyMeanGap: row.variableHourlyMeanGap,
+			variableHourlyMedianGap: row.variableHourlyMedianGap,
+			variableProportionWomen: row.variableProportionWomen,
+			variableProportionMen: row.variableProportionMen,
+			annualQuartile1ProportionWomen: row.annualQuartile1ProportionWomen,
+			annualQuartile2ProportionWomen: row.annualQuartile2ProportionWomen,
+			annualQuartile3ProportionWomen: row.annualQuartile3ProportionWomen,
+			annualQuartile4ProportionWomen: row.annualQuartile4ProportionWomen,
+			annualQuartile1ProportionMen: row.annualQuartile1ProportionMen,
+			annualQuartile2ProportionMen: row.annualQuartile2ProportionMen,
+			annualQuartile3ProportionMen: row.annualQuartile3ProportionMen,
+			annualQuartile4ProportionMen: row.annualQuartile4ProportionMen,
+			hourlyQuartile1ProportionWomen: row.hourlyQuartile1ProportionWomen,
+			hourlyQuartile2ProportionWomen: row.hourlyQuartile2ProportionWomen,
+			hourlyQuartile3ProportionWomen: row.hourlyQuartile3ProportionWomen,
+			hourlyQuartile4ProportionWomen: row.hourlyQuartile4ProportionWomen,
+			hourlyQuartile1ProportionMen: row.hourlyQuartile1ProportionMen,
+			hourlyQuartile2ProportionMen: row.hourlyQuartile2ProportionMen,
+			hourlyQuartile3ProportionMen: row.hourlyQuartile3ProportionMen,
+			hourlyQuartile4ProportionMen: row.hourlyQuartile4ProportionMen,
+		},
+		company: {
+			siren: row.companySiren,
+			name: row.companyName,
+			address: row.companyAddress ?? null,
+			region: row.companyRegion ?? null,
+			departmentCode: row.companyDepartmentCode ?? null,
+			departmentLabel: row.companyDepartmentLabel ?? null,
+			nafCode: row.companyNafCode ?? null,
+			nafLabel: row.companyNafLabel ?? null,
+			statutDiffusion: null,
+			workforceEma: row.workforceEma ?? null,
+		},
+		publicDataReleaseDate: row.publicDataReleaseDate ?? null,
+	}));
+}
+
+function isReleased(
+	publicDataReleaseDate: string | null,
+	today: Date,
+): boolean {
+	const releaseDate = publicDataReleaseDate
+		? new Date(`${publicDataReleaseDate}T00:00:00`)
+		: null;
+	return isYearPubliclyReleased(releaseDate, today);
+}
+
+export async function getPublicDeclarationsBySiren(
+	siren: string,
+	limit?: number,
+): Promise<PublicDeclarationDTO[]> {
+	const rows = await fetchRows(siren);
+	const today = new Date();
+
+	const released = rows.filter((r) =>
+		isReleased(r.publicDataReleaseDate, today),
+	);
+	const limited = limit !== undefined ? released.slice(0, limit) : released;
+	return limited.map((r) => toPublicDeclaration(r.declaration, r.company));
+}
+
+export async function getPublicDeclarationBySirenYear(
+	siren: string,
+	year: number,
+): Promise<PublicDeclarationDTO | null> {
+	const rows = await fetchRows(siren, year);
+	const row = rows[0];
+	if (!row) return null;
+
+	const today = new Date();
+	if (!isReleased(row.publicDataReleaseDate, today)) return null;
+
+	return toPublicDeclaration(row.declaration, row.company);
+}

--- a/packages/app/src/modules/public-api/index.ts
+++ b/packages/app/src/modules/public-api/index.ts
@@ -1,3 +1,7 @@
+export {
+	getPublicDeclarationBySirenYear,
+	getPublicDeclarationsBySiren,
+} from "./declarationsBySirenService";
 export type {
 	PublicCompanySource,
 	PublicDeclarationSource,

--- a/packages/app/src/modules/public-api/projection.test.ts
+++ b/packages/app/src/modules/public-api/projection.test.ts
@@ -142,6 +142,32 @@ describe("toPublicDeclaration", () => {
 		}
 	});
 
+	it("derives diffusibility from a non-null address when statutDiffusion is null", () => {
+		const dto = toPublicDeclaration(declarationFixture, {
+			...companyFixture,
+			statutDiffusion: null,
+		});
+
+		expect(dto.name).toBe("Société Démo");
+		expect(dto.address).toBe("1 rue de la Paix, 75002 Paris");
+		expect(dto.region).toBe("Île-de-France");
+		expect(dto.nafCode).toBe("62.01Z");
+	});
+
+	it("masks company identity when statutDiffusion is null and the address is null", () => {
+		const dto = toPublicDeclaration(declarationFixture, {
+			...companyFixture,
+			statutDiffusion: null,
+			address: null,
+		});
+
+		for (const field of MASKED_COMPANY_FIELDS) {
+			expect(dto[field]).toBeNull();
+		}
+		expect(dto.siren).toBe("123456789");
+		expect(dto.workforceEma).toBe(250);
+	});
+
 	it("keeps siren, year, workforceEma and every indicator for a non-diffusible company", () => {
 		const diffusible = toPublicDeclaration(declarationFixture, companyFixture);
 		const nonDiffusible = toPublicDeclaration(declarationFixture, {

--- a/packages/app/src/modules/public-api/projection.ts
+++ b/packages/app/src/modules/public-api/projection.ts
@@ -63,7 +63,10 @@ export function toPublicDeclaration(
 	declaration: PublicDeclarationSource,
 	company: PublicCompanySource,
 ): PublicDeclarationDTO {
-	const diffusible = isCompanyDiffusible(company.statutDiffusion);
+	const diffusible =
+		company.statutDiffusion !== null
+			? isCompanyDiffusible(company.statutDiffusion)
+			: company.address !== null;
 
 	return {
 		year: declaration.year,


### PR DESCRIPTION
Closes #3712

## Résumé

Deux endpoints REST publics (sans auth) reproduisant la consultation d'une entreprise de la V1 :

- `GET /api/public/declarations/{siren}` — liste toutes les déclarations publiables d'un SIREN, années récentes d'abord ; paramètre `limit` optionnel (1–100)
- `GET /api/public/declarations/{siren}/{year}` — déclaration unique ; 404 si absente ou non encore publiée

### Choix d'implémentation

**Gate date (#3796)** : jointure LEFT JOIN sur `campaignDeadlines` par année ; `isYearPubliclyReleased(publicDataReleaseDate, today)` appliquée côté application pour chaque ligne.

**Masquage non-diffusible** : `statutDiffusion` n'est pas encore persisté en DB. La fonction `toPublicDeclaration` utilise un proxy : quand `statutDiffusion === null`, `diffusible = company.address !== null`. Ceci est fiable car `weez.ts` positionne `address = null` pour toutes les entreprises non-diffusibles — le nom est donc masqué correctement. Le champ sera proprement stocké dans un ticket ultérieur.

**Audit** : `logAction` direct (catégorie `read_sensitive`) pour les 4 cas : 400, 404, 200, 500. CORS `*` + `Cache-Control: public, max-age=300`.

## Fichiers modifiés

- `src/modules/audit/shared/actionKeys.ts` — 2 nouvelles clés `PUBLIC_DECLARATIONS_BY_SIREN` et `PUBLIC_DECLARATIONS_BY_SIREN_YEAR`
- `src/modules/public-api/projection.ts` — fallback address-proxy quand `statutDiffusion === null`
- `src/modules/public-api/declarationsBySirenService.ts` — nouveau service de query Drizzle
- `src/modules/public-api/index.ts` — re-exports
- `src/app/api/public/declarations/[siren]/route.ts` — nouveau route handler
- `src/app/api/public/declarations/[siren]/[year]/route.ts` — nouveau route handler

## Test plan

- [ ] `pnpm test` — 3087 tests verts, 100% couverture sur `projection.ts` et `declarationsBySirenService.ts`
- [ ] `pnpm typecheck` — ✅
- [ ] `pnpm lint:check` — ✅
- [ ] `pnpm format:check` — ✅
- [ ] SIREN invalide → 400
- [ ] Année invalide → 400
- [ ] Déclaration absente → 404
- [ ] Année non encore publiée → 404 (exclue de la liste et de la fiche)
- [ ] Entreprise non diffusible → `name = null` dans la réponse
- [ ] Aucun score/indice ni indicateur G dans les réponses (via projection #3709)