### PR TITLE
fix(a11y): cluster déclaration — fieldsets (#3803), erreurs (#3804), landmarks (#3801), titres (#3802), zoom (#3812)

### DIFF
--- a/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
+++ b/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminDeclarationDetailPage } from "~/modules/admin/declarations";
+
+export const metadata: Metadata = { title: "Détail de la déclaration" };
 
 type Props = {
 	params: Promise<{ declarationId: string }>;

--- a/packages/app/src/app/admin/impersonate/page.tsx
+++ b/packages/app/src/app/admin/impersonate/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { ImpersonatePage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Mimoquer une entreprise" };
 
 export default function Page() {
 	return <ImpersonatePage />;

--- a/packages/app/src/app/admin/liste-referents/page.tsx
+++ b/packages/app/src/app/admin/liste-referents/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminReferentsPage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Liste des référents" };
 
 export default function Page() {
 	return <AdminReferentsPage />;

--- a/packages/app/src/app/admin/page.tsx
+++ b/packages/app/src/app/admin/page.tsx
@@ -1,5 +1,9 @@
+import type { Metadata } from "next";
+
 import { AdminHomePage } from "~/modules/admin";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Backoffice" };
 
 export default async function Page() {
 	// Access control is handled by the edge middleware and the admin layout;

--- a/packages/app/src/app/admin/parametres/page.tsx
+++ b/packages/app/src/app/admin/parametres/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminSettingsPage } from "~/modules/admin/settings";
+
+export const metadata: Metadata = { title: "Paramètres de la plateforme" };
 
 export default function Page() {
 	return <AdminSettingsPage />;

--- a/packages/app/src/app/admin/stats/page.tsx
+++ b/packages/app/src/app/admin/stats/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { StatsDashboard } from "~/modules/admin/stats";
 import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
 
-export const metadata: Metadata = { title: "Statistiques — Egapro" };
+export const metadata: Metadata = { title: "Statistiques" };
 
 export default function Page() {
 	const currentYear = getCurrentYear();

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
 	getEffectiveGipPrefillData,
+	STEP_TITLES,
 	StepPageClient,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
@@ -15,6 +17,20 @@ import { api, HydrateClient } from "~/trpc/server";
 type StepPageProps = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({
+	params,
+}: StepPageProps): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${TOTAL_STEPS} — ${stepTitle}`
+			: "Déclaration des écarts de rémunération",
+	};
+}
 
 export default async function StepPage({ params }: StepPageProps) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+	title: "Déclaration des écarts de rémunération",
+};
 
 export default function DeclarationPage() {
 	redirect("/declaration-remuneration/etape/1");

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
@@ -1,8 +1,14 @@
+import type { Metadata } from "next";
+
 import { FunnelCompleteTracker } from "~/modules/analytics";
 import {
 	COMPLIANCE_FUNNEL,
 	ComplianceConfirmation,
 } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = {
+	title: "Confirmation — Parcours de mise en conformité",
+};
 
 export default function ComplianceConfirmationPage() {
 	return (

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
@@ -1,8 +1,26 @@
-import { SecondDeclarationStepPage } from "~/modules/declaration-remuneration";
+import type { Metadata } from "next";
+
+import {
+	SECOND_DECLARATION_STEP_TITLES,
+	SECOND_DECLARATION_TOTAL_STEPS,
+	SecondDeclarationStepPage,
+} from "~/modules/declaration-remuneration";
 
 type Props = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = SECOND_DECLARATION_STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${SECOND_DECLARATION_TOTAL_STEPS} — ${stepTitle}`
+			: "Parcours de mise en conformité",
+	};
+}
 
 export default async function Page({ params }: Props) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { JointEvaluationPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Évaluation conjointe" };
 
 export default function Page() {
 	return <JointEvaluationPage />;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { CompliancePathPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Parcours de mise en conformité" };
 
 export default function Page() {
 	return <CompliancePathPage />;

--- a/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
@@ -89,7 +89,11 @@ export default async function RecapitulatifRoute({ searchParams }: Props) {
 				</Link>
 			</div>
 
-			<main className="fr-container fr-pb-7w fr-pt-7w" id="content">
+			<main
+				className="fr-container fr-pb-7w fr-pt-7w"
+				id="content"
+				tabIndex={-1}
+			>
 				<div className="fr-grid-row fr-grid-row--center">
 					<div className="fr-col-12 fr-col-lg-8">
 						<RecapitulatifPage

--- a/packages/app/src/app/login/page.tsx
+++ b/packages/app/src/app/login/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { LoginPage, sanitizeCallbackUrl } from "~/modules/login";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Connexion" };
 
 type PageProps = {
 	searchParams: Promise<{ callbackUrl?: string }>;

--- a/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
+++ b/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
@@ -12,7 +12,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { year } = await params;
 	return {
-		title: `Historique des modifications ${year} — Egapro`,
+		title: `Historique des modifications ${year}`,
 	};
 }
 

--- a/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
@@ -84,7 +84,7 @@ export function AdminDeclarationDetailPage({ declarationId }: Props) {
 			{recap && (
 				<section className="fr-mt-6w">
 					<h2 className="fr-h3">Récapitulatif déclaré</h2>
-					<RecapitulatifPage {...recap} />
+					<RecapitulatifPage {...recap} titleTag="h3" />
 				</section>
 			)}
 		</div>

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -71,6 +71,9 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
+import { defaultProps as recapProps } from "~/modules/declaration-remuneration/recapitulatif/__tests__/fixtures";
+import { api } from "~/trpc/react";
+
 import { AdminDeclarationDetailPage } from "../AdminDeclarationDetailPage";
 
 describe("AdminDeclarationDetailPage", () => {
@@ -132,5 +135,21 @@ describe("AdminDeclarationDetailPage", () => {
 		expect(
 			screen.queryByRole("button", { name: "Déverrouiller la déclaration" }),
 		).toBeNull();
+	});
+
+	it("renders the embedded recap title as h3 so the page keeps a single h1", () => {
+		vi.mocked(api.adminDeclarations.getRecap.useQuery).mockReturnValueOnce({
+			data: recapProps(),
+		} as unknown as ReturnType<typeof api.adminDeclarations.getRecap.useQuery>);
+
+		render(<AdminDeclarationDetailPage declarationId="decl-1" />);
+
+		expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
+++ b/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
@@ -54,12 +54,18 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.name ? `${modalId}-name-error` : undefined}
+					aria-invalid={errors.name ? true : undefined}
 					className={`fr-input ${errors.name ? "fr-input--error" : ""}`}
 					id={`${modalId}-name`}
 					type="text"
 					{...register("name")}
 				/>
-				{errors.name && <p className="fr-error-text">{errors.name.message}</p>}
+				{errors.name && (
+					<p className="fr-error-text" id={`${modalId}-name-error`}>
+						{errors.name.message}
+					</p>
+				)}
 			</div>
 
 			<div className="fr-select-group fr-mb-3w">
@@ -67,6 +73,10 @@ export function ReferentFormFields({
 					Région
 				</label>
 				<select
+					aria-describedby={
+						errors.region ? `${modalId}-region-error` : undefined
+					}
+					aria-invalid={errors.region ? true : undefined}
 					className={`fr-select ${errors.region ? "fr-select--error" : ""}`}
 					id={`${modalId}-region`}
 					{...register("region")}
@@ -79,7 +89,9 @@ export function ReferentFormFields({
 					))}
 				</select>
 				{errors.region && (
-					<p className="fr-error-text">{errors.region.message}</p>
+					<p className="fr-error-text" id={`${modalId}-region-error`}>
+						{errors.region.message}
+					</p>
 				)}
 			</div>
 
@@ -143,13 +155,17 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.value ? `${modalId}-value-error` : undefined}
+					aria-invalid={errors.value ? true : undefined}
 					className={`fr-input ${errors.value ? "fr-input--error" : ""}`}
 					id={`${modalId}-value`}
 					type={selectedType === "url" ? "url" : "email"}
 					{...register("value")}
 				/>
 				{errors.value && (
-					<p className="fr-error-text">{errors.value.message}</p>
+					<p className="fr-error-text" id={`${modalId}-value-error`}>
+						{errors.value.message}
+					</p>
 				)}
 			</div>
 
@@ -175,13 +191,21 @@ export function ReferentFormFields({
 							Email du suppléant
 						</label>
 						<input
+							aria-describedby={
+								errors.substituteEmail
+									? `${modalId}-sub-email-error`
+									: undefined
+							}
+							aria-invalid={errors.substituteEmail ? true : undefined}
 							className={`fr-input ${errors.substituteEmail ? "fr-input--error" : ""}`}
 							id={`${modalId}-sub-email`}
 							type="email"
 							{...register("substituteEmail")}
 						/>
 						{errors.substituteEmail && (
-							<p className="fr-error-text">{errors.substituteEmail.message}</p>
+							<p className="fr-error-text" id={`${modalId}-sub-email-error`}>
+								{errors.substituteEmail.message}
+							</p>
 						)}
 					</div>
 				</div>

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -30,7 +30,7 @@ export function CseOpinionLayout({
 	lockHolder = null,
 }: Props) {
 	return (
-		<>
+		<main id="content" tabIndex={-1}>
 			<div className={`fr-py-3w ${styles.banner}`}>
 				<div className="fr-container">
 					<Breadcrumb
@@ -78,7 +78,7 @@ export function CseOpinionLayout({
 					</div>
 				</div>
 			</div>
-			<main className="fr-container fr-py-7w" id="content">
+			<div className="fr-container fr-py-7w">
 				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
 					<div className="fr-grid-row fr-grid-row--center">
 						<div className="fr-col-12 fr-col-lg-8">
@@ -89,7 +89,7 @@ export function CseOpinionLayout({
 						</div>
 					</div>
 				</LockProvider>
-			</main>
-		</>
+			</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -200,7 +200,11 @@ export function Step1Opinions({
 
 	return (
 		<form autoComplete="off" onSubmit={onSubmit}>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Avis du CSE</legend>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
 						<div className="fr-col">

--- a/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
@@ -27,11 +27,11 @@ export function AccuracyOpinionCard({
 				{title}
 			</p>
 
-			<fieldset
-				aria-labelledby={legendId}
-				aria-required="true"
-				className="fr-fieldset"
-			>
+			{/* No aria-required here: the `group` role does not support it (invalid
+			    ARIA). The required indication is carried by the visible mention
+			    "Tous les champs sont obligatoires." at the top of the form
+			    (RGAA 11.10.1). */}
+			<fieldset aria-labelledby={legendId} className="fr-fieldset">
 				<legend
 					className="fr-fieldset__legend--regular fr-fieldset__legend"
 					id={`${id}-opinion-legend`}

--- a/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
@@ -27,7 +27,11 @@ export function AccuracyOpinionCard({
 				{title}
 			</p>
 
-			<fieldset aria-labelledby={legendId} className="fr-fieldset">
+			<fieldset
+				aria-labelledby={legendId}
+				aria-required="true"
+				className="fr-fieldset"
+			>
 				<legend
 					className="fr-fieldset__legend--regular fr-fieldset__legend"
 					id={`${id}-opinion-legend`}

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -31,7 +31,11 @@ export function GapConsultationCard({
 				sexistes de l'indicateur de rémunération par catégorie de salariés
 			</p>
 
-			<fieldset aria-labelledby={legendId} className="fr-fieldset">
+			<fieldset
+				aria-labelledby={legendId}
+				aria-required="true"
+				className="fr-fieldset"
+			>
 				<legend
 					className="fr-fieldset__legend--regular fr-fieldset__legend"
 					id={`${id}-question-legend`}

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -31,11 +31,11 @@ export function GapConsultationCard({
 				sexistes de l'indicateur de rémunération par catégorie de salariés
 			</p>
 
-			<fieldset
-				aria-labelledby={legendId}
-				aria-required="true"
-				className="fr-fieldset"
-			>
+			{/* No aria-required here: the `group` role does not support it (invalid
+			    ARIA). The required indication is carried by the visible mention
+			    "Tous les champs sont obligatoires." at the top of the form
+			    (RGAA 11.10.1). */}
+			<fieldset aria-labelledby={legendId} className="fr-fieldset">
 				<legend
 					className="fr-fieldset__legend--regular fr-fieldset__legend"
 					id={`${id}-question-legend`}

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -28,12 +28,12 @@ export function DeclarationLayout({
 	lockHolder = null,
 }: DeclarationLayoutProps) {
 	return (
-		<>
+		<main id="content" tabIndex={-1}>
 			<CompanyBanner
 				company={company}
 				currentPageLabel={`Démarche des indicateurs de rémunération ${declarationYear}`}
 			/>
-			<main className="fr-container fr-py-7w" id="content">
+			<div className="fr-container fr-py-7w">
 				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
 					<div className="fr-grid-row fr-grid-row--center">
 						<div className="fr-col-12 fr-col-lg-8">
@@ -44,7 +44,7 @@ export function DeclarationLayout({
 						</div>
 					</div>
 				</LockProvider>
-			</main>
-		</>
+			</div>
+		</main>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/MissingSiret.tsx
+++ b/packages/app/src/modules/declaration-remuneration/MissingSiret.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export function MissingSiret() {
 	return (
-		<main className="fr-container fr-my-4w" id="content">
+		<main className="fr-container fr-my-4w" id="content" tabIndex={-1}>
 			<div className="fr-grid-row fr-grid-row--center">
 				<div className="fr-col-12 fr-col-md-8">
 					<h1>SIRET manquant</h1>

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -57,6 +57,7 @@ export { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 export { Step6Review } from "./steps/Step6Review";
 export {
 	COMPLIANCE_FUNNEL,
+	SECOND_DECLARATION_STEP_TITLES,
 	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -42,6 +42,9 @@ type Props = {
 	step4Data: Step4Data;
 	step5Categories: EmployeeCategoryRow[];
 	step5Source: string | null;
+	// Demote the page title when the recap is embedded in a host page that
+	// already renders its own <h1> (e.g. /admin/declarations/[id]) — RGAA 9.1.
+	titleTag?: "h1" | "h3";
 };
 
 type InfoItem = { label: string; value: string };
@@ -84,6 +87,7 @@ export function RecapitulatifPage({
 	step4Data,
 	step5Categories,
 	step5Source,
+	titleTag: TitleTag = "h1",
 }: Props) {
 	const declarantItems: InfoItem[] = [];
 	if (declarantName) {
@@ -121,11 +125,11 @@ export function RecapitulatifPage({
 		<div className={common.flexColumnGap2}>
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
+					<TitleTag className="fr-h4 fr-mb-0">
 						{isCorrection
 							? `Seconde déclaration des écarts de rémunération par catégorie de salariés ${declarationYear}`
 							: `Déclaration des indicateurs de rémunération ${declarationYear}`}
-					</h1>
+					</TitleTag>
 				</div>
 				<div className="fr-col-auto">
 					<a

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -20,6 +20,17 @@ describe("RecapitulatifPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("demotes the title to h3 when embedded via titleTag (no second h1)", () => {
+		render(<RecapitulatifPage {...defaultProps()} titleTag="h3" />);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+	});
+
 	it("renders 'Télécharger' tertiary download button", () => {
 		render(<RecapitulatifPage {...defaultProps()} />);
 		const link = screen.getByRole("link", {

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -10,6 +10,9 @@
 	gap: 0.5rem;
 
 	input {
-		min-width: 5rem;
+		// Keep the entered amount readable at 200% zoom / narrow viewports
+		// (RGAA 10.4): the cell must never crush the input below the width of
+		// a typical amount — the DSFR table wrapper scrolls instead.
+		min-width: 7.5rem;
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/TooltipButton.tsx
@@ -8,22 +8,25 @@ type TooltipButtonProps = {
 	text?: string;
 };
 
-const PLACEHOLDER_TEXT =
-	"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
-
 export function TooltipButton({ id, label, text }: TooltipButtonProps) {
+	const labelId = `${id}-label`;
 	return (
 		<>
 			<button
-				aria-describedby={id}
+				aria-describedby={text ? id : undefined}
+				aria-labelledby={labelId}
 				className={`fr-btn--tooltip fr-btn ${styles.button}`}
 				type="button"
 			>
-				<span className="fr-sr-only">{label}</span>
+				<span className="fr-sr-only" id={labelId}>
+					{label}
+				</span>
 			</button>
-			<span className="fr-tooltip fr-placement" id={id} role="tooltip">
-				{text ?? PLACEHOLDER_TEXT}
-			</span>
+			{text && (
+				<span className="fr-tooltip fr-placement" id={id} role="tooltip">
+					{text}
+				</span>
+			)}
 		</>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -15,7 +15,10 @@ export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {
 
 	return (
 		<div className="fr-alert fr-alert--warning fr-mb-3w" role="alert">
-			<h3 className="fr-alert__title">Déclaration en cours de modification</h3>
+			{/* The alert renders above the page <h1> in every host page (tunnel
+			    layouts, my-space panel), so its title must stay out of the heading
+			    outline (RGAA 9.1) — the DSFR class keeps the visual unchanged. */}
+			<p className="fr-alert__title">Déclaration en cours de modification</p>
 			<p>
 				{`${identity} modifie actuellement cette déclaration. Vous pouvez la consulter en lecture seule jusqu'à la fin de sa modification.`}
 			</p>

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -124,7 +124,11 @@ export function CompliancePathChoice({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Choix du parcours de conformité</legend>
 				<div className={common.flexBetween}>
 					<h1 className="fr-h4 fr-mb-0">
 						Déclaration des indicateurs de rémunération {currentYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
@@ -3,6 +3,13 @@
 		width: 100%;
 	}
 
+	// Keep the entered workforce count readable at 200% zoom / narrow
+	// viewports (RGAA 10.4): the cell must never crush the input below the
+	// width of a 6-digit count — the DSFR table wrapper scrolls instead.
+	input {
+		min-width: 6rem;
+	}
+
 	@include respond-from(md) {
 		table {
 			table-layout: fixed;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -197,7 +197,11 @@ export function Step1Workforce({
 				className={common.flexColumnGap2}
 				onSubmit={onSubmit}
 			>
+				{/* Native `disabled` is kept on purpose: it is the only mechanism
+				    enforcing the read-only mode, and disabled fields remain exposed
+				    to screen readers (#3803). */}
 				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+					<legend className="fr-sr-only">Effectifs</legend>
 					<StepTitleRow
 						hasData={hasData}
 						isPendingSave={isPendingSave}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -136,7 +136,11 @@ export function Step2PayGap({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Écarts de rémunération</legend>
 				<StepTitleRow
 					hasData={hasData}
 					isPendingSave={isPendingSave}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -112,9 +112,10 @@ export function Step3VariablePay({
 	const beneficiaryWomen = formData.indicatorEWomen ?? "";
 	const beneficiaryMen = formData.indicatorEMen ?? "";
 
-	const [benefValidationError, setBenefValidationError] = useState<
-		string | null
-	>(null);
+	const [benefValidationError, setBenefValidationError] = useState<{
+		field: "indicatorEMen" | "indicatorEWomen";
+		message: string;
+	} | null>(null);
 	const hasData = hasSavedData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -149,9 +150,10 @@ export function Step3VariablePay({
 		const n = Number.parseInt(value, 10);
 		if (Number.isNaN(n) || n < 0) return;
 		if (max !== undefined && n > max) {
-			setBenefValidationError(
-				`Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
-			);
+			setBenefValidationError({
+				field,
+				message: `Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
+			});
 			return;
 		}
 		setBenefValidationError(null);
@@ -177,7 +179,13 @@ export function Step3VariablePay({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">
+					Rémunérations variables ou complémentaires
+				</legend>
 				<StepTitleRow
 					hasData={hasData}
 					isPendingSave={isPendingSave}
@@ -296,6 +304,16 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field ===
+																"indicatorEWomen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field ===
+																	"indicatorEWomen" || undefined
+															}
 															aria-label="Bénéficiaires femmes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -327,6 +345,15 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field === "indicatorEMen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field ===
+																	"indicatorEMen" || undefined
+															}
 															aria-label="Bénéficiaires hommes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -361,7 +388,9 @@ export function Step3VariablePay({
 								className="fr-alert fr-alert--error fr-alert--sm"
 								role="alert"
 							>
-								<p>{benefValidationError}</p>
+								<p id="step3-beneficiaries-error">
+									{benefValidationError.message}
+								</p>
 							</div>
 						)}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -261,7 +261,11 @@ export function Step4QuartileDistribution({
 			noValidate
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Distribution par quartile</legend>
 				<StepTitleRow
 					hasData={hasData}
 					isPendingSave={isPendingSave}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -162,7 +162,11 @@ export function Step6Review({
 			className={stepStyles.formColumn}
 			onSubmit={handleSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Récapitulatif de la déclaration</legend>
 				<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -84,7 +84,13 @@ export function JointEvaluationForm({
 				className={common.flexColumnGap2}
 				onSubmit={handleSubmit}
 			>
+				{/* Native `disabled` is kept on purpose: it is the only mechanism
+				    enforcing the read-only mode, and disabled fields remain exposed
+				    to screen readers (#3803). */}
 				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+					<legend className="fr-sr-only">
+						Évaluation conjointe des rémunérations
+					</legend>
 					<div className={common.flexBetween}>
 						<h1 className="fr-h4 fr-mb-0">
 							Parcours de mise en conformité pour l&apos;indicateur par

--- a/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
+++ b/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export function DeclarationHistoryPage({ siren, year }: Props) {
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-4w">
 				<Breadcrumb
 					items={[

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -66,7 +66,7 @@ export function CompanyDeclarationsPage({
 	});
 
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<WelcomeBanner />
 			<CompanyInfoBanner company={company} />
 			<DeclarationsSection

--- a/packages/app/src/modules/my-space/MyCompaniesPage.tsx
+++ b/packages/app/src/modules/my-space/MyCompaniesPage.tsx
@@ -10,7 +10,7 @@ export async function MyCompaniesPage() {
 	const companies = await api.company.list();
 
 	return (
-		<main id="content">
+		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-my-4w">
 				<WelcomeBanner />
 				<CompanyListHeader />

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -80,7 +80,7 @@ export function PanelPlayground() {
 	}
 
 	return (
-		<main className="fr-container fr-py-6w" id="content">
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
 			<h1 className="fr-h3">DeclarationProcessPanel — Playground</h1>
 			<p className="fr-text--sm fr-text-mention--grey">
 				Dev-only page to visually test the panel with arbitrary variant and

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -37,6 +37,7 @@ export function PhoneField({
 			</label>
 			<input
 				aria-describedby={messagesId}
+				aria-required="true"
 				autoComplete="tel"
 				className="fr-input"
 				id={inputId}


### PR DESCRIPTION
Cluster **déclaration** (parcours déclaration-remuneration, avis CSE, formulaire référents) de l'epic a11y #3800.

## #3803 — RGAA 11.6/11.7 · légendes des fieldsets en lecture seule (Closes #3803)
- `<legend class="fr-sr-only">` en **premier enfant** des 8 wrappers `fieldset.readOnlyFieldset` : effectifs (étape 1), écarts de rémunération (étape 2), rémunérations variables (étape 3), distribution par quartile (étape 4), récapitulatif (étape 6), choix du parcours de conformité, évaluation conjointe, avis du CSE.
- Le `disabled` natif est **conservé** (décision réconciliée) : c'est le seul mécanisme du mode lecture seule, et les champs `disabled` restent restitués par les lecteurs d'écran — un commentaire en code documente ce choix. Les fieldsets radio internes déjà conformes ne sont pas touchés.

## #3804 — RGAA 11.10 · association des erreurs (Refs #3804)
- `ReferentFormFields` : id stable sur chaque `fr-error-text` + `aria-invalid` / `aria-describedby` conditionnels sur les 4 champs (nom, région, valeur, email suppléant).
- `Step3VariablePay` : l'erreur « bénéficiaires » est désormais rattachée au champ fautif (`aria-invalid` + `aria-describedby` vers le message `role="alert"`).
- Correction connexe (lint rouge sur la base) : retrait de l'`aria-required` posé sur les `fieldset` des cartes avis CSE (`AccuracyOpinionCard`, `GapConsultationCard`) — le rôle `group` ne supporte pas cet attribut (ARIA invalide, `useAriaPropsSupportedByRole`). L'indication du caractère obligatoire reste portée par la mention visible « Tous les champs sont obligatoires. » en tête de formulaire (conforme 11.10.1). L'`aria-required` de `PhoneField` (valide) n'est pas touché.
- Reste sur #3804 : microcopy d'aide des infobulles (bloquée PO).

## #3801 — RGAA 12.6/12.7 · landmark des tunnels (Refs #3801)
- `DeclarationLayout` et `CseOpinionLayout` : le bandeau entreprise (breadcrumb + infos société) est englobé dans le `<main id="content" tabIndex={-1}>` (unique par page, rendu inchangé — les classes `fr-container fr-py-7w` migrent sur un div interne).
- `MissingSiret` : `tabIndex={-1}` sur le `<main id="content">`.
- Hors périmètre de ce cluster (autres surfaces du ticket) : admin/stats/SkipLinks, et le `tabIndex={-1}` du `<main>` de la route `src/app/declaration-remuneration/recapitulatif/page.tsx` (fichier de route listé sous l'ex-lot T12).

## #3802 — RGAA 9.1 · titres du récapitulatif (Refs #3802)
- `RecapitulatifPage` : nouvelle prop `titleTag` (`"h1"` par défaut — page autonome inchangée ; `"h3"` en imbriqué). ⚠️ Le call site `AdminDeclarationDetailPage.tsx` (cluster admin) doit passer `titleTag="h3"` pour supprimer le second `<h1>` sur `/admin/declarations/[id]`.
- `DeclarationLockAlert` : titre sorti du plan des titres (`p.fr-alert__title`, style DSFR inchangé) — l'alerte précède le `<h1>` sur ses 3 surfaces d'usage, aucun niveau fixe ne peut être cohérent partout.
- Les titres des tableaux du récapitulatif sont déjà structurés en `<caption>` + `<h3>` (retour auditrice : technique caption OK, homogène).

## #3812 / #3807 — RGAA 10.4 · inputs en cellule à 200 % (Refs #3812)
- `min-width` sur les inputs en cellule de tableau : effectifs étape 1 (6rem) et tableaux d'écarts étapes 2-3 (7.5rem) — la cellule ne peut plus écraser l'input sous la largeur d'une valeur type ; le wrapper DSFR scrolle horizontalement à la place. Aucun changement visuel aux largeurs desktop.
- L'étape 4 (layout bloc mobile) et l'étape 5 (`compactInput` dimensionné au contenu) étaient déjà protégées.
- ⚠️ **À confirmer au rendu** (probe zoom 200 % / 320 px / surcharge d'espacement) avant de clore le critère.

## Vérifications
- `pnpm --filter app typecheck` ✅ · `pnpm lint:check` / `pnpm format:check` ✅ (corrige aussi les 2 erreurs biome préexistantes de la base)
- ultra11y (`--jsx --graph --standard rgaa`) : 10 NC → 2 sur le périmètre ; les 2 restantes sont les flags conservateurs `fieldset disabled` (choix documenté #3803, disabled conservé volontairement)
- `vitest` : 79 fichiers / 790 tests du cluster + 212 tests my-space (consommateur du bandeau de verrou) ✅
