### PR TITLE
fix(a11y): mon-espace — listes de description, focus radios CSE, aria-modal, hiérarchie de titres

### DIFF
--- a/packages/app/src/modules/my-space/ArchivesSection.module.scss
+++ b/packages/app/src/modules/my-space/ArchivesSection.module.scss
@@ -2,3 +2,10 @@
 	border: 1px solid var(--border-default-grey);
 	padding: 1.5rem;
 }
+
+// Heading demoted visually to body-text size (was a bold paragraph before the
+// RGAA 9.1 fix) — keeps the rendering unchanged.
+.title {
+	font-size: 1rem;
+	line-height: 1.5rem;
+}

--- a/packages/app/src/modules/my-space/ArchivesSection.tsx
+++ b/packages/app/src/modules/my-space/ArchivesSection.tsx
@@ -14,7 +14,7 @@ export function ArchivesSection() {
 						/>
 					</div>
 					<div className="fr-col">
-						<p className="fr-text--bold fr-mb-1w">Archives</p>
+						<h2 className={`fr-mb-1w ${styles.title}`}>Archives</h2>
 						<p className="fr-text--sm fr-mb-0">
 							Récupérer vos anciennes déclarations de l'index de l'égalité
 							professionnelle femmes-hommes.

--- a/packages/app/src/modules/my-space/CompanyCard.tsx
+++ b/packages/app/src/modules/my-space/CompanyCard.tsx
@@ -11,9 +11,9 @@ export function CompanyCard({ company }: Props) {
 		<div className="fr-card fr-card--horizontal fr-card--sm fr-enlarge-link">
 			<div className="fr-card__body">
 				<div className="fr-card__content">
-					<h3 className="fr-card__title">
+					<h2 className="fr-card__title">
 						<Link href="/mon-espace">{company.name}</Link>
-					</h3>
+					</h2>
 					<div className="fr-card__start">
 						<ul className="fr-badges-group">
 							<li>

--- a/packages/app/src/modules/my-space/CompanyEditModal.module.scss
+++ b/packages/app/src/modules/my-space/CompanyEditModal.module.scss
@@ -1,8 +1,21 @@
+.infoList {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin: 0;
+}
+
 .infoRow {
 	display: flex;
 	align-items: baseline;
 	flex-wrap: wrap;
 	gap: 0.25rem;
+
+	dt,
+	dd {
+		margin: 0;
+		padding: 0;
+	}
 }
 
 .label {
@@ -25,8 +38,13 @@
 }
 
 .cseFieldset {
+	// A non-zero flex-basis keeps both rich radios at equal widths on wide
+	// screens (same rendering as flex-basis 0) but lets them wrap on their own
+	// line at reduced widths instead of being crushed/overflowing, so the DSFR
+	// focus outline (2px width + 2px offset outside the box) stays fully
+	// visible at every viewport width.
 	:global(.fr-fieldset__element--inline) {
-		flex: 1;
+		flex: 1 1 8rem;
 	}
 
 	> .sourceText {

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -60,6 +60,7 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 	return (
 		<dialog
 			aria-labelledby={MODAL_TITLE_ID}
+			aria-modal="true"
 			className="fr-modal"
 			id={MODAL_ID}
 			ref={dialogRef}
@@ -166,20 +167,24 @@ function CompanyReadonlySection({ company }: CompanyReadonlySectionProps) {
 	return (
 		<>
 			<div className={`fr-mb-4w ${styles.section}`}>
-				<InfoRow label="Raison sociale :" value={company.name} />
-				<InfoRow label="SIREN :" value={formatSiren(company.siren)} />
-				<InfoRow label="Adresse :" value={company.address} />
-				<InfoRow label="Code NAF :" value={company.nafCode} />
+				<dl className={styles.infoList}>
+					<InfoRow label="Raison sociale :" value={company.name} />
+					<InfoRow label="SIREN :" value={formatSiren(company.siren)} />
+					<InfoRow label="Adresse :" value={company.address} />
+					<InfoRow label="Code NAF :" value={company.nafCode} />
+				</dl>
 				<p className={`fr-text--sm fr-mb-0 ${styles.sourceText}`}>
 					Source : INSEE.
 				</p>
 			</div>
 
 			<div className={`fr-mb-4w ${styles.section}`}>
-				<InfoRow
-					label={`Effectif annuel moyen en ${CURRENT_YEAR} :`}
-					value={company.workforce?.toLocaleString("fr-FR")}
-				/>
+				<dl className={styles.infoList}>
+					<InfoRow
+						label={`Effectif annuel moyen en ${CURRENT_YEAR} :`}
+						value={company.workforce?.toLocaleString("fr-FR")}
+					/>
+				</dl>
 				<p className={`fr-text--sm fr-mb-0 ${styles.sourceText}`}>
 					Source : DSN (Déclarations sociales nominatives).
 				</p>
@@ -195,10 +200,12 @@ type InfoRowProps = {
 
 function InfoRow({ label, value }: InfoRowProps) {
 	return (
-		<p className={`fr-mb-0 ${styles.infoRow}`}>
-			<span className={styles.label}>{label}</span>
-			<strong>{value ?? "—"}</strong>
-		</p>
+		<div className={styles.infoRow}>
+			<dt className={styles.label}>{label}</dt>
+			<dd>
+				<strong>{value ?? "—"}</strong>
+			</dd>
+		</div>
 	);
 }
 

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
@@ -12,6 +12,7 @@
 	flex-wrap: wrap;
 	gap: 0.5rem 1.5rem;
 	align-items: center;
+	margin: 0;
 }
 
 .datapoint {
@@ -19,4 +20,10 @@
 	align-items: center;
 	gap: 0.25rem;
 	margin: 0;
+
+	dt,
+	dd {
+		margin: 0;
+		padding: 0;
+	}
 }

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -27,7 +27,7 @@ export function CompanyInfoBanner({ company }: Props) {
 
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">
 					<div className="fr-col">
-						<h2 className="fr-h4 fr-mb-0">{company.name}</h2>
+						<h1 className="fr-h4 fr-mb-0">{company.name}</h1>
 					</div>
 					<div className="fr-col-auto">
 						<button
@@ -41,43 +41,55 @@ export function CompanyInfoBanner({ company }: Props) {
 					</div>
 				</div>
 
-				<div className={`${styles.infoRow} fr-mb-1w`}>
-					<p className={styles.datapoint}>
-						SIREN : <strong>{formatSiren(company.siren)}</strong>
-					</p>
+				<dl className={`${styles.infoRow} fr-mb-1w`}>
+					<div className={styles.datapoint}>
+						<dt>SIREN :</dt>
+						<dd>
+							<strong>{formatSiren(company.siren)}</strong>
+						</dd>
+					</div>
 					{company.address && (
-						<p className={styles.datapoint}>
-							Adresse : <strong>{formatAddress(company.address)}</strong>
-						</p>
+						<div className={styles.datapoint}>
+							<dt>Adresse :</dt>
+							<dd>
+								<strong>{formatAddress(company.address)}</strong>
+							</dd>
+						</div>
 					)}
-				</div>
+				</dl>
 
-				<div className={styles.infoRow}>
+				<dl className={styles.infoRow}>
 					{company.nafCode && (
-						<p className={styles.datapoint}>
-							Code NAF :{" "}
-							<strong>
-								{company.nafLabel
-									? `${company.nafCode} — ${company.nafLabel}`
-									: company.nafCode}
-							</strong>
-						</p>
+						<div className={styles.datapoint}>
+							<dt>Code NAF :</dt>
+							<dd>
+								<strong>
+									{company.nafLabel
+										? `${company.nafCode} — ${company.nafLabel}`
+										: company.nafCode}
+								</strong>
+							</dd>
+						</div>
 					)}
 					{company.workforce !== null && (
-						<p className={styles.datapoint}>
-							Effectif annuel moyen en {currentYear} :{" "}
-							<strong>{company.workforce}</strong>
-						</p>
+						<div className={styles.datapoint}>
+							<dt>Effectif annuel moyen en {currentYear} :</dt>
+							<dd>
+								<strong>{company.workforce}</strong>
+							</dd>
+						</div>
 					)}
-					<p className={styles.datapoint}>
-						Existence d'un CSE :{" "}
-						{company.hasCse !== null ? (
-							<strong>{company.hasCse ? "Oui" : "Non"}</strong>
-						) : (
-							<StatusBadge status="to_complete" />
-						)}
-					</p>
-				</div>
+					<div className={styles.datapoint}>
+						<dt>Existence d'un CSE :</dt>
+						<dd>
+							{company.hasCse !== null ? (
+								<strong>{company.hasCse ? "Oui" : "Non"}</strong>
+							) : (
+								<StatusBadge status="to_complete" />
+							)}
+						</dd>
+					</div>
+				</dl>
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/my-space/CompanyListHeader.tsx
+++ b/packages/app/src/modules/my-space/CompanyListHeader.tsx
@@ -4,7 +4,7 @@ export function CompanyListHeader() {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3w">
 			<div className="fr-col">
-				<h2>Mes entreprises</h2>
+				<h1 className="fr-h2">Mes entreprises</h1>
 			</div>
 			<div className="fr-col-auto">
 				{/* TODO: Replace href with real ProConnect account URL */}

--- a/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 import { ArchivesSection } from "../ArchivesSection";
 
 describe("ArchivesSection", () => {
-	it("renders the 'Archives' title", () => {
+	it("renders the 'Archives' title as an h2 heading", () => {
 		render(<ArchivesSection />);
-		expect(screen.getByText("Archives")).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Archives" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders the description text", () => {

--- a/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
@@ -18,6 +18,13 @@ describe("CompanyCard", () => {
 		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
+	it("renders the card title as an h2 heading", () => {
+		render(<CompanyCard company={company} />);
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders the SIREN number", () => {
 		render(<CompanyCard company={company} />);
 		expect(screen.getByText("N° SIREN : 532847196")).toBeInTheDocument();

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -109,7 +109,7 @@ describe("CompanyDeclarationsPage", () => {
 	it("renders the company name", () => {
 		renderPage();
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -54,6 +54,27 @@ describe("CompanyEditModal", () => {
 		);
 	});
 
+	it("marks the dialog as modal for assistive technologies", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		expect(container.querySelector("dialog")).toHaveAttribute(
+			"aria-modal",
+			"true",
+		);
+	});
+
+	it("structures readonly company data as description lists", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		const terms = Array.from(container.querySelectorAll("dl dt")).map(
+			(dt) => dt.textContent,
+		);
+		expect(terms).toContain("Raison sociale :");
+		expect(terms).toContain("SIREN :");
+		expect(terms).toContain("Adresse :");
+		expect(terms).toContain("Code NAF :");
+	});
+
 	it("renders the modal with company info", () => {
 		const { container } = render(<CompanyEditModal company={company} />);
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -15,11 +15,25 @@ const baseCompany: CompanyDetail = {
 };
 
 describe("CompanyInfoBanner", () => {
-	it("renders the company name as an h2 heading", () => {
+	it("renders the company name as the page h1 heading", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
+	});
+
+	it("structures company data as a description list", () => {
+		const { container } = render(
+			<CompanyInfoBanner
+				company={{ ...baseCompany, address: "12 RUE DE PARIS, 75001 PARIS" }}
+			/>,
+		);
+		const terms = Array.from(container.querySelectorAll("dl dt")).map(
+			(dt) => dt.textContent,
+		);
+		expect(terms).toContain("SIREN :");
+		expect(terms).toContain("Adresse :");
+		expect(terms).toContain("Existence d'un CSE :");
 	});
 
 	it("renders the formatted SIREN", () => {

--- a/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it } from "vitest";
 import { CompanyListHeader } from "../CompanyListHeader";
 
 describe("CompanyListHeader", () => {
-	it("renders the H2 title", () => {
+	it("renders the page h1 title", () => {
 		render(<CompanyListHeader />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
@@ -125,7 +125,7 @@ describe("MonEspacePage", () => {
 		render(page);
 		expect(screen.getByRole("main")).toHaveAttribute("id", "content");
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Test Company" }),
+			screen.getByRole("heading", { level: 1, name: "Test Company" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
@@ -45,7 +45,7 @@ describe("MyCompaniesPage", () => {
 		const page = await MyCompaniesPage();
 		render(page);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
## Cluster MY-SPACE — corrections RGAA (audit ARA #3870 / epic #3800)

Corrections behavior-preserving limitées à `packages/app/src/modules/my-space/**`. Rendu visuel inchangé (apparence pilotée par les classes `fr-h*` et le SCSS module).

### Closes #3876 — RGAA 9.3 (listes de description)
- `CompanyInfoBanner` : les couples intitulé/valeur (SIREN, adresse, code NAF, effectif, CSE) passent de `<p>Label : <strong>valeur</strong></p>` à `<dl>` avec `<dt>`/`<dd>` (une `<dl>` par rangée visuelle, paires groupées dans des `<div>` conformes au modèle de contenu de `<dl>`). Rendu inline « Label : valeur » conservé via le SCSS module (dt/dd inline-flex, marges à zéro).
- `CompanyEditModal` : `InfoRow` devient un groupe `<div><dt><dd>` et `CompanyReadonlySection` enveloppe ses rangées dans des `<dl>`. Le fieldset « existence d'un CSE » n'est **pas** modifié.

### Refs #3878 — RGAA 10.7 (prise de focus visible) — à confirmer au rendu
- `CompanyEditModal.module.scss` : la surcharge `.cseFieldset .fr-fieldset__element--inline { flex: 1 }` (flex-basis 0) pouvait écraser les radios rich à largeur réduite et rogner l'outline de focus DSFR (2px + offset 2px hors de la boîte). Remplacée par `flex: 1 1 8rem` : rendu identique aux largeurs desktop (les deux éléments croissent également), mais passage à la ligne aux largeurs réduites au lieu d'un écrasement/débordement.
- ⚠️ Correctif CSS raisonnable au vu de l'analyse statique du CSS DSFR ; **une vérification au rendu (desktop + largeurs réduites + zoom 400 %) reste nécessaire** avant de clore le ticket.

### Refs #3816 — RGAA 7.1 (part CompanyEditModal uniquement)
- `aria-modal="true"` ajouté sur le `<dialog>` de `CompanyEditModal`, aligné sur les modales sœurs (`MissingInfoModal`, `ThemeModal`, …). Les autres volets du ticket (DeclarationTable, UserAccountMenu, ScoreDistributionChart) sont hors périmètre de cette PR.

### Refs #3802 — RGAA 9.1 (part mon-espace uniquement)
- `CompanyInfoBanner` : `h2.fr-h4` → `h1.fr-h4` (la page `/mon-espace` n'avait pas de `<h1>`).
- `CompanyListHeader` : `h2` → `h1.fr-h2` (idem pour `/mon-espace/mes-entreprises`).
- `CompanyCard` : `h3.fr-card__title` → `h2.fr-card__title` (plus de saut h1→h3).
- `ArchivesSection` : paragraphe gras « Archives » → `h2` avec taille visuelle body conservée via le SCSS module.
- Les volets admin / ResourceBanner / RecapitulatifPage du ticket sont hors périmètre de cette PR.

### Vérifications
- `pnpm --filter app typecheck` ✅
- ultra11y (`audit --jsx --graph --standard rgaa`) sur les 5 `.tsx` modifiés : 0 NC avant → 0 NC après ✅
- `pnpm run test:a11y` (gate statique repo, `--fail-on blocking`) : exit 0, aucune remontée my-space ✅
- `pnpm exec vitest run` : 338 fichiers / 3316 tests verts ✅ (tests des niveaux de titres et des `<dl>` mis à jour/ajoutés)
- `pnpm exec biome check` sur le module : clean ✅