### PR TITLE
fix(a11y): #3800 — remédiation RGAA, lot global de l'epic

### DIFF
--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -282,7 +282,7 @@ Never define schemas in `src/server/api/routers/`. Always in `src/modules/{domai
 - `register()` spreads directly on native `<input>` elements with DSFR classes
 - Use `Controller` for non-standard controls (radios, custom selects)
 - Field errors: `fr-input-group--error` + `<p className="fr-error-text">`
-- Form errors: `fr-alert fr-alert--error` with `aria-live="polite"`
+- Form / server-action errors: `fr-alert fr-alert--error` with **`role="alert"`** (implies assertive — never also set `aria-live`). Info / async status → `aria-live="polite"` + `aria-atomic="true"`. See the Accessibility « Live regions » rule and `.claude/rules/rgaa.md`.
 
 ### File uploads
 

--- a/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
+++ b/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminDeclarationDetailPage } from "~/modules/admin/declarations";
+
+export const metadata: Metadata = { title: "Détail de la déclaration" };
 
 type Props = {
 	params: Promise<{ declarationId: string }>;

--- a/packages/app/src/app/admin/declarations/page.tsx
+++ b/packages/app/src/app/admin/declarations/page.tsx
@@ -1,5 +1,7 @@
 import { AdminDeclarationsPage } from "~/modules/admin/declarations";
 
+export const metadata = { title: "Administration des déclarations" };
+
 export default function Page() {
 	return <AdminDeclarationsPage />;
 }

--- a/packages/app/src/app/admin/impersonate/page.tsx
+++ b/packages/app/src/app/admin/impersonate/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { ImpersonatePage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Mimoquer une entreprise" };
 
 export default function Page() {
 	return <ImpersonatePage />;

--- a/packages/app/src/app/admin/liste-referents/page.tsx
+++ b/packages/app/src/app/admin/liste-referents/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminReferentsPage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Liste des référents" };
 
 export default function Page() {
 	return <AdminReferentsPage />;

--- a/packages/app/src/app/admin/page.tsx
+++ b/packages/app/src/app/admin/page.tsx
@@ -1,5 +1,9 @@
+import type { Metadata } from "next";
+
 import { AdminHomePage } from "~/modules/admin";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Backoffice" };
 
 export default async function Page() {
 	// Access control is handled by the edge middleware and the admin layout;

--- a/packages/app/src/app/admin/parametres/page.tsx
+++ b/packages/app/src/app/admin/parametres/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminSettingsPage } from "~/modules/admin/settings";
+
+export const metadata: Metadata = { title: "Paramètres de la plateforme" };
 
 export default function Page() {
 	return <AdminSettingsPage />;

--- a/packages/app/src/app/admin/stats/page.tsx
+++ b/packages/app/src/app/admin/stats/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { StatsDashboard } from "~/modules/admin/stats";
 import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
 
-export const metadata: Metadata = { title: "Statistiques — Egapro" };
+export const metadata: Metadata = { title: "Statistiques" };
 
 export default function Page() {
 	const currentYear = getCurrentYear();

--- a/packages/app/src/app/avis-cse/confirmation/page.tsx
+++ b/packages/app/src/app/avis-cse/confirmation/page.tsx
@@ -9,6 +9,8 @@ import { getWorkforceYearFor } from "~/modules/domain";
 import { auth } from "~/server/auth";
 import { api } from "~/trpc/server";
 
+export const metadata = { title: "Confirmation de l'avis du CSE" };
+
 export default async function CseOpinionConfirmationPage() {
 	const [session, declarationData] = await Promise.all([
 		auth(),

--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -18,6 +18,8 @@ type StepPageProps = {
 	params: Promise<{ step: string }>;
 };
 
+export const metadata = { title: "Déclaration d'un avis du CSE" };
+
 export default async function CseOpinionStepPage({ params }: StepPageProps) {
 	const { step: stepParam } = await params;
 	const step = Number.parseInt(stepParam, 10);

--- a/packages/app/src/app/avis-cse/page.tsx
+++ b/packages/app/src/app/avis-cse/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 
+export const metadata = { title: "Avis du CSE" };
+
 export default function CseOpinionPage() {
 	redirect("/avis-cse/etape/1");
 }

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
 	getEffectiveGipPrefillData,
+	STEP_TITLES,
 	StepPageClient,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
@@ -15,6 +17,20 @@ import { api, HydrateClient } from "~/trpc/server";
 type StepPageProps = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({
+	params,
+}: StepPageProps): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${TOTAL_STEPS} — ${stepTitle}`
+			: "Déclaration des écarts de rémunération",
+	};
+}
 
 export default async function StepPage({ params }: StepPageProps) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+	title: "Déclaration des écarts de rémunération",
+};
 
 export default function DeclarationPage() {
 	redirect("/declaration-remuneration/etape/1");

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
@@ -1,8 +1,14 @@
+import type { Metadata } from "next";
+
 import { FunnelCompleteTracker } from "~/modules/analytics";
 import {
 	COMPLIANCE_FUNNEL,
 	ComplianceConfirmation,
 } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = {
+	title: "Confirmation — Parcours de mise en conformité",
+};
 
 export default function ComplianceConfirmationPage() {
 	return (

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
@@ -1,8 +1,26 @@
-import { SecondDeclarationStepPage } from "~/modules/declaration-remuneration";
+import type { Metadata } from "next";
+
+import {
+	SECOND_DECLARATION_STEP_TITLES,
+	SECOND_DECLARATION_TOTAL_STEPS,
+	SecondDeclarationStepPage,
+} from "~/modules/declaration-remuneration";
 
 type Props = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = SECOND_DECLARATION_STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${SECOND_DECLARATION_TOTAL_STEPS} — ${stepTitle}`
+			: "Parcours de mise en conformité",
+	};
+}
 
 export default async function Page({ params }: Props) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { JointEvaluationPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Évaluation conjointe" };
 
 export default function Page() {
 	return <JointEvaluationPage />;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { CompliancePathPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Parcours de mise en conformité" };
 
 export default function Page() {
 	return <CompliancePathPage />;

--- a/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
@@ -89,7 +89,11 @@ export default async function RecapitulatifRoute({ searchParams }: Props) {
 				</Link>
 			</div>
 
-			<main className="fr-container fr-pb-7w fr-pt-7w" id="content">
+			<main
+				className="fr-container fr-pb-7w fr-pt-7w"
+				id="content"
+				tabIndex={-1}
+			>
 				<div className="fr-grid-row fr-grid-row--center">
 					<div className="fr-col-12 fr-col-lg-8">
 						<RecapitulatifPage

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -13,7 +13,7 @@ import { ProfileModal } from "~/modules/profile";
 import { TRPCReactProvider } from "~/trpc/react";
 
 export const metadata: Metadata = {
-	title: "Egapro",
+	title: { template: "%s — Egapro", default: "Egapro" },
 	description: "Indicateurs d'égalité professionnelle femmes‑hommes",
 };
 

--- a/packages/app/src/app/login/page.tsx
+++ b/packages/app/src/app/login/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { LoginPage, sanitizeCallbackUrl } from "~/modules/login";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Connexion" };
 
 type PageProps = {
 	searchParams: Promise<{ callbackUrl?: string }>;

--- a/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
+++ b/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
@@ -12,7 +12,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { year } = await params;
 	return {
-		title: `Historique des modifications ${year} — Egapro`,
+		title: `Historique des modifications ${year}`,
 	};
 }
 

--- a/packages/app/src/app/mon-espace/mes-entreprises/page.tsx
+++ b/packages/app/src/app/mon-espace/mes-entreprises/page.tsx
@@ -4,6 +4,8 @@ import { MyCompaniesPage } from "~/modules/my-space";
 import { auth } from "~/server/auth";
 import { HydrateClient } from "~/trpc/server";
 
+export const metadata = { title: "Mes entreprises" };
+
 export default async function Page() {
 	const session = await auth();
 

--- a/packages/app/src/app/mon-espace/page.tsx
+++ b/packages/app/src/app/mon-espace/page.tsx
@@ -5,6 +5,8 @@ import { auth } from "~/server/auth";
 import { getEffectiveSiren } from "~/server/auth/companyAccess";
 import { api, HydrateClient } from "~/trpc/server";
 
+export const metadata = { title: "Mon espace" };
+
 export default async function Page() {
 	const session = await auth();
 

--- a/packages/app/src/app/page.tsx
+++ b/packages/app/src/app/page.tsx
@@ -3,6 +3,8 @@ import { HomePage } from "~/modules/home";
 import { auth } from "~/server/auth";
 import { HydrateClient } from "~/trpc/server";
 
+export const metadata = { title: "Accueil" };
+
 export default async function Page() {
 	const session = await auth();
 

--- a/packages/app/src/modules/admin/AdminShell.tsx
+++ b/packages/app/src/modules/admin/AdminShell.tsx
@@ -12,7 +12,9 @@ export function AdminShell({ children }: Props) {
 				<div className={styles.nav}>
 					<AdminNavigation />
 				</div>
-				<div className={styles.content}>{children}</div>
+				<main className={styles.content} id="content" tabIndex={-1}>
+					{children}
+				</main>
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
@@ -23,6 +23,18 @@ describe("AdminShell", () => {
 		expect(screen.getByText("test content")).toBeInTheDocument();
 	});
 
+	it("wraps children in a focusable main landmark targeted by the skip link", () => {
+		render(
+			<AdminShell>
+				<p>test content</p>
+			</AdminShell>,
+		);
+		const main = screen.getByRole("main");
+		expect(main).toHaveAttribute("id", "content");
+		expect(main).toHaveAttribute("tabindex", "-1");
+		expect(main).toContainElement(screen.getByText("test content"));
+	});
+
 	it("wraps content in a fluid container", () => {
 		const { container } = render(<AdminShell>children</AdminShell>);
 		const wrapper = container.firstElementChild as HTMLElement;

--- a/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
@@ -84,7 +84,7 @@ export function AdminDeclarationDetailPage({ declarationId }: Props) {
 			{recap && (
 				<section className="fr-mt-6w">
 					<h2 className="fr-h3">Récapitulatif déclaré</h2>
-					<RecapitulatifPage {...recap} />
+					<RecapitulatifPage {...recap} titleTag="h3" />
 				</section>
 			)}
 		</div>

--- a/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
@@ -97,7 +97,6 @@ function CancelDeclarationButtonInner({
 									<p>{CANCEL_DECLARATION_MODAL_BODY}</p>
 									{error && (
 										<div
-											aria-live="polite"
 											className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
 											role="alert"
 										>

--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -37,11 +37,18 @@ export function DeclarationTable({
 	sortBy,
 	sortOrder,
 }: Props) {
-	const { handleSort, handlePageChange, sortIcon } = useSortableTable({
-		basePath: "/admin/declarations",
-		sortBy,
-		sortOrder,
-	});
+	const { handleSort, handlePageChange, ariaSort, sortIcon } = useSortableTable(
+		{
+			basePath: "/admin/declarations",
+			sortBy,
+			sortOrder,
+		},
+	);
+
+	const renderSortIcon = (column: SortColumn) => {
+		const icon = sortIcon(column);
+		return icon ? <span aria-hidden="true">{icon}</span> : null;
+	};
 
 	return (
 		<>
@@ -55,14 +62,14 @@ export function DeclarationTable({
 				<thead>
 					<tr>
 						{SORT_COLUMNS.map((col) => (
-							<th key={col} scope="col">
+							<th aria-sort={ariaSort(col)} key={col} scope="col">
 								<button
 									className="fr-text--sm"
 									onClick={() => handleSort(col)}
 									type="button"
 								>
 									{COLUMN_LABELS[col]}
-									{sortIcon(col)}
+									{renderSortIcon(col)}
 								</button>
 							</th>
 						))}

--- a/packages/app/src/modules/admin/declarations/DetailSections.tsx
+++ b/packages/app/src/modules/admin/declarations/DetailSections.tsx
@@ -193,7 +193,7 @@ export function FilesSection({ files }: { files: DeclarationDetail["files"] }) {
 							<td>{formatShortDate(file.uploadedAt)}</td>
 							<td>
 								<a
-									aria-label={`Télécharger ${file.fileName}`}
+									aria-label={`Télécharger ${file.fileName} (PDF)`}
 									className="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-download-line"
 									download
 									href={`/api/v1/files/${file.id}`}

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -20,7 +20,7 @@ export function SiblingDeclarationsSection({ siblings }: Props) {
 
 	return (
 		<section className="fr-mt-4w">
-			<h3 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h3>
+			<h2 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h2>
 			<ul className="fr-raw-list">
 				{siblings.map((sibling) => (
 					<li className="fr-mb-1w" key={sibling.id}>

--- a/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
@@ -90,8 +90,8 @@ function UnlockDeclarationButtonInner({
 									<p>{UNLOCK_DECLARATION_MODAL_BODY}</p>
 									{error && (
 										<div
-											aria-live="polite"
 											className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
+											role="alert"
 										>
 											<p>{error}</p>
 										</div>

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -71,6 +71,9 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
+import { defaultProps as recapProps } from "~/modules/declaration-remuneration/recapitulatif/__tests__/fixtures";
+import { api } from "~/trpc/react";
+
 import { AdminDeclarationDetailPage } from "../AdminDeclarationDetailPage";
 
 describe("AdminDeclarationDetailPage", () => {
@@ -113,7 +116,7 @@ describe("AdminDeclarationDetailPage", () => {
 		).toBeInTheDocument();
 		expect(screen.getByText("avis-cse.pdf")).toBeInTheDocument();
 		const downloadLink = screen.getByRole("link", {
-			name: "Télécharger avis-cse.pdf",
+			name: "Télécharger avis-cse.pdf (PDF)",
 		});
 		expect(downloadLink).toHaveAttribute("href", "/api/v1/files/file-1");
 	});
@@ -132,5 +135,21 @@ describe("AdminDeclarationDetailPage", () => {
 		expect(
 			screen.queryByRole("button", { name: "Déverrouiller la déclaration" }),
 		).toBeNull();
+	});
+
+	it("renders the embedded recap title as h3 so the page keeps a single h1", () => {
+		vi.mocked(api.adminDeclarations.getRecap.useQuery).mockReturnValueOnce({
+			data: recapProps(),
+		} as unknown as ReturnType<typeof api.adminDeclarations.getRecap.useQuery>);
+
+		render(<AdminDeclarationDetailPage declarationId="decl-1" />);
+
+		expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
@@ -64,6 +64,23 @@ describe("DeclarationTable", () => {
 		expect(screen.getByText("15/06/2024")).toBeInTheDocument();
 	});
 
+	it("exposes aria-sort on the sorted column and hides the sort glyph", () => {
+		render(<DeclarationTable {...defaultProps} />);
+
+		const sortedHeader = screen
+			.getByRole("button", { name: /date de dépôt/i })
+			.closest("th");
+		expect(sortedHeader).toHaveAttribute("aria-sort", "descending");
+
+		const unsortedHeader = screen
+			.getByRole("button", { name: /^siren/i })
+			.closest("th");
+		expect(unsortedHeader).not.toHaveAttribute("aria-sort");
+
+		const glyph = sortedHeader?.querySelector("[aria-hidden='true']");
+		expect(glyph).not.toBeNull();
+	});
+
 	it("shows empty state when no rows", () => {
 		render(<DeclarationTable {...defaultProps} rows={[]} total={0} />);
 

--- a/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
@@ -138,7 +138,7 @@ describe("FilesSection", () => {
 		expect(screen.getByText("avis-cse.pdf")).toBeInTheDocument();
 		expect(screen.getByText("Avis CSE")).toBeInTheDocument();
 		const link = screen.getByRole("link", {
-			name: "Télécharger avis-cse.pdf",
+			name: "Télécharger avis-cse.pdf (PDF)",
 		});
 		expect(link).toHaveAttribute("href", "/api/v1/files/file-1");
 	});

--- a/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
@@ -28,7 +28,7 @@ describe("SiblingDeclarationsSection", () => {
 
 		expect(
 			screen.getByRole("heading", {
-				level: 3,
+				level: 2,
 				name: "Autres déclarations pour ce SIREN / cette année",
 			}),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
+++ b/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
@@ -114,7 +114,7 @@ export function ImpersonateForm() {
 
 			{serverError && (
 				<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
-					<h3 className="fr-alert__title">Erreur</h3>
+					<h2 className="fr-alert__title">Erreur</h2>
 					<p>{serverError}</p>
 				</div>
 			)}

--- a/packages/app/src/modules/admin/referents/AdminReferentsPage.tsx
+++ b/packages/app/src/modules/admin/referents/AdminReferentsPage.tsx
@@ -208,8 +208,8 @@ function ReferentsContent() {
 			</div>
 			{deleteError && (
 				<div
-					aria-live="polite"
 					className="fr-alert fr-alert--error fr-alert--sm fr-mb-2w"
+					role="alert"
 				>
 					<p>{deleteError}</p>
 				</div>

--- a/packages/app/src/modules/admin/referents/ImportReferentsModal.tsx
+++ b/packages/app/src/modules/admin/referents/ImportReferentsModal.tsx
@@ -116,8 +116,8 @@ export function ImportReferentsModal({ modalRef, onClose, onSuccess }: Props) {
 								</div>
 								{error && (
 									<div
-										aria-live="polite"
 										className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
+										role="alert"
 									>
 										<p>{error}</p>
 									</div>

--- a/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
+++ b/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
@@ -54,12 +54,18 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.name ? `${modalId}-name-error` : undefined}
+					aria-invalid={errors.name ? true : undefined}
 					className={`fr-input ${errors.name ? "fr-input--error" : ""}`}
 					id={`${modalId}-name`}
 					type="text"
 					{...register("name")}
 				/>
-				{errors.name && <p className="fr-error-text">{errors.name.message}</p>}
+				{errors.name && (
+					<p className="fr-error-text" id={`${modalId}-name-error`}>
+						{errors.name.message}
+					</p>
+				)}
 			</div>
 
 			<div className="fr-select-group fr-mb-3w">
@@ -67,6 +73,10 @@ export function ReferentFormFields({
 					Région
 				</label>
 				<select
+					aria-describedby={
+						errors.region ? `${modalId}-region-error` : undefined
+					}
+					aria-invalid={errors.region ? true : undefined}
 					className={`fr-select ${errors.region ? "fr-select--error" : ""}`}
 					id={`${modalId}-region`}
 					{...register("region")}
@@ -79,7 +89,9 @@ export function ReferentFormFields({
 					))}
 				</select>
 				{errors.region && (
-					<p className="fr-error-text">{errors.region.message}</p>
+					<p className="fr-error-text" id={`${modalId}-region-error`}>
+						{errors.region.message}
+					</p>
 				)}
 			</div>
 
@@ -143,13 +155,17 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.value ? `${modalId}-value-error` : undefined}
+					aria-invalid={errors.value ? true : undefined}
 					className={`fr-input ${errors.value ? "fr-input--error" : ""}`}
 					id={`${modalId}-value`}
 					type={selectedType === "url" ? "url" : "email"}
 					{...register("value")}
 				/>
 				{errors.value && (
-					<p className="fr-error-text">{errors.value.message}</p>
+					<p className="fr-error-text" id={`${modalId}-value-error`}>
+						{errors.value.message}
+					</p>
 				)}
 			</div>
 
@@ -175,13 +191,21 @@ export function ReferentFormFields({
 							Email du suppléant
 						</label>
 						<input
+							aria-describedby={
+								errors.substituteEmail
+									? `${modalId}-sub-email-error`
+									: undefined
+							}
+							aria-invalid={errors.substituteEmail ? true : undefined}
 							className={`fr-input ${errors.substituteEmail ? "fr-input--error" : ""}`}
 							id={`${modalId}-sub-email`}
 							type="email"
 							{...register("substituteEmail")}
 						/>
 						{errors.substituteEmail && (
-							<p className="fr-error-text">{errors.substituteEmail.message}</p>
+							<p className="fr-error-text" id={`${modalId}-sub-email-error`}>
+								{errors.substituteEmail.message}
+							</p>
 						)}
 					</div>
 				</div>

--- a/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
+++ b/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import type { FieldErrors } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { ReferentFormFields } from "../ReferentFormFields";
+import type { ReferentFormValues } from "../schemas";
+
+function Harness({ errors }: { errors: FieldErrors<ReferentFormValues> }) {
+	const { register, watch } = useForm<ReferentFormValues>({
+		defaultValues: {
+			principal: false,
+			name: "",
+			county: "",
+			type: "email",
+			value: "",
+			substituteName: "",
+			substituteEmail: "",
+		},
+	});
+	return (
+		<ReferentFormFields
+			errors={errors}
+			modalId="referent-modal"
+			register={register}
+			watch={watch}
+		/>
+	);
+}
+
+describe("ReferentFormFields", () => {
+	it("renders fields without error attributes when there is no error", () => {
+		render(<Harness errors={{}} />);
+		// Anchored on the field's own label ("Nom"), decoupled from the hint
+		// wording; the negative lookahead avoids matching "Nom du suppléant".
+		const nameInput = screen.getByRole("textbox", { name: /^Nom(?! du)/ });
+		expect(nameInput).not.toHaveAttribute("aria-invalid");
+		expect(nameInput).not.toHaveAttribute("aria-describedby");
+		const regionSelect = screen.getByLabelText("Région");
+		expect(regionSelect).not.toHaveAttribute("aria-invalid");
+		expect(regionSelect).not.toHaveAttribute("aria-describedby");
+	});
+
+	it("associates the name error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					name: { type: "required", message: "Le nom est obligatoire" },
+				}}
+			/>,
+		);
+		// Anchored on the field's own label ("Nom"), decoupled from the hint
+		// wording; the negative lookahead avoids matching "Nom du suppléant".
+		const nameInput = screen.getByRole("textbox", { name: /^Nom(?! du)/ });
+		expect(nameInput).toHaveAttribute("aria-invalid", "true");
+		expect(nameInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-name-error",
+		);
+		expect(screen.getByText("Le nom est obligatoire")).toHaveAttribute(
+			"id",
+			"referent-modal-name-error",
+		);
+	});
+
+	it("associates the region error with its select (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					region: {
+						type: "invalid_type",
+						message: "La région est obligatoire",
+					},
+				}}
+			/>,
+		);
+		const regionSelect = screen.getByLabelText("Région");
+		expect(regionSelect).toHaveAttribute("aria-invalid", "true");
+		expect(regionSelect).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-region-error",
+		);
+		expect(screen.getByText("La région est obligatoire")).toHaveAttribute(
+			"id",
+			"referent-modal-region-error",
+		);
+	});
+
+	it("associates the value error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					value: { type: "invalid_string", message: "L'email est invalide" },
+				}}
+			/>,
+		);
+		const valueInput = screen.getByRole("textbox", { name: /^Valeur/ });
+		expect(valueInput).toHaveAttribute("aria-invalid", "true");
+		expect(valueInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-value-error",
+		);
+		expect(screen.getByText("L'email est invalide")).toHaveAttribute(
+			"id",
+			"referent-modal-value-error",
+		);
+	});
+
+	it("associates the substitute email error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					substituteEmail: {
+						type: "invalid_string",
+						message: "L'email du suppléant est invalide",
+					},
+				}}
+			/>,
+		);
+		const substituteEmailInput = screen.getByRole("textbox", {
+			name: "Email du suppléant",
+		});
+		expect(substituteEmailInput).toHaveAttribute("aria-invalid", "true");
+		expect(substituteEmailInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-sub-email-error",
+		);
+		expect(
+			screen.getByText("L'email du suppléant est invalide"),
+		).toHaveAttribute("id", "referent-modal-sub-email-error");
+	});
+});

--- a/packages/app/src/modules/admin/stats/StatsDashboard.tsx
+++ b/packages/app/src/modules/admin/stats/StatsDashboard.tsx
@@ -207,7 +207,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								<p aria-live="polite">Chargement du graphique…</p>
 							)}
 							{progressionQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des statistiques.
 									</p>
@@ -249,7 +249,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								<p aria-live="polite">Chargement du graphique…</p>
 							)}
 							{stepDurationsQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des délais par
 										étape.
@@ -281,7 +281,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								<p aria-live="polite">Chargement du graphique…</p>
 							)}
 							{stepDropoffQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des taux
 										d'abandon.
@@ -335,7 +335,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 					</p>
 				)}
 				{funnelQuery.isError && (
-					<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-4w">
+					<div className="fr-alert fr-alert--error fr-mt-4w" role="alert">
 						<p>Une erreur est survenue lors du chargement des funnels.</p>
 					</div>
 				)}
@@ -456,7 +456,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 					</p>
 				)}
 				{matomoFunnelQuery.isError && (
-					<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-4w">
+					<div className="fr-alert fr-alert--error fr-mt-4w" role="alert">
 						<p>
 							Une erreur est survenue lors du chargement des funnels Matomo.
 						</p>
@@ -547,7 +547,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								Usage du modèle (indicateur par catégorie)
 							</h3>
 							{matomoCategoryModelQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement de l&apos;usage
 										du modèle.
@@ -593,7 +593,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								Liens d&apos;aide les plus cliqués
 							</h3>
 							{matomoHelpLinksQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des liens
 										d&apos;aide.
@@ -631,7 +631,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								Répartition par appareil
 							</h3>
 							{matomoDeviceQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement de la répartition
 										par appareil.

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -30,7 +30,7 @@ export function CseOpinionLayout({
 	lockHolder = null,
 }: Props) {
 	return (
-		<>
+		<main id="content" tabIndex={-1}>
 			<div className={`fr-py-3w ${styles.banner}`}>
 				<div className="fr-container">
 					<Breadcrumb
@@ -78,7 +78,7 @@ export function CseOpinionLayout({
 					</div>
 				</div>
 			</div>
-			<main className="fr-container fr-py-7w" id="content">
+			<div className="fr-container fr-py-7w">
 				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
 					<div className="fr-grid-row fr-grid-row--center">
 						<div className="fr-col-12 fr-col-lg-8">
@@ -89,7 +89,7 @@ export function CseOpinionLayout({
 						</div>
 					</div>
 				</LockProvider>
-			</main>
-		</>
+			</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
@@ -9,4 +9,13 @@
 	margin: 0;
 	padding: 0;
 	min-width: 0;
+
+	// Read-only inputs mirror the DSFR disabled styling so the locked state
+	// stays visually identical while the content remains exposed to assistive
+	// technologies (issue 3803).
+	input[readonly] {
+		color: var(--text-disabled-grey);
+		box-shadow: inset 0 -2px 0 0 var(--border-disabled-grey);
+		cursor: default;
+	}
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -203,7 +203,11 @@ export function Step1Opinions({
 			{/* noValidate: the required radios expose the required state to
 			    assistive tech (RGAA 11.10) without native browser bubbles
 			    preempting the app's own zod + custom validation messages. */}
-			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (disabled radios, readOnly
+			    dates, disabled submit button): a fieldset-level `disabled` would
+			    hide the content from some assistive technologies (#3803). */}
+			<fieldset className={styles.readOnlyFieldset}>
+				<legend className="fr-sr-only">Avis du CSE</legend>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
 						<div className="fr-col">
@@ -261,6 +265,7 @@ export function Step1Opinions({
 							triggerDraftSave();
 						}}
 						opinion={firstDeclOpinion ?? null}
+						readOnly={isReadOnly}
 						title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
 					/>
 
@@ -285,6 +290,7 @@ export function Step1Opinions({
 									triggerDraftSave();
 								}}
 								opinion={firstDeclGapOpinion ?? null}
+								readOnly={isReadOnly}
 							/>
 						)}
 					/>
@@ -311,6 +317,7 @@ export function Step1Opinions({
 									triggerDraftSave();
 								}}
 								opinion={secondDeclOpinion ?? null}
+								readOnly={isReadOnly}
 								title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
 							/>
 
@@ -335,6 +342,7 @@ export function Step1Opinions({
 											triggerDraftSave();
 										}}
 										opinion={secondDeclGapOpinion ?? null}
+										readOnly={isReadOnly}
 									/>
 								)}
 							/>

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -199,7 +199,10 @@ export function Step1Opinions({
 	}
 
 	return (
-		<form autoComplete="off" onSubmit={onSubmit}>
+		<form autoComplete="off" noValidate onSubmit={onSubmit}>
+			{/* noValidate: the required radios expose the required state to
+			    assistive tech (RGAA 11.10) without native browser bubbles
+			    preempting the app's own zod + custom validation messages. */}
 			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -128,6 +128,16 @@ describe("Step1Opinions", () => {
 		);
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
+
+		expect(
+			screen.getByRole("group", { name: "Avis du CSE" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders compliance path title when compliancePath is joint_evaluation", () => {
 		render(
 			<Step1Opinions
@@ -700,11 +710,15 @@ describe("Step1Opinions", () => {
 			);
 		}
 
-		it("disables the whole fieldset when the declaration is locked", () => {
+		it("keeps the fieldset enabled and marks the date inputs read-only when the declaration is locked", () => {
 			const { container } = renderLocked();
 
-			const fieldset = container.querySelector("fieldset");
-			expect(fieldset).toBeDisabled();
+			// The fieldset stays enabled so its content remains exposed to
+			// assistive technologies; each control is locked individually.
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			expect(
+				container.querySelector("#first-decl-accuracy-date"),
+			).toHaveAttribute("readonly");
 		});
 
 		it("disables every input and the next button when locked", () => {
@@ -721,8 +735,8 @@ describe("Step1Opinions", () => {
 			renderLocked();
 
 			const favorable = screen.getAllByLabelText("Favorable")[0] as HTMLElement;
-			// A disabled fieldset still lets us fire the handler imperatively; the
-			// click is a no-op but we assert no draft write occurs regardless.
+			// The radio is individually disabled while locked; the click is a
+			// no-op but we assert no draft write occurs regardless.
 			await user.click(favorable);
 
 			expect(mockSetField).not.toHaveBeenCalled();
@@ -750,11 +764,12 @@ describe("Step1Opinions", () => {
 			mockedUseSession.mockReset();
 		});
 
-		it("disables the fieldset and next button under the static provider when impersonating", () => {
+		it("disables the radios and next button under the static provider when impersonating", () => {
 			mockImpersonating();
 
 			// The static provider receives `isReadOnly={false}` from the layout but
-			// must still disable writes when an admin is impersonating.
+			// must still disable writes when an admin is impersonating. The
+			// fieldset itself stays enabled for assistive technologies.
 			const { container } = render(
 				<LockProvider isReadOnly={false}>
 					<Step1Opinions
@@ -765,7 +780,10 @@ describe("Step1Opinions", () => {
 				</LockProvider>,
 			);
 
-			expect(container.querySelector("fieldset")).toBeDisabled();
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			for (const radio of screen.getAllByRole("radio")) {
+				expect(radio).toBeDisabled();
+			}
 			expect(screen.getByRole("button", { name: /Suivant/ })).toBeDisabled();
 		});
 

--- a/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
@@ -8,6 +8,7 @@ type Props = {
 	date: string;
 	onOpinionChange: (value: OpinionType) => void;
 	onDateChange: (value: string) => void;
+	readOnly?: boolean;
 };
 
 export function AccuracyOpinionCard({
@@ -17,6 +18,7 @@ export function AccuracyOpinionCard({
 	date,
 	onOpinionChange,
 	onDateChange,
+	readOnly = false,
 }: Props) {
 	const legendId = `${id}-legend`;
 	const dateId = `${id}-date`;
@@ -38,6 +40,7 @@ export function AccuracyOpinionCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={opinion === "favorable"}
+							disabled={readOnly}
 							id={`${id}-favorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("favorable")}
@@ -54,6 +57,7 @@ export function AccuracyOpinionCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={opinion === "unfavorable"}
+							disabled={readOnly}
 							id={`${id}-unfavorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("unfavorable")}
@@ -83,6 +87,7 @@ export function AccuracyOpinionCard({
 					id={dateId}
 					onChange={(e) => onDateChange(e.target.value)}
 					placeholder="Sélectionner une date"
+					readOnly={readOnly}
 					type="date"
 					value={date}
 				/>

--- a/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
@@ -41,6 +41,7 @@ export function AccuracyOpinionCard({
 							id={`${id}-favorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("favorable")}
+							required
 							type="radio"
 							value="favorable"
 						/>
@@ -56,6 +57,7 @@ export function AccuracyOpinionCard({
 							id={`${id}-unfavorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("unfavorable")}
+							required
 							type="radio"
 							value="unfavorable"
 						/>

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -46,6 +46,7 @@ export function GapConsultationCard({
 							id={`${id}-yes`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(true)}
+							required
 							type="radio"
 							value="yes"
 						/>
@@ -61,6 +62,7 @@ export function GapConsultationCard({
 							id={`${id}-no`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(false)}
+							required
 							type="radio"
 							value="no"
 						/>
@@ -92,6 +94,7 @@ export function GapConsultationCard({
 									id={`${id}-favorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("favorable")}
+									required
 									type="radio"
 									value="favorable"
 								/>
@@ -107,6 +110,7 @@ export function GapConsultationCard({
 									id={`${id}-unfavorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("unfavorable")}
+									required
 									type="radio"
 									value="unfavorable"
 								/>

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -9,6 +9,7 @@ type Props = {
 	onConsultedChange: (value: boolean) => void;
 	onOpinionChange: (value: OpinionType) => void;
 	onDateChange: (value: string) => void;
+	readOnly?: boolean;
 };
 
 export function GapConsultationCard({
@@ -19,6 +20,7 @@ export function GapConsultationCard({
 	onConsultedChange,
 	onOpinionChange,
 	onDateChange,
+	readOnly = false,
 }: Props) {
 	const legendId = `${id}-legend`;
 	const opinionLegendId = `${id}-opinion-legend`;
@@ -43,6 +45,7 @@ export function GapConsultationCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={consulted === true}
+							disabled={readOnly}
 							id={`${id}-yes`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(true)}
@@ -59,6 +62,7 @@ export function GapConsultationCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={consulted === false}
+							disabled={readOnly}
 							id={`${id}-no`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(false)}
@@ -91,6 +95,7 @@ export function GapConsultationCard({
 							<div className="fr-radio-group fr-radio-rich">
 								<input
 									checked={opinion === "favorable"}
+									disabled={readOnly}
 									id={`${id}-favorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("favorable")}
@@ -107,6 +112,7 @@ export function GapConsultationCard({
 							<div className="fr-radio-group fr-radio-rich">
 								<input
 									checked={opinion === "unfavorable"}
+									disabled={readOnly}
 									id={`${id}-unfavorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("unfavorable")}
@@ -131,6 +137,7 @@ export function GapConsultationCard({
 							id={dateId}
 							onChange={(e) => onDateChange(e.target.value)}
 							placeholder="Sélectionner une date"
+							readOnly={readOnly}
 							type="date"
 							value={date}
 						/>

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -28,12 +28,12 @@ export function DeclarationLayout({
 	lockHolder = null,
 }: DeclarationLayoutProps) {
 	return (
-		<>
+		<main id="content" tabIndex={-1}>
 			<CompanyBanner
 				company={company}
 				currentPageLabel={`Démarche des indicateurs de rémunération ${declarationYear}`}
 			/>
-			<main className="fr-container fr-py-7w" id="content">
+			<div className="fr-container fr-py-7w">
 				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
 					<div className="fr-grid-row fr-grid-row--center">
 						<div className="fr-col-12 fr-col-lg-8">
@@ -44,7 +44,7 @@ export function DeclarationLayout({
 						</div>
 					</div>
 				</LockProvider>
-			</main>
-		</>
+			</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/MissingSiret.tsx
+++ b/packages/app/src/modules/declaration-remuneration/MissingSiret.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export function MissingSiret() {
 	return (
-		<main className="fr-container fr-my-4w" id="content">
+		<main className="fr-container fr-my-4w" id="content" tabIndex={-1}>
 			<div className="fr-grid-row fr-grid-row--center">
 				<div className="fr-col-12 fr-col-md-8">
 					<h1>SIRET manquant</h1>

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -57,6 +57,7 @@ export { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 export { Step6Review } from "./steps/Step6Review";
 export {
 	COMPLIANCE_FUNNEL,
+	SECOND_DECLARATION_STEP_TITLES,
 	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -116,7 +116,9 @@ export function CategoryRecapTable({
 										<th scope="row">Effectif physique</th>
 										<td className={indicatorStyles.numeric}>{womenCount} nb</td>
 										<td className={indicatorStyles.numeric}>{menCount} nb</td>
-										<td />
+										<td>
+											<span className="fr-sr-only">Non applicable</span>
+										</td>
 									</tr>
 
 									<tr className={styles.sectionRow}>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
@@ -343,7 +343,9 @@ function QuartileDistributionTable({
 									})}
 									<tr>
 										<th scope="row">Tous les salariés</th>
-										<td colSpan={2} />
+										<td colSpan={2}>
+											<span className="fr-sr-only">Non applicable</span>
+										</td>
 										<td className={styles.numeric}>
 											<strong>{totalWomen || "-"}</strong>
 										</td>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -42,6 +42,9 @@ type Props = {
 	step4Data: Step4Data;
 	step5Categories: EmployeeCategoryRow[];
 	step5Source: string | null;
+	// Demote the page title when the recap is embedded in a host page that
+	// already renders its own <h1> (e.g. /admin/declarations/[id]) — RGAA 9.1.
+	titleTag?: "h1" | "h3";
 };
 
 type InfoItem = { label: string; value: string };
@@ -84,6 +87,7 @@ export function RecapitulatifPage({
 	step4Data,
 	step5Categories,
 	step5Source,
+	titleTag: TitleTag = "h1",
 }: Props) {
 	const declarantItems: InfoItem[] = [];
 	if (declarantName) {
@@ -121,14 +125,15 @@ export function RecapitulatifPage({
 		<div className={common.flexColumnGap2}>
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
+					<TitleTag className="fr-h4 fr-mb-0">
 						{isCorrection
 							? `Seconde déclaration des écarts de rémunération par catégorie de salariés ${declarationYear}`
 							: `Déclaration des indicateurs de rémunération ${declarationYear}`}
-					</h1>
+					</TitleTag>
 				</div>
 				<div className="fr-col-auto">
 					<a
+						aria-label="Télécharger la déclaration des indicateurs de rémunération (PDF)"
 						className="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-download-line"
 						download
 						href={buildPdfHref(declarationYear, isCorrection)}

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -20,16 +20,31 @@ describe("RecapitulatifPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("demotes the title to h3 when embedded via titleTag (no second h1)", () => {
+		render(<RecapitulatifPage {...defaultProps()} titleTag="h3" />);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+	});
+
 	it("renders 'Télécharger' tertiary download button", () => {
 		render(<RecapitulatifPage {...defaultProps()} />);
-		const link = screen.getByRole("link", { name: "Télécharger" });
+		const link = screen.getByRole("link", {
+			name: "Télécharger la déclaration des indicateurs de rémunération (PDF)",
+		});
 		expect(link).toHaveAttribute("href", "/api/declaration-pdf?year=2025");
 		expect(link.className).toContain("fr-btn--tertiary");
 	});
 
 	it("renders download link with correction param when isCorrection", () => {
 		render(<RecapitulatifPage {...defaultProps()} isCorrection />);
-		const link = screen.getByRole("link", { name: "Télécharger" });
+		const link = screen.getByRole("link", {
+			name: "Télécharger la déclaration des indicateurs de rémunération (PDF)",
+		});
 		expect(link).toHaveAttribute(
 			"href",
 			"/api/declaration-pdf?year=2025&type=correction",

--- a/packages/app/src/modules/declaration-remuneration/shared/DevFillButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/DevFillButton.tsx
@@ -4,14 +4,16 @@ import { env } from "~/env";
 
 type Props = {
 	onFill: () => void;
+	disabled?: boolean;
 };
 
-export function DevFillButton({ onFill }: Props) {
+export function DevFillButton({ onFill, disabled = false }: Props) {
 	if (env.NEXT_PUBLIC_EGAPRO_ENV !== "dev") return null;
 
 	return (
 		<button
 			className="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left"
+			disabled={disabled}
 			onClick={onFill}
 			type="button"
 		>

--- a/packages/app/src/modules/declaration-remuneration/shared/FormErrors.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormErrors.tsx
@@ -10,12 +10,12 @@ export function FormErrors({
 	return (
 		<>
 			{validationError && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
+				<div className="fr-alert fr-alert--error" role="alert">
 					<p>{validationError}</p>
 				</div>
 			)}
 			{mutationError && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
+				<div className="fr-alert fr-alert--error" role="alert">
 					<p>{mutationError}</p>
 				</div>
 			)}

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -10,6 +10,9 @@
 	gap: 0.5rem;
 
 	input {
-		min-width: 5rem;
+		// Keep the entered amount readable at 200% zoom / narrow viewports
+		// (RGAA 10.4): the cell must never crush the input below the width of
+		// a typical amount — the DSFR table wrapper scrolls instead.
+		min-width: 7.5rem;
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
@@ -40,6 +40,7 @@ type PayGapTableProps = {
 	onRowChange: (index: number, field: PayGapField, value: string) => void;
 	className?: string;
 	disabled?: boolean;
+	readOnly?: boolean;
 };
 
 export function PayGapTable({
@@ -49,6 +50,7 @@ export function PayGapTable({
 	onRowChange,
 	className,
 	disabled = false,
+	readOnly = false,
 }: PayGapTableProps) {
 	return (
 		<div
@@ -97,6 +99,7 @@ export function PayGapTable({
 														onChange={(e) =>
 															onRowChange(i, "womenValue", e.target.value)
 														}
+														readOnly={readOnly}
 														type="text"
 														value={displayDecimal(row.womenValue)}
 													/>
@@ -118,6 +121,7 @@ export function PayGapTable({
 														onChange={(e) =>
 															onRowChange(i, "menValue", e.target.value)
 														}
+														readOnly={readOnly}
 														type="text"
 														value={displayDecimal(row.menValue)}
 													/>

--- a/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
@@ -9,6 +9,7 @@ type StepTitleRowProps = {
 	hasData: boolean;
 	isSaving?: boolean;
 	isPendingSave?: boolean;
+	devFillDisabled?: boolean;
 };
 
 export function StepTitleRow({
@@ -17,12 +18,13 @@ export function StepTitleRow({
 	hasData,
 	isSaving = false,
 	isPendingSave = false,
+	devFillDisabled = false,
 }: StepTitleRowProps) {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 			<div className="fr-col">{title}</div>
 			<div className="fr-col-auto">
-				<DevFillButton onFill={onDevFill} />
+				<DevFillButton disabled={devFillDisabled} onFill={onDevFill} />
 			</div>
 			<div className="fr-col-auto">
 				<SavedIndicator

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
@@ -8,22 +8,25 @@ type TooltipButtonProps = {
 	text?: string;
 };
 
-const PLACEHOLDER_TEXT =
-	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-
 export function TooltipButton({ id, label, text }: TooltipButtonProps) {
+	const labelId = `${id}-label`;
 	return (
 		<>
 			<button
-				aria-describedby={id}
+				aria-describedby={text ? id : undefined}
+				aria-labelledby={labelId}
 				className={`fr-btn--tooltip fr-btn ${styles.button}`}
 				type="button"
 			>
-				<span className="fr-sr-only">{label}</span>
+				<span className="fr-sr-only" id={labelId}>
+					{label}
+				</span>
 			</button>
-			<span className="fr-tooltip fr-placement" id={id} role="tooltip">
-				{text ?? PLACEHOLDER_TEXT}
-			</span>
+			{text && (
+				<span className="fr-tooltip fr-placement" id={id} role="tooltip">
+					{text}
+				</span>
+			)}
 		</>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
@@ -16,10 +16,11 @@ export function TooltipButton({ id, label, text }: TooltipButtonProps) {
 		<>
 			<button
 				aria-describedby={id}
-				aria-label={label}
 				className={`fr-btn--tooltip fr-btn ${styles.button}`}
 				type="button"
-			/>
+			>
+				<span className="fr-sr-only">{label}</span>
+			</button>
 			<span className="fr-tooltip fr-placement" id={id} role="tooltip">
 				{text ?? PLACEHOLDER_TEXT}
 			</span>

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
@@ -36,7 +36,9 @@ describe("PrefillSource", () => {
 		render(<PrefillSource periodEnd={null} />);
 
 		expect(
-			screen.getByLabelText("Information sur la source des données"),
+			screen.getByRole("button", {
+				name: "Information sur la source des données",
+			}),
 		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
@@ -70,4 +70,13 @@
 	margin: 0;
 	padding: 0;
 	min-width: 0;
+
+	// Read-only inputs mirror the DSFR disabled styling so the locked state
+	// stays visually identical while the content remains exposed to assistive
+	// technologies (issue 3803).
+	input[readonly] {
+		color: var(--text-disabled-grey);
+		box-shadow: inset 0 -2px 0 0 var(--border-disabled-grey);
+		cursor: default;
+	}
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -15,7 +15,10 @@ export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {
 
 	return (
 		<div className="fr-alert fr-alert--warning fr-mb-3w" role="alert">
-			<h3 className="fr-alert__title">Déclaration en cours de modification</h3>
+			{/* The alert renders above the page <h1> in every host page (tunnel
+			    layouts, my-space panel), so its title must stay out of the heading
+			    outline (RGAA 9.1) — the DSFR class keeps the visual unchanged. */}
+			<p className="fr-alert__title">Déclaration en cours de modification</p>
 			<p>
 				{`${identity} modifie actuellement cette déclaration. Vous pouvez la consulter en lecture seule jusqu'à la fin de sa modification.`}
 			</p>

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -124,7 +124,11 @@ export function CompliancePathChoice({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (disabled radios and submit
+			    button): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
+				<legend className="fr-sr-only">Choix du parcours de conformité</legend>
 				<div className={common.flexBetween}>
 					<h1 className="fr-h4 fr-mb-0">
 						Déclaration des indicateurs de rémunération {currentYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
@@ -1,6 +1,18 @@
+// Minimum width of a workforce-count input, sized for a 6-digit value. Shared
+// between the input rule (which keeps the value readable) and the column rule
+// so both stay in sync (RGAA 10.4).
+$workforce-input-min-width: 6rem;
+
 .workforceTable {
 	table {
 		width: 100%;
+	}
+
+	// Keep the entered workforce count readable at 200% zoom / narrow
+	// viewports (RGAA 10.4): the cell must never crush the input below the
+	// width of a 6-digit count — the DSFR table wrapper scrolls instead.
+	input {
+		min-width: $workforce-input-min-width;
 	}
 
 	@include respond-from(md) {
@@ -17,7 +29,7 @@
 }
 
 .inputCol {
-	min-width: 6rem;
+	min-width: $workforce-input-min-width;
 
 	@include respond-from(md) {
 		width: 30%;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -270,7 +270,9 @@ export function Step1Workforce({
 												</colgroup>
 												<thead>
 													<tr>
-														<th scope="col">{/* vide */}</th>
+														<th scope="col">
+															<span className="fr-sr-only">Donnée</span>
+														</th>
 														<th scope="col">Femmes</th>
 														<th scope="col">Hommes</th>
 														<th scope="col">Total</th>
@@ -278,9 +280,7 @@ export function Step1Workforce({
 												</thead>
 												<tbody>
 													<tr>
-														<td>
-															<strong>Nombre de salariés</strong>
-														</td>
+														<th scope="row">Nombre de salariés</th>
 														<td>
 															<div
 																className={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -197,8 +197,13 @@ export function Step1Workforce({
 				className={common.flexColumnGap2}
 				onSubmit={onSubmit}
 			>
-				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				{/* Read-only mode is enforced per control (readOnly inputs, disabled
+				    buttons): a fieldset-level `disabled` would hide the content from
+				    some assistive technologies (#3803). */}
+				<fieldset className={common.readOnlyFieldset}>
+					<legend className="fr-sr-only">Effectifs</legend>
 					<StepTitleRow
+						devFillDisabled={isReadOnly}
 						hasData={hasData}
 						isPendingSave={isPendingSave}
 						isSaving={isSaving}
@@ -295,6 +300,7 @@ export function Step1Workforce({
 																	inputMode="numeric"
 																	onChange={handleWomenChange}
 																	pattern="[0-9]*"
+																	readOnly={isReadOnly}
 																	type="text"
 																	value={womenRaw}
 																/>
@@ -324,6 +330,7 @@ export function Step1Workforce({
 																	inputMode="numeric"
 																	onChange={handleMenChange}
 																	pattern="[0-9]*"
+																	readOnly={isReadOnly}
 																	type="text"
 																	value={menRaw}
 																/>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -136,8 +136,13 @@ export function Step2PayGap({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (readOnly inputs, disabled
+			    buttons): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
+				<legend className="fr-sr-only">Écarts de rémunération</legend>
 				<StepTitleRow
+					devFillDisabled={isReadOnly}
 					hasData={hasData}
 					isPendingSave={isPendingSave}
 					isSaving={isSaving}
@@ -190,6 +195,7 @@ export function Step2PayGap({
 							columnHeader="Rémunération"
 							disabled={isImpersonating}
 							onRowChange={handleRowChange}
+							readOnly={isReadOnly}
 							rows={rows}
 						/>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -112,9 +112,10 @@ export function Step3VariablePay({
 	const beneficiaryWomen = formData.indicatorEWomen ?? "";
 	const beneficiaryMen = formData.indicatorEMen ?? "";
 
-	const [benefValidationError, setBenefValidationError] = useState<
-		string | null
-	>(null);
+	const [benefValidationError, setBenefValidationError] = useState<{
+		field: "indicatorEMen" | "indicatorEWomen";
+		message: string;
+	} | null>(null);
 	const hasData = hasSavedData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -149,9 +150,10 @@ export function Step3VariablePay({
 		const n = Number.parseInt(value, 10);
 		if (Number.isNaN(n) || n < 0) return;
 		if (max !== undefined && n > max) {
-			setBenefValidationError(
-				`Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
-			);
+			setBenefValidationError({
+				field,
+				message: `Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
+			});
 			return;
 		}
 		setBenefValidationError(null);
@@ -177,8 +179,15 @@ export function Step3VariablePay({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (readOnly inputs, disabled
+			    buttons): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
+				<legend className="fr-sr-only">
+					Rémunérations variables ou complémentaires
+				</legend>
 				<StepTitleRow
+					devFillDisabled={isReadOnly}
 					hasData={hasData}
 					isPendingSave={isPendingSave}
 					isSaving={isSaving}
@@ -240,6 +249,7 @@ export function Step3VariablePay({
 							}
 							disabled={isImpersonating}
 							onRowChange={handleRowChange}
+							readOnly={isReadOnly}
 							rows={rows}
 						/>
 
@@ -296,6 +306,18 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field ===
+																"indicatorEWomen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field ===
+																"indicatorEWomen"
+																	? true
+																	: undefined
+															}
 															aria-label="Bénéficiaires femmes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -308,6 +330,7 @@ export function Step3VariablePay({
 																)
 															}
 															pattern="[0-9]*"
+															readOnly={isReadOnly}
 															type="text"
 															value={beneficiaryWomen}
 														/>
@@ -327,6 +350,16 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field === "indicatorEMen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field === "indicatorEMen"
+																	? true
+																	: undefined
+															}
 															aria-label="Bénéficiaires hommes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -339,6 +372,7 @@ export function Step3VariablePay({
 																)
 															}
 															pattern="[0-9]*"
+															readOnly={isReadOnly}
 															type="text"
 															value={beneficiaryMen}
 														/>
@@ -361,7 +395,9 @@ export function Step3VariablePay({
 								className="fr-alert fr-alert--error fr-alert--sm"
 								role="alert"
 							>
-								<p>{benefValidationError}</p>
+								<p id="step3-beneficiaries-error">
+									{benefValidationError.message}
+								</p>
 							</div>
 						)}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -358,8 +358,8 @@ export function Step3VariablePay({
 
 						{benefValidationError && (
 							<div
-								aria-live="polite"
 								className="fr-alert fr-alert--error fr-alert--sm"
+								role="alert"
 							>
 								<p>{benefValidationError}</p>
 							</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -261,8 +261,13 @@ export function Step4QuartileDistribution({
 			noValidate
 			onSubmit={onSubmit}
 		>
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (readOnly inputs, disabled
+			    buttons): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
+				<legend className="fr-sr-only">Distribution par quartile</legend>
 				<StepTitleRow
+					devFillDisabled={isReadOnly}
 					hasData={hasData}
 					isPendingSave={isPendingSave}
 					isSaving={isSaving}
@@ -345,6 +350,7 @@ export function Step4QuartileDistribution({
 							handleQuartileChange("annual", index, field, value)
 						}
 						quartiles={annual}
+						readOnly={isReadOnly}
 						sourceNote={
 							gipPrefillData ? (
 								<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />
@@ -362,6 +368,7 @@ export function Step4QuartileDistribution({
 							handleQuartileChange("hourly", index, field, value)
 						}
 						quartiles={hourly}
+						readOnly={isReadOnly}
 						sourceNote={
 							gipPrefillData ? (
 								<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -13,7 +13,6 @@ import {
 	DECLARATION_FUNNEL,
 	declarationFunnelDimensions,
 } from "../shared/funnelConfig";
-import { useLockContext } from "../shared/lock/LockContext";
 import { NextStepsBox } from "../shared/NextStepsBox";
 import { SavedIndicator } from "../shared/SavedIndicator";
 import { StepIndicator } from "../shared/StepIndicator";
@@ -61,7 +60,6 @@ export function Step6Review({
 	hasCse = null,
 }: Props) {
 	const router = useRouter();
-	const { isReadOnly } = useLockContext();
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const submitMutation = api.declaration.submit.useMutation({
 		onSuccess: () => {
@@ -162,7 +160,11 @@ export function Step6Review({
 			className={stepStyles.formColumn}
 			onSubmit={handleSubmit}
 		>
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (the submit button reads the
+			    lock context): a fieldset-level `disabled` would hide the content
+			    from some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
+				<legend className="fr-sr-only">Récapitulatif de la déclaration</legend>
 				<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -94,6 +94,21 @@ describe("CompliancePathChoice", () => {
 		).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Choix du parcours de conformité" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders all 3 compliance path options", () => {
 		render(
 			<CompliancePathChoice
@@ -470,7 +485,7 @@ describe("CompliancePathChoice", () => {
 			expect(mockSetField).not.toHaveBeenCalled();
 		});
 
-		it("disables the path fieldset when the declaration is locked read-only", () => {
+		it("disables each control while keeping the fieldset enabled when the declaration is locked read-only", () => {
 			const { container } = render(
 				<LockProvider isReadOnly>
 					<CompliancePathChoice
@@ -483,8 +498,12 @@ describe("CompliancePathChoice", () => {
 				</LockProvider>,
 			);
 
-			// The outermost fieldset wraps the entire form in read-only mode.
-			expect(container.querySelector("fieldset")).toBeDisabled();
+			// The outermost fieldset stays enabled so its content remains exposed
+			// to assistive technologies; each control is disabled individually.
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			expect(
+				screen.getByLabelText("Actions correctives et seconde déclaration"),
+			).toBeDisabled();
 			expect(screen.getByRole("button", { name: /suivant/i })).toBeDisabled();
 		});
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -71,6 +71,25 @@ describe("Step1Workforce", () => {
 		expect(screen.getByLabelText("Nombre d'hommes")).toHaveValue("");
 	});
 
+	it("gives every column header a non-empty accessible name and exposes the row label as a rowheader (RGAA 5.7)", () => {
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
+		);
+		for (const header of screen.getAllByRole("columnheader")) {
+			expect(header).toHaveAccessibleName();
+		}
+		expect(
+			screen.getByRole("columnheader", { name: "Donnée" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("rowheader", { name: "Nombre de salariés" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders reference period and mandatory fields notice", () => {
 		render(
 			<Step1Workforce
@@ -101,7 +120,7 @@ describe("Step1Workforce", () => {
 			.getByText("Nombre de salariés")
 			.closest("tr") as HTMLElement;
 		const cells = within(row).getAllByRole("cell");
-		expect(cells[3]).toHaveTextContent("30");
+		expect(cells[2]).toHaveTextContent("30");
 	});
 
 	it("shows SavedIndicator when initial data has values", () => {
@@ -152,7 +171,7 @@ describe("Step1Workforce", () => {
 			.getByText("Nombre de salariés")
 			.closest("tr") as HTMLElement;
 		const cells = within(row).getAllByRole("cell");
-		expect(cells[3]).toHaveTextContent("40");
+		expect(cells[2]).toHaveTextContent("40");
 	});
 
 	it("validates total > 0 on submit", async () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -40,6 +40,19 @@ describe("Step1Workforce", () => {
 		);
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Effectifs" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders default state with zero totals", () => {
 		render(
 			<Step1Workforce

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -45,6 +45,19 @@ describe("Step2PayGap", () => {
 		expect(screen.getByText("Horaire brute médiane")).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Écarts de rémunération" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
 			<Step2PayGap

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -47,6 +47,21 @@ describe("Step3VariablePay", () => {
 		expect(screen.getByText("Horaire brute médiane")).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", {
+				name: "Rémunérations variables ou complémentaires",
+			}),
+		).toBeInTheDocument();
+	});
+
 	it("renders the beneficiaries table with workforce totals", () => {
 		render(
 			<Step3VariablePay
@@ -220,6 +235,93 @@ describe("Step3VariablePay", () => {
 
 		// Should show validation error since 20 > 15
 		expect(screen.getByText(/ne peut pas dépasser/i)).toBeInTheDocument();
+	});
+
+	it("associates the beneficiaries error with the women input (RGAA 11.10)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+		const menInput = screen.getByLabelText("Bénéficiaires hommes");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
+
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
+		expect(womenInput).toHaveAttribute(
+			"aria-describedby",
+			"step3-beneficiaries-error",
+		);
+		expect(menInput).not.toHaveAttribute("aria-invalid");
+		expect(menInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.getByText(/ne peut pas dépasser/i)).toHaveAttribute(
+			"id",
+			"step3-beneficiaries-error",
+		);
+	});
+
+	it("associates the beneficiaries error with the men input (RGAA 11.10)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+		const menInput = screen.getByLabelText("Bénéficiaires hommes");
+
+		await user.clear(menInput);
+		await user.type(menInput, "30");
+
+		expect(menInput).toHaveAttribute("aria-invalid", "true");
+		expect(menInput).toHaveAttribute(
+			"aria-describedby",
+			"step3-beneficiaries-error",
+		);
+		expect(womenInput).not.toHaveAttribute("aria-invalid");
+		expect(womenInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.getByText(/ne peut pas dépasser/i)).toHaveAttribute(
+			"id",
+			"step3-beneficiaries-error",
+		);
+	});
+
+	it("clears the error association once the value is valid again", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "10");
+		expect(womenInput).not.toHaveAttribute("aria-invalid");
+		expect(womenInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.queryByText(/ne peut pas dépasser/i)).not.toBeInTheDocument();
 	});
 
 	it("renders previous link pointing to step 2", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -63,6 +63,19 @@ describe("Step4QuartileDistribution", () => {
 		expect(screen.getAllByText(/Tous les salariés/).length).toBe(2);
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Distribution par quartile" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders renumeration tranche header and Pourcentage columns", () => {
 		render(
 			<Step4QuartileDistribution

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -63,6 +63,22 @@ describe("Step4QuartileDistribution", () => {
 		expect(screen.getAllByText(/Tous les salariés/).length).toBe(2);
 	});
 
+	it("gives every column header a non-empty accessible name, including the previously empty quartile header (RGAA 5.7)", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+		for (const header of screen.getAllByRole("columnheader")) {
+			expect(header).toHaveAccessibleName();
+		}
+		expect(
+			screen.getAllByRole("columnheader", { name: "Quartile" }),
+		).toHaveLength(2);
+	});
+
 	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
 		render(
 			<Step4QuartileDistribution

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -129,6 +129,28 @@ describe("Step5EmployeeCategories", () => {
 		expect(descriptionParagraph.nextElementSibling).toBe(obligatoiresParagraph);
 	});
 
+	it("gives every column header a non-empty accessible name and exposes row labels as rowheaders (RGAA 5.7)", () => {
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+		for (const header of screen.getAllByRole("columnheader")) {
+			expect(header).toHaveAccessibleName();
+		}
+		expect(
+			screen.getByRole("columnheader", { name: "Donnée" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("rowheader", { name: "Effectif physique" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByRole("rowheader", { name: "Salaire de base" }),
+		).toHaveLength(2);
+		expect(screen.getAllByRole("rowheader", { name: "Total" })).toHaveLength(2);
+	});
+
 	it("renders table headers for the category", () => {
 		render(
 			<Step5EmployeeCategories

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -108,6 +108,22 @@ describe("Step6Review", () => {
 		).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step6Review
+				companyWorkforce={null}
+				declaration={emptyDeclaration()}
+				declarationYear={2025}
+				step2Data={emptyStep2Data()}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Récapitulatif de la déclaration" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders description text", () => {
 		render(
 			<Step6Review

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -84,7 +84,13 @@ export function JointEvaluationForm({
 				className={common.flexColumnGap2}
 				onSubmit={handleSubmit}
 			>
-				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				{/* Read-only mode is enforced per control (disabled upload and submit
+				    button): a fieldset-level `disabled` would hide the content from
+				    some assistive technologies (#3803). */}
+				<fieldset className={common.readOnlyFieldset}>
+					<legend className="fr-sr-only">
+						Évaluation conjointe des rémunérations
+					</legend>
 					<div className={common.flexBetween}>
 						<h1 className="fr-h4 fr-mb-0">
 							Parcours de mise en conformité pour l&apos;indicateur par

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -88,6 +88,16 @@ describe("JointEvaluationForm", () => {
 		).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(<JointEvaluationForm {...defaultProps} />);
+
+		expect(
+			screen.getByRole("group", {
+				name: "Évaluation conjointe des rémunérations",
+			}),
+		).toBeInTheDocument();
+	});
+
 	it("renders the deadline callout with the current year", () => {
 		render(<JointEvaluationForm {...defaultProps} />);
 
@@ -204,7 +214,7 @@ describe("JointEvaluationForm", () => {
 			vi.mocked(useSession).mockReset();
 		});
 
-		it("disables the fieldset and submit button under the static provider when impersonating", () => {
+		it("disables the upload and submit controls under the static provider when impersonating", () => {
 			vi.mocked(useSession).mockReturnValue({
 				data: {
 					user: {
@@ -217,14 +227,19 @@ describe("JointEvaluationForm", () => {
 			} as unknown as ReturnType<typeof useSession>);
 
 			// The layout feeds `isReadOnly={false}` but impersonation must still
-			// disable writes through the unified context.
+			// disable writes through the unified context. The fieldset itself
+			// stays enabled so its content remains exposed to assistive
+			// technologies; each control is disabled individually.
 			const { container } = render(
 				<LockProvider isReadOnly={false}>
 					<JointEvaluationForm {...defaultProps} />
 				</LockProvider>,
 			);
 
-			expect(container.querySelector("fieldset")).toBeDisabled();
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			expect(
+				screen.getByRole("button", { name: /Sélectionner un fichier/ }),
+			).toBeDisabled();
 			expect(
 				screen.getByRole("button", { name: /transmettre/i }),
 			).toBeDisabled();

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.module.scss
@@ -1,3 +1,14 @@
-.periodLabel {
+.fieldset {
+	border: 0;
+	margin: 0;
+	padding: 0;
+	min-width: 0;
+}
+
+.legend {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0;
 	font-weight: 500;
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
@@ -17,21 +17,17 @@ export function ReferencePeriodPicker({
 	disabled = false,
 }: Props) {
 	return (
-		<div>
-			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-2w">
-				<div className="fr-col-auto">
-					<p className={`fr-mb-0 ${styles.periodLabel}`}>
-						Quelle est la période de référence pour le calcul de
-						l&apos;indicateur ?
-					</p>
-				</div>
-				<div className="fr-col-auto">
-					<TooltipButton
-						id="tooltip-second-decl-period"
-						label="Informations sur la période prise en compte pour la seconde déclaration"
-					/>
-				</div>
-			</div>
+		<fieldset className={styles.fieldset}>
+			<legend className={`fr-mb-2w ${styles.legend}`}>
+				<span>
+					Quelle est la période de référence pour le calcul de l&apos;indicateur
+					?
+				</span>
+				<TooltipButton
+					id="tooltip-second-decl-period"
+					label="Informations sur la période prise en compte pour la seconde déclaration"
+				/>
+			</legend>
 			<div className="fr-grid-row fr-grid-row--gutters">
 				<div className="fr-col-12 fr-col-md-4">
 					<div className="fr-input-group">
@@ -66,6 +62,6 @@ export function ReferencePeriodPicker({
 					</div>
 				</div>
 			</div>
-		</div>
+		</fieldset>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -77,15 +77,13 @@ describe("SecondDeclarationStep2Form", () => {
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		expect(
-			screen.getByText("Libellé de la catégorie d'emploi :"),
-		).toBeInTheDocument();
+		// The category label is now carried by the accordion heading and the
+		// table <caption> (RGAA 5.2) — no redundant read-only <p>, no editable input.
 		expect(
 			screen.getByRole("button", {
 				name: "Catégorie d'emplois n°1 : Ouvriers",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Ouvriers")).toBeInTheDocument();
 		expect(
 			screen.queryByLabelText("Libellé de la catégorie d'emploi"),
 		).not.toBeInTheDocument();
@@ -181,6 +179,5 @@ describe("SecondDeclarationStep2Form", () => {
 				name: "Catégorie d'emplois n°1 : Techniciens",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Techniciens")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -119,8 +119,12 @@ export function QuartileTable({
 										))}
 										<tr>
 											<th scope="row">Tous les salariés</th>
-											<td className={stepStyles.minCell} />
-											<td className={stepStyles.maxCell} />
+											<td className={stepStyles.minCell}>
+												<span className="fr-sr-only">Non applicable</span>
+											</td>
+											<td className={stepStyles.maxCell}>
+												<span className="fr-sr-only">Non applicable</span>
+											</td>
 											<td
 												className={stepStyles.numericCell}
 												data-mobile-label="Nombre de femmes"

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -78,7 +78,9 @@ export function QuartileTable({
 									</colgroup>
 									<thead>
 										<tr>
-											<th scope="col">{/* row label */}</th>
+											<th scope="col">
+												<span className="fr-sr-only">Quartile</span>
+											</th>
 											<th colSpan={2} scope="col">
 												Tranche de rémunération
 												<br />

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -29,6 +29,7 @@ type Props = {
 	sourceNote?: React.ReactNode;
 	onQuartileChange: (index: number, field: Field, value: string) => void;
 	disabled?: boolean;
+	readOnly?: boolean;
 };
 
 export function QuartileTable({
@@ -41,6 +42,7 @@ export function QuartileTable({
 	sourceNote,
 	onQuartileChange,
 	disabled = false,
+	readOnly = false,
 }: Props) {
 	const {
 		women: totalWomen,
@@ -114,6 +116,7 @@ export function QuartileTable({
 												min={mins[i] ?? ""}
 												onQuartileChange={onQuartileChange}
 												quartile={quartiles[i] ?? { threshold: undefined }}
+												readOnly={readOnly}
 												tableType={tableType}
 											/>
 										))}

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -68,6 +68,7 @@ type Props = {
 	min: string;
 	errors: QuartileFieldErrors;
 	disabled: boolean;
+	readOnly?: boolean;
 	onQuartileChange: (index: number, field: Field, value: string) => void;
 };
 
@@ -78,6 +79,7 @@ export function QuartileTableRow({
 	min,
 	errors,
 	disabled,
+	readOnly = false,
 	onQuartileChange,
 }: Props) {
 	const isLast = index === 3;
@@ -139,6 +141,7 @@ export function QuartileTableRow({
 								onChange={(e) =>
 									onQuartileChange(index, "threshold", e.target.value)
 								}
+								readOnly={readOnly}
 								type="text"
 								value={displayDecimal(quartile.threshold ?? "")}
 							/>
@@ -179,6 +182,7 @@ export function QuartileTableRow({
 						inputMode="numeric"
 						onChange={(e) => onQuartileChange(index, "women", e.target.value)}
 						pattern="[0-9]*"
+						readOnly={readOnly}
 						type="text"
 						value={quartile.women ?? ""}
 					/>
@@ -216,6 +220,7 @@ export function QuartileTableRow({
 						inputMode="numeric"
 						onChange={(e) => onQuartileChange(index, "men", e.target.value)}
 						pattern="[0-9]*"
+						readOnly={readOnly}
 						type="text"
 						value={quartile.men ?? ""}
 					/>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -217,7 +217,11 @@ export function CategoryDataTable({
 				<div className="fr-table__container">
 					<div className="fr-table__content">
 						<table>
-							<caption>Données catégorie {catIndex + 1}</caption>
+							<caption>
+								{cat.name.trim()
+									? `Catégorie d'emplois n°${catIndex + 1} : ${cat.name}`
+									: `Catégorie d'emplois n°${catIndex + 1}`}
+							</caption>
 							<thead>
 								<tr>
 									<th className={stepStyles.nameColumnHeader} scope="col">
@@ -237,7 +241,7 @@ export function CategoryDataTable({
 							<tbody>
 								<tr>
 									<td className={stepStyles.sectionHeader} colSpan={4}>
-										<strong>
+										<strong aria-atomic="true" aria-live="polite">
 											Total salariés
 											{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
 										</strong>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -281,7 +281,9 @@ export function CategoryDataTable({
 											<span className="fr-text--sm">nb</span>
 										</div>
 									</td>
-									<td />
+									<td>
+										<span className="fr-sr-only">Non applicable</span>
+									</td>
 								</tr>
 
 								<RemunerationSection

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -129,7 +129,7 @@ function RemunerationSection({
 				</td>
 			</tr>
 			<tr className={stepStyles.dataRow}>
-				<td>Salaire de base</td>
+				<th scope="row">Salaire de base</th>
 				<EuroInputCell
 					ariaLabel={`Salaire de base ${scope} femmes, catégorie ${catIndex + 1}`}
 					disabled={disabled}
@@ -153,11 +153,11 @@ function RemunerationSection({
 				</td>
 			</tr>
 			<tr className={stepStyles.dataRow}>
-				<td>
+				<th scope="row">
 					Composantes variables
 					<br />
 					ou complémentaires
-				</td>
+				</th>
 				<EuroInputCell
 					ariaLabel={`Composantes variables ${scope === "annuel" ? "annuelles" : "horaires"} femmes, catégorie ${catIndex + 1}`}
 					disabled={disabled}
@@ -183,9 +183,7 @@ function RemunerationSection({
 				</td>
 			</tr>
 			<tr className={stepStyles.dataRow}>
-				<td>
-					<strong>Total</strong>
-				</td>
+				<th scope="row">Total</th>
 				<td className={stepStyles.totalCell}>{formatTotal(totalWomen, "€")}</td>
 				<td className={stepStyles.totalCell}>{formatTotal(totalMen, "€")}</td>
 				<td>
@@ -225,7 +223,7 @@ export function CategoryDataTable({
 							<thead>
 								<tr>
 									<th className={stepStyles.nameColumnHeader} scope="col">
-										{/* row label */}
+										<span className="fr-sr-only">Donnée</span>
 									</th>
 									<th scope="col">Femmes</th>
 									<th scope="col">Hommes</th>
@@ -248,7 +246,7 @@ export function CategoryDataTable({
 									</td>
 								</tr>
 								<tr className={stepStyles.dataRow}>
-									<td>Effectif physique</td>
+									<th scope="row">Effectif physique</th>
 									<td>
 										<div className={stepStyles.inputCell}>
 											<input

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -488,14 +488,7 @@ export function CategoryForm({
 								}}
 							>
 								<div className={stepStyles.categoryBlock}>
-									{readOnlyLabel ? (
-										<p className="fr-mb-0">
-											<span className="fr-text--bold">
-												Libellé de la catégorie d'emploi :{" "}
-											</span>
-											{cat?.name}
-										</p>
-									) : (
+									{!readOnlyLabel && (
 										<div className="fr-input-group fr-mb-0">
 											<label className="fr-label" htmlFor={`cat-${index}-name`}>
 												Libellé de la catégorie d'emploi

--- a/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
+++ b/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function DeclarationHistoryPage({ siren, year }: Props) {
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-4w">
 				<Breadcrumb
 					items={[

--- a/packages/app/src/modules/layout/Header/HeaderBrand.tsx
+++ b/packages/app/src/modules/layout/Header/HeaderBrand.tsx
@@ -14,7 +14,12 @@ export function HeaderBrand() {
 						et des solidarités
 					</p>
 				</div>
-				<div className="fr-header__navbar">
+				{/* RGAA 9.2: mobile counterpart of the desktop quick-access <nav>
+				    (`.fr-header__tools-links` in HeaderQuickAccess). The two share
+				    the same accessible name because only one is displayed per
+				    breakpoint (DSFR hides the navbar on desktop and the tools bar
+				    on mobile). */}
+				<nav aria-label="Accès rapides" className="fr-header__navbar">
 					<button
 						aria-controls="modal-menu"
 						aria-haspopup="dialog"
@@ -25,7 +30,7 @@ export function HeaderBrand() {
 					>
 						Menu
 					</button>
-				</div>
+				</nav>
 			</div>
 			<div className="fr-header__service">
 				<Link

--- a/packages/app/src/modules/layout/Header/HeaderQuickAccess.tsx
+++ b/packages/app/src/modules/layout/Header/HeaderQuickAccess.tsx
@@ -16,12 +16,16 @@ export async function HeaderQuickAccess() {
 
 	return (
 		<div className="fr-header__tools">
-			<div className="fr-header__tools-links">
+			{/* RGAA 9.2: the quick-access zone is a navigation landmark. The <nav>
+			    itself carries `.fr-header__tools-links` so the DSFR `HeaderLinks`
+			    script (which clones this element's innerHTML into the mobile menu)
+			    keeps comparing the exact same inner content. */}
+			<nav aria-label="Accès rapides" className="fr-header__tools-links">
 				<HeaderQuickAccessLinks
 					session={session}
 					userPhone={profile?.phone ?? null}
 				/>
-			</div>
+			</nav>
 		</div>
 	);
 }

--- a/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
+++ b/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { getDsfrModal } from "~/modules/shared";
 import styles from "./MobileUserBlock.module.scss";
+
+/** Frames to wait for the DSFR focus trap before focusing the name anyway. */
+const FOCUS_TRAP_MAX_FRAMES = 30;
 
 type Props = {
 	userName: string;
@@ -21,15 +24,69 @@ type Props = {
  * `.fr-header__menu-links` container).
  */
 export function MobileUserBlock({ userName, userEmail, userPhone }: Props) {
+	const userNameRef = useRef<HTMLParagraphElement>(null);
+
 	const openProfileModal = useCallback(() => {
 		const profile = document.getElementById("profile-modal");
 		if (profile) getDsfrModal(profile)?.disclose();
 	}, []);
 
+	// RGAA 12.8: when the mobile menu opens, the DSFR focus trap moves focus to
+	// the first interactive element (the "Fermer" button). The expected target
+	// is the first *content* element instead: the user name. Wait for the trap
+	// to settle (it polls with requestAnimationFrame until the modal is
+	// focusable), then re-target the focus onto the name. Closing the menu is
+	// untouched: DSFR gives focus back to the burger button natively.
+	useEffect(() => {
+		const menuModal = document.getElementById("modal-menu");
+		if (!menuModal) return;
+
+		let frame: number | null = null;
+
+		const cancelPendingFocus = () => {
+			if (frame !== null) window.cancelAnimationFrame(frame);
+			frame = null;
+		};
+
+		const handleDisclose = () => {
+			// Rapid re-opens (or a spurious double event) must not stack two
+			// concurrent polling loops onto the same ref.
+			cancelPendingFocus();
+			let attemptsLeft = FOCUS_TRAP_MAX_FRAMES;
+			const settle = () => {
+				if (attemptsLeft <= 0) {
+					// The trap never settled within the allowed frames — abort
+					// silently rather than steal focus from wherever it currently is
+					// (e.g. the modal never actually opened).
+					frame = null;
+					return;
+				}
+				if (menuModal.contains(document.activeElement)) {
+					frame = null;
+					userNameRef.current?.focus();
+					return;
+				}
+				attemptsLeft -= 1;
+				frame = window.requestAnimationFrame(settle);
+			};
+			frame = window.requestAnimationFrame(settle);
+		};
+
+		menuModal.addEventListener("dsfr.disclose", handleDisclose);
+		menuModal.addEventListener("dsfr.conceal", cancelPendingFocus);
+		return () => {
+			menuModal.removeEventListener("dsfr.disclose", handleDisclose);
+			menuModal.removeEventListener("dsfr.conceal", cancelPendingFocus);
+			cancelPendingFocus();
+		};
+	}, []);
+
 	return (
 		<div className={styles.wrapper}>
 			<div className={styles.userInfo}>
-				<p className={styles.userName}>{userName}</p>
+				<p className={styles.userName} ref={userNameRef} tabIndex={-1}>
+					{userName}
+				</p>
 				<p className={styles.userMeta}>{userEmail}</p>
 				{userPhone && <p className={styles.userMeta}>{userPhone}</p>}
 			</div>

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
@@ -34,6 +34,15 @@
 	gap: 0.5rem;
 }
 
+// role="menu" wrapper around the action groups: replicates the dropdown's
+// column flow so inserting it keeps the rendering pixel-identical.
+.menu {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
 .userName {
 	margin: 0;
 	font-size: 0.875rem;

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
@@ -65,6 +65,13 @@ export function UserAccountMenu({
 				case "Escape":
 					close();
 					break;
+				case "Tab":
+					// APG menu pattern: Tab dismisses the menu. Focus is handed back
+					// to the toggle button (via close) instead of letting the default
+					// move happen inside a menu that is about to unmount.
+					event.preventDefault();
+					close();
+					break;
 				case "ArrowDown": {
 					event.preventDefault();
 					const items = getMenuItems();
@@ -107,6 +114,7 @@ export function UserAccountMenu({
 				aria-expanded={isOpen}
 				aria-haspopup="menu"
 				className="fr-btn fr-btn--tertiary fr-icon-account-circle-line fr-btn--icon-left"
+				id="user-account-menu-button"
 				onClick={() => setIsOpen((prev) => !prev)}
 				ref={buttonRef}
 				type="button"
@@ -115,53 +123,72 @@ export function UserAccountMenu({
 			</button>
 
 			{isOpen && (
-				<div className={styles.dropdown} ref={menuRef} role="menu">
+				<div className={styles.dropdown} ref={menuRef}>
+					{/* The user info block sits outside the role="menu" element: a menu
+					    may only own menuitem/group/separator children, and static text
+					    would be skipped by screen readers in menu navigation mode. */}
 					<div className={styles.userInfo}>
 						<p className={styles.userName}>{userName}</p>
 						<p className={styles.userEmail}>{userEmail}</p>
 						{userPhone && <p className={styles.userEmail}>{userPhone}</p>}
 					</div>
 
-					<div className={styles.links}>
-						{isAdmin && (
+					{/* The two inner divs stay role-less: generic containers are
+					    ownership-transparent, so the menuitems remain owned by the
+					    menu (verified against axe aria-required-children). */}
+					<div
+						aria-labelledby="user-account-menu-button"
+						className={styles.menu}
+						role="menu"
+					>
+						<div className={styles.links}>
+							{isAdmin && (
+								<Link
+									className={styles.menuLink}
+									href="/admin"
+									onClick={close}
+									role="menuitem"
+									tabIndex={-1}
+								>
+									Administration
+								</Link>
+							)}
 							<Link
 								className={styles.menuLink}
-								href="/admin"
+								href="/mon-espace/mes-entreprises"
 								onClick={close}
 								role="menuitem"
+								tabIndex={-1}
 							>
-								Administration
+								Mes entreprises
 							</Link>
-						)}
-						<Link
-							className={styles.menuLink}
-							href="/mon-espace/mes-entreprises"
-							onClick={close}
-							role="menuitem"
-						>
-							Mes entreprises
-						</Link>
-						<button
-							className={styles.menuLink}
-							onClick={openProfileModal}
-							role="menuitem"
-							type="button"
-						>
-							Voir mon profil
-						</button>
-					</div>
+							<button
+								className={styles.menuLink}
+								onClick={openProfileModal}
+								role="menuitem"
+								tabIndex={-1}
+								type="button"
+							>
+								Voir mon profil
+							</button>
+						</div>
 
-					<div className={styles.logout}>
-						{/* Native <a> required: this route redirects to an external IdP (ProConnect),
-						    so we need a full browser navigation, not a client-side RSC fetch. */}
-						<a
-							className={styles.logoutLink}
-							href="/api/auth/logout"
-							role="menuitem"
-						>
-							<span aria-hidden="true" className="fr-icon-logout-box-r-line" />
-							Se déconnecter
-						</a>
+						<div className={styles.logout}>
+							{/* Native <a> required: this route redirects to an external IdP (ProConnect),
+							    so we need a full browser navigation, not a client-side RSC fetch. */}
+							<a
+								className={styles.logoutLink}
+								href="/api/auth/logout"
+								role="menuitem"
+								tabIndex={-1}
+							>
+								<span
+									aria-hidden="true"
+									className="fr-icon-logout-box-r-line"
+								/>
+								Se déconnecter
+							</a>
+						</div>
 					</div>
 				</div>
 			)}

--- a/packages/app/src/modules/layout/Header/__tests__/HeaderQuickAccess.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/HeaderQuickAccess.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	auth: vi.fn(),
+	profileGet: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+	auth: mocks.auth,
+}));
+
+vi.mock("~/trpc/server", () => ({
+	api: { profile: { get: mocks.profileGet } },
+}));
+
+import { HeaderQuickAccess } from "../HeaderQuickAccess";
+
+beforeEach(() => {
+	mocks.auth.mockResolvedValue(null);
+	mocks.profileGet.mockResolvedValue({ phone: null });
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("HeaderQuickAccess", () => {
+	it("wraps the quick access links in a 'Accès rapides' navigation landmark (RGAA 9.2)", async () => {
+		render(await HeaderQuickAccess());
+
+		const nav = screen.getByRole("navigation", { name: "Accès rapides" });
+		expect(nav).toContainElement(screen.getByRole("link", { name: "Aide" }));
+		expect(nav).toContainElement(
+			screen.getByRole("link", { name: "Se connecter" }),
+		);
+		// The profile query must stay guarded behind an authenticated session.
+		expect(mocks.profileGet).not.toHaveBeenCalled();
+	});
+
+	it("keeps the DSFR tools-links class on the navigation element (DSFR HeaderLinks hook)", async () => {
+		render(await HeaderQuickAccess());
+
+		expect(
+			screen.getByRole("navigation", { name: "Accès rapides" }),
+		).toHaveClass("fr-header__tools-links");
+	});
+
+	it("renders the account menu inside the landmark when signed in", async () => {
+		mocks.auth.mockResolvedValue({
+			user: {
+				email: "jean.dupont@example.fr",
+				name: "Jean Dupont",
+				phone: null,
+			},
+		});
+
+		render(await HeaderQuickAccess());
+
+		expect(
+			screen.getByRole("navigation", { name: "Accès rapides" }),
+		).toContainElement(screen.getByRole("button", { name: "Mon espace" }));
+	});
+});

--- a/packages/app/src/modules/layout/Header/__tests__/MobileUserBlock.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/MobileUserBlock.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { MobileUserBlock } from "../MobileUserBlock";
@@ -42,6 +42,39 @@ describe("MobileUserBlock", () => {
 		render(<MobileUserBlock {...defaultProps} />);
 		const link = screen.getByRole("link", { name: "Se déconnecter" });
 		expect(link).toHaveAttribute("href", "/api/auth/logout");
+	});
+
+	describe("focus on mobile menu opening (RGAA 12.8)", () => {
+		it("moves focus onto the user name once the DSFR focus trap settled", async () => {
+			// Simulate the DSFR mobile menu modal wrapping the block.
+			const menuModal = document.createElement("div");
+			menuModal.id = "modal-menu";
+			const closeButton = document.createElement("button");
+			closeButton.textContent = "Fermer";
+			menuModal.appendChild(closeButton);
+			document.body.appendChild(menuModal);
+
+			const { container } = render(<MobileUserBlock {...defaultProps} />, {
+				container: menuModal.appendChild(document.createElement("div")),
+			});
+
+			// DSFR dispatches dsfr.disclose, then its focus trap moves focus to
+			// the first interactive element (the close button).
+			fireEvent(menuModal, new Event("dsfr.disclose"));
+			closeButton.focus();
+
+			await waitFor(() => {
+				expect(screen.getByText("Jean Dupont")).toHaveFocus();
+			});
+
+			container.remove();
+			menuModal.remove();
+		});
+
+		it("makes the user name programmatically focusable only", () => {
+			render(<MobileUserBlock {...defaultProps} />);
+			expect(screen.getByText("Jean Dupont")).toHaveAttribute("tabindex", "-1");
+		});
 	});
 
 	it("opens the profile modal when 'Voir mon profil' is clicked", () => {

--- a/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
@@ -36,6 +36,30 @@ describe("UserAccountMenu", () => {
 			expect(screen.getByRole("menu")).toBeInTheDocument();
 		});
 
+		it("names the menu 'Mon espace'", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			expect(
+				screen.getByRole("menu", { name: "Mon espace" }),
+			).toBeInTheDocument();
+		});
+
+		it("keeps the user info block outside the menu element", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			expect(screen.getByRole("menu")).not.toContainElement(
+				screen.getByText("Jean Dupont"),
+			);
+		});
+
+		it("removes menu items from the natural tab order (roving focus)", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			for (const item of screen.getAllByRole("menuitem")) {
+				expect(item).toHaveAttribute("tabindex", "-1");
+			}
+		});
+
 		it("sets aria-expanded=true when open", () => {
 			render(<UserAccountMenu {...defaultProps} />);
 			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
@@ -104,6 +128,16 @@ describe("UserAccountMenu", () => {
 			expect(screen.getByRole("menu")).toBeInTheDocument();
 			fireEvent.keyDown(document, { key: "Escape" });
 			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+		});
+
+		it("closes the menu on Tab and returns focus to the toggle button", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			const toggle = screen.getByRole("button", { name: "Mon espace" });
+			fireEvent.click(toggle);
+			expect(screen.getByRole("menu")).toBeInTheDocument();
+			fireEvent.keyDown(document, { key: "Tab" });
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+			expect(toggle).toHaveFocus();
 		});
 
 		it("closes the menu when clicking outside", () => {

--- a/packages/app/src/modules/layout/PublicChrome.tsx
+++ b/packages/app/src/modules/layout/PublicChrome.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 
 import { Footer } from "./Footer";
 import { ResourceBanner } from "./ResourceBanner";
+import { isAdminRoute } from "./shared/routeUtils";
 
 /**
  * Renders the public help banner + footer on every route except the backoffice.
@@ -13,9 +14,7 @@ import { ResourceBanner } from "./ResourceBanner";
  */
 export function PublicChrome() {
 	const pathname = usePathname();
-	// Match the `/admin` segment boundary so hypothetical sibling routes like
-	// `/administrator` or `/admin-tools` keep the public chrome.
-	if (pathname === "/admin" || pathname?.startsWith("/admin/")) {
+	if (isAdminRoute(pathname)) {
 		return null;
 	}
 	const showResourceBanner = pathname !== "/login";

--- a/packages/app/src/modules/layout/ResourceBanner.tsx
+++ b/packages/app/src/modules/layout/ResourceBanner.tsx
@@ -44,6 +44,7 @@ export function ResourceBanner() {
 			className="fr-background-alt--blue-france fr-py-7w"
 		>
 			<div className="fr-container">
+				<h2 className="fr-sr-only">Ressources et aides</h2>
 				<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
 					<div className="fr-col-12 fr-col-md-10">
 						<div className="fr-grid-row fr-grid-row--gutters">

--- a/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
@@ -44,6 +44,16 @@ describe("ResourceBanner", () => {
 		expect(headings).toHaveLength(3);
 	});
 
+	it("renders a screen-reader-only section heading above the tiles", () => {
+		render(<ResourceBanner />);
+
+		const heading = screen.getByRole("heading", {
+			level: 2,
+			name: "Ressources et aides",
+		});
+		expect(heading).toHaveClass("fr-sr-only");
+	});
+
 	it("uses a 10/2 column ratio so the illustration sits flush right", () => {
 		const { container } = render(<ResourceBanner />);
 

--- a/packages/app/src/modules/layout/shared/SkipLinks.tsx
+++ b/packages/app/src/modules/layout/shared/SkipLinks.tsx
@@ -1,9 +1,21 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { isAdminRoute } from "./routeUtils";
+
 /**
  * Skip links — mandatory RGAA criterion 12.7.
  * Allow keyboard/screen reader users to skip directly
  * to the main content or the footer.
+ *
+ * Admin routes (`/admin/**`) render no footer (`PublicChrome` returns null),
+ * so the "Pied de page" link is hidden there to avoid an orphan anchor.
  */
 export function SkipLinks() {
+	const pathname = usePathname();
+	const hasFooter = !isAdminRoute(pathname);
+
 	return (
 		<div className="fr-skiplinks">
 			<nav aria-label="Accès rapide" className="fr-container">
@@ -13,11 +25,13 @@ export function SkipLinks() {
 							Contenu
 						</a>
 					</li>
-					<li>
-						<a className="fr-link" href="#footer">
-							Pied de page
-						</a>
-					</li>
+					{hasFooter && (
+						<li>
+							<a className="fr-link" href="#footer">
+								Pied de page
+							</a>
+						</li>
+					)}
 				</ul>
 			</nav>
 		</div>

--- a/packages/app/src/modules/layout/shared/__tests__/SkipLinks.test.tsx
+++ b/packages/app/src/modules/layout/shared/__tests__/SkipLinks.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { usePathname } from "next/navigation";
+import { beforeEach, describe, expect, it, type Mock } from "vitest";
 import { SkipLinks } from "../SkipLinks";
 
 describe("SkipLinks", () => {
+	beforeEach(() => {
+		(usePathname as Mock).mockReturnValue("/");
+	});
+
 	it("renders a <nav> with aria-label 'Accès rapide'", () => {
 		render(<SkipLinks />);
 		expect(
@@ -25,5 +30,41 @@ describe("SkipLinks", () => {
 	it("renders exactly two skip links", () => {
 		render(<SkipLinks />);
 		expect(screen.getAllByRole("link")).toHaveLength(2);
+	});
+
+	describe("on admin routes (no footer rendered)", () => {
+		it("hides the #footer link on /admin", () => {
+			(usePathname as Mock).mockReturnValue("/admin");
+			render(<SkipLinks />);
+			expect(
+				screen.queryByRole("link", { name: /pied de page/i }),
+			).not.toBeInTheDocument();
+			expect(screen.getAllByRole("link")).toHaveLength(1);
+		});
+
+		it("hides the #footer link on nested /admin/* routes", () => {
+			(usePathname as Mock).mockReturnValue("/admin/declarations");
+			render(<SkipLinks />);
+			expect(
+				screen.queryByRole("link", { name: /pied de page/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("keeps the #content link on /admin", () => {
+			(usePathname as Mock).mockReturnValue("/admin");
+			render(<SkipLinks />);
+			expect(screen.getByRole("link", { name: /contenu/i })).toHaveAttribute(
+				"href",
+				"#content",
+			);
+		});
+
+		it("keeps the #footer link on sibling routes merely starting with 'admin'", () => {
+			(usePathname as Mock).mockReturnValue("/administrator");
+			render(<SkipLinks />);
+			expect(
+				screen.getByRole("link", { name: /pied de page/i }),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/packages/app/src/modules/layout/shared/routeUtils.ts
+++ b/packages/app/src/modules/layout/shared/routeUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns true for the `/admin` root and every nested `/admin/**` route.
+ * Matches the `/admin` segment boundary so hypothetical sibling routes like
+ * `/administrator` or `/admin-tools` keep the public chrome.
+ *
+ * Shared by `PublicChrome` (which renders no footer on those routes) and
+ * `SkipLinks` (which hides the "Pied de page" skip link there so it never
+ * points to a missing anchor — RGAA 12.7).
+ */
+export function isAdminRoute(pathname: string | null): boolean {
+	return (
+		pathname !== null &&
+		(pathname === "/admin" || pathname.startsWith("/admin/"))
+	);
+}

--- a/packages/app/src/modules/login/ProConnectButton.tsx
+++ b/packages/app/src/modules/login/ProConnectButton.tsx
@@ -40,7 +40,6 @@ export function ProConnectButton({ callbackUrl }: Props) {
 					href="https://www.proconnect.gouv.fr/"
 					rel="noopener"
 					target="_blank"
-					title="Qu'est-ce que ProConnect ? - nouvelle fenêtre"
 				>
 					Qu'est-ce que ProConnect ?
 					<NewTabNotice />

--- a/packages/app/src/modules/my-space/ArchivesSection.tsx
+++ b/packages/app/src/modules/my-space/ArchivesSection.tsx
@@ -14,7 +14,7 @@ export function ArchivesSection() {
 						/>
 					</div>
 					<div className="fr-col">
-						<p className="fr-text--bold fr-mb-1w">Archives</p>
+						<h2 className="fr-text--md fr-mb-1w">Archives</h2>
 						<p className="fr-text--sm fr-mb-0">
 							Récupérer vos anciennes déclarations de l'index de l'égalité
 							professionnelle femmes-hommes.

--- a/packages/app/src/modules/my-space/CompanyCard.tsx
+++ b/packages/app/src/modules/my-space/CompanyCard.tsx
@@ -11,9 +11,9 @@ export function CompanyCard({ company }: Props) {
 		<div className="fr-card fr-card--horizontal fr-card--sm fr-enlarge-link">
 			<div className="fr-card__body">
 				<div className="fr-card__content">
-					<h3 className="fr-card__title">
+					<h2 className="fr-card__title">
 						<Link href="/mon-espace">{company.name}</Link>
-					</h3>
+					</h2>
 					<div className="fr-card__start">
 						<ul className="fr-badges-group">
 							<li>

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -66,7 +66,7 @@ export function CompanyDeclarationsPage({
 	});
 
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<WelcomeBanner />
 			<CompanyInfoBanner company={company} />
 			<DeclarationsSection

--- a/packages/app/src/modules/my-space/CompanyEditModal.module.scss
+++ b/packages/app/src/modules/my-space/CompanyEditModal.module.scss
@@ -1,8 +1,21 @@
+.infoList {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin: 0;
+}
+
 .infoRow {
 	display: flex;
 	align-items: baseline;
 	flex-wrap: wrap;
 	gap: 0.25rem;
+
+	dt,
+	dd {
+		margin: 0;
+		padding: 0;
+	}
 }
 
 .label {
@@ -25,8 +38,16 @@
 }
 
 .cseFieldset {
+	// A non-zero flex-basis keeps both rich radios at equal widths on wide
+	// screens (same rendering as flex-basis 0) but lets them wrap on their own
+	// line at reduced widths instead of being crushed/overflowing, so the DSFR
+	// focus outline (2px width + 2px offset outside the box) stays fully
+	// visible at every viewport width. The basis matches a rich radio card's
+	// natural width (~10rem incl. padding) so wrapping kicks in before any
+	// compression; no DSFR ancestor sets overflow:hidden, so nothing clips the
+	// outline once it wraps.
 	:global(.fr-fieldset__element--inline) {
-		flex: 1;
+		flex: 1 1 10rem;
 	}
 
 	> .sourceText {

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -60,6 +60,7 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 	return (
 		<dialog
 			aria-labelledby={MODAL_TITLE_ID}
+			aria-modal="true"
 			className="fr-modal"
 			id={MODAL_ID}
 			ref={dialogRef}
@@ -166,20 +167,24 @@ function CompanyReadonlySection({ company }: CompanyReadonlySectionProps) {
 	return (
 		<>
 			<div className={`fr-mb-4w ${styles.section}`}>
-				<InfoRow label="Raison sociale :" value={company.name} />
-				<InfoRow label="SIREN :" value={formatSiren(company.siren)} />
-				<InfoRow label="Adresse :" value={company.address} />
-				<InfoRow label="Code NAF :" value={company.nafCode} />
+				<dl className={styles.infoList}>
+					<InfoRow label="Raison sociale :" value={company.name} />
+					<InfoRow label="SIREN :" value={formatSiren(company.siren)} />
+					<InfoRow label="Adresse :" value={company.address} />
+					<InfoRow label="Code NAF :" value={company.nafCode} />
+				</dl>
 				<p className={`fr-text--sm fr-mb-0 ${styles.sourceText}`}>
 					Source : INSEE.
 				</p>
 			</div>
 
 			<div className={`fr-mb-4w ${styles.section}`}>
-				<InfoRow
-					label={`Effectif annuel moyen en ${CURRENT_YEAR} :`}
-					value={company.workforce?.toLocaleString("fr-FR")}
-				/>
+				<dl className={styles.infoList}>
+					<InfoRow
+						label={`Effectif annuel moyen en ${CURRENT_YEAR} :`}
+						value={company.workforce?.toLocaleString("fr-FR")}
+					/>
+				</dl>
 				<p className={`fr-text--sm fr-mb-0 ${styles.sourceText}`}>
 					Source : DSN (Déclarations sociales nominatives).
 				</p>
@@ -195,10 +200,12 @@ type InfoRowProps = {
 
 function InfoRow({ label, value }: InfoRowProps) {
 	return (
-		<p className={`fr-mb-0 ${styles.infoRow}`}>
-			<span className={styles.label}>{label}</span>
-			<strong>{value ?? "—"}</strong>
-		</p>
+		<div className={styles.infoRow}>
+			<dt className={styles.label}>{label}</dt>
+			<dd>
+				<strong>{value ?? "—"}</strong>
+			</dd>
+		</div>
 	);
 }
 

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
@@ -12,6 +12,7 @@
 	flex-wrap: wrap;
 	gap: 0.5rem 1.5rem;
 	align-items: center;
+	margin: 0;
 }
 
 .datapoint {
@@ -19,4 +20,10 @@
 	align-items: center;
 	gap: 0.25rem;
 	margin: 0;
+
+	dt,
+	dd {
+		margin: 0;
+		padding: 0;
+	}
 }

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -41,43 +41,55 @@ export function CompanyInfoBanner({ company }: Props) {
 					</div>
 				</div>
 
-				<div className={`${styles.infoRow} fr-mb-1w`}>
-					<p className={styles.datapoint}>
-						SIREN : <strong>{formatSiren(company.siren)}</strong>
-					</p>
+				<dl className={`${styles.infoRow} fr-mb-1w`}>
+					<div className={styles.datapoint}>
+						<dt>SIREN :</dt>
+						<dd>
+							<strong>{formatSiren(company.siren)}</strong>
+						</dd>
+					</div>
 					{company.address && (
-						<p className={styles.datapoint}>
-							Adresse : <strong>{formatAddress(company.address)}</strong>
-						</p>
+						<div className={styles.datapoint}>
+							<dt>Adresse :</dt>
+							<dd>
+								<strong>{formatAddress(company.address)}</strong>
+							</dd>
+						</div>
 					)}
-				</div>
+				</dl>
 
-				<div className={styles.infoRow}>
+				<dl className={styles.infoRow}>
 					{company.nafCode && (
-						<p className={styles.datapoint}>
-							Code NAF :{" "}
-							<strong>
-								{company.nafLabel
-									? `${company.nafCode} — ${company.nafLabel}`
-									: company.nafCode}
-							</strong>
-						</p>
+						<div className={styles.datapoint}>
+							<dt>Code NAF :</dt>
+							<dd>
+								<strong>
+									{company.nafLabel
+										? `${company.nafCode} — ${company.nafLabel}`
+										: company.nafCode}
+								</strong>
+							</dd>
+						</div>
 					)}
 					{company.workforce !== null && (
-						<p className={styles.datapoint}>
-							Effectif annuel moyen en {currentYear} :{" "}
-							<strong>{company.workforce}</strong>
-						</p>
+						<div className={styles.datapoint}>
+							<dt>Effectif annuel moyen en {currentYear} :</dt>
+							<dd>
+								<strong>{company.workforce}</strong>
+							</dd>
+						</div>
 					)}
-					<p className={styles.datapoint}>
-						Existence d'un CSE :{" "}
-						{company.hasCse !== null ? (
-							<strong>{company.hasCse ? "Oui" : "Non"}</strong>
-						) : (
-							<StatusBadge status="to_complete" />
-						)}
-					</p>
-				</div>
+					<div className={styles.datapoint}>
+						<dt>Existence d'un CSE :</dt>
+						<dd>
+							{company.hasCse !== null ? (
+								<strong>{company.hasCse ? "Oui" : "Non"}</strong>
+							) : (
+								<StatusBadge status="to_complete" />
+							)}
+						</dd>
+					</div>
+				</dl>
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -27,7 +27,7 @@ export function CompanyInfoBanner({ company }: Props) {
 
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">
 					<div className="fr-col">
-						<h2 className="fr-h4 fr-mb-0">{company.name}</h2>
+						<h1 className="fr-h4 fr-mb-0">{company.name}</h1>
 					</div>
 					<div className="fr-col-auto">
 						<button

--- a/packages/app/src/modules/my-space/CompanyListHeader.tsx
+++ b/packages/app/src/modules/my-space/CompanyListHeader.tsx
@@ -4,7 +4,7 @@ export function CompanyListHeader() {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3w">
 			<div className="fr-col">
-				<h2>Mes entreprises</h2>
+				<h1 className="fr-h2">Mes entreprises</h1>
 			</div>
 			<div className="fr-col-auto">
 				{/* TODO: Replace href with real ProConnect account URL */}

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
 import { useState } from "react";
 
 import type { CampaignDeadlines } from "~/modules/domain";
@@ -100,7 +99,9 @@ export function DeclarationsSection({
 		<div className="fr-container fr-my-6w">
 			<div className="fr-grid-row fr-grid-row--middle fr-mb-4w">
 				<div className="fr-col">
-					<h2 className="fr-mb-0">Démarche en cours</h2>
+					<h2 className="fr-mb-0" id="demarches-en-cours-title">
+						Démarche en cours
+					</h2>
 				</div>
 				{hasNoSanction && (
 					<div className="fr-col-auto">
@@ -117,38 +118,22 @@ export function DeclarationsSection({
 			{visibleCurrentDeclarations.length > 0 && (
 				<DeclarationsTable
 					campaignDeadlines={campaignDeadlines}
-					caption={
-						<>
-							Ce tableau présente la liste des démarches en cours.
-							<br />
-							Chaque ligne correspond à une démarche, avec les informations
-							suivantes : le type de démarche, l'année concernée, l'étape
-							actuelle, la date d'échéance, l'état d'avancement et les
-							ressources disponibles.
-						</>
-					}
 					declarations={visibleCurrentDeclarations}
 					hasCse={hasCse}
+					labelledById="demarches-en-cours-title"
 					userPhone={userPhone}
 				/>
 			)}
 			{visiblePreviousDeclarations.length > 0 && (
 				<>
-					<h2 className="fr-mt-6w fr-mb-3w">Années précédentes</h2>
+					<h2 className="fr-mt-6w fr-mb-3w" id="annees-precedentes-title">
+						Années précédentes
+					</h2>
 					<DeclarationsTable
 						campaignDeadlines={campaignDeadlines}
-						caption={
-							<>
-								Ce tableau présente l'historique des démarches.
-								<br />
-								Chaque ligne correspond à une démarche passée, avec les
-								informations suivantes : le type de démarche, l'année concernée,
-								les différentes étapes, les échéances, l'état final et les
-								ressources associées.
-							</>
-						}
 						declarations={visiblePreviousDeclarations}
 						hasCse={hasCse}
+						labelledById="annees-precedentes-title"
 						userPhone={userPhone}
 					/>
 				</>
@@ -190,7 +175,7 @@ export function DeclarationsSection({
 type DeclarationsTableProps = {
 	campaignDeadlines: CampaignDeadlines;
 	declarations: DeclarationItem[];
-	caption: ReactNode;
+	labelledById: string;
 	userPhone: string | null;
 	hasCse: boolean | null;
 };
@@ -198,7 +183,7 @@ type DeclarationsTableProps = {
 function DeclarationsTable({
 	campaignDeadlines,
 	declarations,
-	caption,
+	labelledById,
 	userPhone,
 	hasCse,
 }: DeclarationsTableProps) {
@@ -207,8 +192,7 @@ function DeclarationsTable({
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">
 					<div className="fr-table__content">
-						<table className={styles.tableSm}>
-							<caption className="fr-sr-only">{caption}</caption>
+						<table aria-labelledby={labelledById} className={styles.tableSm}>
 							<thead>
 								<tr>
 									<th scope="col">Déclaration</th>

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -218,10 +218,7 @@ export function MissingInfoModal({ siren, userPhone, hasCse }: Props) {
 							</fieldset>
 						)}
 						{submitError && (
-							<div
-								aria-live="polite"
-								className="fr-alert fr-alert--error fr-mt-2w"
-							>
+							<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
 								<p>{submitError}</p>
 							</div>
 						)}

--- a/packages/app/src/modules/my-space/MyCompaniesPage.tsx
+++ b/packages/app/src/modules/my-space/MyCompaniesPage.tsx
@@ -10,7 +10,7 @@ export async function MyCompaniesPage() {
 	const companies = await api.company.list();
 
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-my-4w">
 				<WelcomeBanner />
 				<CompanyListHeader />

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -80,7 +80,7 @@ export function PanelPlayground() {
 	}
 
 	return (
-		<main className="fr-container fr-py-6w" id="content">
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
 			<h1 className="fr-h3">DeclarationProcessPanel — Playground</h1>
 			<p className="fr-text--sm fr-text-mention--grey">
 				Dev-only page to visually test the panel with arbitrary variant and

--- a/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 import { ArchivesSection } from "../ArchivesSection";
 
 describe("ArchivesSection", () => {
-	it("renders the 'Archives' title", () => {
+	it("renders the 'Archives' title as an h2 heading", () => {
 		render(<ArchivesSection />);
-		expect(screen.getByText("Archives")).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Archives" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders the description text", () => {

--- a/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
@@ -18,6 +18,13 @@ describe("CompanyCard", () => {
 		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
+	it("renders the card title as an h2 heading", () => {
+		render(<CompanyCard company={company} />);
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders the SIREN number", () => {
 		render(<CompanyCard company={company} />);
 		expect(screen.getByText("N° SIREN : 532847196")).toBeInTheDocument();

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -109,7 +109,7 @@ describe("CompanyDeclarationsPage", () => {
 	it("renders the company name", () => {
 		renderPage();
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -54,6 +54,27 @@ describe("CompanyEditModal", () => {
 		);
 	});
 
+	it("marks the dialog as modal for assistive technologies", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		expect(container.querySelector("dialog")).toHaveAttribute(
+			"aria-modal",
+			"true",
+		);
+	});
+
+	it("structures readonly company data as description lists", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		const terms = Array.from(container.querySelectorAll("dl dt")).map(
+			(dt) => dt.textContent,
+		);
+		expect(terms).toContain("Raison sociale :");
+		expect(terms).toContain("SIREN :");
+		expect(terms).toContain("Adresse :");
+		expect(terms).toContain("Code NAF :");
+	});
+
 	it("renders the modal with company info", () => {
 		const { container } = render(<CompanyEditModal company={company} />);
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -15,10 +15,10 @@ const baseCompany: CompanyDetail = {
 };
 
 describe("CompanyInfoBanner", () => {
-	it("renders the company name as an h2 heading", () => {
+	it("renders the company name as the page h1 heading", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -22,6 +22,20 @@ describe("CompanyInfoBanner", () => {
 		).toBeInTheDocument();
 	});
 
+	it("structures company data as a description list", () => {
+		const { container } = render(
+			<CompanyInfoBanner
+				company={{ ...baseCompany, address: "12 RUE DE PARIS, 75001 PARIS" }}
+			/>,
+		);
+		const terms = Array.from(container.querySelectorAll("dl dt")).map(
+			(dt) => dt.textContent,
+		);
+		expect(terms).toContain("SIREN :");
+		expect(terms).toContain("Adresse :");
+		expect(terms).toContain("Existence d'un CSE :");
+	});
+
 	it("renders the formatted SIREN", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
 		expect(screen.getByText("532 847 196")).toBeInTheDocument();

--- a/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it } from "vitest";
 import { CompanyListHeader } from "../CompanyListHeader";
 
 describe("CompanyListHeader", () => {
-	it("renders the H2 title", () => {
+	it("renders the page h1 title", () => {
 		render(<CompanyListHeader />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
@@ -125,7 +125,7 @@ describe("MonEspacePage", () => {
 		render(page);
 		expect(screen.getByRole("main")).toHaveAttribute("id", "content");
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Test Company" }),
+			screen.getByRole("heading", { level: 1, name: "Test Company" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
@@ -45,7 +45,7 @@ describe("MyCompaniesPage", () => {
 		const page = await MyCompaniesPage();
 		render(page);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/profile/ProfileModal.module.scss
+++ b/packages/app/src/modules/profile/ProfileModal.module.scss
@@ -14,10 +14,14 @@
 }
 
 .readonlyValue {
+	width: 100%;
+	box-sizing: border-box;
 	padding: 0.5rem 1rem;
 	background-color: var(--background-contrast-grey);
+	border: none;
 	border-radius: 0.25rem 0.25rem 0 0;
 	border-bottom: 2px solid var(--border-default-grey);
+	font-family: inherit;
 	font-size: 1rem;
 	line-height: 1.5;
 	color: var(--text-mention-grey);

--- a/packages/app/src/modules/profile/ProfileModal.tsx
+++ b/packages/app/src/modules/profile/ProfileModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useId, useRef } from "react";
 
 import { getDsfrModal } from "~/modules/shared";
 import { PhoneField } from "~/modules/shared/PhoneField";
@@ -89,10 +89,11 @@ export function ProfileModal() {
 									<div className="fr-col-auto">
 										<button
 											aria-describedby="profile-tooltip"
-											aria-label="Aide"
 											className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-question-line"
 											type="button"
-										/>
+										>
+											<span className="fr-sr-only">Aide</span>
+										</button>
 										<span
 											className="fr-tooltip fr-placement"
 											id="profile-tooltip"
@@ -180,15 +181,21 @@ function ReadonlyField({
 	showEditIcon = true,
 	value,
 }: ReadonlyFieldProps) {
+	const fieldId = useId();
 	return (
 		<div className={styles.readonlyField}>
-			<div className={styles.readonlyLabel}>
+			<label className={styles.readonlyLabel} htmlFor={fieldId}>
 				<span>{label}</span>
 				{showEditIcon && (
 					<span aria-hidden="true" className="fr-icon-edit-line fr-icon--sm" />
 				)}
-			</div>
-			<div className={styles.readonlyValue}>{value || "—"}</div>
+			</label>
+			<input
+				className={styles.readonlyValue}
+				id={fieldId}
+				readOnly
+				value={value || "—"}
+			/>
 		</div>
 	);
 }

--- a/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
+++ b/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
@@ -112,20 +112,20 @@ describe("ProfileModal", () => {
 	it("renders the readonly Nom field with label and edit icon", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Nom")).toBeInTheDocument();
-		expect(screen.getByText("Martin")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Martin")).toBeInTheDocument();
 	});
 
 	it("renders the readonly Prénom field with label and edit icon", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Prénom")).toBeInTheDocument();
-		expect(screen.getByText("Julien")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Julien")).toBeInTheDocument();
 	});
 
 	it("renders the readonly Email field", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Email du déclarant")).toBeInTheDocument();
 		expect(
-			screen.getByText("julien.martin@alpha-solution.fr"),
+			screen.getByDisplayValue("julien.martin@alpha-solution.fr"),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/publicStats/PublicStatsPage.tsx
+++ b/packages/app/src/modules/publicStats/PublicStatsPage.tsx
@@ -3,13 +3,13 @@ import { ScoreDistributionTile } from "./ScoreDistributionTile";
 
 export function PublicStatsPage() {
 	return (
-		<div className="fr-container fr-py-6w">
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
 			<h1 className="fr-h1">Statistiques publiques</h1>
 			<p className="fr-text--lead fr-mb-4w">
 				Indicateurs clés sur l'égalité professionnelle femmes-hommes en France.
 			</p>
 			<CurrentCampaignRateTile />
 			<ScoreDistributionTile />
-		</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
@@ -1,4 +1,6 @@
 .chartWrapper {
 	width: 100%;
+	max-width: 100%;
+	min-width: 0;
 	height: 320px;
 }

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
@@ -75,9 +75,13 @@ export function ChartTooltip({ active, payload }: ChartTooltipProps) {
 
 export function ScoreDistributionChart({ brackets }: Props) {
 	return (
-		<div aria-hidden="true" className={styles.chartWrapper} role="presentation">
+		<div aria-hidden="true" className={styles.chartWrapper}>
 			<ResponsiveContainer>
-				<BarChart data={brackets} margin={{ top: 16, right: 16, bottom: 8 }}>
+				<BarChart
+					accessibilityLayer={false}
+					data={brackets}
+					margin={{ top: 16, right: 16, bottom: 8 }}
+				>
 					<CartesianGrid strokeDasharray="3 3" vertical={false} />
 					<XAxis dataKey="label" />
 					<YAxis tickFormatter={formatYAxisTick} />

--- a/packages/app/src/modules/publicStats/ScoreDistributionStates.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionStates.tsx
@@ -8,7 +8,7 @@ export function ScoreDistributionLoading() {
 
 export function ScoreDistributionTileError() {
 	return (
-		<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-6w">
+		<div className="fr-alert fr-alert--error fr-mt-6w" role="alert">
 			<p>
 				Une erreur est survenue lors du chargement de la distribution des
 				scores.

--- a/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
@@ -27,6 +27,13 @@ describe("PublicStatsPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders a focusable main landmark targeted by the skip link", () => {
+		render(<PublicStatsPage />);
+		const main = screen.getByRole("main");
+		expect(main).toHaveAttribute("id", "content");
+		expect(main).toHaveAttribute("tabindex", "-1");
+	});
+
 	it("renders the lead paragraph describing the page content", () => {
 		render(<PublicStatsPage />);
 		expect(

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
@@ -46,7 +46,15 @@ describe("ScoreDistributionChart", () => {
 			<ScoreDistributionChart brackets={baseBrackets} />,
 		);
 		const wrapper = container.querySelector("[aria-hidden='true']");
-		expect(wrapper).toHaveAttribute("role", "presentation");
+		expect(wrapper).not.toHaveAttribute("role");
+	});
+
+	it("exposes no focusable element under the aria-hidden wrapper", () => {
+		const { container } = render(
+			<ScoreDistributionChart brackets={baseBrackets} />,
+		);
+		const wrapper = container.querySelector("[aria-hidden='true']");
+		expect(wrapper?.querySelector("[tabindex]")).toBeNull();
 	});
 
 	it("renders even with an empty dataset (defensive)", () => {

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionStates.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionStates.test.tsx
@@ -15,13 +15,13 @@ describe("ScoreDistributionLoading", () => {
 });
 
 describe("ScoreDistributionTileError", () => {
-	it("renders a DSFR error alert with a polite live region", () => {
+	it("renders a DSFR error alert with role=alert", () => {
 		const { container } = render(<ScoreDistributionTileError />);
 		expect(
 			screen.getByText(/erreur est survenue lors du chargement/i),
 		).toBeInTheDocument();
 		const alert = container.querySelector(".fr-alert");
 		expect(alert).toHaveClass("fr-alert--error");
-		expect(alert).toHaveAttribute("aria-live", "polite");
+		expect(alert).toHaveAttribute("role", "alert");
 	});
 });

--- a/packages/app/src/modules/referents/PublicReferentsPage.tsx
+++ b/packages/app/src/modules/referents/PublicReferentsPage.tsx
@@ -55,7 +55,7 @@ function ReferentsContent() {
 				<p aria-live="polite">Chargement des résultats…</p>
 			)}
 			{hasFilter && isError && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
+				<div className="fr-alert fr-alert--error" role="alert">
 					<p>
 						Une erreur est survenue lors de la recherche. Veuillez réessayer.
 					</p>

--- a/packages/app/src/modules/shared/CampaignRateTileStates.tsx
+++ b/packages/app/src/modules/shared/CampaignRateTileStates.tsx
@@ -8,7 +8,7 @@ export function CampaignRateTileLoading() {
 
 export function CampaignRateTileError() {
 	return (
-		<div aria-live="polite" className="fr-alert fr-alert--error">
+		<div className="fr-alert fr-alert--error" role="alert">
 			<p>Une erreur est survenue lors du chargement du taux de déclaration.</p>
 		</div>
 	);

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -37,6 +37,7 @@ export function PhoneField({
 			</label>
 			<input
 				aria-describedby={messagesId}
+				autoComplete="tel"
 				className="fr-input"
 				id={inputId}
 				type="tel"

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -37,6 +37,7 @@ export function PhoneField({
 			</label>
 			<input
 				aria-describedby={messagesId}
+				aria-required="true"
 				autoComplete="tel"
 				className="fr-input"
 				id={inputId}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.javascript.lcov.reportPaths=packages/app/coverage/lcov.info
 sonar.exclusions=**/__tests__/**,**/*.test.*,**/*.spec.*,**/migrations/**,**/e2e/**,**/test/**
 
 # Exclusions from coverage analysis (infra/config files that cannot be unit tested)
-sonar.coverage.exclusions=**/instrumentation.ts,**/instrumentation-client.ts,**/sentry.*.config.ts,**/env.js,**/trpc/**,**/server/db/**,**/server/auth/**,**/server/services/**,**/app/api/**,**/testError/**,**/pdfStyles.ts,**/pdfFonts.ts,**/modules/export/queries.ts,**/app/test-panel/**,**/PanelPlayground.tsx,**/modules/mail/buildReceiptAttachments.ts
+sonar.coverage.exclusions=**/instrumentation.ts,**/instrumentation-client.ts,**/sentry.*.config.ts,**/env.js,**/trpc/**,**/server/db/**,**/server/auth/**,**/server/services/**,**/app/api/**,**/testError/**,**/pdfStyles.ts,**/pdfFonts.ts,**/modules/export/queries.ts,**/app/test-panel/**,**/PanelPlayground.tsx,**/modules/mail/buildReceiptAttachments.ts,**/app/**/page.tsx,**/app/**/layout.tsx
 
 # Duplication exclusions (data-only files with repetitive structure)
 sonar.cpd.exclusions=**/faqData.ts,**/devFillData.ts,**/PrefillPdfDocument.tsx


### PR DESCRIPTION
## Lot global — remédiation RGAA (epic #3800)

Cette PR est la **branche d'intégration** de la remédiation accessibilité RGAA : toutes les sous-PRs du lot ont été squash-mergées dedans (stack refermée). Elle livre l'ensemble dans `alpha` en un seul merge.

### Correctifs inclus

| Sous-PR | Issues | Correctifs |
|---|---|---|
| — | #3879 | Champs date « période de référence » dans un `<fieldset>`/`<legend>` (RGAA 11.5) |
| #3890 | #3871 #3873 | Caption du tableau catégorie d'emploi + région `aria-live` du total salariés (étapes 5/2) |
| #3891 | #3818 | Cellules de tableau vides restituées « vide » (`fr-sr-only`) |
| #3892 | #3805 | Autocomplétion du champ téléphone (`autocomplete="tel"`) |
| #3897 | #3813 #3801 #3802 #3804 #3808 #3810 #3872 #3874 #3877 | Intitulés de liens explicites (PDF, ProConnect) · landmark `<main>` & liens d'évitement · hiérarchie de titres · infobulles sans placeholder + `aria-required` · titre de page distinct par route · messages d'erreur `role="alert"` · titre du tableau « démarches en cours » → `aria-labelledby` · champs lecture seule & tooltips |
| #3912 | #3876 #3816 #3878 | Infos entreprise en `<dl><dt><dd>` · nom/rôle/valeur (`aria-sort`, `aria-modal`, menu compte, chart) · focus visible des radios CSE |
| #3916 | #3875 #3880 #3803 #3804 #3806 #3812 | Accès rapides dans un `<nav>` · focus à l'ouverture du menu mobile · légendes des fieldsets en lecture seule · association des messages d'erreur + `aria-invalid` · reflow /stats & inputs en cellule (zoom) |

À venir dans ce lot : #3659 (`<th>` de première colonne / en-têtes vides, étapes 1, 4 et 5 — analyse en cours).

### Vérification

Chaque sous-PR est passée par la pipeline complète (CI, audit RGAA ultra11y, validators, review humaine) avant son squash-merge dans cette branche.

Closes #3879
