### PR TITLE
fix(a11y): #3813 — intitulés de liens explicites (PDF) + ProConnect

### DIFF
--- a/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
@@ -89,7 +89,11 @@ export default async function RecapitulatifRoute({ searchParams }: Props) {
 				</Link>
 			</div>
 
-			<main className="fr-container fr-pb-7w fr-pt-7w" id="content">
+			<main
+				className="fr-container fr-pb-7w fr-pt-7w"
+				id="content"
+				tabIndex={-1}
+			>
 				<div className="fr-grid-row fr-grid-row--center">
 					<div className="fr-col-12 fr-col-lg-8">
 						<RecapitulatifPage

--- a/packages/app/src/modules/admin/AdminShell.tsx
+++ b/packages/app/src/modules/admin/AdminShell.tsx
@@ -12,7 +12,9 @@ export function AdminShell({ children }: Props) {
 				<div className={styles.nav}>
 					<AdminNavigation />
 				</div>
-				<div className={styles.content}>{children}</div>
+				<main className={styles.content} id="content" tabIndex={-1}>
+					{children}
+				</main>
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
@@ -23,6 +23,18 @@ describe("AdminShell", () => {
 		expect(screen.getByText("test content")).toBeInTheDocument();
 	});
 
+	it("wraps children in a focusable main landmark targeted by the skip link", () => {
+		render(
+			<AdminShell>
+				<p>test content</p>
+			</AdminShell>,
+		);
+		const main = screen.getByRole("main");
+		expect(main).toHaveAttribute("id", "content");
+		expect(main).toHaveAttribute("tabindex", "-1");
+		expect(main).toContainElement(screen.getByText("test content"));
+	});
+
 	it("wraps content in a fluid container", () => {
 		const { container } = render(<AdminShell>children</AdminShell>);
 		const wrapper = container.firstElementChild as HTMLElement;

--- a/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
@@ -84,7 +84,7 @@ export function AdminDeclarationDetailPage({ declarationId }: Props) {
 			{recap && (
 				<section className="fr-mt-6w">
 					<h2 className="fr-h3">Récapitulatif déclaré</h2>
-					<RecapitulatifPage {...recap} />
+					<RecapitulatifPage {...recap} titleTag="h3" />
 				</section>
 			)}
 		</div>

--- a/packages/app/src/modules/admin/declarations/DetailSections.tsx
+++ b/packages/app/src/modules/admin/declarations/DetailSections.tsx
@@ -193,7 +193,7 @@ export function FilesSection({ files }: { files: DeclarationDetail["files"] }) {
 							<td>{formatShortDate(file.uploadedAt)}</td>
 							<td>
 								<a
-									aria-label={`Télécharger ${file.fileName}`}
+									aria-label={`Télécharger ${file.fileName} (PDF)`}
 									className="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-download-line"
 									download
 									href={`/api/v1/files/${file.id}`}

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -20,7 +20,7 @@ export function SiblingDeclarationsSection({ siblings }: Props) {
 
 	return (
 		<section className="fr-mt-4w">
-			<h3 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h3>
+			<h2 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h2>
 			<ul className="fr-raw-list">
 				{siblings.map((sibling) => (
 					<li className="fr-mb-1w" key={sibling.id}>

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -113,7 +113,7 @@ describe("AdminDeclarationDetailPage", () => {
 		).toBeInTheDocument();
 		expect(screen.getByText("avis-cse.pdf")).toBeInTheDocument();
 		const downloadLink = screen.getByRole("link", {
-			name: "Télécharger avis-cse.pdf",
+			name: "Télécharger avis-cse.pdf (PDF)",
 		});
 		expect(downloadLink).toHaveAttribute("href", "/api/v1/files/file-1");
 	});

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -71,6 +71,9 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
+import { defaultProps as recapProps } from "~/modules/declaration-remuneration/recapitulatif/__tests__/fixtures";
+import { api } from "~/trpc/react";
+
 import { AdminDeclarationDetailPage } from "../AdminDeclarationDetailPage";
 
 describe("AdminDeclarationDetailPage", () => {
@@ -132,5 +135,21 @@ describe("AdminDeclarationDetailPage", () => {
 		expect(
 			screen.queryByRole("button", { name: "Déverrouiller la déclaration" }),
 		).toBeNull();
+	});
+
+	it("renders the embedded recap title as h3 so the page keeps a single h1", () => {
+		vi.mocked(api.adminDeclarations.getRecap.useQuery).mockReturnValueOnce({
+			data: recapProps(),
+		} as unknown as ReturnType<typeof api.adminDeclarations.getRecap.useQuery>);
+
+		render(<AdminDeclarationDetailPage declarationId="decl-1" />);
+
+		expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DetailSections.test.tsx
@@ -138,7 +138,7 @@ describe("FilesSection", () => {
 		expect(screen.getByText("avis-cse.pdf")).toBeInTheDocument();
 		expect(screen.getByText("Avis CSE")).toBeInTheDocument();
 		const link = screen.getByRole("link", {
-			name: "Télécharger avis-cse.pdf",
+			name: "Télécharger avis-cse.pdf (PDF)",
 		});
 		expect(link).toHaveAttribute("href", "/api/v1/files/file-1");
 	});

--- a/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
@@ -28,7 +28,7 @@ describe("SiblingDeclarationsSection", () => {
 
 		expect(
 			screen.getByRole("heading", {
-				level: 3,
+				level: 2,
 				name: "Autres déclarations pour ce SIREN / cette année",
 			}),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
+++ b/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
@@ -114,7 +114,7 @@ export function ImpersonateForm() {
 
 			{serverError && (
 				<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
-					<h3 className="fr-alert__title">Erreur</h3>
+					<h2 className="fr-alert__title">Erreur</h2>
 					<p>{serverError}</p>
 				</div>
 			)}

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -30,7 +30,7 @@ export function CseOpinionLayout({
 	lockHolder = null,
 }: Props) {
 	return (
-		<>
+		<main id="content" tabIndex={-1}>
 			<div className={`fr-py-3w ${styles.banner}`}>
 				<div className="fr-container">
 					<Breadcrumb
@@ -78,7 +78,7 @@ export function CseOpinionLayout({
 					</div>
 				</div>
 			</div>
-			<main className="fr-container fr-py-7w" id="content">
+			<div className="fr-container fr-py-7w">
 				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
 					<div className="fr-grid-row fr-grid-row--center">
 						<div className="fr-col-12 fr-col-lg-8">
@@ -89,7 +89,7 @@ export function CseOpinionLayout({
 						</div>
 					</div>
 				</LockProvider>
-			</main>
-		</>
+			</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -199,7 +199,10 @@ export function Step1Opinions({
 	}
 
 	return (
-		<form autoComplete="off" onSubmit={onSubmit}>
+		<form autoComplete="off" noValidate onSubmit={onSubmit}>
+			{/* noValidate: the required radios expose the required state to
+			    assistive tech (RGAA 11.10) without native browser bubbles
+			    preempting the app's own zod + custom validation messages. */}
 			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">

--- a/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
@@ -41,6 +41,7 @@ export function AccuracyOpinionCard({
 							id={`${id}-favorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("favorable")}
+							required
 							type="radio"
 							value="favorable"
 						/>
@@ -56,6 +57,7 @@ export function AccuracyOpinionCard({
 							id={`${id}-unfavorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("unfavorable")}
+							required
 							type="radio"
 							value="unfavorable"
 						/>

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -46,6 +46,7 @@ export function GapConsultationCard({
 							id={`${id}-yes`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(true)}
+							required
 							type="radio"
 							value="yes"
 						/>
@@ -61,6 +62,7 @@ export function GapConsultationCard({
 							id={`${id}-no`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(false)}
+							required
 							type="radio"
 							value="no"
 						/>
@@ -92,6 +94,7 @@ export function GapConsultationCard({
 									id={`${id}-favorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("favorable")}
+									required
 									type="radio"
 									value="favorable"
 								/>
@@ -107,6 +110,7 @@ export function GapConsultationCard({
 									id={`${id}-unfavorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("unfavorable")}
+									required
 									type="radio"
 									value="unfavorable"
 								/>

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -28,12 +28,12 @@ export function DeclarationLayout({
 	lockHolder = null,
 }: DeclarationLayoutProps) {
 	return (
-		<>
+		<main id="content" tabIndex={-1}>
 			<CompanyBanner
 				company={company}
 				currentPageLabel={`Démarche des indicateurs de rémunération ${declarationYear}`}
 			/>
-			<main className="fr-container fr-py-7w" id="content">
+			<div className="fr-container fr-py-7w">
 				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
 					<div className="fr-grid-row fr-grid-row--center">
 						<div className="fr-col-12 fr-col-lg-8">
@@ -44,7 +44,7 @@ export function DeclarationLayout({
 						</div>
 					</div>
 				</LockProvider>
-			</main>
-		</>
+			</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/MissingSiret.tsx
+++ b/packages/app/src/modules/declaration-remuneration/MissingSiret.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export function MissingSiret() {
 	return (
-		<main className="fr-container fr-my-4w" id="content">
+		<main className="fr-container fr-my-4w" id="content" tabIndex={-1}>
 			<div className="fr-grid-row fr-grid-row--center">
 				<div className="fr-col-12 fr-col-md-8">
 					<h1>SIRET manquant</h1>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -42,6 +42,9 @@ type Props = {
 	step4Data: Step4Data;
 	step5Categories: EmployeeCategoryRow[];
 	step5Source: string | null;
+	// Demote the page title when the recap is embedded in a host page that
+	// already renders its own <h1> (e.g. /admin/declarations/[id]) — RGAA 9.1.
+	titleTag?: "h1" | "h3";
 };
 
 type InfoItem = { label: string; value: string };
@@ -84,6 +87,7 @@ export function RecapitulatifPage({
 	step4Data,
 	step5Categories,
 	step5Source,
+	titleTag: TitleTag = "h1",
 }: Props) {
 	const declarantItems: InfoItem[] = [];
 	if (declarantName) {
@@ -121,11 +125,11 @@ export function RecapitulatifPage({
 		<div className={common.flexColumnGap2}>
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
+					<TitleTag className="fr-h4 fr-mb-0">
 						{isCorrection
 							? `Seconde déclaration des écarts de rémunération par catégorie de salariés ${declarationYear}`
 							: `Déclaration des indicateurs de rémunération ${declarationYear}`}
-					</h1>
+					</TitleTag>
 				</div>
 				<div className="fr-col-auto">
 					<a

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -129,6 +129,7 @@ export function RecapitulatifPage({
 				</div>
 				<div className="fr-col-auto">
 					<a
+						aria-label="Télécharger la déclaration des indicateurs de rémunération (PDF)"
 						className="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-download-line"
 						download
 						href={buildPdfHref(declarationYear, isCorrection)}

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -20,6 +20,17 @@ describe("RecapitulatifPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("demotes the title to h3 when embedded via titleTag (no second h1)", () => {
+		render(<RecapitulatifPage {...defaultProps()} titleTag="h3" />);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+	});
+
 	it("renders 'Télécharger' tertiary download button", () => {
 		render(<RecapitulatifPage {...defaultProps()} />);
 		const link = screen.getByRole("link", {

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -22,14 +22,18 @@ describe("RecapitulatifPage", () => {
 
 	it("renders 'Télécharger' tertiary download button", () => {
 		render(<RecapitulatifPage {...defaultProps()} />);
-		const link = screen.getByRole("link", { name: "Télécharger" });
+		const link = screen.getByRole("link", {
+			name: "Télécharger la déclaration des indicateurs de rémunération (PDF)",
+		});
 		expect(link).toHaveAttribute("href", "/api/declaration-pdf?year=2025");
 		expect(link.className).toContain("fr-btn--tertiary");
 	});
 
 	it("renders download link with correction param when isCorrection", () => {
 		render(<RecapitulatifPage {...defaultProps()} isCorrection />);
-		const link = screen.getByRole("link", { name: "Télécharger" });
+		const link = screen.getByRole("link", {
+			name: "Télécharger la déclaration des indicateurs de rémunération (PDF)",
+		});
 		expect(link).toHaveAttribute(
 			"href",
 			"/api/declaration-pdf?year=2025&type=correction",

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
@@ -8,22 +8,25 @@ type TooltipButtonProps = {
 	text?: string;
 };
 
-const PLACEHOLDER_TEXT =
-	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-
 export function TooltipButton({ id, label, text }: TooltipButtonProps) {
+	const labelId = `${id}-label`;
 	return (
 		<>
 			<button
-				aria-describedby={id}
+				aria-describedby={text ? id : undefined}
+				aria-labelledby={labelId}
 				className={`fr-btn--tooltip fr-btn ${styles.button}`}
 				type="button"
 			>
-				<span className="fr-sr-only">{label}</span>
+				<span className="fr-sr-only" id={labelId}>
+					{label}
+				</span>
 			</button>
-			<span className="fr-tooltip fr-placement" id={id} role="tooltip">
-				{text ?? PLACEHOLDER_TEXT}
-			</span>
+			{text && (
+				<span className="fr-tooltip fr-placement" id={id} role="tooltip">
+					{text}
+				</span>
+			)}
 		</>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -15,7 +15,10 @@ export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {
 
 	return (
 		<div className="fr-alert fr-alert--warning fr-mb-3w" role="alert">
-			<h3 className="fr-alert__title">Déclaration en cours de modification</h3>
+			{/* The alert renders above the page <h1> in every host page (tunnel
+			    layouts, my-space panel), so its title must stay out of the heading
+			    outline (RGAA 9.1) — the DSFR class keeps the visual unchanged. */}
+			<p className="fr-alert__title">Déclaration en cours de modification</p>
 			<p>
 				{`${identity} modifie actuellement cette déclaration. Vous pouvez la consulter en lecture seule jusqu'à la fin de sa modification.`}
 			</p>

--- a/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
+++ b/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function DeclarationHistoryPage({ siren, year }: Props) {
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-4w">
 				<Breadcrumb
 					items={[

--- a/packages/app/src/modules/layout/PublicChrome.tsx
+++ b/packages/app/src/modules/layout/PublicChrome.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 
 import { Footer } from "./Footer";
 import { ResourceBanner } from "./ResourceBanner";
+import { isAdminRoute } from "./shared/routeUtils";
 
 /**
  * Renders the public help banner + footer on every route except the backoffice.
@@ -13,9 +14,7 @@ import { ResourceBanner } from "./ResourceBanner";
  */
 export function PublicChrome() {
 	const pathname = usePathname();
-	// Match the `/admin` segment boundary so hypothetical sibling routes like
-	// `/administrator` or `/admin-tools` keep the public chrome.
-	if (pathname === "/admin" || pathname?.startsWith("/admin/")) {
+	if (isAdminRoute(pathname)) {
 		return null;
 	}
 	const showResourceBanner = pathname !== "/login";

--- a/packages/app/src/modules/layout/ResourceBanner.tsx
+++ b/packages/app/src/modules/layout/ResourceBanner.tsx
@@ -44,6 +44,7 @@ export function ResourceBanner() {
 			className="fr-background-alt--blue-france fr-py-7w"
 		>
 			<div className="fr-container">
+				<h2 className="fr-sr-only">Ressources et aides</h2>
 				<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
 					<div className="fr-col-12 fr-col-md-10">
 						<div className="fr-grid-row fr-grid-row--gutters">

--- a/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
@@ -44,6 +44,16 @@ describe("ResourceBanner", () => {
 		expect(headings).toHaveLength(3);
 	});
 
+	it("renders a screen-reader-only section heading above the tiles", () => {
+		render(<ResourceBanner />);
+
+		const heading = screen.getByRole("heading", {
+			level: 2,
+			name: "Ressources et aides",
+		});
+		expect(heading).toHaveClass("fr-sr-only");
+	});
+
 	it("uses a 10/2 column ratio so the illustration sits flush right", () => {
 		const { container } = render(<ResourceBanner />);
 

--- a/packages/app/src/modules/layout/shared/SkipLinks.tsx
+++ b/packages/app/src/modules/layout/shared/SkipLinks.tsx
@@ -1,9 +1,21 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { isAdminRoute } from "./routeUtils";
+
 /**
  * Skip links — mandatory RGAA criterion 12.7.
  * Allow keyboard/screen reader users to skip directly
  * to the main content or the footer.
+ *
+ * Admin routes (`/admin/**`) render no footer (`PublicChrome` returns null),
+ * so the "Pied de page" link is hidden there to avoid an orphan anchor.
  */
 export function SkipLinks() {
+	const pathname = usePathname();
+	const hasFooter = !isAdminRoute(pathname);
+
 	return (
 		<div className="fr-skiplinks">
 			<nav aria-label="Accès rapide" className="fr-container">
@@ -13,11 +25,13 @@ export function SkipLinks() {
 							Contenu
 						</a>
 					</li>
-					<li>
-						<a className="fr-link" href="#footer">
-							Pied de page
-						</a>
-					</li>
+					{hasFooter && (
+						<li>
+							<a className="fr-link" href="#footer">
+								Pied de page
+							</a>
+						</li>
+					)}
 				</ul>
 			</nav>
 		</div>

--- a/packages/app/src/modules/layout/shared/__tests__/SkipLinks.test.tsx
+++ b/packages/app/src/modules/layout/shared/__tests__/SkipLinks.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { usePathname } from "next/navigation";
+import { beforeEach, describe, expect, it, type Mock } from "vitest";
 import { SkipLinks } from "../SkipLinks";
 
 describe("SkipLinks", () => {
+	beforeEach(() => {
+		(usePathname as Mock).mockReturnValue("/");
+	});
+
 	it("renders a <nav> with aria-label 'Accès rapide'", () => {
 		render(<SkipLinks />);
 		expect(
@@ -25,5 +30,41 @@ describe("SkipLinks", () => {
 	it("renders exactly two skip links", () => {
 		render(<SkipLinks />);
 		expect(screen.getAllByRole("link")).toHaveLength(2);
+	});
+
+	describe("on admin routes (no footer rendered)", () => {
+		it("hides the #footer link on /admin", () => {
+			(usePathname as Mock).mockReturnValue("/admin");
+			render(<SkipLinks />);
+			expect(
+				screen.queryByRole("link", { name: /pied de page/i }),
+			).not.toBeInTheDocument();
+			expect(screen.getAllByRole("link")).toHaveLength(1);
+		});
+
+		it("hides the #footer link on nested /admin/* routes", () => {
+			(usePathname as Mock).mockReturnValue("/admin/declarations");
+			render(<SkipLinks />);
+			expect(
+				screen.queryByRole("link", { name: /pied de page/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("keeps the #content link on /admin", () => {
+			(usePathname as Mock).mockReturnValue("/admin");
+			render(<SkipLinks />);
+			expect(screen.getByRole("link", { name: /contenu/i })).toHaveAttribute(
+				"href",
+				"#content",
+			);
+		});
+
+		it("keeps the #footer link on sibling routes merely starting with 'admin'", () => {
+			(usePathname as Mock).mockReturnValue("/administrator");
+			render(<SkipLinks />);
+			expect(
+				screen.getByRole("link", { name: /pied de page/i }),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/packages/app/src/modules/layout/shared/routeUtils.ts
+++ b/packages/app/src/modules/layout/shared/routeUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns true for the `/admin` root and every nested `/admin/**` route.
+ * Matches the `/admin` segment boundary so hypothetical sibling routes like
+ * `/administrator` or `/admin-tools` keep the public chrome.
+ *
+ * Shared by `PublicChrome` (which renders no footer on those routes) and
+ * `SkipLinks` (which hides the "Pied de page" skip link there so it never
+ * points to a missing anchor — RGAA 12.7).
+ */
+export function isAdminRoute(pathname: string | null): boolean {
+	return (
+		pathname !== null &&
+		(pathname === "/admin" || pathname.startsWith("/admin/"))
+	);
+}

--- a/packages/app/src/modules/login/ProConnectButton.tsx
+++ b/packages/app/src/modules/login/ProConnectButton.tsx
@@ -40,7 +40,6 @@ export function ProConnectButton({ callbackUrl }: Props) {
 					href="https://www.proconnect.gouv.fr/"
 					rel="noopener"
 					target="_blank"
-					title="Qu'est-ce que ProConnect ? - nouvelle fenêtre"
 				>
 					Qu'est-ce que ProConnect ?
 					<NewTabNotice />

--- a/packages/app/src/modules/my-space/ArchivesSection.tsx
+++ b/packages/app/src/modules/my-space/ArchivesSection.tsx
@@ -14,7 +14,7 @@ export function ArchivesSection() {
 						/>
 					</div>
 					<div className="fr-col">
-						<p className="fr-text--bold fr-mb-1w">Archives</p>
+						<h2 className="fr-text--md fr-mb-1w">Archives</h2>
 						<p className="fr-text--sm fr-mb-0">
 							Récupérer vos anciennes déclarations de l'index de l'égalité
 							professionnelle femmes-hommes.

--- a/packages/app/src/modules/my-space/CompanyCard.tsx
+++ b/packages/app/src/modules/my-space/CompanyCard.tsx
@@ -11,9 +11,9 @@ export function CompanyCard({ company }: Props) {
 		<div className="fr-card fr-card--horizontal fr-card--sm fr-enlarge-link">
 			<div className="fr-card__body">
 				<div className="fr-card__content">
-					<h3 className="fr-card__title">
+					<h2 className="fr-card__title">
 						<Link href="/mon-espace">{company.name}</Link>
-					</h3>
+					</h2>
 					<div className="fr-card__start">
 						<ul className="fr-badges-group">
 							<li>

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -66,7 +66,7 @@ export function CompanyDeclarationsPage({
 	});
 
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<WelcomeBanner />
 			<CompanyInfoBanner company={company} />
 			<DeclarationsSection

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -27,7 +27,7 @@ export function CompanyInfoBanner({ company }: Props) {
 
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">
 					<div className="fr-col">
-						<h2 className="fr-h4 fr-mb-0">{company.name}</h2>
+						<h1 className="fr-h4 fr-mb-0">{company.name}</h1>
 					</div>
 					<div className="fr-col-auto">
 						<button

--- a/packages/app/src/modules/my-space/CompanyListHeader.tsx
+++ b/packages/app/src/modules/my-space/CompanyListHeader.tsx
@@ -4,7 +4,7 @@ export function CompanyListHeader() {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3w">
 			<div className="fr-col">
-				<h2>Mes entreprises</h2>
+				<h1 className="fr-h2">Mes entreprises</h1>
 			</div>
 			<div className="fr-col-auto">
 				{/* TODO: Replace href with real ProConnect account URL */}

--- a/packages/app/src/modules/my-space/MyCompaniesPage.tsx
+++ b/packages/app/src/modules/my-space/MyCompaniesPage.tsx
@@ -10,7 +10,7 @@ export async function MyCompaniesPage() {
 	const companies = await api.company.list();
 
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-my-4w">
 				<WelcomeBanner />
 				<CompanyListHeader />

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -80,7 +80,7 @@ export function PanelPlayground() {
 	}
 
 	return (
-		<main className="fr-container fr-py-6w" id="content">
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
 			<h1 className="fr-h3">DeclarationProcessPanel — Playground</h1>
 			<p className="fr-text--sm fr-text-mention--grey">
 				Dev-only page to visually test the panel with arbitrary variant and

--- a/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 import { ArchivesSection } from "../ArchivesSection";
 
 describe("ArchivesSection", () => {
-	it("renders the 'Archives' title", () => {
+	it("renders the 'Archives' title as an h2 heading", () => {
 		render(<ArchivesSection />);
-		expect(screen.getByText("Archives")).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Archives" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders the description text", () => {

--- a/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
@@ -18,6 +18,13 @@ describe("CompanyCard", () => {
 		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
+	it("renders the card title as an h2 heading", () => {
+		render(<CompanyCard company={company} />);
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders the SIREN number", () => {
 		render(<CompanyCard company={company} />);
 		expect(screen.getByText("N° SIREN : 532847196")).toBeInTheDocument();

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -109,7 +109,7 @@ describe("CompanyDeclarationsPage", () => {
 	it("renders the company name", () => {
 		renderPage();
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -15,10 +15,10 @@ const baseCompany: CompanyDetail = {
 };
 
 describe("CompanyInfoBanner", () => {
-	it("renders the company name as an h2 heading", () => {
+	it("renders the company name as the page h1 heading", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it } from "vitest";
 import { CompanyListHeader } from "../CompanyListHeader";
 
 describe("CompanyListHeader", () => {
-	it("renders the H2 title", () => {
+	it("renders the page h1 title", () => {
 		render(<CompanyListHeader />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
@@ -125,7 +125,7 @@ describe("MonEspacePage", () => {
 		render(page);
 		expect(screen.getByRole("main")).toHaveAttribute("id", "content");
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Test Company" }),
+			screen.getByRole("heading", { level: 1, name: "Test Company" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
@@ -45,7 +45,7 @@ describe("MyCompaniesPage", () => {
 		const page = await MyCompaniesPage();
 		render(page);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/publicStats/PublicStatsPage.tsx
+++ b/packages/app/src/modules/publicStats/PublicStatsPage.tsx
@@ -3,13 +3,13 @@ import { ScoreDistributionTile } from "./ScoreDistributionTile";
 
 export function PublicStatsPage() {
 	return (
-		<div className="fr-container fr-py-6w">
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
 			<h1 className="fr-h1">Statistiques publiques</h1>
 			<p className="fr-text--lead fr-mb-4w">
 				Indicateurs clés sur l'égalité professionnelle femmes-hommes en France.
 			</p>
 			<CurrentCampaignRateTile />
 			<ScoreDistributionTile />
-		</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
@@ -27,6 +27,13 @@ describe("PublicStatsPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders a focusable main landmark targeted by the skip link", () => {
+		render(<PublicStatsPage />);
+		const main = screen.getByRole("main");
+		expect(main).toHaveAttribute("id", "content");
+		expect(main).toHaveAttribute("tabindex", "-1");
+	});
+
 	it("renders the lead paragraph describing the page content", () => {
 		render(<PublicStatsPage />);
 		expect(

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -37,6 +37,7 @@ export function PhoneField({
 			</label>
 			<input
 				aria-describedby={messagesId}
+				aria-required="true"
 				autoComplete="tel"
 				className="fr-input"
 				id={inputId}


### PR DESCRIPTION
## Critère — RGAA 6.1 (WCAG 2.4.4 A) — réconcilié

- `ProConnectButton` : `title` redondant retiré (texte visible « Qu'est-ce que ProConnect ? » + `NewTabNotice` suffisent).
- `RecapitulatifPage` : le lien de téléchargement au libellé générique « Télécharger » reçoit un `aria-label` explicite **avec le format (PDF)**.
- `DetailSections` : l'`aria-label` expose désormais le format (« Télécharger {fichier} **(PDF)** »).
- `ConfirmationPage` (avis CSE) : déjà conforme (« PDF » visible dans le lien, intitulés distincts) → **non modifié**.

## Vérification
- ultra11y `audit` → **100% réussite, 0 NC**.
- `typecheck` ✅ · `format:check` ✅ · tests login/recapitulatif/admin ✅ (129 tests, assertions de nom accessible mises à jour).

Stack : #3887 ← … ← #3896 ← _cette PR_. Closes #3813