### PR TITLE
feat(notifications): mail dépôt évaluation conjointe — 3 variantes (mails 7-9)

### DIFF
--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -12,12 +12,18 @@ import {
 const SIREN = "552100554";
 const YEAR = 2027;
 const DEADLINE = "2027-06-01T00:00:00.000Z";
+const RAISON_SOCIALE = "Entreprise Test";
 
 const PAYLOADS: NotificationPayloadMap = {
 	declaration_confirmation: { siren: SIREN, year: YEAR },
 	second_declaration_confirmation: { siren: SIREN, year: YEAR },
 	cse_opinion_receipt: { siren: SIREN, year: YEAR },
-	joint_evaluation_submitted: { siren: SIREN, year: YEAR },
+	joint_evaluation_submitted: {
+		siren: SIREN,
+		year: YEAR,
+		variant: "completed",
+		raisonSociale: RAISON_SOCIALE,
+	},
 	cycle_opening_info: { siren: SIREN, year: YEAR, deadline: DEADLINE },
 	declaration_deadline_reminder: {
 		siren: SIREN,
@@ -135,15 +141,70 @@ describe("per-type rendering details", () => {
 		expect(mail.html).toContain("/declaration?siren=552100554");
 	});
 
-	it("joint_evaluation_submitted confirms upload", async () => {
+	it("joint_evaluation_submitted variant=completed ends the process", async () => {
 		const mail = await buildMail("joint_evaluation_submitted", {
 			siren: SIREN,
 			year: YEAR,
+			variant: "completed",
+			raisonSociale: RAISON_SOCIALE,
 		});
 		expect(mail.subject).toContain("évaluation conjointe");
-		expect(mail.html.toLowerCase()).toContain("évaluation conjointe");
-		expect(mail.html).toContain("Prochaine étape");
+		expect(mail.subject).toContain("et fin de démarche");
+		expect(mail.html).toContain(RAISON_SOCIALE);
+		expect(mail.html).toContain("Votre démarche est désormais terminée");
+		expect(mail.html).toContain("Mon espace");
 		expect(mail.html).toContain("/mon-espace");
+		expect(mail.html).not.toContain("/avis-cse");
+	});
+
+	it("joint_evaluation_submitted variant=cse_to_deposit asks for the CSE opinion", async () => {
+		const mail = await buildMail("joint_evaluation_submitted", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "cse_to_deposit",
+			raisonSociale: RAISON_SOCIALE,
+		});
+		expect(mail.subject).toBe(
+			"Egapro - Dépôt rapport de l'évaluation conjointe des rémunérations",
+		);
+		expect(mail.subject).not.toContain("fin de démarche");
+		expect(mail.html).toContain(
+			"Vous devez à présent déposer le ou les avis du CSE portant sur",
+		);
+		expect(mail.html).toContain(
+			"exactitude des données et des méthodes de calcul utilisées",
+		);
+		expect(mail.html).toContain("Déposer le ou les avis");
+		expect(mail.html).toContain(`/avis-cse?siren=${SIREN}`);
+	});
+
+	it("joint_evaluation_submitted variant=cse_first_and_second covers both declarations", async () => {
+		const mail = await buildMail("joint_evaluation_submitted", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "cse_first_and_second",
+			raisonSociale: RAISON_SOCIALE,
+		});
+		expect(mail.subject).toBe(
+			"Egapro - Dépôt rapport de l'évaluation conjointe des rémunérations",
+		);
+		expect(mail.html).toContain("pour la première et la seconde déclaration");
+		expect(mail.html).toContain(
+			"exactitude des données et des méthodes de calcul utilisées",
+		);
+		expect(mail.html).toContain("Déposer le ou les avis");
+		expect(mail.html).toContain(`/avis-cse?siren=${SIREN}`);
+	});
+
+	it("joint_evaluation_submitted throws on an unknown variant", async () => {
+		await expect(
+			buildMail("joint_evaluation_submitted", {
+				siren: SIREN,
+				year: YEAR,
+				variant: "not_a_variant" as never,
+				raisonSociale: RAISON_SOCIALE,
+			}),
+		).rejects.toThrow(/Unknown joint_evaluation_submitted variant/);
 	});
 
 	it("cycle_opening_info announces the declaration period", async () => {

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -197,6 +197,9 @@ describe("per-type rendering details", () => {
 		expect(mail.html).toContain(
 			"exactitude des données et des méthodes de calcul utilisées",
 		);
+		expect(mail.html).toContain(
+			"justification éventuelle des écarts de rémunération supérieurs ou égaux à 5 %",
+		);
 		expect(mail.html).toContain("Déposer le ou les avis");
 		expect(mail.html).toContain(`/avis-cse?siren=${SIREN}`);
 	});
@@ -214,6 +217,9 @@ describe("per-type rendering details", () => {
 		expect(mail.html).toContain("pour la première et la seconde déclaration");
 		expect(mail.html).toContain(
 			"exactitude des données et des méthodes de calcul utilisées",
+		);
+		expect(mail.html).toContain(
+			"justification éventuelle des écarts de rémunération supérieurs ou égaux à 5 %",
 		);
 		expect(mail.html).toContain("Déposer le ou les avis");
 		expect(mail.html).toContain(`/avis-cse?siren=${SIREN}`);

--- a/packages/notifications/src/mails/builders/jointEvaluationSubmitted.tsx
+++ b/packages/notifications/src/mails/builders/jointEvaluationSubmitted.tsx
@@ -1,45 +1,125 @@
 import { renderEmail } from "../shared/render.js";
-import { getMySpaceUrl } from "../shared/urls.js";
+import { getAvisCseUrl, getMySpaceUrl } from "../shared/urls.js";
 import {
 	EmailCtaWithLink,
 	EmailGreeting,
 	EmailParagraph,
 	EmailShell,
 	EmailSignature,
+	FONT,
+	SPACING,
 } from "../template/index.js";
 import type { MailBuilder } from "../types.js";
 
+const BULLET_ITEMS = [
+	"l'exactitude des données et des méthodes de calcul utilisées ;",
+	"la justification éventuelle des écarts de rémunération supérieurs ou égaux à 5 %, au regard de critères objectifs et non sexistes, pour l'indicateur de rémunération par catégorie de salariés.",
+];
+
 export const buildJointEvaluationSubmittedMail: MailBuilder<
 	"joint_evaluation_submitted"
-> = async () => {
-	const subject = "Egapro - Réception du rapport d'évaluation conjointe";
+> = async ({ siren, year, variant, raisonSociale }) => {
+	let subject: string;
+	let bodyContent: React.ReactNode;
+
+	const introParagraph = (
+		<EmailParagraph>
+			Vous avez transmis aux services du ministre chargé du Travail le rapport
+			de l'évaluation conjointe des rémunérations pour {year}, concernant
+			l'entreprise <strong>{raisonSociale}</strong> (SIREN : {siren}).
+			L'administration du travail accuse réception de cette transmission. Cet
+			accusé de réception ne vaut pas contrôle de conformité de votre dépôt.
+		</EmailParagraph>
+	);
+
+	const bulletList = (
+		<ul
+			style={{
+				margin: 0,
+				marginBottom: SPACING.md,
+				paddingLeft: SPACING.lg,
+				fontFamily: FONT.family,
+				fontSize: FONT.size.body,
+				lineHeight: FONT.lineHeight.body,
+			}}
+		>
+			{BULLET_ITEMS.map((item) => (
+				<li key={item} style={{ marginBottom: SPACING.xs }}>
+					{item}
+				</li>
+			))}
+		</ul>
+	);
+
+	switch (variant) {
+		case "completed": {
+			subject =
+				"Egapro - Dépôt rapport de l'évaluation conjointe des rémunérations et fin de démarche";
+			bodyContent = (
+				<>
+					{introParagraph}
+					<EmailParagraph>
+						Votre démarche est désormais terminée. Vous pouvez à tout moment
+						consulter et télécharger les documents relatifs à cette démarche
+						depuis votre espace.
+					</EmailParagraph>
+					<EmailCtaWithLink href={getMySpaceUrl()} label="Mon espace" />
+				</>
+			);
+			break;
+		}
+		case "cse_to_deposit": {
+			subject =
+				"Egapro - Dépôt rapport de l'évaluation conjointe des rémunérations";
+			bodyContent = (
+				<>
+					{introParagraph}
+					<EmailParagraph>
+						Vous devez à présent déposer le ou les avis du CSE portant sur :
+					</EmailParagraph>
+					{bulletList}
+					<EmailCtaWithLink
+						href={getAvisCseUrl(siren)}
+						label="Déposer le ou les avis"
+					/>
+				</>
+			);
+			break;
+		}
+		case "cse_first_and_second": {
+			subject =
+				"Egapro - Dépôt rapport de l'évaluation conjointe des rémunérations";
+			bodyContent = (
+				<>
+					{introParagraph}
+					<EmailParagraph>
+						Vous devez à présent déposer, pour la première et la seconde
+						déclaration, le ou les avis du CSE portant sur :
+					</EmailParagraph>
+					{bulletList}
+					<EmailCtaWithLink
+						href={getAvisCseUrl(siren)}
+						label="Déposer le ou les avis"
+					/>
+				</>
+			);
+			break;
+		}
+		default: {
+			const _exhaustive: never = variant;
+			throw new Error(
+				`Unknown joint_evaluation_submitted variant: ${_exhaustive}`,
+			);
+		}
+	}
+
 	const previewText =
-		"Le rapport d'évaluation conjointe déposé pour votre entreprise a bien été pris en compte.";
+		"Vous avez transmis aux services du ministre chargé du Travail le rapport de l'évaluation conjointe des rémunérations.";
+
 	const { html, text } = await renderEmail(
 		<EmailShell previewText={previewText}>
 			<EmailGreeting>Bonjour,</EmailGreeting>
-			<EmailParagraph>
-				Le rapport d'évaluation conjointe déposé pour votre entreprise a bien
-				été pris en compte.
-			</EmailParagraph>
-			<EmailParagraph>
-				Conformément à la réglementation, l'évaluation conjointe menée avec le
-				CSE permet de retracer les mesures correctives décidées en commun pour
-				réduire les écarts de rémunération constatés.
-			</EmailParagraph>
-			<EmailParagraph>
-				Prochaine étape : votre CSE doit désormais rendre son avis sur le
-				rapport déposé. Cet avis devra être téléversé sur la plateforme avant la
-				date limite affichée dans votre espace personnel.
-			</EmailParagraph>
-			<EmailParagraph>
-				Vous pouvez à tout moment consulter la suite de votre parcours depuis le
-				portail Egapro.
-			</EmailParagraph>
-			<EmailCtaWithLink
-				href={getMySpaceUrl()}
-				label="Voir la suite du parcours"
-			/>
+			{bodyContent}
 			<EmailParagraph>
 				Pour tout renseignement, vous pouvez contacter votre référent égalité
 				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce

--- a/packages/notifications/src/mails/shared/index.ts
+++ b/packages/notifications/src/mails/shared/index.ts
@@ -7,6 +7,7 @@ export {
 export { type RenderedEmail, renderEmail } from "./render.js";
 export {
 	getAssetUrl,
+	getAvisCseUrl,
 	getConnectionUrl,
 	getDeclarationUrl,
 	getImageUrl,

--- a/packages/notifications/src/mails/shared/urls.ts
+++ b/packages/notifications/src/mails/shared/urls.ts
@@ -11,6 +11,10 @@ export function getMySpaceUrl(): string {
 	return `${getPublicUrl()}/mon-espace`;
 }
 
+export function getAvisCseUrl(siren: string): string {
+	return `${getPublicUrl()}/avis-cse?siren=${encodeURIComponent(siren)}`;
+}
+
 export function getConnectionUrl(): string {
 	return `${getPublicUrl()}/connexion`;
 }


### PR DESCRIPTION
Closes #3785

## Résumé

Implémente les 3 variantes de contenu du mail de confirmation de dépôt du rapport d'évaluation conjointe des rémunérations (mails 7, 8, 9 du plan d'envoi), en utilisant le discriminateur `variant` câblé par #3836.

### Variantes

| Variante | Mail | Sujet | CTA |
|---|---|---|---|
| `completed` | 7 | "…et fin de démarche" | Mon espace |
| `cse_to_deposit` | 8 | "Dépôt rapport…" | Déposer le ou les avis |
| `cse_first_and_second` | 9 | "Dépôt rapport…" | Déposer le ou les avis |

### Fichiers modifiés

- `packages/notifications/src/mails/builders/jointEvaluationSubmitted.tsx` — builder réécrit avec `switch(variant)`, intro commune, liste à puces CSE pour les variantes 8 et 9
- `packages/notifications/src/mails/shared/urls.ts` — ajout de `getAvisCseUrl(siren)` → `/avis-cse?siren=…`
- `packages/notifications/src/mails/shared/index.ts` — re-export de `getAvisCseUrl` depuis le barrel
- `packages/notifications/src/mails/__tests__/builders.test.ts` — payload mis à jour + 4 tests variant ajoutés (par `tu-dev`)

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert — 3227/3227 tests (118 notifications)
- [x] `pnpm lint:check` vert
- [x] `pnpm format:check` vert
- [x] 4 tests variant ajoutés : `completed` → sujet "fin de démarche" + CTA Mon espace ; `cse_to_deposit` → liste à puces + CTA Déposer ; `cse_first_and_second` → "première et la seconde" + liste ; branche `default` → throw
- [x] Validators IA : validator PASS, structural-auditor PASS, rgaa-auditor MINOR (WARN pré-existants dans `EmailCtaWithLink` partagé), security-auditor SECURE