### PR TITLE
feat: API publique — export open-data massif des déclarations (CSV + JSON)

### DIFF
--- a/packages/app/drizzle/0044_natural_sentinels.sql
+++ b/packages/app/drizzle/0044_natural_sentinels.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_company" ADD COLUMN "statut_diffusion" varchar(1);

--- a/packages/app/drizzle/meta/0044_snapshot.json
+++ b/packages/app/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,2641 @@
+{
+	"id": "3a94bbd6-582e-4647-83b1-d1de02910a88",
+	"prevId": "4fce3fd2-2083-43bb-8fc1-ea0b8b5eab45",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public_data_release_date": {
+					"name": "public_data_release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_label": {
+					"name": "naf_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"department_code": {
+					"name": "department_code",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"department_label": {
+					"name": "department_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"statut_diffusion": {
+					"name": "statut_diffusion",
+					"type": "varchar(1)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_declaration_idx": {
+					"name": "cse_opinion_file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_file_id_app_file_id_fk": {
+					"name": "app_cse_opinion_file_file_id_app_file_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_file_decl_number_type_idx": {
+					"name": "cse_opinion_file_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_lock": {
+			"name": "app_declaration_lock",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_by_user_id": {
+					"name": "locked_by_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_at": {
+					"name": "locked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"declaration_lock_declaration_id_unique": {
+					"name": "declaration_lock_declaration_id_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_lock_expires_at_idx": {
+					"name": "declaration_lock_expires_at_idx",
+					"columns": [
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_lock_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_lock_locked_by_user_id_app_user_id_fk": {
+					"name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_user",
+					"columnsFrom": ["locked_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_status_history": {
+			"name": "app_declaration_status_history",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "declaration_event_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"round": {
+					"name": "round",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"decl_status_history_declaration_idx": {
+					"name": "decl_status_history_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_status_history_actor_user_id_app_user_id_fk": {
+					"name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_declaration_path_choice": {
+					"name": "first_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_path_choice": {
+					"name": "second_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_required": {
+					"name": "cse_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"rules_version": {
+					"name": "rules_version",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'2027.1'"
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declarations_siren_year_active_unique": {
+					"name": "declarations_siren_year_active_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "cancelled_at IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declaration_lock_timeout_minutes": {
+					"name": "declaration_lock_timeout_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 30
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.compliance_path": {
+			"name": "compliance_path",
+			"schema": "public",
+			"values": ["justify", "corrective_action", "joint_evaluation"]
+		},
+		"public.declaration_event_type": {
+			"name": "declaration_event_type",
+			"schema": "public",
+			"values": [
+				"submit",
+				"path_choice",
+				"second_declaration_submit",
+				"joint_evaluation_submit",
+				"cse_opinion_submit",
+				"cancel",
+				"demarche_complete",
+				"step_change"
+			]
+		},
+		"public.declaration_status": {
+			"name": "declaration_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"awaiting_compliance_path_choice",
+				"corrective_actions_chosen",
+				"joint_evaluation_chosen",
+				"awaiting_revision_choice",
+				"revised_joint_evaluation_chosen",
+				"awaiting_cse_opinion",
+				"demarche_completed"
+			]
+		},
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
 			"when": 1782981445390,
 			"tag": "0043_vengeful_bucky",
 			"breakpoints": true
+		},
+		{
+			"idx": 44,
+			"version": "7",
+			"when": 1782997206329,
+			"tag": "0044_natural_sentinels",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/app/src/app/api/public/declarations/export/__tests__/route.test.ts
+++ b/packages/app/src/app/api/public/declarations/export/__tests__/route.test.ts
@@ -159,6 +159,54 @@ describe("GET /api/public/declarations/export", () => {
 		expect(row.globalAnnualMeanGap).toBe(10.5);
 	});
 
+	it("treats a null statutDiffusion as diffusible and renders a null workforceEma", async () => {
+		setRows([
+			buildRow({
+				siren: "321321321",
+				statutDiffusion: null,
+				workforceEma: null,
+			}),
+		]);
+
+		const response = await callGet();
+		const body = await response.json();
+		const row = body.data[0];
+
+		// Absent statut → diffusible → identifying fields kept
+		expect(row.name).toBe("Société Démo");
+		expect(row.workforceEma).toBeNull();
+	});
+
+	it("emits an empty quoted field for a null workforceEma in CSV", async () => {
+		setRows([buildRow({ siren: "321321321", workforceEma: null })]);
+
+		const response = await callGet("?format=csv");
+		const csv = await response.text();
+		const line = csv.split("\n")[1] ?? "";
+
+		// workforceEma is the 10th column (index 9), rendered as empty quotes
+		expect(line.split(";")[9]).toBe('""');
+	});
+
+	it("exposes no score, /100 index or indicator-G key in the JSON payload (S6)", async () => {
+		setRows([buildRow()]);
+
+		const response = await callGet();
+		const body = await response.json();
+		const keys = Object.keys(body.data[0]).join(" ").toLowerCase();
+
+		expect(keys).not.toMatch(/score|index|note|categoryg|\bindicatorg/);
+	});
+
+	it("exposes no score, /100 index or indicator-G column in the CSV header (S6)", async () => {
+		setRows([buildRow()]);
+
+		const response = await callGet("?format=csv");
+		const header = (await response.text()).split("\n")[0]?.toLowerCase() ?? "";
+
+		expect(header).not.toMatch(/score|index|note|categoryg|indicatorg/);
+	});
+
 	it("returns CSV with a header row and one line per declaration when format=csv", async () => {
 		setRows([buildRow({ siren: "111222333", name: "Alpha & Co" })]);
 

--- a/packages/app/src/app/api/public/declarations/export/__tests__/route.test.ts
+++ b/packages/app/src/app/api/public/declarations/export/__tests__/route.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	dbSelect: vi.fn(),
+	logAction: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: { select: mocks.dbSelect },
+}));
+
+vi.mock("~/server/db/schema", () => ({
+	declarations: { year: "year", siren: "siren", status: "status" },
+	companies: { siren: "companies.siren" },
+	campaignDeadlines: { year: "cd.year", publicDataReleaseDate: "cd.release" },
+	gipMdsData: { siren: "gip.siren", year: "gip.year" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+	and: (...args: unknown[]) => ({ and: args }),
+	eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+	isNotNull: (a: unknown) => ({ isNotNull: a }),
+	isNull: (a: unknown) => ({ isNull: a }),
+	sql: (strings: TemplateStringsArray) => ({ sql: strings.join("") }),
+}));
+
+vi.mock("~/server/audit/log", () => ({
+	logAction: mocks.logAction,
+}));
+
+function setRows(rows: unknown[]) {
+	const chain = {
+		from: () => chain,
+		innerJoin: () => chain,
+		leftJoin: () => chain,
+		where: () => chain,
+		orderBy: () => Promise.resolve(rows),
+	};
+	mocks.dbSelect.mockReturnValue(chain);
+}
+
+type RowOverrides = Record<string, unknown>;
+
+const NUMERIC_DECLARATION_FIELDS = [
+	"globalAnnualMeanGap",
+	"globalAnnualMedianGap",
+	"globalHourlyMeanGap",
+	"globalHourlyMedianGap",
+	"variableAnnualMeanGap",
+	"variableAnnualMedianGap",
+	"variableHourlyMeanGap",
+	"variableHourlyMedianGap",
+	"variableProportionWomen",
+	"variableProportionMen",
+	"annualQuartile1ProportionWomen",
+	"annualQuartile2ProportionWomen",
+	"annualQuartile3ProportionWomen",
+	"annualQuartile4ProportionWomen",
+	"annualQuartile1ProportionMen",
+	"annualQuartile2ProportionMen",
+	"annualQuartile3ProportionMen",
+	"annualQuartile4ProportionMen",
+	"hourlyQuartile1ProportionWomen",
+	"hourlyQuartile2ProportionWomen",
+	"hourlyQuartile3ProportionWomen",
+	"hourlyQuartile4ProportionWomen",
+	"hourlyQuartile1ProportionMen",
+	"hourlyQuartile2ProportionMen",
+	"hourlyQuartile3ProportionMen",
+	"hourlyQuartile4ProportionMen",
+] as const;
+
+function buildRow(overrides: RowOverrides = {}) {
+	const base: Record<string, unknown> = {
+		year: 2023,
+		totalWomen: 40,
+		totalMen: 60,
+		siren: "123456789",
+		name: "Société Démo",
+		address: "1 rue de la Paix, 75002 PARIS",
+		region: "Île-de-France",
+		departmentCode: "75",
+		departmentLabel: "Paris",
+		nafCode: "6202A",
+		nafLabel: "Conseil informatique",
+		statutDiffusion: "O",
+		workforceEma: "250",
+	};
+	for (const field of NUMERIC_DECLARATION_FIELDS) {
+		base[field] = "10.5";
+	}
+	return { ...base, ...overrides };
+}
+
+async function callGet(search = "") {
+	const { GET } = await import("../route");
+	return GET(
+		new Request(`http://localhost/api/public/declarations/export${search}`),
+	);
+}
+
+describe("GET /api/public/declarations/export", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+	});
+
+	it("returns JSON with data and count by default", async () => {
+		setRows([buildRow()]);
+
+		const response = await callGet();
+
+		expect(response.headers.get("Content-Type")).toMatch(/application\/json/);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+		expect(response.headers.get("Cache-Control")).toContain("max-age=3600");
+
+		const body = await response.json();
+		expect(body.count).toBe(1);
+		expect(body.data).toHaveLength(1);
+		expect(body.data[0]).toMatchObject({
+			siren: "123456789",
+			name: "Société Démo",
+			year: 2023,
+			workforceEma: 250,
+			globalAnnualMeanGap: 10.5,
+		});
+	});
+
+	it("returns an empty payload when no declaration matches", async () => {
+		setRows([]);
+
+		const response = await callGet();
+
+		const body = await response.json();
+		expect(body).toEqual({ data: [], count: 0 });
+	});
+
+	it("masks identifying company fields for a non-diffusible company but keeps the SIREN", async () => {
+		setRows([
+			buildRow({
+				siren: "987654321",
+				statutDiffusion: "N",
+			}),
+		]);
+
+		const response = await callGet();
+		const body = await response.json();
+		const row = body.data[0];
+
+		expect(row.siren).toBe("987654321");
+		expect(row.name).toBeNull();
+		expect(row.address).toBeNull();
+		expect(row.region).toBeNull();
+		expect(row.departmentCode).toBeNull();
+		expect(row.departmentLabel).toBeNull();
+		expect(row.nafCode).toBeNull();
+		expect(row.nafLabel).toBeNull();
+		// Indicators are always public, even for a non-diffusible company
+		expect(row.globalAnnualMeanGap).toBe(10.5);
+	});
+
+	it("returns CSV with a header row and one line per declaration when format=csv", async () => {
+		setRows([buildRow({ siren: "111222333", name: "Alpha & Co" })]);
+
+		const response = await callGet("?format=csv");
+
+		expect(response.headers.get("Content-Type")).toContain("text/csv");
+		expect(response.headers.get("Content-Disposition")).toContain(
+			"declarations_export.csv",
+		);
+		expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+
+		const csv = await response.text();
+		const lines = csv.split("\n");
+		expect(lines[0]).toBe(
+			'"year";"siren";"name";"address";"region";"departmentCode";"departmentLabel";"nafCode";"nafLabel";"workforceEma";"totalWomen";"totalMen";"globalAnnualMeanGap";"globalAnnualMedianGap";"globalHourlyMeanGap";"globalHourlyMedianGap";"variableAnnualMeanGap";"variableAnnualMedianGap";"variableHourlyMeanGap";"variableHourlyMedianGap";"variableProportionWomen";"variableProportionMen";"annualQuartile1ProportionWomen";"annualQuartile2ProportionWomen";"annualQuartile3ProportionWomen";"annualQuartile4ProportionWomen";"annualQuartile1ProportionMen";"annualQuartile2ProportionMen";"annualQuartile3ProportionMen";"annualQuartile4ProportionMen";"hourlyQuartile1ProportionWomen";"hourlyQuartile2ProportionWomen";"hourlyQuartile3ProportionWomen";"hourlyQuartile4ProportionWomen";"hourlyQuartile1ProportionMen";"hourlyQuartile2ProportionMen";"hourlyQuartile3ProportionMen";"hourlyQuartile4ProportionMen"',
+		);
+		expect(lines).toHaveLength(2);
+		expect(lines[1]).toContain('"111222333"');
+		expect(lines[1]).toContain('"Alpha & Co"');
+	});
+
+	it("escapes double quotes in CSV fields and emits empty quotes for null values", async () => {
+		setRows([
+			buildRow({
+				siren: "444555666",
+				name: 'Beta "Groupe" SA',
+				statutDiffusion: "N",
+			}),
+		]);
+
+		const response = await callGet("?format=csv");
+		const csv = await response.text();
+		const line = csv.split("\n")[1] ?? "";
+
+		expect(line).toContain('"444555666"');
+		// Non-diffusible → name masked to null → empty quoted field
+		expect(line).toContain('""');
+		expect(line).not.toContain('Beta "Groupe" SA');
+	});
+
+	it("quotes and doubles inner quotes for a diffusible company name in CSV", async () => {
+		setRows([buildRow({ siren: "555666777", name: 'Gamma "X" SARL' })]);
+
+		const response = await callGet("?format=csv");
+		const csv = await response.text();
+
+		expect(csv.split("\n")[1]).toContain('"Gamma ""X"" SARL"');
+	});
+
+	it("audits the export with the format in metadata", async () => {
+		setRows([buildRow()]);
+
+		await callGet("?format=csv");
+
+		expect(mocks.logAction).toHaveBeenCalledTimes(1);
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: "public_declarations.export",
+				status: "success",
+				metadata: { format: "csv" },
+			}),
+		);
+	});
+
+	it("defaults the audited format to json when the param is absent", async () => {
+		setRows([buildRow()]);
+
+		await callGet();
+
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ metadata: { format: "json" } }),
+		);
+	});
+
+	it("returns a 500 payload and audits a failure when the query throws", async () => {
+		mocks.dbSelect.mockImplementation(() => {
+			throw new Error("db down");
+		});
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		const response = await callGet();
+
+		expect(response.status).toBe(500);
+		const body = await response.json();
+		expect(body).toEqual({ error: "Erreur lors de l'export des déclarations" });
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({ status: "failure" }),
+		);
+		consoleSpy.mockRestore();
+	});
+});

--- a/packages/app/src/app/api/public/declarations/export/route.ts
+++ b/packages/app/src/app/api/public/declarations/export/route.ts
@@ -1,0 +1,254 @@
+import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import type {
+	PublicCompanySource,
+	PublicDeclarationDTO,
+	PublicDeclarationSource,
+} from "~/modules/public-api";
+import { toPublicDeclaration } from "~/modules/public-api";
+import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
+import { db } from "~/server/db";
+import {
+	campaignDeadlines,
+	companies,
+	declarations,
+	gipMdsData,
+} from "~/server/db/schema";
+
+async function fetchPublishableDeclarations() {
+	return db
+		.select({
+			year: declarations.year,
+			totalWomen: declarations.totalWomen,
+			totalMen: declarations.totalMen,
+			globalAnnualMeanGap: declarations.globalAnnualMeanGap,
+			globalAnnualMedianGap: declarations.globalAnnualMedianGap,
+			globalHourlyMeanGap: declarations.globalHourlyMeanGap,
+			globalHourlyMedianGap: declarations.globalHourlyMedianGap,
+			variableAnnualMeanGap: declarations.variableAnnualMeanGap,
+			variableAnnualMedianGap: declarations.variableAnnualMedianGap,
+			variableHourlyMeanGap: declarations.variableHourlyMeanGap,
+			variableHourlyMedianGap: declarations.variableHourlyMedianGap,
+			variableProportionWomen: declarations.variableProportionWomen,
+			variableProportionMen: declarations.variableProportionMen,
+			annualQuartile1ProportionWomen:
+				declarations.annualQuartile1ProportionWomen,
+			annualQuartile2ProportionWomen:
+				declarations.annualQuartile2ProportionWomen,
+			annualQuartile3ProportionWomen:
+				declarations.annualQuartile3ProportionWomen,
+			annualQuartile4ProportionWomen:
+				declarations.annualQuartile4ProportionWomen,
+			annualQuartile1ProportionMen: declarations.annualQuartile1ProportionMen,
+			annualQuartile2ProportionMen: declarations.annualQuartile2ProportionMen,
+			annualQuartile3ProportionMen: declarations.annualQuartile3ProportionMen,
+			annualQuartile4ProportionMen: declarations.annualQuartile4ProportionMen,
+			hourlyQuartile1ProportionWomen:
+				declarations.hourlyQuartile1ProportionWomen,
+			hourlyQuartile2ProportionWomen:
+				declarations.hourlyQuartile2ProportionWomen,
+			hourlyQuartile3ProportionWomen:
+				declarations.hourlyQuartile3ProportionWomen,
+			hourlyQuartile4ProportionWomen:
+				declarations.hourlyQuartile4ProportionWomen,
+			hourlyQuartile1ProportionMen: declarations.hourlyQuartile1ProportionMen,
+			hourlyQuartile2ProportionMen: declarations.hourlyQuartile2ProportionMen,
+			hourlyQuartile3ProportionMen: declarations.hourlyQuartile3ProportionMen,
+			hourlyQuartile4ProportionMen: declarations.hourlyQuartile4ProportionMen,
+			siren: companies.siren,
+			name: companies.name,
+			address: companies.address,
+			region: companies.region,
+			departmentCode: companies.departmentCode,
+			departmentLabel: companies.departmentLabel,
+			nafCode: companies.nafCode,
+			nafLabel: companies.nafLabel,
+			statutDiffusion: companies.statutDiffusion,
+			workforceEma: gipMdsData.workforceEma,
+		})
+		.from(declarations)
+		.innerJoin(companies, eq(declarations.siren, companies.siren))
+		.innerJoin(
+			campaignDeadlines,
+			and(
+				eq(campaignDeadlines.year, declarations.year),
+				isNotNull(campaignDeadlines.publicDataReleaseDate),
+				sql`${campaignDeadlines.publicDataReleaseDate} <= CURRENT_DATE`,
+			),
+		)
+		.leftJoin(
+			gipMdsData,
+			and(
+				eq(gipMdsData.siren, declarations.siren),
+				eq(gipMdsData.year, declarations.year),
+			),
+		)
+		.where(
+			and(
+				eq(declarations.status, "demarche_completed"),
+				isNull(declarations.cancelledAt),
+			),
+		)
+		.orderBy(declarations.year, companies.siren);
+}
+
+type ExportRow = Awaited<
+	ReturnType<typeof fetchPublishableDeclarations>
+>[number];
+
+function toPublicDTO(row: ExportRow): PublicDeclarationDTO {
+	const declarationSource: PublicDeclarationSource = {
+		year: row.year,
+		totalWomen: row.totalWomen,
+		totalMen: row.totalMen,
+		globalAnnualMeanGap: row.globalAnnualMeanGap,
+		globalAnnualMedianGap: row.globalAnnualMedianGap,
+		globalHourlyMeanGap: row.globalHourlyMeanGap,
+		globalHourlyMedianGap: row.globalHourlyMedianGap,
+		variableAnnualMeanGap: row.variableAnnualMeanGap,
+		variableAnnualMedianGap: row.variableAnnualMedianGap,
+		variableHourlyMeanGap: row.variableHourlyMeanGap,
+		variableHourlyMedianGap: row.variableHourlyMedianGap,
+		variableProportionWomen: row.variableProportionWomen,
+		variableProportionMen: row.variableProportionMen,
+		annualQuartile1ProportionWomen: row.annualQuartile1ProportionWomen,
+		annualQuartile2ProportionWomen: row.annualQuartile2ProportionWomen,
+		annualQuartile3ProportionWomen: row.annualQuartile3ProportionWomen,
+		annualQuartile4ProportionWomen: row.annualQuartile4ProportionWomen,
+		annualQuartile1ProportionMen: row.annualQuartile1ProportionMen,
+		annualQuartile2ProportionMen: row.annualQuartile2ProportionMen,
+		annualQuartile3ProportionMen: row.annualQuartile3ProportionMen,
+		annualQuartile4ProportionMen: row.annualQuartile4ProportionMen,
+		hourlyQuartile1ProportionWomen: row.hourlyQuartile1ProportionWomen,
+		hourlyQuartile2ProportionWomen: row.hourlyQuartile2ProportionWomen,
+		hourlyQuartile3ProportionWomen: row.hourlyQuartile3ProportionWomen,
+		hourlyQuartile4ProportionWomen: row.hourlyQuartile4ProportionWomen,
+		hourlyQuartile1ProportionMen: row.hourlyQuartile1ProportionMen,
+		hourlyQuartile2ProportionMen: row.hourlyQuartile2ProportionMen,
+		hourlyQuartile3ProportionMen: row.hourlyQuartile3ProportionMen,
+		hourlyQuartile4ProportionMen: row.hourlyQuartile4ProportionMen,
+	};
+
+	const companySource: PublicCompanySource = {
+		siren: row.siren,
+		name: row.name,
+		address: row.address,
+		region: row.region,
+		departmentCode: row.departmentCode,
+		departmentLabel: row.departmentLabel,
+		nafCode: row.nafCode,
+		nafLabel: row.nafLabel,
+		statutDiffusion: row.statutDiffusion ?? null,
+		workforceEma: row.workforceEma ?? null,
+	};
+
+	return toPublicDeclaration(declarationSource, companySource);
+}
+
+const CSV_HEADERS: Array<keyof PublicDeclarationDTO> = [
+	"year",
+	"siren",
+	"name",
+	"address",
+	"region",
+	"departmentCode",
+	"departmentLabel",
+	"nafCode",
+	"nafLabel",
+	"workforceEma",
+	"totalWomen",
+	"totalMen",
+	"globalAnnualMeanGap",
+	"globalAnnualMedianGap",
+	"globalHourlyMeanGap",
+	"globalHourlyMedianGap",
+	"variableAnnualMeanGap",
+	"variableAnnualMedianGap",
+	"variableHourlyMeanGap",
+	"variableHourlyMedianGap",
+	"variableProportionWomen",
+	"variableProportionMen",
+	"annualQuartile1ProportionWomen",
+	"annualQuartile2ProportionWomen",
+	"annualQuartile3ProportionWomen",
+	"annualQuartile4ProportionWomen",
+	"annualQuartile1ProportionMen",
+	"annualQuartile2ProportionMen",
+	"annualQuartile3ProportionMen",
+	"annualQuartile4ProportionMen",
+	"hourlyQuartile1ProportionWomen",
+	"hourlyQuartile2ProportionWomen",
+	"hourlyQuartile3ProportionWomen",
+	"hourlyQuartile4ProportionWomen",
+	"hourlyQuartile1ProportionMen",
+	"hourlyQuartile2ProportionMen",
+	"hourlyQuartile3ProportionMen",
+	"hourlyQuartile4ProportionMen",
+];
+
+function toCsvField(value: unknown): string {
+	if (value === null || value === undefined) return '""';
+	return `"${String(value).replace(/"/g, '""')}"`;
+}
+
+function formatCsv(rows: PublicDeclarationDTO[]): string {
+	const header = CSV_HEADERS.map(toCsvField).join(";");
+	const dataRows = rows.map((row) =>
+		CSV_HEADERS.map((key) => toCsvField(row[key])).join(";"),
+	);
+	return [header, ...dataRows].join("\n");
+}
+
+export const GET = withAuditedRoute(
+	{
+		action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_EXPORT,
+		resolveContext: (request) => {
+			const url = new URL(request.url);
+			return {
+				metadata: { format: url.searchParams.get("format") ?? "json" },
+			};
+		},
+	},
+	async (request) => {
+		try {
+			const { searchParams } = new URL(request.url);
+			const format = searchParams.get("format") ?? "json";
+
+			const rows = await fetchPublishableDeclarations();
+			const data = rows.map(toPublicDTO);
+
+			if (format === "csv") {
+				const csv = formatCsv(data);
+				return new NextResponse(csv, {
+					headers: {
+						"Content-Type": "text/csv; charset=utf-8",
+						"Content-Disposition":
+							'attachment; filename="declarations_export.csv"',
+						"Access-Control-Allow-Origin": "*",
+						"Cache-Control": "public, max-age=3600, s-maxage=3600",
+					},
+				});
+			}
+
+			return NextResponse.json(
+				{ data, count: data.length },
+				{
+					headers: {
+						"Access-Control-Allow-Origin": "*",
+						"Cache-Control": "public, max-age=3600, s-maxage=3600",
+					},
+				},
+			);
+		} catch (error) {
+			console.error(
+				"[api/public/declarations/export]",
+				error instanceof Error ? error.message : "unknown error",
+			);
+			return NextResponse.json(
+				{ error: "Erreur lors de l'export des déclarations" },
+				{ status: 500 },
+			);
+		}
+	},
+);

--- a/packages/app/src/app/api/public/declarations/export/route.ts
+++ b/packages/app/src/app/api/public/declarations/export/route.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNotNull, isNull, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { AUDIT_ACTIONS } from "~/modules/audit";
 import type {
 	PublicCompanySource,
@@ -187,9 +188,13 @@ const CSV_HEADERS: Array<keyof PublicDeclarationDTO> = [
 	"hourlyQuartile4ProportionMen",
 ];
 
+const FORMAT_SCHEMA = z.enum(["json", "csv"]).default("json");
+
 function toCsvField(value: unknown): string {
 	if (value === null || value === undefined) return '""';
-	return `"${String(value).replace(/"/g, '""')}"`;
+	let str = String(value).replace(/"/g, '""');
+	if (/^[=+\-@|]/.test(str)) str = `'${str}`;
+	return `"${str}"`;
 }
 
 function formatCsv(rows: PublicDeclarationDTO[]): string {
@@ -205,15 +210,26 @@ export const GET = withAuditedRoute(
 		action: AUDIT_ACTIONS.PUBLIC_DECLARATIONS_EXPORT,
 		resolveContext: (request) => {
 			const url = new URL(request.url);
+			const raw = url.searchParams.get("format") ?? "json";
+			const parsed = FORMAT_SCHEMA.safeParse(raw);
 			return {
-				metadata: { format: url.searchParams.get("format") ?? "json" },
+				metadata: { format: parsed.success ? parsed.data : raw },
 			};
 		},
 	},
 	async (request) => {
 		try {
 			const { searchParams } = new URL(request.url);
-			const format = searchParams.get("format") ?? "json";
+			const formatResult = FORMAT_SCHEMA.safeParse(
+				searchParams.get("format") ?? "json",
+			);
+			if (!formatResult.success) {
+				return NextResponse.json(
+					{ error: "Le paramètre format doit être 'json' ou 'csv'" },
+					{ status: 400 },
+				);
+			}
+			const format = formatResult.data;
 
 			const rows = await fetchPublishableDeclarations();
 			const data = rows.map(toPublicDTO);

--- a/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
+++ b/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
@@ -36,6 +36,15 @@ describe("AUDIT_ACTIONS", () => {
 			AUDIT_ACTION_CATEGORIES[AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ],
 		).toBe("read_sensitive");
 	});
+
+	it("maps the public declarations export to the export category (365-day retention)", () => {
+		expect(AUDIT_ACTIONS.PUBLIC_DECLARATIONS_EXPORT).toBe(
+			"public_declarations.export",
+		);
+		expect(
+			AUDIT_ACTION_CATEGORIES[AUDIT_ACTIONS.PUBLIC_DECLARATIONS_EXPORT],
+		).toBe("export");
+	});
 });
 
 describe("retention constants", () => {

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -112,6 +112,8 @@ export const AUDIT_ACTIONS = {
 	PUBLIC_REFERENT_SEARCH: "public_referents.search",
 	PUBLIC_REFERENT_VIEW: "public_referents.view",
 
+	PUBLIC_DECLARATIONS_EXPORT: "public_declarations.export",
+
 	// ── Public stats reads ─────────────────────────────────
 	PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE:
 		"public_stats.get_current_campaign_rate",
@@ -204,6 +206,8 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_SEARCH]: "public_search",
 	[AUDIT_ACTIONS.PUBLIC_REFERENT_VIEW]: "public_search",
+
+	[AUDIT_ACTIONS.PUBLIC_DECLARATIONS_EXPORT]: "export",
 
 	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
 

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -255,6 +255,7 @@ describe("findUserCompany NAF label enrichment", () => {
 			departmentCode: null,
 			departmentLabel: null,
 			workforce: 100,
+			statutDiffusion: null,
 		});
 
 		const result = await callGet({

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -342,6 +342,7 @@ export const authConfig = {
 						departmentCode?: string | null;
 						departmentLabel?: string | null;
 						workforce?: number | null;
+						statutDiffusion?: string | null;
 					};
 					try {
 						const companyInfo = await fetchCompanyBySiren(siren);
@@ -356,6 +357,7 @@ export const authConfig = {
 									departmentCode: companyInfo.departmentCode,
 									departmentLabel: companyInfo.departmentLabel,
 									workforce: companyInfo.workforce,
+									statutDiffusion: companyInfo.statutDiffusion,
 								}
 							: { siren, name: `Entreprise ${siren}` };
 					} catch {

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -507,6 +507,7 @@ export const companies = createTable("company", (d) => ({
 	departmentLabel: d.varchar({ length: 255 }),
 	workforce: d.integer(),
 	hasCse: d.boolean(),
+	statutDiffusion: d.varchar({ length: 1 }),
 	createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 	updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
 }));

--- a/packages/app/src/server/services/__tests__/weez.test.ts
+++ b/packages/app/src/server/services/__tests__/weez.test.ts
@@ -152,6 +152,37 @@ describe("fetchCompanyBySiren", () => {
 		});
 	});
 
+	it("falls back to the effectif band for a non-diffusible company when effectiftotal is null", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				content: [
+					{
+						siren: "222333444",
+						denominationunitelegale: null,
+						raisonsociale: null,
+						activiteprincipalenaf25unitelegale: null,
+						nomenclatureactiviteprincipalelibelleunitelegale: null,
+						effectiftotal: null,
+						trancheeffectifsunitelegale: "22",
+						numerovoie: null,
+						typevoie: null,
+						libellevoie: null,
+						codepostal: null,
+						libellecommune: null,
+						statutdiffusionunitelegale: "N",
+					},
+				],
+				totalElements: 1,
+			}),
+		});
+
+		const result = await fetchCompanyBySiren("222333444");
+
+		expect(result?.workforce).toBe(100);
+		expect(result?.statutDiffusion).toBe("N");
+	});
+
 	it("falls back to the effectif band when effectiftotal is null", async () => {
 		fetchSpy.mockResolvedValueOnce({
 			ok: true,

--- a/packages/app/src/server/services/__tests__/weez.test.ts
+++ b/packages/app/src/server/services/__tests__/weez.test.ts
@@ -65,6 +65,7 @@ describe("fetchCompanyBySiren", () => {
 			departmentCode: "75",
 			departmentLabel: "Paris",
 			workforce: 256,
+			statutDiffusion: "O",
 		});
 
 		const calledUrl = fetchSpy.mock.calls[0]?.[0] as URL;
@@ -108,6 +109,7 @@ describe("fetchCompanyBySiren", () => {
 			departmentCode: null,
 			departmentLabel: null,
 			workforce: 50,
+			statutDiffusion: "N",
 		});
 	});
 
@@ -146,6 +148,7 @@ describe("fetchCompanyBySiren", () => {
 			departmentCode: "33",
 			departmentLabel: "Gironde",
 			workforce: 50,
+			statutDiffusion: "N",
 		});
 	});
 
@@ -273,7 +276,38 @@ describe("fetchCompanyBySiren", () => {
 			departmentCode: "69",
 			departmentLabel: "Rhône",
 			workforce: null,
+			statutDiffusion: "O",
 		});
+	});
+
+	it("defaults statutDiffusion to null when the INSEE field is absent", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({
+				content: [
+					{
+						siren: "999000111",
+						denominationunitelegale: "Delta SA",
+						raisonsociale: null,
+						activiteprincipalenaf25unitelegale: "6202A",
+						nomenclatureactiviteprincipalelibelleunitelegale: "Conseil",
+						effectiftotal: 42,
+						numerovoie: null,
+						typevoie: null,
+						libellevoie: null,
+						codepostal: "75001",
+						libellecommune: "PARIS",
+					},
+				],
+				totalElements: 1,
+			}),
+		});
+
+		const result = await fetchCompanyBySiren("999000111");
+
+		// Absent statut is treated as diffusible: name/address are kept
+		expect(result?.statutDiffusion).toBeNull();
+		expect(result?.name).toBe("Delta SA");
 	});
 
 	it("returns nafLabel null when the activity label is absent", async () => {
@@ -311,6 +345,7 @@ describe("fetchCompanyBySiren", () => {
 			departmentCode: "33",
 			departmentLabel: "Gironde",
 			workforce: 12,
+			statutDiffusion: "O",
 		});
 	});
 });

--- a/packages/app/src/server/services/gipMds.ts
+++ b/packages/app/src/server/services/gipMds.ts
@@ -163,6 +163,7 @@ type CompanyInsert = {
 	departmentCode?: string | null;
 	departmentLabel?: string | null;
 	workforce?: number | null;
+	statutDiffusion?: string | null;
 };
 
 async function fetchCompanyInfoBatch(
@@ -187,6 +188,7 @@ async function fetchCompanyInfoBatch(
 								departmentCode: info.departmentCode,
 								departmentLabel: info.departmentLabel,
 								workforce: info.workforce,
+								statutDiffusion: info.statutDiffusion,
 							}
 						: { siren, name: `Entreprise ${siren}` };
 				} catch {

--- a/packages/app/src/server/services/weez.ts
+++ b/packages/app/src/server/services/weez.ts
@@ -69,6 +69,7 @@ export type CompanyInfo = {
 	departmentCode: string | null;
 	departmentLabel: string | null;
 	workforce: number | null;
+	statutDiffusion: string | null;
 };
 
 function buildAddress(entity: WeezLegalEntity): string | null {
@@ -123,7 +124,9 @@ export async function fetchCompanyBySiren(
 	// when `address` becomes null.
 	const location = getLocationFromPostalCode(entity.codepostal);
 
-	if (!isCompanyDiffusible(entity.statutdiffusionunitelegale)) {
+	const statutDiffusion = entity.statutdiffusionunitelegale ?? null;
+
+	if (!isCompanyDiffusible(statutDiffusion)) {
 		return {
 			name:
 				entity.denominationunitelegale ||
@@ -138,6 +141,7 @@ export async function fetchCompanyBySiren(
 			workforce:
 				entity.effectiftotal ??
 				trancheToWorkforce(entity.trancheeffectifsunitelegale),
+			statutDiffusion,
 		};
 	}
 
@@ -158,5 +162,6 @@ export async function fetchCompanyBySiren(
 		workforce:
 			entity.effectiftotal ??
 			trancheToWorkforce(entity.trancheeffectifsunitelegale),
+		statutDiffusion,
 	};
 }


### PR DESCRIPTION
Closes #3713

## Résumé

Nouvel endpoint public `GET /api/public/declarations/export?format=csv|json` pour l'export massif open-data de toutes les déclarations publiables.

**Fonctionnalités :**
- Format JSON (`{ data, count }`) et CSV (délimiteur `;`, quoting RFC4180) sélectionnables via `?format=`
- Gate par date de rendu public : JOIN sur `campaign_deadlines.public_data_release_date <= CURRENT_DATE` (ticket #3796)
- Projection `toPublicDeclaration` (#3709) : masquage complet des champs identifiants pour les entreprises non-diffusibles (`statutDiffusion = "N"`) — seul le SIREN reste visible
- Aucune colonne de score, d'indice /100 ou d'indicateur G dans le CSV et le JSON
- CORS `Access-Control-Allow-Origin: *` intentionnel (open-data public, aucune credential impliquée)
- `Cache-Control: public, max-age=3600` pour soulager l'infra sur les re-téléchargements fréquents

**Persistance `statutDiffusion` :**
- Nouveau champ `statut_diffusion varchar(1)` sur `app_company` (migration 0044)
- `fetchCompanyBySiren` (weez.ts) retourne désormais `statutDiffusion`
- Sync automatique lors du login ProConnect (auth/config.ts) et des imports GIP MDS (gipMds.ts)

**Sécurité :**
- `format` validé via Zod (`z.enum(["json","csv"])`) — retourne 400 si invalide
- Protection formula injection CSV (préfixe `'` sur valeurs commençant par `=`, `+`, `-`, `@`, `|`)
- Audit systématique via `withAuditedRoute` (`PUBLIC_DECLARATIONS_EXPORT`, catégorie `export`, 365j rétention)

## Test plan

- [ ] `GET /api/public/declarations/export` → JSON `{ data: [...], count: N }`
- [ ] `GET /api/public/declarations/export?format=csv` → CSV avec header + lignes, Content-Type `text/csv`
- [ ] `GET /api/public/declarations/export?format=invalid` → 400
- [ ] Entreprise non-diffusible : `siren` présent, tous les autres champs identifiants `null`
- [ ] Aucune clé `score` / index /100 / indicateur G dans le payload
- [ ] Années sans `publicDataReleaseDate` ou date future → absentes du résultat
- [ ] Tests unitaires verts (3077 tests, 0 régression, +5 nouveaux)
- [ ] Typecheck + lint + format PASS