### PR TITLE
feat(notifications): mail confirmation seconde déclaration — 3 variantes (mails 4-6)

### DIFF
--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -193,6 +193,18 @@ describe("per-type rendering details", () => {
 		expect(mail.html).toContain("/declaration?siren=552100554");
 	});
 
+	it("second_declaration_confirmation variant=path_to_select requires the compliance deadline", async () => {
+		await expect(
+			buildMail("second_declaration_confirmation", {
+				siren: SIREN,
+				year: YEAR,
+				variant: "path_to_select",
+				raisonSociale: "Société Démo",
+			}),
+		).rejects.toThrow(/complianceDeadline is required/);
+	});
+
+
 	it("joint_evaluation_submitted confirms upload", async () => {
 		const mail = await buildMail("joint_evaluation_submitted", {
 			siren: SIREN,

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -204,7 +204,6 @@ describe("per-type rendering details", () => {
 		).rejects.toThrow(/complianceDeadline is required/);
 	});
 
-
 	it("joint_evaluation_submitted confirms upload", async () => {
 		const mail = await buildMail("joint_evaluation_submitted", {
 			siren: SIREN,

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -145,15 +145,51 @@ describe("per-type rendering details", () => {
 		expect(mail.html).toContain(RAISON_SOCIALE);
 	});
 
-	it("second_declaration_confirmation mentions the corrective second declaration", async () => {
+	it("second_declaration_confirmation variant=completed ends the process", async () => {
 		const mail = await buildMail("second_declaration_confirmation", {
 			siren: SIREN,
 			year: YEAR,
+			variant: "completed",
+			raisonSociale: "Société Démo",
 		});
 		expect(mail.subject).toBe(
-			"Egapro - Accusé de réception de votre seconde déclaration",
+			"Egapro - Transmission de la seconde déclaration et fin de démarche",
 		);
-		expect(mail.html.toLowerCase()).toContain("actions correctives");
+		expect(mail.html).toContain("Société Démo");
+		expect(mail.html).toContain("552 100 554");
+		expect(mail.html).toContain("Mon espace");
+		expect(mail.html).toContain("/mon-espace");
+	});
+
+	it("second_declaration_confirmation variant=cse_to_deposit asks for the CSE opinion", async () => {
+		const mail = await buildMail("second_declaration_confirmation", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "cse_to_deposit",
+			raisonSociale: "Société Démo",
+		});
+		expect(mail.subject).toBe(
+			"Egapro - Transmission de la seconde déclaration",
+		);
+		expect(mail.html).toContain("Déposer");
+		expect(mail.html).toContain("première et la seconde déclaration");
+		expect(mail.html).toContain("/declaration?siren=552100554");
+	});
+
+	it("second_declaration_confirmation variant=path_to_select names the compliance deadline", async () => {
+		const mail = await buildMail("second_declaration_confirmation", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "path_to_select",
+			raisonSociale: "Société Démo",
+			complianceDeadline: DEADLINE,
+		});
+		expect(mail.subject).toBe(
+			"Egapro - Transmission de la seconde déclaration",
+		);
+		expect(mail.html).toContain("Sélectionner le parcours");
+		expect(mail.html).toContain("5 %");
+		expect(mail.html).toContain("1ᵉʳ juin 2027");
 		expect(mail.html).toContain("/declaration?siren=552100554");
 	});
 

--- a/packages/notifications/src/mails/builders/secondDeclarationConfirmation.tsx
+++ b/packages/notifications/src/mails/builders/secondDeclarationConfirmation.tsx
@@ -1,5 +1,6 @@
+import { formatFrenchDate, formatSiren } from "../shared/formatters.js";
 import { renderEmail } from "../shared/render.js";
-import { getDeclarationUrl } from "../shared/urls.js";
+import { getDeclarationUrl, getMySpaceUrl } from "../shared/urls.js";
 import {
 	EmailCtaWithLink,
 	EmailGreeting,
@@ -7,38 +8,81 @@ import {
 	EmailShell,
 	EmailSignature,
 } from "../template/index.js";
-import type { MailBuilder } from "../types.js";
+import type { DeclarationConfirmationVariant, MailBuilder } from "../types.js";
+
+type VariantContent = {
+	subject: string;
+	previewText: string;
+	variantParagraph: string;
+	ctaLabel: string;
+	ctaHref: string;
+};
+
+function getVariantContent(
+	variant: DeclarationConfirmationVariant,
+	siren: string,
+	year: number,
+	complianceDeadline: string | undefined,
+): VariantContent {
+	switch (variant) {
+		case "completed":
+			return {
+				subject:
+					"Egapro - Transmission de la seconde déclaration et fin de démarche",
+				previewText:
+					"Votre seconde déclaration des indicateurs de rémunération a bien été transmise.",
+				variantParagraph:
+					"Votre démarche est désormais terminée. Vous pouvez à tout moment consulter et télécharger vos déclarations depuis votre espace.",
+				ctaLabel: "Mon espace",
+				ctaHref: getMySpaceUrl(),
+			};
+		case "cse_to_deposit":
+			return {
+				subject: "Egapro - Transmission de la seconde déclaration",
+				previewText:
+					"Votre seconde déclaration des indicateurs de rémunération a bien été transmise.",
+				variantParagraph:
+					"Vous devez à présent déposer le ou les avis du CSE portant sur l'exactitude des données et des méthodes de calcul utilisées pour la première et la seconde déclaration.",
+				ctaLabel: "Déposer l'avis",
+				ctaHref: getDeclarationUrl(siren, year),
+			};
+		case "path_to_select": {
+			const formattedDeadline = formatFrenchDate(complianceDeadline);
+			return {
+				subject: "Egapro - Transmission de la seconde déclaration",
+				previewText:
+					"Votre seconde déclaration des indicateurs de rémunération a bien été transmise.",
+				variantParagraph: `L'indicateur d'écart de rémunération par catégorie de salariés fait à nouveau apparaître un ou plusieurs écarts de rémunération supérieurs ou égaux à 5 %. En conséquence, vous devez sélectionner un parcours de mise en conformité au plus tard le ${formattedDeadline}.`,
+				ctaLabel: "Sélectionner le parcours",
+				ctaHref: getDeclarationUrl(siren, year),
+			};
+		}
+	}
+}
 
 export const buildSecondDeclarationConfirmationMail: MailBuilder<
 	"second_declaration_confirmation"
-> = async ({ siren, year }) => {
-	const subject = "Egapro - Accusé de réception de votre seconde déclaration";
-	const previewText =
-		"Votre seconde déclaration au titre des actions correctives a bien été enregistrée.";
+> = async (payload) => {
+	const { siren, year, variant, raisonSociale, complianceDeadline } = payload;
+	const content = getVariantContent(variant, siren, year, complianceDeadline);
+	const formattedSiren = formatSiren(siren);
 	const { html, text } = await renderEmail(
-		<EmailShell previewText={previewText}>
+		<EmailShell previewText={content.previewText}>
 			<EmailGreeting>Bonjour,</EmailGreeting>
 			<EmailParagraph>
-				Votre seconde déclaration au titre des actions correctives a bien été
-				enregistrée.
+				Vous avez transmis aux services du ministre chargé du Travail{" "}
+				<strong>
+					l'indicateur d'écart de rémunération par catégorie de salariée entre
+					les femmes et les hommes
+				</strong>
+				, issu de votre seconde déclaration pour {year}, concernant l'entreprise{" "}
+				<strong>{raisonSociale}</strong> (SIREN : {formattedSiren}).
+				L'administration du travail accuse réception de cette transmission. Cet
+				accusé de réception ne vaut pas contrôle de conformité de votre
+				déclaration.
 			</EmailParagraph>
-			<EmailParagraph>
-				Conformément à la réglementation, dès lors que l'écart de rémunération
-				constaté est supérieur ou égal à 5 %, votre entreprise doit déposer une
-				seconde déclaration retraçant les actions correctives mises en œuvre.
-			</EmailParagraph>
-			<EmailParagraph>
-				Le récapitulatif détaillé de votre seconde déclaration est joint à cet
-				e-mail au format PDF.
-			</EmailParagraph>
-			<EmailParagraph>
-				Vous pouvez à tout moment consulter votre déclaration depuis le portail
-				Egapro.
-			</EmailParagraph>
-			<EmailCtaWithLink
-				href={getDeclarationUrl(siren, year)}
-				label="Consulter ma déclaration"
-			/>
+			<EmailParagraph>{content.variantParagraph}</EmailParagraph>
+			<EmailCtaWithLink href={content.ctaHref} label={content.ctaLabel} />
 			<EmailParagraph>
 				Pour tout renseignement, vous pouvez contacter votre référent égalité
 				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
@@ -47,5 +91,5 @@ export const buildSecondDeclarationConfirmationMail: MailBuilder<
 			<EmailSignature />
 		</EmailShell>,
 	);
-	return { subject, html, text };
+	return { subject: content.subject, html, text };
 };

--- a/packages/notifications/src/mails/builders/secondDeclarationConfirmation.tsx
+++ b/packages/notifications/src/mails/builders/secondDeclarationConfirmation.tsx
@@ -47,6 +47,11 @@ function getVariantContent(
 				ctaHref: getDeclarationUrl(siren, year),
 			};
 		case "path_to_select": {
+			if (!complianceDeadline) {
+				throw new Error(
+					"complianceDeadline is required for path_to_select variant",
+				);
+			}
 			const formattedDeadline = formatFrenchDate(complianceDeadline);
 			return {
 				subject: "Egapro - Transmission de la seconde déclaration",
@@ -72,7 +77,7 @@ export const buildSecondDeclarationConfirmationMail: MailBuilder<
 			<EmailParagraph>
 				Vous avez transmis aux services du ministre chargé du Travail{" "}
 				<strong>
-					l'indicateur d'écart de rémunération par catégorie de salariée entre
+					l'indicateur d'écart de rémunération par catégorie de salariés entre
 					les femmes et les hommes
 				</strong>
 				, issu de votre seconde déclaration pour {year}, concernant l'entreprise{" "}


### PR DESCRIPTION
Closes #3784

## Résumé

Implémente les 3 variantes de contenu du builder `secondDeclarationConfirmation` (mails 4-6) conformément au Figma et à la spec du ticket.

### Variantes

| Variante | Sujet | CTA |
|---|---|---|
| `completed` (Mail 4) | Egapro - Transmission de la seconde déclaration et fin de démarche | Mon espace |
| `cse_to_deposit` (Mail 5) | Egapro - Transmission de la seconde déclaration | Déposer l'avis |
| `path_to_select` (Mail 6) | Egapro - Transmission de la seconde déclaration | Sélectionner le parcours |

Toutes les variantes partagent un paragraphe d'intro commun mentionnant l'indicateur, la raison sociale et le SIREN formaté.

## Fichiers modifiés

- `packages/notifications/src/mails/builders/secondDeclarationConfirmation.tsx` — réécriture avec `switch (variant)`, intro commune, paragraphe variant-spécifique, CTA correct
- `packages/notifications/src/mails/__tests__/builders.test.ts` — payload mis à jour + 3 tests par variante

## Test plan

- [x] `pnpm typecheck` → vert (0 erreurs notifications + app)
- [x] `pnpm test` → 3226/3226 tests passés (117 notifications + 3109 app)
- [x] `pnpm lint:check` / `pnpm format:check` → vert
- [x] structural-auditor → PASS
- [x] rgaa-auditor → PASS (email builder, RGAA hors scope)