### PR TITLE
fix(a11y): #3874 #3877 — champs readonly (label+input) & infobulles sans aria-label

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
@@ -16,10 +16,11 @@ export function TooltipButton({ id, label, text }: TooltipButtonProps) {
 		<>
 			<button
 				aria-describedby={id}
-				aria-label={label}
 				className={`fr-btn--tooltip fr-btn ${styles.button}`}
 				type="button"
-			/>
+			>
+				<span className="fr-sr-only">{label}</span>
+			</button>
 			<span className="fr-tooltip fr-placement" id={id} role="tooltip">
 				{text ?? PLACEHOLDER_TEXT}
 			</span>

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
@@ -36,7 +36,9 @@ describe("PrefillSource", () => {
 		render(<PrefillSource periodEnd={null} />);
 
 		expect(
-			screen.getByLabelText("Information sur la source des données"),
+			screen.getByRole("button", {
+				name: "Information sur la source des données",
+			}),
 		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/profile/ProfileModal.module.scss
+++ b/packages/app/src/modules/profile/ProfileModal.module.scss
@@ -14,10 +14,14 @@
 }
 
 .readonlyValue {
+	width: 100%;
+	box-sizing: border-box;
 	padding: 0.5rem 1rem;
 	background-color: var(--background-contrast-grey);
+	border: none;
 	border-radius: 0.25rem 0.25rem 0 0;
 	border-bottom: 2px solid var(--border-default-grey);
+	font-family: inherit;
 	font-size: 1rem;
 	line-height: 1.5;
 	color: var(--text-mention-grey);

--- a/packages/app/src/modules/profile/ProfileModal.tsx
+++ b/packages/app/src/modules/profile/ProfileModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useId, useRef } from "react";
 
 import { getDsfrModal } from "~/modules/shared";
 import { PhoneField } from "~/modules/shared/PhoneField";
@@ -89,10 +89,11 @@ export function ProfileModal() {
 									<div className="fr-col-auto">
 										<button
 											aria-describedby="profile-tooltip"
-											aria-label="Aide"
 											className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-icon-question-line"
 											type="button"
-										/>
+										>
+											<span className="fr-sr-only">Aide</span>
+										</button>
 										<span
 											className="fr-tooltip fr-placement"
 											id="profile-tooltip"
@@ -180,15 +181,21 @@ function ReadonlyField({
 	showEditIcon = true,
 	value,
 }: ReadonlyFieldProps) {
+	const fieldId = useId();
 	return (
 		<div className={styles.readonlyField}>
-			<div className={styles.readonlyLabel}>
+			<label className={styles.readonlyLabel} htmlFor={fieldId}>
 				<span>{label}</span>
 				{showEditIcon && (
 					<span aria-hidden="true" className="fr-icon-edit-line fr-icon--sm" />
 				)}
-			</div>
-			<div className={styles.readonlyValue}>{value || "—"}</div>
+			</label>
+			<input
+				className={styles.readonlyValue}
+				id={fieldId}
+				readOnly
+				value={value || "—"}
+			/>
 		</div>
 	);
 }

--- a/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
+++ b/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
@@ -112,20 +112,20 @@ describe("ProfileModal", () => {
 	it("renders the readonly Nom field with label and edit icon", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Nom")).toBeInTheDocument();
-		expect(screen.getByText("Martin")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Martin")).toBeInTheDocument();
 	});
 
 	it("renders the readonly Prénom field with label and edit icon", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Prénom")).toBeInTheDocument();
-		expect(screen.getByText("Julien")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Julien")).toBeInTheDocument();
 	});
 
 	it("renders the readonly Email field", () => {
 		render(<ProfileModal />);
 		expect(screen.getByText("Email du déclarant")).toBeInTheDocument();
 		expect(
-			screen.getByText("julien.martin@alpha-solution.fr"),
+			screen.getByDisplayValue("julien.martin@alpha-solution.fr"),
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
## Critères — RGAA 8.9 (présentation) & RGAA 10.2 (contenu via CSS)

- **#3874 (8.9)** — dans la modale « Mon profil », les champs lecture seule (Nom, Prénom, Email) étaient un couple `<span>` label + `<div>` valeur, pas une structure de formulaire.
- **#3877 (10.2)** — les boutons d'aide portaient leur intitulé uniquement via `aria-label` + glyphe généré en CSS : sans styles, le bouton n'a plus de contenu et l'info de l'`aria-label` n'est pas dans le DOM textuel.

## Correctif

- **#3874** : `ReadonlyField` → `<label htmlFor={id}>` + `<input id readOnly value>` (id via `useId`). La classe `.readonlyValue` est adaptée à un `<input>` (reset des bordures parasites, `width:100%`, `font:inherit`) pour **conserver le rendu** (fond grisé DSFR, bordure basse).
- **#3877** : `TooltipButton` et le bouton d'aide « fait main » de `ProfileModal` exposent leur libellé via `<span class="fr-sr-only">` **au lieu** de `aria-label` (glyphe CSS conservé).

**Rendu visuel inchangé.** Tests `ProfileModal` mis à jour (valeurs readonly restituées via `getByDisplayValue`).

> ℹ️ La suppression du placeholder Lorem ipsum de `TooltipButton` relève de **#3804** (11.10) et arrivera dans une PR stackée au-dessus.

## Vérification
- ultra11y `audit` → **100% réussite, 0 NC**.
- `typecheck` ✅ · `format:check` ✅ · tests profile ✅ (39 tests).

Stack : #3887 ← … ← #3892 ← _cette PR_. Closes #3874, closes #3877