### PR TITLE
fix(a11y): #3659 — th pour la première colonne des tableaux étapes 1/4/5

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -270,7 +270,9 @@ export function Step1Workforce({
 												</colgroup>
 												<thead>
 													<tr>
-														<th scope="col">{/* vide */}</th>
+														<th scope="col">
+															<span className="fr-sr-only">Donnée</span>
+														</th>
 														<th scope="col">Femmes</th>
 														<th scope="col">Hommes</th>
 														<th scope="col">Total</th>
@@ -278,9 +280,7 @@ export function Step1Workforce({
 												</thead>
 												<tbody>
 													<tr>
-														<td>
-															<strong>Nombre de salariés</strong>
-														</td>
+														<th scope="row">Nombre de salariés</th>
 														<td>
 															<div
 																className={

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -71,6 +71,25 @@ describe("Step1Workforce", () => {
 		expect(screen.getByLabelText("Nombre d'hommes")).toHaveValue("");
 	});
 
+	it("gives every column header a non-empty accessible name and exposes the row label as a rowheader (RGAA 5.7)", () => {
+		render(
+			<Step1Workforce
+				declarationSiren="123456789"
+				declarationYear={2026}
+				initialData={emptyStep1Data()}
+			/>,
+		);
+		for (const header of screen.getAllByRole("columnheader")) {
+			expect(header).toHaveAccessibleName();
+		}
+		expect(
+			screen.getByRole("columnheader", { name: "Donnée" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("rowheader", { name: "Nombre de salariés" }),
+		).toBeInTheDocument();
+	});
+
 	it("renders reference period and mandatory fields notice", () => {
 		render(
 			<Step1Workforce
@@ -101,7 +120,7 @@ describe("Step1Workforce", () => {
 			.getByText("Nombre de salariés")
 			.closest("tr") as HTMLElement;
 		const cells = within(row).getAllByRole("cell");
-		expect(cells[3]).toHaveTextContent("30");
+		expect(cells[2]).toHaveTextContent("30");
 	});
 
 	it("shows SavedIndicator when initial data has values", () => {
@@ -152,7 +171,7 @@ describe("Step1Workforce", () => {
 			.getByText("Nombre de salariés")
 			.closest("tr") as HTMLElement;
 		const cells = within(row).getAllByRole("cell");
-		expect(cells[3]).toHaveTextContent("40");
+		expect(cells[2]).toHaveTextContent("40");
 	});
 
 	it("validates total > 0 on submit", async () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -63,6 +63,22 @@ describe("Step4QuartileDistribution", () => {
 		expect(screen.getAllByText(/Tous les salariés/).length).toBe(2);
 	});
 
+	it("gives every column header a non-empty accessible name, including the previously empty quartile header (RGAA 5.7)", () => {
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialData={emptyStep4Data()}
+			/>,
+		);
+		for (const header of screen.getAllByRole("columnheader")) {
+			expect(header).toHaveAccessibleName();
+		}
+		expect(
+			screen.getAllByRole("columnheader", { name: "Quartile" }),
+		).toHaveLength(2);
+	});
+
 	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
 		render(
 			<Step4QuartileDistribution

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -129,6 +129,28 @@ describe("Step5EmployeeCategories", () => {
 		expect(descriptionParagraph.nextElementSibling).toBe(obligatoiresParagraph);
 	});
 
+	it("gives every column header a non-empty accessible name and exposes row labels as rowheaders (RGAA 5.7)", () => {
+		render(
+			<Step5EmployeeCategories
+				declarationSiren="123456789"
+				declarationYear={2025}
+			/>,
+		);
+		for (const header of screen.getAllByRole("columnheader")) {
+			expect(header).toHaveAccessibleName();
+		}
+		expect(
+			screen.getByRole("columnheader", { name: "Donnée" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("rowheader", { name: "Effectif physique" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getAllByRole("rowheader", { name: "Salaire de base" }),
+		).toHaveLength(2);
+		expect(screen.getAllByRole("rowheader", { name: "Total" })).toHaveLength(2);
+	});
+
 	it("renders table headers for the category", () => {
 		render(
 			<Step5EmployeeCategories

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -78,7 +78,9 @@ export function QuartileTable({
 									</colgroup>
 									<thead>
 										<tr>
-											<th scope="col">{/* row label */}</th>
+											<th scope="col">
+												<span className="fr-sr-only">Quartile</span>
+											</th>
 											<th colSpan={2} scope="col">
 												Tranche de rémunération
 												<br />

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -129,7 +129,7 @@ function RemunerationSection({
 				</td>
 			</tr>
 			<tr className={stepStyles.dataRow}>
-				<td>Salaire de base</td>
+				<th scope="row">Salaire de base</th>
 				<EuroInputCell
 					ariaLabel={`Salaire de base ${scope} femmes, catégorie ${catIndex + 1}`}
 					disabled={disabled}
@@ -153,11 +153,11 @@ function RemunerationSection({
 				</td>
 			</tr>
 			<tr className={stepStyles.dataRow}>
-				<td>
+				<th scope="row">
 					Composantes variables
 					<br />
 					ou complémentaires
-				</td>
+				</th>
 				<EuroInputCell
 					ariaLabel={`Composantes variables ${scope === "annuel" ? "annuelles" : "horaires"} femmes, catégorie ${catIndex + 1}`}
 					disabled={disabled}
@@ -183,9 +183,7 @@ function RemunerationSection({
 				</td>
 			</tr>
 			<tr className={stepStyles.dataRow}>
-				<td>
-					<strong>Total</strong>
-				</td>
+				<th scope="row">Total</th>
 				<td className={stepStyles.totalCell}>{formatTotal(totalWomen, "€")}</td>
 				<td className={stepStyles.totalCell}>{formatTotal(totalMen, "€")}</td>
 				<td>
@@ -225,7 +223,7 @@ export function CategoryDataTable({
 							<thead>
 								<tr>
 									<th className={stepStyles.nameColumnHeader} scope="col">
-										{/* row label */}
+										<span className="fr-sr-only">Donnée</span>
 									</th>
 									<th scope="col">Femmes</th>
 									<th scope="col">Hommes</th>
@@ -248,7 +246,7 @@ export function CategoryDataTable({
 									</td>
 								</tr>
 								<tr className={stepStyles.dataRow}>
-									<td>Effectif physique</td>
+									<th scope="row">Effectif physique</th>
 									<td>
 										<div className={stepStyles.inputCell}>
 											<input


### PR DESCRIPTION
Closes #3659

## Résumé

Corrige le défaut RGAA `empty-table-header` (5.7 / WCAG 1.3.1) détecté par le re-audit dynamique axe-core de l'epic #3800 (#3818) sur les tableaux de saisie des étapes 1, 4 et 5 du parcours de déclaration :

- L'en-tête de première colonne (`<th scope="col">`) était laissé vide (choix visuel) sans alternative accessible → un lecteur d'écran annonce des cellules sans en-tête de colonne.
- Le label de ligne (première colonne du corps du tableau) était un `<td>` au lieu d'un `<th scope="row">`.

**Fix** :
- `Step1Workforce.tsx` : en-tête vide → `<span className="fr-sr-only">Donnée</span>` ; label de ligne "Nombre de salariés" `<td>` → `<th scope="row">`
- `step4/QuartileTable.tsx` : en-tête vide → `<span className="fr-sr-only">Quartile</span>` (les `<th scope="row">` du tbody étaient déjà corrects)
- `step5/CategoryDataTable.tsx` : en-tête vide → `fr-sr-only` ; les 4 labels de ligne ("Effectif physique", "Salaire de base", "Composantes variables", "Total") `<td>` → `<th scope="row">`

Périmètre strict validé par l'utilisateur (voir `## Analyse du bug` sur #3659) — la page récapitulatif présente le même défaut mais est hors périmètre (ticket dédié à venir).

PR stackée sur `fix/3879-reference-period-fieldset` (#3889) qui modifie les 3 mêmes fichiers — décision utilisateur pour éviter un conflit de merge.

## Test plan

- [x] Tests unitaires (`tu-dev`) : `Step1Workforce.test.tsx`, `Step4QuartileDistribution.test.tsx`, `Step5EmployeeCategories.test.tsx` — assertions `columnheader`/`rowheader` avec nom accessible non vide, reproduction prouvée par revert-verify
- [x] `pnpm typecheck` / `pnpm lint:check` / `pnpm format:check` verts
- [x] Suite vitest complète verte (3354/3354)
- [x] Audit RGAA (ultra11y) sur les 3 composants modifiés — structure de tableau conforme