### PR TITLE
feat(declaration-remuneration): #3861 — refonte design déclaration rémunération (pages 1-5)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
@@ -148,7 +148,7 @@ describe("CategoryRecapTable", () => {
 		expect(screen.getAllByRole("row").length).toBeGreaterThan(0);
 	});
 
-	it("renders '-' for the total gap when the men total is zero", () => {
+	it("renders '- %' for the total gap when the men total is zero", () => {
 		render(
 			<CategoryRecapTable
 				category={makeCategory({
@@ -160,8 +160,7 @@ describe("CategoryRecapTable", () => {
 			/>,
 		);
 		const [annualTotalGapCell, hourlyTotalGapCell] = totalRowGapCell();
-		expect(annualTotalGapCell).toHaveTextContent("-");
-		expect(annualTotalGapCell).not.toHaveTextContent("%");
-		expect(hourlyTotalGapCell).toHaveTextContent("-");
+		expect(annualTotalGapCell).toHaveTextContent("- %");
+		expect(hourlyTotalGapCell).toHaveTextContent("- %");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.module.scss
@@ -2,4 +2,8 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	// Consistent spacing above the action row on every screen — with or without
+	// the interpretation callout above it (Figma). The fieldset is a block, so
+	// this margin collapses with any preceding element's margin instead of adding.
+	margin-top: 2rem;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/FormActions.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/FormActions.module.scss
@@ -2,8 +2,6 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	// Consistent spacing above the action row on every screen — with or without
-	// the interpretation callout above it (Figma). The fieldset is a block, so
-	// this margin collapses with any preceding element's margin instead of adding.
+	// relies on block margin-collapse (fieldset): stays 2rem with or without a callout above
 	margin-top: 2rem;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/InterpretationCallout.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/InterpretationCallout.module.scss
@@ -1,8 +1,5 @@
 .callout {
-	// 32px above the interpretation callout, matching the Figma vertical rhythm
-	// (data container → callout → boutons, tous à 2rem). Scoped to .fr-callout so
-	// it outranks DSFR's own `.fr-callout { margin-top: 0 }` (equal specificity,
-	// which otherwise wins on source order).
+	// scoped to .fr-callout to outrank DSFR's `.fr-callout { margin-top: 0 }` (same specificity, else wins on source order)
 	&:global(.fr-callout) {
 		margin-top: 2rem;
 	}

--- a/packages/app/src/modules/declaration-remuneration/shared/InterpretationCallout.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/InterpretationCallout.module.scss
@@ -1,4 +1,12 @@
 .callout {
+	// 32px above the interpretation callout, matching the Figma vertical rhythm
+	// (data container → callout → boutons, tous à 2rem). Scoped to .fr-callout so
+	// it outranks DSFR's own `.fr-callout { margin-top: 0 }` (equal specificity,
+	// which otherwise wins on source order).
+	&:global(.fr-callout) {
+		margin-top: 2rem;
+	}
+
 	:global(.fr-callout__text) {
 		font-size: 1rem;
 	}

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -1,6 +1,8 @@
 .gapDisplay {
+	// Figma: the gap value is pinned to the right of the cell, badge to its left.
 	display: flex;
 	align-items: baseline;
+	justify-content: flex-end;
 	gap: 0.5rem;
 }
 

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -29,6 +29,13 @@
 	table-layout: fixed;
 }
 
+.fixedTable table thead th:nth-child(2),
+.fixedTable table thead th:nth-child(3) {
+	// Let "Rémunération des femmes/hommes" wrap instead of overflowing the cell,
+	// without touching the écart header's own two-line layout.
+	white-space: normal;
+}
+
 .colLabel {
 	width: 230px;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -1,9 +1,14 @@
 .gapDisplay {
-	// Figma: the gap value is pinned to the right of the cell, badge to its left.
+	// Figma: the écart column reads as two sub-cells [label | value] with no
+	// visible divider. Single cell here: the value is pinned to the right, the
+	// badge (when present) sits at the far left.
 	display: flex;
 	align-items: baseline;
-	justify-content: flex-end;
 	gap: 0.5rem;
+}
+
+.gapValue {
+	margin-left: auto;
 }
 
 .inputWithUnit {

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -18,3 +18,22 @@
 		min-width: 7.5rem;
 	}
 }
+
+.fixedTable table {
+	// Figma column widths (label 230 / values 185 / écart 190) so the table
+	// fits the ~790px data container instead of overflowing; narrow viewports
+	// scroll via the DSFR table wrapper (RGAA reflow).
+	table-layout: fixed;
+}
+
+.colLabel {
+	width: 230px;
+}
+
+.colValue {
+	width: 185px;
+}
+
+.colGap {
+	width: 190px;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.module.scss
@@ -1,7 +1,5 @@
 .gapDisplay {
-	// Figma: the écart column reads as two sub-cells [label | value] with no
-	// visible divider. Single cell here: the value is pinned to the right, the
-	// badge (when present) sits at the far left.
+	// Écart: value pinned right, badge (when present) at the far left, no divider (single cell).
 	display: flex;
 	align-items: baseline;
 	gap: 0.5rem;

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
@@ -62,8 +62,8 @@ export function PayGapTable({
 							<thead>
 								<tr>
 									<th scope="col">{columnHeader}</th>
-									<th scope="col">Femmes</th>
-									<th scope="col">Hommes</th>
+									<th scope="col">Rémunération des femmes</th>
+									<th scope="col">Rémunération des hommes</th>
 									<th scope="col">
 										<strong>Écart</strong>
 										<br />

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
@@ -54,13 +54,19 @@ export function PayGapTable({
 }: PayGapTableProps) {
 	return (
 		<div
-			className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${className ?? ""}`}
+			className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.fixedTable} ${className ?? ""}`}
 		>
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">
 					<div className="fr-table__content">
 						<table>
 							<caption>{caption}</caption>
+							<colgroup>
+								<col className={styles.colLabel} />
+								<col className={styles.colValue} />
+								<col className={styles.colValue} />
+								<col className={styles.colGap} />
+							</colgroup>
 							<thead>
 								<tr>
 									<th scope="col">{columnHeader}</th>

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
@@ -130,14 +130,14 @@ export function PayGapTable({
 											</td>
 											<td>
 												<span className={styles.gapDisplay}>
-													<span className="fr-text--bold">
-														{formatGap(gap)}
-													</span>
 													{level === "high" && (
 														<span className={gapBadgeClass(level)}>
 															{GAP_LEVEL_LABELS[level]}
 														</span>
 													)}
+													<span className="fr-text--bold">
+														{formatGap(gap)}
+													</span>
 												</span>
 											</td>
 										</tr>

--- a/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PayGapTable.tsx
@@ -54,7 +54,7 @@ export function PayGapTable({
 }: PayGapTableProps) {
 	return (
 		<div
-			className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.fixedTable} ${className ?? ""}`}
+			className={`fr-table fr-table--bordered fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.fixedTable} ${className ?? ""}`}
 		>
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">
@@ -141,7 +141,7 @@ export function PayGapTable({
 															{GAP_LEVEL_LABELS[level]}
 														</span>
 													)}
-													<span className="fr-text--bold">
+													<span className={`fr-text--bold ${styles.gapValue}`}>
 														{formatGap(gap)}
 													</span>
 												</span>

--- a/packages/app/src/modules/declaration-remuneration/shared/PrefillSource.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/PrefillSource.tsx
@@ -1,33 +1,34 @@
+import { resolveGipReferencePeriod } from "~/modules/domain";
+
 import { TooltipButton } from "./TooltipButton";
 
 /**
  * Source attribution line shown under tables when GIP DSN data is available.
- * Displays the DSN data source and last update date with a tooltip.
+ * Displays the DSN data source and the reference period — the GIP data-collection
+ * window when available, falling back to the campaign civil year.
  */
 type Props = {
-	periodEnd: string | null;
+	periodStart: string | null | undefined;
+	periodEnd: string | null | undefined;
+	year: number;
 	tooltipId?: string;
 };
 
 export function PrefillSource({
+	periodStart,
 	periodEnd,
+	year,
 	tooltipId = "tooltip-source",
 }: Props) {
 	return (
 		<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
-			Source&nbsp;: DSN (Déclarations Sociales Nominatives)
-			{periodEnd && `, mise à jour le ${formatFrenchDate(periodEnd)}`}.
+			Source&nbsp;: DSN (Déclarations Sociales Nominatives), période de
+			référence&nbsp;: {resolveGipReferencePeriod(periodStart, periodEnd, year)}
+			.
 			<TooltipButton
 				id={tooltipId}
 				label="Information sur la source des données"
 			/>
 		</p>
 	);
-}
-
-/** Format "2026-12-31" → "31/12/2026" */
-function formatFrenchDate(isoDate: string): string {
-	const parts = isoDate.split("-");
-	if (parts.length !== 3) return isoDate;
-	return `${parts[2]}/${parts[1]}/${parts[0]}`;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.module.scss
@@ -1,4 +1,6 @@
 .stepper {
-	// Breathing room between the page title and "Étape X sur 6" (Figma).
-	margin-top: 1.5rem;
+	// 32px above and below the stepper, matching the Figma vertical rhythm
+	// (titre → stepper → instructions, tous à 2rem).
+	margin-top: 2rem;
+	margin-bottom: 2rem;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.module.scss
@@ -1,6 +1,4 @@
 .stepper {
-	// 32px above and below the stepper, matching the Figma vertical rhythm
-	// (titre → stepper → instructions, tous à 2rem).
 	margin-top: 2rem;
 	margin-bottom: 2rem;
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.module.scss
@@ -1,0 +1,4 @@
+.stepper {
+	// Breathing room between the page title and "Étape X sur 6" (Figma).
+	margin-top: 1.5rem;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.tsx
@@ -11,7 +11,7 @@ export function StepIndicator({ currentStep }: StepIndicatorProps) {
 		currentStep < TOTAL_STEPS ? STEP_TITLES[currentStep + 1] : undefined;
 
 	return (
-		<div className={`fr-stepper fr-mb-0 ${styles.stepper}`}>
+		<div className={`fr-stepper ${styles.stepper}`}>
 			<h2 className="fr-stepper__title">
 				{title}
 				<span className="fr-stepper__state">

--- a/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.tsx
@@ -1,4 +1,5 @@
 import { STEP_TITLES, TOTAL_STEPS } from "../types";
+import styles from "./StepIndicator.module.scss";
 
 type StepIndicatorProps = {
 	currentStep: number;
@@ -10,7 +11,7 @@ export function StepIndicator({ currentStep }: StepIndicatorProps) {
 		currentStep < TOTAL_STEPS ? STEP_TITLES[currentStep + 1] : undefined;
 
 	return (
-		<div className="fr-stepper fr-mb-0">
+		<div className={`fr-stepper fr-mb-0 ${styles.stepper}`}>
 			<h2 className="fr-stepper__title">
 				{title}
 				<span className="fr-stepper__state">

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/PrefillSource.test.tsx
@@ -4,8 +4,8 @@ import { describe, expect, it } from "vitest";
 import { PrefillSource } from "../PrefillSource";
 
 describe("PrefillSource", () => {
-	it("renders DSN source text", () => {
-		render(<PrefillSource periodEnd={null} />);
+	it("renders the DSN source text", () => {
+		render(<PrefillSource periodEnd={null} periodStart={null} year={2026} />);
 
 		expect(screen.getByText(/DSN/)).toBeInTheDocument();
 		expect(
@@ -13,27 +13,27 @@ describe("PrefillSource", () => {
 		).toBeInTheDocument();
 	});
 
-	it("formats the date correctly (ISO to French format)", () => {
-		render(<PrefillSource periodEnd="2026-12-31" />);
+	it("shows the GIP collection window as the reference period", () => {
+		render(
+			<PrefillSource
+				periodEnd="2026-12-31"
+				periodStart="2026-01-01"
+				year={2026}
+			/>,
+		);
 
-		expect(screen.getByText(/31\/12\/2026/)).toBeInTheDocument();
+		expect(screen.getByText(/période de référence/)).toBeInTheDocument();
+		expect(screen.getByText(/01\/01\/2026 - 31\/12\/2026/)).toBeInTheDocument();
 	});
 
-	it("renders without period end date", () => {
-		render(<PrefillSource periodEnd={null} />);
+	it("falls back to the civil year when a period bound is missing", () => {
+		render(<PrefillSource periodEnd={null} periodStart={null} year={2026} />);
 
-		expect(screen.getByText(/Source/)).toBeInTheDocument();
-		expect(screen.queryByText(/mise à jour le/)).not.toBeInTheDocument();
-	});
-
-	it("shows update date text when periodEnd is provided", () => {
-		render(<PrefillSource periodEnd="2025-03-15" />);
-
-		expect(screen.getByText(/mise à jour le 15\/03\/2025/)).toBeInTheDocument();
+		expect(screen.getByText(/01\/01\/2026 - 31\/12\/2026/)).toBeInTheDocument();
 	});
 
 	it("renders the tooltip button", () => {
-		render(<PrefillSource periodEnd={null} />);
+		render(<PrefillSource periodEnd={null} periodStart={null} year={2026} />);
 
 		expect(
 			screen.getByLabelText("Information sur la source des données"),

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.module.scss
@@ -12,7 +12,8 @@
 
 .labelCol {
 	@include respond-from(md) {
-		width: 20%;
+		// Figma: 172 / 790 of the data container.
+		width: 22%;
 	}
 }
 
@@ -20,7 +21,8 @@
 	min-width: 6rem;
 
 	@include respond-from(md) {
-		width: 30%;
+		// Figma: 206 / 790 — the three data columns share equal width.
+		width: 26%;
 	}
 }
 
@@ -28,6 +30,7 @@
 	min-width: 4rem;
 
 	@include respond-from(md) {
-		width: 20%;
+		// Figma: 206 / 790 — same width as the input columns.
+		width: 26%;
 	}
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -380,7 +380,6 @@ export function Step1Workforce({
 					/>
 
 					<FormActions
-						className="fr-mt-0"
 						isSubmitting={mutation.isPending}
 						mimoquageNextHref={
 							hasInitialData ? "/declaration-remuneration/etape/2" : undefined

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -5,7 +5,10 @@ import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
 
 import { useIsImpersonating } from "~/modules/auth";
-import { computeWorkforceTotal } from "~/modules/domain";
+import {
+	computeWorkforceTotal,
+	resolveGipReferencePeriod,
+} from "~/modules/domain";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import { updateStep1Schema } from "../schemas";
@@ -222,7 +225,7 @@ export function Step1Workforce({
 
 					<div className={common.flexColumnGap1}>
 						<p className="fr-mb-0">
-							{`Période de référence pour le calcul des indicateurs : 01/01/${declarationYear} - 31/12/${declarationYear}.`}
+							{`Période de référence pour le calcul des indicateurs : ${resolveGipReferencePeriod(gipPrefillData?.periodStart, gipPrefillData?.periodEnd, declarationYear)}.`}
 							<TooltipButton
 								id="tooltip-period"
 								label="Information sur la période de référence"
@@ -346,7 +349,11 @@ export function Step1Workforce({
 							</div>
 
 							{isPrefilled && (
-								<PrefillSource periodEnd={gipPrefillData.periodEnd} />
+								<PrefillSource
+									periodEnd={gipPrefillData.periodEnd}
+									periodStart={gipPrefillData.periodStart}
+									year={declarationYear}
+								/>
 							)}
 
 							{showResetWarning && <PrefillResetWarning />}
@@ -371,7 +378,6 @@ export function Step1Workforce({
 						mimoquageNextHref={
 							hasInitialData ? "/declaration-remuneration/etape/2" : undefined
 						}
-						previousHref="/"
 					/>
 				</fieldset>
 			</form>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -255,7 +255,7 @@ export function Step1Workforce({
 					<div className={`${common.dataSection} ${common.tableGap}`}>
 						<div className={common.flexColumnGapHalf}>
 							<div
-								className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.workforceTable}`}
+								className={`fr-table fr-table--bordered fr-table--no-caption fr-mt-0 fr-mb-0 ${styles.workforceTable}`}
 							>
 								<div className="fr-table__wrapper">
 									<div className="fr-table__container">

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -344,7 +344,7 @@ export function Step1Workforce({
 																)}
 															</div>
 														</td>
-														<td>
+														<td className="fr-cell--right">
 															<strong>{total}</strong>
 														</td>
 													</tr>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -192,7 +192,9 @@ export function Step2PayGap({
 					<div className={common.flexColumnGapHalf}>
 						<PayGapTable
 							caption="Écart de rémunération"
-							columnHeader="Rémunération"
+							columnHeader={
+								<span className="fr-sr-only">Type de rémunération</span>
+							}
 							disabled={isImpersonating}
 							onRowChange={handleRowChange}
 							readOnly={isReadOnly}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -196,7 +196,9 @@ export function Step2PayGap({
 						{gipPrefillData && (
 							<PrefillSource
 								periodEnd={gipPrefillData.periodEnd}
+								periodStart={gipPrefillData.periodStart}
 								tooltipId="tooltip-source-step2"
+								year={declarationYear}
 							/>
 						)}
 					</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -227,7 +227,10 @@ export function Step3VariablePay({
 				</div>
 
 				<div className={`${common.dataSection} ${common.tableGap}`}>
-					<div className={common.flexColumnGapHalf}>
+					<div className={common.flexColumnGap1}>
+						<h2 className="fr-h6 fr-mb-0">
+							Écart de rémunération variable ou complémentaire
+						</h2>
 						<PayGapTable
 							caption="Écart de rémunération variable ou complémentaire"
 							className={stepStyles.payGapTable}
@@ -246,12 +249,17 @@ export function Step3VariablePay({
 						{gipPrefillData && (
 							<PrefillSource
 								periodEnd={gipPrefillData.periodEnd}
+								periodStart={gipPrefillData.periodStart}
 								tooltipId="tooltip-source-step3-paygap"
+								year={declarationYear}
 							/>
 						)}
 					</div>
 
-					<div className={common.flexColumnGapHalf}>
+					<div className={common.flexColumnGap1}>
+						<h2 className="fr-h6 fr-mb-0">
+							Bénéficiaires de composantes variables ou complémentaires
+						</h2>
 						<div
 							className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}
 						>
@@ -368,7 +376,9 @@ export function Step3VariablePay({
 						{gipPrefillData && (
 							<PrefillSource
 								periodEnd={gipPrefillData.periodEnd}
+								periodStart={gipPrefillData.periodStart}
 								tooltipId="tooltip-source-step3"
+								year={declarationYear}
 							/>
 						)}
 					</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -229,17 +229,13 @@ export function Step3VariablePay({
 				<div className={`${common.dataSection} ${common.tableGap}`}>
 					<div className={common.flexColumnGap1}>
 						<h2 className="fr-h6 fr-mb-0">
-							Écart de rémunération variable ou complémentaire
+							Rémunération variable ou complémentaire
 						</h2>
 						<PayGapTable
 							caption="Écart de rémunération variable ou complémentaire"
 							className={stepStyles.payGapTable}
 							columnHeader={
-								<>
-									Rémunération variable
-									<br />
-									ou complémentaire
-								</>
+								<span className="fr-sr-only">Type de rémunération</span>
 							}
 							disabled={isImpersonating}
 							onRowChange={handleRowChange}
@@ -258,7 +254,7 @@ export function Step3VariablePay({
 
 					<div className={common.flexColumnGap1}>
 						<h2 className="fr-h6 fr-mb-0">
-							Bénéficiaires de composantes variables ou complémentaires
+							Proportion de femmes et d&apos;hommes bénéficiaires
 						</h2>
 						<div
 							className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -267,7 +267,7 @@ export function Step3VariablePay({
 							Proportion de femmes et d&apos;hommes bénéficiaires
 						</h2>
 						<div
-							className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}
+							className={`fr-table fr-table--bordered fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.payGapTable}`}
 						>
 							<div className="fr-table__wrapper">
 								<div className="fr-table__container">

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -285,7 +285,9 @@ export function Step3VariablePay({
 											</colgroup>
 											<thead>
 												<tr>
-													<th scope="col">Sexe</th>
+													<th scope="col">
+														<span className="fr-sr-only">Sexe</span>
+													</th>
 													<th scope="col">
 														Total de salariés
 														{maxWomen !== undefined && maxMen !== undefined
@@ -302,9 +304,7 @@ export function Step3VariablePay({
 											</thead>
 											<tbody>
 												<tr>
-													<td>
-														<strong>Femmes</strong>
-													</td>
+													<th scope="row">Femmes</th>
 													<td className="fr-cell--right">
 														<strong>{maxWomen ?? "-"}</strong>
 													</td>
@@ -346,9 +346,7 @@ export function Step3VariablePay({
 													</td>
 												</tr>
 												<tr>
-													<td>
-														<strong>Hommes</strong>
-													</td>
+													<th scope="row">Hommes</th>
 													<td className="fr-cell--right">
 														<strong>{maxMen ?? "-"}</strong>
 													</td>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -65,15 +65,16 @@
 	}
 
 	.colMin {
-		width: 17%;
+		width: 15%;
 	}
 
 	.colMax {
-		width: 17%;
+		width: 15%;
 	}
 
 	.colCount {
-		width: 12%;
+		// Wider so "Nombre de femmes/hommes" wraps to two lines, not three (Figma).
+		width: 14%;
 	}
 
 	.colPercent {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -122,6 +122,20 @@
 		max-width: 0;
 	}
 
+	// The colspan-2 "Montants des tranches" column is two sub-cells (min | max)
+	// that must read as a single bordered column (Figma): drop the vertical
+	// divider on the min cell, keeping only its bottom border (same contrast
+	// grey as the row separators).
+	&:global(.fr-table--bordered) :global(.fr-table__content) td.minCell {
+		background-image: linear-gradient(
+			0deg,
+			var(--border-contrast-grey),
+			var(--border-contrast-grey)
+		);
+		background-size: 100% 1px;
+		background-position: 0 100%;
+	}
+
 	tbody td input:global(.fr-input) {
 		text-align: right;
 		width: 100%;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -61,15 +61,17 @@
 	// redistribute, so columns never shift based on cell content (e.g. a long
 	// "1 000 000,00 €" threshold or a large effectif).
 	.colRowLabel {
-		width: 18%;
+		width: 16%;
 	}
 
 	.colMin {
-		width: 15%;
+		width: 14%;
 	}
 
 	.colMax {
-		width: 15%;
+		// Wider input column for the salary-bracket amount (Figma node 10908:44385,
+		// the input cell, is ~1.3x the read-only min cell node 10908:44384).
+		width: 18%;
 	}
 
 	.colCount {
@@ -93,9 +95,12 @@
 
 	tbody th[scope="row"] {
 		background-color: transparent;
-		background-image: linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey));
-		background-size: 100% 1px;
-		background-position: 0 100%;
+		// Full grid like the data cells (Figma: every cell bordered): bottom + right.
+		background-image:
+			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey)),
+			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey));
+		background-size: 100% 1px, 1px 100%;
+		background-position: 0 100%, 100% 0;
 		background-repeat: no-repeat;
 		white-space: nowrap;
 		padding: 0.5rem 10px;
@@ -121,19 +126,6 @@
 	.maxCell,
 	.numericCell {
 		max-width: 0;
-	}
-
-	// Desktop grid only — "Montants des tranches" is two sub-cells (min | max) read as one bordered column: drop the min cell's right divider.
-	@include respond-from(md) {
-		&:global(.fr-table--bordered) :global(.fr-table__content) td.minCell {
-			background-image: linear-gradient(
-				0deg,
-				var(--border-contrast-grey),
-				var(--border-contrast-grey)
-			);
-			background-size: 100% 1px;
-			background-position: 0 100%;
-		}
 	}
 
 	tbody td input:global(.fr-input) {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -69,8 +69,6 @@
 	}
 
 	.colMax {
-		// Wider input column for the salary-bracket amount (Figma node 10908:44385,
-		// the input cell, is ~1.3x the read-only min cell node 10908:44384).
 		width: 18%;
 	}
 
@@ -95,7 +93,6 @@
 
 	tbody th[scope="row"] {
 		background-color: transparent;
-		// Full grid like the data cells (Figma: every cell bordered): bottom + right.
 		background-image:
 			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey)),
 			linear-gradient(0deg, var(--border-contrast-grey), var(--border-contrast-grey));

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.module.scss
@@ -122,18 +122,17 @@
 		max-width: 0;
 	}
 
-	// The colspan-2 "Montants des tranches" column is two sub-cells (min | max)
-	// that must read as a single bordered column (Figma): drop the vertical
-	// divider on the min cell, keeping only its bottom border (same contrast
-	// grey as the row separators).
-	&:global(.fr-table--bordered) :global(.fr-table__content) td.minCell {
-		background-image: linear-gradient(
-			0deg,
-			var(--border-contrast-grey),
-			var(--border-contrast-grey)
-		);
-		background-size: 100% 1px;
-		background-position: 0 100%;
+	// Desktop grid only — "Montants des tranches" is two sub-cells (min | max) read as one bordered column: drop the min cell's right divider.
+	@include respond-from(md) {
+		&:global(.fr-table--bordered) :global(.fr-table__content) td.minCell {
+			background-image: linear-gradient(
+				0deg,
+				var(--border-contrast-grey),
+				var(--border-contrast-grey)
+			);
+			background-size: 100% 1px;
+			background-position: 0 100%;
+		}
 	}
 
 	tbody td input:global(.fr-input) {
@@ -193,6 +192,12 @@
 			border-bottom: none;
 			padding: 0.5rem 0;
 			text-align: left;
+		}
+
+		// Clear the desktop grid borders (fr-table--bordered draws them via background-image) so the block-stacked layout keeps only the per-row divider.
+		&:global(.fr-table--bordered) :global(.fr-table__content) tbody td,
+		&:global(.fr-table--bordered) :global(.fr-table__content) tbody th {
+			background-image: none;
 		}
 
 		tbody th[scope="row"] {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -347,7 +347,12 @@ export function Step4QuartileDistribution({
 						quartiles={annual}
 						sourceNote={
 							gipPrefillData ? (
-								<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />
+								<PrefillSource
+									periodEnd={gipPrefillData.periodEnd ?? null}
+									periodStart={gipPrefillData.periodStart}
+									tooltipId="tooltip-source-step4-annual"
+									year={declarationYear}
+								/>
 							) : undefined
 						}
 						tableType="annual"
@@ -364,7 +369,12 @@ export function Step4QuartileDistribution({
 						quartiles={hourly}
 						sourceNote={
 							gipPrefillData ? (
-								<PrefillSource periodEnd={gipPrefillData.periodEnd ?? null} />
+								<PrefillSource
+									periodEnd={gipPrefillData.periodEnd ?? null}
+									periodStart={gipPrefillData.periodStart}
+									tooltipId="tooltip-source-step4-hourly"
+									year={declarationYear}
+								/>
 							) : undefined
 						}
 						tableType="hourly"

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -43,6 +43,13 @@
 	table-layout: fixed;
 }
 
+.fixedTable table thead th:nth-child(2),
+.fixedTable table thead th:nth-child(3) {
+	// Let "Rémunération des femmes/hommes" wrap instead of overflowing the cell,
+	// without touching the écart header's own two-line layout.
+	white-space: normal;
+}
+
 // Shared label column across the effectifs and rémunération tables so their
 // left column lines up (Figma page 5).
 .colLabel {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -70,6 +70,16 @@
 	display: flex;
 	flex-direction: column;
 	gap: 2rem;
+
+	// The shared StepIndicator carries block-layout margins (mt/mb 2rem) for the
+	// fieldset steps (1-4, block + margin-collapse). This form spaces its children
+	// with flex `gap`, where margins add instead of collapse — so strip them here to
+	// keep every gap at 32px. (FormActions gets the same treatment via `fr-mt-0` in
+	// CategoryForm, since a trailing <dialog> makes it not the flex `:last-child`.)
+	> :global(.fr-stepper) {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
 }
 
 .categoryBlock {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -1,10 +1,3 @@
-.sectionHeader {
-	// DSFR's `.fr-table__content table tbody td` rule wins on specificity, so
-	// override the variable it reads instead of fighting the selector.
-	--background-default-grey: var(--background-contrast-grey);
-	background-color: var(--background-contrast-grey);
-}
-
 .sourceSelectGroup {
 	:global(.fr-select) {
 		max-width: 18rem;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -35,8 +35,28 @@
 	text-align: right;
 }
 
-.nameColumnHeader {
-	width: 230px;
+.fixedTable table {
+	// Column widths come from the <colgroup> below (not content), so all three
+	// category tables share the same wide label column and none overflows the
+	// ~776px card (Figma page 5); narrow viewports scroll via the DSFR table
+	// wrapper (RGAA reflow).
+	table-layout: fixed;
+}
+
+// Shared label column across the effectifs and rémunération tables so their
+// left column lines up (Figma page 5).
+.colLabel {
+	width: 28%;
+}
+
+// Workforce (effectifs) table: two equal data columns (women / men).
+.colWorkforceData {
+	width: 36%;
+}
+
+// Rémunération tables: three equal data columns (women / men / gap).
+.colRemunData {
+	width: 24%;
 }
 
 .form {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -30,7 +30,8 @@
 	height: 64px;
 }
 
-:global(.fr-table__content) table tbody td.totalCell {
+:global(.fr-table__content) table tbody td.totalCell,
+:global(.fr-table__content) table tbody td.gapCell {
 	text-align: right;
 }
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss
@@ -71,11 +71,7 @@
 	flex-direction: column;
 	gap: 2rem;
 
-	// The shared StepIndicator carries block-layout margins (mt/mb 2rem) for the
-	// fieldset steps (1-4, block + margin-collapse). This form spaces its children
-	// with flex `gap`, where margins add instead of collapse — so strip them here to
-	// keep every gap at 32px. (FormActions gets the same treatment via `fr-mt-0` in
-	// CategoryForm, since a trailing <dialog> makes it not the flex `:last-child`.)
+	// this form uses flex `gap` (margins add, not collapse) — strip the shared stepper's mt/mb so gaps stay 32px
 	> :global(.fr-stepper) {
 		margin-top: 0;
 		margin-bottom: 0;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
@@ -49,9 +49,16 @@
 }
 
 .inlineGap {
-	display: inline-flex;
+	// Écart cell: value pinned right, badge (when present) at the far left, no
+	// divider between them (Figma). Full-width flex so the auto margin can push
+	// the value to the cell's right edge.
+	display: flex;
 	align-items: center;
 	gap: 0.5rem;
+}
+
+.gapValue {
+	margin-left: auto;
 }
 
 .subSection {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
@@ -49,7 +49,13 @@
 }
 
 .inlineGap {
-	// Écart cell: full-width flex so margin-auto pins the value right, badge at the far left.
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+}
+
+// Bordered grid cell (étape 5): full-width flex so margin-auto pins the value right, badge at the far left.
+.gapCell {
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
@@ -4,6 +4,16 @@
 	gap: 2rem;
 }
 
+// Recap body inside the block fieldset: the intro, the IndicatorSections blocks
+// and the NextStepsBox carry no margins of their own, so space them at 32px like
+// the rest of the flow. Scoped here (not on the shared .group / NextStepsBox) so
+// the second-declaration recap is left untouched.
+.recapBody {
+	display: flex;
+	flex-direction: column;
+	gap: 2rem;
+}
+
 .section {
 	display: flex;
 	flex-direction: column;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
@@ -4,10 +4,7 @@
 	gap: 2rem;
 }
 
-// Recap body inside the block fieldset: the intro, the IndicatorSections blocks
-// and the NextStepsBox carry no margins of their own, so space them at 32px like
-// the rest of the flow. Scoped here (not on the shared .group / NextStepsBox) so
-// the second-declaration recap is left untouched.
+// scoped wrapper so the recap blocks get 32px gaps without touching the shared .group / NextStepsBox (second-declaration recap)
 .recapBody {
 	display: flex;
 	flex-direction: column;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.module.scss
@@ -49,9 +49,7 @@
 }
 
 .inlineGap {
-	// Écart cell: value pinned right, badge (when present) at the far left, no
-	// divider between them (Figma). Full-width flex so the auto margin can push
-	// the value to the cell's right edge.
+	// Écart cell: full-width flex so margin-auto pins the value right, badge at the far left.
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -178,28 +178,30 @@ export function Step6Review({
 
 				<StepIndicator currentStep={6} />
 
-				<p className={`fr-mb-0 ${stepStyles.intro}`}>
-					Vérifiez que toutes les informations ont été complétées avant de
-					soumettre votre déclaration aux services du ministère chargé du
-					travail.
-				</p>
+				<div className={stepStyles.recapBody}>
+					<p className={`fr-mb-0 ${stepStyles.intro}`}>
+						Vérifiez que toutes les informations ont été complétées avant de
+						soumettre votre déclaration aux services du ministère chargé du
+						travail.
+					</p>
 
-				<IndicatorSections
-					step2Data={step2Data}
-					step3Data={step3Data}
-					step4Data={step4Data}
-					step5Categories={step5Categories}
-					totalMen={totalMen}
-					totalWomen={totalWomen}
-					withTooltips
-				/>
-
-				{highGap && declaration.siren && (
-					<NextStepsBox
-						hasGapsAboveThreshold={highGap}
-						siren={declaration.siren}
+					<IndicatorSections
+						step2Data={step2Data}
+						step3Data={step3Data}
+						step4Data={step4Data}
+						step5Categories={step5Categories}
+						totalMen={totalMen}
+						totalWomen={totalWomen}
+						withTooltips
 					/>
-				)}
+
+					{highGap && declaration.siren && (
+						<NextStepsBox
+							hasGapsAboveThreshold={highGap}
+							siren={declaration.siren}
+						/>
+					)}
+				</div>
 
 				<FormActions
 					nextHref={

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -217,7 +217,7 @@ describe("Step1Workforce", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders previous link pointing to home", () => {
+	it("does not render a previous link (exit is handled by the breadcrumb)", () => {
 		render(
 			<Step1Workforce
 				declarationSiren="123456789"
@@ -225,10 +225,9 @@ describe("Step1Workforce", () => {
 				initialData={emptyStep1Data()}
 			/>,
 		);
-		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
-			"href",
-			"/",
-		);
+		expect(
+			screen.queryByRole("link", { name: /précédent/i }),
+		).not.toBeInTheDocument();
 	});
 
 	it("hides the reset warning by default", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -84,7 +84,7 @@ describe("Step2PayGap", () => {
 				initialData={emptyStep2Data()}
 			/>,
 		);
-		expect(screen.getByText("Rémunération")).toBeInTheDocument();
+		expect(screen.getByText("Type de rémunération")).toBeInTheDocument();
 		expect(screen.getByText("Rémunération des femmes")).toBeInTheDocument();
 		expect(screen.getByText("Rémunération des hommes")).toBeInTheDocument();
 		expect(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -72,8 +72,8 @@ describe("Step2PayGap", () => {
 			/>,
 		);
 		expect(screen.getByText("Rémunération")).toBeInTheDocument();
-		expect(screen.getByText("Femmes")).toBeInTheDocument();
-		expect(screen.getByText("Hommes")).toBeInTheDocument();
+		expect(screen.getByText("Rémunération des femmes")).toBeInTheDocument();
+		expect(screen.getByText("Rémunération des hommes")).toBeInTheDocument();
 		expect(
 			screen.getByText("Écart", { selector: "strong" }),
 		).toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -102,11 +102,11 @@ describe("Step4QuartileDistribution", () => {
 		);
 		const headers = screen.getAllByRole("columnheader");
 		const annualHeader = headers.find((h) =>
-			/Tranche de rémunération[\s\S]*annuelle brute/.test(h.textContent ?? ""),
+			/Montants des tranches[\s\S]*annuelle brut/.test(h.textContent ?? ""),
 		);
 		expect(annualHeader).toBeDefined();
 		const hourlyHeader = headers.find((h) =>
-			/Tranche de rémunération[\s\S]*horaire brute/.test(h.textContent ?? ""),
+			/Montants des tranches[\s\S]*horaire brut/.test(h.textContent ?? ""),
 		);
 		expect(hourlyHeader).toBeDefined();
 		expect(screen.getAllByText(/Pourcentage/).length).toBeGreaterThanOrEqual(4);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -136,8 +136,11 @@ describe("Step5EmployeeCategories", () => {
 				declarationYear={2025}
 			/>,
 		);
-		expect(screen.getAllByText("Femmes").length).toBeGreaterThanOrEqual(1);
-		expect(screen.getAllByText("Hommes").length).toBeGreaterThanOrEqual(1);
+		expect(screen.getByText("Nombre de femmes")).toBeInTheDocument();
+		expect(screen.getByText("Nombre d'hommes")).toBeInTheDocument();
+		expect(
+			screen.getAllByText("Rémunération des femmes").length,
+		).toBeGreaterThanOrEqual(1);
 		expect(
 			screen.getAllByText("Seuil réglementaire : 5%").length,
 		).toBeGreaterThanOrEqual(1);

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -50,7 +50,9 @@ export function QuartileTable({
 		total: totalAll,
 	} = sumQuartileWorkforce(quartiles);
 	const trancheSuffix =
-		tableType === "annual" ? "annuelle brute" : "horaire brute";
+		tableType === "annual"
+			? "de rémunération annuelle brut"
+			: "de rémunération horaire brut";
 
 	return (
 		<div className={stepStyles.tableWrapper}>
@@ -82,7 +84,7 @@ export function QuartileTable({
 												<span className="fr-sr-only">Quartile</span>
 											</th>
 											<th colSpan={2} scope="col">
-												Tranche de rémunération
+												Montants des tranches
 												<br />
 												{trancheSuffix}
 											</th>

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -52,7 +52,7 @@ export function QuartileTable({
 
 	return (
 		<div className={stepStyles.tableWrapper}>
-			<h3 className="fr-h5 fr-mb-0">{title}</h3>
+			<h3 className="fr-h6 fr-mb-0">{title}</h3>
 			<div className={stepStyles.tableSection}>
 				{readingNote}
 				<div

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTable.tsx
@@ -60,7 +60,7 @@ export function QuartileTable({
 			<div className={stepStyles.tableSection}>
 				{readingNote}
 				<div
-					className={`fr-table fr-table--no-scroll fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
+					className={`fr-table fr-table--bordered fr-table--no-scroll fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.quartileTable}`}
 				>
 					<div className="fr-table__wrapper">
 						<div className="fr-table__container">

--- a/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step4/QuartileTableRow.tsx
@@ -45,7 +45,7 @@ function menAriaLabel(tableType: TableType, index: number) {
 
 function pct(q: QuartileData, gender: "women" | "men") {
 	const total = (q.women ?? 0) + (q.men ?? 0);
-	if (total === 0) return "-";
+	if (total === 0) return "- %";
 	return computePercentage(q[gender] ?? 0, total);
 }
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -174,7 +174,7 @@ function RemunerationTable({
 				<RemunerationHead />
 				<tbody>
 					<tr className={stepStyles.dataRow}>
-						<td>Salaire de base</td>
+						<th scope="row">Salaire de base</th>
 						<EuroInputCell
 							ariaLabel={`Salaire de base ${scope} femmes, catégorie ${catIndex + 1}`}
 							disabled={disabled}
@@ -198,11 +198,11 @@ function RemunerationTable({
 						</td>
 					</tr>
 					<tr className={stepStyles.dataRow}>
-						<td>
+						<th scope="row">
 							Composantes variables
 							<br />
 							ou complémentaires
-						</td>
+						</th>
 						<EuroInputCell
 							ariaLabel={`Composantes variables ${variableScope} femmes, catégorie ${catIndex + 1}`}
 							disabled={disabled}
@@ -229,9 +229,7 @@ function RemunerationTable({
 						</td>
 					</tr>
 					<tr className={stepStyles.dataRow}>
-						<td>
-							<strong>Total</strong>
-						</td>
+						<th scope="row">Total</th>
 						<td className={stepStyles.totalCell}>
 							{formatTotal(totalWomen, "€")}
 						</td>
@@ -283,7 +281,7 @@ export function CategoryDataTable({
 					</thead>
 					<tbody>
 						<tr className={stepStyles.dataRow}>
-							<td>Effectif physique</td>
+							<th scope="row">Effectif physique</th>
 							<td>
 								<div className={stepStyles.inputCell}>
 									<input

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -114,7 +114,7 @@ function TableFrame({
 }) {
 	return (
 		<div
-			className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.fixedTable}`}
+			className={`fr-table fr-table--bordered fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.fixedTable}`}
 		>
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -90,7 +90,7 @@ function RemunerationHead() {
 	return (
 		<thead>
 			<tr>
-				<th className={stepStyles.nameColumnHeader} scope="col">
+				<th scope="col">
 					<span className="fr-sr-only">Donnée</span>
 				</th>
 				<th scope="col">Rémunération des femmes</th>
@@ -113,7 +113,9 @@ function TableFrame({
 	children: React.ReactNode;
 }) {
 	return (
-		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
+		<div
+			className={`fr-table fr-table--no-caption fr-mt-0 fr-mb-0 ${stepStyles.fixedTable}`}
+		>
 			<div className="fr-table__wrapper">
 				<div className="fr-table__container">
 					<div className="fr-table__content">
@@ -171,6 +173,12 @@ function RemunerationTable({
 			<TableFrame
 				caption={`Catégorie d'emplois n°${catIndex + 1}${cat.name.trim() ? ` : ${cat.name}` : ""} — ${title}`}
 			>
+				<colgroup>
+					<col className={stepStyles.colLabel} />
+					<col className={stepStyles.colRemunData} />
+					<col className={stepStyles.colRemunData} />
+					<col className={stepStyles.colRemunData} />
+				</colgroup>
 				<RemunerationHead />
 				<tbody>
 					<tr className={stepStyles.dataRow}>
@@ -272,9 +280,14 @@ export function CategoryDataTable({
 				<TableFrame
 					caption={`Catégorie d'emplois n°${catIndex + 1}${cat.name.trim() ? ` : ${cat.name}` : ""} — Effectifs physiques`}
 				>
+					<colgroup>
+						<col className={stepStyles.colLabel} />
+						<col className={stepStyles.colWorkforceData} />
+						<col className={stepStyles.colWorkforceData} />
+					</colgroup>
 					<thead>
 						<tr>
-							<th className={stepStyles.nameColumnHeader} scope="col">
+							<th scope="col">
 								<span className="fr-sr-only">Donnée</span>
 							</th>
 							<th scope="col">Nombre de femmes</th>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -300,36 +300,30 @@ export function CategoryDataTable({
 						<tr className={stepStyles.dataRow}>
 							<th scope="row">Effectif physique</th>
 							<td>
-								<div className={stepStyles.inputCell}>
-									<input
-										aria-label={`Effectif femmes, catégorie ${catIndex + 1}`}
-										className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
-										disabled={disabled}
-										id={`${idPrefix}-women-count`}
-										inputMode="numeric"
-										onChange={pos(catIndex, "womenCount", true)}
-										pattern="[0-9]*"
-										type="text"
-										value={cat.womenCount}
-									/>
-									<span className="fr-text--sm">nb</span>
-								</div>
+								<input
+									aria-label={`Effectif femmes, catégorie ${catIndex + 1}`}
+									className={`fr-input ${common.numericInput}`}
+									disabled={disabled}
+									id={`${idPrefix}-women-count`}
+									inputMode="numeric"
+									onChange={pos(catIndex, "womenCount", true)}
+									pattern="[0-9]*"
+									type="text"
+									value={cat.womenCount}
+								/>
 							</td>
 							<td>
-								<div className={stepStyles.inputCell}>
-									<input
-										aria-label={`Effectif hommes, catégorie ${catIndex + 1}`}
-										className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
-										disabled={disabled}
-										id={`${idPrefix}-men-count`}
-										inputMode="numeric"
-										onChange={pos(catIndex, "menCount", true)}
-										pattern="[0-9]*"
-										type="text"
-										value={cat.menCount}
-									/>
-									<span className="fr-text--sm">nb</span>
-								</div>
+								<input
+									aria-label={`Effectif hommes, catégorie ${catIndex + 1}`}
+									className={`fr-input ${common.numericInput}`}
+									disabled={disabled}
+									id={`${idPrefix}-men-count`}
+									inputMode="numeric"
+									onChange={pos(catIndex, "menCount", true)}
+									pattern="[0-9]*"
+									type="text"
+									value={cat.menCount}
+								/>
 							</td>
 						</tr>
 					</tbody>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -202,6 +202,7 @@ function RemunerationTable({
 						<td className={stepStyles.gapCell}>
 							<GapBadge
 								gap={computeGap(cat[fields.baseWomen], cat[fields.baseMen])}
+								layout="cell"
 							/>
 						</td>
 					</tr>
@@ -233,6 +234,7 @@ function RemunerationTable({
 									cat[fields.variableWomen],
 									cat[fields.variableMen],
 								)}
+								layout="cell"
 							/>
 						</td>
 					</tr>
@@ -245,7 +247,7 @@ function RemunerationTable({
 							{formatTotal(totalMen, "€")}
 						</td>
 						<td className={stepStyles.gapCell}>
-							<GapBadge gap={totalGap} />
+							<GapBadge gap={totalGap} layout="cell" />
 						</td>
 					</tr>
 				</tbody>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -86,13 +86,12 @@ function EuroInputCell({
 	);
 }
 
-/** Column headers shared by the annual and hourly remuneration tables. */
 function RemunerationHead() {
 	return (
 		<thead>
 			<tr>
 				<th className={stepStyles.nameColumnHeader} scope="col">
-					{/* row label */}
+					<span className="fr-sr-only">Libellé</span>
 				</th>
 				<th scope="col">Femmes</th>
 				<th scope="col">Hommes</th>
@@ -106,7 +105,6 @@ function RemunerationHead() {
 	);
 }
 
-/** A styled DSFR table wrapper — keeps the fr-table structure in one place. */
 function TableFrame({
 	caption,
 	children,
@@ -273,7 +271,7 @@ export function CategoryDataTable({
 					<thead>
 						<tr>
 							<th className={stepStyles.nameColumnHeader} scope="col">
-								{/* row label */}
+								<span className="fr-sr-only">Libellé</span>
 							</th>
 							<th scope="col">Femmes</th>
 							<th scope="col">Hommes</th>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -86,8 +86,52 @@ function EuroInputCell({
 	);
 }
 
-type RemunerationSectionProps = {
-	sectionLabel: string;
+/** Column headers shared by the annual and hourly remuneration tables. */
+function RemunerationHead() {
+	return (
+		<thead>
+			<tr>
+				<th className={stepStyles.nameColumnHeader} scope="col">
+					{/* row label */}
+				</th>
+				<th scope="col">Femmes</th>
+				<th scope="col">Hommes</th>
+				<th scope="col">
+					<strong>Écart</strong>
+					<br />
+					<span className={common.fontRegular}>Seuil réglementaire : 5%</span>
+				</th>
+			</tr>
+		</thead>
+	);
+}
+
+/** A styled DSFR table wrapper — keeps the fr-table structure in one place. */
+function TableFrame({
+	caption,
+	children,
+}: {
+	caption: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
+			<div className="fr-table__wrapper">
+				<div className="fr-table__container">
+					<div className="fr-table__content">
+						<table>
+							<caption>{caption}</caption>
+							{children}
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+type RemunerationTableProps = {
+	title: string;
 	scope: "annuel" | "horaire";
 	fields: EuroFields;
 	cat: EmployeeCategory;
@@ -98,8 +142,8 @@ type RemunerationSectionProps = {
 	idPrefix: string;
 };
 
-function RemunerationSection({
-	sectionLabel,
+function RemunerationTable({
+	title,
 	scope,
 	fields,
 	cat,
@@ -108,7 +152,7 @@ function RemunerationSection({
 	pos,
 	blur,
 	idPrefix,
-}: RemunerationSectionProps) {
+}: RemunerationTableProps) {
 	const totalWomen = computeTotal(
 		cat[fields.baseWomen],
 		cat[fields.variableWomen],
@@ -119,80 +163,88 @@ function RemunerationSection({
 			? computeGap(totalWomen.toString(), totalMen.toString())
 			: null;
 
-	const idFor = (suffix: string) => `${idPrefix}-${suffix}`;
+	const scopeId = scope === "annuel" ? "annual" : "hourly";
+	const variableScope = scope === "annuel" ? "annuelles" : "horaires";
+	const idFor = (suffix: string) => `${idPrefix}-${scopeId}-${suffix}`;
 
 	return (
-		<>
-			<tr>
-				<td className={stepStyles.sectionHeader} colSpan={4}>
-					<strong>{sectionLabel}</strong>
-				</td>
-			</tr>
-			<tr className={stepStyles.dataRow}>
-				<td>Salaire de base</td>
-				<EuroInputCell
-					ariaLabel={`Salaire de base ${scope} femmes, catégorie ${catIndex + 1}`}
-					disabled={disabled}
-					id={idFor(`${scope === "annuel" ? "annual" : "hourly"}-base-women`)}
-					onBlur={blur(catIndex, fields.baseWomen)}
-					onChange={pos(catIndex, fields.baseWomen, false)}
-					value={cat[fields.baseWomen]}
-				/>
-				<EuroInputCell
-					ariaLabel={`Salaire de base ${scope} hommes, catégorie ${catIndex + 1}`}
-					disabled={disabled}
-					id={idFor(`${scope === "annuel" ? "annual" : "hourly"}-base-men`)}
-					onBlur={blur(catIndex, fields.baseMen)}
-					onChange={pos(catIndex, fields.baseMen, false)}
-					value={cat[fields.baseMen]}
-				/>
-				<td>
-					<GapBadge
-						gap={computeGap(cat[fields.baseWomen], cat[fields.baseMen])}
-					/>
-				</td>
-			</tr>
-			<tr className={stepStyles.dataRow}>
-				<td>
-					Composantes variables
-					<br />
-					ou complémentaires
-				</td>
-				<EuroInputCell
-					ariaLabel={`Composantes variables ${scope === "annuel" ? "annuelles" : "horaires"} femmes, catégorie ${catIndex + 1}`}
-					disabled={disabled}
-					id={idFor(
-						`${scope === "annuel" ? "annual" : "hourly"}-variable-women`,
-					)}
-					onBlur={blur(catIndex, fields.variableWomen)}
-					onChange={pos(catIndex, fields.variableWomen, false)}
-					value={cat[fields.variableWomen]}
-				/>
-				<EuroInputCell
-					ariaLabel={`Composantes variables ${scope === "annuel" ? "annuelles" : "horaires"} hommes, catégorie ${catIndex + 1}`}
-					disabled={disabled}
-					id={idFor(`${scope === "annuel" ? "annual" : "hourly"}-variable-men`)}
-					onBlur={blur(catIndex, fields.variableMen)}
-					onChange={pos(catIndex, fields.variableMen, false)}
-					value={cat[fields.variableMen]}
-				/>
-				<td>
-					<GapBadge
-						gap={computeGap(cat[fields.variableWomen], cat[fields.variableMen])}
-					/>
-				</td>
-			</tr>
-			<tr className={stepStyles.dataRow}>
-				<td>
-					<strong>Total</strong>
-				</td>
-				<td className={stepStyles.totalCell}>{formatTotal(totalWomen, "€")}</td>
-				<td className={stepStyles.totalCell}>{formatTotal(totalMen, "€")}</td>
-				<td>
-					<GapBadge gap={totalGap} />
-				</td>
-			</tr>
-		</>
+		<div className={common.flexColumnGap1}>
+			<h3 className="fr-h6 fr-mb-0">{title}</h3>
+			<TableFrame caption={`${title} — catégorie ${catIndex + 1}`}>
+				<RemunerationHead />
+				<tbody>
+					<tr className={stepStyles.dataRow}>
+						<td>Salaire de base</td>
+						<EuroInputCell
+							ariaLabel={`Salaire de base ${scope} femmes, catégorie ${catIndex + 1}`}
+							disabled={disabled}
+							id={idFor("base-women")}
+							onBlur={blur(catIndex, fields.baseWomen)}
+							onChange={pos(catIndex, fields.baseWomen, false)}
+							value={cat[fields.baseWomen]}
+						/>
+						<EuroInputCell
+							ariaLabel={`Salaire de base ${scope} hommes, catégorie ${catIndex + 1}`}
+							disabled={disabled}
+							id={idFor("base-men")}
+							onBlur={blur(catIndex, fields.baseMen)}
+							onChange={pos(catIndex, fields.baseMen, false)}
+							value={cat[fields.baseMen]}
+						/>
+						<td>
+							<GapBadge
+								gap={computeGap(cat[fields.baseWomen], cat[fields.baseMen])}
+							/>
+						</td>
+					</tr>
+					<tr className={stepStyles.dataRow}>
+						<td>
+							Composantes variables
+							<br />
+							ou complémentaires
+						</td>
+						<EuroInputCell
+							ariaLabel={`Composantes variables ${variableScope} femmes, catégorie ${catIndex + 1}`}
+							disabled={disabled}
+							id={idFor("variable-women")}
+							onBlur={blur(catIndex, fields.variableWomen)}
+							onChange={pos(catIndex, fields.variableWomen, false)}
+							value={cat[fields.variableWomen]}
+						/>
+						<EuroInputCell
+							ariaLabel={`Composantes variables ${variableScope} hommes, catégorie ${catIndex + 1}`}
+							disabled={disabled}
+							id={idFor("variable-men")}
+							onBlur={blur(catIndex, fields.variableMen)}
+							onChange={pos(catIndex, fields.variableMen, false)}
+							value={cat[fields.variableMen]}
+						/>
+						<td>
+							<GapBadge
+								gap={computeGap(
+									cat[fields.variableWomen],
+									cat[fields.variableMen],
+								)}
+							/>
+						</td>
+					</tr>
+					<tr className={stepStyles.dataRow}>
+						<td>
+							<strong>Total</strong>
+						</td>
+						<td className={stepStyles.totalCell}>
+							{formatTotal(totalWomen, "€")}
+						</td>
+						<td className={stepStyles.totalCell}>
+							{formatTotal(totalMen, "€")}
+						</td>
+						<td>
+							<GapBadge gap={totalGap} />
+						</td>
+					</tr>
+				</tbody>
+			</TableFrame>
+		</div>
 	);
 }
 
@@ -211,103 +263,87 @@ export function CategoryDataTable({
 			: null;
 
 	const idPrefix = `cat-${catIndex}`;
+
 	return (
-		<div className="fr-table fr-table--no-caption fr-mt-0 fr-mb-0">
-			<div className="fr-table__wrapper">
-				<div className="fr-table__container">
-					<div className="fr-table__content">
-						<table>
-							<caption>Données catégorie {catIndex + 1}</caption>
-							<thead>
-								<tr>
-									<th className={stepStyles.nameColumnHeader} scope="col">
-										{/* row label */}
-									</th>
-									<th scope="col">Femmes</th>
-									<th scope="col">Hommes</th>
-									<th scope="col">
-										<strong>Écart</strong>
-										<br />
-										<span className={common.fontRegular}>
-											Seuil réglementaire : 5%
-										</span>
-									</th>
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td className={stepStyles.sectionHeader} colSpan={4}>
-										<strong>
-											Total salariés
-											{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
-										</strong>
-									</td>
-								</tr>
-								<tr className={stepStyles.dataRow}>
-									<td>Effectif physique</td>
-									<td>
-										<div className={stepStyles.inputCell}>
-											<input
-												aria-label={`Effectif femmes, catégorie ${catIndex + 1}`}
-												className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
-												disabled={disabled}
-												id={`${idPrefix}-women-count`}
-												inputMode="numeric"
-												onChange={pos(catIndex, "womenCount", true)}
-												pattern="[0-9]*"
-												type="text"
-												value={cat.womenCount}
-											/>
-											<span className="fr-text--sm">nb</span>
-										</div>
-									</td>
-									<td>
-										<div className={stepStyles.inputCell}>
-											<input
-												aria-label={`Effectif hommes, catégorie ${catIndex + 1}`}
-												className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
-												disabled={disabled}
-												id={`${idPrefix}-men-count`}
-												inputMode="numeric"
-												onChange={pos(catIndex, "menCount", true)}
-												pattern="[0-9]*"
-												type="text"
-												value={cat.menCount}
-											/>
-											<span className="fr-text--sm">nb</span>
-										</div>
-									</td>
-									<td />
-								</tr>
-
-								<RemunerationSection
-									blur={blur}
-									cat={cat}
-									catIndex={catIndex}
-									disabled={disabled}
-									fields={ANNUAL_FIELDS}
-									idPrefix={idPrefix}
-									pos={pos}
-									scope="annuel"
-									sectionLabel="Rémunération annuelle brute moyenne"
-								/>
-
-								<RemunerationSection
-									blur={blur}
-									cat={cat}
-									catIndex={catIndex}
-									disabled={disabled}
-									fields={HOURLY_FIELDS}
-									idPrefix={idPrefix}
-									pos={pos}
-									scope="horaire"
-									sectionLabel="Rémunération horaire brute moyenne"
-								/>
-							</tbody>
-						</table>
-					</div>
-				</div>
+		<div className={common.dataSection}>
+			<div className={common.flexColumnGap1}>
+				<h3 className="fr-h6 fr-mb-0">
+					Total salariés
+					{totalEmployees !== null ? ` : ${totalEmployees}` : ""}
+				</h3>
+				<TableFrame caption={`Effectifs physiques — catégorie ${catIndex + 1}`}>
+					<thead>
+						<tr>
+							<th className={stepStyles.nameColumnHeader} scope="col">
+								{/* row label */}
+							</th>
+							<th scope="col">Femmes</th>
+							<th scope="col">Hommes</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr className={stepStyles.dataRow}>
+							<td>Effectif physique</td>
+							<td>
+								<div className={stepStyles.inputCell}>
+									<input
+										aria-label={`Effectif femmes, catégorie ${catIndex + 1}`}
+										className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
+										disabled={disabled}
+										id={`${idPrefix}-women-count`}
+										inputMode="numeric"
+										onChange={pos(catIndex, "womenCount", true)}
+										pattern="[0-9]*"
+										type="text"
+										value={cat.womenCount}
+									/>
+									<span className="fr-text--sm">nb</span>
+								</div>
+							</td>
+							<td>
+								<div className={stepStyles.inputCell}>
+									<input
+										aria-label={`Effectif hommes, catégorie ${catIndex + 1}`}
+										className={`fr-input ${stepStyles.compactInput} ${common.numericInput}`}
+										disabled={disabled}
+										id={`${idPrefix}-men-count`}
+										inputMode="numeric"
+										onChange={pos(catIndex, "menCount", true)}
+										pattern="[0-9]*"
+										type="text"
+										value={cat.menCount}
+									/>
+									<span className="fr-text--sm">nb</span>
+								</div>
+							</td>
+						</tr>
+					</tbody>
+				</TableFrame>
 			</div>
+
+			<RemunerationTable
+				blur={blur}
+				cat={cat}
+				catIndex={catIndex}
+				disabled={disabled}
+				fields={ANNUAL_FIELDS}
+				idPrefix={idPrefix}
+				pos={pos}
+				scope="annuel"
+				title="Rémunération annuelle brute moyenne"
+			/>
+
+			<RemunerationTable
+				blur={blur}
+				cat={cat}
+				catIndex={catIndex}
+				disabled={disabled}
+				fields={HOURLY_FIELDS}
+				idPrefix={idPrefix}
+				pos={pos}
+				scope="horaire"
+				title="Rémunération horaire brute moyenne"
+			/>
 		</div>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -93,8 +93,8 @@ function RemunerationHead() {
 				<th className={stepStyles.nameColumnHeader} scope="col">
 					<span className="fr-sr-only">Libellé</span>
 				</th>
-				<th scope="col">Femmes</th>
-				<th scope="col">Hommes</th>
+				<th scope="col">Rémunération des femmes</th>
+				<th scope="col">Rémunération des hommes</th>
 				<th scope="col">
 					<strong>Écart</strong>
 					<br />
@@ -273,8 +273,8 @@ export function CategoryDataTable({
 							<th className={stepStyles.nameColumnHeader} scope="col">
 								<span className="fr-sr-only">Libellé</span>
 							</th>
-							<th scope="col">Femmes</th>
-							<th scope="col">Hommes</th>
+							<th scope="col">Nombre de femmes</th>
+							<th scope="col">Nombre d&apos;hommes</th>
 						</tr>
 					</thead>
 					<tbody>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -191,7 +191,7 @@ function RemunerationTable({
 							onChange={pos(catIndex, fields.baseMen, false)}
 							value={cat[fields.baseMen]}
 						/>
-						<td>
+						<td className={stepStyles.gapCell}>
 							<GapBadge
 								gap={computeGap(cat[fields.baseWomen], cat[fields.baseMen])}
 							/>
@@ -219,7 +219,7 @@ function RemunerationTable({
 							onChange={pos(catIndex, fields.variableMen, false)}
 							value={cat[fields.variableMen]}
 						/>
-						<td>
+						<td className={stepStyles.gapCell}>
 							<GapBadge
 								gap={computeGap(
 									cat[fields.variableWomen],
@@ -236,7 +236,7 @@ function RemunerationTable({
 						<td className={stepStyles.totalCell}>
 							{formatTotal(totalMen, "€")}
 						</td>
-						<td>
+						<td className={stepStyles.gapCell}>
 							<GapBadge gap={totalGap} />
 						</td>
 					</tr>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -592,6 +592,7 @@ export function CategoryForm({
 			/>
 
 			<FormActions
+				className="fr-mt-0"
 				isSubmitting={isSubmitting}
 				mimoquageNextHref={mimoquageNextHref}
 				previousHref={previousHref}

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/GapBadge.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/GapBadge.tsx
@@ -16,10 +16,10 @@ export function GapBadge({ gap }: Props) {
 	if (!level) return <span className="fr-text--sm">{formatGap(gap)}</span>;
 	return (
 		<span className={`fr-text--sm ${stepStyles.inlineGap}`}>
-			<strong>{formatGap(gap)}</strong>
 			{level === "high" && (
 				<span className={gapBadgeClass(level)}>{GAP_LEVEL_LABELS[level]}</span>
 			)}
+			<strong className={stepStyles.gapValue}>{formatGap(gap)}</strong>
 		</span>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/GapBadge.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/GapBadge.tsx
@@ -7,19 +7,35 @@ import stepStyles from "../Step6Review.module.scss";
 
 type Props = {
 	gap: number | null;
+	/**
+	 * "cell" pins the value to the right of a bordered grid cell with the badge
+	 * at the far left (Figma declaration tables). "inline" (default) keeps the
+	 * value then badge together, for the compact recap summary.
+	 */
+	layout?: "inline" | "cell";
 };
 
 /** Displays a formatted gap value with an optional severity badge */
-export function GapBadge({ gap }: Props) {
+export function GapBadge({ gap, layout = "inline" }: Props) {
 	if (gap === null) return <span className="fr-text--sm">-</span>;
 	const level = gapLevel(gap);
 	if (!level) return <span className="fr-text--sm">{formatGap(gap)}</span>;
+	const badge =
+		level === "high" ? (
+			<span className={gapBadgeClass(level)}>{GAP_LEVEL_LABELS[level]}</span>
+		) : null;
+	if (layout === "cell") {
+		return (
+			<span className={`fr-text--sm ${stepStyles.gapCell}`}>
+				{badge}
+				<strong className={stepStyles.gapValue}>{formatGap(gap)}</strong>
+			</span>
+		);
+	}
 	return (
 		<span className={`fr-text--sm ${stepStyles.inlineGap}`}>
-			{level === "high" && (
-				<span className={gapBadgeClass(level)}>{GAP_LEVEL_LABELS[level]}</span>
-			)}
-			<strong className={stepStyles.gapValue}>{formatGap(gap)}</strong>
+			<strong>{formatGap(gap)}</strong>
+			{badge}
 		</span>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
@@ -61,7 +61,7 @@ describe("IndicatorSections", () => {
 		expect(screen.queryByText("110 %")).not.toBeInTheDocument();
 	});
 
-	it("renders '-' for the proportion when the workforce total is zero", () => {
+	it("renders '- %' for the proportion when the workforce total is zero", () => {
 		render(
 			<IndicatorSections
 				step2Data={emptyStep2Data()}
@@ -74,10 +74,10 @@ describe("IndicatorSections", () => {
 		);
 
 		expect(screen.getByText("Proportion")).toBeInTheDocument();
-		expect(screen.getAllByText("-")).toHaveLength(2);
+		expect(screen.getAllByText("- %")).toHaveLength(2);
 	});
 
-	it("renders '-' for the proportion when the workforce total is missing", () => {
+	it("renders '- %' for the proportion when the workforce total is missing", () => {
 		render(
 			<IndicatorSections
 				step2Data={emptyStep2Data()}
@@ -87,6 +87,6 @@ describe("IndicatorSections", () => {
 			/>,
 		);
 
-		expect(screen.getAllByText("-")).toHaveLength(2);
+		expect(screen.getAllByText("- %")).toHaveLength(2);
 	});
 });

--- a/packages/app/src/modules/declarationPdf/sections/__tests__/VariablePaySection.test.tsx
+++ b/packages/app/src/modules/declarationPdf/sections/__tests__/VariablePaySection.test.tsx
@@ -88,7 +88,7 @@ describe("VariablePaySection", () => {
 			/>,
 		);
 
-		expect(screen.getAllByText("-")).toHaveLength(2);
+		expect(screen.getAllByText("- %")).toHaveLength(2);
 	});
 
 	it("omits the proportion row when there are no beneficiary rows", () => {

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+	formatIsoDateToFrench,
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
@@ -11,6 +12,7 @@ import {
 	getWorkforceYear,
 	getWorkforceYearFor,
 	isDeadlinePassed,
+	resolveGipReferencePeriod,
 	shouldRedirectSubmittedToRecap,
 } from "../shared/campaign";
 
@@ -29,6 +31,41 @@ describe("getRepresentationDeadline", () => {
 describe("getReferencePeriod", () => {
 	it("returns the full civil year window", () => {
 		expect(getReferencePeriod(2025)).toBe("01/01/2025 - 31/12/2025");
+	});
+});
+
+describe("formatIsoDateToFrench", () => {
+	it("formats an ISO date as DD/MM/YYYY", () => {
+		expect(formatIsoDateToFrench("2026-01-01")).toBe("01/01/2026");
+		expect(formatIsoDateToFrench("2026-12-31")).toBe("31/12/2026");
+	});
+
+	it("returns the input unchanged when not a 3-part ISO date", () => {
+		expect(formatIsoDateToFrench("2026")).toBe("2026");
+		expect(formatIsoDateToFrench("")).toBe("");
+	});
+});
+
+describe("resolveGipReferencePeriod", () => {
+	it("uses the GIP collection window when both bounds are present", () => {
+		expect(resolveGipReferencePeriod("2026-01-01", "2026-12-31", 2026)).toBe(
+			"01/01/2026 - 31/12/2026",
+		);
+		expect(resolveGipReferencePeriod("2025-04-01", "2026-03-31", 2026)).toBe(
+			"01/04/2025 - 31/03/2026",
+		);
+	});
+
+	it("falls back to the full civil year when a bound is missing", () => {
+		expect(resolveGipReferencePeriod(null, "2026-12-31", 2026)).toBe(
+			"01/01/2026 - 31/12/2026",
+		);
+		expect(resolveGipReferencePeriod(undefined, "2026-12-31", 2026)).toBe(
+			"01/01/2026 - 31/12/2026",
+		);
+		expect(resolveGipReferencePeriod("2026-01-01", null, 2026)).toBe(
+			"01/01/2026 - 31/12/2026",
+		);
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/format.test.ts
+++ b/packages/app/src/modules/domain/__tests__/format.test.ts
@@ -17,8 +17,8 @@ describe("formatGap", () => {
 		expect(formatGap(5.3)).toBe("5,3 %");
 	});
 
-	it("returns dash for null", () => {
-		expect(formatGap(null)).toBe("-");
+	it("returns '- %' for null", () => {
+		expect(formatGap(null)).toBe("- %");
 	});
 });
 
@@ -37,8 +37,8 @@ describe("computeProportion", () => {
 		expect(computeProportion("25", 100)).toBe("25,0 %");
 	});
 
-	it("returns dash when total is zero", () => {
-		expect(computeProportion("10", 0)).toBe("-");
+	it("returns '- %' when total is zero", () => {
+		expect(computeProportion("10", 0)).toBe("- %");
 	});
 });
 
@@ -57,8 +57,8 @@ describe("computePercentage", () => {
 		expect(computePercentage(25, 100)).toBe("25,0 %");
 	});
 
-	it("returns dash when total is zero", () => {
-		expect(computePercentage(10, 0)).toBe("-");
+	it("returns '- %' when total is zero", () => {
+		expect(computePercentage(10, 0)).toBe("- %");
 	});
 });
 
@@ -67,8 +67,8 @@ describe("formatTotal", () => {
 		expect(formatTotal(1234.5, "€")).toMatch(/1[\s\u202f]234,5 €/);
 	});
 
-	it("returns dash for null", () => {
-		expect(formatTotal(null, "€")).toBe("-");
+	it("returns '- €' for null", () => {
+		expect(formatTotal(null, "€")).toBe("- €");
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -2,6 +2,7 @@
 
 // Campaign
 export {
+	formatIsoDateToFrench,
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
@@ -12,6 +13,7 @@ export {
 	getWorkforceYear,
 	getWorkforceYearFor,
 	isDeadlinePassed,
+	resolveGipReferencePeriod,
 	shouldRedirectSubmittedToRecap,
 } from "./shared/campaign";
 // Company obligation

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -2,7 +2,6 @@
 
 // Campaign
 export {
-	formatIsoDateToFrench,
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -25,6 +25,25 @@ export function getReferencePeriod(year: number): string {
 	return `01/01/${year} - 31/12/${year}`;
 }
 
+/** Formats an ISO date "YYYY-MM-DD" as "DD/MM/YYYY"; returns the input unchanged when it is not a 3-part ISO date. */
+export function formatIsoDateToFrench(isoDate: string): string {
+	const parts = isoDate.split("-");
+	if (parts.length !== 3) return isoDate;
+	return `${parts[2]}/${parts[1]}/${parts[0]}`;
+}
+
+/** Reference-period label under prefilled tables: the GIP collection window (periodStart to periodEnd) when both bounds exist, else the campaign civil year. Format "DD/MM/YYYY - DD/MM/YYYY". */
+export function resolveGipReferencePeriod(
+	periodStart: string | null | undefined,
+	periodEnd: string | null | undefined,
+	campaignYear: number,
+): string {
+	if (!periodStart || !periodEnd) {
+		return getReferencePeriod(campaignYear);
+	}
+	return `${formatIsoDateToFrench(periodStart)} - ${formatIsoDateToFrench(periodEnd)}`;
+}
+
 /** Returns the declaration modification deadline for a given year. */
 export function getDeclarationDeadline(year: number): string {
 	return `1\u1D49\u02B3 juin ${year}`;

--- a/packages/app/src/modules/domain/shared/format.ts
+++ b/packages/app/src/modules/domain/shared/format.ts
@@ -11,7 +11,7 @@
 
 /** Format a gap value with one decimal and a percent sign: `5.3` → `"5,3 %"`. */
 export function formatGap(gap: number | null): string {
-	if (gap === null) return "-";
+	if (gap === null) return "- %";
 	return `${gap.toFixed(1).replace(".", ",")} %`;
 }
 
@@ -24,7 +24,7 @@ export function formatGapCompact(gap: number | null): string {
 /** Compute count/total as a formatted percentage string. `count` is a raw string from form input. */
 export function computeProportion(count: string, total?: number): string {
 	const n = Number.parseInt(count, 10);
-	if (Number.isNaN(n) || !total || total === 0) return "-";
+	if (Number.isNaN(n) || !total || total === 0) return "- %";
 	return `${((n / total) * 100).toFixed(1).replace(".", ",")} %`;
 }
 
@@ -38,13 +38,13 @@ export function formatCurrency(value?: string | null): string {
 
 /** Compute count/total as a formatted percentage string. Both arguments are numbers. */
 export function computePercentage(count: number, total: number): string {
-	if (total === 0) return "-";
+	if (total === 0) return "- %";
 	return `${((count / total) * 100).toFixed(1).replace(".", ",")} %`;
 }
 
 /** Format a numeric total with an arbitrary unit suffix: `(1234.5, "€")` → `"1 234,5 €"`. */
 export function formatTotal(value: number | null, unit: string): string {
-	if (value === null) return "-";
+	if (value === null) return `- ${unit}`;
 	return `${value.toLocaleString("fr-FR", { minimumFractionDigits: 0, maximumFractionDigits: 2 })} ${unit}`;
 }
 


### PR DESCRIPTION
## Contexte

Refresh visuel des pages du parcours « Déclaration des indicateurs de rémunération » (#3861), aligné sur les maquettes Figma. **Aucune règle métier modifiée** (calculs, seuil 5 %, préremplissage GIP, brouillons, navigation inchangés). Préempli et saisie manuelle passent par les mêmes composants.

## Contenu de cette PR (5 des 6 phases)

- **Phase 1 — Ligne de source dynamique** : « Source : DSN (…), période de référence : {dates} », dates dérivées de la fenêtre de collecte GIP (`periodStart`/`periodEnd`, fallback année de campagne). Nouveaux helpers domain `resolveGipReferencePeriod` + `formatIsoDateToFrench` (testés). Câblé sur les 4 steps. La « période de référence pour le calcul » (Step 1) réutilise le même helper → fix d'une double période divergente à l'écran (détectée par l'audit structurel).
- **Phase 2 — Page 1 Effectifs** : bouton Retour supprimé (sortie assurée par le fil d'Ariane), largeurs de colonnes alignées Figma.
- **Phase 4 — Page 3 Écart variable** : titres visibles ajoutés aux 2 tableaux.
- **Phase 5 — Page 4 Quartiles** : titres de tableaux réduits (`fr-h5` → `fr-h6`, pattern « Titre de section » Figma). Les infobulles utilisent déjà le déclenchement au clic DSFR (`fr-btn--tooltip`). tooltipId distincts (fix id dupliqué relevé par l'audit RGAA).
- **Phase 6 — Page 5 Catégories** : tableau unique scindé en **3 tableaux distincts** (effectifs / rémunération annuelle / horaire), chacun avec titre + en-tête. Câblage react-hook-form (ids, aria-labels, handlers), totaux et GapBadge **préservés à l'identique**. La 2ᵉ déclaration (`SecondDeclarationStep2Form`, composant partagé) hérite de la scission sans régression.

## Qualité

- **564 tests** declaration-remuneration verts, typecheck propre, biome propre.
- Gates : audit **structurel** (1 bug de cohérence corrigé) + **RGAA** (changements jugés conformes). Dette RGAA **pré-existante** relevée et sortie en tickets séparés (`<fieldset disabled>` du verrouillage, `aria-required` manquant sur le funnel).

## Reste à faire (hors cette PR)

- **Page 4 — contenu des infobulles** : le texte est une note Figma (annotation non extractible via MCP) ; à fournir par le design pour remplacer le Lorem ipsum de fallback.
- **Page 2 (Écart de rémunération)** + **fidélité pixel-perfect des tableaux** (bordures / justification / marges fines sur toutes les pages) : à finaliser via le gate `design-validator` (rendu live vs Figma).
- **Page 6 (Récapitulatif)** : contrôle de conformité (aucune modification attendue).

> ⚠️ **Draft** — PR partielle ouverte pour revue / test des phases livrées. Voir #3861 pour le spec complet (`## Analyse architecte`).
