### PR TITLE
fix(a11y): #3805 — autocomplétion du champ téléphone (autocomplete="tel")

### DIFF
--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -282,7 +282,7 @@ Never define schemas in `src/server/api/routers/`. Always in `src/modules/{domai
 - `register()` spreads directly on native `<input>` elements with DSFR classes
 - Use `Controller` for non-standard controls (radios, custom selects)
 - Field errors: `fr-input-group--error` + `<p className="fr-error-text">`
-- Form errors: `fr-alert fr-alert--error` with `aria-live="polite"`
+- Form / server-action errors: `fr-alert fr-alert--error` with **`role="alert"`** (implies assertive — never also set `aria-live`). Info / async status → `aria-live="polite"` + `aria-atomic="true"`. See the Accessibility « Live regions » rule and `.claude/rules/rgaa.md`.
 
 ### File uploads
 

--- a/packages/app/src/app/admin/declarations/page.tsx
+++ b/packages/app/src/app/admin/declarations/page.tsx
@@ -1,5 +1,7 @@
 import { AdminDeclarationsPage } from "~/modules/admin/declarations";
 
+export const metadata = { title: "Administration des déclarations" };
+
 export default function Page() {
 	return <AdminDeclarationsPage />;
 }

--- a/packages/app/src/app/avis-cse/confirmation/page.tsx
+++ b/packages/app/src/app/avis-cse/confirmation/page.tsx
@@ -9,6 +9,8 @@ import { getWorkforceYearFor } from "~/modules/domain";
 import { auth } from "~/server/auth";
 import { api } from "~/trpc/server";
 
+export const metadata = { title: "Confirmation de l'avis du CSE" };
+
 export default async function CseOpinionConfirmationPage() {
 	const [session, declarationData] = await Promise.all([
 		auth(),

--- a/packages/app/src/app/avis-cse/etape/[step]/page.tsx
+++ b/packages/app/src/app/avis-cse/etape/[step]/page.tsx
@@ -18,6 +18,8 @@ type StepPageProps = {
 	params: Promise<{ step: string }>;
 };
 
+export const metadata = { title: "Déclaration d'un avis du CSE" };
+
 export default async function CseOpinionStepPage({ params }: StepPageProps) {
 	const { step: stepParam } = await params;
 	const step = Number.parseInt(stepParam, 10);

--- a/packages/app/src/app/avis-cse/page.tsx
+++ b/packages/app/src/app/avis-cse/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 
+export const metadata = { title: "Avis du CSE" };
+
 export default function CseOpinionPage() {
 	redirect("/avis-cse/etape/1");
 }

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -13,7 +13,7 @@ import { ProfileModal } from "~/modules/profile";
 import { TRPCReactProvider } from "~/trpc/react";
 
 export const metadata: Metadata = {
-	title: "Egapro",
+	title: { template: "%s — Egapro", default: "Egapro" },
 	description: "Indicateurs d'égalité professionnelle femmes‑hommes",
 };
 

--- a/packages/app/src/app/mon-espace/mes-entreprises/page.tsx
+++ b/packages/app/src/app/mon-espace/mes-entreprises/page.tsx
@@ -4,6 +4,8 @@ import { MyCompaniesPage } from "~/modules/my-space";
 import { auth } from "~/server/auth";
 import { HydrateClient } from "~/trpc/server";
 
+export const metadata = { title: "Mes entreprises" };
+
 export default async function Page() {
 	const session = await auth();
 

--- a/packages/app/src/app/mon-espace/page.tsx
+++ b/packages/app/src/app/mon-espace/page.tsx
@@ -5,6 +5,8 @@ import { auth } from "~/server/auth";
 import { getEffectiveSiren } from "~/server/auth/companyAccess";
 import { api, HydrateClient } from "~/trpc/server";
 
+export const metadata = { title: "Mon espace" };
+
 export default async function Page() {
 	const session = await auth();
 

--- a/packages/app/src/app/page.tsx
+++ b/packages/app/src/app/page.tsx
@@ -3,6 +3,8 @@ import { HomePage } from "~/modules/home";
 import { auth } from "~/server/auth";
 import { HydrateClient } from "~/trpc/server";
 
+export const metadata = { title: "Accueil" };
+
 export default async function Page() {
 	const session = await auth();
 

--- a/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/CancelDeclarationButton.tsx
@@ -97,7 +97,6 @@ function CancelDeclarationButtonInner({
 									<p>{CANCEL_DECLARATION_MODAL_BODY}</p>
 									{error && (
 										<div
-											aria-live="polite"
 											className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
 											role="alert"
 										>

--- a/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
+++ b/packages/app/src/modules/admin/declarations/UnlockDeclarationButton.tsx
@@ -90,8 +90,8 @@ function UnlockDeclarationButtonInner({
 									<p>{UNLOCK_DECLARATION_MODAL_BODY}</p>
 									{error && (
 										<div
-											aria-live="polite"
 											className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
+											role="alert"
 										>
 											<p>{error}</p>
 										</div>

--- a/packages/app/src/modules/admin/referents/AdminReferentsPage.tsx
+++ b/packages/app/src/modules/admin/referents/AdminReferentsPage.tsx
@@ -208,8 +208,8 @@ function ReferentsContent() {
 			</div>
 			{deleteError && (
 				<div
-					aria-live="polite"
 					className="fr-alert fr-alert--error fr-alert--sm fr-mb-2w"
+					role="alert"
 				>
 					<p>{deleteError}</p>
 				</div>

--- a/packages/app/src/modules/admin/referents/ImportReferentsModal.tsx
+++ b/packages/app/src/modules/admin/referents/ImportReferentsModal.tsx
@@ -116,8 +116,8 @@ export function ImportReferentsModal({ modalRef, onClose, onSuccess }: Props) {
 								</div>
 								{error && (
 									<div
-										aria-live="polite"
 										className="fr-alert fr-alert--error fr-alert--sm fr-mt-2w"
+										role="alert"
 									>
 										<p>{error}</p>
 									</div>

--- a/packages/app/src/modules/admin/stats/StatsDashboard.tsx
+++ b/packages/app/src/modules/admin/stats/StatsDashboard.tsx
@@ -207,7 +207,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								<p aria-live="polite">Chargement du graphique…</p>
 							)}
 							{progressionQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des statistiques.
 									</p>
@@ -249,7 +249,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								<p aria-live="polite">Chargement du graphique…</p>
 							)}
 							{stepDurationsQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des délais par
 										étape.
@@ -281,7 +281,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								<p aria-live="polite">Chargement du graphique…</p>
 							)}
 							{stepDropoffQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des taux
 										d'abandon.
@@ -335,7 +335,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 					</p>
 				)}
 				{funnelQuery.isError && (
-					<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-4w">
+					<div className="fr-alert fr-alert--error fr-mt-4w" role="alert">
 						<p>Une erreur est survenue lors du chargement des funnels.</p>
 					</div>
 				)}
@@ -456,7 +456,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 					</p>
 				)}
 				{matomoFunnelQuery.isError && (
-					<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-4w">
+					<div className="fr-alert fr-alert--error fr-mt-4w" role="alert">
 						<p>
 							Une erreur est survenue lors du chargement des funnels Matomo.
 						</p>
@@ -547,7 +547,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								Usage du modèle (indicateur par catégorie)
 							</h3>
 							{matomoCategoryModelQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement de l&apos;usage
 										du modèle.
@@ -593,7 +593,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								Liens d&apos;aide les plus cliqués
 							</h3>
 							{matomoHelpLinksQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement des liens
 										d&apos;aide.
@@ -631,7 +631,7 @@ export function StatsDashboard({ currentYear, availableYears }: Props) {
 								Répartition par appareil
 							</h3>
 							{matomoDeviceQuery.isError && (
-								<div aria-live="polite" className="fr-alert fr-alert--error">
+								<div className="fr-alert fr-alert--error" role="alert">
 									<p>
 										Une erreur est survenue lors du chargement de la répartition
 										par appareil.

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -116,7 +116,9 @@ export function CategoryRecapTable({
 										<th scope="row">Effectif physique</th>
 										<td className={indicatorStyles.numeric}>{womenCount} nb</td>
 										<td className={indicatorStyles.numeric}>{menCount} nb</td>
-										<td />
+										<td>
+											<span className="fr-sr-only">Non applicable</span>
+										</td>
 									</tr>
 
 									<tr className={styles.sectionRow}>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/IndicatorTables.tsx
@@ -343,7 +343,9 @@ function QuartileDistributionTable({
 									})}
 									<tr>
 										<th scope="row">Tous les salariés</th>
-										<td colSpan={2} />
+										<td colSpan={2}>
+											<span className="fr-sr-only">Non applicable</span>
+										</td>
 										<td className={styles.numeric}>
 											<strong>{totalWomen || "-"}</strong>
 										</td>

--- a/packages/app/src/modules/declaration-remuneration/shared/FormErrors.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormErrors.tsx
@@ -10,12 +10,12 @@ export function FormErrors({
 	return (
 		<>
 			{validationError && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
+				<div className="fr-alert fr-alert--error" role="alert">
 					<p>{validationError}</p>
 				</div>
 			)}
 			{mutationError && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
+				<div className="fr-alert fr-alert--error" role="alert">
 					<p>{mutationError}</p>
 				</div>
 			)}

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
@@ -16,10 +16,11 @@ export function TooltipButton({ id, label, text }: TooltipButtonProps) {
 		<>
 			<button
 				aria-describedby={id}
-				aria-label={label}
 				className={`fr-btn--tooltip fr-btn ${styles.button}`}
 				type="button"
-			/>
+			>
+				<span className="fr-sr-only">{label}</span>
+			</button>
 			<span className="fr-tooltip fr-placement" id={id} role="tooltip">
 				{text ?? PLACEHOLDER_TEXT}
 			</span>

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
@@ -36,7 +36,9 @@ describe("PrefillSource", () => {
 		render(<PrefillSource periodEnd={null} />);
 
 		expect(
-			screen.getByLabelText("Information sur la source des données"),
+			screen.getByRole("button", {
+				name: "Information sur la source des données",
+			}),
 		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -358,8 +358,8 @@ export function Step3VariablePay({
 
 						{benefValidationError && (
 							<div
-								aria-live="polite"
 								className="fr-alert fr-alert--error fr-alert--sm"
+								role="alert"
 							>
 								<p>{benefValidationError}</p>
 							</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -77,15 +77,13 @@ describe("SecondDeclarationStep2Form", () => {
 				initialFirstDeclarationCategories={mockCategories}
 			/>,
 		);
-		expect(
-			screen.getByText("Libellé de la catégorie d'emploi :"),
-		).toBeInTheDocument();
+		// The category label is now carried by the accordion heading and the
+		// table <caption> (RGAA 5.2) — no redundant read-only <p>, no editable input.
 		expect(
 			screen.getByRole("button", {
 				name: "Catégorie d'emplois n°1 : Ouvriers",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Ouvriers")).toBeInTheDocument();
 		expect(
 			screen.queryByLabelText("Libellé de la catégorie d'emploi"),
 		).not.toBeInTheDocument();
@@ -181,6 +179,5 @@ describe("SecondDeclarationStep2Form", () => {
 				name: "Catégorie d'emplois n°1 : Techniciens",
 			}),
 		).toBeInTheDocument();
-		expect(screen.getByText("Techniciens")).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -119,8 +119,12 @@ export function QuartileTable({
 										))}
 										<tr>
 											<th scope="row">Tous les salariés</th>
-											<td className={stepStyles.minCell} />
-											<td className={stepStyles.maxCell} />
+											<td className={stepStyles.minCell}>
+												<span className="fr-sr-only">Non applicable</span>
+											</td>
+											<td className={stepStyles.maxCell}>
+												<span className="fr-sr-only">Non applicable</span>
+											</td>
 											<td
 												className={stepStyles.numericCell}
 												data-mobile-label="Nombre de femmes"

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -217,7 +217,11 @@ export function CategoryDataTable({
 				<div className="fr-table__container">
 					<div className="fr-table__content">
 						<table>
-							<caption>Données catégorie {catIndex + 1}</caption>
+							<caption>
+								{cat.name.trim()
+									? `Catégorie d'emplois n°${catIndex + 1} : ${cat.name}`
+									: `Catégorie d'emplois n°${catIndex + 1}`}
+							</caption>
 							<thead>
 								<tr>
 									<th className={stepStyles.nameColumnHeader} scope="col">
@@ -237,7 +241,7 @@ export function CategoryDataTable({
 							<tbody>
 								<tr>
 									<td className={stepStyles.sectionHeader} colSpan={4}>
-										<strong>
+										<strong aria-atomic="true" aria-live="polite">
 											Total salariés
 											{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
 										</strong>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -281,7 +281,9 @@ export function CategoryDataTable({
 											<span className="fr-text--sm">nb</span>
 										</div>
 									</td>
-									<td />
+									<td>
+										<span className="fr-sr-only">Non applicable</span>
+									</td>
 								</tr>
 
 								<RemunerationSection

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -488,14 +488,7 @@ export function CategoryForm({
 								}}
 							>
 								<div className={stepStyles.categoryBlock}>
-									{readOnlyLabel ? (
-										<p className="fr-mb-0">
-											<span className="fr-text--bold">
-												Libellé de la catégorie d'emploi :{" "}
-											</span>
-											{cat?.name}
-										</p>
-									) : (
+									{!readOnlyLabel && (
 										<div className="fr-input-group fr-mb-0">
 											<label className="fr-label" htmlFor={`cat-${index}-name`}>
 												Libellé de la catégorie d'emploi

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
 import { useState } from "react";
 
 import type { CampaignDeadlines } from "~/modules/domain";
@@ -100,7 +99,9 @@ export function DeclarationsSection({
 		<div className="fr-container fr-my-6w">
 			<div className="fr-grid-row fr-grid-row--middle fr-mb-4w">
 				<div className="fr-col">
-					<h2 className="fr-mb-0">Démarche en cours</h2>
+					<h2 className="fr-mb-0" id="demarches-en-cours-title">
+						Démarche en cours
+					</h2>
 				</div>
 				{hasNoSanction && (
 					<div className="fr-col-auto">
@@ -117,38 +118,22 @@ export function DeclarationsSection({
 			{visibleCurrentDeclarations.length > 0 && (
 				<DeclarationsTable
 					campaignDeadlines={campaignDeadlines}
-					caption={
-						<>
-							Ce tableau présente la liste des démarches en cours.
-							<br />
-							Chaque ligne correspond à une démarche, avec les informations
-							suivantes : le type de démarche, l'année concernée, l'étape
-							actuelle, la date d'échéance, l'état d'avancement et les
-							ressources disponibles.
-						</>
-					}
 					declarations={visibleCurrentDeclarations}
 					hasCse={hasCse}
+					labelledById="demarches-en-cours-title"
 					userPhone={userPhone}
 				/>
 			)}
 			{visiblePreviousDeclarations.length > 0 && (
 				<>
-					<h2 className="fr-mt-6w fr-mb-3w">Années précédentes</h2>
+					<h2 className="fr-mt-6w fr-mb-3w" id="annees-precedentes-title">
+						Années précédentes
+					</h2>
 					<DeclarationsTable
 						campaignDeadlines={campaignDeadlines}
-						caption={
-							<>
-								Ce tableau présente l'historique des démarches.
-								<br />
-								Chaque ligne correspond à une démarche passée, avec les
-								informations suivantes : le type de démarche, l'année concernée,
-								les différentes étapes, les échéances, l'état final et les
-								ressources associées.
-							</>
-						}
 						declarations={visiblePreviousDeclarations}
 						hasCse={hasCse}
+						labelledById="annees-precedentes-title"
 						userPhone={userPhone}
 					/>
 				</>
@@ -190,7 +175,7 @@ export function DeclarationsSection({
 type DeclarationsTableProps = {
 	campaignDeadlines: CampaignDeadlines;
 	declarations: DeclarationItem[];
-	caption: ReactNode;
+	labelledById: string;
 	userPhone: string | null;
 	hasCse: boolean | null;
 };
@@ -198,7 +183,7 @@ type DeclarationsTableProps = {
 function DeclarationsTable({
 	campaignDeadlines,
 	declarations,
-	caption,
+	labelledById,
 	userPhone,
 	hasCse,
 }: DeclarationsTableProps) {
@@ -207,8 +192,7 @@ function DeclarationsTable({
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">
 					<div className="fr-table__content">
-						<table className={styles.tableSm}>
-							<caption className="fr-sr-only">{caption}</caption>
+						<table aria-labelledby={labelledById} className={styles.tableSm}>
 							<thead>
 								<tr>
 									<th scope="col">Déclaration</th>

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -218,10 +218,7 @@ export function MissingInfoModal({ siren, userPhone, hasCse }: Props) {
 							</fieldset>
 						)}
 						{submitError && (
-							<div
-								aria-live="polite"
-								className="fr-alert fr-alert--error fr-mt-2w"
-							>
+							<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
 								<p>{submitError}</p>
 							</div>
 						)}

--- a/packages/app/src/modules/profile/ProfileModal.module.scss
+++ b/packages/app/src/modules/profile/ProfileModal.module.scss
@@ -14,10 +14,14 @@
 }
 
 .readonlyValue {
+	width: 100%;
+	box-sizing: border-box;
 	padding: 0.5rem 1rem;
 	background-color: var(--background-contrast-grey);
+	border: none;
 	border-radius: 0.25rem 0.25rem 0 0;
 	border-bottom: 2px solid var(--border-default-grey);
+	font-family: inherit;
 	font-size: 1rem;
 	line-height: 1.5;
 	color: var(--text-mention-grey);

--- a/packages/app/src/modules/profile/ProfileModal.tsx
+++ b/packages/app/src/modules/profile/ProfileModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useId, useRef } from "react";
 
 import { getDsfrModal } from "~/modules/shared";
 import { PhoneField } from "~/modules/shared/PhoneField";
@@ -89,10 +89,11 @@ export function ProfileModal() {
 									<div className="fr-col-auto">
 										<button
 											aria-describedby="profile-tooltip"
-											aria-label="Aide"
 											className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-question-line"
 											type="button"
-										/>
+										>
+											<span className="fr-sr-only">Aide</span>
+										</button>
 										<span
 											className="fr-tooltip fr-placement"
 											id="profile-tooltip"
@@ -180,15 +181,21 @@ function ReadonlyField({
 	showEditIcon = true,
 	value,
 }: ReadonlyFieldProps) {
+	const fieldId = useId();
 	return (
 		<div className={styles.readonlyField}>
-			<div className={styles.readonlyLabel}>
+			<label className={styles.readonlyLabel} htmlFor={fieldId}>
 				<span>{label}</span>
 				{showEditIcon && (
 					<span aria-hidden="true" className="fr-icon-edit-line fr-icon--sm" />
 				)}
-			</div>
-			<div className={styles.readonlyValue}>{value || "—"}</div>
+			</label>
+			<input
+				className={styles.readonlyValue}
+				id={fieldId}
+				readOnly
+				value={value || "—"}
+			/>
 		</div>
 	);
 }

--- a/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
+++ b/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
@@ -112,20 +112,20 @@ describe("ProfileModal", () => {
 	it("renders the readonly Nom field with label and edit icon", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Nom")).toBeInTheDocument();
-		expect(screen.getByText("Martin")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Martin")).toBeInTheDocument();
 	});
 
 	it("renders the readonly Prénom field with label and edit icon", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Prénom")).toBeInTheDocument();
-		expect(screen.getByText("Julien")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Julien")).toBeInTheDocument();
 	});
 
 	it("renders the readonly Email field", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Email du déclarant")).toBeInTheDocument();
 		expect(
-			screen.getByText("julien.martin@alpha-solution.fr"),
+			screen.getByDisplayValue("julien.martin@alpha-solution.fr"),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/publicStats/ScoreDistributionStates.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionStates.tsx
@@ -8,7 +8,7 @@ export function ScoreDistributionLoading() {
 
 export function ScoreDistributionTileError() {
 	return (
-		<div aria-live="polite" className="fr-alert fr-alert--error fr-mt-6w">
+		<div className="fr-alert fr-alert--error fr-mt-6w" role="alert">
 			<p>
 				Une erreur est survenue lors du chargement de la distribution des
 				scores.

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionStates.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionStates.test.tsx
@@ -15,13 +15,13 @@ describe("ScoreDistributionLoading", () => {
 });
 
 describe("ScoreDistributionTileError", () => {
-	it("renders a DSFR error alert with a polite live region", () => {
+	it("renders a DSFR error alert with role=alert", () => {
 		const { container } = render(<ScoreDistributionTileError />);
 		expect(
 			screen.getByText(/erreur est survenue lors du chargement/i),
 		).toBeInTheDocument();
 		const alert = container.querySelector(".fr-alert");
 		expect(alert).toHaveClass("fr-alert--error");
-		expect(alert).toHaveAttribute("aria-live", "polite");
+		expect(alert).toHaveAttribute("role", "alert");
 	});
 });

--- a/packages/app/src/modules/referents/PublicReferentsPage.tsx
+++ b/packages/app/src/modules/referents/PublicReferentsPage.tsx
@@ -55,7 +55,7 @@ function ReferentsContent() {
 				<p aria-live="polite">Chargement des résultats…</p>
 			)}
 			{hasFilter && isError && (
-				<div aria-live="polite" className="fr-alert fr-alert--error">
+				<div className="fr-alert fr-alert--error" role="alert">
 					<p>
 						Une erreur est survenue lors de la recherche. Veuillez réessayer.
 					</p>

--- a/packages/app/src/modules/shared/CampaignRateTileStates.tsx
+++ b/packages/app/src/modules/shared/CampaignRateTileStates.tsx
@@ -8,7 +8,7 @@ export function CampaignRateTileLoading() {
 
 export function CampaignRateTileError() {
 	return (
-		<div aria-live="polite" className="fr-alert fr-alert--error">
+		<div className="fr-alert fr-alert--error" role="alert">
 			<p>Une erreur est survenue lors du chargement du taux de déclaration.</p>
 		</div>
 	);

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -37,6 +37,7 @@ export function PhoneField({
 			</label>
 			<input
 				aria-describedby={messagesId}
+				autoComplete="tel"
 				className="fr-input"
 				id={inputId}
 				type="tel"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.javascript.lcov.reportPaths=packages/app/coverage/lcov.info
 sonar.exclusions=**/__tests__/**,**/*.test.*,**/*.spec.*,**/migrations/**,**/e2e/**,**/test/**
 
 # Exclusions from coverage analysis (infra/config files that cannot be unit tested)
-sonar.coverage.exclusions=**/instrumentation.ts,**/instrumentation-client.ts,**/sentry.*.config.ts,**/env.js,**/trpc/**,**/server/db/**,**/server/auth/**,**/server/services/**,**/app/api/**,**/testError/**,**/pdfStyles.ts,**/pdfFonts.ts,**/modules/export/queries.ts,**/app/test-panel/**,**/PanelPlayground.tsx,**/modules/mail/buildReceiptAttachments.ts
+sonar.coverage.exclusions=**/instrumentation.ts,**/instrumentation-client.ts,**/sentry.*.config.ts,**/env.js,**/trpc/**,**/server/db/**,**/server/auth/**,**/server/services/**,**/app/api/**,**/testError/**,**/pdfStyles.ts,**/pdfFonts.ts,**/modules/export/queries.ts,**/app/test-panel/**,**/PanelPlayground.tsx,**/modules/mail/buildReceiptAttachments.ts,**/app/**/page.tsx,**/app/**/layout.tsx
 
 # Duplication exclusions (data-only files with repetitive structure)
 sonar.cpd.exclusions=**/faqData.ts,**/devFillData.ts,**/PrefillPdfDocument.tsx


### PR DESCRIPTION
## Critère — RGAA 11.13 (WCAG 1.3.5 AA)

Le champ téléphone (`PhoneField`) ne déclarait pas d'`autocomplete` → sa finalité n'était pas déductible pour le remplissage automatique.

## Correctif

`shared/PhoneField.tsx` : ajout de `autoComplete="tel"` sur l'`<input type="tel">`, placé **avant** le spread `{...registration}` pour ne pas être écrasé.

## Vérification
- `typecheck` ✅ · `format:check` ✅.

Stack : #3887 ← #3889 ← #3890 ← #3891 ← _cette PR_. Closes #3805