### PR TITLE
docs(claude): discipline de fidélité Figma (mesure, thème clair, états, tableaux, espaces verticaux)

### DIFF
--- a/.claude/rules/figma-workflow.md
+++ b/.claude/rules/figma-workflow.md
@@ -144,6 +144,13 @@ When a sentence contains mixed styles (e.g. *"écart de **4,5 %**"*), wrap the b
 
 Do not add elements (tooltips, icons, decorations) absent from the Figma design. Every element must have a corresponding Figma node.
 
+#### 10. Bordures, séparateurs, dimensions — mesurer, ne rien retirer
+
+- **Bordures & séparateurs** : chaque cellule / bloc que le Figma borde doit l'être dans le rendu. Un composant « tableau bordé » DSFR trace une bordure sur **chaque** cellule (grille complète) — vérifier cellule par cellule (`get_screenshot` + mesure du `background-image` / `border` dans le DOM), pas seulement l'aspect global.
+- **Ne jamais retirer / fusionner / « simplifier »** un élément que le node montre (bordure, séparateur, sous-cellule). Le point #9 interdit d'*ajouter* du fantôme ; celui-ci interdit l'**inverse** : *supprimer* du réel. Le node fait autorité, pas ton interprétation du layout — en cas de doute (« ces 2 sous-cellules ne forment-elles pas une colonne unique ? »), confirmer sur le node **avant** de retirer quoi que ce soit.
+- **Largeurs / tailles fixes** : lire la **largeur du node** (`get_metadata` → `width`) et la reproduire au ratio, jamais « à peu près égales » à l'œil. Deux colonnes que le Figma donne à 115px / 151px ne sont pas « 15 % / 15 % ».
+- **Règle générale — mesurer, pas comparer à l'œil** : pour toute propriété dimensionnelle (largeur, bordure, gap, taille), confronter la valeur **mesurée** du DOM (`getBoundingClientRect` / `getComputedStyle`) à celle du node. Même discipline que le gate `design-validator`, mais à appliquer **pendant la construction** et sur les **fixes UI ad-hoc hors pipeline** — ce qui « semble à peu près bon » à l'œil est exactement ce qui dérive.
+
 ---
 
 ## Per-screen verification method (mandatory)

--- a/.claude/rules/figma-workflow.md
+++ b/.claude/rules/figma-workflow.md
@@ -46,6 +46,7 @@ egapro est en **DSFR vanilla** (`@gouvfr/dsfr`, classes `fr-*` en markup, pas de
 
 - **Une URL = un node précis** (`?node-id=...`). Jamais une URL de fichier générique : `code-dev` doit aller direct au bon écran, sans deviner.
 - **Un frame / composant à la fois.** Un gros node explose le contexte : `get_metadata` d'abord pour cartographier, puis `get_design_context` sur les node-ids enfants pertinents.
+- **Frames archivées.** L'ancienne version d'un écran garde le **même nom** préfixé de `[ARCHIVE]` (posée à gauche de la nouvelle sur le canvas). Ne **jamais** implémenter ni mesurer depuis un frame `[ARCHIVE]` — toujours le node courant. En cas de doute sur lequel est courant, **demander le node-id à l'utilisateur** plutôt que deviner.
 
 ---
 
@@ -151,6 +152,19 @@ Do not add elements (tooltips, icons, decorations) absent from the Figma design.
 - **Largeurs / tailles fixes** : lire la **largeur du node** (`get_metadata` → `width`) et la reproduire au ratio, jamais « à peu près égales » à l'œil. Deux colonnes que le Figma donne à 115px / 151px ne sont pas « 15 % / 15 % ».
 - **Règle générale — mesurer, pas comparer à l'œil** : pour toute propriété dimensionnelle (largeur, bordure, gap, taille), confronter la valeur **mesurée** du DOM (`getBoundingClientRect` / `getComputedStyle`) à celle du node. Même discipline que le gate `design-validator`, mais à appliquer **pendant la construction** et sur les **fixes UI ad-hoc hors pipeline** — ce qui « semble à peu près bon » à l'œil est exactement ce qui dérive.
 
+#### 11. Tableaux — revue colonne par colonne
+
+Pour **chaque** tableau, vérifier explicitement :
+
+- **Alignement** de chaque valeur (gauche / droite) tel que le node le montre — pas seulement la première ligne.
+- **Nombre de lignes de chaque en-tête** : tout wrap ou débordement non prévu par le Figma = défaut (élargir la colonne ou ajuster). Un en-tête qui passe sur 3 lignes au lieu de 2 est bloquant.
+- **Largeur des colonnes** : lue sur le node (`get_metadata` → `width`), jamais « à peu près égales ».
+- **Texte exact des placeholders** quand une valeur n'est pas calculée : « - % », « - € » — **jamais** un « - » nu si le Figma affiche l'unité.
+
+#### 12. Tous les états (vide / partiel / rempli)
+
+Vérifier l'écran **vide**, **partiellement rempli** et **rempli**. Les placeholders de l'état vide comptent **autant** que les valeurs calculées — ne **jamais** vérifier uniquement avec `[DEV] Remplir`. Un « - % » manquant à vide est un défaut au même titre qu'une valeur fausse.
+
 ---
 
 ## Per-screen verification method (mandatory)
@@ -165,11 +179,23 @@ When comparing a Figma screen to existing code, **never** rely on a flat text ex
 
 This prevents missing structural elements (alert blocks, source lines, description paragraphs) that a flat text search would overlook.
 
+### Tableau de diff avant de coder, passe QA après
+
+**Avant de coder**, produire un **tableau de diff** — `élément | spec Figma | rendu actuel | écart` — couvrant **alignement, wrapping d'en-tête, espacement, largeurs, placeholders**. Flag chaque écart *avant* d'écrire la moindre ligne.
+
+**Après avoir codé**, refaire une **passe QA design élément par élément** et lister **toute** déviation, même minime : chacune est **bloquante** (pas de « c'est presque bon »). Idéalement, déléguer cette passe au gate indépendant `design-validator` (`rules/visual-quality-validation.md`).
+
 ---
 
 ## Phase 4 — Final verification
 
 L'implémentation pixel-perfect (Phases 1–3) repose sur la lecture de `get_design_context` + `get_variable_defs` (chaque propriété mappée à sa classe / token DSFR). Quand cette lecture a été faite proprement, la Phase 4 **ferme la boucle** : confirmer que le rendu réel correspond au plan, et produire les artefacts pour la review humaine.
+
+### 0. État de rendu contrôlé (obligatoire avant toute comparaison)
+
+- **Thème clair forcé.** Le site suit le thème du navigateur ; un rendu en sombre ne matche pas la maquette (claire) et fausse l'overlay onion-skin + la lecture des couleurs. Forcer le clair **avant toute comparaison** : `data-fr-scheme="light"` + `data-fr-theme="light"` sur `<html>`, ou le toggle DSFR « Paramètres d'affichage » en pied de page.
+- **Viewport connu, ≥2 largeurs.** Desktop **et** mobile — un `space-between` ou une marge qui collapse ne se voit qu'à certaines hauteurs (cf. `visual-quality-validation.md`).
+- **Pages derrière ProConnect.** Un écran authentifié ne rend pas sans session valide (sinon 500). Demander à l'utilisateur de se connecter, **ou** débloquer la session locale (seed DB — voir la mémoire `project_local_session_500_seed`). Sans session, aucune comparaison n'est possible.
 
 ### 1. Sanity check structurel
 

--- a/.claude/rules/visual-quality-validation.md
+++ b/.claude/rules/visual-quality-validation.md
@@ -23,10 +23,23 @@ Why a gate at all: a structural read of the Figma tree (`code-dev` step 7) verif
 
 Measurement is deterministic and pinpoints the fix; vision catches the long tail measurement can't enumerate. Neither alone is enough — run both.
 
+## Méthode — espaces verticaux (systématique, jamais à l'œil)
+
+L'écart vertical est l'erreur la plus fréquente et la plus invisible à l'œil. Pour chaque écran :
+
+1. **Depuis Figma** (`get_metadata` du frame) : extraire `y` + `hauteur` de **chaque** bloc de haut en bas (titre, « Étape X sur 6 », sous-titre, chaque paragraphe d'instruction, tableau, accordéon, callout, ligne de boutons…). Écart entre deux blocs consécutifs = `y_suivant − (y_courant + hauteur_courant)`.
+2. **Dans le rendu live** : mesurer les mêmes écarts via `getBoundingClientRect` (`bottom` du bloc N → `top` du bloc N+1), **marge-collapse incluse**.
+3. **Produire le tableau** : `entre A et B | écart Figma | écart live | Δ`. Tout **Δ au-delà du bruit sub-pixel (> ~2px) = bug bloquant** (viser ±1px).
+4. Faire la passe sur **tous les états** (vide / rempli), à **≥2 largeurs** (desktop + mobile), **thème clair forcé**.
+5. Vérifier en plus que les écarts **« snapent » sur l'échelle DSFR** (multiples de 0,25 rem = 4px) : un gap de 30px là où le Figma veut 32px (`2rem`) est un défaut, pas un arrondi.
+
 ## Render conditions (non-negotiable)
 
+- **Force light theme.** The site follows the browser theme; a dark-mode render never matches the (light) mock and throws off both the onion-skin overlay and colour reads. Force light **before any comparison**: `data-fr-scheme="light"` + `data-fr-theme="light"` on `<html>`, or the DSFR « Paramètres d'affichage » footer toggle.
 - **Always ≥2 viewport heights.** Spacing bugs frequently hide at the Figma frame height and only appear when content fills the panel (a `space-between` gap collapses to 0). Render e.g. `1280×1024` (frame) **and** `1280×760` (laptop) and compare the gap across both. A single render at the designed size is the #1 way these slip through.
+- **All states — empty / partial / filled.** Render each: the empty-state placeholders (« - % », « - € ») are validated exactly like computed values. Never judge only the `[DEV] Remplir` state — a missing placeholder when empty is a finding.
 - **Deterministic state.** Prefer an isolation harness (`/test-panel` → `PanelPlayground`) over the real route; if you must use the real route, freeze data (seeded fixture + `[DEV] Remplir`) so the diff is fidelity, not content drift.
+- **Authenticated pages.** A screen behind ProConnect won't render without a valid session (otherwise 500). Ask the user to log in, or unblock the local session (DB seed — memory `project_local_session_500_seed`).
 - **Match scale.** Browser `deviceScaleFactor: 2` ↔ `get_screenshot` at ~2× the node's natural size (`maxDimension` = 2 × its longer edge) so the overlay aligns.
 
 ## Tolerances

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -180,6 +180,14 @@ The `next-devtools` MCP provides runtime diagnostics directly from the Next.js d
 
 Before writing any DSFR HTML, use `get_component_doc` or `search_components` to verify the correct structure. Never guess DSFR classes from memory.
 
+### MCP figma — fidélité visuelle (mandatory)
+
+Depuis un design Figma : **mesurer, ne jamais comparer à l'œil.** Chaque dimension (largeur de colonne/cellule, bordure, gap, taille de police) se vérifie en confrontant la valeur **mesurée du DOM** (`getBoundingClientRect` / `getComputedStyle`) à celle du **node Figma** (`get_metadata` → `width`, `get_design_context` / `get_variable_defs` → tokens) — jamais sur le rendu global. Deux colonnes que le Figma donne à 115px / 151px ne sont pas « 15 % / 15 % ».
+
+**Ne jamais retirer, fusionner ou « simplifier »** un élément que le node montre (une bordure, un séparateur, une sous-cellule) sur une **interprétation** de l'intention : le node fait autorité, pas ta lecture du layout. En cas de doute (« ces deux sous-cellules ne forment-elles pas une colonne unique ? »), confirmer sur le node **avant** de retirer quoi que ce soit.
+
+Vaut aussi pour les **fixes UI ad-hoc hors pipeline**, pas seulement le gate `design-validator`. Discipline complète → `.claude/rules/figma-workflow.md`.
+
 ### Styling strategy (strict priority order)
 
 Inline `style={}` is **blocked by hook** — the edit will be rejected.

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -186,7 +186,9 @@ Depuis un design Figma : **mesurer, ne jamais comparer à l'œil.** Chaque dimen
 
 **Ne jamais retirer, fusionner ou « simplifier »** un élément que le node montre (une bordure, un séparateur, une sous-cellule) sur une **interprétation** de l'intention : le node fait autorité, pas ta lecture du layout. En cas de doute (« ces deux sous-cellules ne forment-elles pas une colonne unique ? »), confirmer sur le node **avant** de retirer quoi que ce soit.
 
-Vaut aussi pour les **fixes UI ad-hoc hors pipeline**, pas seulement le gate `design-validator`. Discipline complète → `.claude/rules/figma-workflow.md`.
+Avant toute comparaison : **forcer le thème clair** (`data-fr-scheme="light"` + `data-fr-theme="light"` sur `<html>`) et **tester tous les états** — vide / partiel / rempli, les placeholders « - % » / « - € » de l'état vide comptent autant que les valeurs. Les **espaces verticaux** se mesurent (`bottom(N) → top(N+1)` vs `y` / hauteur Figma), jamais à l'œil.
+
+Vaut aussi pour les **fixes UI ad-hoc hors pipeline**, pas seulement le gate `design-validator`. Discipline complète → `.claude/rules/figma-workflow.md` (construction) + `.claude/rules/visual-quality-validation.md` (vérification, espaces verticaux, états).
 
 ### Styling strategy (strict priority order)
 


### PR DESCRIPTION
## Contexte

Discipline tirée de la refonte design de la déclaration rémunération (#3861) — plusieurs ratés de fidélité qui **ne dérivent pas à l'œil** : bordures de cellules supprimées à tort sur une interprétation, colonnes dimensionnées « à peu près », espaces verticaux jugés visuellement, dark mode qui fausse les screenshots, états vides non vérifiés. Cette PR encode ces règles pour qu'elles soient respectées **par défaut**, y compris sur les fixes UI ad-hoc hors pipeline.

## Changements

**`packages/app/CLAUDE.md`** (toujours en contexte) — section « MCP figma — fidélité visuelle » : mesurer DOM vs node ; ne jamais retirer / fusionner ce que le node montre ; forcer le thème clair ; tester tous les états ; mesurer les espaces verticaux.

**`.claude/rules/figma-workflow.md`** (discipline de construction) :
- frames `[ARCHIVE]` à ignorer (toujours le node courant, demander en cas de doute)
- checklist **#10** (bordures / séparateurs / dimensions, ne rien retirer), **#11** (tableaux : alignement, wrapping d'en-tête, largeurs, placeholders exacts « - % » / « - € »), **#12** (états vide / partiel / rempli, pas seulement `[DEV] Remplir`)
- **tableau de diff avant de coder** + **passe QA élément-par-élément bloquante après**
- Phase 4 « état de rendu contrôlé » : thème clair forcé, ≥2 largeurs, pages ProConnect (login ou seed local)

**`.claude/rules/visual-quality-validation.md`** (gate `design-validator`) :
- **méthode systématique des espaces verticaux** (`y`+hauteur Figma → gaps live via `getBoundingClientRect` → `Δ > 2px` bloquant, snap sur l'échelle DSFR 0,25 rem)
- render conditions étendues : thème clair, tous les états, pages authentifiées

Docs uniquement (instructions agents) — aucun code applicatif touché.
