### PR TITLE
fix(auth): prod — retire l'envFrom moncomptepro (réf pendante après suppression du secret)

### DIFF
--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -32,10 +32,9 @@ api:
 app:
   env:
     # ProConnect Fédération: le client_id/secret (lus par l'app comme
-    # SECURITY_MONCOMPTEPRO_*) proviennent du nouveau sealed secret `proconnect`.
-    # Ce mapping `env` prend le pas sur le legacy `moncomptepro` (envFrom) pour
-    # ces deux clés. Sans ça, prod enverrait l'ancien client MonComptePro à la
-    # Fédération → invalid_client. Aligne prod sur preprod.
+    # SECURITY_MONCOMPTEPRO_*) proviennent du sealed secret `proconnect`
+    # (client Fédération 4ce62b87). Le legacy secret `moncomptepro` est supprimé
+    # (plus d'envFrom moncomptepro). Aligne prod sur preprod.
     - name: SECURITY_MONCOMPTEPRO_CLIENT_ID
       valueFrom:
         secretKeyRef:
@@ -61,8 +60,6 @@ app:
   envFrom:
     - secretRef:
         name: "{{ .Values.global.pgSecretName }}"
-    - secretRef:
-        name: "moncomptepro"
     - secretRef:
         name: "staff"
     - secretRef:


### PR DESCRIPTION
Suite de #3865 : le sealed secret `moncomptepro` a bien été supprimé de master, **mais le retrait de l'`envFrom: moncomptepro` n'y était pas** (commit poussé après le merge de #3865).

Master a donc le secret supprimé + un `envFrom` qui le référence encore → toute réconciliation/déploiement casse les nouveaux pods avec `CreateContainerConfigError: secret "moncomptepro" not found` (blocage de rollout observé en prod, pods v3.18.3 `Pending`).

Cette PR retire l'`envFrom: secretRef: name: moncomptepro` de `.kontinuous/env/prod/values.yaml`. Le client vient déjà du mapping `env → secret proconnect` (4ce62b87) ; seul `SECURITY_MONCOMPTEPRO_TEST` disparaît → défaut `false` (OK prod).