### PR TITLE
feat(notifications): mail confirmation 1re déclaration — 3 variantes (mails 1-3)

### DIFF
--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -8,16 +8,40 @@ import {
 	type NotificationPayloadMap,
 	type NotificationType,
 } from "../index.js";
+import { getConnectionUrl, getDeclarationUrl } from "../shared/urls.js";
+import { DECLARATION_CONFIRMATION_VARIANTS } from "../types.js";
 
 const SIREN = "552100554";
 const YEAR = 2027;
 const DEADLINE = "2027-06-01T00:00:00.000Z";
+const RAISON_SOCIALE = "Société Démo";
+const COMPLIANCE_DEADLINE = "1er septembre 2028";
 
 const PAYLOADS: NotificationPayloadMap = {
-	declaration_confirmation: { siren: SIREN, year: YEAR },
-	second_declaration_confirmation: { siren: SIREN, year: YEAR },
-	cse_opinion_receipt: { siren: SIREN, year: YEAR },
-	joint_evaluation_submitted: { siren: SIREN, year: YEAR },
+	declaration_confirmation: {
+		siren: SIREN,
+		year: YEAR,
+		variant: "completed",
+		raisonSociale: RAISON_SOCIALE,
+	},
+	second_declaration_confirmation: {
+		siren: SIREN,
+		year: YEAR,
+		variant: "completed",
+		raisonSociale: RAISON_SOCIALE,
+	},
+	cse_opinion_receipt: {
+		siren: SIREN,
+		year: YEAR,
+		variant: "single",
+		raisonSociale: RAISON_SOCIALE,
+	},
+	joint_evaluation_submitted: {
+		siren: SIREN,
+		year: YEAR,
+		variant: "completed",
+		raisonSociale: RAISON_SOCIALE,
+	},
 	cycle_opening_info: { siren: SIREN, year: YEAR, deadline: DEADLINE },
 	declaration_deadline_reminder: {
 		siren: SIREN,
@@ -101,16 +125,21 @@ describe("isNotificationType", () => {
 });
 
 describe("per-type rendering details", () => {
-	it("declaration_confirmation acknowledges the declaration", async () => {
+	it("declaration_confirmation completed variant ends the process toward the user space", async () => {
 		const mail = await buildMail("declaration_confirmation", {
 			siren: SIREN,
 			year: YEAR,
+			variant: "completed",
+			raisonSociale: RAISON_SOCIALE,
 		});
 		expect(mail.subject).toBe(
-			"Egapro - Accusé de réception de votre déclaration des indicateurs",
+			"Egapro - Transmission de déclaration et fin de démarche",
 		);
-		expect(mail.html.toLowerCase()).toContain("récapitulatif");
-		expect(mail.html).toContain("/declaration?siren=552100554");
+		expect(mail.html.toLowerCase()).toContain(
+			"démarche est désormais terminée",
+		);
+		expect(mail.html).toContain("Mon espace");
+		expect(mail.html).toContain(RAISON_SOCIALE);
 	});
 
 	it("second_declaration_confirmation mentions the corrective second declaration", async () => {
@@ -238,11 +267,95 @@ describe("per-type rendering details", () => {
 	});
 });
 
-describe("HTML safety", () => {
-	it("does not leak raw HTML from a payload field even when builders ignore it", async () => {
+describe("declaration_confirmation variants", () => {
+	const connectionUrl = getConnectionUrl();
+	// @react-email escapes "&" to "&amp;" inside href attributes
+	const declarationHref = getDeclarationUrl(SIREN, YEAR).replace(/&/g, "&amp;");
+
+	it("covers every declared variant", () => {
+		expect(DECLARATION_CONFIRMATION_VARIANTS).toStrictEqual([
+			"completed",
+			"cse_to_deposit",
+			"path_to_select",
+		]);
+	});
+
+	it.each(
+		DECLARATION_CONFIRMATION_VARIANTS,
+	)("%s shares the common intro naming the indicators and the company", async (variant) => {
 		const mail = await buildMail("declaration_confirmation", {
-			siren: "<script>alert(1)</script>",
+			siren: SIREN,
 			year: YEAR,
+			variant,
+			raisonSociale: RAISON_SOCIALE,
+			complianceDeadline: COMPLIANCE_DEADLINE,
+		});
+		expect(mail.html).toContain(
+			"les indicateurs relatifs aux écarts de rémunération",
+		);
+		expect(mail.html).toContain(RAISON_SOCIALE);
+		expect(mail.html).toContain("accuse réception de cette transmission");
+		expect(mail.html).toContain("SIREN :");
+		expect(mail.html).toContain(SIREN);
+		expect(mail.html).toContain("au titre des données");
+	});
+
+	it("completed: subject, 'Mon espace' CTA and matching link both point to the connection URL", async () => {
+		const mail = await buildMail("declaration_confirmation", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "completed",
+			raisonSociale: RAISON_SOCIALE,
+		});
+		expect(mail.subject).toBe(
+			"Egapro - Transmission de déclaration et fin de démarche",
+		);
+		expect(mail.html).toContain("Mon espace");
+		expect(mail.html).toContain("démarche est désormais terminée");
+		// Button and fallback link share the connection URL, so it appears at least twice
+		expect(mail.html.split(connectionUrl).length - 1).toBeGreaterThanOrEqual(2);
+		expect(mail.html).not.toContain("/declaration?siren=");
+	});
+
+	it("cse_to_deposit: subject, deposit CTA to the declaration URL and fallback link to the connection URL", async () => {
+		const mail = await buildMail("declaration_confirmation", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "cse_to_deposit",
+			raisonSociale: RAISON_SOCIALE,
+		});
+		expect(mail.subject).toBe("Egapro - Transmission de déclaration");
+		expect(mail.html).toContain("Déposer l&#x27;avis");
+		expect(mail.html).toContain("déposer l&#x27;avis du CSE");
+		expect(mail.html).toContain(`href="${declarationHref}"`);
+		expect(mail.html).toContain(`href="${connectionUrl}"`);
+		expect(mail.html).toContain(`>${connectionUrl}<`);
+	});
+
+	it("path_to_select: subject, 5 % gap wording, compliance deadline and split button/link URLs", async () => {
+		const mail = await buildMail("declaration_confirmation", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "path_to_select",
+			raisonSociale: RAISON_SOCIALE,
+			complianceDeadline: COMPLIANCE_DEADLINE,
+		});
+		expect(mail.subject).toBe("Egapro - Transmission de la déclaration");
+		expect(mail.html).toContain("Sélectionner le parcours");
+		expect(mail.html).toContain("supérieurs ou égaux à 5 %");
+		expect(mail.html).toContain(COMPLIANCE_DEADLINE);
+		expect(mail.html).toContain(`href="${declarationHref}"`);
+		expect(mail.html).toContain(`>${connectionUrl}<`);
+	});
+});
+
+describe("HTML safety", () => {
+	it("does not leak raw HTML from the raisonSociale field", async () => {
+		const mail = await buildMail("declaration_confirmation", {
+			siren: SIREN,
+			year: YEAR,
+			variant: "completed",
+			raisonSociale: "<script>alert(1)</script>",
 		});
 		expect(mail.html).not.toContain("<script>alert(1)</script>");
 	});

--- a/packages/notifications/src/mails/__tests__/template.test.tsx
+++ b/packages/notifications/src/mails/__tests__/template.test.tsx
@@ -99,6 +99,26 @@ describe("EmailCtaWithLink", () => {
 		// The DSFR primary-button border construct
 		expect(html).toContain("solid 1px #000091");
 	});
+
+	it("uses linkHref for the fallback link while keeping href on the button", async () => {
+		const href = "https://test.example/declaration";
+		const linkHref = "https://test.example/connexion";
+		const { html } = await renderEmail(
+			<EmailShell previewText="t">
+				<EmailCtaWithLink
+					href={href}
+					label="Déposer l'avis"
+					linkHref={linkHref}
+				/>
+			</EmailShell>,
+		);
+		// The button targets href, the fallback link targets linkHref (both href attr and visible text)
+		expect(html).toContain(`href="${href}"`);
+		expect(html).toContain(`href="${linkHref}"`);
+		expect(html).toContain(`>${linkHref}<`);
+		// The button destination is never shown as the fallback link text
+		expect(html).not.toContain(`>${href}<`);
+	});
 });
 
 describe("formatSiren", () => {

--- a/packages/notifications/src/mails/builders/declarationConfirmation.tsx
+++ b/packages/notifications/src/mails/builders/declarationConfirmation.tsx
@@ -1,5 +1,5 @@
 import { renderEmail } from "../shared/render.js";
-import { getDeclarationUrl } from "../shared/urls.js";
+import { getConnectionUrl, getDeclarationUrl } from "../shared/urls.js";
 import {
 	EmailCtaWithLink,
 	EmailGreeting,
@@ -11,43 +11,111 @@ import type { MailBuilder } from "../types.js";
 
 export const buildDeclarationConfirmationMail: MailBuilder<
 	"declaration_confirmation"
-> = async ({ siren, year }) => {
-	const subject =
-		"Egapro - Accusé de réception de votre déclaration des indicateurs";
-	const previewText =
-		"Votre déclaration des indicateurs relatifs à l'égalité professionnelle entre les femmes et les hommes a bien été enregistrée.";
-	const { html, text } = await renderEmail(
-		<EmailShell previewText={previewText}>
-			<EmailGreeting>Bonjour,</EmailGreeting>
-			<EmailParagraph>
-				Votre déclaration des indicateurs relatifs à l'égalité professionnelle
-				entre les femmes et les hommes a bien été enregistrée.
-			</EmailParagraph>
-			<EmailParagraph>
-				Conformément à la réglementation, votre entreprise satisfait à
-				l'obligation annuelle de déclaration des indicateurs relatifs aux écarts
-				de rémunération.
-			</EmailParagraph>
-			<EmailParagraph>
-				Le récapitulatif détaillé de votre déclaration est joint à cet e-mail au
-				format PDF. Il reprend l'ensemble des indicateurs enregistrés ainsi que
-				le niveau de résultat obtenu.
-			</EmailParagraph>
-			<EmailParagraph>
-				Vous pouvez à tout moment consulter ou modifier votre déclaration depuis
-				le portail Egapro.
-			</EmailParagraph>
-			<EmailCtaWithLink
-				href={getDeclarationUrl(siren, year)}
-				label="Consulter ma déclaration"
-			/>
-			<EmailParagraph>
-				Pour tout renseignement, vous pouvez contacter votre référent égalité
-				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
-				message.
-			</EmailParagraph>
-			<EmailSignature />
-		</EmailShell>,
+> = async (payload) => {
+	const { variant, siren, year, raisonSociale, complianceDeadline } = payload;
+	const connectionUrl = getConnectionUrl();
+	const declarationUrl = getDeclarationUrl(siren, year);
+
+	const introParagraph = (
+		<EmailParagraph>
+			Vous avez transmis aux services du ministre chargé du Travail{" "}
+			<strong>
+				les indicateurs relatifs aux écarts de rémunération entre les femmes et
+				les hommes
+			</strong>{" "}
+			pour l&apos;année {year}, au titre des données {year - 1}, concernant
+			l&apos;entreprise <strong>{raisonSociale}</strong> (SIREN : {siren}).
+		</EmailParagraph>
 	);
-	return { subject, html, text };
+
+	const accuseParagraph = (
+		<EmailParagraph>
+			L&apos;administration du travail accuse réception de cette transmission.
+			Cet accusé de réception ne vaut pas contrôle de conformité de votre
+			déclaration.
+		</EmailParagraph>
+	);
+
+	const contactParagraph = (
+		<EmailParagraph>
+			Pour tout renseignement, vous pouvez contacter votre référent égalité
+			professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+			message.
+		</EmailParagraph>
+	);
+
+	switch (variant) {
+		case "completed": {
+			const subject = "Egapro - Transmission de déclaration et fin de démarche";
+			const previewText =
+				"Votre démarche est désormais terminée. Vous pouvez à tout moment consulter et télécharger votre déclaration depuis votre espace.";
+			const { html, text } = await renderEmail(
+				<EmailShell previewText={previewText}>
+					<EmailGreeting>Bonjour,</EmailGreeting>
+					{introParagraph}
+					{accuseParagraph}
+					<EmailParagraph>
+						Votre démarche est désormais terminée. Vous pouvez à tout moment
+						consulter et télécharger votre déclaration depuis votre espace.
+					</EmailParagraph>
+					<EmailCtaWithLink href={connectionUrl} label="Mon espace" />
+					{contactParagraph}
+					<EmailSignature />
+				</EmailShell>,
+			);
+			return { subject, html, text };
+		}
+		case "cse_to_deposit": {
+			const subject = "Egapro - Transmission de déclaration";
+			const previewText =
+				"Vous devez à présent déposer l'avis du CSE portant sur l'exactitude des données et des méthodes de calcul.";
+			const { html, text } = await renderEmail(
+				<EmailShell previewText={previewText}>
+					<EmailGreeting>Bonjour,</EmailGreeting>
+					{introParagraph}
+					{accuseParagraph}
+					<EmailParagraph>
+						Vous devez à présent déposer l&apos;avis du CSE portant sur
+						l&apos;exactitude des données et des méthodes de calcul de la
+						déclaration de l&apos;ensemble des indicateurs.
+					</EmailParagraph>
+					<EmailCtaWithLink
+						href={declarationUrl}
+						label="Déposer l'avis"
+						linkHref={connectionUrl}
+					/>
+					{contactParagraph}
+					<EmailSignature />
+				</EmailShell>,
+			);
+			return { subject, html, text };
+		}
+		case "path_to_select": {
+			const subject = "Egapro - Transmission de la déclaration";
+			const previewText =
+				"Un ou plusieurs écarts de rémunération supérieurs ou égaux à 5 % ont été constatés. Vous devez sélectionner un parcours de mise en conformité.";
+			const { html, text } = await renderEmail(
+				<EmailShell previewText={previewText}>
+					<EmailGreeting>Bonjour,</EmailGreeting>
+					{introParagraph}
+					{accuseParagraph}
+					<EmailParagraph>
+						L&apos;indicateur d&apos;écart de rémunération par catégorie de
+						salariée fait apparaître un ou plusieurs écarts de rémunération
+						supérieurs ou égaux à 5 %. Vous devez, en conséquence, sélectionner
+						un parcours de mise en conformité au plus tard le{" "}
+						{complianceDeadline}.
+					</EmailParagraph>
+					<EmailCtaWithLink
+						href={declarationUrl}
+						label="Sélectionner le parcours"
+						linkHref={connectionUrl}
+					/>
+					{contactParagraph}
+					<EmailSignature />
+				</EmailShell>,
+			);
+			return { subject, html, text };
+		}
+	}
 };

--- a/packages/notifications/src/mails/template/EmailCtaWithLink.tsx
+++ b/packages/notifications/src/mails/template/EmailCtaWithLink.tsx
@@ -4,6 +4,7 @@ import { COLORS, FONT, SPACING } from "./tokens.js";
 type EmailCtaWithLinkProps = {
 	href: string;
 	label: string;
+	linkHref?: string;
 };
 
 const SPACER = {
@@ -12,7 +13,12 @@ const SPACER = {
 	fontSize: SPACING.md,
 } as const;
 
-export function EmailCtaWithLink({ href, label }: EmailCtaWithLinkProps) {
+export function EmailCtaWithLink({
+	href,
+	label,
+	linkHref,
+}: EmailCtaWithLinkProps) {
+	const displayedLink = linkHref ?? href;
 	return (
 		<table
 			role="presentation"
@@ -42,12 +48,12 @@ export function EmailCtaWithLink({ href, label }: EmailCtaWithLinkProps) {
 						}}
 					>
 						<a
-							href={href}
+							href={displayedLink}
 							target="_blank"
 							rel="noopener noreferrer"
 							style={{ color: COLORS.blueFrance, textDecoration: "underline" }}
 						>
-							{href}
+							{displayedLink}
 						</a>
 					</td>
 				</tr>


### PR DESCRIPTION
Closes #3783

## Résumé

Implémente les 3 variantes de contenu du mail de confirmation de 1re déclaration des indicateurs de rémunération, conformément au Figma et à la spec du ticket #3783.

### Variantes
| Variante | Sujet | CTA |
|---|---|---|
| `completed` | Egapro - Transmission de déclaration et fin de démarche | Mon espace → `/connexion` |
| `cse_to_deposit` | Egapro - Transmission de déclaration | Déposer l'avis → `/declaration?…` |
| `path_to_select` | Egapro - Transmission de la déclaration | Sélectionner le parcours → `/declaration?…` |

### Changements
- **`declarationConfirmation.tsx`** : réécriture complète avec `switch (variant)`. Intro commune avec bold inline sur `raisonSociale` et "les indicateurs relatifs…", paragraphe commun "accusé de réception", puis contenu et CTA spécifiques à chaque variante.
- **`EmailCtaWithLink.tsx`** : ajout d'une prop optionnelle `linkHref` pour dissocier le href du bouton du lien de repli affiché sous le bouton (le lien texte est toujours `/connexion` pour les variantes `cse_to_deposit` et `path_to_select`). Backward-compatible.

## Test plan

- [x] Typecheck vert (`pnpm typecheck`)
- [x] 123/123 tests notifications verts
- [x] 3 variantes couvertes dans `builders.test.ts` (sujet exact, CTA label, contenu spécifique, URL bouton vs lien-texte)
- [x] `EmailCtaWithLink` avec `linkHref` couvert dans `template.test.tsx`
- [x] Validator PASS, Structural-auditor PASS, Security SECURE, RGAA MINOR WARN (raw URL link text — pattern email industry standard, identique aux autres builders)
- [x] Lint + format clean