### PR TITLE
fix(release): la création du tag échoue sur le signage GPG (canal alpha, semantic-release 25)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,12 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
           git_push_gpgsign: false
-          git_tag_gpgsign: true
+          # Tag signing must stay off: semantic-release >= 20 creates
+          # lightweight tags (`git tag <name> <sha>`, no -m), and
+          # tag.gpgSign=true turns them into signed tags that require a
+          # message — git then aborts in CI with "Terminal is dumb, but
+          # EDITOR unset". Release commits (master/beta) remain GPG-signed.
+          git_tag_gpgsign: false
 
       - name: Semantic Release
         env:


### PR DESCRIPTION
## Problème

Suite au merge de #3905, le workflow **🔖 Release** sur `alpha` passe l'étape qui bloquait avant… et échoue maintenant un cran plus loin, à la **création du tag** (run 29416926641) :

```
ExecaError: Command failed with exit code 1: git tag v3.14.0-alpha.1 <sha>
error: Terminal is dumb, but EDITOR unset
```

## Cause

semantic-release >= 20 crée des **tags légers** (`git tag <name> <sha>`, sans `-m`). Avec `git_tag_gpgsign: true` (posé par `ghaction-import-gpg`), git transforme ce tag en tag **signé**, qui exige un message — et tente d'ouvrir un éditeur, absent en CI.

Le run `master` de `v3.18.4` passait uniquement parce qu'il tourne encore avec **semantic-release 19.0.5** (ancien lockfile de `master`). Le canal `alpha`, sur **25.0.3**, échoue systématiquement — et `master` cassera de la même façon dès que le lockfile d'`alpha` y arrivera.

## Fix

`git_tag_gpgsign: true` → `false` dans `release.yml`. Les **commits** de release (`master`/`beta`) restent signés (`git_commit_gpgsign` inchangé) ; seuls les tags deviennent des tags légers non signés — le comportement standard de semantic-release.

## Vérification attendue

Au merge, le push sur `alpha` re-déclenche Release, qui doit publier **`v3.14.0-alpha.1`**.

> Note : la version calculée est `v3.14.0-alpha.1` (et non `v3.19.0-alpha.1`) car les tags `v3.18.x` pointent sur les commits `chore(release)` de `master`, absents de l'historique d'`alpha`. Le dernier tag vu par le canal alpha est `v3.13.2`. Sans incidence : les canaux sont indépendants et les numéros ne collisionnent pas.
