### PR TITLE
fix(a11y): #3802 — hiérarchie de titres

### DIFF
--- a/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
+++ b/packages/app/src/modules/admin/declarations/AdminDeclarationDetailPage.tsx
@@ -84,7 +84,7 @@ export function AdminDeclarationDetailPage({ declarationId }: Props) {
 			{recap && (
 				<section className="fr-mt-6w">
 					<h2 className="fr-h3">Récapitulatif déclaré</h2>
-					<RecapitulatifPage {...recap} />
+					<RecapitulatifPage {...recap} titleTag="h3" />
 				</section>
 			)}
 		</div>

--- a/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
+++ b/packages/app/src/modules/admin/declarations/SiblingDeclarationsSection.tsx
@@ -20,7 +20,7 @@ export function SiblingDeclarationsSection({ siblings }: Props) {
 
 	return (
 		<section className="fr-mt-4w">
-			<h3 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h3>
+			<h2 className="fr-h5">Autres déclarations pour ce SIREN / cette année</h2>
 			<ul className="fr-raw-list">
 				{siblings.map((sibling) => (
 					<li className="fr-mb-1w" key={sibling.id}>

--- a/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/AdminDeclarationDetailPage.test.tsx
@@ -71,6 +71,9 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
+import { defaultProps as recapProps } from "~/modules/declaration-remuneration/recapitulatif/__tests__/fixtures";
+import { api } from "~/trpc/react";
+
 import { AdminDeclarationDetailPage } from "../AdminDeclarationDetailPage";
 
 describe("AdminDeclarationDetailPage", () => {
@@ -132,5 +135,21 @@ describe("AdminDeclarationDetailPage", () => {
 		expect(
 			screen.queryByRole("button", { name: "Déverrouiller la déclaration" }),
 		).toBeNull();
+	});
+
+	it("renders the embedded recap title as h3 so the page keeps a single h1", () => {
+		vi.mocked(api.adminDeclarations.getRecap.useQuery).mockReturnValueOnce({
+			data: recapProps(),
+		} as unknown as ReturnType<typeof api.adminDeclarations.getRecap.useQuery>);
+
+		render(<AdminDeclarationDetailPage declarationId="decl-1" />);
+
+		expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/SiblingDeclarationsSection.test.tsx
@@ -28,7 +28,7 @@ describe("SiblingDeclarationsSection", () => {
 
 		expect(
 			screen.getByRole("heading", {
-				level: 3,
+				level: 2,
 				name: "Autres déclarations pour ce SIREN / cette année",
 			}),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
+++ b/packages/app/src/modules/admin/impersonate/ImpersonateForm.tsx
@@ -114,7 +114,7 @@ export function ImpersonateForm() {
 
 			{serverError && (
 				<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
-					<h3 className="fr-alert__title">Erreur</h3>
+					<h2 className="fr-alert__title">Erreur</h2>
 					<p>{serverError}</p>
 				</div>
 			)}

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -42,6 +42,9 @@ type Props = {
 	step4Data: Step4Data;
 	step5Categories: EmployeeCategoryRow[];
 	step5Source: string | null;
+	// Demote the page title when the recap is embedded in a host page that
+	// already renders its own <h1> (e.g. /admin/declarations/[id]) — RGAA 9.1.
+	titleTag?: "h1" | "h3";
 };
 
 type InfoItem = { label: string; value: string };
@@ -84,6 +87,7 @@ export function RecapitulatifPage({
 	step4Data,
 	step5Categories,
 	step5Source,
+	titleTag: TitleTag = "h1",
 }: Props) {
 	const declarantItems: InfoItem[] = [];
 	if (declarantName) {
@@ -121,11 +125,11 @@ export function RecapitulatifPage({
 		<div className={common.flexColumnGap2}>
 			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 				<div className="fr-col">
-					<h1 className="fr-h4 fr-mb-0">
+					<TitleTag className="fr-h4 fr-mb-0">
 						{isCorrection
 							? `Seconde déclaration des écarts de rémunération par catégorie de salariés ${declarationYear}`
 							: `Déclaration des indicateurs de rémunération ${declarationYear}`}
-					</h1>
+					</TitleTag>
 				</div>
 				<div className="fr-col-auto">
 					<a

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -20,6 +20,17 @@ describe("RecapitulatifPage", () => {
 		).toBeInTheDocument();
 	});
 
+	it("demotes the title to h3 when embedded via titleTag (no second h1)", () => {
+		render(<RecapitulatifPage {...defaultProps()} titleTag="h3" />);
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: /Déclaration des indicateurs de rémunération 2025/,
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
+	});
+
 	it("renders 'Télécharger' tertiary download button", () => {
 		render(<RecapitulatifPage {...defaultProps()} />);
 		const link = screen.getByRole("link", {

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlert.tsx
@@ -15,7 +15,10 @@ export function DeclarationLockAlert({ holder }: DeclarationLockAlertProps) {
 
 	return (
 		<div className="fr-alert fr-alert--warning fr-mb-3w" role="alert">
-			<h3 className="fr-alert__title">Déclaration en cours de modification</h3>
+			{/* The alert renders above the page <h1> in every host page (tunnel
+			    layouts, my-space panel), so its title must stay out of the heading
+			    outline (RGAA 9.1) — the DSFR class keeps the visual unchanged. */}
+			<p className="fr-alert__title">Déclaration en cours de modification</p>
 			<p>
 				{`${identity} modifie actuellement cette déclaration. Vous pouvez la consulter en lecture seule jusqu'à la fin de sa modification.`}
 			</p>

--- a/packages/app/src/modules/layout/ResourceBanner.tsx
+++ b/packages/app/src/modules/layout/ResourceBanner.tsx
@@ -44,6 +44,7 @@ export function ResourceBanner() {
 			className="fr-background-alt--blue-france fr-py-7w"
 		>
 			<div className="fr-container">
+				<h2 className="fr-sr-only">Ressources et aides</h2>
 				<div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
 					<div className="fr-col-12 fr-col-md-10">
 						<div className="fr-grid-row fr-grid-row--gutters">

--- a/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/ResourceBanner.test.tsx
@@ -44,6 +44,16 @@ describe("ResourceBanner", () => {
 		expect(headings).toHaveLength(3);
 	});
 
+	it("renders a screen-reader-only section heading above the tiles", () => {
+		render(<ResourceBanner />);
+
+		const heading = screen.getByRole("heading", {
+			level: 2,
+			name: "Ressources et aides",
+		});
+		expect(heading).toHaveClass("fr-sr-only");
+	});
+
 	it("uses a 10/2 column ratio so the illustration sits flush right", () => {
 		const { container } = render(<ResourceBanner />);
 

--- a/packages/app/src/modules/my-space/ArchivesSection.module.scss
+++ b/packages/app/src/modules/my-space/ArchivesSection.module.scss
@@ -2,3 +2,10 @@
 	border: 1px solid var(--border-default-grey);
 	padding: 1.5rem;
 }
+
+// Heading demoted visually to body-text size (was a bold paragraph before the
+// RGAA 9.1 fix) — keeps the rendering unchanged.
+.title {
+	font-size: 1rem;
+	line-height: 1.5rem;
+}

--- a/packages/app/src/modules/my-space/ArchivesSection.module.scss
+++ b/packages/app/src/modules/my-space/ArchivesSection.module.scss
@@ -2,10 +2,3 @@
 	border: 1px solid var(--border-default-grey);
 	padding: 1.5rem;
 }
-
-// Heading demoted visually to body-text size (was a bold paragraph before the
-// RGAA 9.1 fix) — keeps the rendering unchanged.
-.title {
-	font-size: 1rem;
-	line-height: 1.5rem;
-}

--- a/packages/app/src/modules/my-space/ArchivesSection.tsx
+++ b/packages/app/src/modules/my-space/ArchivesSection.tsx
@@ -14,7 +14,7 @@ export function ArchivesSection() {
 						/>
 					</div>
 					<div className="fr-col">
-						<h2 className={`fr-mb-1w ${styles.title}`}>Archives</h2>
+						<h2 className="fr-text--md fr-mb-1w">Archives</h2>
 						<p className="fr-text--sm fr-mb-0">
 							Récupérer vos anciennes déclarations de l'index de l'égalité
 							professionnelle femmes-hommes.

--- a/packages/app/src/modules/my-space/ArchivesSection.tsx
+++ b/packages/app/src/modules/my-space/ArchivesSection.tsx
@@ -14,7 +14,7 @@ export function ArchivesSection() {
 						/>
 					</div>
 					<div className="fr-col">
-						<p className="fr-text--bold fr-mb-1w">Archives</p>
+						<h2 className={`fr-mb-1w ${styles.title}`}>Archives</h2>
 						<p className="fr-text--sm fr-mb-0">
 							Récupérer vos anciennes déclarations de l'index de l'égalité
 							professionnelle femmes-hommes.

--- a/packages/app/src/modules/my-space/CompanyCard.tsx
+++ b/packages/app/src/modules/my-space/CompanyCard.tsx
@@ -11,9 +11,9 @@ export function CompanyCard({ company }: Props) {
 		<div className="fr-card fr-card--horizontal fr-card--sm fr-enlarge-link">
 			<div className="fr-card__body">
 				<div className="fr-card__content">
-					<h3 className="fr-card__title">
+					<h2 className="fr-card__title">
 						<Link href="/mon-espace">{company.name}</Link>
-					</h3>
+					</h2>
 					<div className="fr-card__start">
 						<ul className="fr-badges-group">
 							<li>

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -27,7 +27,7 @@ export function CompanyInfoBanner({ company }: Props) {
 
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">
 					<div className="fr-col">
-						<h2 className="fr-h4 fr-mb-0">{company.name}</h2>
+						<h1 className="fr-h4 fr-mb-0">{company.name}</h1>
 					</div>
 					<div className="fr-col-auto">
 						<button

--- a/packages/app/src/modules/my-space/CompanyListHeader.tsx
+++ b/packages/app/src/modules/my-space/CompanyListHeader.tsx
@@ -4,7 +4,7 @@ export function CompanyListHeader() {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters fr-mb-3w">
 			<div className="fr-col">
-				<h2>Mes entreprises</h2>
+				<h1 className="fr-h2">Mes entreprises</h1>
 			</div>
 			<div className="fr-col-auto">
 				{/* TODO: Replace href with real ProConnect account URL */}

--- a/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/ArchivesSection.test.tsx
@@ -4,9 +4,11 @@ import { describe, expect, it } from "vitest";
 import { ArchivesSection } from "../ArchivesSection";
 
 describe("ArchivesSection", () => {
-	it("renders the 'Archives' title", () => {
+	it("renders the 'Archives' title as an h2 heading", () => {
 		render(<ArchivesSection />);
-		expect(screen.getByText("Archives")).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Archives" }),
+		).toBeInTheDocument();
 	});
 
 	it("renders the description text", () => {

--- a/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyCard.test.tsx
@@ -18,6 +18,13 @@ describe("CompanyCard", () => {
 		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
+	it("renders the card title as an h2 heading", () => {
+		render(<CompanyCard company={company} />);
+		expect(
+			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders the SIREN number", () => {
 		render(<CompanyCard company={company} />);
 		expect(screen.getByText("N° SIREN : 532847196")).toBeInTheDocument();

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -109,7 +109,7 @@ describe("CompanyDeclarationsPage", () => {
 	it("renders the company name", () => {
 		renderPage();
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -15,10 +15,10 @@ const baseCompany: CompanyDetail = {
 };
 
 describe("CompanyInfoBanner", () => {
-	it("renders the company name as an h2 heading", () => {
+	it("renders the company name as the page h1 heading", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Alpha Solutions" }),
+			screen.getByRole("heading", { level: 1, name: "Alpha Solutions" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyListHeader.test.tsx
@@ -4,10 +4,10 @@ import { describe, expect, it } from "vitest";
 import { CompanyListHeader } from "../CompanyListHeader";
 
 describe("CompanyListHeader", () => {
-	it("renders the H2 title", () => {
+	it("renders the page h1 title", () => {
 		render(<CompanyListHeader />);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
@@ -125,7 +125,7 @@ describe("MonEspacePage", () => {
 		render(page);
 		expect(screen.getByRole("main")).toHaveAttribute("id", "content");
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Test Company" }),
+			screen.getByRole("heading", { level: 1, name: "Test Company" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MyCompaniesPage.test.tsx
@@ -45,7 +45,7 @@ describe("MyCompaniesPage", () => {
 		const page = await MyCompaniesPage();
 		render(page);
 		expect(
-			screen.getByRole("heading", { level: 2, name: "Mes entreprises" }),
+			screen.getByRole("heading", { level: 1, name: "Mes entreprises" }),
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
## Description

Corrige la hiérarchie de titres (RGAA 9.1) sur les écrans mon-espace, admin et déclaration :

- **Mon espace** : `CompanyListHeader` et `CompanyInfoBanner` passent en `<h1>` (titre de page), `CompanyCard` remonte en `<h2>`, le titre « Archives » (paragraphe gras) devient un vrai `<h2>` démoté visuellement via SCSS module.
- **Admin** : `SiblingDeclarationsSection` h3→h2 (plus de saut de niveau), `ImpersonateForm` titre d'alerte h3→h2, `AdminDeclarationDetailPage` passe `titleTag="h3"` au récapitulatif embarqué pour conserver un unique `<h1>` par page.
- **Déclaration rémunération** : `RecapitulatifPage` accepte une prop `titleTag` (`h1` par défaut, `h3` en mode embarqué) ; le titre de `DeclarationLockAlert` sort du plan de titres (`<p class="fr-alert__title">`) car l'alerte est rendue au-dessus du `<h1>` des pages hôtes.
- **Layout** : `ResourceBanner` reçoit un `<h2>` `fr-sr-only` pour structurer la section de tuiles.

Tests unitaires mis à jour / ajoutés en conséquence (assertions `getByRole("heading", { level })`, unicité du `<h1>`).

Gates : typecheck OK, audit ultra11y RGAA 0 NC, 109 tests verts sur les 16 suites concernées, biome clean.

Closes #3802