### PR TITLE
[TEST pipeline iterion] Ajouter formatSiret au domaine

### DIFF
--- a/packages/app/src/modules/domain/__tests__/siren.test.ts
+++ b/packages/app/src/modules/domain/__tests__/siren.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { extractSiren, formatSiren, parseSiren } from "../shared/siren";
+import {
+	extractSiren,
+	formatSiren,
+	formatSiret,
+	parseSiren,
+} from "../shared/siren";
 
 describe("extractSiren", () => {
 	it("extracts first 9 chars from a 14-digit SIRET", () => {
@@ -15,6 +20,16 @@ describe("extractSiren", () => {
 describe("formatSiren", () => {
 	it("formats a 9-digit SIREN with spaces", () => {
 		expect(formatSiren("532847196")).toBe("532 847 196");
+	});
+});
+
+describe("formatSiret", () => {
+	it("formats a 14-digit SIRET with spaces", () => {
+		expect(formatSiret("53284719600015")).toBe("532 847 196 00015");
+	});
+
+	it("formats an all-zero SIRET", () => {
+		expect(formatSiret("00000000000000")).toBe("000 000 000 00000");
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -166,7 +166,12 @@ export {
 export type { ScoreBracket, ScoreBracketId } from "./shared/scoreBracket";
 export { getScoreBracket, SCORE_BRACKETS } from "./shared/scoreBracket";
 // SIREN utilities
-export { extractSiren, formatSiren, formatSiret, parseSiren } from "./shared/siren";
+export {
+	extractSiren,
+	formatSiren,
+	formatSiret,
+	parseSiren,
+} from "./shared/siren";
 // Submission rate helpers (shared by admin/public stats routers and KPI tiles)
 export type { CampaignRateTileProps } from "./shared/submissionRate";
 export {

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -166,7 +166,7 @@ export {
 export type { ScoreBracket, ScoreBracketId } from "./shared/scoreBracket";
 export { getScoreBracket, SCORE_BRACKETS } from "./shared/scoreBracket";
 // SIREN utilities
-export { extractSiren, formatSiren, parseSiren } from "./shared/siren";
+export { extractSiren, formatSiren, formatSiret, parseSiren } from "./shared/siren";
 // Submission rate helpers (shared by admin/public stats routers and KPI tiles)
 export type { CampaignRateTileProps } from "./shared/submissionRate";
 export {

--- a/packages/app/src/modules/domain/shared/siren.ts
+++ b/packages/app/src/modules/domain/shared/siren.ts
@@ -10,6 +10,10 @@ export function formatSiren(siren: string): string {
 	return `${siren.slice(0, 3)} ${siren.slice(3, 6)} ${siren.slice(6, 9)}`;
 }
 
+export function formatSiret(siret: string): string {
+	return `${formatSiren(siret.slice(0, 9))} ${siret.slice(9, 14)}`;
+}
+
 /**
  * Extracts and validates the SIREN from a SIRET string.
  * Returns the 9-digit SIREN, or null if the input is missing or invalid.


### PR DESCRIPTION
Closes #3850

Adds a pure `formatSiret` function to the domain layer that formats a 14-digit SIRET into display format `XXX XXX XXX XXXXX`, reusing `formatSiren` for the SIREN part (DRY).

## Changes

- `packages/app/src/modules/domain/shared/siren.ts` — added `formatSiret(siret: string): string`
- `packages/app/src/modules/domain/index.ts` — exported `formatSiret` from the domain barrel alongside `formatSiren` / `extractSiren` / `parseSiren`

## Test plan

- `pnpm typecheck` — green
- `formatSiret("53284719600015")` → `"532 847 196 00015"`
- `formatSiret("00000000000000")` → `"000 000 000 00000"`
- Unit tests handled by tu-dev (vitest, `__tests__/siren.test.ts`)

## Notes

Pure domain function — no DB, no dev server, no UI changes.