### PR TITLE
fix(ci): permissions OIDC manquantes sur le workflow de promotion des envs de test

### DIFF
--- a/.github/workflows/promote-test-env.yaml
+++ b/.github/workflows/promote-test-env.yaml
@@ -34,6 +34,9 @@ jobs:
   promote:
     name: "Promote ${{ inputs.release }} → ${{ inputs.target }}-persist"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # the push uses the token-bureau app token, not GITHUB_TOKEN
+      id-token: write # OIDC identity, required by token-bureau
     steps:
       - name: Get GitHub App Token
         id: token


### PR DESCRIPTION
## Problème

Premier essai réel du workflow **🎯 Promote test env** ([run 29423053807](https://github.com/SocialGouv/egapro/actions/runs/29423053807)) : échec immédiat à l'étape « Get GitHub App Token » :

```
Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

`token-bureau` s'authentifie via OIDC et exige `id-token: write` — le bloc `permissions` manquait (il est présent dans `release.yml` mais n'avait pas été reporté).

## Fix

Ajout des permissions minimales sur le job :

- `id-token: write` — identité OIDC pour token-bureau
- `contents: read` — checkout ; le push vers `*-persist` utilise le token d'app, pas le `GITHUB_TOKEN`

## Au passage

Le dispatch depuis `alpha` fonctionne (le run s'est bien lancé) — pas besoin d'attendre que le fichier arrive sur `master`.

Pour re-tester après merge : release = `v3.14.0-alpha.1` (avec le préfixe `v`), target = `rgaa` ou `perf`.
