### PR TITLE
fix(a11y): cluster stats/admin — landmarks, aria-sort, hiérarchie de titres, reflow /stats

### DIFF
--- a/packages/app/src/modules/admin/AdminShell.tsx
+++ b/packages/app/src/modules/admin/AdminShell.tsx
@@ -12,7 +12,9 @@ export function AdminShell({ children }: Props) {
 				<div className={styles.nav}>
 					<AdminNavigation />
 				</div>
-				<div className={styles.content}>{children}</div>
+				<main className={styles.content} id="content" tabIndex={-1}>
+					{children}
+				</main>
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
+++ b/packages/app/src/modules/admin/__tests__/AdminShell.test.tsx
@@ -23,6 +23,18 @@ describe("AdminShell", () => {
 		expect(screen.getByText("test content")).toBeInTheDocument();
 	});
 
+	it("wraps children in a focusable main landmark targeted by the skip link", () => {
+		render(
+			<AdminShell>
+				<p>test content</p>
+			</AdminShell>,
+		);
+		const main = screen.getByRole("main");
+		expect(main).toHaveAttribute("id", "content");
+		expect(main).toHaveAttribute("tabindex", "-1");
+		expect(main).toContainElement(screen.getByText("test content"));
+	});
+
 	it("wraps content in a fluid container", () => {
 		const { container } = render(<AdminShell>children</AdminShell>);
 		const wrapper = container.firstElementChild as HTMLElement;

--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -37,11 +37,18 @@ export function DeclarationTable({
 	sortBy,
 	sortOrder,
 }: Props) {
-	const { handleSort, handlePageChange, sortIcon } = useSortableTable({
-		basePath: "/admin/declarations",
-		sortBy,
-		sortOrder,
-	});
+	const { handleSort, handlePageChange, ariaSort, sortIcon } = useSortableTable(
+		{
+			basePath: "/admin/declarations",
+			sortBy,
+			sortOrder,
+		},
+	);
+
+	const renderSortIcon = (column: SortColumn) => {
+		const icon = sortIcon(column);
+		return icon ? <span aria-hidden="true">{icon}</span> : null;
+	};
 
 	return (
 		<>
@@ -55,14 +62,14 @@ export function DeclarationTable({
 				<thead>
 					<tr>
 						{SORT_COLUMNS.map((col) => (
-							<th key={col} scope="col">
+							<th aria-sort={ariaSort(col)} key={col} scope="col">
 								<button
 									className="fr-text--sm"
 									onClick={() => handleSort(col)}
 									type="button"
 								>
 									{COLUMN_LABELS[col]}
-									{sortIcon(col)}
+									{renderSortIcon(col)}
 								</button>
 							</th>
 						))}

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -20,7 +20,7 @@ export function SiblingDeclarationsSection({ siblings }: Props) {
 
 	return (
 		<section className="fr-mt-4w">
-			<h3 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h3>
+			<h2 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h2>
 			<ul className="fr-raw-list">
 				{siblings.map((sibling) => (
 					<li className="fr-mb-1w" key={sibling.id}>

--- a/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
@@ -64,6 +64,23 @@ describe("DeclarationTable", () => {
 		expect(screen.getByText("15/06/2024")).toBeInTheDocument();
 	});
 
+	it("exposes aria-sort on the sorted column and hides the sort glyph", () => {
+		render(<DeclarationTable {...defaultProps} />);
+
+		const sortedHeader = screen
+			.getByRole("button", { name: /date de dépôt/i })
+			.closest("th");
+		expect(sortedHeader).toHaveAttribute("aria-sort", "descending");
+
+		const unsortedHeader = screen
+			.getByRole("button", { name: /^siren/i })
+			.closest("th");
+		expect(unsortedHeader).not.toHaveAttribute("aria-sort");
+
+		const glyph = sortedHeader?.querySelector("[aria-hidden='true']");
+		expect(glyph).not.toBeNull();
+	});
+
 	it("shows empty state when no rows", () => {
 		render(<DeclarationTable {...defaultProps} rows={[]} total={0} />);
 

--- a/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
@@ -28,7 +28,7 @@ describe("SiblingDeclarationsSection", () => {
 
 		expect(
 			screen.getByRole("heading", {
-				level: 3,
+				level: 2,
 				name: "Autres déclarations pour ce SIREN / cette année",
 			}),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
+++ b/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
@@ -114,7 +114,7 @@ export function ImpersonateForm() {
 
 			{serverError && (
 				<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
-					<h3 className="fr-alert__title">Erreur</h3>
+					<h2 className="fr-alert__title">Erreur</h2>
 					<p>{serverError}</p>
 				</div>
 			)}

--- a/packages/app/src/modules/layout/ResourceBanner.tsx
+++ b/packages/app/src/modules/layout/ResourceBanner.tsx
@@ -44,6 +44,7 @@ export function ResourceBanner() {
 			className="fr-background-alt--blue-france fr-py-7w"
 		>
 			<div className="fr-container">
+				<h2 className="fr-sr-only">Ressources et aides</h2>
 				<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
 					<div className="fr-col-12 fr-col-md-10">
 						<div className="fr-grid-row fr-grid-row--gutters">

--- a/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
@@ -44,6 +44,16 @@ describe("ResourceBanner", () => {
 		expect(headings).toHaveLength(3);
 	});
 
+	it("renders a screen-reader-only section heading above the tiles", () => {
+		render(<ResourceBanner />);
+
+		const heading = screen.getByRole("heading", {
+			level: 2,
+			name: "Ressources et aides",
+		});
+		expect(heading).toHaveClass("fr-sr-only");
+	});
+
 	it("uses a 10/2 column ratio so the illustration sits flush right", () => {
 		const { container } = render(<ResourceBanner />);
 

--- a/packages/app/src/modules/publicStats/PublicStatsPage.tsx
+++ b/packages/app/src/modules/publicStats/PublicStatsPage.tsx
@@ -3,13 +3,13 @@ import { ScoreDistributionTile } from "./ScoreDistributionTile";
 
 export function PublicStatsPage() {
 	return (
-		<div className="fr-container fr-py-6w">
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
 			<h1 className="fr-h1">Statistiques publiques</h1>
 			<p className="fr-text--lead fr-mb-4w">
 				Indicateurs clés sur l'égalité professionnelle femmes-hommes en France.
 			</p>
 			<CurrentCampaignRateTile />
 			<ScoreDistributionTile />
-		</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
@@ -1,4 +1,6 @@
 .chartWrapper {
 	width: 100%;
+	max-width: 100%;
+	min-width: 0;
 	height: 320px;
 }

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
@@ -75,9 +75,13 @@ export function ChartTooltip({ active, payload }: ChartTooltipProps) {
 
 export function ScoreDistributionChart({ brackets }: Props) {
 	return (
-		<div aria-hidden="true" className={styles.chartWrapper} role="presentation">
+		<div aria-hidden="true" className={styles.chartWrapper}>
 			<ResponsiveContainer>
-				<BarChart data={brackets} margin={{ top: 16, right: 16, bottom: 8 }}>
+				<BarChart
+					accessibilityLayer={false}
+					data={brackets}
+					margin={{ top: 16, right: 16, bottom: 8 }}
+				>
 					<CartesianGrid strokeDasharray="3 3" vertical={false} />
 					<XAxis dataKey="label" />
 					<YAxis tickFormatter={formatYAxisTick} />

--- a/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/PublicStatsPage.test.tsx
@@ -27,6 +27,13 @@ describe("PublicStatsPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders a focusable main landmark targeted by the skip link", () => {
+		render(<PublicStatsPage />);
+		const main = screen.getByRole("main");
+		expect(main).toHaveAttribute("id", "content");
+		expect(main).toHaveAttribute("tabindex", "-1");
+	});
+
 	it("renders the lead paragraph describing the page content", () => {
 		render(<PublicStatsPage />);
 		expect(

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
@@ -46,7 +46,15 @@ describe("ScoreDistributionChart", () => {
 			<ScoreDistributionChart brackets={baseBrackets} />,
 		);
 		const wrapper = container.querySelector("[aria-hidden='true']");
-		expect(wrapper).toHaveAttribute("role", "presentation");
+		expect(wrapper).not.toHaveAttribute("role");
+	});
+
+	it("exposes no focusable element under the aria-hidden wrapper", () => {
+		const { container } = render(
+			<ScoreDistributionChart brackets={baseBrackets} />,
+		);
+		const wrapper = container.querySelector("[aria-hidden='true']");
+		expect(wrapper?.querySelector("[tabindex]")).toBeNull();
 	});
 
 	it("renders even with an empty dataset (defensive)", () => {


### PR DESCRIPTION
## Cluster STATS/ADMIN — corrections RGAA (parts des tickets transverses)

Corrections behavior-preserving (markup/ARIA, rendu visuel inchangé) sur le périmètre `publicStats/**`, `admin/**` et `layout/ResourceBanner`.

### RGAA 12.6/12.7 — Landmarks (Refs #3801)
- `AdminShell` : le contenu passe de `<div>` à `<main id="content" tabIndex={-1}>` — le lien d'évitement « Aller au contenu » a désormais une cible valide sur `/admin/**`.
- `PublicStatsPage` : racine en `<main id="content" tabIndex={-1}>` (aligné sur `HomePage`).
- Vérifié : pas de `<main>` imbriqué (RecapitulatifPage nesté n'émet pas de `main`) ; parts tunnels/footer du ticket hors périmètre de ce cluster.

### RGAA 7.1/7.3 — Scripts (Refs #3816)
- `DeclarationTable` : `aria-sort` exposé sur les `<th scope="col">` triables (via `ariaSort` de `useSortableTable`), glyphe de tri enveloppé dans `<span aria-hidden="true">` — aligné sur `ReferentTable`.
- `ScoreDistributionChart` : retrait du `role="presentation"` résiduel (le `aria-hidden="true"` est conservé) et suppression du focusable sous `aria-hidden` en désactivant `accessibilityLayer` sur le `BarChart` recharts (le svg n'a plus `tabIndex=0` ni `role="application"` ; l'alternative accessible reste la table de données adjacente).
- Parts `UserAccountMenu` / `CompanyEditModal` / `ThemeModal` hors périmètre de ce cluster.

### RGAA 9.1 — Hiérarchie de titres (Refs #3802)
- `SiblingDeclarationsSection` : `h3.fr-h5` → `h2.fr-h5` (apparence inchangée).
- `ResourceBanner` : ajout d'un `<h2 class="fr-sr-only">Ressources et aides</h2>` — variante recommandée par la revue access (pas d'`aria-labelledby`).
- `ImpersonateForm` : titre de l'alerte d'erreur `h3` → `h2`.
- Parts mon-espace / RecapitulatifPage / tuiles 404-referents hors périmètre de ce cluster.

### RGAA 10.11/10.4 — Reflow 320 px sur /stats (Refs #3806, Refs #3812)
- `ScoreDistributionChart.module.scss` : `max-width: 100%` + `min-width: 0` défensifs sur le conteneur du graphique.
- Le reste de `/stats` est déjà fluide (`fr-container`, grilles DSFR, table DSFR avec défilement propre — acceptable en conformité selon la revue access). **À confirmer au rendu à 320 px / zoom 200 %.**

### Vérifications
- `pnpm --filter app typecheck` ✅
- ultra11y (`--jsx --graph --standard rgaa`) sur les 7 `.tsx` modifiés : 0 NC avant → 0 NC après (moteur statique) ✅
- `vitest run` sur `publicStats`, `admin`, `ResourceBanner` : 383 tests verts ✅ (tests mis à jour : niveau de titre, `aria-sort`, wrapper sans `role`, landmarks `main`)
- `biome check` clean ✅
