### PR TITLE
fix(a11y): #3871 #3873 — caption catégorie + aria-live du total salariés (étape 5/2)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -77,15 +77,13 @@ describe("SecondDeclarationStep2Form", () => {
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		expect(
-			screen.getByText("Libellé de la catégorie d'emploi :"),
-		).toBeInTheDocument();
+		// The category label is now carried by the accordion heading and the
+		// table <caption> (RGAA 5.2) — no redundant read-only <p>, no editable input.
 		expect(
 			screen.getByRole("button", {
 				name: "Catégorie d'emplois n°1 : Ouvriers",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Ouvriers")).toBeInTheDocument();
 		expect(
 			screen.queryByLabelText("Libellé de la catégorie d'emploi"),
 		).not.toBeInTheDocument();
@@ -181,6 +179,5 @@ describe("SecondDeclarationStep2Form", () => {
 				name: "Catégorie d'emplois n°1 : Techniciens",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Techniciens")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -217,7 +217,11 @@ export function CategoryDataTable({
 				<div className="fr-table__container">
 					<div className="fr-table__content">
 						<table>
-							<caption>Données catégorie {catIndex + 1}</caption>
+							<caption>
+								{cat.name.trim()
+									? `Catégorie d'emplois n°${catIndex + 1} : ${cat.name}`
+									: `Catégorie d'emplois n°${catIndex + 1}`}
+							</caption>
 							<thead>
 								<tr>
 									<th className={stepStyles.nameColumnHeader} scope="col">
@@ -237,7 +241,7 @@ export function CategoryDataTable({
 							<tbody>
 								<tr>
 									<td className={stepStyles.sectionHeader} colSpan={4}>
-										<strong>
+										<strong aria-atomic="true" aria-live="polite">
 											Total salariés
 											{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
 										</strong>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -488,14 +488,7 @@ export function CategoryForm({
 								}}
 							>
 								<div className={stepStyles.categoryBlock}>
-									{readOnlyLabel ? (
-										<p className="fr-mb-0">
-											<span className="fr-text--bold">
-												Libellé de la catégorie d'emploi :{" "}
-											</span>
-											{cat?.name}
-										</p>
-									) : (
+									{!readOnlyLabel && (
 										<div className="fr-input-group fr-mb-0">
 											<label className="fr-label" htmlFor={`cat-${index}-name`}>
 												Libellé de la catégorie d'emploi


### PR DESCRIPTION
## Critères — RGAA 5.2 (titre de tableau) & RGAA 7.4 (changement de contexte)

- **#3871 (5.2)** — le titre « catégorie d'emploi » était un `<p>` au-dessus du tableau ; il en est pourtant le titre.
- **#3873 (7.4)** — le « Total salariés » se recalculait à la saisie sans annonce pour les lecteurs d'écran.

## Correctif (`CategoryDataTable.tsx`, `CategoryForm.tsx`)

- **#3871** : le libellé est désormais porté par le `<caption>` du tableau (« Catégorie d'emplois n°N : {nom} », masqué via `fr-table--no-caption`). Le `<p>` redondant en lecture seule est supprimé — le nom reste visible dans le titre d'accordéon `<h2>`.
- **#3873** : le conteneur du total (élément **stable présent au chargement**) devient une région `aria-live="polite"` `aria-atomic="true"` → le nouveau total est annoncé à la saisie.

**Rendu visuel inchangé.** Tests `SecondDeclarationStep2Form` mis à jour (le nom est restitué par le `<caption>` + l'accordéon, plus par un `<p>`).

> ℹ️ Le tableau conserve une cellule d'écart vide (`<td/>`) sur la ligne effectif — c'est le périmètre de **#3818** (cellules vides → `fr-sr-only`), traité séparément.

## Vérification
- ultra11y `audit` sur les 2 fichiers → 0 NC nouvelle (la seule restante = cellule vide #3818).
- `typecheck` ✅ · `format:check` ✅ · tests step5 + secondDeclaration ✅ (57 tests).

Stack : #3887 ← #3889 ← _cette PR_. Closes #3871, closes #3873