### PR TITLE
fix(auth): bascule ProConnect de l'Identité vers la Fédération

### DIFF
--- a/.kontinuous/env/preprod/templates/egapro.configmap.yaml
+++ b/.kontinuous/env/preprod/templates/egapro.configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: egapro
 data:
   EGAPRO_PROCONNECT_SCOPE: "openid email given_name usual_name siret phone"
-  EGAPRO_PROCONNECT_DISCOVERY_URL: "https://identite.proconnect.gouv.fr"
+  EGAPRO_PROCONNECT_DISCOVERY_URL: "https://auth.agentconnect.gouv.fr/api/v2"
   EGAPRO_PROCONNECT_SIGN_IN_URL: "https://identite.proconnect.gouv.fr/users/start-sign-in"
   EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL: "https://identite.proconnect.gouv.fr/manage-organizations"
   EGAPRO_PROCONNECT_PERSONAL_INFORMATION_URL: "https://identite.proconnect.gouv.fr/personal-information"

--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -33,7 +33,7 @@ app:
     MAILER_SMTP_SSL: "False"
     NODE_ENV: production
 #    EMAIL_LOGIN: "True"
-    EGAPRO_PROCONNECT_DISCOVERY_URL: "https://identite.proconnect.gouv.fr"
+    EGAPRO_PROCONNECT_DISCOVERY_URL: "https://auth.agentconnect.gouv.fr/api/v2"
     EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL: "https://identite.proconnect.gouv.fr/manage-organizations"
     EGAPRO_PROCONNECT_PERSONAL_INFORMATION_URL: "https://identite.proconnect.gouv.fr/personal-information"
     REDIS_SENTINEL_MASTER_NAME: "mymaster"

--- a/.kontinuous/templates/egapro.configmap.yaml
+++ b/.kontinuous/templates/egapro.configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: egapro
 data:
   EGAPRO_PROCONNECT_SCOPE: "openid email given_name usual_name siret phone"
-  EGAPRO_PROCONNECT_DISCOVERY_URL: "https://identite.proconnect.gouv.fr"
+  EGAPRO_PROCONNECT_DISCOVERY_URL: "https://auth.agentconnect.gouv.fr/api/v2"
   EGAPRO_PROCONNECT_SIGN_IN_URL: "https://identite.proconnect.gouv.fr/users/start-sign-in"
   EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL: "https://identite.proconnect.gouv.fr/manage-organizations"
   EGAPRO_PROCONNECT_PERSONAL_INFORMATION_URL: "https://identite.proconnect.gouv.fr/personal-information"


### PR DESCRIPTION
## Contexte

L'authentification ProConnect en **preprod** échouait avec une page d'erreur `400 invalid_client: client is invalid` renvoyée par `identite.proconnect.gouv.fr`, dès le clic sur « S'identifier avec ProConnect » (avant l'écran de login).

## Diagnostic

ProConnect expose **deux serveurs OIDC distincts, avec des registres de clients séparés** :

| Produit | Host | Chemins |
|---|---|---|
| ProConnect **Identité** (ex‑MonComptePro) | `identite.proconnect.gouv.fr` | `/oauth/*` |
| ProConnect **Fédération** (ex‑AgentConnect) | `auth.agentconnect.gouv.fr` | `/api/v2/*` |

- Le FS egapro (`client_id 4ce62b87-…`) a été créé sur la **Fédération** (formulaire `demande-creation-fs-fca`).
- Or le code egapro appelait l'**Identité** (`EGAPRO_PROCONNECT_DISCOVERY_URL=https://identite.proconnect.gouv.fr`), héritage de l'intégration MonComptePro directe de la V1.
- L'Identité ne connaît pas ce client → `invalid_client` (sémantique `checkClient` de node‑oidc‑provider : client non résolu sur cette instance, vérifié **avant** le redirect_uri, indépendant du secret).

**Vérifié empiriquement** (endpoint `/authorize`, GET, le secret n'y est pas requis) :

| Serveur | `4ce62b87` |
|---|---|
| `identite.proconnect.gouv.fr/oauth/authorize` | ❌ `400 invalid_client` (comme un client inventé) |
| `auth.agentconnect.gouv.fr/api/v2/authorize` | ✅ `303 → /api/v2/interaction/…` (client + redirect_uri acceptés) |

Contrôles : client bidon sur la Fédération → `400` ; `4ce62b87` + redirect_uri bidon → `400` (donc le client est bien trouvé puis le redirect_uri vérifié).

## Changement

Bascule de l'URL de discovery ProConnect vers la **Fédération** (`https://auth.agentconnect.gouv.fr/api/v2`). NextAuth récupère alors les endpoints `/api/v2/authorize|token|userinfo` via le `.well-known` (vérifié vivant).

- `.kontinuous/templates/egapro.configmap.yaml` (base → couvre **prod**, qui n'a pas d'override)
- `.kontinuous/env/preprod/templates/egapro.configmap.yaml` (preprod)
- `.kontinuous/env/preprod/values.yaml` (preprod)

## Volontairement **non** modifié

- **`acr_values: "eidas0"`** (`ProConnectProvider.ts`) : la Fédération accepte `eidas0`→`eidas3` (tous → `303`), on garde le niveau le plus permissif (intention actuelle). Aucun changement de code.
- **URLs UI** `EGAPRO_PROCONNECT_SIGN_IN_URL` / `_MANAGE_ORGANISATIONS_URL` / `_PERSONAL_INFORMATION_URL` : laissées sur `identite.proconnect.gouv.fr` — ce sont les pages de gestion du compte ProConnect Identité, valides même via la Fédération (le compte de l'utilisateur vit sur l'Identité).
- **dev** : reste sur le mock interne charon (`egapro-charon…/proconnecttest`).

## S'appuie sur (déjà sur master)

- Provider NextAuth `moncomptepro → proconnect` (callback `/api/auth/callback/proconnect` whitelisté côté FS).
- Nouveaux sealed secrets ProConnect (preprod + prod).

## À valider après déploiement preprod

- [ ] Login complet de bout en bout sur preprod (redirection Fédération → écran ProConnect → callback → session), pas seulement le handshake `/authorize`.
- [ ] Récupération correcte des claims (`sub`, `email`, `given_name`, `usual_name`, `siret`, `phone`) et de l'organisation active.
- [ ] Logout (`end_session_endpoint` de la Fédération, URLs `/login` whitelistées).
