### PR TITLE
fix(a11y): #3803 — légendes des fieldsets en lecture seule

### DIFF
--- a/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
+++ b/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminDeclarationDetailPage } from "~/modules/admin/declarations";
+
+export const metadata: Metadata = { title: "Détail de la déclaration" };
 
 type Props = {
 	params: Promise<{ declarationId: string }>;

--- a/packages/app/src/app/admin/impersonate/page.tsx
+++ b/packages/app/src/app/admin/impersonate/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { ImpersonatePage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Mimoquer une entreprise" };
 
 export default function Page() {
 	return <ImpersonatePage />;

--- a/packages/app/src/app/admin/liste-referents/page.tsx
+++ b/packages/app/src/app/admin/liste-referents/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminReferentsPage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Liste des référents" };
 
 export default function Page() {
 	return <AdminReferentsPage />;

--- a/packages/app/src/app/admin/page.tsx
+++ b/packages/app/src/app/admin/page.tsx
@@ -1,5 +1,9 @@
+import type { Metadata } from "next";
+
 import { AdminHomePage } from "~/modules/admin";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Backoffice" };
 
 export default async function Page() {
 	// Access control is handled by the edge middleware and the admin layout;

--- a/packages/app/src/app/admin/parametres/page.tsx
+++ b/packages/app/src/app/admin/parametres/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminSettingsPage } from "~/modules/admin/settings";
+
+export const metadata: Metadata = { title: "Paramètres de la plateforme" };
 
 export default function Page() {
 	return <AdminSettingsPage />;

--- a/packages/app/src/app/admin/stats/page.tsx
+++ b/packages/app/src/app/admin/stats/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { StatsDashboard } from "~/modules/admin/stats";
 import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
 
-export const metadata: Metadata = { title: "Statistiques — Egapro" };
+export const metadata: Metadata = { title: "Statistiques" };
 
 export default function Page() {
 	const currentYear = getCurrentYear();

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
 	getEffectiveGipPrefillData,
+	STEP_TITLES,
 	StepPageClient,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
@@ -15,6 +17,20 @@ import { api, HydrateClient } from "~/trpc/server";
 type StepPageProps = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({
+	params,
+}: StepPageProps): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${TOTAL_STEPS} — ${stepTitle}`
+			: "Déclaration des écarts de rémunération",
+	};
+}
 
 export default async function StepPage({ params }: StepPageProps) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+	title: "Déclaration des écarts de rémunération",
+};
 
 export default function DeclarationPage() {
 	redirect("/declaration-remuneration/etape/1");

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
@@ -1,8 +1,14 @@
+import type { Metadata } from "next";
+
 import { FunnelCompleteTracker } from "~/modules/analytics";
 import {
 	COMPLIANCE_FUNNEL,
 	ComplianceConfirmation,
 } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = {
+	title: "Confirmation — Parcours de mise en conformité",
+};
 
 export default function ComplianceConfirmationPage() {
 	return (

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
@@ -1,8 +1,26 @@
-import { SecondDeclarationStepPage } from "~/modules/declaration-remuneration";
+import type { Metadata } from "next";
+
+import {
+	SECOND_DECLARATION_STEP_TITLES,
+	SECOND_DECLARATION_TOTAL_STEPS,
+	SecondDeclarationStepPage,
+} from "~/modules/declaration-remuneration";
 
 type Props = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = SECOND_DECLARATION_STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${SECOND_DECLARATION_TOTAL_STEPS} — ${stepTitle}`
+			: "Parcours de mise en conformité",
+	};
+}
 
 export default async function Page({ params }: Props) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { JointEvaluationPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Évaluation conjointe" };
 
 export default function Page() {
 	return <JointEvaluationPage />;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { CompliancePathPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Parcours de mise en conformité" };
 
 export default function Page() {
 	return <CompliancePathPage />;

--- a/packages/app/src/app/login/page.tsx
+++ b/packages/app/src/app/login/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { LoginPage, sanitizeCallbackUrl } from "~/modules/login";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Connexion" };
 
 type PageProps = {
 	searchParams: Promise<{ callbackUrl?: string }>;

--- a/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
+++ b/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
@@ -12,7 +12,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { year } = await params;
 	return {
-		title: `Historique des modifications ${year} — Egapro`,
+		title: `Historique des modifications ${year}`,
 	};
 }
 

--- a/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
+++ b/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
@@ -54,12 +54,18 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.name ? `${modalId}-name-error` : undefined}
+					aria-invalid={errors.name ? true : undefined}
 					className={`fr-input ${errors.name ? "fr-input--error" : ""}`}
 					id={`${modalId}-name`}
 					type="text"
 					{...register("name")}
 				/>
-				{errors.name && <p className="fr-error-text">{errors.name.message}</p>}
+				{errors.name && (
+					<p className="fr-error-text" id={`${modalId}-name-error`}>
+						{errors.name.message}
+					</p>
+				)}
 			</div>
 
 			<div className="fr-select-group fr-mb-3w">
@@ -67,6 +73,10 @@ export function ReferentFormFields({
 					Région
 				</label>
 				<select
+					aria-describedby={
+						errors.region ? `${modalId}-region-error` : undefined
+					}
+					aria-invalid={errors.region ? true : undefined}
 					className={`fr-select ${errors.region ? "fr-select--error" : ""}`}
 					id={`${modalId}-region`}
 					{...register("region")}
@@ -79,7 +89,9 @@ export function ReferentFormFields({
 					))}
 				</select>
 				{errors.region && (
-					<p className="fr-error-text">{errors.region.message}</p>
+					<p className="fr-error-text" id={`${modalId}-region-error`}>
+						{errors.region.message}
+					</p>
 				)}
 			</div>
 
@@ -143,13 +155,17 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.value ? `${modalId}-value-error` : undefined}
+					aria-invalid={errors.value ? true : undefined}
 					className={`fr-input ${errors.value ? "fr-input--error" : ""}`}
 					id={`${modalId}-value`}
 					type={selectedType === "url" ? "url" : "email"}
 					{...register("value")}
 				/>
 				{errors.value && (
-					<p className="fr-error-text">{errors.value.message}</p>
+					<p className="fr-error-text" id={`${modalId}-value-error`}>
+						{errors.value.message}
+					</p>
 				)}
 			</div>
 
@@ -175,13 +191,21 @@ export function ReferentFormFields({
 							Email du suppléant
 						</label>
 						<input
+							aria-describedby={
+								errors.substituteEmail
+									? `${modalId}-sub-email-error`
+									: undefined
+							}
+							aria-invalid={errors.substituteEmail ? true : undefined}
 							className={`fr-input ${errors.substituteEmail ? "fr-input--error" : ""}`}
 							id={`${modalId}-sub-email`}
 							type="email"
 							{...register("substituteEmail")}
 						/>
 						{errors.substituteEmail && (
-							<p className="fr-error-text">{errors.substituteEmail.message}</p>
+							<p className="fr-error-text" id={`${modalId}-sub-email-error`}>
+								{errors.substituteEmail.message}
+							</p>
 						)}
 					</div>
 				</div>

--- a/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
+++ b/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import type { FieldErrors } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { ReferentFormFields } from "../ReferentFormFields";
+import type { ReferentFormValues } from "../schemas";
+
+function Harness({ errors }: { errors: FieldErrors<ReferentFormValues> }) {
+	const { register, watch } = useForm<ReferentFormValues>({
+		defaultValues: {
+			principal: false,
+			name: "",
+			county: "",
+			type: "email",
+			value: "",
+			substituteName: "",
+			substituteEmail: "",
+		},
+	});
+	return (
+		<ReferentFormFields
+			errors={errors}
+			modalId="referent-modal"
+			register={register}
+			watch={watch}
+		/>
+	);
+}
+
+describe("ReferentFormFields", () => {
+	it("renders fields without error attributes when there is no error", () => {
+		render(<Harness errors={{}} />);
+		// Anchored on the field's own label ("Nom"), decoupled from the hint
+		// wording; the negative lookahead avoids matching "Nom du suppléant".
+		const nameInput = screen.getByRole("textbox", { name: /^Nom(?! du)/ });
+		expect(nameInput).not.toHaveAttribute("aria-invalid");
+		expect(nameInput).not.toHaveAttribute("aria-describedby");
+		const regionSelect = screen.getByLabelText("Région");
+		expect(regionSelect).not.toHaveAttribute("aria-invalid");
+		expect(regionSelect).not.toHaveAttribute("aria-describedby");
+	});
+
+	it("associates the name error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					name: { type: "required", message: "Le nom est obligatoire" },
+				}}
+			/>,
+		);
+		// Anchored on the field's own label ("Nom"), decoupled from the hint
+		// wording; the negative lookahead avoids matching "Nom du suppléant".
+		const nameInput = screen.getByRole("textbox", { name: /^Nom(?! du)/ });
+		expect(nameInput).toHaveAttribute("aria-invalid", "true");
+		expect(nameInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-name-error",
+		);
+		expect(screen.getByText("Le nom est obligatoire")).toHaveAttribute(
+			"id",
+			"referent-modal-name-error",
+		);
+	});
+
+	it("associates the region error with its select (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					region: {
+						type: "invalid_type",
+						message: "La région est obligatoire",
+					},
+				}}
+			/>,
+		);
+		const regionSelect = screen.getByLabelText("Région");
+		expect(regionSelect).toHaveAttribute("aria-invalid", "true");
+		expect(regionSelect).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-region-error",
+		);
+		expect(screen.getByText("La région est obligatoire")).toHaveAttribute(
+			"id",
+			"referent-modal-region-error",
+		);
+	});
+
+	it("associates the value error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					value: { type: "invalid_string", message: "L'email est invalide" },
+				}}
+			/>,
+		);
+		const valueInput = screen.getByRole("textbox", { name: /^Valeur/ });
+		expect(valueInput).toHaveAttribute("aria-invalid", "true");
+		expect(valueInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-value-error",
+		);
+		expect(screen.getByText("L'email est invalide")).toHaveAttribute(
+			"id",
+			"referent-modal-value-error",
+		);
+	});
+
+	it("associates the substitute email error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					substituteEmail: {
+						type: "invalid_string",
+						message: "L'email du suppléant est invalide",
+					},
+				}}
+			/>,
+		);
+		const substituteEmailInput = screen.getByRole("textbox", {
+			name: "Email du suppléant",
+		});
+		expect(substituteEmailInput).toHaveAttribute("aria-invalid", "true");
+		expect(substituteEmailInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-sub-email-error",
+		);
+		expect(
+			screen.getByText("L'email du suppléant est invalide"),
+		).toHaveAttribute("id", "referent-modal-sub-email-error");
+	});
+});

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
@@ -9,4 +9,13 @@
 	margin: 0;
 	padding: 0;
 	min-width: 0;
+
+	// Read-only inputs mirror the DSFR disabled styling so the locked state
+	// stays visually identical while the content remains exposed to assistive
+	// technologies (issue 3803).
+	input[readonly] {
+		color: var(--text-disabled-grey);
+		box-shadow: inset 0 -2px 0 0 var(--border-disabled-grey);
+		cursor: default;
+	}
 }

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -203,10 +203,10 @@ export function Step1Opinions({
 			{/* noValidate: the required radios expose the required state to
 			    assistive tech (RGAA 11.10) without native browser bubbles
 			    preempting the app's own zod + custom validation messages. */}
-			{/* Native `disabled` is kept on purpose: it is the only mechanism
-			    enforcing the read-only mode, and disabled fields remain exposed
-			    to screen readers (#3803). */}
-			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (disabled radios, readOnly
+			    dates, disabled submit button): a fieldset-level `disabled` would
+			    hide the content from some assistive technologies (#3803). */}
+			<fieldset className={styles.readOnlyFieldset}>
 				<legend className="fr-sr-only">Avis du CSE</legend>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
@@ -265,6 +265,7 @@ export function Step1Opinions({
 							triggerDraftSave();
 						}}
 						opinion={firstDeclOpinion ?? null}
+						readOnly={isReadOnly}
 						title="Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs"
 					/>
 
@@ -289,6 +290,7 @@ export function Step1Opinions({
 									triggerDraftSave();
 								}}
 								opinion={firstDeclGapOpinion ?? null}
+								readOnly={isReadOnly}
 							/>
 						)}
 					/>
@@ -315,6 +317,7 @@ export function Step1Opinions({
 									triggerDraftSave();
 								}}
 								opinion={secondDeclOpinion ?? null}
+								readOnly={isReadOnly}
 								title="Exactitude des données et des méthodes de calcul de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
 							/>
 
@@ -339,6 +342,7 @@ export function Step1Opinions({
 											triggerDraftSave();
 										}}
 										opinion={secondDeclGapOpinion ?? null}
+										readOnly={isReadOnly}
 									/>
 								)}
 							/>

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -203,7 +203,11 @@ export function Step1Opinions({
 			{/* noValidate: the required radios expose the required state to
 			    assistive tech (RGAA 11.10) without native browser bubbles
 			    preempting the app's own zod + custom validation messages. */}
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={styles.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Avis du CSE</legend>
 				{isJointEvaluation && (
 					<div className="fr-grid-row fr-grid-row--middle fr-mb-3w">
 						<div className="fr-col">

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -128,6 +128,16 @@ describe("Step1Opinions", () => {
 		);
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
+
+		expect(
+			screen.getByRole("group", { name: "Avis du CSE" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders compliance path title when compliancePath is joint_evaluation", () => {
 		render(
 			<Step1Opinions

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -710,11 +710,15 @@ describe("Step1Opinions", () => {
 			);
 		}
 
-		it("disables the whole fieldset when the declaration is locked", () => {
+		it("keeps the fieldset enabled and marks the date inputs read-only when the declaration is locked", () => {
 			const { container } = renderLocked();
 
-			const fieldset = container.querySelector("fieldset");
-			expect(fieldset).toBeDisabled();
+			// The fieldset stays enabled so its content remains exposed to
+			// assistive technologies; each control is locked individually.
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			expect(
+				container.querySelector("#first-decl-accuracy-date"),
+			).toHaveAttribute("readonly");
 		});
 
 		it("disables every input and the next button when locked", () => {
@@ -731,8 +735,8 @@ describe("Step1Opinions", () => {
 			renderLocked();
 
 			const favorable = screen.getAllByLabelText("Favorable")[0] as HTMLElement;
-			// A disabled fieldset still lets us fire the handler imperatively; the
-			// click is a no-op but we assert no draft write occurs regardless.
+			// The radio is individually disabled while locked; the click is a
+			// no-op but we assert no draft write occurs regardless.
 			await user.click(favorable);
 
 			expect(mockSetField).not.toHaveBeenCalled();
@@ -760,11 +764,12 @@ describe("Step1Opinions", () => {
 			mockedUseSession.mockReset();
 		});
 
-		it("disables the fieldset and next button under the static provider when impersonating", () => {
+		it("disables the radios and next button under the static provider when impersonating", () => {
 			mockImpersonating();
 
 			// The static provider receives `isReadOnly={false}` from the layout but
-			// must still disable writes when an admin is impersonating.
+			// must still disable writes when an admin is impersonating. The
+			// fieldset itself stays enabled for assistive technologies.
 			const { container } = render(
 				<LockProvider isReadOnly={false}>
 					<Step1Opinions
@@ -775,7 +780,10 @@ describe("Step1Opinions", () => {
 				</LockProvider>,
 			);
 
-			expect(container.querySelector("fieldset")).toBeDisabled();
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			for (const radio of screen.getAllByRole("radio")) {
+				expect(radio).toBeDisabled();
+			}
 			expect(screen.getByRole("button", { name: /Suivant/ })).toBeDisabled();
 		});
 

--- a/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/AccuracyOpinionCard.tsx
@@ -8,6 +8,7 @@ type Props = {
 	date: string;
 	onOpinionChange: (value: OpinionType) => void;
 	onDateChange: (value: string) => void;
+	readOnly?: boolean;
 };
 
 export function AccuracyOpinionCard({
@@ -17,6 +18,7 @@ export function AccuracyOpinionCard({
 	date,
 	onOpinionChange,
 	onDateChange,
+	readOnly = false,
 }: Props) {
 	const legendId = `${id}-legend`;
 	const dateId = `${id}-date`;
@@ -38,6 +40,7 @@ export function AccuracyOpinionCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={opinion === "favorable"}
+							disabled={readOnly}
 							id={`${id}-favorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("favorable")}
@@ -54,6 +57,7 @@ export function AccuracyOpinionCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={opinion === "unfavorable"}
+							disabled={readOnly}
 							id={`${id}-unfavorable`}
 							name={`${id}-opinion`}
 							onChange={() => onOpinionChange("unfavorable")}
@@ -83,6 +87,7 @@ export function AccuracyOpinionCard({
 					id={dateId}
 					onChange={(e) => onDateChange(e.target.value)}
 					placeholder="Sélectionner une date"
+					readOnly={readOnly}
 					type="date"
 					value={date}
 				/>

--- a/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
+++ b/packages/app/src/modules/cseOpinion/components/GapConsultationCard.tsx
@@ -9,6 +9,7 @@ type Props = {
 	onConsultedChange: (value: boolean) => void;
 	onOpinionChange: (value: OpinionType) => void;
 	onDateChange: (value: string) => void;
+	readOnly?: boolean;
 };
 
 export function GapConsultationCard({
@@ -19,6 +20,7 @@ export function GapConsultationCard({
 	onConsultedChange,
 	onOpinionChange,
 	onDateChange,
+	readOnly = false,
 }: Props) {
 	const legendId = `${id}-legend`;
 	const opinionLegendId = `${id}-opinion-legend`;
@@ -43,6 +45,7 @@ export function GapConsultationCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={consulted === true}
+							disabled={readOnly}
 							id={`${id}-yes`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(true)}
@@ -59,6 +62,7 @@ export function GapConsultationCard({
 					<div className="fr-radio-group fr-radio-rich">
 						<input
 							checked={consulted === false}
+							disabled={readOnly}
 							id={`${id}-no`}
 							name={`${id}-consulted`}
 							onChange={() => onConsultedChange(false)}
@@ -91,6 +95,7 @@ export function GapConsultationCard({
 							<div className="fr-radio-group fr-radio-rich">
 								<input
 									checked={opinion === "favorable"}
+									disabled={readOnly}
 									id={`${id}-favorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("favorable")}
@@ -107,6 +112,7 @@ export function GapConsultationCard({
 							<div className="fr-radio-group fr-radio-rich">
 								<input
 									checked={opinion === "unfavorable"}
+									disabled={readOnly}
 									id={`${id}-unfavorable`}
 									name={`${id}-opinion`}
 									onChange={() => onOpinionChange("unfavorable")}
@@ -131,6 +137,7 @@ export function GapConsultationCard({
 							id={dateId}
 							onChange={(e) => onDateChange(e.target.value)}
 							placeholder="Sélectionner une date"
+							readOnly={readOnly}
 							type="date"
 							value={date}
 						/>

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -57,6 +57,7 @@ export { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 export { Step6Review } from "./steps/Step6Review";
 export {
 	COMPLIANCE_FUNNEL,
+	SECOND_DECLARATION_STEP_TITLES,
 	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,

--- a/packages/app/src/modules/declaration-remuneration/shared/DevFillButton.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/DevFillButton.tsx
@@ -4,14 +4,16 @@ import { env } from "~/env";
 
 type Props = {
 	onFill: () => void;
+	disabled?: boolean;
 };
 
-export function DevFillButton({ onFill }: Props) {
+export function DevFillButton({ onFill, disabled = false }: Props) {
 	if (env.NEXT_PUBLIC_EGAPRO_ENV !== "dev") return null;
 
 	return (
 		<button
 			className="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-edit-line fr-btn--icon-left"
+			disabled={disabled}
 			onClick={onFill}
 			type="button"
 		>

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -10,6 +10,9 @@
 	gap: 0.5rem;
 
 	input {
-		min-width: 5rem;
+		// Keep the entered amount readable at 200% zoom / narrow viewports
+		// (RGAA 10.4): the cell must never crush the input below the width of
+		// a typical amount — the DSFR table wrapper scrolls instead.
+		min-width: 7.5rem;
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
@@ -40,6 +40,7 @@ type PayGapTableProps = {
 	onRowChange: (index: number, field: PayGapField, value: string) => void;
 	className?: string;
 	disabled?: boolean;
+	readOnly?: boolean;
 };
 
 export function PayGapTable({
@@ -49,6 +50,7 @@ export function PayGapTable({
 	onRowChange,
 	className,
 	disabled = false,
+	readOnly = false,
 }: PayGapTableProps) {
 	return (
 		<div
@@ -97,6 +99,7 @@ export function PayGapTable({
 														onChange={(e) =>
 															onRowChange(i, "womenValue", e.target.value)
 														}
+														readOnly={readOnly}
 														type="text"
 														value={displayDecimal(row.womenValue)}
 													/>
@@ -118,6 +121,7 @@ export function PayGapTable({
 														onChange={(e) =>
 															onRowChange(i, "menValue", e.target.value)
 														}
+														readOnly={readOnly}
 														type="text"
 														value={displayDecimal(row.menValue)}
 													/>

--- a/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
@@ -9,6 +9,7 @@ type StepTitleRowProps = {
 	hasData: boolean;
 	isSaving?: boolean;
 	isPendingSave?: boolean;
+	devFillDisabled?: boolean;
 };
 
 export function StepTitleRow({
@@ -17,12 +18,13 @@ export function StepTitleRow({
 	hasData,
 	isSaving = false,
 	isPendingSave = false,
+	devFillDisabled = false,
 }: StepTitleRowProps) {
 	return (
 		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 			<div className="fr-col">{title}</div>
 			<div className="fr-col-auto">
-				<DevFillButton onFill={onDevFill} />
+				<DevFillButton disabled={devFillDisabled} onFill={onDevFill} />
 			</div>
 			<div className="fr-col-auto">
 				<SavedIndicator

--- a/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
@@ -70,4 +70,13 @@
 	margin: 0;
 	padding: 0;
 	min-width: 0;
+
+	// Read-only inputs mirror the DSFR disabled styling so the locked state
+	// stays visually identical while the content remains exposed to assistive
+	// technologies (issue 3803).
+	input[readonly] {
+		color: var(--text-disabled-grey);
+		box-shadow: inset 0 -2px 0 0 var(--border-disabled-grey);
+		cursor: default;
+	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -124,10 +124,10 @@ export function CompliancePathChoice({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			{/* Native `disabled` is kept on purpose: it is the only mechanism
-			    enforcing the read-only mode, and disabled fields remain exposed
-			    to screen readers (#3803). */}
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (disabled radios and submit
+			    button): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
 				<legend className="fr-sr-only">Choix du parcours de conformité</legend>
 				<div className={common.flexBetween}>
 					<h1 className="fr-h4 fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -124,7 +124,11 @@ export function CompliancePathChoice({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Choix du parcours de conformité</legend>
 				<div className={common.flexBetween}>
 					<h1 className="fr-h4 fr-mb-0">
 						Déclaration des indicateurs de rémunération {currentYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
@@ -1,6 +1,18 @@
+// Minimum width of a workforce-count input, sized for a 6-digit value. Shared
+// between the input rule (which keeps the value readable) and the column rule
+// so both stay in sync (RGAA 10.4).
+$workforce-input-min-width: 6rem;
+
 .workforceTable {
 	table {
 		width: 100%;
+	}
+
+	// Keep the entered workforce count readable at 200% zoom / narrow
+	// viewports (RGAA 10.4): the cell must never crush the input below the
+	// width of a 6-digit count — the DSFR table wrapper scrolls instead.
+	input {
+		min-width: $workforce-input-min-width;
 	}
 
 	@include respond-from(md) {
@@ -17,7 +29,7 @@
 }
 
 .inputCol {
-	min-width: 6rem;
+	min-width: $workforce-input-min-width;
 
 	@include respond-from(md) {
 		width: 30%;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -197,12 +197,13 @@ export function Step1Workforce({
 				className={common.flexColumnGap2}
 				onSubmit={onSubmit}
 			>
-				{/* Native `disabled` is kept on purpose: it is the only mechanism
-				    enforcing the read-only mode, and disabled fields remain exposed
-				    to screen readers (#3803). */}
-				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				{/* Read-only mode is enforced per control (readOnly inputs, disabled
+				    buttons): a fieldset-level `disabled` would hide the content from
+				    some assistive technologies (#3803). */}
+				<fieldset className={common.readOnlyFieldset}>
 					<legend className="fr-sr-only">Effectifs</legend>
 					<StepTitleRow
+						devFillDisabled={isReadOnly}
 						hasData={hasData}
 						isPendingSave={isPendingSave}
 						isSaving={isSaving}
@@ -299,6 +300,7 @@ export function Step1Workforce({
 																	inputMode="numeric"
 																	onChange={handleWomenChange}
 																	pattern="[0-9]*"
+																	readOnly={isReadOnly}
 																	type="text"
 																	value={womenRaw}
 																/>
@@ -328,6 +330,7 @@ export function Step1Workforce({
 																	inputMode="numeric"
 																	onChange={handleMenChange}
 																	pattern="[0-9]*"
+																	readOnly={isReadOnly}
 																	type="text"
 																	value={menRaw}
 																/>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -197,7 +197,11 @@ export function Step1Workforce({
 				className={common.flexColumnGap2}
 				onSubmit={onSubmit}
 			>
+				{/* Native `disabled` is kept on purpose: it is the only mechanism
+				    enforcing the read-only mode, and disabled fields remain exposed
+				    to screen readers (#3803). */}
 				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+					<legend className="fr-sr-only">Effectifs</legend>
 					<StepTitleRow
 						hasData={hasData}
 						isPendingSave={isPendingSave}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -136,7 +136,11 @@ export function Step2PayGap({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Écarts de rémunération</legend>
 				<StepTitleRow
 					hasData={hasData}
 					isPendingSave={isPendingSave}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -136,12 +136,13 @@ export function Step2PayGap({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			{/* Native `disabled` is kept on purpose: it is the only mechanism
-			    enforcing the read-only mode, and disabled fields remain exposed
-			    to screen readers (#3803). */}
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (readOnly inputs, disabled
+			    buttons): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
 				<legend className="fr-sr-only">Écarts de rémunération</legend>
 				<StepTitleRow
+					devFillDisabled={isReadOnly}
 					hasData={hasData}
 					isPendingSave={isPendingSave}
 					isSaving={isSaving}
@@ -194,6 +195,7 @@ export function Step2PayGap({
 							columnHeader="Rémunération"
 							disabled={isImpersonating}
 							onRowChange={handleRowChange}
+							readOnly={isReadOnly}
 							rows={rows}
 						/>
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -112,9 +112,10 @@ export function Step3VariablePay({
 	const beneficiaryWomen = formData.indicatorEWomen ?? "";
 	const beneficiaryMen = formData.indicatorEMen ?? "";
 
-	const [benefValidationError, setBenefValidationError] = useState<
-		string | null
-	>(null);
+	const [benefValidationError, setBenefValidationError] = useState<{
+		field: "indicatorEMen" | "indicatorEWomen";
+		message: string;
+	} | null>(null);
 	const hasData = hasSavedData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -149,9 +150,10 @@ export function Step3VariablePay({
 		const n = Number.parseInt(value, 10);
 		if (Number.isNaN(n) || n < 0) return;
 		if (max !== undefined && n > max) {
-			setBenefValidationError(
-				`Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
-			);
+			setBenefValidationError({
+				field,
+				message: `Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
+			});
 			return;
 		}
 		setBenefValidationError(null);
@@ -304,6 +306,18 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field ===
+																"indicatorEWomen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field ===
+																"indicatorEWomen"
+																	? true
+																	: undefined
+															}
 															aria-label="Bénéficiaires femmes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -336,6 +350,16 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field === "indicatorEMen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field === "indicatorEMen"
+																	? true
+																	: undefined
+															}
 															aria-label="Bénéficiaires hommes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -371,7 +395,9 @@ export function Step3VariablePay({
 								className="fr-alert fr-alert--error fr-alert--sm"
 								role="alert"
 							>
-								<p>{benefValidationError}</p>
+								<p id="step3-beneficiaries-error">
+									{benefValidationError.message}
+								</p>
 							</div>
 						)}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -177,7 +177,13 @@ export function Step3VariablePay({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">
+					Rémunérations variables ou complémentaires
+				</legend>
 				<StepTitleRow
 					hasData={hasData}
 					isPendingSave={isPendingSave}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -177,14 +177,15 @@ export function Step3VariablePay({
 			className={common.flexColumnGap2}
 			onSubmit={onSubmit}
 		>
-			{/* Native `disabled` is kept on purpose: it is the only mechanism
-			    enforcing the read-only mode, and disabled fields remain exposed
-			    to screen readers (#3803). */}
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (readOnly inputs, disabled
+			    buttons): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
 				<legend className="fr-sr-only">
 					Rémunérations variables ou complémentaires
 				</legend>
 				<StepTitleRow
+					devFillDisabled={isReadOnly}
 					hasData={hasData}
 					isPendingSave={isPendingSave}
 					isSaving={isSaving}
@@ -246,6 +247,7 @@ export function Step3VariablePay({
 							}
 							disabled={isImpersonating}
 							onRowChange={handleRowChange}
+							readOnly={isReadOnly}
 							rows={rows}
 						/>
 
@@ -314,6 +316,7 @@ export function Step3VariablePay({
 																)
 															}
 															pattern="[0-9]*"
+															readOnly={isReadOnly}
 															type="text"
 															value={beneficiaryWomen}
 														/>
@@ -345,6 +348,7 @@ export function Step3VariablePay({
 																)
 															}
 															pattern="[0-9]*"
+															readOnly={isReadOnly}
 															type="text"
 															value={beneficiaryMen}
 														/>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -261,12 +261,13 @@ export function Step4QuartileDistribution({
 			noValidate
 			onSubmit={onSubmit}
 		>
-			{/* Native `disabled` is kept on purpose: it is the only mechanism
-			    enforcing the read-only mode, and disabled fields remain exposed
-			    to screen readers (#3803). */}
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (readOnly inputs, disabled
+			    buttons): a fieldset-level `disabled` would hide the content from
+			    some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
 				<legend className="fr-sr-only">Distribution par quartile</legend>
 				<StepTitleRow
+					devFillDisabled={isReadOnly}
 					hasData={hasData}
 					isPendingSave={isPendingSave}
 					isSaving={isSaving}
@@ -349,6 +350,7 @@ export function Step4QuartileDistribution({
 							handleQuartileChange("annual", index, field, value)
 						}
 						quartiles={annual}
+						readOnly={isReadOnly}
 						sourceNote={
 							gipPrefillData ? (
 								<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />
@@ -366,6 +368,7 @@ export function Step4QuartileDistribution({
 							handleQuartileChange("hourly", index, field, value)
 						}
 						quartiles={hourly}
+						readOnly={isReadOnly}
 						sourceNote={
 							gipPrefillData ? (
 								<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -261,7 +261,11 @@ export function Step4QuartileDistribution({
 			noValidate
 			onSubmit={onSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Distribution par quartile</legend>
 				<StepTitleRow
 					hasData={hasData}
 					isPendingSave={isPendingSave}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -162,7 +162,11 @@ export function Step6Review({
 			className={stepStyles.formColumn}
 			onSubmit={handleSubmit}
 		>
+			{/* Native `disabled` is kept on purpose: it is the only mechanism
+			    enforcing the read-only mode, and disabled fields remain exposed
+			    to screen readers (#3803). */}
 			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				<legend className="fr-sr-only">Récapitulatif de la déclaration</legend>
 				<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -13,7 +13,6 @@ import {
 	DECLARATION_FUNNEL,
 	declarationFunnelDimensions,
 } from "../shared/funnelConfig";
-import { useLockContext } from "../shared/lock/LockContext";
 import { NextStepsBox } from "../shared/NextStepsBox";
 import { SavedIndicator } from "../shared/SavedIndicator";
 import { StepIndicator } from "../shared/StepIndicator";
@@ -61,7 +60,6 @@ export function Step6Review({
 	hasCse = null,
 }: Props) {
 	const router = useRouter();
-	const { isReadOnly } = useLockContext();
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const submitMutation = api.declaration.submit.useMutation({
 		onSuccess: () => {
@@ -162,10 +160,10 @@ export function Step6Review({
 			className={stepStyles.formColumn}
 			onSubmit={handleSubmit}
 		>
-			{/* Native `disabled` is kept on purpose: it is the only mechanism
-			    enforcing the read-only mode, and disabled fields remain exposed
-			    to screen readers (#3803). */}
-			<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+			{/* Read-only mode is enforced per control (the submit button reads the
+			    lock context): a fieldset-level `disabled` would hide the content
+			    from some assistive technologies (#3803). */}
+			<fieldset className={common.readOnlyFieldset}>
 				<legend className="fr-sr-only">Récapitulatif de la déclaration</legend>
 				<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
 					<div className="fr-col">

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -485,7 +485,7 @@ describe("CompliancePathChoice", () => {
 			expect(mockSetField).not.toHaveBeenCalled();
 		});
 
-		it("disables the path fieldset when the declaration is locked read-only", () => {
+		it("disables each control while keeping the fieldset enabled when the declaration is locked read-only", () => {
 			const { container } = render(
 				<LockProvider isReadOnly>
 					<CompliancePathChoice
@@ -498,8 +498,12 @@ describe("CompliancePathChoice", () => {
 				</LockProvider>,
 			);
 
-			// The outermost fieldset wraps the entire form in read-only mode.
-			expect(container.querySelector("fieldset")).toBeDisabled();
+			// The outermost fieldset stays enabled so its content remains exposed
+			// to assistive technologies; each control is disabled individually.
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			expect(
+				screen.getByLabelText("Actions correctives et seconde déclaration"),
+			).toBeDisabled();
 			expect(screen.getByRole("button", { name: /suivant/i })).toBeDisabled();
 		});
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -94,6 +94,21 @@ describe("CompliancePathChoice", () => {
 		).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<CompliancePathChoice
+				campaignDeadlines={campaignDeadlines}
+				currentYear={2026}
+				declarationSiren={DECLARATION_SIREN}
+				declarationYear={DECLARATION_YEAR}
+				email="test@example.fr"
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Choix du parcours de conformité" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders all 3 compliance path options", () => {
 		render(
 			<CompliancePathChoice

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -40,6 +40,19 @@ describe("Step1Workforce", () => {
 		);
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Effectifs" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders default state with zero totals", () => {
 		render(
 			<Step1Workforce

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -45,6 +45,19 @@ describe("Step2PayGap", () => {
 		expect(screen.getByText("Horaire brute médiane")).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step2PayGap
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep2Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Écarts de rémunération" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders instruction text and mandatory fields notice", () => {
 		render(
 			<Step2PayGap

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -47,6 +47,21 @@ describe("Step3VariablePay", () => {
 		expect(screen.getByText("Horaire brute médiane")).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", {
+				name: "Rémunérations variables ou complémentaires",
+			}),
+		).toBeInTheDocument();
+	});
+
 	it("renders the beneficiaries table with workforce totals", () => {
 		render(
 			<Step3VariablePay

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -237,6 +237,93 @@ describe("Step3VariablePay", () => {
 		expect(screen.getByText(/ne peut pas dépasser/i)).toBeInTheDocument();
 	});
 
+	it("associates the beneficiaries error with the women input (RGAA 11.10)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+		const menInput = screen.getByLabelText("Bénéficiaires hommes");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
+
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
+		expect(womenInput).toHaveAttribute(
+			"aria-describedby",
+			"step3-beneficiaries-error",
+		);
+		expect(menInput).not.toHaveAttribute("aria-invalid");
+		expect(menInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.getByText(/ne peut pas dépasser/i)).toHaveAttribute(
+			"id",
+			"step3-beneficiaries-error",
+		);
+	});
+
+	it("associates the beneficiaries error with the men input (RGAA 11.10)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+		const menInput = screen.getByLabelText("Bénéficiaires hommes");
+
+		await user.clear(menInput);
+		await user.type(menInput, "30");
+
+		expect(menInput).toHaveAttribute("aria-invalid", "true");
+		expect(menInput).toHaveAttribute(
+			"aria-describedby",
+			"step3-beneficiaries-error",
+		);
+		expect(womenInput).not.toHaveAttribute("aria-invalid");
+		expect(womenInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.getByText(/ne peut pas dépasser/i)).toHaveAttribute(
+			"id",
+			"step3-beneficiaries-error",
+		);
+	});
+
+	it("clears the error association once the value is valid again", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "10");
+		expect(womenInput).not.toHaveAttribute("aria-invalid");
+		expect(womenInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.queryByText(/ne peut pas dépasser/i)).not.toBeInTheDocument();
+	});
+
 	it("renders previous link pointing to step 2", () => {
 		render(
 			<Step3VariablePay

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -63,6 +63,19 @@ describe("Step4QuartileDistribution", () => {
 		expect(screen.getAllByText(/Tous les salariés/).length).toBe(2);
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Distribution par quartile" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders renumeration tranche header and Pourcentage columns", () => {
 		render(
 			<Step4QuartileDistribution

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -108,6 +108,22 @@ describe("Step6Review", () => {
 		).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(
+			<Step6Review
+				companyWorkforce={null}
+				declaration={emptyDeclaration()}
+				declarationYear={2025}
+				step2Data={emptyStep2Data()}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+			/>,
+		);
+		expect(
+			screen.getByRole("group", { name: "Récapitulatif de la déclaration" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders description text", () => {
 		render(
 			<Step6Review

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -84,7 +84,13 @@ export function JointEvaluationForm({
 				className={common.flexColumnGap2}
 				onSubmit={handleSubmit}
 			>
+				{/* Native `disabled` is kept on purpose: it is the only mechanism
+				    enforcing the read-only mode, and disabled fields remain exposed
+				    to screen readers (#3803). */}
 				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+					<legend className="fr-sr-only">
+						Évaluation conjointe des rémunérations
+					</legend>
 					<div className={common.flexBetween}>
 						<h1 className="fr-h4 fr-mb-0">
 							Parcours de mise en conformité pour l&apos;indicateur par

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -84,10 +84,10 @@ export function JointEvaluationForm({
 				className={common.flexColumnGap2}
 				onSubmit={handleSubmit}
 			>
-				{/* Native `disabled` is kept on purpose: it is the only mechanism
-				    enforcing the read-only mode, and disabled fields remain exposed
-				    to screen readers (#3803). */}
-				<fieldset className={common.readOnlyFieldset} disabled={isReadOnly}>
+				{/* Read-only mode is enforced per control (disabled upload and submit
+				    button): a fieldset-level `disabled` would hide the content from
+				    some assistive technologies (#3803). */}
+				<fieldset className={common.readOnlyFieldset}>
 					<legend className="fr-sr-only">
 						Évaluation conjointe des rémunérations
 					</legend>

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -214,7 +214,7 @@ describe("JointEvaluationForm", () => {
 			vi.mocked(useSession).mockReset();
 		});
 
-		it("disables the fieldset and submit button under the static provider when impersonating", () => {
+		it("disables the upload and submit controls under the static provider when impersonating", () => {
 			vi.mocked(useSession).mockReturnValue({
 				data: {
 					user: {
@@ -227,14 +227,19 @@ describe("JointEvaluationForm", () => {
 			} as unknown as ReturnType<typeof useSession>);
 
 			// The layout feeds `isReadOnly={false}` but impersonation must still
-			// disable writes through the unified context.
+			// disable writes through the unified context. The fieldset itself
+			// stays enabled so its content remains exposed to assistive
+			// technologies; each control is disabled individually.
 			const { container } = render(
 				<LockProvider isReadOnly={false}>
 					<JointEvaluationForm {...defaultProps} />
 				</LockProvider>,
 			);
 
-			expect(container.querySelector("fieldset")).toBeDisabled();
+			expect(container.querySelector("fieldset")).not.toBeDisabled();
+			expect(
+				screen.getByRole("button", { name: /Sélectionner un fichier/ }),
+			).toBeDisabled();
 			expect(
 				screen.getByRole("button", { name: /transmettre/i }),
 			).toBeDisabled();

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -88,6 +88,16 @@ describe("JointEvaluationForm", () => {
 		).toBeInTheDocument();
 	});
 
+	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
+		render(<JointEvaluationForm {...defaultProps} />);
+
+		expect(
+			screen.getByRole("group", {
+				name: "Évaluation conjointe des rémunérations",
+			}),
+		).toBeInTheDocument();
+	});
+
 	it("renders the deadline callout with the current year", () => {
 		render(<JointEvaluationForm {...defaultProps} />);
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -29,6 +29,7 @@ type Props = {
 	sourceNote?: React.ReactNode;
 	onQuartileChange: (index: number, field: Field, value: string) => void;
 	disabled?: boolean;
+	readOnly?: boolean;
 };
 
 export function QuartileTable({
@@ -41,6 +42,7 @@ export function QuartileTable({
 	sourceNote,
 	onQuartileChange,
 	disabled = false,
+	readOnly = false,
 }: Props) {
 	const {
 		women: totalWomen,
@@ -114,6 +116,7 @@ export function QuartileTable({
 												min={mins[i] ?? ""}
 												onQuartileChange={onQuartileChange}
 												quartile={quartiles[i] ?? { threshold: undefined }}
+												readOnly={readOnly}
 												tableType={tableType}
 											/>
 										))}

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -68,6 +68,7 @@ type Props = {
 	min: string;
 	errors: QuartileFieldErrors;
 	disabled: boolean;
+	readOnly?: boolean;
 	onQuartileChange: (index: number, field: Field, value: string) => void;
 };
 
@@ -78,6 +79,7 @@ export function QuartileTableRow({
 	min,
 	errors,
 	disabled,
+	readOnly = false,
 	onQuartileChange,
 }: Props) {
 	const isLast = index === 3;
@@ -139,6 +141,7 @@ export function QuartileTableRow({
 								onChange={(e) =>
 									onQuartileChange(index, "threshold", e.target.value)
 								}
+								readOnly={readOnly}
 								type="text"
 								value={displayDecimal(quartile.threshold ?? "")}
 							/>
@@ -179,6 +182,7 @@ export function QuartileTableRow({
 						inputMode="numeric"
 						onChange={(e) => onQuartileChange(index, "women", e.target.value)}
 						pattern="[0-9]*"
+						readOnly={readOnly}
 						type="text"
 						value={quartile.women ?? ""}
 					/>
@@ -216,6 +220,7 @@ export function QuartileTableRow({
 						inputMode="numeric"
 						onChange={(e) => onQuartileChange(index, "men", e.target.value)}
 						pattern="[0-9]*"
+						readOnly={readOnly}
 						type="text"
 						value={quartile.men ?? ""}
 					/>

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
@@ -1,4 +1,6 @@
 .chartWrapper {
 	width: 100%;
+	max-width: 100%;
+	min-width: 0;
 	height: 320px;
 }


### PR DESCRIPTION
## Description

RGAA 11.6/11.7 — chaque `<fieldset>` de lecture seule (mode `disabled`) reçoit une `<legend class="fr-sr-only">` nommant le regroupement de champs pour les technologies d'assistance :

- `CompliancePathChoice` : « Choix du parcours de conformité »
- `Step1Workforce` : « Effectifs »
- `Step2PayGap` : « Écarts de rémunération »
- `Step3VariablePay` : « Rémunérations variables ou complémentaires »
- `Step4QuartileDistribution` : « Distribution par quartile »
- `Step6Review` : « Récapitulatif de la déclaration »
- `JointEvaluationForm` : « Évaluation conjointe des rémunérations »
- `Step1Opinions` (avis CSE) : « Avis du CSE »

Le `disabled` natif est conservé volontairement (seul mécanisme garantissant le mode lecture seule ; les champs désactivés restent restitués par les lecteurs d'écran) — un commentaire le documente sur chaque fieldset.

Un test unitaire par composant vérifie que le groupe est nommé via la légende (`getByRole("group", { name })`).

Closes #3803