### PR TITLE
fix(a11y): #3816 — nom/rôle/valeur (aria-sort, aria-modal, menu, chart)

### DIFF
--- a/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
+++ b/packages/app/src/modules/admin/declarations/DeclarationTable.tsx
@@ -37,11 +37,18 @@ export function DeclarationTable({
 	sortBy,
 	sortOrder,
 }: Props) {
-	const { handleSort, handlePageChange, sortIcon } = useSortableTable({
-		basePath: "/admin/declarations",
-		sortBy,
-		sortOrder,
-	});
+	const { handleSort, handlePageChange, ariaSort, sortIcon } = useSortableTable(
+		{
+			basePath: "/admin/declarations",
+			sortBy,
+			sortOrder,
+		},
+	);
+
+	const renderSortIcon = (column: SortColumn) => {
+		const icon = sortIcon(column);
+		return icon ? <span aria-hidden="true">{icon}</span> : null;
+	};
 
 	return (
 		<>
@@ -55,14 +62,14 @@ export function DeclarationTable({
 				<thead>
 					<tr>
 						{SORT_COLUMNS.map((col) => (
-							<th key={col} scope="col">
+							<th aria-sort={ariaSort(col)} key={col} scope="col">
 								<button
 									className="fr-text--sm"
 									onClick={() => handleSort(col)}
 									type="button"
 								>
 									{COLUMN_LABELS[col]}
-									{sortIcon(col)}
+									{renderSortIcon(col)}
 								</button>
 							</th>
 						))}

--- a/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
+++ b/packages/app/src/modules/admin/declarations/__tests__/DeclarationTable.test.tsx
@@ -64,6 +64,23 @@ describe("DeclarationTable", () => {
 		expect(screen.getByText("15/06/2024")).toBeInTheDocument();
 	});
 
+	it("exposes aria-sort on the sorted column and hides the sort glyph", () => {
+		render(<DeclarationTable {...defaultProps} />);
+
+		const sortedHeader = screen
+			.getByRole("button", { name: /date de dépôt/i })
+			.closest("th");
+		expect(sortedHeader).toHaveAttribute("aria-sort", "descending");
+
+		const unsortedHeader = screen
+			.getByRole("button", { name: /^siren/i })
+			.closest("th");
+		expect(unsortedHeader).not.toHaveAttribute("aria-sort");
+
+		const glyph = sortedHeader?.querySelector("[aria-hidden='true']");
+		expect(glyph).not.toBeNull();
+	});
+
 	it("shows empty state when no rows", () => {
 		render(<DeclarationTable {...defaultProps} rows={[]} total={0} />);
 

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.module.scss
@@ -34,6 +34,15 @@
 	gap: 0.5rem;
 }
 
+// role="menu" wrapper around the action groups: replicates the dropdown's
+// column flow so inserting it keeps the rendering pixel-identical.
+.menu {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+}
+
 .userName {
 	margin: 0;
 	font-size: 0.875rem;

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
@@ -114,6 +114,7 @@ export function UserAccountMenu({
 				aria-expanded={isOpen}
 				aria-haspopup="menu"
 				className="fr-btn fr-btn--tertiary fr-icon-account-circle-line fr-btn--icon-left"
+				id="user-account-menu-button"
 				onClick={() => setIsOpen((prev) => !prev)}
 				ref={buttonRef}
 				type="button"
@@ -135,7 +136,11 @@ export function UserAccountMenu({
 					{/* The two inner divs stay role-less: generic containers are
 					    ownership-transparent, so the menuitems remain owned by the
 					    menu (verified against axe aria-required-children). */}
-					<div aria-label="Mon espace" className={styles.menu} role="menu">
+					<div
+						aria-labelledby="user-account-menu-button"
+						className={styles.menu}
+						role="menu"
+					>
 						<div className={styles.links}>
 							{isAdmin && (
 								<Link

--- a/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
+++ b/packages/app/src/modules/layout/Header/UserAccountMenu.tsx
@@ -65,6 +65,13 @@ export function UserAccountMenu({
 				case "Escape":
 					close();
 					break;
+				case "Tab":
+					// APG menu pattern: Tab dismisses the menu. Focus is handed back
+					// to the toggle button (via close) instead of letting the default
+					// move happen inside a menu that is about to unmount.
+					event.preventDefault();
+					close();
+					break;
 				case "ArrowDown": {
 					event.preventDefault();
 					const items = getMenuItems();
@@ -115,53 +122,68 @@ export function UserAccountMenu({
 			</button>
 
 			{isOpen && (
-				<div className={styles.dropdown} ref={menuRef} role="menu">
+				<div className={styles.dropdown} ref={menuRef}>
+					{/* The user info block sits outside the role="menu" element: a menu
+					    may only own menuitem/group/separator children, and static text
+					    would be skipped by screen readers in menu navigation mode. */}
 					<div className={styles.userInfo}>
 						<p className={styles.userName}>{userName}</p>
 						<p className={styles.userEmail}>{userEmail}</p>
 						{userPhone && <p className={styles.userEmail}>{userPhone}</p>}
 					</div>
 
-					<div className={styles.links}>
-						{isAdmin && (
+					{/* The two inner divs stay role-less: generic containers are
+					    ownership-transparent, so the menuitems remain owned by the
+					    menu (verified against axe aria-required-children). */}
+					<div aria-label="Mon espace" className={styles.menu} role="menu">
+						<div className={styles.links}>
+							{isAdmin && (
+								<Link
+									className={styles.menuLink}
+									href="/admin"
+									onClick={close}
+									role="menuitem"
+									tabIndex={-1}
+								>
+									Administration
+								</Link>
+							)}
 							<Link
 								className={styles.menuLink}
-								href="/admin"
+								href="/mon-espace/mes-entreprises"
 								onClick={close}
 								role="menuitem"
+								tabIndex={-1}
 							>
-								Administration
+								Mes entreprises
 							</Link>
-						)}
-						<Link
-							className={styles.menuLink}
-							href="/mon-espace/mes-entreprises"
-							onClick={close}
-							role="menuitem"
-						>
-							Mes entreprises
-						</Link>
-						<button
-							className={styles.menuLink}
-							onClick={openProfileModal}
-							role="menuitem"
-							type="button"
-						>
-							Voir mon profil
-						</button>
-					</div>
+							<button
+								className={styles.menuLink}
+								onClick={openProfileModal}
+								role="menuitem"
+								tabIndex={-1}
+								type="button"
+							>
+								Voir mon profil
+							</button>
+						</div>
 
-					<div className={styles.logout}>
-						{/* Native <a> required: this route redirects to an external IdP (ProConnect),
-						    so we need a full browser navigation, not a client-side RSC fetch. */}
-						<a
-							className={styles.logoutLink}
-							href="/api/auth/logout"
-							role="menuitem"
-						>
-							<span aria-hidden="true" className="fr-icon-logout-box-r-line" />
-							Se déconnecter
-						</a>
+						<div className={styles.logout}>
+							{/* Native <a> required: this route redirects to an external IdP (ProConnect),
+							    so we need a full browser navigation, not a client-side RSC fetch. */}
+							<a
+								className={styles.logoutLink}
+								href="/api/auth/logout"
+								role="menuitem"
+								tabIndex={-1}
+							>
+								<span
+									aria-hidden="true"
+									className="fr-icon-logout-box-r-line"
+								/>
+								Se déconnecter
+							</a>
+						</div>
 					</div>
 				</div>
 			)}

--- a/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/UserAccountMenu.test.tsx
@@ -36,6 +36,30 @@ describe("UserAccountMenu", () => {
 			expect(screen.getByRole("menu")).toBeInTheDocument();
 		});
 
+		it("names the menu 'Mon espace'", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			expect(
+				screen.getByRole("menu", { name: "Mon espace" }),
+			).toBeInTheDocument();
+		});
+
+		it("keeps the user info block outside the menu element", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			expect(screen.getByRole("menu")).not.toContainElement(
+				screen.getByText("Jean Dupont"),
+			);
+		});
+
+		it("removes menu items from the natural tab order (roving focus)", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
+			for (const item of screen.getAllByRole("menuitem")) {
+				expect(item).toHaveAttribute("tabindex", "-1");
+			}
+		});
+
 		it("sets aria-expanded=true when open", () => {
 			render(<UserAccountMenu {...defaultProps} />);
 			fireEvent.click(screen.getByRole("button", { name: "Mon espace" }));
@@ -104,6 +128,16 @@ describe("UserAccountMenu", () => {
 			expect(screen.getByRole("menu")).toBeInTheDocument();
 			fireEvent.keyDown(document, { key: "Escape" });
 			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+		});
+
+		it("closes the menu on Tab and returns focus to the toggle button", () => {
+			render(<UserAccountMenu {...defaultProps} />);
+			const toggle = screen.getByRole("button", { name: "Mon espace" });
+			fireEvent.click(toggle);
+			expect(screen.getByRole("menu")).toBeInTheDocument();
+			fireEvent.keyDown(document, { key: "Tab" });
+			expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+			expect(toggle).toHaveFocus();
 		});
 
 		it("closes the menu when clicking outside", () => {

--- a/packages/app/src/modules/my-space/CompanyEditModal.module.scss
+++ b/packages/app/src/modules/my-space/CompanyEditModal.module.scss
@@ -38,8 +38,16 @@
 }
 
 .cseFieldset {
+	// A non-zero flex-basis keeps both rich radios at equal widths on wide
+	// screens (same rendering as flex-basis 0) but lets them wrap on their own
+	// line at reduced widths instead of being crushed/overflowing, so the DSFR
+	// focus outline (2px width + 2px offset outside the box) stays fully
+	// visible at every viewport width. The basis matches a rich radio card's
+	// natural width (~10rem incl. padding) so wrapping kicks in before any
+	// compression; no DSFR ancestor sets overflow:hidden, so nothing clips the
+	// outline once it wraps.
 	:global(.fr-fieldset__element--inline) {
-		flex: 1;
+		flex: 1 1 10rem;
 	}
 
 	> .sourceText {

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -60,6 +60,7 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 	return (
 		<dialog
 			aria-labelledby={MODAL_TITLE_ID}
+			aria-modal="true"
 			className="fr-modal"
 			id={MODAL_ID}
 			ref={dialogRef}

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -54,6 +54,15 @@ describe("CompanyEditModal", () => {
 		);
 	});
 
+	it("marks the dialog as modal for assistive technologies", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		expect(container.querySelector("dialog")).toHaveAttribute(
+			"aria-modal",
+			"true",
+		);
+	});
+
 	it("structures readonly company data as description lists", () => {
 		const { container } = render(<CompanyEditModal company={company} />);
 

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.tsx
@@ -75,9 +75,13 @@ export function ChartTooltip({ active, payload }: ChartTooltipProps) {
 
 export function ScoreDistributionChart({ brackets }: Props) {
 	return (
-		<div aria-hidden="true" className={styles.chartWrapper} role="presentation">
+		<div aria-hidden="true" className={styles.chartWrapper}>
 			<ResponsiveContainer>
-				<BarChart data={brackets} margin={{ top: 16, right: 16, bottom: 8 }}>
+				<BarChart
+					accessibilityLayer={false}
+					data={brackets}
+					margin={{ top: 16, right: 16, bottom: 8 }}
+				>
 					<CartesianGrid strokeDasharray="3 3" vertical={false} />
 					<XAxis dataKey="label" />
 					<YAxis tickFormatter={formatYAxisTick} />

--- a/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
+++ b/packages/app/src/modules/publicStats/__tests__/ScoreDistributionChart.test.tsx
@@ -46,7 +46,15 @@ describe("ScoreDistributionChart", () => {
 			<ScoreDistributionChart brackets={baseBrackets} />,
 		);
 		const wrapper = container.querySelector("[aria-hidden='true']");
-		expect(wrapper).toHaveAttribute("role", "presentation");
+		expect(wrapper).not.toHaveAttribute("role");
+	});
+
+	it("exposes no focusable element under the aria-hidden wrapper", () => {
+		const { container } = render(
+			<ScoreDistributionChart brackets={baseBrackets} />,
+		);
+		const wrapper = container.querySelector("[aria-hidden='true']");
+		expect(wrapper?.querySelector("[tabindex]")).toBeNull();
 	});
 
 	it("renders even with an empty dataset (defensive)", () => {


### PR DESCRIPTION
## Objet

RGAA 7.1/7.3 — chaque composant d'interface expose correctement son nom, son rôle et sa valeur :

- **`DeclarationTable`** (admin) : `aria-sort` sur le `<th>` de la colonne triée + glyphe de tri masqué aux lecteurs d'écran (`aria-hidden="true"`).
- **`CompanyEditModal`** (mon espace) : `aria-modal="true"` sur le `<dialog>`.
- **`ScoreDistributionChart`** (stats publiques) : retrait du `role="presentation"` redondant sous `aria-hidden`, et `accessibilityLayer={false}` pour qu'aucun élément focusable ne subsiste sous le wrapper masqué.
- **`UserAccountMenu`** (header) : motif menu APG complet — `role="menu"` nommé « Mon espace » limité aux `menuitem` (bloc d'infos utilisateur sorti du menu), roving tabindex (`tabIndex={-1}`), fermeture sur Tab avec retour du focus sur le bouton déclencheur.

Tests unitaires ajoutés pour chaque comportement.

Closes #3816