### PR TITLE
fix(a11y): header — accès rapides, focus menu mobile, lien d'évitement footer, menu compte

### DIFF
--- a/packages/app/src/modules/layout/Header/HeaderBrand.tsx
+++ b/packages/app/src/modules/layout/Header/HeaderBrand.tsx
@@ -14,7 +14,12 @@ export function HeaderBrand() {
 						et des solidarités
 					</p>
 				</div>
-				<div className="fr-header__navbar">
+				{/* RGAA 9.2: mobile counterpart of the desktop quick-access <nav>
+				    (`.fr-header__tools-links` in HeaderQuickAccess). The two share
+				    the same accessible name because only one is displayed per
+				    breakpoint (DSFR hides the navbar on desktop and the tools bar
+				    on mobile). */}
+				<nav aria-label="Accès rapides" className="fr-header__navbar">
 					<button
 						aria-controls="modal-menu"
 						aria-haspopup="dialog"
@@ -25,7 +30,7 @@ export function HeaderBrand() {
 					>
 						Menu
 					</button>
-				</div>
+				</nav>
 			</div>
 			<div className="fr-header__service">
 				<Link

--- a/packages/app/src/modules/layout/Header/HeaderQuickAccess.tsx
+++ b/packages/app/src/modules/layout/Header/HeaderQuickAccess.tsx
@@ -16,12 +16,16 @@ export async function HeaderQuickAccess() {
 
 	return (
 		<div className="fr-header__tools">
-			<div className="fr-header__tools-links">
+			{/* RGAA 9.2: the quick-access zone is a navigation landmark. The <nav>
+			    itself carries `.fr-header__tools-links` so the DSFR `HeaderLinks`
+			    script (which clones this element's innerHTML into the mobile menu)
+			    keeps comparing the exact same inner content. */}
+			<nav aria-label="Accès rapides" className="fr-header__tools-links">
 				<HeaderQuickAccessLinks
 					session={session}
 					userPhone={profile?.phone ?? null}
 				/>
-			</div>
+			</nav>
 		</div>
 	);
 }

--- a/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
+++ b/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { getDsfrModal } from "~/modules/shared";
 import styles from "./MobileUserBlock.module.scss";
+
+/** Frames to wait for the DSFR focus trap before focusing the name anyway. */
+const FOCUS_TRAP_MAX_FRAMES = 30;
 
 type Props = {
 	userName: string;
@@ -21,15 +24,60 @@ type Props = {
  * `.fr-header__menu-links` container).
  */
 export function MobileUserBlock({ userName, userEmail, userPhone }: Props) {
+	const userNameRef = useRef<HTMLParagraphElement>(null);
+
 	const openProfileModal = useCallback(() => {
 		const profile = document.getElementById("profile-modal");
 		if (profile) getDsfrModal(profile)?.disclose();
 	}, []);
 
+	// RGAA 12.8: when the mobile menu opens, the DSFR focus trap moves focus to
+	// the first interactive element (the "Fermer" button). The expected target
+	// is the first *content* element instead: the user name. Wait for the trap
+	// to settle (it polls with requestAnimationFrame until the modal is
+	// focusable), then re-target the focus onto the name. Closing the menu is
+	// untouched: DSFR gives focus back to the burger button natively.
+	useEffect(() => {
+		const menuModal = document.getElementById("modal-menu");
+		if (!menuModal) return;
+
+		let frame: number | null = null;
+
+		const cancelPendingFocus = () => {
+			if (frame !== null) window.cancelAnimationFrame(frame);
+			frame = null;
+		};
+
+		const handleDisclose = () => {
+			let attemptsLeft = FOCUS_TRAP_MAX_FRAMES;
+			const settle = () => {
+				const trapSettled = menuModal.contains(document.activeElement);
+				if (trapSettled || attemptsLeft <= 0) {
+					frame = null;
+					userNameRef.current?.focus();
+					return;
+				}
+				attemptsLeft -= 1;
+				frame = window.requestAnimationFrame(settle);
+			};
+			frame = window.requestAnimationFrame(settle);
+		};
+
+		menuModal.addEventListener("dsfr.disclose", handleDisclose);
+		menuModal.addEventListener("dsfr.conceal", cancelPendingFocus);
+		return () => {
+			menuModal.removeEventListener("dsfr.disclose", handleDisclose);
+			menuModal.removeEventListener("dsfr.conceal", cancelPendingFocus);
+			cancelPendingFocus();
+		};
+	}, []);
+
 	return (
 		<div className={styles.wrapper}>
 			<div className={styles.userInfo}>
-				<p className={styles.userName}>{userName}</p>
+				<p className={styles.userName} ref={userNameRef} tabIndex={-1}>
+					{userName}
+				</p>
 				<p className={styles.userMeta}>{userEmail}</p>
 				{userPhone && <p className={styles.userMeta}>{userPhone}</p>}
 			</div>

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
@@ -34,6 +34,15 @@
 	gap: 0.5rem;
 }
 
+// role="menu" wrapper around the action groups: replicates the dropdown's
+// column flow so inserting it keeps the rendering pixel-identical.
+.menu {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
 .userName {
 	margin: 0;
 	font-size: 0.875rem;

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
@@ -65,6 +65,13 @@ export function UserAccountMenu({
 				case "Escape":
 					close();
 					break;
+				case "Tab":
+					// APG menu pattern: Tab dismisses the menu. Focus is handed back
+					// to the toggle button (via close) instead of letting the default
+					// move happen inside a menu that is about to unmount.
+					event.preventDefault();
+					close();
+					break;
 				case "ArrowDown": {
 					event.preventDefault();
 					const items = getMenuItems();
@@ -115,53 +122,68 @@ export function UserAccountMenu({
 			</button>
 
 			{isOpen && (
-				<div className={styles.dropdown} ref={menuRef} role="menu">
+				<div className={styles.dropdown} ref={menuRef}>
+					{/* The user info block sits outside the role="menu" element: a menu
+					    may only own menuitem/group/separator children, and static text
+					    would be skipped by screen readers in menu navigation mode. */}
 					<div className={styles.userInfo}>
 						<p className={styles.userName}>{userName}</p>
 						<p className={styles.userEmail}>{userEmail}</p>
 						{userPhone && <p className={styles.userEmail}>{userPhone}</p>}
 					</div>
 
-					<div className={styles.links}>
-						{isAdmin && (
+					{/* The two inner divs stay role-less: generic containers are
+					    ownership-transparent, so the menuitems remain owned by the
+					    menu (verified against axe aria-required-children). */}
+					<div aria-label="Mon espace" className={styles.menu} role="menu">
+						<div className={styles.links}>
+							{isAdmin && (
+								<Link
+									className={styles.menuLink}
+									href="/admin"
+									onClick={close}
+									role="menuitem"
+									tabIndex={-1}
+								>
+									Administration
+								</Link>
+							)}
 							<Link
 								className={styles.menuLink}
-								href="/admin"
+								href="/mon-espace/mes-entreprises"
 								onClick={close}
 								role="menuitem"
+								tabIndex={-1}
 							>
-								Administration
+								Mes entreprises
 							</Link>
-						)}
-						<Link
-							className={styles.menuLink}
-							href="/mon-espace/mes-entreprises"
-							onClick={close}
-							role="menuitem"
-						>
-							Mes entreprises
-						</Link>
-						<button
-							className={styles.menuLink}
-							onClick={openProfileModal}
-							role="menuitem"
-							type="button"
-						>
-							Voir mon profil
-						</button>
-					</div>
+							<button
+								className={styles.menuLink}
+								onClick={openProfileModal}
+								role="menuitem"
+								tabIndex={-1}
+								type="button"
+							>
+								Voir mon profil
+							</button>
+						</div>
 
-					<div className={styles.logout}>
-						{/* Native <a> required: this route redirects to an external IdP (ProConnect),
-						    so we need a full browser navigation, not a client-side RSC fetch. */}
-						<a
-							className={styles.logoutLink}
-							href="/api/auth/logout"
-							role="menuitem"
-						>
-							<span aria-hidden="true" className="fr-icon-logout-box-r-line" />
-							Se déconnecter
-						</a>
+						<div className={styles.logout}>
+							{/* Native <a> required: this route redirects to an external IdP (ProConnect),
+							    so we need a full browser navigation, not a client-side RSC fetch. */}
+							<a
+								className={styles.logoutLink}
+								href="/api/auth/logout"
+								role="menuitem"
+								tabIndex={-1}
+							>
+								<span
+									aria-hidden="true"
+									className="fr-icon-logout-box-r-line"
+								/>
+								Se déconnecter
+							</a>
+						</div>
 					</div>
 				</div>
 			)}

--- a/packages/app/src/modules/layout/Header/__tests__/HeaderBrand.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/HeaderBrand.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { HeaderBrand } from "../HeaderBrand";
+
+describe("HeaderBrand", () => {
+	it("wraps the mobile menu trigger in a 'Accès rapides' navigation landmark (RGAA 9.2)", () => {
+		render(<HeaderBrand />);
+		const nav = screen.getByRole("navigation", { name: "Accès rapides" });
+		expect(nav).toContainElement(screen.getByRole("button", { name: "Menu" }));
+	});
+
+	it("keeps the DSFR navbar class on the navigation element", () => {
+		render(<HeaderBrand />);
+		expect(
+			screen.getByRole("navigation", { name: "Accès rapides" }),
+		).toHaveClass("fr-header__navbar");
+	});
+
+	it("renders the service link to the home page", () => {
+		render(<HeaderBrand />);
+		expect(screen.getByRole("link", { name: /egapro/i })).toHaveAttribute(
+			"href",
+			"/",
+		);
+	});
+});

--- a/packages/app/src/modules/layout/Header/__tests__/HeaderQuickAccess.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/HeaderQuickAccess.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	auth: vi.fn(),
+	profileGet: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({
+	auth: mocks.auth,
+}));
+
+vi.mock("~/trpc/server", () => ({
+	api: { profile: { get: mocks.profileGet } },
+}));
+
+import { HeaderQuickAccess } from "../HeaderQuickAccess";
+
+beforeEach(() => {
+	mocks.auth.mockResolvedValue(null);
+	mocks.profileGet.mockResolvedValue({ phone: null });
+});
+
+describe("HeaderQuickAccess", () => {
+	it("wraps the quick access links in a 'Accès rapides' navigation landmark (RGAA 9.2)", async () => {
+		render(await HeaderQuickAccess());
+
+		const nav = screen.getByRole("navigation", { name: "Accès rapides" });
+		expect(nav).toContainElement(screen.getByRole("link", { name: "Aide" }));
+		expect(nav).toContainElement(
+			screen.getByRole("link", { name: "Se connecter" }),
+		);
+	});
+
+	it("keeps the DSFR tools-links class on the navigation element (DSFR HeaderLinks hook)", async () => {
+		render(await HeaderQuickAccess());
+
+		expect(
+			screen.getByRole("navigation", { name: "Accès rapides" }),
+		).toHaveClass("fr-header__tools-links");
+	});
+
+	it("renders the account menu inside the landmark when signed in", async () => {
+		mocks.auth.mockResolvedValue({
+			user: {
+				email: "jean.dupont@example.fr",
+				name: "Jean Dupont",
+				phone: null,
+			},
+		});
+
+		render(await HeaderQuickAccess());
+
+		expect(
+			screen.getByRole("navigation", { name: "Accès rapides" }),
+		).toContainElement(screen.getByRole("button", { name: "Mon espace" }));
+	});
+});

--- a/packages/app/src/modules/layout/Header/__tests__/MobileUserBlock.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/MobileUserBlock.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { MobileUserBlock } from "../MobileUserBlock";
@@ -42,6 +42,39 @@ describe("MobileUserBlock", () => {
 		render(<MobileUserBlock {...defaultProps} />);
 		const link = screen.getByRole("link", { name: "Se déconnecter" });
 		expect(link).toHaveAttribute("href", "/api/auth/logout");
+	});
+
+	describe("focus on mobile menu opening (RGAA 12.8)", () => {
+		it("moves focus onto the user name once the DSFR focus trap settled", async () => {
+			// Simulate the DSFR mobile menu modal wrapping the block.
+			const menuModal = document.createElement("div");
+			menuModal.id = "modal-menu";
+			const closeButton = document.createElement("button");
+			closeButton.textContent = "Fermer";
+			menuModal.appendChild(closeButton);
+			document.body.appendChild(menuModal);
+
+			const { container } = render(<MobileUserBlock {...defaultProps} />, {
+				container: menuModal.appendChild(document.createElement("div")),
+			});
+
+			// DSFR dispatches dsfr.disclose, then its focus trap moves focus to
+			// the first interactive element (the close button).
+			fireEvent(menuModal, new Event("dsfr.disclose"));
+			closeButton.focus();
+
+			await waitFor(() => {
+				expect(screen.getByText("Jean Dupont")).toHaveFocus();
+			});
+
+			container.remove();
+			menuModal.remove();
+		});
+
+		it("makes the user name programmatically focusable only", () => {
+			render(<MobileUserBlock {...defaultProps} />);
+			expect(screen.getByText("Jean Dupont")).toHaveAttribute("tabindex", "-1");
+		});
 	});
 
 	it("opens the profile modal when 'Voir mon profil' is clicked", () => {

--- a/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
@@ -36,6 +36,30 @@ describe("UserAccountMenu", () => {
 			expect(screen.getByRole("menu")).toBeInTheDocument();
 		});
 
+		it("names the menu 'Mon espace'", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			expect(
+				screen.getByRole("menu", { name: "Mon espace" }),
+			).toBeInTheDocument();
+		});
+
+		it("keeps the user info block outside the menu element", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			expect(screen.getByRole("menu")).not.toContainElement(
+				screen.getByText("Jean Dupont"),
+			);
+		});
+
+		it("removes menu items from the natural tab order (roving focus)", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			for (const item of screen.getAllByRole("menuitem")) {
+				expect(item).toHaveAttribute("tabindex", "-1");
+			}
+		});
+
 		it("sets aria-expanded=true when open", () => {
 			render(<UserAccountMenu {...defaultProps} />);
 			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
@@ -104,6 +128,16 @@ describe("UserAccountMenu", () => {
 			expect(screen.getByRole("menu")).toBeInTheDocument();
 			fireEvent.keyDown(document, { key: "Escape" });
 			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+		});
+
+		it("closes the menu on Tab and returns focus to the toggle button", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			const toggle = screen.getByRole("button", { name: "Mon espace" });
+			fireEvent.click(toggle);
+			expect(screen.getByRole("menu")).toBeInTheDocument();
+			fireEvent.keyDown(document, { key: "Tab" });
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+			expect(toggle).toHaveFocus();
 		});
 
 		it("closes the menu when clicking outside", () => {

--- a/packages/app/src/modules/layout/PublicChrome.tsx
+++ b/packages/app/src/modules/layout/PublicChrome.tsx
@@ -6,6 +6,17 @@ import { Footer } from "./Footer";
 import { ResourceBanner } from "./ResourceBanner";
 
 /**
+ * Backoffice routes render no public chrome — hence no footer landmark.
+ * Matches the `/admin` segment boundary so hypothetical sibling routes like
+ * `/administrator` or `/admin-tools` keep the public chrome. Shared with
+ * `SkipLinks`, which hides the "Pied de page" skip link on those routes
+ * (RGAA 12.7: a skip link must not point to a missing anchor).
+ */
+export function isAdminRoute(pathname: string | null): boolean {
+	return pathname === "/admin" || Boolean(pathname?.startsWith("/admin/"));
+}
+
+/**
  * Renders the public help banner + footer on every route except the backoffice.
  * Admin pages (`/admin/**`) get a stripped-down chrome so the sidebar + admin
  * content fill the viewport without competing with public navigation.
@@ -13,9 +24,7 @@ import { ResourceBanner } from "./ResourceBanner";
  */
 export function PublicChrome() {
 	const pathname = usePathname();
-	// Match the `/admin` segment boundary so hypothetical sibling routes like
-	// `/administrator` or `/admin-tools` keep the public chrome.
-	if (pathname === "/admin" || pathname?.startsWith("/admin/")) {
+	if (isAdminRoute(pathname)) {
 		return null;
 	}
 	const showResourceBanner = pathname !== "/login";

--- a/packages/app/src/modules/layout/shared/SkipLinks.tsx
+++ b/packages/app/src/modules/layout/shared/SkipLinks.tsx
@@ -1,9 +1,21 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { isAdminRoute } from "../PublicChrome";
+
 /**
  * Skip links — mandatory RGAA criterion 12.7.
  * Allow keyboard/screen reader users to skip directly
  * to the main content or the footer.
+ *
+ * Admin routes (`/admin/**`) render no footer (`PublicChrome` returns null),
+ * so the "Pied de page" link is hidden there to avoid an orphan anchor.
  */
 export function SkipLinks() {
+	const pathname = usePathname();
+	const hasFooter = !isAdminRoute(pathname);
+
 	return (
 		<div className="fr-skiplinks">
 			<nav aria-label="Accès rapide" className="fr-container">
@@ -13,11 +25,13 @@ export function SkipLinks() {
 							Contenu
 						</a>
 					</li>
-					<li>
-						<a className="fr-link" href="#footer">
-							Pied de page
-						</a>
-					</li>
+					{hasFooter && (
+						<li>
+							<a className="fr-link" href="#footer">
+								Pied de page
+							</a>
+						</li>
+					)}
 				</ul>
 			</nav>
 		</div>

--- a/packages/app/src/modules/layout/shared/__tests__/SkipLinks.test.tsx
+++ b/packages/app/src/modules/layout/shared/__tests__/SkipLinks.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { usePathname } from "next/navigation";
+import { beforeEach, describe, expect, it, type Mock } from "vitest";
 import { SkipLinks } from "../SkipLinks";
 
 describe("SkipLinks", () => {
+	beforeEach(() => {
+		(usePathname as Mock).mockReturnValue("/");
+	});
+
 	it("renders a <nav> with aria-label 'Accès rapide'", () => {
 		render(<SkipLinks />);
 		expect(
@@ -25,5 +30,41 @@ describe("SkipLinks", () => {
 	it("renders exactly two skip links", () => {
 		render(<SkipLinks />);
 		expect(screen.getAllByRole("link")).toHaveLength(2);
+	});
+
+	describe("on admin routes (no footer rendered)", () => {
+		it("hides the #footer link on /admin", () => {
+			(usePathname as Mock).mockReturnValue("/admin");
+			render(<SkipLinks />);
+			expect(
+				screen.queryByRole("link", { name: /pied de page/i }),
+			).not.toBeInTheDocument();
+			expect(screen.getAllByRole("link")).toHaveLength(1);
+		});
+
+		it("hides the #footer link on nested /admin/* routes", () => {
+			(usePathname as Mock).mockReturnValue("/admin/declarations");
+			render(<SkipLinks />);
+			expect(
+				screen.queryByRole("link", { name: /pied de page/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("keeps the #content link on /admin", () => {
+			(usePathname as Mock).mockReturnValue("/admin");
+			render(<SkipLinks />);
+			expect(screen.getByRole("link", { name: /contenu/i })).toHaveAttribute(
+				"href",
+				"#content",
+			);
+		});
+
+		it("keeps the #footer link on sibling routes merely starting with 'admin'", () => {
+			(usePathname as Mock).mockReturnValue("/administrator");
+			render(<SkipLinks />);
+			expect(
+				screen.getByRole("link", { name: /pied de page/i }),
+			).toBeInTheDocument();
+		});
 	});
 });


### PR DESCRIPTION
Cluster **header** de l'audit RGAA : landmarks d'accès rapides, focus du menu mobile, lien d'évitement footer, motif ARIA du menu compte.

Closes #3875 — Refs #3880 — Refs #3801 — Refs #3816

## #3875 — RGAA 9.2 : navigation structurée par `<nav>`
- `HeaderQuickAccess` : la liste Aide / Se connecter / Mon espace (desktop) est enveloppée dans un `<nav aria-label="Accès rapides">`. Le `<nav>` porte **lui-même** la classe `.fr-header__tools-links` : la JS DSFR (`HeaderLinks`) compare/clone l'`innerHTML` de cet élément vers le menu mobile, qui reste donc strictement identique (vérifié dans la source DSFR 1.14 : sélecteur par classe, aucun sélecteur qualifié par tag).
- `HeaderBrand` : le déclencheur menu mobile (`.fr-header__navbar`) devient également un `<nav aria-label="Accès rapides">`. Les deux landmarks partagent le même nom accessible car un seul est affiché par breakpoint (DSFR masque la navbar en desktop et les tools en mobile) — pas de doublon dans l'arbre d'accessibilité restitué.
- Distinct du `<nav aria-label="Menu principal">` existant (Navigation.tsx), non modifié.

## #3880 (partiel) — RGAA 12.8 : focus à l'ouverture du menu mobile
- `MobileUserBlock` : le `<p>` nom devient focusable programmatiquement (`tabIndex={-1}`) ; à l'événement `dsfr.disclose` du `#modal-menu`, un hook attend que le focus trap DSFR soit posé (poll rAF, borné) puis déplace le focus sur le nom au lieu du bouton « Fermer ».
- La fermeture reste entièrement gérée par la JS DSFR (retour du focus au burger).
- Le volet SPA du ticket (restitution de titre / ordre de tabulation aux rechargements partiels) est explicitement délégué à #3816 par le ticket — non traité ici.

## #3801 (partiel) — RGAA 12.7 : lien d'évitement `#footer`
- Les routes `/admin/**` ne rendent aucun footer (`PublicChrome` retourne `null`) : le lien « Pied de page » de `SkipLinks` pointait vers une ancre inexistante. Il est masqué sur ces routes ; prédicat `isAdminRoute` partagé entre `PublicChrome` et `SkipLinks` (source unique, même frontière de segment `/admin`).
- Le reste du ticket (landmark `<main>` admin/stats/tunnels) est porté par un autre lot.
- Note sur le commentaire de revue demandant `role="navigation"` explicite sur le `<nav>` du menu : le rôle `navigation` est implicite sur `<nav>` et la convention du repo interdit les rôles redondants (`packages/app/CLAUDE.md`, hook + gate ultra11y). Non appliqué ici — à arbitrer en revue si l'exigence de compatibilité AT legacy est confirmée.

## #3816 (partiel) — RGAA 7.1/7.3 : motif ARIA du menu compte
- `UserAccountMenu` : `role="menu"` nommé (`aria-label="Mon espace"`) et restreint aux actions ; le bloc d'infos utilisateur (texte statique) sort du menu pour rester restituable hors mode menu des lecteurs d'écran.
- Roving focus complété : `menuitem` en `tabIndex={-1}`, `Tab` referme le menu et rend le focus au bouton déclencheur ; flèches / Home / End / Échap / clic extérieur inchangés. Le handler `[role="menuitem"]` existant est conservé.
- Conteneurs intermédiaires laissés sans rôle : vérifié sans violation `aria-required-children` / `aria-required-parent` (axe-core 4.11) — pas de `role="group"` (refusé par la gate lint).
- Les autres surfaces du ticket (DeclarationTable, CompanyEditModal, ScoreDistributionChart, ThemeModal) sont hors de ce lot.

## Vérifications
- `pnpm --filter app typecheck` ✅
- ultra11y (`--jsx --graph --standard rgaa`) sur le périmètre header/footer/chrome : 0 NC avant → 0 NC après ✅
- `vitest` : suite complète 340 fichiers / 3328 tests ✅ (dont nouveaux tests HeaderBrand, HeaderQuickAccess, SkipLinks admin, Tab/nom de menu, focus mobile)
- `biome check` ✅

## À vérifier au rendu (review app / device)
- Menu mobile : ouverture/fermeture toujours fonctionnelles avec le `<nav>` porteur de `.fr-header__tools-links` (le clonage DSFR est vérifié en source, pas en device réel).
- Focus effectif sur le nom à l'ouverture du menu mobile connecté (le timing du focus trap DSFR n'est vérifiable qu'au rendu).
- Rendu visuel du dropdown « Mon espace » inchangé (wrapper `.menu` répliquant le flux colonne).
