### PR TITLE
fix(a11y): #3809 — alternative des graphiques recharts (role="img")

### DIFF
--- a/packages/app/src/modules/admin/stats/CampaignProgressionChart.module.scss
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionChart.module.scss
@@ -3,6 +3,11 @@
 	height: 360px;
 }
 
+.chartContainer {
+	width: 100%;
+	height: 100%;
+}
+
 .tooltipList {
 	margin: 0;
 	padding: 0;

--- a/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
+++ b/packages/app/src/modules/admin/stats/CampaignProgressionChart.tsx
@@ -43,6 +43,9 @@ type MergedPoint = {
 	[year: number]: number | null;
 };
 
+const CHART_CAPTION =
+	"Courbe de progression cumulative des déclarations soumises par année.";
+
 // DSFR palette — pulled from design system tokens, not guessed.
 const EMPHASIS_COLOR = "var(--background-action-high-blue-france)";
 const N_MINUS_1_COLOR = "var(--text-mention-grey)";
@@ -136,34 +139,40 @@ export function CampaignProgressionChart({ series, currentYear }: Props) {
 	return (
 		<figure className={styles.chartWrapper}>
 			<figcaption className="fr-sr-only">
-				Courbe de progression cumulative des déclarations soumises par année.
-				Les données équivalentes sont disponibles dans le tableau ci-dessous.
+				{CHART_CAPTION} Les données équivalentes sont disponibles dans le
+				tableau ci-dessous.
 			</figcaption>
-			<ResponsiveContainer>
-				<LineChart data={data}>
-					<CartesianGrid strokeDasharray="3 3" />
-					<XAxis
-						dataKey="dayOfYear"
-						interval={6}
-						tickFormatter={(value: string) => formatMonthDay(value)}
-					/>
-					<YAxis tickFormatter={(value: number) => formatCount(value)} />
-					<Tooltip content={<ProgressionTooltip totals={totals} />} />
-					<Legend />
-					{series.map(({ year }) => (
-						<Line
-							connectNulls
-							dataKey={year}
-							dot={false}
-							key={year}
-							name={String(year)}
-							stroke={colorForYear(year, currentYear)}
-							strokeWidth={year === currentYear ? 3 : 2}
-							type="monotone"
+			<div
+				aria-label={CHART_CAPTION}
+				className={styles.chartContainer}
+				role="img"
+			>
+				<ResponsiveContainer>
+					<LineChart data={data}>
+						<CartesianGrid strokeDasharray="3 3" />
+						<XAxis
+							dataKey="dayOfYear"
+							interval={6}
+							tickFormatter={(value: string) => formatMonthDay(value)}
 						/>
-					))}
-				</LineChart>
-			</ResponsiveContainer>
+						<YAxis tickFormatter={(value: number) => formatCount(value)} />
+						<Tooltip content={<ProgressionTooltip totals={totals} />} />
+						<Legend />
+						{series.map(({ year }) => (
+							<Line
+								connectNulls
+								dataKey={year}
+								dot={false}
+								key={year}
+								name={String(year)}
+								stroke={colorForYear(year, currentYear)}
+								strokeWidth={year === currentYear ? 3 : 2}
+								type="monotone"
+							/>
+						))}
+					</LineChart>
+				</ResponsiveContainer>
+			</div>
 		</figure>
 	);
 }

--- a/packages/app/src/modules/admin/stats/StepDropoffChart.module.scss
+++ b/packages/app/src/modules/admin/stats/StepDropoffChart.module.scss
@@ -3,6 +3,11 @@
 	height: 600px;
 }
 
+.chartContainer {
+	width: 100%;
+	height: 100%;
+}
+
 .tooltipList {
 	margin: 0;
 	padding: 0;

--- a/packages/app/src/modules/admin/stats/StepDropoffChart.tsx
+++ b/packages/app/src/modules/admin/stats/StepDropoffChart.tsx
@@ -33,6 +33,8 @@ type DropoffTooltipProps = {
 	payload?: TooltipEntry[];
 };
 
+const CHART_CAPTION = `Taux d'abandon par phase de la démarche déclarative : pourcentage de déclarations entrées sur chaque étape du wizard ou phase post-soumission et qui n'ont pas progressé depuis le délai sélectionné. Les barres rouges signalent une phase dont le taux dépasse ${DROPOFF_RATE_ALERT_THRESHOLD} %.`;
+
 const WIZARD_NORMAL_COLOR = "var(--background-action-high-blue-france)";
 const WIZARD_ALERT_COLOR = "var(--background-action-high-red-marianne)";
 const POST_SUBMIT_NORMAL_COLOR = "var(--background-action-low-blue-france)";
@@ -85,49 +87,51 @@ export function StepDropoffChart({ rows }: Props) {
 	return (
 		<figure className={styles.chartWrapper}>
 			<figcaption className="fr-sr-only">
-				Taux d'abandon par phase de la démarche déclarative : pourcentage de
-				déclarations entrées sur chaque étape du wizard ou phase post-soumission
-				et qui n'ont pas progressé depuis le délai sélectionné. Les barres
-				rouges signalent une phase dont le taux dépasse{" "}
-				{DROPOFF_RATE_ALERT_THRESHOLD} %. Les données équivalentes sont
-				disponibles dans le tableau ci-dessous.
+				{CHART_CAPTION} Les données équivalentes sont disponibles dans le
+				tableau ci-dessous.
 			</figcaption>
-			<ResponsiveContainer>
-				<BarChart
-					data={rows}
-					layout="vertical"
-					margin={{ top: 16, right: 32, bottom: 24, left: 8 }}
-				>
-					<CartesianGrid strokeDasharray="3 3" />
-					<XAxis
-						domain={[0, 100]}
-						label={{
-							value: "Taux d'abandon (%)",
-							position: "insideBottom",
-							offset: -8,
-						}}
-						tickFormatter={(value: number) => `${value}`}
-						type="number"
-					/>
-					<YAxis
-						dataKey="label"
-						interval={0}
-						tick={{ fontSize: 12 }}
-						type="category"
-						width={260}
-					/>
-					<Tooltip content={<DropoffTooltip />} />
-					<Bar
-						dataKey="dropoffRate"
-						fill={WIZARD_NORMAL_COLOR}
-						name="Taux d'abandon"
+			<div
+				aria-label={CHART_CAPTION}
+				className={styles.chartContainer}
+				role="img"
+			>
+				<ResponsiveContainer>
+					<BarChart
+						data={rows}
+						layout="vertical"
+						margin={{ top: 16, right: 32, bottom: 24, left: 8 }}
 					>
-						{rows.map((row) => (
-							<Cell fill={getBarColor(row)} key={row.key} />
-						))}
-					</Bar>
-				</BarChart>
-			</ResponsiveContainer>
+						<CartesianGrid strokeDasharray="3 3" />
+						<XAxis
+							domain={[0, 100]}
+							label={{
+								value: "Taux d'abandon (%)",
+								position: "insideBottom",
+								offset: -8,
+							}}
+							tickFormatter={(value: number) => `${value}`}
+							type="number"
+						/>
+						<YAxis
+							dataKey="label"
+							interval={0}
+							tick={{ fontSize: 12 }}
+							type="category"
+							width={260}
+						/>
+						<Tooltip content={<DropoffTooltip />} />
+						<Bar
+							dataKey="dropoffRate"
+							fill={WIZARD_NORMAL_COLOR}
+							name="Taux d'abandon"
+						>
+							{rows.map((row) => (
+								<Cell fill={getBarColor(row)} key={row.key} />
+							))}
+						</Bar>
+					</BarChart>
+				</ResponsiveContainer>
+			</div>
 		</figure>
 	);
 }

--- a/packages/app/src/modules/admin/stats/StepDurationsChart.module.scss
+++ b/packages/app/src/modules/admin/stats/StepDurationsChart.module.scss
@@ -3,6 +3,11 @@
 	height: 640px;
 }
 
+.chartContainer {
+	width: 100%;
+	height: 100%;
+}
+
 .tooltipList {
 	margin: 0;
 	padding: 0;

--- a/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
+++ b/packages/app/src/modules/admin/stats/StepDurationsChart.tsx
@@ -32,6 +32,9 @@ type DurationsTooltipProps = {
 	payload?: TooltipEntry[];
 };
 
+const CHART_CAPTION =
+	"Délai médian et 90e percentile passé par les déclarations sur chaque étape du parcours indicateurs puis sur chaque jalon de la démarche post-soumission.";
+
 // Distinct DSFR palettes per phase — the colour break makes the wizard /
 // post-submit handoff readable without referencing the labels.
 const WIZARD_MEDIAN_COLOR = "var(--background-action-high-blue-france)";
@@ -83,60 +86,64 @@ export function StepDurationsChart({ rows }: Props) {
 	return (
 		<figure className={styles.chartWrapper}>
 			<figcaption className="fr-sr-only">
-				Délai médian et 90e percentile passé par les déclarations sur chaque
-				étape du parcours indicateurs puis sur chaque jalon de la démarche
-				post-soumission. Les données équivalentes sont disponibles dans le
+				{CHART_CAPTION} Les données équivalentes sont disponibles dans le
 				tableau ci-dessous.
 			</figcaption>
-			<ResponsiveContainer>
-				<BarChart
-					data={rows}
-					layout="vertical"
-					margin={{ top: 16, right: 24, bottom: 16, left: 16 }}
-				>
-					<CartesianGrid strokeDasharray="3 3" />
-					<XAxis
-						label={{
-							value: "Jours",
-							position: "insideBottom",
-							offset: -4,
-						}}
-						tickFormatter={(value: number) => formatCount(value)}
-						type="number"
-					/>
-					<YAxis dataKey="label" interval={0} type="category" width={220} />
-					<Tooltip content={<DurationsTooltip />} />
-					<Legend />
-					<Bar
-						dataKey="medianDays"
-						fill={WIZARD_MEDIAN_COLOR}
-						name="Médiane (j)"
+			<div
+				aria-label={CHART_CAPTION}
+				className={styles.chartContainer}
+				role="img"
+			>
+				<ResponsiveContainer>
+					<BarChart
+						data={rows}
+						layout="vertical"
+						margin={{ top: 16, right: 24, bottom: 16, left: 16 }}
 					>
-						{rows.map((row) => (
-							<Cell
-								fill={
-									row.phase === "wizard"
-										? WIZARD_MEDIAN_COLOR
-										: POST_SUBMIT_MEDIAN_COLOR
-								}
-								key={row.key}
-							/>
-						))}
-					</Bar>
-					<Bar dataKey="p90Days" fill={WIZARD_P90_COLOR} name="p90 (j)">
-						{rows.map((row) => (
-							<Cell
-								fill={
-									row.phase === "wizard"
-										? WIZARD_P90_COLOR
-										: POST_SUBMIT_P90_COLOR
-								}
-								key={row.key}
-							/>
-						))}
-					</Bar>
-				</BarChart>
-			</ResponsiveContainer>
+						<CartesianGrid strokeDasharray="3 3" />
+						<XAxis
+							label={{
+								value: "Jours",
+								position: "insideBottom",
+								offset: -4,
+							}}
+							tickFormatter={(value: number) => formatCount(value)}
+							type="number"
+						/>
+						<YAxis dataKey="label" interval={0} type="category" width={220} />
+						<Tooltip content={<DurationsTooltip />} />
+						<Legend />
+						<Bar
+							dataKey="medianDays"
+							fill={WIZARD_MEDIAN_COLOR}
+							name="Médiane (j)"
+						>
+							{rows.map((row) => (
+								<Cell
+									fill={
+										row.phase === "wizard"
+											? WIZARD_MEDIAN_COLOR
+											: POST_SUBMIT_MEDIAN_COLOR
+									}
+									key={row.key}
+								/>
+							))}
+						</Bar>
+						<Bar dataKey="p90Days" fill={WIZARD_P90_COLOR} name="p90 (j)">
+							{rows.map((row) => (
+								<Cell
+									fill={
+										row.phase === "wizard"
+											? WIZARD_P90_COLOR
+											: POST_SUBMIT_P90_COLOR
+									}
+									key={row.key}
+								/>
+							))}
+						</Bar>
+					</BarChart>
+				</ResponsiveContainer>
+			</div>
 		</figure>
 	);
 }


### PR DESCRIPTION
## Critère d'accessibilité — RGAA 1.1 / 1.3 (WCAG 1.1.1 A)

Les 3 graphiques recharts du back-office statistiques avaient bien une `<figcaption class="fr-sr-only">` mais **pas** le wrapper `role="img"` + `aria-label` — l'image porteuse d'information n'était donc pas exposée comme telle aux technologies d'assistance.

## Correctif

Enveloppe le `<ResponsiveContainer>` de chaque chart dans `<div role="img" aria-label={caption}>`, **en miroir du pattern conforme `StatsBarChart`** :
- `CampaignProgressionChart.tsx`
- `StepDropoffChart.tsx`
- `StepDurationsChart.tsx`

La hauteur fixe reste sur la `figure` ; le nouveau conteneur la remplit (`.chartContainer { height: 100% }`) → **rendu visuel inchangé**. `CompletionFunnelChart` (ECharts, déjà conforme) non modifié.

## Vérification

- ultra11y : `audit` sur les 3 fichiers → **100% réussite, 0 NC**.
- `typecheck` ✅ · `format:check` ✅ · tests charts + StatsDashboard ✅ (47 tests).

Stack : basée sur #3887 (fondation ultra11y). Closes #3809