### PR TITLE
fix(a11y): #3804 — infobulles sans placeholder + aria-required

### DIFF
--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -199,7 +199,10 @@ export function Step1Opinions({
 	}
 
 	return (
-		<form autoComplete="off" onSubmit={onSubmit}>
+		<form autoComplete="off" noValidate onSubmit={onSubmit}>
+			{/* noValidate: the required radios expose the required state to
+			    assistive tech (RGAA 11.10) without native browser bubbles
+			    preempting the app's own zod + custom validation messages. */}
 			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">

--- a/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
@@ -41,6 +41,7 @@ export function AccuracyOpinionCard({
 							id={`${id}-favorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("favorable")}
+							required
 							type="radio"
 							value="favorable"
 						/>
@@ -56,6 +57,7 @@ export function AccuracyOpinionCard({
 							id={`${id}-unfavorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("unfavorable")}
+							required
 							type="radio"
 							value="unfavorable"
 						/>

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -46,6 +46,7 @@ export function GapConsultationCard({
 							id={`${id}-yes`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(true)}
+							required
 							type="radio"
 							value="yes"
 						/>
@@ -61,6 +62,7 @@ export function GapConsultationCard({
 							id={`${id}-no`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(false)}
+							required
 							type="radio"
 							value="no"
 						/>
@@ -92,6 +94,7 @@ export function GapConsultationCard({
 									id={`${id}-favorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("favorable")}
+									required
 									type="radio"
 									value="favorable"
 								/>
@@ -107,6 +110,7 @@ export function GapConsultationCard({
 									id={`${id}-unfavorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("unfavorable")}
+									required
 									type="radio"
 									value="unfavorable"
 								/>

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
@@ -8,22 +8,25 @@ type TooltipButtonProps = {
 	text?: string;
 };
 
-const PLACEHOLDER_TEXT =
-	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-
 export function TooltipButton({ id, label, text }: TooltipButtonProps) {
+	const labelId = `${id}-label`;
 	return (
 		<>
 			<button
-				aria-describedby={id}
+				aria-describedby={text ? id : undefined}
+				aria-labelledby={labelId}
 				className={`fr-btn--tooltip fr-btn ${styles.button}`}
 				type="button"
 			>
-				<span className="fr-sr-only">{label}</span>
+				<span className="fr-sr-only" id={labelId}>
+					{label}
+				</span>
 			</button>
-			<span className="fr-tooltip fr-placement" id={id} role="tooltip">
-				{text ?? PLACEHOLDER_TEXT}
-			</span>
+			{text && (
+				<span className="fr-tooltip fr-placement" id={id} role="tooltip">
+					{text}
+				</span>
+			)}
 		</>
 	);
 }

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -37,6 +37,7 @@ export function PhoneField({
 			</label>
 			<input
 				aria-describedby={messagesId}
+				aria-required="true"
 				autoComplete="tel"
 				className="fr-input"
 				id={inputId}


### PR DESCRIPTION
## Critère — RGAA 11.10 (contrôle de saisie) — parties implémentables

- **TooltipButton** : suppression du fallback Lorem ipsum (`PLACEHOLDER_TEXT`) → plus d'infobulle rendue sans contenu réel (`aria-describedby` conditionnel). Ajout d'`aria-labelledby` vers le texte `fr-sr-only` → le nom accessible est exposé explicitement (**conserve la conformité 10.2** « contenu hors CSS » de #3877, et **corrige 5 findings `--graph` « nom perdu »** que le passage `aria-label` → `sr-only` de #3877 avait fait apparaître dans le moteur).
- **aria-required** : champ téléphone (`PhoneField`) + groupes radio obligatoires des cartes avis CSE (`AccuracyOpinionCard`, `GapConsultationCard`).

## Reste sur #3804 (follow-up)
Association des erreurs (`aria-invalid` + `aria-describedby` sur `ReferentFormFields` / `Step3VariablePay`) et **microcopy d'aide** (bloquée PO). Le ticket #3804 n'est donc **pas** clos par cette PR.

## Vérification
- ultra11y `audit` module complet : **15 → 10 NC** (les 5 findings tooltip soldés ; restent les 10 fieldsets de #3803).
- `typecheck` ✅ · `format:check` ✅ · **suite complète 3312 tests** ✅.

Stack : #3887 ← … ← #3897 ← _cette PR_. Refs #3804