### PR TITLE
revert: #3736 — canal prerelease alpha avec déclenchement automatique (#3799)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,6 @@ name: 🔖 Release
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - alpha
 
 permissions:
   contents: write
@@ -20,7 +17,7 @@ env:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha'
+    if: github.ref == 'refs/heads/beta'
     name: Release
     runs-on: ubuntu-latest
     steps:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,7 @@
 {
   "branches": [
     "master",
-    { "name": "beta", "prerelease": true },
-    { "name": "alpha", "prerelease": true }
+    { "name": "beta", "prerelease": true }
   ],
   "plugins": [
     "@semantic-release/commit-analyzer",
@@ -13,7 +12,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]"
+        "message": "chore(release): ${nextRelease.version}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
Revert de #3799 (commit `7094be4a`).

Annule la mise en place du canal prerelease `alpha` avec déclenchement automatique :
- `.github/workflows/release.yml` : retrait du trigger `push` sur `alpha` et de la condition `github.ref == alpha`
- `.releaserc.json` : retrait de la branche `alpha` en prerelease et du `[skip ci]` sur le message de release

Reverts #3799