### PR TITLE
fix(a11y): #3804 — association des messages d'erreur

### DIFF
--- a/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
+++ b/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminDeclarationDetailPage } from "~/modules/admin/declarations";
+
+export const metadata: Metadata = { title: "Détail de la déclaration" };
 
 type Props = {
 	params: Promise<{ declarationId: string }>;

--- a/packages/app/src/app/admin/impersonate/page.tsx
+++ b/packages/app/src/app/admin/impersonate/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { ImpersonatePage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Mimoquer une entreprise" };
 
 export default function Page() {
 	return <ImpersonatePage />;

--- a/packages/app/src/app/admin/liste-referents/page.tsx
+++ b/packages/app/src/app/admin/liste-referents/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminReferentsPage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Liste des référents" };
 
 export default function Page() {
 	return <AdminReferentsPage />;

--- a/packages/app/src/app/admin/page.tsx
+++ b/packages/app/src/app/admin/page.tsx
@@ -1,5 +1,9 @@
+import type { Metadata } from "next";
+
 import { AdminHomePage } from "~/modules/admin";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Backoffice" };
 
 export default async function Page() {
 	// Access control is handled by the edge middleware and the admin layout;

--- a/packages/app/src/app/admin/parametres/page.tsx
+++ b/packages/app/src/app/admin/parametres/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminSettingsPage } from "~/modules/admin/settings";
+
+export const metadata: Metadata = { title: "Paramètres de la plateforme" };
 
 export default function Page() {
 	return <AdminSettingsPage />;

--- a/packages/app/src/app/admin/stats/page.tsx
+++ b/packages/app/src/app/admin/stats/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { StatsDashboard } from "~/modules/admin/stats";
 import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
 
-export const metadata: Metadata = { title: "Statistiques — Egapro" };
+export const metadata: Metadata = { title: "Statistiques" };
 
 export default function Page() {
 	const currentYear = getCurrentYear();

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
 	getEffectiveGipPrefillData,
+	STEP_TITLES,
 	StepPageClient,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
@@ -15,6 +17,20 @@ import { api, HydrateClient } from "~/trpc/server";
 type StepPageProps = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({
+	params,
+}: StepPageProps): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${TOTAL_STEPS} — ${stepTitle}`
+			: "Déclaration des écarts de rémunération",
+	};
+}
 
 export default async function StepPage({ params }: StepPageProps) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+	title: "Déclaration des écarts de rémunération",
+};
 
 export default function DeclarationPage() {
 	redirect("/declaration-remuneration/etape/1");

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
@@ -1,8 +1,14 @@
+import type { Metadata } from "next";
+
 import { FunnelCompleteTracker } from "~/modules/analytics";
 import {
 	COMPLIANCE_FUNNEL,
 	ComplianceConfirmation,
 } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = {
+	title: "Confirmation — Parcours de mise en conformité",
+};
 
 export default function ComplianceConfirmationPage() {
 	return (

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
@@ -1,8 +1,26 @@
-import { SecondDeclarationStepPage } from "~/modules/declaration-remuneration";
+import type { Metadata } from "next";
+
+import {
+	SECOND_DECLARATION_STEP_TITLES,
+	SECOND_DECLARATION_TOTAL_STEPS,
+	SecondDeclarationStepPage,
+} from "~/modules/declaration-remuneration";
 
 type Props = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = SECOND_DECLARATION_STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${SECOND_DECLARATION_TOTAL_STEPS} — ${stepTitle}`
+			: "Parcours de mise en conformité",
+	};
+}
 
 export default async function Page({ params }: Props) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { JointEvaluationPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Évaluation conjointe" };
 
 export default function Page() {
 	return <JointEvaluationPage />;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { CompliancePathPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Parcours de mise en conformité" };
 
 export default function Page() {
 	return <CompliancePathPage />;

--- a/packages/app/src/app/login/page.tsx
+++ b/packages/app/src/app/login/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { LoginPage, sanitizeCallbackUrl } from "~/modules/login";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Connexion" };
 
 type PageProps = {
 	searchParams: Promise<{ callbackUrl?: string }>;

--- a/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
+++ b/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
@@ -12,7 +12,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { year } = await params;
 	return {
-		title: `Historique des modifications ${year} — Egapro`,
+		title: `Historique des modifications ${year}`,
 	};
 }
 

--- a/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
+++ b/packages/app/src/modules/admin/referents/ReferentFormFields.tsx
@@ -54,12 +54,18 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.name ? `${modalId}-name-error` : undefined}
+					aria-invalid={errors.name ? true : undefined}
 					className={`fr-input ${errors.name ? "fr-input--error" : ""}`}
 					id={`${modalId}-name`}
 					type="text"
 					{...register("name")}
 				/>
-				{errors.name && <p className="fr-error-text">{errors.name.message}</p>}
+				{errors.name && (
+					<p className="fr-error-text" id={`${modalId}-name-error`}>
+						{errors.name.message}
+					</p>
+				)}
 			</div>
 
 			<div className="fr-select-group fr-mb-3w">
@@ -67,6 +73,10 @@ export function ReferentFormFields({
 					Région
 				</label>
 				<select
+					aria-describedby={
+						errors.region ? `${modalId}-region-error` : undefined
+					}
+					aria-invalid={errors.region ? true : undefined}
 					className={`fr-select ${errors.region ? "fr-select--error" : ""}`}
 					id={`${modalId}-region`}
 					{...register("region")}
@@ -79,7 +89,9 @@ export function ReferentFormFields({
 					))}
 				</select>
 				{errors.region && (
-					<p className="fr-error-text">{errors.region.message}</p>
+					<p className="fr-error-text" id={`${modalId}-region-error`}>
+						{errors.region.message}
+					</p>
 				)}
 			</div>
 
@@ -143,13 +155,17 @@ export function ReferentFormFields({
 					</span>
 				</label>
 				<input
+					aria-describedby={errors.value ? `${modalId}-value-error` : undefined}
+					aria-invalid={errors.value ? true : undefined}
 					className={`fr-input ${errors.value ? "fr-input--error" : ""}`}
 					id={`${modalId}-value`}
 					type={selectedType === "url" ? "url" : "email"}
 					{...register("value")}
 				/>
 				{errors.value && (
-					<p className="fr-error-text">{errors.value.message}</p>
+					<p className="fr-error-text" id={`${modalId}-value-error`}>
+						{errors.value.message}
+					</p>
 				)}
 			</div>
 
@@ -175,13 +191,21 @@ export function ReferentFormFields({
 							Email du suppléant
 						</label>
 						<input
+							aria-describedby={
+								errors.substituteEmail
+									? `${modalId}-sub-email-error`
+									: undefined
+							}
+							aria-invalid={errors.substituteEmail ? true : undefined}
 							className={`fr-input ${errors.substituteEmail ? "fr-input--error" : ""}`}
 							id={`${modalId}-sub-email`}
 							type="email"
 							{...register("substituteEmail")}
 						/>
 						{errors.substituteEmail && (
-							<p className="fr-error-text">{errors.substituteEmail.message}</p>
+							<p className="fr-error-text" id={`${modalId}-sub-email-error`}>
+								{errors.substituteEmail.message}
+							</p>
 						)}
 					</div>
 				</div>

--- a/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
+++ b/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import type { FieldErrors } from "react-hook-form";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { ReferentFormFields } from "../ReferentFormFields";
+import type { ReferentFormValues } from "../schemas";
+
+function Harness({ errors }: { errors: FieldErrors<ReferentFormValues> }) {
+	const { register, watch } = useForm<ReferentFormValues>({
+		defaultValues: {
+			principal: false,
+			name: "",
+			county: "",
+			type: "email",
+			value: "",
+			substituteName: "",
+			substituteEmail: "",
+		},
+	});
+	return (
+		<ReferentFormFields
+			errors={errors}
+			modalId="referent-modal"
+			register={register}
+			watch={watch}
+		/>
+	);
+}
+
+describe("ReferentFormFields", () => {
+	it("renders fields without error attributes when there is no error", () => {
+		render(<Harness errors={{}} />);
+		const nameInput = screen.getByRole("textbox", { name: /Format/ });
+		expect(nameInput).not.toHaveAttribute("aria-invalid");
+		expect(nameInput).not.toHaveAttribute("aria-describedby");
+		const regionSelect = screen.getByLabelText("Région");
+		expect(regionSelect).not.toHaveAttribute("aria-invalid");
+		expect(regionSelect).not.toHaveAttribute("aria-describedby");
+	});
+
+	it("associates the name error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					name: { type: "required", message: "Le nom est obligatoire" },
+				}}
+			/>,
+		);
+		const nameInput = screen.getByRole("textbox", { name: /Format/ });
+		expect(nameInput).toHaveAttribute("aria-invalid", "true");
+		expect(nameInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-name-error",
+		);
+		expect(screen.getByText("Le nom est obligatoire")).toHaveAttribute(
+			"id",
+			"referent-modal-name-error",
+		);
+	});
+
+	it("associates the region error with its select (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					region: {
+						type: "invalid_type",
+						message: "La région est obligatoire",
+					},
+				}}
+			/>,
+		);
+		const regionSelect = screen.getByLabelText("Région");
+		expect(regionSelect).toHaveAttribute("aria-invalid", "true");
+		expect(regionSelect).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-region-error",
+		);
+		expect(screen.getByText("La région est obligatoire")).toHaveAttribute(
+			"id",
+			"referent-modal-region-error",
+		);
+	});
+
+	it("associates the value error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					value: { type: "invalid_string", message: "L'email est invalide" },
+				}}
+			/>,
+		);
+		const valueInput = screen.getByRole("textbox", { name: /Valeur/ });
+		expect(valueInput).toHaveAttribute("aria-invalid", "true");
+		expect(valueInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-value-error",
+		);
+		expect(screen.getByText("L'email est invalide")).toHaveAttribute(
+			"id",
+			"referent-modal-value-error",
+		);
+	});
+
+	it("associates the substitute email error with its input (RGAA 11.10)", () => {
+		render(
+			<Harness
+				errors={{
+					substituteEmail: {
+						type: "invalid_string",
+						message: "L'email du suppléant est invalide",
+					},
+				}}
+			/>,
+		);
+		const substituteEmailInput = screen.getByRole("textbox", {
+			name: "Email du suppléant",
+		});
+		expect(substituteEmailInput).toHaveAttribute("aria-invalid", "true");
+		expect(substituteEmailInput).toHaveAttribute(
+			"aria-describedby",
+			"referent-modal-sub-email-error",
+		);
+		expect(
+			screen.getByText("L'email du suppléant est invalide"),
+		).toHaveAttribute("id", "referent-modal-sub-email-error");
+	});
+});

--- a/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
+++ b/packages/app/src/modules/admin/referents/__tests__/ReferentFormFields.test.tsx
@@ -31,7 +31,9 @@ function Harness({ errors }: { errors: FieldErrors<ReferentFormValues> }) {
 describe("ReferentFormFields", () => {
 	it("renders fields without error attributes when there is no error", () => {
 		render(<Harness errors={{}} />);
-		const nameInput = screen.getByRole("textbox", { name: /Format/ });
+		// Anchored on the field's own label ("Nom"), decoupled from the hint
+		// wording; the negative lookahead avoids matching "Nom du suppléant".
+		const nameInput = screen.getByRole("textbox", { name: /^Nom(?! du)/ });
 		expect(nameInput).not.toHaveAttribute("aria-invalid");
 		expect(nameInput).not.toHaveAttribute("aria-describedby");
 		const regionSelect = screen.getByLabelText("Région");
@@ -47,7 +49,9 @@ describe("ReferentFormFields", () => {
 				}}
 			/>,
 		);
-		const nameInput = screen.getByRole("textbox", { name: /Format/ });
+		// Anchored on the field's own label ("Nom"), decoupled from the hint
+		// wording; the negative lookahead avoids matching "Nom du suppléant".
+		const nameInput = screen.getByRole("textbox", { name: /^Nom(?! du)/ });
 		expect(nameInput).toHaveAttribute("aria-invalid", "true");
 		expect(nameInput).toHaveAttribute(
 			"aria-describedby",
@@ -90,7 +94,7 @@ describe("ReferentFormFields", () => {
 				}}
 			/>,
 		);
-		const valueInput = screen.getByRole("textbox", { name: /Valeur/ });
+		const valueInput = screen.getByRole("textbox", { name: /^Valeur/ });
 		expect(valueInput).toHaveAttribute("aria-invalid", "true");
 		expect(valueInput).toHaveAttribute(
 			"aria-describedby",

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -57,6 +57,7 @@ export { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 export { Step6Review } from "./steps/Step6Review";
 export {
 	COMPLIANCE_FUNNEL,
+	SECOND_DECLARATION_STEP_TITLES,
 	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -10,6 +10,9 @@
 	gap: 0.5rem;
 
 	input {
-		min-width: 5rem;
+		// Keep the entered amount readable at 200% zoom / narrow viewports
+		// (RGAA 10.4): the cell must never crush the input below the width of
+		// a typical amount — the DSFR table wrapper scrolls instead.
+		min-width: 7.5rem;
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
@@ -1,6 +1,18 @@
+// Minimum width of a workforce-count input, sized for a 6-digit value. Shared
+// between the input rule (which keeps the value readable) and the column rule
+// so both stay in sync (RGAA 10.4).
+$workforce-input-min-width: 6rem;
+
 .workforceTable {
 	table {
 		width: 100%;
+	}
+
+	// Keep the entered workforce count readable at 200% zoom / narrow
+	// viewports (RGAA 10.4): the cell must never crush the input below the
+	// width of a 6-digit count — the DSFR table wrapper scrolls instead.
+	input {
+		min-width: $workforce-input-min-width;
 	}
 
 	@include respond-from(md) {
@@ -17,7 +29,7 @@
 }
 
 .inputCol {
-	min-width: 6rem;
+	min-width: $workforce-input-min-width;
 
 	@include respond-from(md) {
 		width: 30%;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -314,7 +314,9 @@ export function Step3VariablePay({
 															}
 															aria-invalid={
 																benefValidationError?.field ===
-																	"indicatorEWomen" || undefined
+																"indicatorEWomen"
+																	? true
+																	: undefined
 															}
 															aria-label="Bénéficiaires femmes"
 															className={`fr-input ${common.numericInput}`}
@@ -354,8 +356,9 @@ export function Step3VariablePay({
 																	: undefined
 															}
 															aria-invalid={
-																benefValidationError?.field ===
-																	"indicatorEMen" || undefined
+																benefValidationError?.field === "indicatorEMen"
+																	? true
+																	: undefined
 															}
 															aria-label="Bénéficiaires hommes"
 															className={`fr-input ${common.numericInput}`}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -112,9 +112,10 @@ export function Step3VariablePay({
 	const beneficiaryWomen = formData.indicatorEWomen ?? "";
 	const beneficiaryMen = formData.indicatorEMen ?? "";
 
-	const [benefValidationError, setBenefValidationError] = useState<
-		string | null
-	>(null);
+	const [benefValidationError, setBenefValidationError] = useState<{
+		field: "indicatorEMen" | "indicatorEWomen";
+		message: string;
+	} | null>(null);
 	const hasData = hasSavedData || hasDraft;
 	const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -149,9 +150,10 @@ export function Step3VariablePay({
 		const n = Number.parseInt(value, 10);
 		if (Number.isNaN(n) || n < 0) return;
 		if (max !== undefined && n > max) {
-			setBenefValidationError(
-				`Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
-			);
+			setBenefValidationError({
+				field,
+				message: `Le nombre de bénéficiaires ne peut pas dépasser l'effectif de l'étape 1 (${max}).`,
+			});
 			return;
 		}
 		setBenefValidationError(null);
@@ -304,6 +306,16 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field ===
+																"indicatorEWomen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field ===
+																	"indicatorEWomen" || undefined
+															}
 															aria-label="Bénéficiaires femmes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -336,6 +348,15 @@ export function Step3VariablePay({
 													</td>
 													<td>
 														<input
+															aria-describedby={
+																benefValidationError?.field === "indicatorEMen"
+																	? "step3-beneficiaries-error"
+																	: undefined
+															}
+															aria-invalid={
+																benefValidationError?.field ===
+																	"indicatorEMen" || undefined
+															}
 															aria-label="Bénéficiaires hommes"
 															className={`fr-input ${common.numericInput}`}
 															disabled={isImpersonating}
@@ -371,7 +392,9 @@ export function Step3VariablePay({
 								className="fr-alert fr-alert--error fr-alert--sm"
 								role="alert"
 							>
-								<p>{benefValidationError}</p>
+								<p id="step3-beneficiaries-error">
+									{benefValidationError.message}
+								</p>
 							</div>
 						)}
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -237,6 +237,93 @@ describe("Step3VariablePay", () => {
 		expect(screen.getByText(/ne peut pas dépasser/i)).toBeInTheDocument();
 	});
 
+	it("associates the beneficiaries error with the women input (RGAA 11.10)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+		const menInput = screen.getByLabelText("Bénéficiaires hommes");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
+
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
+		expect(womenInput).toHaveAttribute(
+			"aria-describedby",
+			"step3-beneficiaries-error",
+		);
+		expect(menInput).not.toHaveAttribute("aria-invalid");
+		expect(menInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.getByText(/ne peut pas dépasser/i)).toHaveAttribute(
+			"id",
+			"step3-beneficiaries-error",
+		);
+	});
+
+	it("associates the beneficiaries error with the men input (RGAA 11.10)", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+		const menInput = screen.getByLabelText("Bénéficiaires hommes");
+
+		await user.clear(menInput);
+		await user.type(menInput, "30");
+
+		expect(menInput).toHaveAttribute("aria-invalid", "true");
+		expect(menInput).toHaveAttribute(
+			"aria-describedby",
+			"step3-beneficiaries-error",
+		);
+		expect(womenInput).not.toHaveAttribute("aria-invalid");
+		expect(womenInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.getByText(/ne peut pas dépasser/i)).toHaveAttribute(
+			"id",
+			"step3-beneficiaries-error",
+		);
+	});
+
+	it("clears the error association once the value is valid again", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step3VariablePay
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep3Data()}
+				maxMen={25}
+				maxWomen={15}
+			/>,
+		);
+
+		const womenInput = screen.getByLabelText("Bénéficiaires femmes");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "20");
+		expect(womenInput).toHaveAttribute("aria-invalid", "true");
+
+		await user.clear(womenInput);
+		await user.type(womenInput, "10");
+		expect(womenInput).not.toHaveAttribute("aria-invalid");
+		expect(womenInput).not.toHaveAttribute("aria-describedby");
+		expect(screen.queryByText(/ne peut pas dépasser/i)).not.toBeInTheDocument();
+	});
+
 	it("renders previous link pointing to step 2", () => {
 		render(
 			<Step3VariablePay

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
@@ -1,4 +1,6 @@
 .chartWrapper {
 	width: 100%;
+	max-width: 100%;
+	min-width: 0;
 	height: 320px;
 }


### PR DESCRIPTION
## Quoi

Association programmatique des messages d'erreur à leurs champs (RGAA 11.10) :

- **`ReferentFormFields.tsx`** (admin / référents) : chaque `fr-error-text` reçoit un `id` stable (`${modalId}-*-error`) ; le champ correspondant porte `aria-invalid` + `aria-describedby` quand l'erreur est présente (nom, région, valeur, email du suppléant).
- **`Step3VariablePay.tsx`** (déclaration rémunération) : l'erreur « bénéficiaires > effectif » est typée par champ (`indicatorEWomen` / `indicatorEMen`) ; l'input fautif porte `aria-invalid` + `aria-describedby="step3-beneficiaries-error"`, le message porte l'`id` cible.

## Tests

- Nouveau `ReferentFormFields.test.tsx` : association erreur ↔ champ pour les 4 champs, et absence des attributs sans erreur.
- `Step3VariablePay.test.tsx` : association côté femmes / hommes, non-contamination de l'autre input, et nettoyage des attributs quand la valeur redevient valide.

Le volet microcopy d'aide à la saisie (suivi par #3814) a été fermé *NOT_PLANNED* côté PO ; toutes les parties implémentables du contrôle de saisie (association des erreurs, champ obligatoire) sont couvertes ici → `Closes`.

Closes #3804
