### PR TITLE
fix(a11y): #3880 — focus sur le nom à l'ouverture du menu mobile

### DIFF
--- a/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
+++ b/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { getDsfrModal } from "~/modules/shared";
 import styles from "./MobileUserBlock.module.scss";
+
+/** Frames to wait for the DSFR focus trap before focusing the name anyway. */
+const FOCUS_TRAP_MAX_FRAMES = 30;
 
 type Props = {
 	userName: string;
@@ -21,15 +24,60 @@ type Props = {
  * `.fr-header__menu-links` container).
  */
 export function MobileUserBlock({ userName, userEmail, userPhone }: Props) {
+	const userNameRef = useRef<HTMLParagraphElement>(null);
+
 	const openProfileModal = useCallback(() => {
 		const profile = document.getElementById("profile-modal");
 		if (profile) getDsfrModal(profile)?.disclose();
 	}, []);
 
+	// RGAA 12.8: when the mobile menu opens, the DSFR focus trap moves focus to
+	// the first interactive element (the "Fermer" button). The expected target
+	// is the first *content* element instead: the user name. Wait for the trap
+	// to settle (it polls with requestAnimationFrame until the modal is
+	// focusable), then re-target the focus onto the name. Closing the menu is
+	// untouched: DSFR gives focus back to the burger button natively.
+	useEffect(() => {
+		const menuModal = document.getElementById("modal-menu");
+		if (!menuModal) return;
+
+		let frame: number | null = null;
+
+		const cancelPendingFocus = () => {
+			if (frame !== null) window.cancelAnimationFrame(frame);
+			frame = null;
+		};
+
+		const handleDisclose = () => {
+			let attemptsLeft = FOCUS_TRAP_MAX_FRAMES;
+			const settle = () => {
+				const trapSettled = menuModal.contains(document.activeElement);
+				if (trapSettled || attemptsLeft <= 0) {
+					frame = null;
+					userNameRef.current?.focus();
+					return;
+				}
+				attemptsLeft -= 1;
+				frame = window.requestAnimationFrame(settle);
+			};
+			frame = window.requestAnimationFrame(settle);
+		};
+
+		menuModal.addEventListener("dsfr.disclose", handleDisclose);
+		menuModal.addEventListener("dsfr.conceal", cancelPendingFocus);
+		return () => {
+			menuModal.removeEventListener("dsfr.disclose", handleDisclose);
+			menuModal.removeEventListener("dsfr.conceal", cancelPendingFocus);
+			cancelPendingFocus();
+		};
+	}, []);
+
 	return (
 		<div className={styles.wrapper}>
 			<div className={styles.userInfo}>
-				<p className={styles.userName}>{userName}</p>
+				<p className={styles.userName} ref={userNameRef} tabIndex={-1}>
+					{userName}
+				</p>
 				<p className={styles.userMeta}>{userEmail}</p>
 				{userPhone && <p className={styles.userMeta}>{userPhone}</p>}
 			</div>

--- a/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
+++ b/packages/app/src/modules/layout/Header/MobileUserBlock.tsx
@@ -49,10 +49,19 @@ export function MobileUserBlock({ userName, userEmail, userPhone }: Props) {
 		};
 
 		const handleDisclose = () => {
+			// Rapid re-opens (or a spurious double event) must not stack two
+			// concurrent polling loops onto the same ref.
+			cancelPendingFocus();
 			let attemptsLeft = FOCUS_TRAP_MAX_FRAMES;
 			const settle = () => {
-				const trapSettled = menuModal.contains(document.activeElement);
-				if (trapSettled || attemptsLeft <= 0) {
+				if (attemptsLeft <= 0) {
+					// The trap never settled within the allowed frames — abort
+					// silently rather than steal focus from wherever it currently is
+					// (e.g. the modal never actually opened).
+					frame = null;
+					return;
+				}
+				if (menuModal.contains(document.activeElement)) {
 					frame = null;
 					userNameRef.current?.focus();
 					return;

--- a/packages/app/src/modules/layout/Header/__tests__/MobileUserBlock.test.tsx
+++ b/packages/app/src/modules/layout/Header/__tests__/MobileUserBlock.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { MobileUserBlock } from "../MobileUserBlock";
@@ -42,6 +42,39 @@ describe("MobileUserBlock", () => {
 		render(<MobileUserBlock {...defaultProps} />);
 		const link = screen.getByRole("link", { name: "Se déconnecter" });
 		expect(link).toHaveAttribute("href", "/api/auth/logout");
+	});
+
+	describe("focus on mobile menu opening (RGAA 12.8)", () => {
+		it("moves focus onto the user name once the DSFR focus trap settled", async () => {
+			// Simulate the DSFR mobile menu modal wrapping the block.
+			const menuModal = document.createElement("div");
+			menuModal.id = "modal-menu";
+			const closeButton = document.createElement("button");
+			closeButton.textContent = "Fermer";
+			menuModal.appendChild(closeButton);
+			document.body.appendChild(menuModal);
+
+			const { container } = render(<MobileUserBlock {...defaultProps} />, {
+				container: menuModal.appendChild(document.createElement("div")),
+			});
+
+			// DSFR dispatches dsfr.disclose, then its focus trap moves focus to
+			// the first interactive element (the close button).
+			fireEvent(menuModal, new Event("dsfr.disclose"));
+			closeButton.focus();
+
+			await waitFor(() => {
+				expect(screen.getByText("Jean Dupont")).toHaveFocus();
+			});
+
+			container.remove();
+			menuModal.remove();
+		});
+
+		it("makes the user name programmatically focusable only", () => {
+			render(<MobileUserBlock {...defaultProps} />);
+			expect(screen.getByText("Jean Dupont")).toHaveAttribute("tabindex", "-1");
+		});
 	});
 
 	it("opens the profile modal when 'Voir mon profil' is clicked", () => {


### PR DESCRIPTION
## Contexte

RGAA 12.8 — à l'ouverture du menu mobile (modale DSFR `modal-menu`), le focus doit être déplacé sur le premier élément de contenu (le nom de l'utilisateur) plutôt que rester sur le bouton « Fermer » ciblé par le focus trap DSFR.

## Changements

- `MobileUserBlock.tsx` : le nom de l'utilisateur reçoit `tabIndex={-1}` (focusable programmatiquement uniquement) ; un hook écoute `dsfr.disclose` sur `#modal-menu`, attend que le focus trap DSFR se stabilise (polling `requestAnimationFrame`, plafond de frames), puis déplace le focus sur le nom. `dsfr.conceal` annule tout focus en attente — la fermeture reste native (retour focus sur le burger).
- Tests : 2 cas ajoutés (focus déplacé sur le nom une fois le trap stabilisé, `tabindex="-1"` présent).

> Comportement à confirmer au rendu (interaction réelle avec le focus trap DSFR sur mobile).

Closes #3880