### PR TITLE
fix(a11y): #3878 — focus visible des radios CSE

### DIFF
--- a/packages/app/src/modules/my-space/CompanyEditModal.module.scss
+++ b/packages/app/src/modules/my-space/CompanyEditModal.module.scss
@@ -38,8 +38,13 @@
 }
 
 .cseFieldset {
+	// A non-zero flex-basis keeps both rich radios at equal widths on wide
+	// screens (same rendering as flex-basis 0) but lets them wrap on their own
+	// line at reduced widths instead of being crushed/overflowing, so the DSFR
+	// focus outline (2px width + 2px offset outside the box) stays fully
+	// visible at every viewport width.
 	:global(.fr-fieldset__element--inline) {
-		flex: 1;
+		flex: 1 1 8rem;
 	}
 
 	> .sourceText {

--- a/packages/app/src/modules/my-space/CompanyEditModal.module.scss
+++ b/packages/app/src/modules/my-space/CompanyEditModal.module.scss
@@ -42,9 +42,12 @@
 	// screens (same rendering as flex-basis 0) but lets them wrap on their own
 	// line at reduced widths instead of being crushed/overflowing, so the DSFR
 	// focus outline (2px width + 2px offset outside the box) stays fully
-	// visible at every viewport width.
+	// visible at every viewport width. The basis matches a rich radio card's
+	// natural width (~10rem incl. padding) so wrapping kicks in before any
+	// compression; no DSFR ancestor sets overflow:hidden, so nothing clips the
+	// outline once it wraps.
 	:global(.fr-fieldset__element--inline) {
-		flex: 1 1 8rem;
+		flex: 1 1 10rem;
 	}
 
 	> .sourceText {


### PR DESCRIPTION
## Contexte

RGAA 10.7 — visibilité du focus. Dans la modale d'édition entreprise (mon espace), les deux radios riches du fieldset CSE étaient posées en `flex: 1` (flex-basis 0) : à largeur réduite, elles étaient écrasées côte à côte et l'outline de focus DSFR (2px + offset 2px, dessiné hors de la boîte) était rogné.

## Changement

`CompanyEditModal.module.scss` : `flex: 1` → `flex: 1 1 8rem` sur `.fr-fieldset__element--inline` du `.cseFieldset`. Rendu identique sur écran large (les deux radios restent à largeurs égales), mais à largeur réduite chaque radio passe à la ligne au lieu d'être écrasée, ce qui laisse l'outline de focus entièrement visible à toutes les largeurs de viewport.

À confirmer au rendu (vérification visuelle de l'outline aux viewports réduits).

Closes #3878