### PR TITLE
fix(remuneration): afficher la vraie proportion de bénéficiaires (étape 6 + PDF)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -144,6 +144,8 @@ export function StepPageClient({
 						step3Data={step3Data}
 						step4Data={step4Data}
 						step5Categories={step5Categories}
+						totalMen={declaration.totalMen ?? undefined}
+						totalWomen={declaration.totalWomen ?? undefined}
 					/>
 				);
 			default:

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -50,6 +50,8 @@ type Props = {
 	step3Data: Step3Data;
 	step4Data: Step4Data;
 	step5Categories?: EmployeeCategoryRow[];
+	totalWomen?: number;
+	totalMen?: number;
 	isSubmitted?: boolean;
 	hasCse?: boolean | null;
 };
@@ -62,6 +64,8 @@ export function Step6Review({
 	step3Data,
 	step4Data,
 	step5Categories = [],
+	totalWomen,
+	totalMen,
 	isSubmitted = false,
 	hasCse = null,
 }: Props) {
@@ -192,6 +196,8 @@ export function Step6Review({
 					step3Data={step3Data}
 					step4Data={step4Data}
 					step5Categories={step5Categories}
+					totalMen={totalMen}
+					totalWomen={totalWomen}
 					withTooltips
 				/>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -299,10 +299,13 @@ describe("Step6Review", () => {
 					indicatorEMen: "55",
 				}}
 				step4Data={emptyStep4Data()}
+				totalMen={100}
+				totalWomen={90}
 			/>,
 		);
-		expect(screen.getByText("45 %")).toBeInTheDocument();
-		expect(screen.getByText("55 %")).toBeInTheDocument();
+		// Proportion = beneficiaries / workforce total, not the raw beneficiary count
+		expect(screen.getByText("50,0 %")).toBeInTheDocument();
+		expect(screen.getByText("55,0 %")).toBeInTheDocument();
 		expect(screen.getByText("Proportion")).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/IndicatorSections.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/IndicatorSections.tsx
@@ -7,7 +7,7 @@ import type {
 	Step3Data,
 	Step4Data,
 } from "~/modules/declaration-remuneration/types";
-import { computeGap } from "~/modules/domain";
+import { computeGap, computeProportion } from "~/modules/domain";
 import { CardTitle } from "./CardTitle";
 import { GapColumn } from "./GapColumn";
 import { GapSideBySide } from "./GapSideBySide";
@@ -19,6 +19,8 @@ type Props = {
 	step3Data: Step3Data;
 	step4Data: Step4Data;
 	step5Categories: EmployeeCategoryRow[];
+	totalWomen?: number;
+	totalMen?: number;
 	/**
 	 * In the Step6Review (in-flow) the cards expose tooltips for the quartile
 	 * and category sections. The post-submission recap renders the same cards
@@ -42,6 +44,8 @@ export function IndicatorSections({
 	step3Data,
 	step4Data,
 	step5Categories,
+	totalWomen,
+	totalMen,
 	withTooltips = false,
 }: Props) {
 	const annualMeanGap = computeGap(
@@ -131,17 +135,16 @@ export function IndicatorSections({
 											<div className={stepStyles.flex1}>
 												<p className="fr-text--sm fr-mb-0">Femmes</p>
 												<strong className="fr-text--sm">
-													{step3Data.indicatorEWomen
-														? `${step3Data.indicatorEWomen} %`
-														: "-"}
+													{computeProportion(
+														step3Data.indicatorEWomen,
+														totalWomen,
+													)}
 												</strong>
 											</div>
 											<div className={stepStyles.flex1}>
 												<p className="fr-text--sm fr-mb-0">Hommes</p>
 												<strong className="fr-text--sm">
-													{step3Data.indicatorEMen
-														? `${step3Data.indicatorEMen} %`
-														: "-"}
+													{computeProportion(step3Data.indicatorEMen, totalMen)}
 												</strong>
 											</div>
 										</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+	Step2Data,
+	Step3Data,
+	Step4Data,
+} from "~/modules/declaration-remuneration/types";
+import { IndicatorSections } from "../IndicatorSections";
+
+const emptyStep2Data = (): Step2Data => ({
+	indicatorAAnnualWomen: "",
+	indicatorAAnnualMen: "",
+	indicatorAHourlyWomen: "",
+	indicatorAHourlyMen: "",
+	indicatorCAnnualWomen: "",
+	indicatorCAnnualMen: "",
+	indicatorCHourlyWomen: "",
+	indicatorCHourlyMen: "",
+});
+
+const emptyStep4Data = (): Step4Data => ({
+	annual: [{}, {}, {}, {}],
+	hourly: [{}, {}, {}, {}],
+});
+
+// All four gap fields are populated so GapBadge never renders "-"; the only "-"
+// cells left in the card are the two proportion values under test.
+const step3WithProportion = (
+	indicatorEWomen: string,
+	indicatorEMen: string,
+): Step3Data => ({
+	indicatorBAnnualWomen: "95",
+	indicatorBAnnualMen: "100",
+	indicatorBHourlyWomen: "95",
+	indicatorBHourlyMen: "100",
+	indicatorDAnnualWomen: "95",
+	indicatorDAnnualMen: "100",
+	indicatorDHourlyWomen: "95",
+	indicatorDHourlyMen: "100",
+	indicatorEWomen,
+	indicatorEMen,
+});
+
+describe("IndicatorSections", () => {
+	it("renders variable pay proportion as a share of the workforce total, not the raw beneficiary count", () => {
+		render(
+			<IndicatorSections
+				step2Data={emptyStep2Data()}
+				step3Data={step3WithProportion("95", "80")}
+				step4Data={emptyStep4Data()}
+				step5Categories={[]}
+				totalMen={100}
+				totalWomen={200}
+			/>,
+		);
+
+		expect(screen.getByText("47,5 %")).toBeInTheDocument();
+		expect(screen.getByText("80,0 %")).toBeInTheDocument();
+		expect(screen.queryByText("95 %")).not.toBeInTheDocument();
+		expect(screen.queryByText("110 %")).not.toBeInTheDocument();
+	});
+
+	it("renders '-' for the proportion when the workforce total is zero", () => {
+		render(
+			<IndicatorSections
+				step2Data={emptyStep2Data()}
+				step3Data={step3WithProportion("95", "80")}
+				step4Data={emptyStep4Data()}
+				step5Categories={[]}
+				totalMen={0}
+				totalWomen={0}
+			/>,
+		);
+
+		expect(screen.getByText("Proportion")).toBeInTheDocument();
+		expect(screen.getAllByText("-")).toHaveLength(2);
+	});
+
+	it("renders '-' for the proportion when the workforce total is missing", () => {
+		render(
+			<IndicatorSections
+				step2Data={emptyStep2Data()}
+				step3Data={step3WithProportion("95", "80")}
+				step4Data={emptyStep4Data()}
+				step5Categories={[]}
+			/>,
+		);
+
+		expect(screen.getAllByText("-")).toHaveLength(2);
+	});
+});

--- a/packages/app/src/modules/declarationPdf/sections/VariablePaySection.tsx
+++ b/packages/app/src/modules/declarationPdf/sections/VariablePaySection.tsx
@@ -1,5 +1,6 @@
 import { Text, View } from "@react-pdf/renderer";
 
+import { computeProportion } from "~/modules/domain";
 import { styles } from "../pdfStyles";
 import type { DeclarationPdfData } from "../types";
 import { PayGapTable } from "./PayGapTable";
@@ -18,9 +19,10 @@ export function VariablePaySection({ data }: { data: DeclarationPdfData }) {
 							Proportion de bénéficiaires — Femmes
 						</Text>
 						<Text style={styles.proportionValue}>
-							{data.step3Data.beneficiaryWomen
-								? `${data.step3Data.beneficiaryWomen} %`
-								: "-"}
+							{computeProportion(
+								data.step3Data.beneficiaryWomen,
+								data.totalWomen,
+							)}
 						</Text>
 					</View>
 					<View style={styles.proportionItem}>
@@ -28,9 +30,7 @@ export function VariablePaySection({ data }: { data: DeclarationPdfData }) {
 							Proportion de bénéficiaires — Hommes
 						</Text>
 						<Text style={styles.proportionValue}>
-							{data.step3Data.beneficiaryMen
-								? `${data.step3Data.beneficiaryMen} %`
-								: "-"}
+							{computeProportion(data.step3Data.beneficiaryMen, data.totalMen)}
 						</Text>
 					</View>
 				</View>

--- a/packages/app/src/modules/declarationPdf/sections/__tests__/VariablePaySection.test.tsx
+++ b/packages/app/src/modules/declarationPdf/sections/__tests__/VariablePaySection.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+	DeclarationPdfData,
+	VariablePayData,
+} from "~/modules/declarationPdf/types";
+
+vi.mock("@react-pdf/renderer", async () => {
+	const React = await import("react");
+
+	return {
+		Text: ({ children }: { children: React.ReactNode }) =>
+			React.createElement("span", null, children),
+		View: ({ children }: { children: React.ReactNode }) =>
+			React.createElement("div", null, children),
+		StyleSheet: {
+			create: <T,>(styles: T) => styles,
+		},
+	};
+});
+
+vi.mock("../PayGapTable", async () => {
+	const React = await import("react");
+
+	return {
+		PayGapTable: ({ title }: { title: string }) =>
+			React.createElement("div", { "data-testid": "pay-gap-table" }, title),
+	};
+});
+
+import { VariablePaySection } from "../VariablePaySection";
+
+const makeData = (
+	step3: VariablePayData,
+	totals: { totalWomen: number; totalMen: number },
+): DeclarationPdfData => ({
+	companyName: "Société Démo",
+	siren: "123456789",
+	year: 2026,
+	generatedAt: "10 mars 2026",
+	isSecondDeclaration: false,
+	totalWomen: totals.totalWomen,
+	totalMen: totals.totalMen,
+	step1Categories: [],
+	step2Rows: [],
+	step3Data: step3,
+	step4Categories: [],
+	step5Categories: [],
+});
+
+const beneficiaryRows: VariablePayData["rows"] = [
+	{ label: "Primes", womenValue: "5000", menValue: "6000" },
+];
+
+describe("VariablePaySection", () => {
+	it("renders beneficiary proportion as a share of the workforce total, not the raw beneficiary count", () => {
+		render(
+			<VariablePaySection
+				data={makeData(
+					{
+						rows: beneficiaryRows,
+						beneficiaryWomen: "95",
+						beneficiaryMen: "80",
+					},
+					{ totalWomen: 200, totalMen: 100 },
+				)}
+			/>,
+		);
+
+		expect(screen.getByText("47,5 %")).toBeInTheDocument();
+		expect(screen.getByText("80,0 %")).toBeInTheDocument();
+		expect(screen.queryByText("95 %")).not.toBeInTheDocument();
+		expect(screen.queryByText("110 %")).not.toBeInTheDocument();
+	});
+
+	it("renders '-' for the proportion when the workforce total is zero", () => {
+		render(
+			<VariablePaySection
+				data={makeData(
+					{
+						rows: beneficiaryRows,
+						beneficiaryWomen: "95",
+						beneficiaryMen: "80",
+					},
+					{ totalWomen: 0, totalMen: 0 },
+				)}
+			/>,
+		);
+
+		expect(screen.getAllByText("-")).toHaveLength(2);
+	});
+
+	it("omits the proportion row when there are no beneficiary rows", () => {
+		render(
+			<VariablePaySection
+				data={makeData(
+					{ rows: [], beneficiaryWomen: "95", beneficiaryMen: "80" },
+					{ totalWomen: 200, totalMen: 100 },
+				)}
+			/>,
+		);
+
+		expect(
+			screen.queryByText("Proportion de bénéficiaires — Femmes"),
+		).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Contexte

Sur l'étape 6 du parcours de déclaration rémunération (carte « Écart de rémunération variable ou complémentaire »), les proportions de bénéficiaires étaient affichées comme des **nombres bruts de bénéficiaires** suffixés d'un « % » — d'où le « 110 % » impossible du rapport de bug.

## Cause

`indicatorEWomen`/`indicatorEMen` (funnel) et `beneficiaryWomen`/`beneficiaryMen` (PDF) sont des **comptes bruts de bénéficiaires**, pas des pourcentages. Deux surfaces collaient un `%` littéral sur ces comptes au lieu de calculer la proportion `bénéficiaires / effectif total × 100` via le helper domaine existant `computeProportion(count, total)` — utilisé correctement partout ailleurs (saisie étape 3, récap post-soumission, callout d'interprétation).

## Correctif

- `IndicatorSections` (revue in-flow étape 6) et `VariablePaySection` (PDF) utilisent désormais `computeProportion(...)`.
- Les totaux d'effectif (`totalWomen`/`totalMen`), déjà disponibles côté déclaration, transitent via les props jusqu'aux composants d'affichage (même pattern que `maxWomen`/`maxMen` pour les steps 3/4/5).
- `computeProportion` gère déjà vide/NaN/total=0 → affiche `"-"`.

## Tests

Tests unitaires (Vitest) reproduisant le bug : `indicatorEWomen=95` / `totalWomen=200` rend `47,5 %` (et plus `95 %`), `indicatorEMen=110`… n'existe plus. Couvre aussi les cas total=0 et total manquant → `"-"`.

Closes #3795
