### PR TITLE
feat(notifications): mail dépôt d'avis CSE — 3 variantes (mails 10-12)

### DIFF
--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -9,7 +9,10 @@ import {
 	type NotificationType,
 } from "../index.js";
 import { getConnectionUrl, getDeclarationUrl } from "../shared/urls.js";
-import { DECLARATION_CONFIRMATION_VARIANTS } from "../types.js";
+import {
+	CSE_OPINION_RECEIPT_VARIANTS,
+	DECLARATION_CONFIRMATION_VARIANTS,
+} from "../types.js";
 
 const SIREN = "552100554";
 const YEAR = 2027;
@@ -151,16 +154,6 @@ describe("per-type rendering details", () => {
 			"Egapro - Accusé de réception de votre seconde déclaration",
 		);
 		expect(mail.html.toLowerCase()).toContain("actions correctives");
-		expect(mail.html).toContain("/declaration?siren=552100554");
-	});
-
-	it("cse_opinion_receipt mentions CSE", async () => {
-		const mail = await buildMail("cse_opinion_receipt", {
-			siren: SIREN,
-			year: YEAR,
-		});
-		expect(mail.subject).toBe("Egapro - Réception de l'avis du CSE");
-		expect(mail.html).toContain("CSE");
 		expect(mail.html).toContain("/declaration?siren=552100554");
 	});
 
@@ -346,6 +339,66 @@ describe("declaration_confirmation variants", () => {
 		expect(mail.html).toContain(COMPLIANCE_DEADLINE);
 		expect(mail.html).toContain(`href="${declarationHref}"`);
 		expect(mail.html).toContain(`>${connectionUrl}<`);
+	});
+});
+
+describe("cse_opinion_receipt variants", () => {
+	const buildReceipt = (
+		variant: (typeof CSE_OPINION_RECEIPT_VARIANTS)[number],
+	) =>
+		buildMail("cse_opinion_receipt", {
+			siren: SIREN,
+			year: YEAR,
+			variant,
+			raisonSociale: RAISON_SOCIALE,
+		});
+
+	it("covers every declared variant", () => {
+		expect(CSE_OPINION_RECEIPT_VARIANTS).toStrictEqual([
+			"single",
+			"with_gap",
+			"first_and_second",
+		]);
+	});
+
+	it.each(
+		CSE_OPINION_RECEIPT_VARIANTS,
+	)("%s ends the process with the 'Mon espace' CTA and names the company", async (variant) => {
+		const mail = await buildReceipt(variant);
+		expect(mail.subject).toBe("Egapro - Dépôt d'avis CSE et fin de démarche");
+		expect(mail.html).toContain("accuse réception");
+		expect(mail.html).toContain("démarche est désormais terminée");
+		expect(mail.html).toContain("Mon espace");
+		expect(mail.html).toContain("/mon-espace");
+		expect(mail.html).not.toContain("/declaration?siren=");
+		expect(mail.html).toContain(RAISON_SOCIALE);
+		expect(mail.html).toContain("SIREN :");
+		expect(mail.html).toContain(SIREN);
+	});
+
+	it("single: 'exactitude' intro without the gap bullet list", async () => {
+		const mail = await buildReceipt("single");
+		expect(mail.html).toContain(
+			"l&#x27;avis du CSE sur l&#x27;exactitude des données et des méthodes de calcul utilisés",
+		);
+		expect(mail.html).not.toContain("<ul");
+		expect(mail.html).not.toContain("justification éventuelle des écarts");
+	});
+
+	it("with_gap: 'les avis CSE' intro with the gap justification bullet list", async () => {
+		const mail = await buildReceipt("with_gap");
+		expect(mail.html).toContain("les avis CSE");
+		expect(mail.html).not.toContain("première et la seconde déclaration");
+		expect(mail.html).toContain("<ul");
+		expect(mail.html).toContain("justification éventuelle des écarts");
+	});
+
+	it("first_and_second: names the two declarations with the gap justification bullet list", async () => {
+		const mail = await buildReceipt("first_and_second");
+		expect(mail.html).toContain("les avis CSE");
+		expect(mail.html).toContain("première et la seconde déclaration");
+		expect(mail.html).toContain("<ul");
+		expect(mail.html).toContain("justification éventuelle des écarts");
 	});
 });
 

--- a/packages/notifications/src/mails/builders/cseOpinionReceipt.tsx
+++ b/packages/notifications/src/mails/builders/cseOpinionReceipt.tsx
@@ -1,52 +1,124 @@
 import { renderEmail } from "../shared/render.js";
-import { getDeclarationUrl } from "../shared/urls.js";
+import { getMySpaceUrl } from "../shared/urls.js";
 import {
 	EmailCtaWithLink,
 	EmailGreeting,
 	EmailParagraph,
 	EmailShell,
 	EmailSignature,
+	FONT,
+	SPACING,
 } from "../template/index.js";
 import type { MailBuilder } from "../types.js";
 
 export const buildCseOpinionReceiptMail: MailBuilder<
 	"cse_opinion_receipt"
-> = async ({ siren, year }) => {
-	const subject = "Egapro - Réception de l'avis du CSE";
+> = async ({ siren, year, variant, raisonSociale }) => {
+	const subject = "Egapro - Dépôt d'avis CSE et fin de démarche";
 	const previewText =
-		"L'avis du CSE déposé pour votre déclaration des indicateurs a bien été pris en compte.";
-	const { html, text } = await renderEmail(
-		<EmailShell previewText={previewText}>
-			<EmailGreeting>Bonjour,</EmailGreeting>
-			<EmailParagraph>
-				L'avis du CSE déposé pour votre déclaration des indicateurs relatifs à
-				l'égalité professionnelle entre les femmes et les hommes a bien été pris
-				en compte.
-			</EmailParagraph>
-			<EmailParagraph>
-				Conformément à la réglementation, les entreprises d'au moins 100
-				salariés sont tenues de consulter leur CSE sur les indicateurs publiés
-				et de déposer cet avis sur la plateforme Egapro.
-			</EmailParagraph>
-			<EmailParagraph>
-				Le document que vous avez transmis est conservé dans votre dossier et
-				reste consultable depuis votre espace personnel.
-			</EmailParagraph>
-			<EmailParagraph>
-				Vous pouvez à tout moment consulter votre dossier depuis le portail
-				Egapro.
-			</EmailParagraph>
-			<EmailCtaWithLink
-				href={getDeclarationUrl(siren, year)}
-				label="Consulter mon dossier"
-			/>
-			<EmailParagraph>
-				Pour tout renseignement, vous pouvez contacter votre référent égalité
-				professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
-				message.
-			</EmailParagraph>
-			<EmailSignature />
-		</EmailShell>,
+		"L'administration du travail accuse réception de votre dépôt d'avis CSE. Votre démarche est désormais terminée.";
+
+	const gapBullets = (
+		<ul
+			style={{
+				marginTop: 0,
+				marginBottom: SPACING.md,
+				paddingLeft: SPACING.xl,
+				fontFamily: FONT.family,
+				fontSize: FONT.size.body,
+				lineHeight: FONT.lineHeight.body,
+			}}
+		>
+			<li>
+				l&apos;exactitude des données et des méthodes de calcul utilisés ;
+			</li>
+			<li>
+				la justification éventuelle des écarts de rémunération supérieurs ou
+				égaux à 5 %, au regard de critères objectifs et non sexistes, pour
+				l&apos;indicateur de rémunération par catégorie de salariés.
+			</li>
+		</ul>
 	);
-	return { subject, html, text };
+
+	const receiptParagraph = (
+		<EmailParagraph>
+			L&apos;administration du travail accuse réception de cette transmission.
+			Cet accusé de réception ne vaut pas contrôle de conformité de votre dépôt.
+			Votre démarche est désormais terminée. Vous pouvez à tout moment consulter
+			et télécharger les documents relatifs à cette démarche depuis votre
+			espace.
+		</EmailParagraph>
+	);
+
+	const contactParagraph = (
+		<EmailParagraph>
+			Pour tout renseignement, vous pouvez contacter votre référent égalité
+			professionnelle femmes-hommes au sein de votre DREETS en répondant à ce
+			message.
+		</EmailParagraph>
+	);
+
+	switch (variant) {
+		case "single": {
+			const { html, text } = await renderEmail(
+				<EmailShell previewText={previewText}>
+					<EmailGreeting>Bonjour,</EmailGreeting>
+					<EmailParagraph>
+						Vous avez transmis aux services du ministre chargé du Travail{" "}
+						<strong>
+							l&apos;avis du CSE sur l&apos;exactitude des données et des
+							méthodes de calcul utilisés
+						</strong>{" "}
+						pour la déclaration des indicateurs de rémunération {year},
+						concernant l&apos;entreprise <strong>{raisonSociale}</strong> (SIREN
+						: {siren}).
+					</EmailParagraph>
+					{receiptParagraph}
+					<EmailCtaWithLink href={getMySpaceUrl()} label="Mon espace" />
+					{contactParagraph}
+					<EmailSignature />
+				</EmailShell>,
+			);
+			return { subject, html, text };
+		}
+		case "with_gap": {
+			const { html, text } = await renderEmail(
+				<EmailShell previewText={previewText}>
+					<EmailGreeting>Bonjour,</EmailGreeting>
+					<EmailParagraph noMarginBottom>
+						Vous avez transmis aux services du ministre chargé du Travail{" "}
+						<strong>les avis CSE</strong> pour la déclaration des indicateurs de
+						rémunération {year}, concernant l&apos;entreprise{" "}
+						<strong>{raisonSociale}</strong> (SIREN : {siren}) :
+					</EmailParagraph>
+					{gapBullets}
+					{receiptParagraph}
+					<EmailCtaWithLink href={getMySpaceUrl()} label="Mon espace" />
+					{contactParagraph}
+					<EmailSignature />
+				</EmailShell>,
+			);
+			return { subject, html, text };
+		}
+		case "first_and_second": {
+			const { html, text } = await renderEmail(
+				<EmailShell previewText={previewText}>
+					<EmailGreeting>Bonjour,</EmailGreeting>
+					<EmailParagraph noMarginBottom>
+						Vous avez transmis aux services du ministre chargé du Travail{" "}
+						<strong>les avis CSE</strong> pour la première et la seconde
+						déclaration des indicateurs de rémunération {year}, concernant
+						l&apos;entreprise <strong>{raisonSociale}</strong> (SIREN : {siren})
+						:
+					</EmailParagraph>
+					{gapBullets}
+					{receiptParagraph}
+					<EmailCtaWithLink href={getMySpaceUrl()} label="Mon espace" />
+					{contactParagraph}
+					<EmailSignature />
+				</EmailShell>,
+			);
+			return { subject, html, text };
+		}
+	}
 };


### PR DESCRIPTION
Closes #3786

## Résumé

Implémente les 3 variantes du builder de confirmation de dépôt d'avis CSE (`cse_opinion_receipt`) conformément au Figma et au spec du ticket #3786 (mails 10, 11, 12 du plan d'envoi).

## Changements

- `packages/notifications/src/mails/builders/cseOpinionReceipt.tsx` — Réécriture complète avec `switch (variant)` sur les 3 variantes :
  - `single` : intro « l'avis du CSE sur l'exactitude des données et des méthodes de calcul utilisés »
  - `with_gap` : intro « les avis CSE » + liste à puces (exactitude + justification écarts ≥ 5 %)
  - `first_and_second` : intro « première et la seconde déclaration » + liste à puces
  - Sujet commun : « Egapro - Dépôt d'avis CSE et fin de démarche »
  - CTA « Mon espace » → `/mon-espace` sur les 3 variantes
  - Paragraphe d'accusé de réception commun (fin de démarche)
- `packages/notifications/src/mails/__tests__/builders.test.ts` — Mise à jour du test obsolète + ajout du bloc `cse_opinion_receipt variants` couvrant les 3 variantes

## Plan de test

- [x] `pnpm typecheck` — vert
- [x] `pnpm test` — 129 tests passés (100% coverage sur `cseOpinionReceipt.tsx`)
- [x] `pnpm lint:check` / `pnpm format:check` — vert
- [x] Validator, structural-auditor, rgaa-auditor, security-auditor — tous PASS
- [x] Les 3 variantes testées : sujet, intro, présence/absence liste à puces, CTA « Mon espace », raisonSociale/SIREN, accusé de réception