### PR TITLE
ci: migrate image builds from buildkit-service to buildkit-operator

### DIFF
--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -11,6 +11,9 @@ concurrency:
 
 jobs:
   build-app:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-preproduction
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -28,23 +31,25 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=850
             type=sha,prefix=sha-,format=long,priority=890
 
-      - name: 📦 Build and push Docker image for app
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for app
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "packages/app/Dockerfile"
+          file: "packages/app/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
-          cache-enabled: true
-          fallback-enabled: true
           build-args: |
             NEXT_PUBLIC_EGAPRO_ENV=preprod
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
@@ -53,6 +58,7 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+          push: true
 
   kontinuous:
     needs: [build-app]

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -11,6 +11,9 @@ concurrency:
 
 jobs:
   build-app:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-production
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -29,23 +32,25 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }},priority=200
 
-      - name: 📦 Build and push Docker image for app
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for app
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "packages/app/Dockerfile"
+          file: "packages/app/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
-          cache-enabled: true
-          fallback-enabled: true
           build-args: |
             NEXT_PUBLIC_EGAPRO_ENV=prod
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
@@ -54,6 +59,7 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+          push: true
 
   kontinuous:
     needs: [build-app]

--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -12,6 +12,9 @@ concurrency:
 
 jobs:
   build-app:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -36,23 +39,25 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for app
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for app
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "packages/app/Dockerfile"
+          file: "packages/app/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
-          cache-enabled: true
-          fallback-enabled: true
           build-args: |
             NEXT_PUBLIC_EGAPRO_ENV=dev
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
@@ -61,6 +66,7 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+          push: true
 
   kontinuous:
     needs: [build-app]

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -10,6 +10,9 @@ concurrency:
 
 jobs:
   build-app:
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -34,23 +37,25 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
 
-      - name: 📦 Build and push Docker image for app
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image for app
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "packages/app/Dockerfile"
+          file: "packages/app/Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
-          cache-enabled: true
-          fallback-enabled: true
           build-args: |
             NEXT_PUBLIC_EGAPRO_ENV=dev
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
@@ -59,6 +64,7 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+          push: true
 
   kontinuous:
     needs: [build-app]


### PR DESCRIPTION
Migre les builds d'images CI du service legacy **buildkit-service** (`socialgouv/workflows/actions/buildkit@v1`, `buildctl` sur le runner) vers **[buildkit-operator](https://github.com/SocialGouv/buildkit-operator)** (`socialgouv/buildkit-operator@v1`) : chaque build est routé vers le buildkitd chaud dédié au repo (cache par projet). Même migration que SocialGouv/revu#278 et SocialGouv/da-manager#28 (validées e2e, build + deploy verts).

## Mapping

- `socialgouv/workflows/actions/buildkit@v1` → `socialgouv/buildkit-operator@v1` (`dockerfile:` → `file:`, `push: true` explicite ; `build-args`, `secrets`, `target` inchangés).
- Auth `/route` : GitHub OIDC (`permissions.id-token: write` sur le job de build) — identité du repo vérifiée côté serveur, aucun token partagé.
- Secrets/vars org-level (`BUILDKIT_OPERATOR_CA/CERT/KEY`, `BUILDKIT_OPERATOR_BUILDD_URL`, `BUILDKIT_OPERATOR_GATEWAY_HOST`) → zéro setup côté repo.
- Login registry : `docker/login-action@v4` (auth forwardée au daemon via la session buildx) — remplace les inputs `registry*` de l'action legacy.
- Supprimés (sans objet) : `buildkit-daemon-address`, `buildkit-svc-count`, `buildkit-cert-*`.

## Rollback

Revert de cette PR — buildkit-service reste en service pendant toute la migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
