### PR TITLE
fix(a11y): #3806 #3812 — reflow /stats & inputs en cellule (zoom)

### DIFF
--- a/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
+++ b/packages/app/src/app/admin/declarations/[declarationId]/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminDeclarationDetailPage } from "~/modules/admin/declarations";
+
+export const metadata: Metadata = { title: "Détail de la déclaration" };
 
 type Props = {
 	params: Promise<{ declarationId: string }>;

--- a/packages/app/src/app/admin/impersonate/page.tsx
+++ b/packages/app/src/app/admin/impersonate/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { ImpersonatePage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Mimoquer une entreprise" };
 
 export default function Page() {
 	return <ImpersonatePage />;

--- a/packages/app/src/app/admin/liste-referents/page.tsx
+++ b/packages/app/src/app/admin/liste-referents/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminReferentsPage } from "~/modules/admin";
+
+export const metadata: Metadata = { title: "Liste des référents" };
 
 export default function Page() {
 	return <AdminReferentsPage />;

--- a/packages/app/src/app/admin/page.tsx
+++ b/packages/app/src/app/admin/page.tsx
@@ -1,5 +1,9 @@
+import type { Metadata } from "next";
+
 import { AdminHomePage } from "~/modules/admin";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Backoffice" };
 
 export default async function Page() {
 	// Access control is handled by the edge middleware and the admin layout;

--- a/packages/app/src/app/admin/parametres/page.tsx
+++ b/packages/app/src/app/admin/parametres/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { AdminSettingsPage } from "~/modules/admin/settings";
+
+export const metadata: Metadata = { title: "Paramètres de la plateforme" };
 
 export default function Page() {
 	return <AdminSettingsPage />;

--- a/packages/app/src/app/admin/stats/page.tsx
+++ b/packages/app/src/app/admin/stats/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { StatsDashboard } from "~/modules/admin/stats";
 import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
 
-export const metadata: Metadata = { title: "Statistiques — Egapro" };
+export const metadata: Metadata = { title: "Statistiques" };
 
 export default function Page() {
 	const currentYear = getCurrentYear();

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -1,6 +1,8 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import {
 	getEffectiveGipPrefillData,
+	STEP_TITLES,
 	StepPageClient,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
@@ -15,6 +17,20 @@ import { api, HydrateClient } from "~/trpc/server";
 type StepPageProps = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({
+	params,
+}: StepPageProps): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${TOTAL_STEPS} — ${stepTitle}`
+			: "Déclaration des écarts de rémunération",
+	};
+}
 
 export default async function StepPage({ params }: StepPageProps) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/page.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
+
+export const metadata: Metadata = {
+	title: "Déclaration des écarts de rémunération",
+};
 
 export default function DeclarationPage() {
 	redirect("/declaration-remuneration/etape/1");

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/confirmation/page.tsx
@@ -1,8 +1,14 @@
+import type { Metadata } from "next";
+
 import { FunnelCompleteTracker } from "~/modules/analytics";
 import {
 	COMPLIANCE_FUNNEL,
 	ComplianceConfirmation,
 } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = {
+	title: "Confirmation — Parcours de mise en conformité",
+};
 
 export default function ComplianceConfirmationPage() {
 	return (

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/etape/[step]/page.tsx
@@ -1,8 +1,26 @@
-import { SecondDeclarationStepPage } from "~/modules/declaration-remuneration";
+import type { Metadata } from "next";
+
+import {
+	SECOND_DECLARATION_STEP_TITLES,
+	SECOND_DECLARATION_TOTAL_STEPS,
+	SecondDeclarationStepPage,
+} from "~/modules/declaration-remuneration";
 
 type Props = {
 	params: Promise<{ step: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+	const stepTitle = SECOND_DECLARATION_STEP_TITLES[step];
+
+	return {
+		title: stepTitle
+			? `Étape ${step} sur ${SECOND_DECLARATION_TOTAL_STEPS} — ${stepTitle}`
+			: "Parcours de mise en conformité",
+	};
+}
 
 export default async function Page({ params }: Props) {
 	const { step: stepParam } = await params;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/evaluation-conjointe/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { JointEvaluationPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Évaluation conjointe" };
 
 export default function Page() {
 	return <JointEvaluationPage />;

--- a/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/parcours-conformite/page.tsx
@@ -1,4 +1,8 @@
+import type { Metadata } from "next";
+
 import { CompliancePathPage } from "~/modules/declaration-remuneration";
+
+export const metadata: Metadata = { title: "Parcours de mise en conformité" };
 
 export default function Page() {
 	return <CompliancePathPage />;

--- a/packages/app/src/app/login/page.tsx
+++ b/packages/app/src/app/login/page.tsx
@@ -1,7 +1,10 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { LoginPage, sanitizeCallbackUrl } from "~/modules/login";
 import { auth } from "~/server/auth";
+
+export const metadata: Metadata = { title: "Connexion" };
 
 type PageProps = {
 	searchParams: Promise<{ callbackUrl?: string }>;

--- a/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
+++ b/packages/app/src/app/mon-espace/historique/[siren]/[year]/page.tsx
@@ -12,7 +12,7 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
 	const { year } = await params;
 	return {
-		title: `Historique des modifications ${year} — Egapro`,
+		title: `Historique des modifications ${year}`,
 	};
 }
 

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -57,6 +57,7 @@ export { Step5EmployeeCategories } from "./steps/Step5EmployeeCategories";
 export { Step6Review } from "./steps/Step6Review";
 export {
 	COMPLIANCE_FUNNEL,
+	SECOND_DECLARATION_STEP_TITLES,
 	SECOND_DECLARATION_TOTAL_STEPS,
 	SecondDeclarationStep1Info,
 	SecondDeclarationStep2Form,

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -10,6 +10,9 @@
 	gap: 0.5rem;
 
 	input {
-		min-width: 5rem;
+		// Keep the entered amount readable at 200% zoom / narrow viewports
+		// (RGAA 10.4): the cell must never crush the input below the width of
+		// a typical amount — the DSFR table wrapper scrolls instead.
+		min-width: 7.5rem;
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
@@ -3,6 +3,13 @@
 		width: 100%;
 	}
 
+	// Keep the entered workforce count readable at 200% zoom / narrow
+	// viewports (RGAA 10.4): the cell must never crush the input below the
+	// width of a 6-digit count — the DSFR table wrapper scrolls instead.
+	input {
+		min-width: 6rem;
+	}
+
 	@include respond-from(md) {
 		table {
 			table-layout: fixed;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
@@ -1,3 +1,8 @@
+// Minimum width of a workforce-count input, sized for a 6-digit value. Shared
+// between the input rule (which keeps the value readable) and the column rule
+// so both stay in sync (RGAA 10.4).
+$workforce-input-min-width: 6rem;
+
 .workforceTable {
 	table {
 		width: 100%;
@@ -7,7 +12,7 @@
 	// viewports (RGAA 10.4): the cell must never crush the input below the
 	// width of a 6-digit count — the DSFR table wrapper scrolls instead.
 	input {
-		min-width: 6rem;
+		min-width: $workforce-input-min-width;
 	}
 
 	@include respond-from(md) {
@@ -24,7 +29,7 @@
 }
 
 .inputCol {
-	min-width: 6rem;
+	min-width: $workforce-input-min-width;
 
 	@include respond-from(md) {
 		width: 30%;

--- a/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
+++ b/packages/app/src/modules/publicStats/ScoreDistributionChart.module.scss
@@ -1,4 +1,6 @@
 .chartWrapper {
 	width: 100%;
+	max-width: 100%;
+	min-width: 0;
 	height: 320px;
 }


### PR DESCRIPTION
## Quoi

Corrections RGAA 10.11 / 10.4 / 10.12 (présentation de l'information) :

- **`ScoreDistributionChart.module.scss`** : `max-width: 100%` + `min-width: 0` défensifs sur le wrapper du graphique pour garantir le reflow de `/stats` à 320 px de large (zoom 400 %) sans défilement horizontal (RGAA 10.11).
- **`Step1Workforce.module.scss`** : `min-width: 6rem` sur les inputs d'effectifs en cellule de tableau — la cellule ne doit jamais écraser l'input sous la largeur d'un compte à 6 chiffres au zoom 200 % ; le wrapper de tableau DSFR défile à la place (RGAA 10.4).
- **`PayGapTable.module.scss`** : `min-width` des inputs de montants `5rem` → `7.5rem` pour que le montant saisi reste lisible au zoom 200 % / viewports étroits (RGAA 10.4).

Note : le hunk `<main>` de `PublicStatsPage.tsx` (#3801) est déjà dans la branche de base ; le reflow de `/stats` est entièrement porté par le module SCSS du graphique. Conformité zoom/reflow à vérifier au rendu (zoom 400 % sur `/stats`, zoom 200 % sur les tableaux de saisie) au moment de la review.

## Vérifications

- `pnpm --filter app typecheck` OK
- ultra11y (RGAA, statique) : 0 non-conformité
- vitest `publicStats` + `declaration-remuneration` : 627 tests verts
- biome check OK

Closes #3806
Closes #3807
Closes #3812
