### PR TITLE
Mail confirmation — moteur de règles d'envoi + discriminateur de variante

### DIFF
--- a/packages/app/src/app/api/upload/__tests__/route.test.ts
+++ b/packages/app/src/app/api/upload/__tests__/route.test.ts
@@ -5,10 +5,18 @@ const mocks = vi.hoisted(() => ({
 	runUploadPipeline: vi.fn(),
 	logAction: vi.fn().mockResolvedValue(undefined),
 	getActiveLock: vi.fn(),
+	enqueueReceipt: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("~/server/auth", () => ({
 	auth: mocks.auth,
+}));
+
+// The success path fires a confirmation mail via a dynamic import of
+// ~/modules/mail/server; mock it so the receipt kind can be asserted without
+// touching the real queue.
+vi.mock("~/modules/mail/server", () => ({
+	enqueueReceipt: mocks.enqueueReceipt,
 }));
 
 vi.mock("~/server/services/uploadPipeline", () => ({
@@ -652,5 +660,81 @@ describe("POST /api/upload", () => {
 
 		expect(response.status).toBe(200);
 		expect(mocks.runUploadPipeline).toHaveBeenCalled();
+	});
+
+	describe("confirmation mail on success", () => {
+		function mockUploadSuccess() {
+			mocks.runUploadPipeline.mockResolvedValue({
+				ok: true,
+				fileId: "file-uuid",
+				fileName: "avis.pdf",
+				filePath: "123456789/2027/file-uuid.pdf",
+			});
+		}
+
+		// The mail is dispatched from a fire-and-forget IIFE that awaits a dynamic
+		// import of ~/modules/mail/server, so its work lands after the response is
+		// returned. Yield to the microtask queue before asserting the call.
+		const flushMailDispatch = () =>
+			new Promise((resolve) => setTimeout(resolve, 0));
+
+		async function upload(flowType: string) {
+			const { POST } = await import("../route");
+			const response = await POST(
+				buildRequest({
+					"Content-Type": "application/pdf",
+					"X-Filename": "avis.pdf",
+					"X-Flow-Type": flowType,
+				}),
+			);
+			await flushMailDispatch();
+			return response;
+		}
+
+		it("enqueues a cseOpinion receipt for a cse_opinion flow", async () => {
+			validSession();
+			mockUploadSuccess();
+
+			const response = await upload("cse_opinion");
+
+			expect(response.status).toBe(200);
+			expect(mocks.enqueueReceipt).toHaveBeenCalledWith({
+				kind: "cseOpinion",
+				to: "user@example.com",
+				siren: "123456789",
+				year: expect.any(Number),
+				userId: "user-1",
+				isResend: false,
+			});
+		});
+
+		it("enqueues a jointEvaluation receipt for a joint_evaluation flow", async () => {
+			validSession();
+			mockUploadSuccess();
+
+			const response = await upload("joint_evaluation");
+
+			expect(response.status).toBe(200);
+			expect(mocks.enqueueReceipt).toHaveBeenCalledWith({
+				kind: "jointEvaluation",
+				to: "user@example.com",
+				siren: "123456789",
+				year: expect.any(Number),
+				userId: "user-1",
+				isResend: false,
+			});
+		});
+
+		it("does not enqueue any receipt when the session has no email", async () => {
+			mocks.auth.mockResolvedValue({
+				user: { id: "user-1", siret: "12345678901234" },
+			});
+			mockUploadSuccess();
+
+			const response = await upload("cse_opinion");
+
+			expect(response.status).toBe(200);
+			expect(mocks.enqueueReceipt).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -311,34 +311,14 @@ export async function POST(request: Request): Promise<Response> {
 					return;
 				}
 				if (flowType === "joint_evaluation") {
-					const { enqueueNotification } = await import(
-						"notifications/publisher"
-					);
-					const enqueueResult = await enqueueNotification({
-						type: "joint_evaluation_submitted",
-						recipientEmail: userEmail,
-						recipientUserId: userId,
+					const { enqueueReceipt } = await import("~/modules/mail/server");
+					await enqueueReceipt({
+						kind: "jointEvaluation",
+						to: userEmail,
 						siren,
-						payload: { siren, year },
-					});
-					void logAction({
-						action: AUDIT_ACTIONS.NOTIFICATION_ENQUEUE,
-						status: enqueueResult.status === "enqueued" ? "success" : "failure",
+						year,
 						userId,
-						userEmail,
-						siren,
-						...(enqueueResult.status === "enqueued"
-							? {
-									resourceType: "notification",
-									resourceId: enqueueResult.id,
-								}
-							: {
-									errorMessage:
-										enqueueResult.status === "error"
-											? enqueueResult.error
-											: "queue_unavailable",
-								}),
-						metadata: { type: "joint_evaluation_submitted" },
+						isResend: false,
 					});
 				}
 			})();

--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -1,5 +1,4 @@
 import { and, eq } from "drizzle-orm";
-import { z } from "zod";
 import { AUDIT_ACTIONS, type AuditActionKey } from "~/modules/audit";
 import { getCurrentYear } from "~/modules/domain";
 import { validateFileName } from "~/modules/shared/fileNameValidation";
@@ -9,19 +8,20 @@ import {
 	type FlowType,
 } from "~/modules/shared/uploadConfig";
 import { logAction } from "~/server/audit/log";
-import {
-	buildRequestContext,
-	type RequestContext,
-} from "~/server/audit/requestContext";
+import { buildRequestContext } from "~/server/audit/requestContext";
 import { auth } from "~/server/auth";
 import { db } from "~/server/db";
 import { declarations } from "~/server/db/schema";
 import { getActiveLock } from "~/server/services/declarationLockService";
 import {
-	type PipelineFailureReason,
 	runUploadPipeline,
 	type UploadPipelineResult,
 } from "~/server/services/uploadPipeline";
+import {
+	mapFailureToHttp,
+	uploadAuditMetadataSchema,
+	writeFailure,
+} from "./uploadAudit";
 
 const FLOW_TO_ACTION: Record<FlowType, AuditActionKey> = {
 	cse_opinion: AUDIT_ACTIONS.CSE_OPINION_UPLOAD_FILE,
@@ -353,116 +353,4 @@ export async function POST(request: Request): Promise<Response> {
 		},
 		{ status },
 	);
-}
-
-function mapFailureToHttp(reason: PipelineFailureReason): {
-	status: number;
-	errorMessage: string;
-} {
-	switch (reason) {
-		case "not_found":
-			return { status: 403, errorMessage: "HTTP 403 declaration_not_found" };
-		case "max_files":
-			return { status: 400, errorMessage: "HTTP 400 max_files" };
-		case "too_large":
-			return { status: 400, errorMessage: "HTTP 400 too_large" };
-		case "wrong_type":
-			return { status: 400, errorMessage: "HTTP 400 wrong_type" };
-		case "empty":
-			return { status: 400, errorMessage: "HTTP 400 empty_file" };
-		case "virus":
-			return { status: 422, errorMessage: "HTTP 422 virus_detected" };
-		case "scan_unavailable":
-			return { status: 503, errorMessage: "HTTP 503 antivirus_unavailable" };
-		case "aborted":
-			// 499 is the nginx-style "client closed request" status. The body is
-			// never consumed by the client (they are gone), so the status is
-			// purely for server-side observability.
-			return { status: 499, errorMessage: "HTTP 499 client_aborted" };
-		case "server_error":
-			return { status: 500, errorMessage: "HTTP 500 server_error" };
-	}
-}
-
-/**
- * Strips control characters (including ANSI escape sequences) and clips to
- * 255 chars before a user-supplied string is persisted to the audit log or
- * echoed to a terminal via console.error. Defence-in-depth: a crafted header
- * could carry escape sequences that mislead log readers.
- */
-function sanitizeUserText(value: string): string {
-	let out = "";
-	for (const ch of value) {
-		const code = ch.codePointAt(0) ?? 0;
-		if (code >= 0x20 && code !== 0x7f) out += ch;
-	}
-	return out.slice(0, 255);
-}
-
-/**
- * Audit metadata schema for /api/upload. Fields sourced from user input
- * (fileName, virusName) use `sanitizedUserString` so future additions to the
- * schema are sanitised by construction — a new untrusted string just has to
- * reuse the same transform. Internal literals (flowType, fileId, s3Cleanup)
- * are already constrained and do not need sanitisation.
- */
-const sanitizedUserString = z.string().transform(sanitizeUserText);
-
-const uploadAuditMetadataSchema = z.object({
-	flowType: z.enum(["cse_opinion", "joint_evaluation"]),
-	fileId: z.string().optional(),
-	fileName: sanitizedUserString.optional(),
-	virusName: sanitizedUserString.optional(),
-	s3Cleanup: z.enum(["ok", "failed"]).optional(),
-});
-
-type AuditFailureInput = {
-	action: AuditActionKey;
-	flowType: FlowType;
-	fileName: string | null;
-	fileId: string | null;
-	errorMessage: string;
-	userId: string | null;
-	userEmail: string | null;
-	siren: string | null;
-	requestContext: RequestContext;
-	startedAt: number;
-	virusName?: string | null;
-	s3Cleanup?: "ok" | "failed" | null;
-};
-
-function writeFailure({
-	action,
-	flowType,
-	fileName,
-	fileId,
-	errorMessage,
-	userId,
-	userEmail,
-	siren,
-	requestContext,
-	startedAt,
-	virusName = null,
-	s3Cleanup = null,
-}: AuditFailureInput): void {
-	const metadata = uploadAuditMetadataSchema.parse({
-		flowType,
-		fileName: fileName ?? undefined,
-		fileId: fileId ?? undefined,
-		virusName: virusName ?? undefined,
-		s3Cleanup: s3Cleanup ?? undefined,
-	});
-
-	void logAction({
-		action,
-		status: "failure",
-		userId,
-		userEmail,
-		siren,
-		metadata,
-		errorMessage,
-		ipAddress: requestContext.ipAddress,
-		userAgent: requestContext.userAgent,
-		durationMs: Date.now() - startedAt,
-	});
 }

--- a/packages/app/src/app/api/upload/uploadAudit.ts
+++ b/packages/app/src/app/api/upload/uploadAudit.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+import type { AuditActionKey } from "~/modules/audit";
+import type { FlowType } from "~/modules/shared/uploadConfig";
+import { logAction } from "~/server/audit/log";
+import type { RequestContext } from "~/server/audit/requestContext";
+import type { PipelineFailureReason } from "~/server/services/uploadPipeline";
+
+export function mapFailureToHttp(reason: PipelineFailureReason): {
+	status: number;
+	errorMessage: string;
+} {
+	switch (reason) {
+		case "not_found":
+			return { status: 403, errorMessage: "HTTP 403 declaration_not_found" };
+		case "max_files":
+			return { status: 400, errorMessage: "HTTP 400 max_files" };
+		case "too_large":
+			return { status: 400, errorMessage: "HTTP 400 too_large" };
+		case "wrong_type":
+			return { status: 400, errorMessage: "HTTP 400 wrong_type" };
+		case "empty":
+			return { status: 400, errorMessage: "HTTP 400 empty_file" };
+		case "virus":
+			return { status: 422, errorMessage: "HTTP 422 virus_detected" };
+		case "scan_unavailable":
+			return { status: 503, errorMessage: "HTTP 503 antivirus_unavailable" };
+		case "aborted":
+			// 499 is the nginx-style "client closed request" status. The body is
+			// never consumed by the client (they are gone), so the status is
+			// purely for server-side observability.
+			return { status: 499, errorMessage: "HTTP 499 client_aborted" };
+		case "server_error":
+			return { status: 500, errorMessage: "HTTP 500 server_error" };
+	}
+}
+
+// Strips control characters (including ANSI escape sequences) and clips to
+// 255 chars before a user-supplied string is persisted to the audit log or
+// echoed to a terminal via console.error: a crafted header could carry escape
+// sequences that mislead log readers.
+function sanitizeUserText(value: string): string {
+	let out = "";
+	for (const ch of value) {
+		const code = ch.codePointAt(0) ?? 0;
+		if (code >= 0x20 && code !== 0x7f) out += ch;
+	}
+	return out.slice(0, 255);
+}
+
+// Fields sourced from user input (fileName, virusName) use `sanitizedUserString`
+// so future additions to the schema are sanitised by construction.
+const sanitizedUserString = z.string().transform(sanitizeUserText);
+
+export const uploadAuditMetadataSchema = z.object({
+	flowType: z.enum(["cse_opinion", "joint_evaluation"]),
+	fileId: z.string().optional(),
+	fileName: sanitizedUserString.optional(),
+	virusName: sanitizedUserString.optional(),
+	s3Cleanup: z.enum(["ok", "failed"]).optional(),
+});
+
+type AuditFailureInput = {
+	action: AuditActionKey;
+	flowType: FlowType;
+	fileName: string | null;
+	fileId: string | null;
+	errorMessage: string;
+	userId: string | null;
+	userEmail: string | null;
+	siren: string | null;
+	requestContext: RequestContext;
+	startedAt: number;
+	virusName?: string | null;
+	s3Cleanup?: "ok" | "failed" | null;
+};
+
+export function writeFailure({
+	action,
+	flowType,
+	fileName,
+	fileId,
+	errorMessage,
+	userId,
+	userEmail,
+	siren,
+	requestContext,
+	startedAt,
+	virusName = null,
+	s3Cleanup = null,
+}: AuditFailureInput): void {
+	const metadata = uploadAuditMetadataSchema.parse({
+		flowType,
+		fileName: fileName ?? undefined,
+		fileId: fileId ?? undefined,
+		virusName: virusName ?? undefined,
+		s3Cleanup: s3Cleanup ?? undefined,
+	});
+
+	void logAction({
+		action,
+		status: "failure",
+		userId,
+		userEmail,
+		siren,
+		metadata,
+		errorMessage,
+		ipAddress: requestContext.ipAddress,
+		userAgent: requestContext.userAgent,
+		durationMs: Date.now() - startedAt,
+	});
+}

--- a/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
+++ b/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
@@ -5,6 +5,9 @@ const mocks = vi.hoisted(() => ({
 	logAction: vi.fn(),
 	buildDeclarationAttachments: vi.fn(),
 	buildSecondDeclarationAttachments: vi.fn(),
+	getCampaignDeadlines: vi.fn(),
+	dbResults: [] as unknown[][],
+	limit: vi.fn(),
 }));
 
 vi.mock("notifications/publisher", () => ({
@@ -18,6 +21,22 @@ vi.mock("~/server/audit/log", () => ({
 vi.mock("../buildReceiptAttachments", () => ({
 	buildDeclarationAttachments: mocks.buildDeclarationAttachments,
 	buildSecondDeclarationAttachments: mocks.buildSecondDeclarationAttachments,
+}));
+
+vi.mock("~/server/db/getCampaignDeadlines", () => ({
+	getCampaignDeadlines: mocks.getCampaignDeadlines,
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {
+		select: () => ({
+			from: () => ({
+				where: () => ({
+					limit: () => Promise.resolve(mocks.dbResults.shift() ?? []),
+				}),
+			}),
+		}),
+	},
 }));
 
 import { AUDIT_ACTIONS } from "~/modules/audit";
@@ -37,19 +56,39 @@ const baseInput = {
 	isResend: false,
 };
 
+const declarationRow = {
+	status: "declared",
+	cseRequired: false,
+	secondDeclarationStep: null,
+	firstDeclarationPathChoice: null,
+	secondDeclarationPathChoice: null,
+};
+
+const companyRow = { name: "Société Démo" };
+
+function stubContext(
+	row: Record<string, unknown> | null = declarationRow,
+	company: Record<string, unknown> | null = companyRow,
+) {
+	mocks.dbResults = [row ? [row] : [], company ? [company] : []];
+}
+
 describe("enqueueReceipt", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mocks.buildDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
 		mocks.buildSecondDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
-	});
-
-	it("enqueues a declaration confirmation with PDF attachments and logs success", async () => {
+		mocks.getCampaignDeadlines.mockResolvedValue({
+			pathChoiceDeadline: new Date("2025-09-01T00:00:00.000Z"),
+		});
 		mocks.enqueueNotification.mockResolvedValue({
 			status: "enqueued",
 			id: "job-1",
 		});
+		stubContext();
+	});
 
+	it("enqueues a declaration confirmation with PDF attachments and logs success", async () => {
 		await enqueueReceipt({ ...baseInput, kind: "declaration" });
 
 		expect(mocks.buildDeclarationAttachments).toHaveBeenCalledWith(
@@ -62,7 +101,12 @@ describe("enqueueReceipt", () => {
 				recipientEmail: "user@example.com",
 				recipientUserId: "user-1",
 				siren: "552100554",
-				payload: { siren: "552100554", year: 2025 },
+				payload: {
+					siren: "552100554",
+					year: 2025,
+					raisonSociale: "Société Démo",
+					variant: "completed",
+				},
 				attachments: [PDF_ATTACHMENT],
 			}),
 		);
@@ -80,17 +124,13 @@ describe("enqueueReceipt", () => {
 					kind: "declaration",
 					year: 2025,
 					isResend: false,
+					variant: "completed",
 				}),
 			}),
 		);
 	});
 
 	it("maps secondDeclaration to second_declaration_confirmation", async () => {
-		mocks.enqueueNotification.mockResolvedValue({
-			status: "enqueued",
-			id: "job-2",
-		});
-
 		await enqueueReceipt({ ...baseInput, kind: "secondDeclaration" });
 
 		expect(mocks.buildSecondDeclarationAttachments).toHaveBeenCalledWith(
@@ -103,17 +143,26 @@ describe("enqueueReceipt", () => {
 	});
 
 	it("maps cseOpinion to cse_opinion_receipt without attachments", async () => {
-		mocks.enqueueNotification.mockResolvedValue({
-			status: "enqueued",
-			id: "job-3",
-		});
-
 		await enqueueReceipt({ ...baseInput, kind: "cseOpinion" });
 
 		expect(mocks.buildDeclarationAttachments).not.toHaveBeenCalled();
 		expect(mocks.buildSecondDeclarationAttachments).not.toHaveBeenCalled();
 		expect(mocks.enqueueNotification).toHaveBeenCalledWith(
 			expect.objectContaining({ type: "cse_opinion_receipt" }),
+		);
+		const call = mocks.enqueueNotification.mock.calls[0]?.[0] as {
+			attachments?: unknown;
+		};
+		expect(call.attachments).toBeUndefined();
+	});
+
+	it("maps jointEvaluation to joint_evaluation_submitted without attachments", async () => {
+		await enqueueReceipt({ ...baseInput, kind: "jointEvaluation" });
+
+		expect(mocks.buildDeclarationAttachments).not.toHaveBeenCalled();
+		expect(mocks.buildSecondDeclarationAttachments).not.toHaveBeenCalled();
+		expect(mocks.enqueueNotification).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "joint_evaluation_submitted" }),
 		);
 		const call = mocks.enqueueNotification.mock.calls[0]?.[0] as {
 			attachments?: unknown;
@@ -172,12 +221,22 @@ describe("enqueueReceipt", () => {
 		);
 	});
 
-	it("passes a null userId through when the session has no user id", async () => {
-		mocks.enqueueNotification.mockResolvedValue({
-			status: "enqueued",
-			id: "job-4",
-		});
+	it("logs failure with a generic message when a non-Error value is thrown", async () => {
+		mocks.buildDeclarationAttachments.mockRejectedValue("boom");
 
+		await expect(
+			enqueueReceipt({ ...baseInput, kind: "declaration" }),
+		).resolves.toBeUndefined();
+
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: "failure",
+				errorMessage: "Unknown error",
+			}),
+		);
+	});
+
+	it("passes a null userId through when the session has no user id", async () => {
 		await enqueueReceipt({
 			...baseInput,
 			userId: null,
@@ -190,5 +249,142 @@ describe("enqueueReceipt", () => {
 		expect(mocks.logAction).toHaveBeenCalledWith(
 			expect.objectContaining({ userId: null }),
 		);
+	});
+});
+
+describe("enqueueReceipt — variant derivation", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.buildDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
+		mocks.buildSecondDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
+		mocks.getCampaignDeadlines.mockResolvedValue({
+			pathChoiceDeadline: new Date("2025-09-01T00:00:00.000Z"),
+		});
+		mocks.enqueueNotification.mockResolvedValue({
+			status: "enqueued",
+			id: "job-1",
+		});
+	});
+
+	const payloadOf = () =>
+		mocks.enqueueNotification.mock.calls[0]?.[0].payload as Record<
+			string,
+			unknown
+		>;
+
+	it("selects cse_to_deposit for a declaration when the CSE is required and there is no gap", async () => {
+		stubContext({ ...declarationRow, cseRequired: true });
+
+		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(payloadOf().variant).toBe("cse_to_deposit");
+		expect(payloadOf().complianceDeadline).toBeUndefined();
+		expect(mocks.getCampaignDeadlines).not.toHaveBeenCalled();
+	});
+
+	it("selects path_to_select and attaches the compliance deadline when a compliance path was chosen", async () => {
+		stubContext({
+			...declarationRow,
+			firstDeclarationPathChoice: "justify",
+		});
+
+		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(payloadOf().variant).toBe("path_to_select");
+		expect(payloadOf().complianceDeadline).toBe("2025-09-01T00:00:00.000Z");
+		expect(mocks.getCampaignDeadlines).toHaveBeenCalledWith(2025);
+	});
+
+	it("treats an awaiting_compliance_path_choice status as a gap above the threshold", async () => {
+		stubContext({
+			...declarationRow,
+			status: "awaiting_compliance_path_choice",
+		});
+
+		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(payloadOf().variant).toBe("path_to_select");
+	});
+
+	it("treats an awaiting_revision_choice status as a gap above the threshold", async () => {
+		stubContext({
+			...declarationRow,
+			status: "awaiting_revision_choice",
+		});
+
+		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(payloadOf().variant).toBe("path_to_select");
+	});
+
+	it("selects cse_first_and_second for a joint evaluation when a second declaration exists", async () => {
+		stubContext({ ...declarationRow, secondDeclarationStep: 3 });
+
+		await enqueueReceipt({ ...baseInput, kind: "jointEvaluation" });
+
+		expect(payloadOf().variant).toBe("cse_first_and_second");
+	});
+
+	it("selects cse_to_deposit for a joint evaluation when the CSE is required without a second declaration", async () => {
+		stubContext({ ...declarationRow, cseRequired: true });
+
+		await enqueueReceipt({ ...baseInput, kind: "jointEvaluation" });
+
+		expect(payloadOf().variant).toBe("cse_to_deposit");
+	});
+
+	it("selects completed for a joint evaluation with neither a second declaration nor a required CSE", async () => {
+		stubContext();
+
+		await enqueueReceipt({ ...baseInput, kind: "jointEvaluation" });
+
+		expect(payloadOf().variant).toBe("completed");
+	});
+
+	it("selects first_and_second for a cse opinion receipt when a second declaration exists", async () => {
+		stubContext({
+			...declarationRow,
+			secondDeclarationPathChoice: "corrective_action",
+		});
+
+		await enqueueReceipt({ ...baseInput, kind: "cseOpinion" });
+
+		expect(payloadOf().variant).toBe("first_and_second");
+	});
+
+	it("selects with_gap for a cse opinion receipt when there is a gap for a single declaration", async () => {
+		stubContext({
+			...declarationRow,
+			status: "awaiting_compliance_path_choice",
+		});
+
+		await enqueueReceipt({ ...baseInput, kind: "cseOpinion" });
+
+		expect(payloadOf().variant).toBe("with_gap");
+	});
+
+	it("selects single for a cse opinion receipt with no gap and a single declaration", async () => {
+		stubContext();
+
+		await enqueueReceipt({ ...baseInput, kind: "cseOpinion" });
+
+		expect(payloadOf().variant).toBe("single");
+	});
+
+	it("falls back to a neutral context and the siren as raisonSociale when no declaration and no company are found", async () => {
+		stubContext(null, null);
+
+		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(payloadOf().variant).toBe("completed");
+		expect(payloadOf().raisonSociale).toBe("552100554");
+	});
+
+	it("falls back to the siren as raisonSociale when the company row has a null name", async () => {
+		stubContext(declarationRow, { name: null });
+
+		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(payloadOf().raisonSociale).toBe("552100554");
 	});
 });

--- a/packages/app/src/modules/mail/__tests__/sendRules.test.ts
+++ b/packages/app/src/modules/mail/__tests__/sendRules.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	selectCseOpinionReceiptVariant,
+	selectDeclarationConfirmationVariant,
+	selectJointEvaluationSubmittedVariant,
+} from "../sendRules";
+
+describe("selectDeclarationConfirmationVariant", () => {
+	it("returns path_to_select when the gap is above the threshold", () => {
+		expect(
+			selectDeclarationConfirmationVariant({
+				hasGapAboveThreshold: true,
+				cseRequired: false,
+			}),
+		).toBe("path_to_select");
+	});
+
+	it("returns path_to_select even when a CSE is required (gap takes priority)", () => {
+		expect(
+			selectDeclarationConfirmationVariant({
+				hasGapAboveThreshold: true,
+				cseRequired: true,
+			}),
+		).toBe("path_to_select");
+	});
+
+	it("returns cse_to_deposit when there is no gap but a CSE is required", () => {
+		expect(
+			selectDeclarationConfirmationVariant({
+				hasGapAboveThreshold: false,
+				cseRequired: true,
+			}),
+		).toBe("cse_to_deposit");
+	});
+
+	it("returns completed when there is no gap and no CSE is required", () => {
+		expect(
+			selectDeclarationConfirmationVariant({
+				hasGapAboveThreshold: false,
+				cseRequired: false,
+			}),
+		).toBe("completed");
+	});
+});
+
+describe("selectJointEvaluationSubmittedVariant", () => {
+	it("returns cse_first_and_second when a second declaration exists", () => {
+		expect(
+			selectJointEvaluationSubmittedVariant({
+				hasSecondDeclaration: true,
+				cseOpinionExpected: false,
+			}),
+		).toBe("cse_first_and_second");
+	});
+
+	it("returns cse_first_and_second even when a CSE opinion is expected (second declaration takes priority)", () => {
+		expect(
+			selectJointEvaluationSubmittedVariant({
+				hasSecondDeclaration: true,
+				cseOpinionExpected: true,
+			}),
+		).toBe("cse_first_and_second");
+	});
+
+	it("returns cse_to_deposit when a CSE opinion is expected without a second declaration", () => {
+		expect(
+			selectJointEvaluationSubmittedVariant({
+				hasSecondDeclaration: false,
+				cseOpinionExpected: true,
+			}),
+		).toBe("cse_to_deposit");
+	});
+
+	it("returns completed when there is neither a second declaration nor an expected CSE opinion", () => {
+		expect(
+			selectJointEvaluationSubmittedVariant({
+				hasSecondDeclaration: false,
+				cseOpinionExpected: false,
+			}),
+		).toBe("completed");
+	});
+});
+
+describe("selectCseOpinionReceiptVariant", () => {
+	it("returns first_and_second when the opinion covers both declarations", () => {
+		expect(
+			selectCseOpinionReceiptVariant({
+				forFirstAndSecondDeclaration: true,
+				hasGapAboveThreshold: false,
+			}),
+		).toBe("first_and_second");
+	});
+
+	it("returns first_and_second even when the gap is above the threshold (both declarations take priority)", () => {
+		expect(
+			selectCseOpinionReceiptVariant({
+				forFirstAndSecondDeclaration: true,
+				hasGapAboveThreshold: true,
+			}),
+		).toBe("first_and_second");
+	});
+
+	it("returns with_gap when the gap is above the threshold for a single declaration", () => {
+		expect(
+			selectCseOpinionReceiptVariant({
+				forFirstAndSecondDeclaration: false,
+				hasGapAboveThreshold: true,
+			}),
+		).toBe("with_gap");
+	});
+
+	it("returns single when there is no gap and a single declaration", () => {
+		expect(
+			selectCseOpinionReceiptVariant({
+				forFirstAndSecondDeclaration: false,
+				hasGapAboveThreshold: false,
+			}),
+		).toBe("single");
+	});
+});

--- a/packages/app/src/modules/mail/enqueueReceipt.ts
+++ b/packages/app/src/modules/mail/enqueueReceipt.ts
@@ -1,15 +1,32 @@
 import "server-only";
+import { and, eq, isNull } from "drizzle-orm";
 import { enqueueNotification } from "notifications/publisher";
-import type { NotificationType } from "notifications/queue";
+import type {
+	NotificationPayloadMap,
+	NotificationType,
+} from "notifications/queue";
 import { AUDIT_ACTIONS } from "~/modules/audit";
+import { getCurrentCompliancePath } from "~/modules/domain";
 import { logAction } from "~/server/audit/log";
+import { db } from "~/server/db";
+import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
+import { companies, declarations } from "~/server/db/schema";
 import {
 	buildDeclarationAttachments,
 	buildSecondDeclarationAttachments,
 } from "./buildReceiptAttachments";
+import {
+	selectCseOpinionReceiptVariant,
+	selectDeclarationConfirmationVariant,
+	selectJointEvaluationSubmittedVariant,
+} from "./sendRules";
 import type { MailAttachment } from "./types";
 
-export type ReceiptKind = "declaration" | "secondDeclaration" | "cseOpinion";
+export type ReceiptKind =
+	| "declaration"
+	| "secondDeclaration"
+	| "cseOpinion"
+	| "jointEvaluation";
 
 export type EnqueueReceiptInput = {
 	kind: ReceiptKind;
@@ -20,11 +37,123 @@ export type EnqueueReceiptInput = {
 	isResend: boolean;
 };
 
-const KIND_TO_TYPE: Record<ReceiptKind, NotificationType> = {
+const KIND_TO_TYPE = {
 	declaration: "declaration_confirmation",
 	secondDeclaration: "second_declaration_confirmation",
 	cseOpinion: "cse_opinion_receipt",
+	jointEvaluation: "joint_evaluation_submitted",
+} as const satisfies Record<ReceiptKind, NotificationType>;
+
+type ConfirmationType = (typeof KIND_TO_TYPE)[ReceiptKind];
+
+type ReceiptContext = {
+	raisonSociale: string;
+	cseRequired: boolean;
+	hasGapAboveThreshold: boolean;
+	hasSecondDeclaration: boolean;
 };
+
+async function readReceiptContext(
+	siren: string,
+	year: number,
+): Promise<ReceiptContext> {
+	const [row] = await db
+		.select({
+			status: declarations.status,
+			cseRequired: declarations.cseRequired,
+			secondDeclarationStep: declarations.secondDeclarationStep,
+			firstDeclarationPathChoice: declarations.firstDeclarationPathChoice,
+			secondDeclarationPathChoice: declarations.secondDeclarationPathChoice,
+		})
+		.from(declarations)
+		.where(
+			and(
+				eq(declarations.siren, siren),
+				eq(declarations.year, year),
+				isNull(declarations.cancelledAt),
+			),
+		)
+		.limit(1);
+
+	const [company] = await db
+		.select({ name: companies.name })
+		.from(companies)
+		.where(eq(companies.siren, siren))
+		.limit(1);
+
+	const raisonSociale = company?.name ?? siren;
+
+	if (!row) {
+		return {
+			raisonSociale,
+			cseRequired: false,
+			hasGapAboveThreshold: false,
+			hasSecondDeclaration: false,
+		};
+	}
+
+	const hasGapAboveThreshold =
+		getCurrentCompliancePath(row) !== null ||
+		row.status === "awaiting_compliance_path_choice" ||
+		row.status === "awaiting_revision_choice";
+
+	const hasSecondDeclaration =
+		row.secondDeclarationStep !== null ||
+		row.secondDeclarationPathChoice !== null;
+
+	return {
+		raisonSociale,
+		cseRequired: row.cseRequired,
+		hasGapAboveThreshold,
+		hasSecondDeclaration,
+	};
+}
+
+async function buildConfirmationPayload(
+	type: ConfirmationType,
+	siren: string,
+	year: number,
+	context: ReceiptContext,
+): Promise<NotificationPayloadMap[ConfirmationType]> {
+	const base = { siren, year, raisonSociale: context.raisonSociale };
+
+	switch (type) {
+		case "declaration_confirmation":
+		case "second_declaration_confirmation": {
+			const variant = selectDeclarationConfirmationVariant({
+				hasGapAboveThreshold: context.hasGapAboveThreshold,
+				cseRequired: context.cseRequired,
+			});
+			if (variant === "path_to_select") {
+				const deadlines = await getCampaignDeadlines(year);
+				return {
+					...base,
+					variant,
+					complianceDeadline: deadlines.pathChoiceDeadline.toISOString(),
+				};
+			}
+			return { ...base, variant };
+		}
+		case "joint_evaluation_submitted": {
+			return {
+				...base,
+				variant: selectJointEvaluationSubmittedVariant({
+					hasSecondDeclaration: context.hasSecondDeclaration,
+					cseOpinionExpected: context.cseRequired,
+				}),
+			};
+		}
+		case "cse_opinion_receipt": {
+			return {
+				...base,
+				variant: selectCseOpinionReceiptVariant({
+					forFirstAndSecondDeclaration: context.hasSecondDeclaration,
+					hasGapAboveThreshold: context.hasGapAboveThreshold,
+				}),
+			};
+		}
+	}
+}
 
 async function buildAttachments(
 	kind: ReceiptKind,
@@ -45,13 +174,15 @@ export async function enqueueReceipt(
 	const type = KIND_TO_TYPE[kind];
 
 	try {
+		const context = await readReceiptContext(siren, year);
+		const payload = await buildConfirmationPayload(type, siren, year, context);
 		const attachments = await buildAttachments(kind, siren, year);
 		const result = await enqueueNotification({
 			type,
 			recipientEmail: to,
 			recipientUserId: userId,
 			siren,
-			payload: { siren, year },
+			payload,
 			...(attachments.length > 0 ? { attachments } : {}),
 		});
 
@@ -67,7 +198,7 @@ export async function enqueueReceipt(
 						errorMessage:
 							result.status === "error" ? result.error : "queue_unavailable",
 					}),
-			metadata: { type, kind, year, isResend },
+			metadata: { type, kind, year, isResend, variant: payload.variant },
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : "Unknown error";

--- a/packages/app/src/modules/mail/index.ts
+++ b/packages/app/src/modules/mail/index.ts
@@ -1,4 +1,14 @@
 export { ResendReceiptButton } from "./ResendReceiptButton";
 export type { ResendReceiptInput } from "./schemas";
 export { resendReceiptSchema } from "./schemas";
+export type {
+	CseOpinionReceiptContext,
+	DeclarationConfirmationContext,
+	JointEvaluationSubmittedContext,
+} from "./sendRules";
+export {
+	selectCseOpinionReceiptVariant,
+	selectDeclarationConfirmationVariant,
+	selectJointEvaluationSubmittedVariant,
+} from "./sendRules";
 export type { MailAttachment } from "./types";

--- a/packages/app/src/modules/mail/sendRules.ts
+++ b/packages/app/src/modules/mail/sendRules.ts
@@ -1,0 +1,44 @@
+import type {
+	CseOpinionReceiptVariant,
+	DeclarationConfirmationVariant,
+	JointEvaluationSubmittedVariant,
+} from "notifications/queue";
+
+export type DeclarationConfirmationContext = {
+	hasGapAboveThreshold: boolean;
+	cseRequired: boolean;
+};
+
+export function selectDeclarationConfirmationVariant(
+	context: DeclarationConfirmationContext,
+): DeclarationConfirmationVariant {
+	if (context.hasGapAboveThreshold) return "path_to_select";
+	if (context.cseRequired) return "cse_to_deposit";
+	return "completed";
+}
+
+export type JointEvaluationSubmittedContext = {
+	hasSecondDeclaration: boolean;
+	cseOpinionExpected: boolean;
+};
+
+export function selectJointEvaluationSubmittedVariant(
+	context: JointEvaluationSubmittedContext,
+): JointEvaluationSubmittedVariant {
+	if (context.hasSecondDeclaration) return "cse_first_and_second";
+	if (context.cseOpinionExpected) return "cse_to_deposit";
+	return "completed";
+}
+
+export type CseOpinionReceiptContext = {
+	forFirstAndSecondDeclaration: boolean;
+	hasGapAboveThreshold: boolean;
+};
+
+export function selectCseOpinionReceiptVariant(
+	context: CseOpinionReceiptContext,
+): CseOpinionReceiptVariant {
+	if (context.forFirstAndSecondDeclaration) return "first_and_second";
+	if (context.hasGapAboveThreshold) return "with_gap";
+	return "single";
+}

--- a/packages/notifications/src/__tests__/queue.test.ts
+++ b/packages/notifications/src/__tests__/queue.test.ts
@@ -4,7 +4,12 @@ import { validateJobData } from "../queue.js";
 
 const VALID = {
 	type: "joint_evaluation_submitted",
-	payload: { siren: "552100554", year: 2025 },
+	payload: {
+		siren: "552100554",
+		year: 2025,
+		variant: "completed",
+		raisonSociale: "Société Démo",
+	},
 	recipientEmail: "rh@example.fr",
 	recipientUserId: "user-1",
 	siren: "552100554",
@@ -107,5 +112,252 @@ describe("validateJobData", () => {
 			],
 		});
 		expect(result.ok).toBe(false);
+	});
+});
+
+const buildConfirmation = (type: string, payload: Record<string, unknown>) => ({
+	type,
+	payload,
+	recipientEmail: "rh@example.fr",
+	recipientUserId: "user-1",
+	siren: "552100554",
+});
+
+const BASE_SCOPE = { siren: "552100554", year: 2025 } as const;
+
+describe("validateJobData — confirmation variants", () => {
+	const DECLARATION_TYPES = [
+		"declaration_confirmation",
+		"second_declaration_confirmation",
+	] as const;
+
+	describe.each(DECLARATION_TYPES)("%s", (type) => {
+		it("accepts a valid completed payload", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					...BASE_SCOPE,
+					variant: "completed",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(true);
+		});
+
+		it("accepts a valid path_to_select payload with a complianceDeadline", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					...BASE_SCOPE,
+					variant: "path_to_select",
+					raisonSociale: "Société Démo",
+					complianceDeadline: "2025-09-01T00:00:00.000Z",
+				}),
+			);
+			expect(result.ok).toBe(true);
+		});
+
+		it("rejects a payload without variant", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					...BASE_SCOPE,
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("variant");
+		});
+
+		it("rejects a variant outside the union", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					...BASE_SCOPE,
+					variant: "with_gap",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("variant");
+		});
+
+		it("rejects an empty raisonSociale", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					...BASE_SCOPE,
+					variant: "completed",
+					raisonSociale: "",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("raisonSociale");
+		});
+
+		it("rejects a missing raisonSociale", () => {
+			const result = validateJobData(
+				buildConfirmation(type, { ...BASE_SCOPE, variant: "completed" }),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("raisonSociale");
+		});
+
+		it("rejects a path_to_select variant missing complianceDeadline", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					...BASE_SCOPE,
+					variant: "path_to_select",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("complianceDeadline");
+		});
+
+		it("rejects a path_to_select variant with an empty complianceDeadline", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					...BASE_SCOPE,
+					variant: "path_to_select",
+					raisonSociale: "Société Démo",
+					complianceDeadline: "",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("complianceDeadline");
+		});
+
+		it("rejects a payload missing siren/year", () => {
+			const result = validateJobData(
+				buildConfirmation(type, {
+					variant: "completed",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("siren");
+		});
+	});
+
+	describe("joint_evaluation_submitted", () => {
+		it.each([
+			"completed",
+			"cse_to_deposit",
+			"cse_first_and_second",
+		])("accepts the %s variant", (variant) => {
+			const result = validateJobData(
+				buildConfirmation("joint_evaluation_submitted", {
+					...BASE_SCOPE,
+					variant,
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(true);
+		});
+
+		it("rejects a payload without variant", () => {
+			const result = validateJobData(
+				buildConfirmation("joint_evaluation_submitted", {
+					...BASE_SCOPE,
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("variant");
+		});
+
+		it("rejects a variant outside the union", () => {
+			const result = validateJobData(
+				buildConfirmation("joint_evaluation_submitted", {
+					...BASE_SCOPE,
+					variant: "path_to_select",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("variant");
+		});
+
+		it("rejects an empty raisonSociale", () => {
+			const result = validateJobData(
+				buildConfirmation("joint_evaluation_submitted", {
+					...BASE_SCOPE,
+					variant: "completed",
+					raisonSociale: "",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("raisonSociale");
+		});
+
+		it("rejects a payload missing siren/year", () => {
+			const result = validateJobData(
+				buildConfirmation("joint_evaluation_submitted", {
+					variant: "completed",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("siren");
+		});
+	});
+
+	describe("cse_opinion_receipt", () => {
+		it.each([
+			"single",
+			"with_gap",
+			"first_and_second",
+		])("accepts the %s variant", (variant) => {
+			const result = validateJobData(
+				buildConfirmation("cse_opinion_receipt", {
+					...BASE_SCOPE,
+					variant,
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(true);
+		});
+
+		it("rejects a payload without variant", () => {
+			const result = validateJobData(
+				buildConfirmation("cse_opinion_receipt", {
+					...BASE_SCOPE,
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("variant");
+		});
+
+		it("rejects a variant outside the union", () => {
+			const result = validateJobData(
+				buildConfirmation("cse_opinion_receipt", {
+					...BASE_SCOPE,
+					variant: "completed",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("variant");
+		});
+
+		it("rejects an empty raisonSociale", () => {
+			const result = validateJobData(
+				buildConfirmation("cse_opinion_receipt", {
+					...BASE_SCOPE,
+					variant: "single",
+					raisonSociale: "",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("raisonSociale");
+		});
+
+		it("rejects a payload missing siren/year", () => {
+			const result = validateJobData(
+				buildConfirmation("cse_opinion_receipt", {
+					variant: "single",
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("siren");
+		});
 	});
 });

--- a/packages/notifications/src/mails/types.ts
+++ b/packages/notifications/src/mails/types.ts
@@ -81,11 +81,8 @@ export type DeclarationConfirmationPayload = CompanyScopedPayload & {
 	complianceDeadline?: string;
 };
 
-export type SecondDeclarationConfirmationPayload = CompanyScopedPayload & {
-	variant: DeclarationConfirmationVariant;
-	raisonSociale: string;
-	complianceDeadline?: string;
-};
+export type SecondDeclarationConfirmationPayload =
+	DeclarationConfirmationPayload;
 
 export type JointEvaluationSubmittedPayload = CompanyScopedPayload & {
 	variant: JointEvaluationSubmittedVariant;

--- a/packages/notifications/src/mails/types.ts
+++ b/packages/notifications/src/mails/types.ts
@@ -48,6 +48,55 @@ export type CseOpinionReminderPayload = DeadlinePayload & {
 	variant: CseOpinionReminderVariant;
 };
 
+export const DECLARATION_CONFIRMATION_VARIANTS = [
+	"completed",
+	"cse_to_deposit",
+	"path_to_select",
+] as const;
+
+export type DeclarationConfirmationVariant =
+	(typeof DECLARATION_CONFIRMATION_VARIANTS)[number];
+
+export const JOINT_EVALUATION_SUBMITTED_VARIANTS = [
+	"completed",
+	"cse_to_deposit",
+	"cse_first_and_second",
+] as const;
+
+export type JointEvaluationSubmittedVariant =
+	(typeof JOINT_EVALUATION_SUBMITTED_VARIANTS)[number];
+
+export const CSE_OPINION_RECEIPT_VARIANTS = [
+	"single",
+	"with_gap",
+	"first_and_second",
+] as const;
+
+export type CseOpinionReceiptVariant =
+	(typeof CSE_OPINION_RECEIPT_VARIANTS)[number];
+
+export type DeclarationConfirmationPayload = CompanyScopedPayload & {
+	variant: DeclarationConfirmationVariant;
+	raisonSociale: string;
+	complianceDeadline?: string;
+};
+
+export type SecondDeclarationConfirmationPayload = CompanyScopedPayload & {
+	variant: DeclarationConfirmationVariant;
+	raisonSociale: string;
+	complianceDeadline?: string;
+};
+
+export type JointEvaluationSubmittedPayload = CompanyScopedPayload & {
+	variant: JointEvaluationSubmittedVariant;
+	raisonSociale: string;
+};
+
+export type CseOpinionReceiptPayload = CompanyScopedPayload & {
+	variant: CseOpinionReceiptVariant;
+	raisonSociale: string;
+};
+
 export type NextCycleHandoverPayload = {
 	siren: string;
 	previousYear: number;
@@ -55,10 +104,10 @@ export type NextCycleHandoverPayload = {
 };
 
 export type NotificationPayloadMap = {
-	declaration_confirmation: CompanyScopedPayload;
-	second_declaration_confirmation: CompanyScopedPayload;
-	cse_opinion_receipt: CompanyScopedPayload;
-	joint_evaluation_submitted: CompanyScopedPayload;
+	declaration_confirmation: DeclarationConfirmationPayload;
+	second_declaration_confirmation: SecondDeclarationConfirmationPayload;
+	cse_opinion_receipt: CseOpinionReceiptPayload;
+	joint_evaluation_submitted: JointEvaluationSubmittedPayload;
 	cycle_opening_info: DeadlinePayload;
 	declaration_deadline_reminder: DeclarationDeadlineReminderPayload;
 	compliance_path_choice_reminder: DeadlinePayload;

--- a/packages/notifications/src/queue.ts
+++ b/packages/notifications/src/queue.ts
@@ -1,7 +1,13 @@
 import { isNotificationType } from "./mails/index.js";
 import {
+	CSE_OPINION_RECEIPT_VARIANTS,
 	CSE_OPINION_REMINDER_VARIANTS,
+	type CseOpinionReceiptVariant,
 	type CseOpinionReminderVariant,
+	DECLARATION_CONFIRMATION_VARIANTS,
+	type DeclarationConfirmationVariant,
+	JOINT_EVALUATION_SUBMITTED_VARIANTS,
+	type JointEvaluationSubmittedVariant,
 	type NotificationPayloadMap,
 	type NotificationType,
 } from "./mails/types.js";
@@ -31,9 +37,22 @@ export type JobValidationResult = JobValidationSuccess | JobValidationFailure;
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const VARIANT_SET = new Set<string>(CSE_OPINION_REMINDER_VARIANTS);
+const DECLARATION_CONFIRMATION_VARIANT_SET = new Set<string>(
+	DECLARATION_CONFIRMATION_VARIANTS,
+);
+const JOINT_EVALUATION_SUBMITTED_VARIANT_SET = new Set<string>(
+	JOINT_EVALUATION_SUBMITTED_VARIANTS,
+);
+const CSE_OPINION_RECEIPT_VARIANT_SET = new Set<string>(
+	CSE_OPINION_RECEIPT_VARIANTS,
+);
 
 function isString(value: unknown): value is string {
 	return typeof value === "string";
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
 }
 
 function isPositiveInteger(value: unknown): value is number {
@@ -72,12 +91,54 @@ function validatePayloadForType(
 
 	switch (type) {
 		case "declaration_confirmation":
-		case "second_declaration_confirmation":
-		case "cse_opinion_receipt":
+		case "second_declaration_confirmation": {
+			if (!isCompanyScoped(p)) {
+				return "payload requires { siren: string, year: number }";
+			}
+			if (
+				!isString(p.variant) ||
+				!DECLARATION_CONFIRMATION_VARIANT_SET.has(p.variant)
+			) {
+				return `payload.variant must be one of ${DECLARATION_CONFIRMATION_VARIANTS.join(", ")}`;
+			}
+			if (!isNonEmptyString(p.raisonSociale)) {
+				return "payload.raisonSociale must be a non-empty string";
+			}
+			if (
+				p.variant === "path_to_select" &&
+				!isNonEmptyString(p.complianceDeadline)
+			) {
+				return "payload.complianceDeadline is required for the path_to_select variant";
+			}
+			return null;
+		}
 		case "joint_evaluation_submitted": {
-			return isCompanyScoped(p)
+			if (!isCompanyScoped(p)) {
+				return "payload requires { siren: string, year: number }";
+			}
+			if (
+				!isString(p.variant) ||
+				!JOINT_EVALUATION_SUBMITTED_VARIANT_SET.has(p.variant)
+			) {
+				return `payload.variant must be one of ${JOINT_EVALUATION_SUBMITTED_VARIANTS.join(", ")}`;
+			}
+			return isNonEmptyString(p.raisonSociale)
 				? null
-				: "payload requires { siren: string, year: number }";
+				: "payload.raisonSociale must be a non-empty string";
+		}
+		case "cse_opinion_receipt": {
+			if (!isCompanyScoped(p)) {
+				return "payload requires { siren: string, year: number }";
+			}
+			if (
+				!isString(p.variant) ||
+				!CSE_OPINION_RECEIPT_VARIANT_SET.has(p.variant)
+			) {
+				return `payload.variant must be one of ${CSE_OPINION_RECEIPT_VARIANTS.join(", ")}`;
+			}
+			return isNonEmptyString(p.raisonSociale)
+				? null
+				: "payload.raisonSociale must be a non-empty string";
 		}
 		case "cycle_opening_info":
 		case "compliance_path_choice_reminder":
@@ -162,4 +223,9 @@ export function validateJobData(raw: unknown): JobValidationResult {
 	return { ok: true, data: d as unknown as EmailJobData };
 }
 
-export type { CseOpinionReminderVariant };
+export type {
+	CseOpinionReceiptVariant,
+	CseOpinionReminderVariant,
+	DeclarationConfirmationVariant,
+	JointEvaluationSubmittedVariant,
+};


### PR DESCRIPTION
Closes #3782

## Résumé

Fondation de la feature « emails de confirmation » (epic #3670) : ajoute le **moteur de règles d'envoi** qui sélectionne la **variante** de chaque mail de confirmation, et câble le discriminateur `variant` + les données dynamiques dans le payload. Les 4 tickets de contenu en dépendent.

## Changements

- **`packages/notifications/src/mails/types.ts`** — 3 unions de variantes exportées (`DECLARATION_CONFIRMATION_VARIANTS`, `JOINT_EVALUATION_SUBMITTED_VARIANTS`, `CSE_OPINION_RECEIPT_VARIANTS`) + payloads de confirmation enrichis (`variant`, `raisonSociale`, `complianceDeadline?` pour `path_to_select`). `SecondDeclarationConfirmationPayload` = alias de `DeclarationConfirmationPayload` (shape identique).
- **`packages/notifications/src/queue.ts`** — `validateJobData` durcit la validation des 4 types de confirmation : `variant` ∈ l'union, `raisonSociale` non vide, `complianceDeadline` requis pour `path_to_select`. Un payload de confirmation sans `variant` valide est rejeté (poison-pill).
- **`packages/app/src/modules/mail/sendRules.ts`** (nouveau) — fonctions pures de sélection de variante (contexte explicite, aucune lecture DB). Le seuil d'écart n'est pas hardcodé : le signal « écart ≥ 5 % » est dérivé en amont via la logique domaine (état de démarche/compliance) puis passé en booléen.
- **`packages/app/src/modules/mail/enqueueReceipt.ts`** — dérive le contexte de variante depuis l'état **persisté** de la déclaration (`readReceiptContext`), lit la raison sociale (`companies.name`), calcule la variante via `sendRules`, enrichit le payload. Ajoute le kind `jointEvaluation`.
- **`packages/app/src/app/api/upload/route.ts`** — la confirmation d'évaluation conjointe passe désormais par `enqueueReceipt` (au lieu d'un `enqueueNotification` inline), ce qui centralise le calcul de variante et l'audit. Helpers d'audit extraits dans `uploadAudit.ts` (fichier repassé sous 400 lignes).

### Note de conception

Le contexte de variante (écart, CSE requis, présence 2nde déclaration, raison sociale, échéance) est **dérivé à l'enqueue** depuis l'état persisté de la déclaration plutôt que passé par chaque call site. Ce choix garantit une variante correcte y compris sur le **renvoi d'accusé** (`mailRouter.resendReceipt`), qui n'a pas de contexte frais à disposition, et évite de fuiter des helpers privés du routeur `declaration` dans le module `mail`. Les builders ignorent encore `variant` (build/render vert) ; les tickets de contenu ajouteront le `switch (variant)`.

## Tests (écrits par `tu-dev`)

- `sendRules.test.ts` (nouveau) — **100 % de couverture** : chaque branche des 3 fonctions.
- `queue.test.ts` — validation `variant`/`raisonSociale`/`complianceDeadline` des 4 confirmations.
- `enqueueReceipt.test.ts` — dérivation de variante depuis le contexte DB, fallbacks, mapping `jointEvaluation` (100 % de couverture).
- `route.test.ts` — dispatch `cseOpinion`/`jointEvaluation` sur upload réussi + garde no-email.

## Vérifications

- `pnpm typecheck` ✅ · `pnpm test` ✅ (3223 tests) · `pnpm lint:check` ✅ · `pnpm format:check` ✅
- Gates : validator PASS · structural-auditor (findings adressés) · security-auditor (aucun CRITICAL/HIGH)
- Pas de modif UI (aucun `.tsx`/`.scss`) → pas de screenshots.
