### PR TITLE
fix(auth): prod — câble le client ProConnect sur le secret proconnect (Fédération)

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -30,6 +30,22 @@ api:
         name: smtp
 
 app:
+  env:
+    # ProConnect Fédération: le client_id/secret (lus par l'app comme
+    # SECURITY_MONCOMPTEPRO_*) proviennent du nouveau sealed secret `proconnect`.
+    # Ce mapping `env` prend le pas sur le legacy `moncomptepro` (envFrom) pour
+    # ces deux clés. Sans ça, prod enverrait l'ancien client MonComptePro à la
+    # Fédération → invalid_client. Aligne prod sur preprod.
+    - name: SECURITY_MONCOMPTEPRO_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: proconnect
+          key: EGAPRO_PROCONNECT_CLIENT_ID
+    - name: SECURITY_MONCOMPTEPRO_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: proconnect
+          key: EGAPRO_PROCONNECT_CLIENT_SECRET
   vars:
     MAILER_ENABLE: "True"
     REDIS_SENTINEL_HOSTS: |


### PR DESCRIPTION
## Contexte

La bascule ProConnect Identité → Fédération (#3862) a changé `EGAPRO_PROCONNECT_DISCOVERY_URL` dans le configmap **de base**, qui s'applique aussi à la **prod** (prod n'a pas d'override de configmap). Mais le **câblage du client** n'était fait que pour preprod/dev.

## Problème (prod uniquement)

En prod, `SECURITY_MONCOMPTEPRO_CLIENT_ID/SECRET` (lus par l'app pour ProConnect) proviennent du **legacy** `envFrom: secretRef: name: "moncomptepro"` — l'**ancien** client MonComptePro. Le nouveau sealed secret `proconnect` (client Fédération `4ce62b87-…`) est déployé mais **jamais mappé** vers ces variables.

Résultat : à la prochaine **release prod** (déploiement sur tag `v*`), prod aurait **discovery = Fédération** mais **client_id = ancien MonComptePro** → `invalid_client` → auth prod cassée.

> Pas d'urgence immédiate : la prod ne déploie que sur tag `v*` (dernier = `v3.18.2`), pas sur push master. Prod tourne encore sur l'ancienne config et **n'est pas cassée aujourd'hui**. Ce fix doit juste être mergé **avant la prochaine release prod**.

## Changement

Ajoute à `.kontinuous/env/prod/values.yaml` le mapping `app.env` (miroir de preprod) : `SECURITY_MONCOMPTEPRO_CLIENT_ID/SECRET` ← sealed secret `proconnect`. Le bloc `env` prime sur `envFrom` pour ces deux clés.

- L'env Sentry de la base est **préservé** (vérifié : kontinuous fusionne `app.env` par nom — la preprod en cours a bien `SENTRY_*` + `SECURITY_MONCOMPTEPRO_CLIENT_ID=4ce62b87…`).
- Le `moncomptepro` legacy est **laissé** dans `envFrom` (il fournit encore `SECURITY_MONCOMPTEPRO_TEST` ; `CLIENT_ID/SECRET` sont surchargés).

## Reste vérifié OK pour la prod

- discovery Fédération (configmap base) ✅ · charon désactivé en prod (`env==prod`) ✅
- `NEXTAUTH_URL=https://egapro.travail.gouv.fr/api/auth` → callback `…/api/auth/callback/proconnect` ✅
- redirect_uri **prod** whitelisté sur la Fédération (testé : 303→interaction) ✅
- provider id `proconnect`, `acr_values=eidas0` (accepté par la Fédération) ✅ · logout → `/login` (#3863) ✅

## À confirmer avant release prod

- [ ] Le sealed secret `proconnect` **de prod** (`.kontinuous/env/prod/templates/proconnect.sealed-secret.yaml`) déchiffre bien en `client_id=4ce62b87-…` + son secret, scellé pour le **cluster/namespace prod** (`egapro`). Non vérifiable depuis les manifests.
- [ ] `SECURITY_MONCOMPTEPRO_TEST` (fourni par le legacy `moncomptepro` secret) vaut bien `false` en prod.
- [ ] Après la release : valider le login **et** le logout complets sur `egapro.travail.gouv.fr`.
