### PR TITLE
fix(a11y): #3818 — cellules de tableau vides restituées « vide » (fr-sr-only)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -116,7 +116,9 @@ export function CategoryRecapTable({
 										<th scope="row">Effectif physique</th>
 										<td className={indicatorStyles.numeric}>{womenCount} nb</td>
 										<td className={indicatorStyles.numeric}>{menCount} nb</td>
-										<td />
+										<td>
+											<span className="fr-sr-only">Non applicable</span>
+										</td>
 									</tr>
 
 									<tr className={styles.sectionRow}>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
@@ -343,7 +343,9 @@ function QuartileDistributionTable({
 									})}
 									<tr>
 										<th scope="row">Tous les salariés</th>
-										<td colSpan={2} />
+										<td colSpan={2}>
+											<span className="fr-sr-only">Non applicable</span>
+										</td>
 										<td className={styles.numeric}>
 											<strong>{totalWomen || "-"}</strong>
 										</td>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -77,15 +77,13 @@ describe("SecondDeclarationStep2Form", () => {
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		expect(
-			screen.getByText("Libellé de la catégorie d'emploi :"),
-		).toBeInTheDocument();
+		// The category label is now carried by the accordion heading and the
+		// table <caption> (RGAA 5.2) — no redundant read-only <p>, no editable input.
 		expect(
 			screen.getByRole("button", {
 				name: "Catégorie d'emplois n°1 : Ouvriers",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Ouvriers")).toBeInTheDocument();
 		expect(
 			screen.queryByLabelText("Libellé de la catégorie d'emploi"),
 		).not.toBeInTheDocument();
@@ -181,6 +179,5 @@ describe("SecondDeclarationStep2Form", () => {
 				name: "Catégorie d'emplois n°1 : Techniciens",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Techniciens")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -119,8 +119,12 @@ export function QuartileTable({
 										))}
 										<tr>
 											<th scope="row">Tous les salariés</th>
-											<td className={stepStyles.minCell} />
-											<td className={stepStyles.maxCell} />
+											<td className={stepStyles.minCell}>
+												<span className="fr-sr-only">Non applicable</span>
+											</td>
+											<td className={stepStyles.maxCell}>
+												<span className="fr-sr-only">Non applicable</span>
+											</td>
 											<td
 												className={stepStyles.numericCell}
 												data-mobile-label="Nombre de femmes"

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -217,7 +217,11 @@ export function CategoryDataTable({
 				<div className="fr-table__container">
 					<div className="fr-table__content">
 						<table>
-							<caption>Données catégorie {catIndex + 1}</caption>
+							<caption>
+								{cat.name.trim()
+									? `Catégorie d'emplois n°${catIndex + 1} : ${cat.name}`
+									: `Catégorie d'emplois n°${catIndex + 1}`}
+							</caption>
 							<thead>
 								<tr>
 									<th className={stepStyles.nameColumnHeader} scope="col">
@@ -237,7 +241,7 @@ export function CategoryDataTable({
 							<tbody>
 								<tr>
 									<td className={stepStyles.sectionHeader} colSpan={4}>
-										<strong>
+										<strong aria-atomic="true" aria-live="polite">
 											Total salariés
 											{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
 										</strong>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -281,7 +281,9 @@ export function CategoryDataTable({
 											<span className="fr-text--sm">nb</span>
 										</div>
 									</td>
-									<td />
+									<td>
+										<span className="fr-sr-only">Non applicable</span>
+									</td>
 								</tr>
 
 								<RemunerationSection

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -488,14 +488,7 @@ export function CategoryForm({
 								}}
 							>
 								<div className={stepStyles.categoryBlock}>
-									{readOnlyLabel ? (
-										<p className="fr-mb-0">
-											<span className="fr-text--bold">
-												Libellé de la catégorie d'emploi :{" "}
-											</span>
-											{cat?.name}
-										</p>
-									) : (
+									{!readOnlyLabel && (
 										<div className="fr-input-group fr-mb-0">
 											<label className="fr-label" htmlFor={`cat-${index}-name`}>
 												Libellé de la catégorie d'emploi


### PR DESCRIPTION
## Critère — RGAA 1.3.1 (réconcilié)

Réconciliation **audit ultra11y + revue a11y-Marie** : la vraie non-conformité n'est **pas** sur les `<th>` (en-tête de colonne vide = **recommandation non normative** selon ultra11y, et l'auditrice confirme que les `<th>` sont corrects), mais sur les **cellules de données vides**, restituées « vide » par les lecteurs d'écran.

## Correctif

Chaque cellule vide est un slot **non applicable** (l'effectif n'a pas d'écart de rémunération ; la ligne agrégée « Tous les salariés » n'a pas de seuil min/max). On y ajoute un texte `<span class="fr-sr-only">Non applicable</span>` :

- `steps/step5/CategoryDataTable.tsx` — écart de la ligne effectif
- `steps/step4/QuartileTable.tsx` — seuils min/max de la ligne agrégée (**étape 4**, périmètre du ticket)
- `recapitulatif/CategoryRecapTable.tsx` — écart de la ligne effectif
- `recapitulatif/IndicatorTables.tsx` — seuils de la ligne agrégée

**Rendu visuel inchangé.** Étend #3659.

## Vérification
- ultra11y `audit` module déclaration → **0 NC « cellule vide »** restante.
- `typecheck` ✅ · `format:check` ✅ · tests step4/step5/recapitulatif ✅ (63 tests).

Stack : #3887 ← #3889 ← #3890 ← _cette PR_. Closes #3818