### PR TITLE
fix(declaration): #3929 — effectif GIP comme source unique pour l'affichage, le parcours et SUIT

### DIFF
--- a/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/etape/[step]/page.tsx
@@ -1,12 +1,19 @@
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import {
 	getEffectiveGipPrefillData,
+	INDICATOR_G_STEP,
 	STEP_TITLES,
 	StepPageClient,
+	stepHref,
 	TOTAL_STEPS,
 } from "~/modules/declaration-remuneration";
-import { isDeadlinePassed, isDeclarationSubmitted } from "~/modules/domain";
+import {
+	getObligationWorkforce,
+	isDeadlinePassed,
+	isDeclarationSubmitted,
+	isIndicatorGRequired,
+} from "~/modules/domain";
 import {
 	mapToEmployeeCategoryRows,
 	mapToStepData,
@@ -43,6 +50,15 @@ export default async function StepPage({ params }: StepPageProps) {
 	const data = await api.declaration.getOrCreate();
 	const d = data.declaration;
 	const company = await api.company.get({ siren: d.siren });
+
+	const indicatorGRequired = isIndicatorGRequired(
+		getObligationWorkforce(company.gipWorkforce),
+		d.year,
+	);
+
+	if (step === INDICATOR_G_STEP && !indicatorGRequired) {
+		redirect(stepHref(INDICATOR_G_STEP + 1));
+	}
 
 	const isSubmitted = isDeclarationSubmitted(d.status);
 	let modificationDeadline: Date | undefined;
@@ -97,7 +113,7 @@ export default async function StepPage({ params }: StepPageProps) {
 	return (
 		<HydrateClient>
 			<StepPageClient
-				companyWorkforce={company.workforce}
+				companyWorkforce={company.gipWorkforce}
 				declaration={d}
 				gipPrefillData={effectiveGipPrefillData ?? undefined}
 				hasCse={company.hasCse}

--- a/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
@@ -102,7 +102,7 @@ export default async function RecapitulatifRoute({ searchParams }: Props) {
 								siren: company.siren,
 								nafCode: company.nafCode,
 								address: company.address,
-								workforce: company.workforce,
+								gipWorkforce: company.gipWorkforce,
 							}}
 							declarantEmail={session.user.email ?? ""}
 							declarantName={session.user.name ?? ""}

--- a/packages/app/src/e2e/auth.setup.ts
+++ b/packages/app/src/e2e/auth.setup.ts
@@ -1,8 +1,13 @@
 import { test as setup } from "@playwright/test";
+import { resetGipWorkforce } from "./helpers/db";
 import { AUTH_FILE, loginWithProConnect } from "./helpers/login";
 
 setup("authenticate via ProConnect", async ({ page }) => {
 	setup.setTimeout(60_000);
 	await loginWithProConnect(page);
 	await page.context().storageState({ path: AUTH_FILE });
+
+	// Seeded here rather than in global-setup: app_gip_mds_data references app_company,
+	// and the company row only exists once the first ProConnect login has run.
+	await resetGipWorkforce();
 });

--- a/packages/app/src/e2e/constants.ts
+++ b/packages/app/src/e2e/constants.ts
@@ -2,3 +2,7 @@ import path from "node:path";
 
 export const AUTH_FILE = path.join(import.meta.dirname, ".auth/user.json");
 export const TEST_SIREN = "130025265";
+
+// GIP-MDS annual average workforce of the test company. Every size-based rule reads this value,
+// so the suite baseline is a >= 250 company: 6-step funnel (indicator G required) + CSE field.
+export const TEST_GIP_WORKFORCE = 250;

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -1,5 +1,11 @@
 import { expect, type Page, test } from "@playwright/test";
-import { resetDeclarationToDraft } from "./helpers/db";
+import {
+	getCurrentDbYear,
+	resetDeclarationToDraft,
+	resetGipWorkforce,
+	setGipWorkforce,
+} from "./helpers/db";
+import { submitStepsThroughQuartiles } from "./helpers/declaration-flows";
 
 // Render-structure assertions are covered by the step component tests in declaration-remuneration/**/__tests__.
 
@@ -247,5 +253,91 @@ test.describe("Declaration workflow", () => {
 			(url) => !url.pathname.includes("/declaration-remuneration/etape/"),
 			{ timeout: 15_000 },
 		);
+	});
+});
+
+// The suite baseline above is a >= 250 GIP company: 6 steps, CSE field, indicator G required.
+// Below, the same journeys are replayed for the two smaller GIP profiles of #3929/#3934.
+test.describe("Workforce comes from the GIP file, not the company registry", () => {
+	test.describe.configure({ mode: "serial" });
+
+	let currentYear: number;
+
+	test.beforeAll(async () => {
+		currentYear = await getCurrentDbYear();
+	});
+
+	test.afterAll(async () => {
+		await resetGipWorkforce();
+		await resetDeclarationToDraft();
+	});
+
+	test.describe("company absent from the GIP file", () => {
+		test.beforeAll(async () => {
+			await setGipWorkforce(null);
+			await resetDeclarationToDraft();
+		});
+
+		test('mon espace shows "< 50" and drops the CSE field and the edit button', async ({
+			page,
+		}) => {
+			await page.goto("/mon-espace");
+
+			const companyInfo = page
+				.locator("dl")
+				.filter({ hasText: "Effectif annuel moyen" })
+				.first();
+			await expect(companyInfo).toContainText(
+				`Effectif annuel moyen en ${currentYear} :`,
+			);
+			await expect(companyInfo).toContainText("< 50");
+			await expect(companyInfo).not.toContainText("Existence d'un CSE");
+			await expect(
+				page.getByRole("button", { exact: true, name: "Modifier" }),
+			).toHaveCount(0);
+		});
+
+		test("the funnel drops the indicator G step", async ({ page }) => {
+			await page.goto("/declaration-remuneration/etape/5");
+			await page.waitForURL("**/declaration-remuneration/etape/6");
+
+			await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+		});
+	});
+
+	test.describe("GIP workforce of 70 — below every indicator G threshold", () => {
+		test.beforeAll(async () => {
+			await setGipWorkforce(70);
+			await resetDeclarationToDraft();
+		});
+
+		test("banners display the GIP workforce and drop the CSE field", async ({
+			page,
+		}) => {
+			await page.goto("/mon-espace");
+
+			const companyInfo = page
+				.locator("dl")
+				.filter({ hasText: "Effectif annuel moyen" })
+				.first();
+			await expect(companyInfo).toContainText("70");
+			await expect(companyInfo).not.toContainText("Existence d'un CSE");
+
+			await page.goto("/declaration-remuneration/etape/1");
+			await expect(page.getByText("Étape 1 sur 5")).toBeVisible();
+			await expect(
+				page.getByText(`Effectif annuel moyen en ${currentYear - 1} :`),
+			).toBeVisible();
+			await expect(page.getByText("Existence d'un CSE :")).toHaveCount(0);
+		});
+
+		test("submitting the quartile step lands on the review step (S1 of #3934)", async ({
+			page,
+		}) => {
+			await submitStepsThroughQuartiles(page);
+
+			await page.waitForURL("**/declaration-remuneration/etape/6");
+			await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+		});
 	});
 });

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -1,5 +1,5 @@
 import postgres from "postgres";
-import { TEST_SIREN } from "../constants";
+import { TEST_GIP_WORKFORCE, TEST_SIREN } from "../constants";
 
 const DEFAULT_DB_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
 
@@ -143,6 +143,44 @@ export async function setCompanyHasCse(hasCse: boolean | null) {
 	} finally {
 		await sql.end();
 	}
+}
+
+/**
+ * Set the GIP-MDS annual average workforce of the test company for the current year.
+ *
+ * This is the single source of truth for every size-based rule (banner display, CSE
+ * field, indicator G / step 5 gating, SUIT export). Passing `null` deletes the row,
+ * which models a company absent from the GIP file — treated as "< 50", not subject.
+ */
+export async function setGipWorkforce(workforceEma: number | null) {
+	const sql = createConnection();
+	try {
+		if (workforceEma === null) {
+			await sql`
+				DELETE FROM app_gip_mds_data
+				WHERE siren = ${TEST_SIREN}
+				  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
+			`;
+			return;
+		}
+		await sql`
+			INSERT INTO app_gip_mds_data (siren, year, workforce_ema, imported_at)
+			VALUES (
+				${TEST_SIREN},
+				EXTRACT(YEAR FROM CURRENT_DATE)::int,
+				${workforceEma},
+				NOW()
+			)
+			ON CONFLICT (siren, year) DO UPDATE SET workforce_ema = EXCLUDED.workforce_ema
+		`;
+	} finally {
+		await sql.end();
+	}
+}
+
+/** Restore the suite baseline: the test company is a >= 250 GIP company. */
+export async function resetGipWorkforce() {
+	await setGipWorkforce(TEST_GIP_WORKFORCE);
 }
 
 export async function setCompanyWorkforce(workforce: number | null) {

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -83,13 +83,10 @@ export async function fillStep4Quartiles(
 }
 
 /**
- * Fill and submit a complete declaration through all 6 steps.
- * Controls whether the employee category data produces a pay gap ≥ 5%.
+ * Fill and submit steps 1 → 4, then click "Suivant" on the quartile step without
+ * asserting the destination: it is step 5 when indicator G applies, step 6 otherwise.
  */
-export async function completeDeclaration(
-	page: Page,
-	options: { hasGap: boolean },
-) {
+export async function submitStepsThroughQuartiles(page: Page) {
 	// Navigate to create/resume declaration → redirects to step 1
 	await page.goto("/declaration-remuneration");
 	await page.waitForURL("**/declaration-remuneration/etape/1");
@@ -115,6 +112,18 @@ export async function completeDeclaration(
 	// Step 4: Quartile distribution — fill 8 quartiles (4 annual + 4 hourly)
 	await fillStep4Quartiles(page);
 	await page.getByRole("button", { name: "Suivant" }).click();
+}
+
+/**
+ * Fill and submit a complete declaration through all 6 steps.
+ * Controls whether the employee category data produces a pay gap ≥ 5%.
+ * Requires a company subject to indicator G (step 5), i.e. the suite baseline workforce.
+ */
+export async function completeDeclaration(
+	page: Page,
+	options: { hasGap: boolean },
+) {
+	await submitStepsThroughQuartiles(page);
 	await page.waitForURL("**/declaration-remuneration/etape/5");
 
 	// Step 5: Employee categories — fill salary data to control gap

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -43,6 +43,7 @@ export const AUDIT_ACTIONS = {
 	JOINT_EVALUATION_UPLOAD_FILE: "joint_evaluation.upload_file",
 
 	// ── Company mutations ──────────────────────────────────
+	COMPANY_READ_GIP_DATA: "company.read_gip_data",
 	COMPANY_UPDATE_HAS_CSE: "company.update_has_cse",
 
 	// ── Profile mutations ──────────────────────────────────
@@ -164,6 +165,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 
 	[AUDIT_ACTIONS.JOINT_EVALUATION_UPLOAD_FILE]: "mutation",
 
+	[AUDIT_ACTIONS.COMPANY_READ_GIP_DATA]: "read_sensitive",
 	[AUDIT_ACTIONS.COMPANY_UPDATE_HAS_CSE]: "mutation",
 
 	[AUDIT_ACTIONS.PROFILE_UPDATE_PHONE]: "mutation",

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -2,7 +2,7 @@ import { DeclarationLockAlert } from "~/modules/declaration-remuneration/shared/
 import type { LockHolder } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import {
-	GIP_WORKFORCE_UNKNOWN_LABEL,
+	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getObligationWorkforce,
 	getWorkforceYear,
 	isCseRequired,
@@ -68,7 +68,7 @@ export function CseOpinionLayout({
 						<div className="fr-col-auto">
 							<p className="fr-mb-0 fr-text--sm">
 								{company.gipWorkforce === null ? (
-									GIP_WORKFORCE_UNKNOWN_LABEL
+									GIP_WORKFORCE_ABSENT_DISPLAY
 								) : (
 									<>
 										Effectif annuel moyen en {getWorkforceYear()} :{" "}

--- a/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
+++ b/packages/app/src/modules/cseOpinion/CseOpinionLayout.tsx
@@ -1,7 +1,13 @@
 import { DeclarationLockAlert } from "~/modules/declaration-remuneration/shared/lock/DeclarationLockAlert";
 import type { LockHolder } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
-import { getWorkforceYear } from "~/modules/domain";
+import {
+	GIP_WORKFORCE_UNKNOWN_LABEL,
+	getObligationWorkforce,
+	getWorkforceYear,
+	isCseRequired,
+	toDisplayWorkforce,
+} from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -10,7 +16,7 @@ import styles from "./CseOpinionLayout.module.scss";
 type CompanyData = {
 	name: string;
 	siren: string;
-	workforce: number | null;
+	gipWorkforce: number | null;
 	hasCse: boolean | null;
 };
 
@@ -29,6 +35,10 @@ export function CseOpinionLayout({
 	isReadOnly = false,
 	lockHolder = null,
 }: Props) {
+	const cseApplicable = isCseRequired(
+		getObligationWorkforce(company.gipWorkforce),
+	);
+
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className={`fr-py-3w ${styles.banner}`}>
@@ -55,26 +65,32 @@ export function CseOpinionLayout({
 								{company.name} - {formatSiren(company.siren)}
 							</p>
 						</div>
-						{company.workforce !== null && (
+						<div className="fr-col-auto">
+							<p className="fr-mb-0 fr-text--sm">
+								{company.gipWorkforce === null ? (
+									GIP_WORKFORCE_UNKNOWN_LABEL
+								) : (
+									<>
+										Effectif annuel moyen en {getWorkforceYear()} :{" "}
+										<strong>{toDisplayWorkforce(company.gipWorkforce)}</strong>
+									</>
+								)}
+							</p>
+						</div>
+						{cseApplicable && (
 							<div className="fr-col-auto">
 								<p className="fr-mb-0 fr-text--sm">
-									Effectif annuel moyen en {getWorkforceYear()} :{" "}
-									<strong>{company.workforce}</strong>
+									Existence d'un CSE :{" "}
+									<strong>
+										{company.hasCse === null
+											? "Non renseigné"
+											: company.hasCse
+												? "Oui"
+												: "Non"}
+									</strong>
 								</p>
 							</div>
 						)}
-						<div className="fr-col-auto">
-							<p className="fr-mb-0 fr-text--sm">
-								Existence d'un CSE :{" "}
-								<strong>
-									{company.hasCse === null
-										? "Non renseigné"
-										: company.hasCse
-											? "Oui"
-											: "Non"}
-								</strong>
-							</p>
-						</div>
 					</div>
 				</div>
 			</div>

--- a/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
-import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
+import { GIP_WORKFORCE_ABSENT_DISPLAY } from "~/modules/domain";
 import { CseOpinionLayout } from "../CseOpinionLayout";
 
 const company = {
@@ -144,7 +144,7 @@ describe("CseOpinionLayout", () => {
 			</CseOpinionLayout>,
 		);
 
-		expect(container.textContent).toContain(GIP_WORKFORCE_UNKNOWN_LABEL);
+		expect(container.textContent).toContain(GIP_WORKFORCE_ABSENT_DISPLAY);
 		expect(container.textContent).not.toContain("Existence d'un CSE :");
 	});
 

--- a/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/CseOpinionLayout.test.tsx
@@ -2,12 +2,13 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
+import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
 import { CseOpinionLayout } from "../CseOpinionLayout";
 
 const company = {
 	name: "Alpha Solutions",
 	siren: "123456789",
-	workforce: 256,
+	gipWorkforce: 256,
 	hasCse: true,
 };
 
@@ -133,16 +134,31 @@ describe("CseOpinionLayout", () => {
 		expect(screen.getByText("Non renseigné")).toBeInTheDocument();
 	});
 
-	it("omits the workforce line when the workforce is unknown", () => {
-		render(
+	it("shows the GIP unknown label and hides the CSE line when gipWorkforce is null", () => {
+		const { container } = render(
 			<CseOpinionLayout
-				company={{ ...company, workforce: null }}
+				company={{ ...company, gipWorkforce: null }}
 				declarationYear={2024}
 			>
 				<p>Step content</p>
 			</CseOpinionLayout>,
 		);
 
-		expect(screen.queryByText(/Effectif annuel moyen/)).not.toBeInTheDocument();
+		expect(container.textContent).toContain(GIP_WORKFORCE_UNKNOWN_LABEL);
+		expect(container.textContent).not.toContain("Existence d'un CSE :");
+	});
+
+	it("shows the workforce value and the CSE line when gipWorkforce is 250", () => {
+		const { container } = render(
+			<CseOpinionLayout
+				company={{ ...company, gipWorkforce: 250 }}
+				declarationYear={2024}
+			>
+				<p>Step content</p>
+			</CseOpinionLayout>,
+		);
+
+		expect(screen.getByText("250")).toBeInTheDocument();
+		expect(container.textContent).toContain("Existence d'un CSE :");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -8,7 +8,7 @@ type CompanyData = {
 	siren: string;
 	nafCode: string | null;
 	nafLabel: string | null;
-	workforce: number | null;
+	gipWorkforce: number | null;
 	hasCse: boolean | null;
 };
 

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -2,7 +2,12 @@
 
 import { useMemo } from "react";
 import { useFunnelTracking } from "~/modules/analytics";
-import { getCompanySizeRange, isDeclarationSubmitted } from "~/modules/domain";
+import {
+	getCompanySizeRange,
+	getObligationWorkforce,
+	isDeclarationSubmitted,
+	isIndicatorGRequired,
+} from "~/modules/domain";
 import {
 	DECLARATION_FUNNEL,
 	declarationFunnelDimensions,
@@ -34,10 +39,7 @@ type StepPageClientProps = {
 		totalMen: number | null;
 		status: string | null;
 	};
-	// Official GIP/DSN workforce on the company — the canonical source for every
-	// size-based decision. Used here only to bucket the Matomo funnel dimension,
-	// so analytics segments match the business logic (never the self-reported
-	// `totalWomen + totalMen`, which may differ or be empty early in the funnel).
+	// GIP-MDS annual average workforce; `null` = absent from the GIP file, i.e. not subject to the declaration.
 	companyWorkforce: number | null;
 	gipPrefillData?: GipPrefillData;
 	step1Data: Step1Data;
@@ -71,6 +73,11 @@ export function StepPageClient({
 			? getCompanySizeRange(companyWorkforce)
 			: undefined;
 
+	const indicatorGRequired = isIndicatorGRequired(
+		getObligationWorkforce(companyWorkforce),
+		declaration.year,
+	);
+
 	const dimensions = useMemo(
 		() => declarationFunnelDimensions(declaration.year, sizeRange),
 		[declaration.year, sizeRange],
@@ -85,6 +92,7 @@ export function StepPageClient({
 						declarationSiren={declaration.siren}
 						declarationYear={declaration.year}
 						gipPrefillData={gipPrefillData}
+						indicatorGRequired={indicatorGRequired}
 						initialData={step1Data}
 					/>
 				);
@@ -94,6 +102,7 @@ export function StepPageClient({
 						declarationSiren={declaration.siren}
 						declarationYear={declaration.year}
 						gipPrefillData={gipPrefillData}
+						indicatorGRequired={indicatorGRequired}
 						initialData={step2Data}
 					/>
 				);
@@ -103,6 +112,7 @@ export function StepPageClient({
 						declarationSiren={declaration.siren}
 						declarationYear={declaration.year}
 						gipPrefillData={gipPrefillData}
+						indicatorGRequired={indicatorGRequired}
 						initialData={step3Data}
 						maxMen={declaration.totalMen ?? undefined}
 						maxWomen={declaration.totalWomen ?? undefined}
@@ -114,6 +124,7 @@ export function StepPageClient({
 						declarationSiren={declaration.siren}
 						declarationYear={declaration.year}
 						gipPrefillData={gipPrefillData}
+						indicatorGRequired={indicatorGRequired}
 						initialData={step4Data}
 						maxMen={declaration.totalMen ?? undefined}
 						maxWomen={declaration.totalWomen ?? undefined}
@@ -124,6 +135,7 @@ export function StepPageClient({
 					<Step5EmployeeCategories
 						declarationSiren={declaration.siren}
 						declarationYear={declaration.year}
+						indicatorGRequired={indicatorGRequired}
 						initialCategories={step5Categories}
 						initialSource={initialSource}
 						maxMen={declaration.totalMen ?? undefined}
@@ -137,6 +149,7 @@ export function StepPageClient({
 						declaration={declaration}
 						declarationYear={declaration.year}
 						hasCse={hasCse}
+						indicatorGRequired={indicatorGRequired}
 						isSubmitted={isDeclarationSubmitted(declaration.status)}
 						step2Data={step2Data}
 						step3Data={step3Data}

--- a/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
@@ -9,7 +9,7 @@ const company = {
 	siren: "123456789",
 	nafCode: "62.01Z",
 	nafLabel: "Programmation informatique",
-	workforce: 256,
+	gipWorkforce: 256,
 	hasCse: true,
 };
 

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -25,6 +25,13 @@ export {
 	getDraftInput,
 	saveDraftInput,
 } from "./shared/draft/schemas";
+export {
+	getFunnelSteps,
+	getNextStepHref,
+	getPreviousStepHref,
+	INDICATOR_G_STEP,
+	stepHref,
+} from "./shared/funnelSteps";
 export { GAP_LEVEL_LABELS, gapBadgeClass } from "./shared/gapBadge";
 export type {
 	GipMdsRow,

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -1,4 +1,8 @@
 import Link from "next/link";
+import {
+	GIP_WORKFORCE_UNKNOWN_LABEL,
+	toDisplayWorkforce,
+} from "~/modules/domain";
 import common from "../shared/common.module.scss";
 import type {
 	EmployeeCategoryRow,
@@ -25,7 +29,7 @@ type CompanyInfo = {
 	siren: string;
 	nafCode: string | null;
 	address: string | null;
-	workforce: number | null;
+	gipWorkforce: number | null;
 };
 
 type Props = {
@@ -105,12 +109,12 @@ export function RecapitulatifPage({
 	if (company.nafCode) {
 		companyItems.push({ label: "Code NAF", value: company.nafCode });
 	}
-	if (company.workforce !== null) {
-		companyItems.push({
-			label: `Effectif annuel moyen en ${declarationYear}`,
-			value: String(company.workforce),
-		});
-	}
+	companyItems.push({
+		label: `Effectif annuel moyen en ${declarationYear}`,
+		value:
+			toDisplayWorkforce(company.gipWorkforce)?.toString() ??
+			GIP_WORKFORCE_UNKNOWN_LABEL,
+	});
 
 	const sourceLabel = step5Source
 		? (SOURCE_LABELS[step5Source] ?? step5Source)

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import {
-	GIP_WORKFORCE_UNKNOWN_LABEL,
+	GIP_WORKFORCE_ABSENT_DISPLAY,
 	toDisplayWorkforce,
 } from "~/modules/domain";
 import common from "../shared/common.module.scss";
@@ -113,7 +113,7 @@ export function RecapitulatifPage({
 		label: `Effectif annuel moyen en ${declarationYear}`,
 		value:
 			toDisplayWorkforce(company.gipWorkforce)?.toString() ??
-			GIP_WORKFORCE_UNKNOWN_LABEL,
+			GIP_WORKFORCE_ABSENT_DISPLAY,
 	});
 
 	const sourceLabel = step5Source

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
 import { RecapitulatifPage } from "../RecapitulatifPage";
 import {
 	defaultCompany,
@@ -90,12 +91,13 @@ describe("RecapitulatifPage", () => {
 		expect(screen.getByText("1 rue de Paris, 75001 Paris")).toBeInTheDocument();
 		expect(screen.getByText("Code NAF")).toBeInTheDocument();
 		expect(screen.getByText("6201Z")).toBeInTheDocument();
-		expect(
-			screen.getByText("Effectif annuel moyen en 2025"),
-		).toBeInTheDocument();
-		// "250" appears both as company.workforce and as 120 + 130 total in the
-		// workforce table — both are expected.
-		expect(screen.getAllByText("250").length).toBeGreaterThanOrEqual(1);
+		const workforceLabel = screen.getByText("Effectif annuel moyen en 2025");
+		expect(workforceLabel).toBeInTheDocument();
+		// "250" also appears as the 120 + 130 total of the workforce table, so the
+		// company value is read from the row that carries the label.
+		expect(workforceLabel.parentElement).toHaveTextContent(
+			"Effectif annuel moyen en 2025250",
+		);
 	});
 
 	it("renders 'Informations calcul' with single-line reference period", () => {
@@ -376,16 +378,30 @@ describe("RecapitulatifPage", () => {
 		expect(screen.getByText("source-inconnue")).toBeInTheDocument();
 	});
 
-	it("hides Effectif annuel moyen when company.workforce is null", () => {
+	it("shows 'Effectif non connu du GIP' when company.gipWorkforce is null", () => {
 		render(
 			<RecapitulatifPage
 				{...defaultProps()}
-				company={{ ...defaultCompany(), workforce: null }}
+				company={{ ...defaultCompany(), gipWorkforce: null }}
 			/>,
 		);
 		expect(
-			screen.queryByText(/Effectif annuel moyen en/),
-		).not.toBeInTheDocument();
+			screen.getByText("Effectif annuel moyen en 2025"),
+		).toBeInTheDocument();
+		expect(screen.getByText(GIP_WORKFORCE_UNKNOWN_LABEL)).toBeInTheDocument();
+	});
+
+	it("floors a decimal company.gipWorkforce for display", () => {
+		render(
+			<RecapitulatifPage
+				{...defaultProps()}
+				company={{ ...defaultCompany(), gipWorkforce: 99.97 }}
+			/>,
+		);
+		expect(
+			screen.getByText("Effectif annuel moyen en 2025"),
+		).toBeInTheDocument();
+		expect(screen.getByText("99")).toBeInTheDocument();
 	});
 
 	it("flags 'élevé' badge on high gaps (>= 5%)", () => {

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
+import { GIP_WORKFORCE_ABSENT_DISPLAY } from "~/modules/domain";
 import { RecapitulatifPage } from "../RecapitulatifPage";
 import {
 	defaultCompany,
@@ -378,7 +378,7 @@ describe("RecapitulatifPage", () => {
 		expect(screen.getByText("source-inconnue")).toBeInTheDocument();
 	});
 
-	it("shows 'Effectif non connu du GIP' when company.gipWorkforce is null", () => {
+	it("shows '< 50' when company.gipWorkforce is null", () => {
 		render(
 			<RecapitulatifPage
 				{...defaultProps()}
@@ -388,7 +388,7 @@ describe("RecapitulatifPage", () => {
 		expect(
 			screen.getByText("Effectif annuel moyen en 2025"),
 		).toBeInTheDocument();
-		expect(screen.getByText(GIP_WORKFORCE_UNKNOWN_LABEL)).toBeInTheDocument();
+		expect(screen.getByText(GIP_WORKFORCE_ABSENT_DISPLAY)).toBeInTheDocument();
 	});
 
 	it("floors a decimal company.gipWorkforce for display", () => {

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/fixtures.ts
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/fixtures.ts
@@ -24,7 +24,7 @@ export const defaultCompany = () => ({
 	siren: "123456789",
 	nafCode: "6201Z",
 	address: "1 rue de Paris, 75001 Paris",
-	workforce: 250,
+	gipWorkforce: 250,
 });
 
 export const emptyStep2Data = () => ({

--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
@@ -1,5 +1,5 @@
 import {
-	GIP_WORKFORCE_UNKNOWN_LABEL,
+	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getObligationWorkforce,
 	getWorkforceYear,
 	isCseRequired,
@@ -62,7 +62,7 @@ export function CompanyBanner({
 
 					<div className={styles.datapoint}>
 						{company.gipWorkforce === null ? (
-							<span>{GIP_WORKFORCE_UNKNOWN_LABEL}</span>
+							<span>{GIP_WORKFORCE_ABSENT_DISPLAY}</span>
 						) : (
 							<>
 								<span>

--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
@@ -1,4 +1,10 @@
-import { getWorkforceYear } from "~/modules/domain";
+import {
+	GIP_WORKFORCE_UNKNOWN_LABEL,
+	getObligationWorkforce,
+	getWorkforceYear,
+	isCseRequired,
+	toDisplayWorkforce,
+} from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { formatSiren } from "~/modules/my-space";
 
@@ -10,7 +16,7 @@ type CompanyBannerProps = {
 		siren: string;
 		nafCode: string | null;
 		nafLabel: string | null;
-		workforce: number | null;
+		gipWorkforce: number | null;
 		hasCse: boolean | null;
 	};
 	currentPageLabel: string;
@@ -20,6 +26,10 @@ export function CompanyBanner({
 	company,
 	currentPageLabel,
 }: CompanyBannerProps) {
+	const cseApplicable = isCseRequired(
+		getObligationWorkforce(company.gipWorkforce),
+	);
+
 	return (
 		<div className={`fr-py-3w ${styles.banner}`}>
 			<div className="fr-container">
@@ -50,25 +60,31 @@ export function CompanyBanner({
 						</div>
 					)}
 
-					{company.workforce !== null && (
+					<div className={styles.datapoint}>
+						{company.gipWorkforce === null ? (
+							<span>{GIP_WORKFORCE_UNKNOWN_LABEL}</span>
+						) : (
+							<>
+								<span>
+									{"Effectif annuel moyen en"} {getWorkforceYear()} {":"}
+								</span>
+								<strong>{toDisplayWorkforce(company.gipWorkforce)}</strong>
+							</>
+						)}
+					</div>
+
+					{cseApplicable && (
 						<div className={styles.datapoint}>
-							<span>
-								{"Effectif annuel moyen en"} {getWorkforceYear()} {":"}
-							</span>
-							<strong>{company.workforce}</strong>
+							<span>{"Existence d'un CSE :"}</span>
+							<strong>
+								{company.hasCse === null
+									? "Non renseigné"
+									: company.hasCse
+										? "Oui"
+										: "Non"}
+							</strong>
 						</div>
 					)}
-
-					<div className={styles.datapoint}>
-						<span>{"Existence d'un CSE :"}</span>
-						<strong>
-							{company.hasCse === null
-								? "Non renseigné"
-								: company.hasCse
-									? "Oui"
-									: "Non"}
-						</strong>
-					</div>
 				</div>
 			</div>
 		</div>

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -6,6 +6,7 @@ import styles from "./NextStepsBox.module.scss";
 import { UpdateCseModal } from "./UpdateCseModal";
 
 type Props = {
+	cseApplicable: boolean;
 	hasGapsAboveThreshold: boolean;
 	siren: string;
 	isSecondDeclaration?: boolean;
@@ -13,6 +14,7 @@ type Props = {
 
 /** Shared "Prochaines étapes" box with CSE consultation info and gap warnings */
 export function NextStepsBox({
+	cseApplicable,
 	hasGapsAboveThreshold,
 	siren,
 	isSecondDeclaration,
@@ -49,14 +51,16 @@ export function NextStepsBox({
 						>
 							Voir les modèles d&apos;avis CSE
 						</TrackedLink>
-						<button
-							aria-controls="update-cse-modal"
-							className="fr-btn fr-btn--secondary"
-							data-fr-opened="false"
-							type="button"
-						>
-							Mettre à jour l&apos;existence d&apos;un CSE
-						</button>
+						{cseApplicable && (
+							<button
+								aria-controls="update-cse-modal"
+								className="fr-btn fr-btn--secondary"
+								data-fr-opened="false"
+								type="button"
+							>
+								Mettre à jour l&apos;existence d&apos;un CSE
+							</button>
+						)}
 					</div>
 				</div>
 
@@ -160,7 +164,7 @@ export function NextStepsBox({
 				</div>
 			</div>
 
-			<UpdateCseModal siren={siren} />
+			{cseApplicable && <UpdateCseModal siren={siren} />}
 		</>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepIndicator.tsx
@@ -1,27 +1,35 @@
-import { STEP_TITLES, TOTAL_STEPS } from "../types";
+import { STEP_TITLES } from "../types";
+import { getFunnelSteps } from "./funnelSteps";
 import styles from "./StepIndicator.module.scss";
 
 type StepIndicatorProps = {
 	currentStep: number;
+	indicatorGRequired: boolean;
 };
 
-export function StepIndicator({ currentStep }: StepIndicatorProps) {
+export function StepIndicator({
+	currentStep,
+	indicatorGRequired,
+}: StepIndicatorProps) {
+	const steps = getFunnelSteps(indicatorGRequired);
+	const position = steps.indexOf(currentStep) + 1;
+	const nextStep = steps[position];
+
 	const title = STEP_TITLES[currentStep] ?? "";
-	const nextTitle =
-		currentStep < TOTAL_STEPS ? STEP_TITLES[currentStep + 1] : undefined;
+	const nextTitle = nextStep === undefined ? undefined : STEP_TITLES[nextStep];
 
 	return (
 		<div className={`fr-stepper ${styles.stepper}`}>
 			<h2 className="fr-stepper__title">
 				{title}
 				<span className="fr-stepper__state">
-					Étape {currentStep} sur {TOTAL_STEPS}
+					Étape {position} sur {steps.length}
 				</span>
 			</h2>
 			<div
 				className="fr-stepper__steps"
-				data-fr-current-step={currentStep}
-				data-fr-steps={TOTAL_STEPS}
+				data-fr-current-step={position}
+				data-fr-steps={steps.length}
 			/>
 			{nextTitle && (
 				<p className="fr-stepper__details">

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
 import { CompanyBanner } from "../CompanyBanner";
 
 const defaultCompany = {
@@ -8,7 +9,7 @@ const defaultCompany = {
 	siren: "123456789",
 	nafCode: "62.01Z",
 	nafLabel: "Programmation informatique",
-	workforce: 256,
+	gipWorkforce: 256,
 	hasCse: true,
 };
 
@@ -94,15 +95,44 @@ describe("CompanyBanner", () => {
 		expect(screen.getByText("Oui")).toBeInTheDocument();
 	});
 
-	it("hides workforce when null", () => {
+	it("shows 'Effectif non connu du GIP' and hides the CSE datapoint when gipWorkforce is null", () => {
 		render(
 			<CompanyBanner
-				company={{ ...defaultCompany, workforce: null }}
+				company={{ ...defaultCompany, gipWorkforce: null }}
 				currentPageLabel="Déclaration"
 			/>,
 		);
 
-		expect(screen.queryByText(/Effectif annuel/)).not.toBeInTheDocument();
+		expect(screen.getByText(GIP_WORKFORCE_UNKNOWN_LABEL)).toBeInTheDocument();
+		expect(
+			screen.queryByText(/Effectif annuel moyen en/),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText("Existence d'un CSE :")).not.toBeInTheDocument();
+	});
+
+	it("floors a decimal gipWorkforce and hides the CSE datapoint below 100", () => {
+		render(
+			<CompanyBanner
+				company={{ ...defaultCompany, gipWorkforce: 99.97 }}
+				currentPageLabel="Déclaration"
+			/>,
+		);
+
+		expect(screen.getByText("99")).toBeInTheDocument();
+		expect(screen.queryByText("100")).not.toBeInTheDocument();
+		expect(screen.queryByText("Existence d'un CSE :")).not.toBeInTheDocument();
+	});
+
+	it("shows the CSE datapoint when gipWorkforce is exactly 250", () => {
+		render(
+			<CompanyBanner
+				company={{ ...defaultCompany, gipWorkforce: 250 }}
+				currentPageLabel="Déclaration"
+			/>,
+		);
+
+		expect(screen.getByText("250")).toBeInTheDocument();
+		expect(screen.getByText("Existence d'un CSE :")).toBeInTheDocument();
 	});
 
 	it("shows 'Non renseigné' when hasCse is null", () => {

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
+import { GIP_WORKFORCE_ABSENT_DISPLAY } from "~/modules/domain";
 import { CompanyBanner } from "../CompanyBanner";
 
 const defaultCompany = {
@@ -95,7 +95,7 @@ describe("CompanyBanner", () => {
 		expect(screen.getByText("Oui")).toBeInTheDocument();
 	});
 
-	it("shows 'Effectif non connu du GIP' and hides the CSE datapoint when gipWorkforce is null", () => {
+	it("shows '< 50' and hides the CSE datapoint when gipWorkforce is null", () => {
 		render(
 			<CompanyBanner
 				company={{ ...defaultCompany, gipWorkforce: null }}
@@ -103,7 +103,7 @@ describe("CompanyBanner", () => {
 			/>,
 		);
 
-		expect(screen.getByText(GIP_WORKFORCE_UNKNOWN_LABEL)).toBeInTheDocument();
+		expect(screen.getByText(GIP_WORKFORCE_ABSENT_DISPLAY)).toBeInTheDocument();
 		expect(
 			screen.queryByText(/Effectif annuel moyen en/),
 		).not.toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/StepIndicator.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/StepIndicator.test.tsx
@@ -5,19 +5,19 @@ import { StepIndicator } from "../StepIndicator";
 
 describe("StepIndicator", () => {
 	it("renders current step title", () => {
-		render(<StepIndicator currentStep={2} />);
+		render(<StepIndicator currentStep={2} indicatorGRequired />);
 
 		expect(screen.getByText("Écart de rémunération")).toBeInTheDocument();
 	});
 
 	it("renders 'Étape X sur 6' text", () => {
-		render(<StepIndicator currentStep={3} />);
+		render(<StepIndicator currentStep={3} indicatorGRequired />);
 
 		expect(screen.getByText("Étape 3 sur 6")).toBeInTheDocument();
 	});
 
 	it("renders next step title when not on last step", () => {
-		render(<StepIndicator currentStep={2} />);
+		render(<StepIndicator currentStep={2} indicatorGRequired />);
 
 		expect(
 			screen.getByText("Écart de rémunération variable ou complémentaire"),
@@ -25,8 +25,39 @@ describe("StepIndicator", () => {
 	});
 
 	it("does not render next step on last step", () => {
-		render(<StepIndicator currentStep={6} />);
+		render(<StepIndicator currentStep={6} indicatorGRequired />);
 
 		expect(screen.queryByText(/Étape suivante/)).not.toBeInTheDocument();
+	});
+
+	it("shows 'Étape 4 sur 6' and announces step 5 as next when indicatorGRequired is true", () => {
+		const { container } = render(
+			<StepIndicator currentStep={4} indicatorGRequired />,
+		);
+
+		expect(screen.getByText("Étape 4 sur 6")).toBeInTheDocument();
+		expect(
+			screen.getByText("Écart de rémunération par catégories de salariés"),
+		).toBeInTheDocument();
+		const steps = container.querySelector(".fr-stepper__steps");
+		expect(steps).toHaveAttribute("data-fr-current-step", "4");
+		expect(steps).toHaveAttribute("data-fr-steps", "6");
+	});
+
+	it("shows 'Étape 4 sur 5' and skips to step 6 as next when indicatorGRequired is false", () => {
+		const { container } = render(
+			<StepIndicator currentStep={4} indicatorGRequired={false} />,
+		);
+
+		expect(screen.getByText("Étape 4 sur 5")).toBeInTheDocument();
+		expect(
+			screen.getByText("Récapitulatif de votre déclaration"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Écart de rémunération par catégories de salariés"),
+		).not.toBeInTheDocument();
+		const steps = container.querySelector(".fr-stepper__steps");
+		expect(steps).toHaveAttribute("data-fr-current-step", "4");
+		expect(steps).toHaveAttribute("data-fr-steps", "5");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/funnelSteps.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/funnelSteps.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { TOTAL_STEPS } from "~/modules/declaration-remuneration";
+import {
+	getFunnelSteps,
+	getNextStepHref,
+	getPreviousStepHref,
+	INDICATOR_G_STEP,
+	stepHref,
+} from "../funnelSteps";
+
+describe("stepHref", () => {
+	it("builds the funnel step URL", () => {
+		expect(stepHref(1)).toBe("/declaration-remuneration/etape/1");
+		expect(stepHref(INDICATOR_G_STEP)).toBe(
+			"/declaration-remuneration/etape/5",
+		);
+	});
+});
+
+describe("getFunnelSteps", () => {
+	it("keeps every step when indicator G is required", () => {
+		expect(getFunnelSteps(true)).toEqual([1, 2, 3, 4, 5, 6]);
+		expect(getFunnelSteps(true)).toHaveLength(TOTAL_STEPS);
+	});
+
+	it("drops the indicator G step when it is not required", () => {
+		expect(getFunnelSteps(false)).toEqual([1, 2, 3, 4, 6]);
+		expect(getFunnelSteps(false)).not.toContain(INDICATOR_G_STEP);
+	});
+});
+
+describe("getNextStepHref", () => {
+	it("walks the full funnel when indicator G is required", () => {
+		expect(getNextStepHref(1, true)).toBe("/declaration-remuneration/etape/2");
+		expect(getNextStepHref(4, true)).toBe("/declaration-remuneration/etape/5");
+		expect(getNextStepHref(5, true)).toBe("/declaration-remuneration/etape/6");
+	});
+
+	it("skips from step 4 to step 6 when indicator G is not required", () => {
+		expect(getNextStepHref(4, false)).toBe("/declaration-remuneration/etape/6");
+	});
+
+	it("returns undefined on the last step", () => {
+		expect(getNextStepHref(6, true)).toBeUndefined();
+		expect(getNextStepHref(6, false)).toBeUndefined();
+	});
+});
+
+describe("getPreviousStepHref", () => {
+	it("walks the full funnel backwards when indicator G is required", () => {
+		expect(getPreviousStepHref(6, true)).toBe(
+			"/declaration-remuneration/etape/5",
+		);
+		expect(getPreviousStepHref(2, true)).toBe(
+			"/declaration-remuneration/etape/1",
+		);
+	});
+
+	it("goes back from step 6 to step 4 when indicator G is not required", () => {
+		expect(getPreviousStepHref(6, false)).toBe(
+			"/declaration-remuneration/etape/4",
+		);
+	});
+
+	it("returns undefined on the first step", () => {
+		expect(getPreviousStepHref(1, true)).toBeUndefined();
+		expect(getPreviousStepHref(1, false)).toBeUndefined();
+	});
+
+	it("returns undefined for a step that is not part of the funnel", () => {
+		expect(getPreviousStepHref(5, false)).toBeUndefined();
+		expect(getPreviousStepHref(99, true)).toBeUndefined();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/funnelSteps.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/funnelSteps.ts
@@ -1,0 +1,32 @@
+export const INDICATOR_G_STEP = 5;
+
+const ALL_STEPS = [1, 2, 3, 4, 5, 6] as const;
+
+export function stepHref(step: number): string {
+	return `/declaration-remuneration/etape/${step}`;
+}
+
+export function getFunnelSteps(indicatorGRequired: boolean): number[] {
+	return indicatorGRequired
+		? [...ALL_STEPS]
+		: ALL_STEPS.filter((step) => step !== INDICATOR_G_STEP);
+}
+
+export function getNextStepHref(
+	currentStep: number,
+	indicatorGRequired: boolean,
+): string | undefined {
+	const steps = getFunnelSteps(indicatorGRequired);
+	const next = steps[steps.indexOf(currentStep) + 1];
+	return next === undefined ? undefined : stepHref(next);
+}
+
+export function getPreviousStepHref(
+	currentStep: number,
+	indicatorGRequired: boolean,
+): string | undefined {
+	const steps = getFunnelSteps(indicatorGRequired);
+	const index = steps.indexOf(currentStep);
+	const previous = index <= 0 ? undefined : steps[index - 1];
+	return previous === undefined ? undefined : stepHref(previous);
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/funnelSteps.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/funnelSteps.ts
@@ -17,7 +17,8 @@ export function getNextStepHref(
 	indicatorGRequired: boolean,
 ): string | undefined {
 	const steps = getFunnelSteps(indicatorGRequired);
-	const next = steps[steps.indexOf(currentStep) + 1];
+	const index = steps.indexOf(currentStep);
+	const next = index < 0 ? undefined : steps[index + 1];
 	return next === undefined ? undefined : stepHref(next);
 }
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -35,6 +35,7 @@ import { Step1WorkforceDefinition } from "./Step1WorkforceDefinition";
 type Step1WorkforceProps = {
 	declarationSiren: string;
 	declarationYear: number;
+	indicatorGRequired: boolean;
 	initialData: Step1Data;
 	gipPrefillData?: GipPrefillData;
 };
@@ -42,6 +43,7 @@ type Step1WorkforceProps = {
 export function Step1Workforce({
 	declarationSiren,
 	declarationYear,
+	indicatorGRequired,
 	initialData,
 	gipPrefillData,
 }: Step1WorkforceProps) {
@@ -226,7 +228,10 @@ export function Step1Workforce({
 						}
 					/>
 
-					<StepIndicator currentStep={1} />
+					<StepIndicator
+						currentStep={1}
+						indicatorGRequired={indicatorGRequired}
+					/>
 
 					<div className={common.flexColumnGap1}>
 						<p className="fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step2PayGap.tsx
@@ -32,6 +32,7 @@ import type { PayGapField, Step2Data } from "../types";
 type Step2PayGapProps = {
 	declarationSiren: string;
 	declarationYear: number;
+	indicatorGRequired: boolean;
 	initialData: Step2Data;
 	gipPrefillData?: GipPrefillData;
 };
@@ -39,6 +40,7 @@ type Step2PayGapProps = {
 export function Step2PayGap({
 	declarationSiren,
 	declarationYear,
+	indicatorGRequired,
 	initialData,
 	gipPrefillData,
 }: Step2PayGapProps) {
@@ -161,7 +163,10 @@ export function Step2PayGap({
 					}
 				/>
 
-				<StepIndicator currentStep={2} />
+				<StepIndicator
+					currentStep={2}
+					indicatorGRequired={indicatorGRequired}
+				/>
 
 				<div className={common.flexColumnGap1}>
 					<p className="fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step3VariablePay.tsx
@@ -40,6 +40,7 @@ import stepStyles from "./Step3VariablePay.module.scss";
 type Step3VariablePayProps = {
 	declarationSiren: string;
 	declarationYear: number;
+	indicatorGRequired: boolean;
 	initialData: Step3Data;
 	gipPrefillData?: GipPrefillData;
 	maxWomen?: number;
@@ -59,6 +60,7 @@ function padStep3(data: Step3Data): Step3Data {
 export function Step3VariablePay({
 	declarationSiren,
 	declarationYear,
+	indicatorGRequired,
 	initialData,
 	gipPrefillData,
 	maxWomen,
@@ -208,7 +210,10 @@ export function Step3VariablePay({
 					}
 				/>
 
-				<StepIndicator currentStep={3} />
+				<StepIndicator
+					currentStep={3}
+					indicatorGRequired={indicatorGRequired}
+				/>
 
 				<div className={common.flexColumnGap1}>
 					<p className="fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step4QuartileDistribution.tsx
@@ -16,6 +16,7 @@ import { useDraftAutoSave } from "../shared/draft/useDraftAutoSave";
 import { useDraftHydration } from "../shared/draft/useDraftHydration";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
+import { getNextStepHref } from "../shared/funnelSteps";
 import type { GipPrefillData } from "../shared/gipMdsMapping";
 import { useLockContext } from "../shared/lock/LockContext";
 import { PrefillSource } from "../shared/PrefillSource";
@@ -52,6 +53,7 @@ function padThresholds(qs: QuartileTuple): QuartileTuple {
 type Step4QuartileDistributionProps = {
 	declarationSiren: string;
 	declarationYear: number;
+	indicatorGRequired: boolean;
 	initialData: Step4Data;
 	gipPrefillData?: GipPrefillData;
 	maxWomen?: number;
@@ -61,6 +63,7 @@ type Step4QuartileDistributionProps = {
 export function Step4QuartileDistribution({
 	declarationSiren,
 	declarationYear,
+	indicatorGRequired,
 	initialData,
 	gipPrefillData,
 	maxWomen,
@@ -150,10 +153,12 @@ export function Step4QuartileDistribution({
 	const [fieldErrors, setFieldErrors] = useState<FieldErrorMap>(emptyErrorMap);
 	const [showRecap, setShowRecap] = useState(false);
 
+	const nextHref = getNextStepHref(4, indicatorGRequired);
+
 	const mutation = api.declaration.updateStep4.useMutation({
 		onSuccess: () => {
 			clearDraft();
-			router.push("/declaration-remuneration/etape/5");
+			if (nextHref) router.push(nextHref);
 		},
 	});
 
@@ -294,7 +299,10 @@ export function Step4QuartileDistribution({
 					}
 				/>
 
-				<StepIndicator currentStep={4} />
+				<StepIndicator
+					currentStep={4}
+					indicatorGRequired={indicatorGRequired}
+				/>
 
 				<div className={stepStyles.instructions}>
 					<p className="fr-mb-0">
@@ -435,9 +443,7 @@ export function Step4QuartileDistribution({
 
 				<FormActions
 					isSubmitting={mutation.isPending}
-					mimoquageNextHref={
-						hasSavedData ? "/declaration-remuneration/etape/5" : undefined
-					}
+					mimoquageNextHref={hasSavedData ? nextHref : undefined}
 					previousHref="/declaration-remuneration/etape/3"
 				/>
 			</fieldset>

--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -33,6 +33,7 @@ type Step5FormValues = {
 type Props = {
 	declarationSiren: string;
 	declarationYear: number;
+	indicatorGRequired: boolean;
 	initialCategories?: EmployeeCategoryRow[];
 	initialSource?: string;
 	maxWomen?: number;
@@ -42,6 +43,7 @@ type Props = {
 export function Step5EmployeeCategories({
 	declarationSiren,
 	declarationYear,
+	indicatorGRequired,
 	initialCategories,
 	initialSource,
 	maxWomen,
@@ -133,7 +135,12 @@ export function Step5EmployeeCategories({
 			onValuesChange={(values) => setField(values)}
 			previousHref="/declaration-remuneration/etape/4"
 			referenceYear={declarationYear - 1}
-			stepper={<StepIndicator currentStep={5} />}
+			stepper={
+				<StepIndicator
+					currentStep={5}
+					indicatorGRequired={indicatorGRequired}
+				/>
+			}
 			submitError={mutation.error?.message}
 			title={
 				<h1 className="fr-h4 fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -7,7 +7,7 @@ import {
 	computeGap,
 	getCompanySizeRange,
 	getObligationWorkforce,
-	hasHighGap,
+	isComplianceProcessRequired,
 	isCseRequired,
 } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
@@ -32,7 +32,6 @@ import type {
 } from "../types";
 import stepStyles from "./Step6Review.module.scss";
 import { IndicatorSections } from "./step6/IndicatorSections";
-import { parseEmployeeCategories } from "./step6/parseStep5Categories";
 
 type Props = {
 	declaration: {
@@ -98,64 +97,15 @@ export function Step6Review({
 		}
 	}, []);
 
-	// Step 2 gaps
-	const annualMeanGap = computeGap(
-		step2Data.indicatorAAnnualWomen,
-		step2Data.indicatorAAnnualMen,
-	);
-	const hourlyMeanGap = computeGap(
-		step2Data.indicatorAHourlyWomen,
-		step2Data.indicatorAHourlyMen,
-	);
-	const annualMedianGap = computeGap(
-		step2Data.indicatorCAnnualWomen,
-		step2Data.indicatorCAnnualMen,
-	);
-	const hourlyMedianGap = computeGap(
-		step2Data.indicatorCHourlyWomen,
-		step2Data.indicatorCHourlyMen,
-	);
-
-	// Step 3 gaps
-	const step3AnnualMeanGap = computeGap(
-		step3Data.indicatorBAnnualWomen,
-		step3Data.indicatorBAnnualMen,
-	);
-	const step3HourlyMeanGap = computeGap(
-		step3Data.indicatorBHourlyWomen,
-		step3Data.indicatorBHourlyMen,
-	);
-	const step3AnnualMedianGap = computeGap(
-		step3Data.indicatorDAnnualWomen,
-		step3Data.indicatorDAnnualMen,
-	);
-	const step3HourlyMedianGap = computeGap(
-		step3Data.indicatorDHourlyWomen,
-		step3Data.indicatorDHourlyMen,
-	);
-
-	// Step 5 categories — parsed here to feed `allGaps` below; the cards
-	// re-parse internally inside IndicatorSections (negligible cost).
-	const step5Parsed = parseEmployeeCategories(step5Categories);
-
-	// Check if any gap exceeds the regulatory threshold
-	const allGaps = [
-		annualMeanGap,
-		hourlyMeanGap,
-		annualMedianGap,
-		hourlyMedianGap,
-		step3AnnualMeanGap,
-		step3AnnualMedianGap,
-		step3HourlyMeanGap,
-		step3HourlyMedianGap,
-		...step5Parsed.flatMap((cat) => [
-			cat.annualBaseGap,
-			cat.annualVariableGap,
-			cat.hourlyBaseGap,
-			cat.hourlyVariableGap,
-		]),
-	];
-	const highGap = hasHighGap(allGaps);
+	// Phase 2 gate — domain single source of truth, same rule as the exports/public API.
+	const complianceProcessRequired = isComplianceProcessRequired({
+		workforce: companyWorkforce,
+		hasIndicatorG: indicatorGRequired,
+		gap: computeGap(
+			step2Data.indicatorAAnnualWomen,
+			step2Data.indicatorAAnnualMen,
+		),
+	});
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();
@@ -209,10 +159,10 @@ export function Step6Review({
 						withTooltips
 					/>
 
-					{highGap && declaration.siren && (
+					{complianceProcessRequired && declaration.siren && (
 						<NextStepsBox
 							cseApplicable={cseApplicable}
-							hasGapsAboveThreshold={highGap}
+							hasGapsAboveThreshold={complianceProcessRequired}
 							siren={declaration.siren}
 						/>
 					)}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -3,7 +3,13 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
 import { trackFunnelComplete } from "~/modules/analytics";
-import { computeGap, getCompanySizeRange, hasHighGap } from "~/modules/domain";
+import {
+	computeGap,
+	getCompanySizeRange,
+	getObligationWorkforce,
+	hasHighGap,
+	isCseRequired,
+} from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import common from "../shared/common.module.scss";
@@ -13,6 +19,7 @@ import {
 	DECLARATION_FUNNEL,
 	declarationFunnelDimensions,
 } from "../shared/funnelConfig";
+import { getPreviousStepHref } from "../shared/funnelSteps";
 import { NextStepsBox } from "../shared/NextStepsBox";
 import { SavedIndicator } from "../shared/SavedIndicator";
 import { StepIndicator } from "../shared/StepIndicator";
@@ -36,6 +43,7 @@ type Props = {
 	// (see StepPageClient), kept consistent with all business decisions.
 	companyWorkforce: number | null;
 	declarationYear: number;
+	indicatorGRequired: boolean;
 	step2Data: Step2Data;
 	step3Data: Step3Data;
 	step4Data: Step4Data;
@@ -50,6 +58,7 @@ export function Step6Review({
 	declaration,
 	companyWorkforce,
 	declarationYear,
+	indicatorGRequired,
 	step2Data,
 	step3Data,
 	step4Data,
@@ -61,6 +70,7 @@ export function Step6Review({
 }: Props) {
 	const router = useRouter();
 	const modalRef = useRef<HTMLDialogElement>(null);
+	const cseApplicable = isCseRequired(getObligationWorkforce(companyWorkforce));
 	const submitMutation = api.declaration.submit.useMutation({
 		onSuccess: () => {
 			trackFunnelComplete(
@@ -176,7 +186,10 @@ export function Step6Review({
 					</div>
 				</div>
 
-				<StepIndicator currentStep={6} />
+				<StepIndicator
+					currentStep={6}
+					indicatorGRequired={indicatorGRequired}
+				/>
 
 				<div className={stepStyles.recapBody}>
 					<p className={`fr-mb-0 ${stepStyles.intro}`}>
@@ -186,6 +199,7 @@ export function Step6Review({
 					</p>
 
 					<IndicatorSections
+						indicatorGRequired={indicatorGRequired}
 						step2Data={step2Data}
 						step3Data={step3Data}
 						step4Data={step4Data}
@@ -197,6 +211,7 @@ export function Step6Review({
 
 					{highGap && declaration.siren && (
 						<NextStepsBox
+							cseApplicable={cseApplicable}
 							hasGapsAboveThreshold={highGap}
 							siren={declaration.siren}
 						/>
@@ -210,7 +225,7 @@ export function Step6Review({
 							: undefined
 					}
 					nextLabel="Suivant"
-					previousHref="/declaration-remuneration/etape/5"
+					previousHref={getPreviousStepHref(6, indicatorGRequired)}
 				/>
 
 				{!isSubmitted && (

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -116,6 +116,7 @@ describe("DraftLoadingGate", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1}
 			/>,
 		);
@@ -128,6 +129,7 @@ describe("DraftLoadingGate", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep2}
 			/>,
 		);
@@ -140,6 +142,7 @@ describe("DraftLoadingGate", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep3}
 			/>,
 		);
@@ -152,6 +155,7 @@ describe("DraftLoadingGate", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep4}
 			/>,
 		);
@@ -164,6 +168,7 @@ describe("DraftLoadingGate", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialCategories={[]}
 				initialSource={undefined}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1DevFill.test.tsx
@@ -30,6 +30,7 @@ describe("Step1Workforce dev fill", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step1Workforce.test.tsx
@@ -31,6 +31,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -45,6 +46,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -58,6 +60,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -76,6 +79,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -95,6 +99,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -111,6 +116,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={{ totalWomen: 10, totalMen: 20 }}
 			/>,
 		);
@@ -128,6 +134,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={{ totalWomen: 5, totalMen: 3 }}
 			/>,
 		);
@@ -139,6 +146,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -151,6 +159,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -180,6 +189,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -196,6 +206,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={{ totalWomen: 10, totalMen: 20 }}
 			/>,
 		);
@@ -215,6 +226,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -236,6 +248,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={{ totalWomen: 10, totalMen: 20 }}
 			/>,
 		);
@@ -254,6 +267,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={emptyStep1Data()}
 			/>,
 		);
@@ -267,6 +281,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
 		);
@@ -320,6 +335,7 @@ describe("Step1Workforce", () => {
 					confidenceIndex: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
 		);
@@ -378,6 +394,7 @@ describe("Step1Workforce", () => {
 					confidenceIndex: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
 		);
@@ -409,6 +426,7 @@ describe("Step1Workforce", () => {
 				<Step1Workforce
 					declarationSiren="123456789"
 					declarationYear={2026}
+					indicatorGRequired
 					initialData={{ totalWomen: 50, totalMen: 100 }}
 				/>,
 			);
@@ -427,6 +445,7 @@ describe("Step1Workforce", () => {
 				<Step1Workforce
 					declarationSiren="123456789"
 					declarationYear={2026}
+					indicatorGRequired
 					initialData={{ totalWomen: 50, totalMen: 100 }}
 				/>,
 			);
@@ -448,6 +467,7 @@ describe("Step1Workforce", () => {
 				<Step1Workforce
 					declarationSiren="123456789"
 					declarationYear={2026}
+					indicatorGRequired
 					initialData={{ totalWomen: 50, totalMen: 100 }}
 				/>,
 			);
@@ -466,6 +486,7 @@ describe("Step1Workforce", () => {
 				<Step1Workforce
 					declarationSiren="123456789"
 					declarationYear={2026}
+					indicatorGRequired
 					initialData={{ totalWomen: 50, totalMen: 100 }}
 				/>,
 			);
@@ -486,6 +507,7 @@ describe("Step1Workforce", () => {
 			<Step1Workforce
 				declarationSiren="123456789"
 				declarationYear={2026}
+				indicatorGRequired
 				initialData={{ totalWomen: 50, totalMen: 100 }}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2DevFill.test.tsx
@@ -39,6 +39,7 @@ describe("Step2PayGap dev fill", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step2PayGap.test.tsx
@@ -36,6 +36,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -50,6 +51,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -63,6 +65,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -81,6 +84,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -98,6 +102,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={{
 					indicatorAAnnualWomen: "100",
 					indicatorAAnnualMen: "200",
@@ -118,6 +123,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -130,6 +136,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -157,6 +164,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -180,6 +188,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -203,6 +212,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -256,6 +266,7 @@ describe("Step2PayGap", () => {
 					confidenceIndex: null,
 					periodEnd: "2026-12-31",
 				}}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);
@@ -270,6 +281,7 @@ describe("Step2PayGap", () => {
 			<Step2PayGap
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep2Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3DevFill.test.tsx
@@ -41,6 +41,7 @@ describe("Step3VariablePay dev fill", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step3VariablePay.test.tsx
@@ -38,6 +38,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -52,6 +53,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -67,6 +69,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 				maxMen={60}
 				maxWomen={50}
@@ -83,6 +86,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -101,6 +105,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -116,6 +121,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={{
 					indicatorBAnnualWomen: "100",
 					indicatorBAnnualMen: "200",
@@ -138,6 +144,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -150,6 +157,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -177,6 +185,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -200,6 +209,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -222,6 +232,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 				maxMen={25}
 				maxWomen={15}
@@ -243,6 +254,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 				maxMen={25}
 				maxWomen={15}
@@ -274,6 +286,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 				maxMen={25}
 				maxWomen={15}
@@ -305,6 +318,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 				maxMen={25}
 				maxWomen={15}
@@ -329,6 +343,7 @@ describe("Step3VariablePay", () => {
 			<Step3VariablePay
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -382,6 +397,7 @@ describe("Step3VariablePay", () => {
 					confidenceIndex: null,
 					periodEnd: "2026-12-31",
 				}}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -437,6 +453,7 @@ describe("Step3VariablePay", () => {
 					confidenceIndex: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);
@@ -491,6 +508,7 @@ describe("Step3VariablePay", () => {
 					confidenceIndex: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={emptyStep3Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4DevFill.test.tsx
@@ -43,6 +43,7 @@ describe("Step4QuartileDistribution dev fill", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.submit.test.tsx
@@ -4,13 +4,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Step4QuartileDistribution } from "../Step4QuartileDistribution";
 
 const mockMutate = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({ push: mockPush }),
+}));
 
 vi.mock("~/trpc/react", () => ({
 	api: {
 		declaration: {
 			updateStep4: {
-				useMutation: () => ({
-					mutate: mockMutate,
+				useMutation: (opts: { onSuccess?: () => void }) => ({
+					mutate: (payload: unknown) => {
+						mockMutate(payload);
+						opts.onSuccess?.();
+					},
 					isPending: false,
 					error: null,
 				}),
@@ -21,6 +30,7 @@ vi.mock("~/trpc/react", () => ({
 
 beforeEach(() => {
 	mockMutate.mockClear();
+	mockPush.mockClear();
 });
 
 const validStep4Data = () => ({
@@ -60,6 +70,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={validStep4Data()}
 			/>,
 		);
@@ -82,6 +93,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={{
 					annual: [
 						{ threshold: "30000", women: 1, men: 1 },
@@ -117,6 +129,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={{
 					annual: [
 						{ threshold: "10000", men: 4 },
@@ -152,6 +165,7 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -165,5 +179,45 @@ describe("Step4QuartileDistribution submit behaviour", () => {
 		// All threshold inputs should be aria-invalid
 		const seuil1 = screen.getByLabelText(/Seuil maximum 1er quartile annuel/i);
 		expect(seuil1).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("navigates to step 5 after a successful submit when indicatorGRequired is true", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				indicatorGRequired
+				initialData={validStep4Data()}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		await waitFor(() => {
+			expect(mockPush).toHaveBeenCalledWith(
+				"/declaration-remuneration/etape/5",
+			);
+		});
+	});
+
+	it("navigates to step 6 after a successful submit when indicatorGRequired is false", async () => {
+		const user = userEvent.setup();
+		render(
+			<Step4QuartileDistribution
+				declarationSiren="123456789"
+				declarationYear={2025}
+				indicatorGRequired={false}
+				initialData={validStep4Data()}
+			/>,
+		);
+
+		await user.click(screen.getByRole("button", { name: /suivant/i }));
+
+		await waitFor(() => {
+			expect(mockPush).toHaveBeenCalledWith(
+				"/declaration-remuneration/etape/6",
+			);
+		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistribution.test.tsx
@@ -40,6 +40,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -68,6 +69,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -84,6 +86,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -97,6 +100,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -117,6 +121,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -130,6 +135,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -153,6 +159,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -167,6 +174,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -183,6 +191,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -196,6 +205,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -216,6 +226,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -233,6 +244,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 				maxMen={25}
 				maxWomen={15}
@@ -251,6 +263,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -275,6 +288,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -290,6 +304,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -303,6 +318,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -357,6 +373,7 @@ describe("Step4QuartileDistribution", () => {
 					periodStart: "2026-01-01",
 					periodEnd: "2026-12-31",
 				}}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -413,6 +430,7 @@ describe("Step4QuartileDistribution", () => {
 					periodStart: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -427,6 +445,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={{
 					annual: [
 						{ threshold: "20000", women: 60, men: 30 },
@@ -452,6 +471,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={{
 					annual: [
 						{ threshold: "", women: 10, men: 15 },
@@ -476,6 +496,7 @@ describe("Step4QuartileDistribution", () => {
 			<Step4QuartileDistribution
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step4QuartileDistributionGip.test.tsx
@@ -82,6 +82,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 					confidenceIndex: "0.85",
 					periodEnd: "2026-12-31",
 				}}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -117,6 +118,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 					confidenceIndex: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -149,6 +151,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 					confidenceIndex: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -182,6 +185,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 					confidenceIndex: null,
 					periodEnd: null,
 				}}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);
@@ -220,6 +224,7 @@ describe("Step4QuartileDistribution — GIP prefill", () => {
 					confidenceIndex: "0.85",
 					periodEnd: "2026-12-31",
 				}}
+				indicatorGRequired
 				initialData={emptyStep4Data()}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5DevFill.test.tsx
@@ -33,6 +33,7 @@ describe("Step5EmployeeCategories dev fill", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				maxMen={130}
 				maxWomen={120}
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -68,6 +68,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		const heading = screen.getByRole("heading", {
@@ -262,6 +263,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -51,6 +51,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(
@@ -81,6 +82,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(screen.getByText("Étape 5 sur 6")).toBeInTheDocument();
@@ -91,6 +93,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(
@@ -104,6 +107,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(
@@ -117,6 +121,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(
@@ -132,6 +137,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		const descriptionParagraph = screen.getByText(
@@ -148,6 +154,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		for (const header of screen.getAllByRole("columnheader")) {
@@ -170,6 +177,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(screen.getByText("Nombre de femmes")).toBeInTheDocument();
@@ -187,6 +195,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(screen.getAllByText(/Total salariés/).length).toBe(1);
@@ -203,6 +212,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(document.getElementById("cat-0-name")).toBeInTheDocument();
@@ -214,6 +224,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(
@@ -229,6 +240,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -268,6 +280,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -303,6 +316,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -326,6 +340,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -343,6 +358,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -364,6 +380,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -386,6 +403,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialCategories={[
 					makeCategory({
 						name: "Ingénieurs",
@@ -406,6 +424,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(screen.queryByText("Enregistré")).not.toBeInTheDocument();
@@ -416,6 +435,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				initialCategories={[
 					makeCategory({
 						name: "Cadres",
@@ -442,6 +462,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -479,6 +500,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -504,6 +526,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 				maxMen={20}
 				maxWomen={10}
 			/>,
@@ -538,6 +561,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -560,6 +584,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 
@@ -592,6 +617,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
@@ -605,6 +631,7 @@ describe("Step5EmployeeCategories", () => {
 			<Step5EmployeeCategories
 				declarationSiren="123456789"
 				declarationYear={2025}
+				indicatorGRequired
 			/>,
 		);
 		expect(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -97,6 +97,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -114,6 +115,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -130,6 +132,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -146,6 +149,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -165,6 +169,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -179,6 +184,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -208,6 +214,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -222,6 +229,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -237,6 +245,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -252,6 +261,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={{
 					indicatorAAnnualWomen: "95",
 					indicatorAAnnualMen: "100",
@@ -286,6 +296,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -301,6 +312,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={{
 					indicatorBAnnualWomen: "95",
@@ -331,6 +343,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={{
@@ -366,6 +379,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -406,6 +420,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -417,12 +432,31 @@ describe("Step6Review", () => {
 		);
 	});
 
+	it("renders previous link pointing to step 4 when indicatorGRequired is false", () => {
+		render(
+			<Step6Review
+				companyWorkforce={null}
+				declaration={emptyDeclaration()}
+				declarationYear={2025}
+				indicatorGRequired={false}
+				step2Data={emptyStep2Data()}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+			/>,
+		);
+		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/etape/4",
+		);
+	});
+
 	it("renders next as a submit button when not submitted", () => {
 		render(
 			<Step6Review
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
@@ -439,6 +473,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				isSubmitted
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
@@ -461,6 +496,7 @@ describe("Step6Review", () => {
 				}}
 				declarationYear={2025}
 				hasCse={true}
+				indicatorGRequired
 				isSubmitted
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
@@ -479,6 +515,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				isSubmitted
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
@@ -501,6 +538,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				isSubmitted
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
@@ -521,6 +559,7 @@ describe("Step6Review", () => {
 					status: null,
 				}}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={{
 					indicatorAAnnualWomen: "90",
 					indicatorAAnnualMen: "100",
@@ -560,6 +599,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={{ siren: "532847196", status: null }}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={{
 					indicatorAAnnualWomen: "110",
 					indicatorAAnnualMen: "100",
@@ -583,6 +623,7 @@ describe("Step6Review", () => {
 				companyWorkforce={null}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
+				indicatorGRequired
 				step2Data={{
 					indicatorAAnnualWomen: "98",
 					indicatorAAnnualMen: "100",

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -553,7 +553,7 @@ describe("Step6Review", () => {
 	it("shows 'Prochaines étapes' callout when a gap >= 5%", () => {
 		render(
 			<Step6Review
-				companyWorkforce={null}
+				companyWorkforce={300}
 				declaration={{
 					siren: "532847196",
 					status: null,
@@ -596,7 +596,7 @@ describe("Step6Review", () => {
 		// Women earn 10% more → signed gap -10%: |gap| >= 5% but negative, so no obligation (GIP).
 		render(
 			<Step6Review
-				companyWorkforce={null}
+				companyWorkforce={300}
 				declaration={{ siren: "532847196", status: null }}
 				declarationYear={2025}
 				indicatorGRequired
@@ -620,7 +620,7 @@ describe("Step6Review", () => {
 	it("does not show 'Prochaines étapes' callout when all gaps < 5%", () => {
 		render(
 			<Step6Review
-				companyWorkforce={null}
+				companyWorkforce={300}
 				declaration={emptyDeclaration()}
 				declarationYear={2025}
 				indicatorGRequired
@@ -632,6 +632,81 @@ describe("Step6Review", () => {
 					indicatorCAnnualWomen: "97",
 					indicatorCAnnualMen: "100",
 					indicatorCHourlyWomen: "99",
+					indicatorCHourlyMen: "100",
+				}}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+			/>,
+		);
+		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
+	});
+
+	it("does not show 'Prochaines étapes' callout below 100 employees even with a high gap", () => {
+		// Phase 2 is reserved to 100+ companies — a 50-99 firm never enters it.
+		render(
+			<Step6Review
+				companyWorkforce={80}
+				declaration={{ siren: "532847196", status: null }}
+				declarationYear={2025}
+				indicatorGRequired
+				step2Data={{
+					indicatorAAnnualWomen: "90",
+					indicatorAAnnualMen: "100",
+					indicatorAHourlyWomen: "100",
+					indicatorAHourlyMen: "100",
+					indicatorCAnnualWomen: "100",
+					indicatorCAnnualMen: "100",
+					indicatorCHourlyWomen: "100",
+					indicatorCHourlyMen: "100",
+				}}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+			/>,
+		);
+		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
+	});
+
+	it("does not show 'Prochaines étapes' callout when indicator G is not part of the declaration", () => {
+		// Phase 2 requires indicator G — a 100+ firm that doesn't declare G stays out.
+		render(
+			<Step6Review
+				companyWorkforce={300}
+				declaration={{ siren: "532847196", status: null }}
+				declarationYear={2025}
+				indicatorGRequired={false}
+				step2Data={{
+					indicatorAAnnualWomen: "90",
+					indicatorAAnnualMen: "100",
+					indicatorAHourlyWomen: "100",
+					indicatorAHourlyMen: "100",
+					indicatorCAnnualWomen: "100",
+					indicatorCAnnualMen: "100",
+					indicatorCHourlyWomen: "100",
+					indicatorCHourlyMen: "100",
+				}}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+			/>,
+		);
+		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
+	});
+
+	it("keys the callout off the global annual mean gap (indicator A), not other indicators", () => {
+		// A annual gap 2% (< 5%) but C annual 10%: the trigger only reads the global annual mean gap.
+		render(
+			<Step6Review
+				companyWorkforce={300}
+				declaration={{ siren: "532847196", status: null }}
+				declarationYear={2025}
+				indicatorGRequired
+				step2Data={{
+					indicatorAAnnualWomen: "98",
+					indicatorAAnnualMen: "100",
+					indicatorAHourlyWomen: "100",
+					indicatorAHourlyMen: "100",
+					indicatorCAnnualWomen: "90",
+					indicatorCAnnualMen: "100",
+					indicatorCHourlyWomen: "100",
 					indicatorCHourlyMen: "100",
 				}}
 				step3Data={emptyStep3Data()}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -20,6 +20,7 @@ import { BASE_PATH } from "./constants";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 type Props = {
+	cseApplicable: boolean;
 	declarationYear: number;
 	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
@@ -27,6 +28,7 @@ type Props = {
 };
 
 export function SecondDeclarationStep3Review({
+	cseApplicable,
 	declarationYear,
 	hasCse,
 	secondDeclarationCategories,
@@ -145,6 +147,7 @@ export function SecondDeclarationStep3Review({
 			</div>
 
 			<NextStepsBox
+				cseApplicable={cseApplicable}
 				hasGapsAboveThreshold={gapsExist}
 				isSecondDeclaration
 				siren={siren}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -3,6 +3,8 @@ import { notFound, redirect } from "next/navigation";
 import { campaignYearDimension, FunnelStepTracker } from "~/modules/analytics";
 import {
 	formatShortDate,
+	getObligationWorkforce,
+	isCseRequired,
 	shouldRedirectSubmittedToRecap,
 } from "~/modules/domain";
 import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
@@ -122,6 +124,9 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 			{stepTracker}
 			<HydrateClient>
 				<SecondDeclarationStep3Review
+					cseApplicable={isCseRequired(
+						getObligationWorkforce(company.gipWorkforce),
+					)}
 					declarationYear={currentYear}
 					hasCse={company.hasCse}
 					secondDeclarationCategories={reviewCategories}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -81,6 +81,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the title and step indicator", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -102,6 +103,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders category gap card with category name", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -116,6 +118,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("does not bracket the category title", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -130,6 +133,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the card title without the base-and-bonus parenthetical", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -147,6 +151,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("always shows the CSE consultation heading for second declaration", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -161,6 +166,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders gap columns", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -178,6 +184,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the next steps section", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -190,6 +197,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders the CSE update trigger as a secondary button", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -203,9 +211,27 @@ describe("SecondDeclarationStep3Review", () => {
 		expect(cseButton).toHaveAttribute("aria-controls", "update-cse-modal");
 	});
 
+	it("hides the CSE update trigger when cseApplicable is false", () => {
+		render(
+			<SecondDeclarationStep3Review
+				cseApplicable={false}
+				declarationYear={2025}
+				hasCse={null}
+				secondDeclarationCategories={mockCategories}
+				siren="532847196"
+			/>,
+		);
+		expect(
+			screen.queryByRole("button", {
+				name: "Mettre à jour l'existence d'un CSE",
+			}),
+		).not.toBeInTheDocument();
+	});
+
 	it("renders Soumettre button", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -220,6 +246,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders modal with certification checkbox", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -238,6 +265,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders previous link to step 2", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}
@@ -269,6 +297,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={categoriesWithHighGaps}
@@ -300,6 +329,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={categoriesWithLowGaps}
@@ -323,6 +353,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={true}
 				secondDeclarationCategories={categoriesWithHighGaps}
@@ -360,6 +391,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={true}
 				secondDeclarationCategories={categoriesNoGaps}
@@ -393,6 +425,7 @@ describe("SecondDeclarationStep3Review", () => {
 
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={false}
 				secondDeclarationCategories={categoriesNoGaps}
@@ -420,6 +453,7 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders empty state when no categories", () => {
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={[]}
@@ -433,6 +467,7 @@ describe("SecondDeclarationStep3Review", () => {
 		const user = userEvent.setup();
 		render(
 			<SecondDeclarationStep3Review
+				cseApplicable
 				declarationYear={2025}
 				hasCse={null}
 				secondDeclarationCategories={mockCategories}

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/IndicatorSections.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/IndicatorSections.tsx
@@ -19,6 +19,7 @@ type Props = {
 	step3Data: Step3Data;
 	step4Data: Step4Data;
 	step5Categories: EmployeeCategoryRow[];
+	indicatorGRequired: boolean;
 	totalWomen?: number;
 	totalMen?: number;
 	/**
@@ -44,6 +45,7 @@ export function IndicatorSections({
 	step3Data,
 	step4Data,
 	step5Categories,
+	indicatorGRequired,
 	totalWomen,
 	totalMen,
 	withTooltips = false,
@@ -192,62 +194,67 @@ export function IndicatorSections({
 				</div>
 			</div>
 
-			<div className={stepStyles.group}>
-				<h2 className="fr-h6 fr-mb-0">Indicateurs par catégorie de salariés</h2>
+			{indicatorGRequired && (
+				<div className={stepStyles.group}>
+					<h2 className="fr-h6 fr-mb-0">
+						Indicateurs par catégorie de salariés
+					</h2>
 
-				{/* Card: Employee categories (Step 5) */}
-				<div className={stepStyles.card}>
-					<CardTitle
-						tooltipId={withTooltips ? "tooltip-categories" : undefined}
-					>
-						Écart de rémunération par catégories de salariés
-					</CardTitle>
-					{step5Parsed.length > 0 ? (
-						step5Parsed.map((cat) => {
-							const categoryColumns = [
-								{
-									title: "Annuelle brute",
-									base: cat.annualBaseGap,
-									variable: cat.annualVariableGap,
-								},
-								{
-									title: "Horaire brute",
-									base: cat.hourlyBaseGap,
-									variable: cat.hourlyVariableGap,
-								},
-							];
-							return (
-								<div key={cat.index}>
-									<p className="fr-text--bold fr-text--sm fr-mb-0">
-										{cat.name}
-									</p>
-									<div className={stepStyles.sideBySide}>
-										{categoryColumns.map((col, index) => (
-											<Fragment key={col.title}>
-												{index > 0 && (
-													<div className={stepStyles.verticalSeparator} />
-												)}
-												<GapColumn
-													columns={[
-														{ label: "Salaire de base", gap: col.base },
-														{
-															label: "Composantes variables ou complémentaires",
-															gap: col.variable,
-														},
-													]}
-													title={col.title}
-												/>
-											</Fragment>
-										))}
+					{/* Card: Employee categories (Step 5) */}
+					<div className={stepStyles.card}>
+						<CardTitle
+							tooltipId={withTooltips ? "tooltip-categories" : undefined}
+						>
+							Écart de rémunération par catégories de salariés
+						</CardTitle>
+						{step5Parsed.length > 0 ? (
+							step5Parsed.map((cat) => {
+								const categoryColumns = [
+									{
+										title: "Annuelle brute",
+										base: cat.annualBaseGap,
+										variable: cat.annualVariableGap,
+									},
+									{
+										title: "Horaire brute",
+										base: cat.hourlyBaseGap,
+										variable: cat.hourlyVariableGap,
+									},
+								];
+								return (
+									<div key={cat.index}>
+										<p className="fr-text--bold fr-text--sm fr-mb-0">
+											{cat.name}
+										</p>
+										<div className={stepStyles.sideBySide}>
+											{categoryColumns.map((col, index) => (
+												<Fragment key={col.title}>
+													{index > 0 && (
+														<div className={stepStyles.verticalSeparator} />
+													)}
+													<GapColumn
+														columns={[
+															{ label: "Salaire de base", gap: col.base },
+															{
+																label:
+																	"Composantes variables ou complémentaires",
+																gap: col.variable,
+															},
+														]}
+														title={col.title}
+													/>
+												</Fragment>
+											))}
+										</div>
 									</div>
-								</div>
-							);
-						})
-					) : (
-						<EmptyDataNotice />
-					)}
+								);
+							})
+						) : (
+							<EmptyDataNotice />
+						)}
+					</div>
 				</div>
-			</div>
+			)}
 		</>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step6/__tests__/IndicatorSections.test.tsx
@@ -46,6 +46,7 @@ describe("IndicatorSections", () => {
 	it("renders variable pay proportion as a share of the workforce total, not the raw beneficiary count", () => {
 		render(
 			<IndicatorSections
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={step3WithProportion("95", "80")}
 				step4Data={emptyStep4Data()}
@@ -64,6 +65,7 @@ describe("IndicatorSections", () => {
 	it("renders '- %' for the proportion when the workforce total is zero", () => {
 		render(
 			<IndicatorSections
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={step3WithProportion("95", "80")}
 				step4Data={emptyStep4Data()}
@@ -80,6 +82,7 @@ describe("IndicatorSections", () => {
 	it("renders '- %' for the proportion when the workforce total is missing", () => {
 		render(
 			<IndicatorSections
+				indicatorGRequired
 				step2Data={emptyStep2Data()}
 				step3Data={step3WithProportion("95", "80")}
 				step4Data={emptyStep4Data()}
@@ -88,5 +91,43 @@ describe("IndicatorSections", () => {
 		);
 
 		expect(screen.getAllByText("- %")).toHaveLength(2);
+	});
+
+	it("renders the per-category indicator section when indicatorGRequired is true", () => {
+		render(
+			<IndicatorSections
+				indicatorGRequired
+				step2Data={emptyStep2Data()}
+				step3Data={step3WithProportion("95", "80")}
+				step4Data={emptyStep4Data()}
+				step5Categories={[]}
+			/>,
+		);
+
+		expect(
+			screen.getByText("Indicateurs par catégorie de salariés"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Écart de rémunération par catégories de salariés"),
+		).toBeInTheDocument();
+	});
+
+	it("hides the per-category indicator section when indicatorGRequired is false", () => {
+		render(
+			<IndicatorSections
+				indicatorGRequired={false}
+				step2Data={emptyStep2Data()}
+				step3Data={step3WithProportion("95", "80")}
+				step4Data={emptyStep4Data()}
+				step5Categories={[]}
+			/>,
+		);
+
+		expect(
+			screen.queryByText("Indicateurs par catégorie de salariés"),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText("Écart de rémunération par catégories de salariés"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/declarationPrerequisites.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationPrerequisites.test.ts
@@ -3,24 +3,42 @@ import { describe, expect, it } from "vitest";
 import { hasRequiredDeclarationInfo } from "../shared/declarationPrerequisites";
 
 describe("hasRequiredDeclarationInfo", () => {
-	it("returns true when phone and CSE are provided", () => {
-		expect(hasRequiredDeclarationInfo("0612345678", true)).toBe(true);
-		expect(hasRequiredDeclarationInfo("0612345678", false)).toBe(true);
+	describe("when the CSE applies (GIP workforce >= 100)", () => {
+		it("returns true when phone and CSE are provided", () => {
+			expect(hasRequiredDeclarationInfo("0612345678", true, true)).toBe(true);
+			expect(hasRequiredDeclarationInfo("0612345678", false, true)).toBe(true);
+		});
+
+		it("returns false when phone is missing", () => {
+			expect(hasRequiredDeclarationInfo(null, true, true)).toBe(false);
+		});
+
+		it("returns false when CSE is null", () => {
+			expect(hasRequiredDeclarationInfo("0612345678", null, true)).toBe(false);
+		});
+
+		it("returns false when both are missing", () => {
+			expect(hasRequiredDeclarationInfo(null, null, true)).toBe(false);
+		});
+
+		it("returns false when phone is empty string", () => {
+			expect(hasRequiredDeclarationInfo("", true, true)).toBe(false);
+		});
 	});
 
-	it("returns false when phone is missing", () => {
-		expect(hasRequiredDeclarationInfo(null, true)).toBe(false);
-	});
+	describe("when the CSE does not apply (GIP workforce < 100 or company absent from the GIP file)", () => {
+		it("returns true with only a phone, since hasCse is not collectable", () => {
+			expect(hasRequiredDeclarationInfo("0612345678", null, false)).toBe(true);
+		});
 
-	it("returns false when CSE is null", () => {
-		expect(hasRequiredDeclarationInfo("0612345678", null)).toBe(false);
-	});
+		it("still requires the phone", () => {
+			expect(hasRequiredDeclarationInfo(null, null, false)).toBe(false);
+			expect(hasRequiredDeclarationInfo("", null, false)).toBe(false);
+		});
 
-	it("returns false when both are missing", () => {
-		expect(hasRequiredDeclarationInfo(null, null)).toBe(false);
-	});
-
-	it("returns false when phone is empty string", () => {
-		expect(hasRequiredDeclarationInfo("", true)).toBe(false);
+		it("ignores a legacy hasCse value left over from before the CSE gate", () => {
+			expect(hasRequiredDeclarationInfo("0612345678", true, false)).toBe(true);
+			expect(hasRequiredDeclarationInfo("0612345678", false, false)).toBe(true);
+		});
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/gipWorkforce.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gipWorkforce.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { isCseRequired } from "../shared/companySize";
 import {
-	GIP_WORKFORCE_UNKNOWN_LABEL,
+	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getObligationWorkforce,
 	parseGipWorkforce,
 	toDisplayWorkforce,
@@ -86,8 +86,8 @@ describe("toDisplayWorkforce", () => {
 	});
 });
 
-describe("GIP_WORKFORCE_UNKNOWN_LABEL", () => {
+describe("GIP_WORKFORCE_ABSENT_DISPLAY", () => {
 	it("is the label shown instead of any Weez/INSEE fallback value", () => {
-		expect(GIP_WORKFORCE_UNKNOWN_LABEL).toBe("Effectif non connu du GIP");
+		expect(GIP_WORKFORCE_ABSENT_DISPLAY).toBe("< 50");
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/gipWorkforce.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gipWorkforce.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { isCseRequired } from "../shared/companySize";
+import {
+	GIP_WORKFORCE_UNKNOWN_LABEL,
+	getObligationWorkforce,
+	parseGipWorkforce,
+	toDisplayWorkforce,
+} from "../shared/gipWorkforce";
+import { isIndicatorGRequired } from "../shared/indicatorG";
+
+describe("parseGipWorkforce", () => {
+	it("parses the numeric(9,2) string returned by the postgres driver", () => {
+		expect(parseGipWorkforce("70.00")).toBe(70);
+		expect(parseGipWorkforce("99.97")).toBe(99.97);
+		expect(parseGipWorkforce("0.00")).toBe(0);
+	});
+
+	it("passes a number through unchanged", () => {
+		expect(parseGipWorkforce(250)).toBe(250);
+		expect(parseGipWorkforce(99.97)).toBe(99.97);
+		expect(parseGipWorkforce(0)).toBe(0);
+	});
+
+	it("returns null when the company is absent from the GIP file", () => {
+		expect(parseGipWorkforce(null)).toBeNull();
+		expect(parseGipWorkforce(undefined)).toBeNull();
+	});
+
+	it("returns null for a non-numeric value", () => {
+		expect(parseGipWorkforce("")).toBeNull();
+		expect(parseGipWorkforce("n/a")).toBeNull();
+		expect(parseGipWorkforce(Number.NaN)).toBeNull();
+		expect(parseGipWorkforce(Number.POSITIVE_INFINITY)).toBeNull();
+	});
+
+	it("keeps a negative value rather than silently coercing it", () => {
+		expect(parseGipWorkforce("-1.00")).toBe(-1);
+	});
+});
+
+describe("getObligationWorkforce", () => {
+	it("returns the exact GIP value when the company is known", () => {
+		expect(getObligationWorkforce(70)).toBe(70);
+		expect(getObligationWorkforce(99.97)).toBe(99.97);
+		expect(getObligationWorkforce(0)).toBe(0);
+	});
+
+	it("treats a company absent from the GIP file as a sub-50 headcount", () => {
+		expect(getObligationWorkforce(null)).toBe(0);
+	});
+
+	it("makes a company absent from the GIP file non-subject to CSE and indicator G", () => {
+		const workforce = getObligationWorkforce(null);
+		expect(isCseRequired(workforce)).toBe(false);
+		expect(isIndicatorGRequired(workforce, 2027)).toBe(false);
+	});
+
+	it("compares thresholds on the exact value, so 99,97 stays below 100", () => {
+		expect(isCseRequired(getObligationWorkforce(99.97))).toBe(false);
+		expect(isCseRequired(getObligationWorkforce(100))).toBe(true);
+	});
+
+	it("does not promote 149,99 to the triennial indicator G threshold", () => {
+		expect(isIndicatorGRequired(getObligationWorkforce(149.99), 2027)).toBe(
+			false,
+		);
+		expect(isIndicatorGRequired(getObligationWorkforce(150), 2027)).toBe(true);
+	});
+});
+
+describe("toDisplayWorkforce", () => {
+	it("floors the value so 99,97 never displays as 100", () => {
+		expect(toDisplayWorkforce(99.97)).toBe(99);
+		expect(toDisplayWorkforce(70.5)).toBe(70);
+		expect(toDisplayWorkforce(99.999)).toBe(99);
+	});
+
+	it("leaves an integer value unchanged", () => {
+		expect(toDisplayWorkforce(70)).toBe(70);
+		expect(toDisplayWorkforce(0)).toBe(0);
+	});
+
+	it("returns null when the company is absent from the GIP file", () => {
+		expect(toDisplayWorkforce(null)).toBeNull();
+	});
+});
+
+describe("GIP_WORKFORCE_UNKNOWN_LABEL", () => {
+	it("is the label shown instead of any Weez/INSEE fallback value", () => {
+		expect(GIP_WORKFORCE_UNKNOWN_LABEL).toBe("Effectif non connu du GIP");
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
+++ b/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
@@ -68,7 +68,7 @@ describe("isIndicatorGRequired", () => {
 	});
 
 	it("returns true for workforce 150-249 in triennial year 2030", () => {
-		expect(isIndicatorGRequired(200, 2030)).toBe(false);
+		expect(isIndicatorGRequired(200, 2030)).toBe(true);
 	});
 
 	it("returns false for workforce < 150 in any year before universal year", () => {
@@ -77,9 +77,23 @@ describe("isIndicatorGRequired", () => {
 		expect(isIndicatorGRequired(100, 2029)).toBe(false);
 	});
 
-	it("returns false for workforce < 250 at universal year (2030) when below annual min", () => {
-		expect(isIndicatorGRequired(100, 2030)).toBe(false);
-		expect(isIndicatorGRequired(249, 2030)).toBe(false);
+	it("extends the obligation to every tier >= 50 on triennial years from 2030", () => {
+		expect(isIndicatorGRequired(50, 2030)).toBe(true);
+		expect(isIndicatorGRequired(70, 2030)).toBe(true);
+		expect(isIndicatorGRequired(100, 2030)).toBe(true);
+		expect(isIndicatorGRequired(249, 2030)).toBe(true);
+		expect(isIndicatorGRequired(70, 2033)).toBe(true);
+	});
+
+	it("keeps sub-250 tiers on the triennial cadence after 2030 (non-triennial years excluded)", () => {
+		expect(isIndicatorGRequired(70, 2031)).toBe(false);
+		expect(isIndicatorGRequired(200, 2031)).toBe(false);
+		expect(isIndicatorGRequired(249, 2032)).toBe(false);
+	});
+
+	it("keeps the voluntary tier (< 50) out of the obligation even from 2030", () => {
+		expect(isIndicatorGRequired(49, 2030)).toBe(false);
+		expect(isIndicatorGRequired(0, 2033)).toBe(false);
 	});
 
 	it("returns true for workforce >= 250 at universal year (2030)", () => {
@@ -121,8 +135,13 @@ describe("getApplicableIndicators", () => {
 		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
 	});
 
-	it("excludes G for workforce 100 at universal year 2030", () => {
+	it("includes G for workforce 100 at universal year 2030 (triennial cadence)", () => {
 		const result = getApplicableIndicators(100, 2030);
+		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F", "G"]);
+	});
+
+	it("excludes G for workforce 100 in 2031 (non-triennial year)", () => {
+		const result = getApplicableIndicators(100, 2031);
 		expect(result.indicators).toEqual(["A", "B", "C", "D", "E", "F"]);
 	});
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -145,7 +145,7 @@ export {
 } from "./shared/gap";
 // GIP annual average workforce — canonical headcount for obligations & display
 export {
-	GIP_WORKFORCE_UNKNOWN_LABEL,
+	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getObligationWorkforce,
 	parseGipWorkforce,
 	toDisplayWorkforce,

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -143,6 +143,13 @@ export {
 	hasHighGap,
 	isSignificantGap,
 } from "./shared/gap";
+// GIP annual average workforce — canonical headcount for obligations & display
+export {
+	GIP_WORKFORCE_UNKNOWN_LABEL,
+	getObligationWorkforce,
+	parseGipWorkforce,
+	toDisplayWorkforce,
+} from "./shared/gipWorkforce";
 // Indicator G — applicability rules (workforce thresholds, triennial cycle, universal year)
 export {
 	getApplicableIndicators,

--- a/packages/app/src/modules/domain/shared/declarationPrerequisites.ts
+++ b/packages/app/src/modules/domain/shared/declarationPrerequisites.ts
@@ -1,7 +1,8 @@
-/** Returns true if the user has provided all required info to start a declaration (phone + CSE status). */
+/** Returns true if the user has provided all required info to start a declaration (phone + CSE status when the CSE applies). */
 export function hasRequiredDeclarationInfo(
 	userPhone: string | null,
 	hasCse: boolean | null,
+	cseApplicable: boolean,
 ): boolean {
-	return !!userPhone && hasCse !== null;
+	return !!userPhone && (!cseApplicable || hasCse !== null);
 }

--- a/packages/app/src/modules/domain/shared/gipWorkforce.ts
+++ b/packages/app/src/modules/domain/shared/gipWorkforce.ts
@@ -1,4 +1,6 @@
-export const GIP_WORKFORCE_UNKNOWN_LABEL = "Effectif non connu du GIP";
+// A company absent from the GIP file is deemed below the voluntary threshold,
+// so the banners display "< 50" rather than a raw missing-data mention.
+export const GIP_WORKFORCE_ABSENT_DISPLAY = "< 50";
 
 export function parseGipWorkforce(
 	raw: string | number | null | undefined,

--- a/packages/app/src/modules/domain/shared/gipWorkforce.ts
+++ b/packages/app/src/modules/domain/shared/gipWorkforce.ts
@@ -1,5 +1,4 @@
-// A company absent from the GIP file is deemed below the voluntary threshold,
-// so the banners display "< 50" rather than a raw missing-data mention.
+// Absent from the GIP file ⇒ deemed below the voluntary threshold, so banners display "< 50".
 export const GIP_WORKFORCE_ABSENT_DISPLAY = "< 50";
 
 export function parseGipWorkforce(

--- a/packages/app/src/modules/domain/shared/gipWorkforce.ts
+++ b/packages/app/src/modules/domain/shared/gipWorkforce.ts
@@ -1,0 +1,19 @@
+export const GIP_WORKFORCE_UNKNOWN_LABEL = "Effectif non connu du GIP";
+
+export function parseGipWorkforce(
+	raw: string | number | null | undefined,
+): number | null {
+	if (raw === null || raw === undefined) return null;
+	const value = typeof raw === "number" ? raw : Number.parseFloat(raw);
+	return Number.isFinite(value) ? value : null;
+}
+
+// A company absent from the GIP file is not subject to the declaration, which every threshold rule expresses as a sub-50 headcount.
+export function getObligationWorkforce(gipWorkforce: number | null): number {
+	return gipWorkforce ?? 0;
+}
+
+// Floored so 99,97 never displays as "100" — thresholds compare the exact value.
+export function toDisplayWorkforce(gipWorkforce: number | null): number | null {
+	return gipWorkforce === null ? null : Math.floor(gipWorkforce);
+}

--- a/packages/app/src/modules/domain/shared/indicatorG.ts
+++ b/packages/app/src/modules/domain/shared/indicatorG.ts
@@ -1,3 +1,5 @@
+import { COMPANY_SIZE_VOLUNTARY_MAX } from "./constants";
+
 export const INDICATOR_G_ANNUAL_MIN = 250;
 export const INDICATOR_G_TRIENNIAL_MIN = 150;
 export const INDICATOR_G_UNIVERSAL_YEAR = 2030;
@@ -11,17 +13,12 @@ export function isTriennialYear(year: number): boolean {
 }
 
 export function isIndicatorGRequired(workforce: number, year: number): boolean {
-	if (year >= INDICATOR_G_UNIVERSAL_YEAR) {
-		return workforce >= INDICATOR_G_ANNUAL_MIN;
-	}
 	if (workforce >= INDICATOR_G_ANNUAL_MIN) return true;
-	if (
-		workforce >= INDICATOR_G_TRIENNIAL_MIN &&
-		workforce < INDICATOR_G_ANNUAL_MIN
-	) {
-		return isTriennialYear(year);
+	if (year >= INDICATOR_G_UNIVERSAL_YEAR) {
+		// From 2030 the obligation extends down to every mandatory tier (>= 50), on the triennial cadence.
+		return workforce >= COMPANY_SIZE_VOLUNTARY_MAX && isTriennialYear(year);
 	}
-	return false;
+	return workforce >= INDICATOR_G_TRIENNIAL_MIN && isTriennialYear(year);
 }
 
 type IndicatorCode = "A" | "B" | "C" | "D" | "E" | "F" | "G";

--- a/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
+++ b/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("buildExportRows", () => {
-	// Mock DB chain: select().from().innerJoin().innerJoin().where()
+	// Mock DB chain: select().from().innerJoin().leftJoin().innerJoin().where()
 	const mockWhere = vi.fn();
 	const mockInnerJoin2 = vi.fn(() => ({ where: mockWhere }));
-	const mockInnerJoin1 = vi.fn(() => ({ innerJoin: mockInnerJoin2 }));
+	const mockLeftJoin = vi.fn(() => ({ innerJoin: mockInnerJoin2 }));
+	const mockInnerJoin1 = vi.fn(() => ({ leftJoin: mockLeftJoin }));
 	const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin1 }));
 	// Mock for getDeclarationsWithIndicatorG: selectDistinct().from().where()
 	const mockJobWhere = vi.fn();
@@ -80,7 +81,7 @@ describe("buildExportRows", () => {
 			updatedAt: new Date("2027-03-15T12:00:00Z"),
 			cancelledAt: null,
 			companyName: "ACME Corp",
-			workforce: 250,
+			workforceEma: "250.00",
 			nafCode: "62.02",
 			address: "1 rue test",
 			hasCse: true,
@@ -190,7 +191,7 @@ describe("buildExportRows", () => {
 			updatedAt: new Date("2027-03-15T12:00:00Z"),
 			cancelledAt: null,
 			companyName: "BigCo",
-			workforce: 500,
+			workforceEma: "500.00",
 			nafCode: "70.10",
 			address: "2 rue test",
 			hasCse: true,
@@ -282,7 +283,7 @@ describe("buildExportRows", () => {
 			updatedAt: new Date("2027-03-15T12:00:00Z"),
 			cancelledAt: null,
 			companyName: "ACME Corp",
-			workforce: 250,
+			workforceEma: "250.00",
 			nafCode: "62.02",
 			address: "1 rue test",
 			hasCse: true,
@@ -396,7 +397,7 @@ describe("buildExportRows", () => {
 			updatedAt: null,
 			cancelledAt: null,
 			companyName: "NullCo",
-			workforce: null,
+			workforceEma: null,
 			nafCode: null,
 			address: null,
 			hasCse: null,
@@ -493,7 +494,7 @@ describe("buildExportRows", () => {
 			declarationId: "decl-completed",
 			siren: "100100100",
 			status: "demarche_completed",
-			workforce: 300,
+			workforceEma: "300.00",
 			globalAnnualMeanGap: "0.10",
 			variableAnnualMeanGap: "0.08",
 			firstDeclarationPathChoice: "corrective_action",
@@ -540,7 +541,7 @@ describe("buildExportRows", () => {
 		const dbRow = makeMinimalDbRow({
 			declarationId: "decl-negative-gap",
 			siren: "200200200",
-			workforce: 300,
+			workforceEma: "300.00",
 			globalAnnualMeanGap: "-0.10",
 			variableAnnualMeanGap: "-0.08",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
@@ -556,6 +557,70 @@ describe("buildExportRows", () => {
 		expect(rows[0]).toMatchObject({
 			complianceProcessRequired: false,
 			complianceProcessRevisionRequired: false,
+		});
+	});
+
+	it("should export the GIP workforce floored, not the Weez company workforce (#3929)", async () => {
+		const dbRow = makeMinimalDbRow({
+			declarationId: "decl-gip",
+			siren: "432491777",
+			workforceEma: "70.00",
+		});
+
+		mockWhere.mockResolvedValue([dbRow]);
+		mockJobWhere.mockResolvedValue([]);
+		mockCseWhere.mockResolvedValue([]);
+
+		const { buildExportRows } = await import("../buildExportRows");
+		const rows = await buildExportRows(mockDb as never, 2027);
+
+		expect(rows[0]).toMatchObject({
+			workforce: 70,
+			indicatorGRequired: false,
+		});
+	});
+
+	it("should floor the GIP workforce so 99,97 never exports as 100", async () => {
+		const dbRow = makeMinimalDbRow({
+			declarationId: "decl-rounding",
+			workforceEma: "99.97",
+			globalAnnualMeanGap: "0.10",
+		});
+
+		mockWhere.mockResolvedValue([dbRow]);
+		mockJobWhere.mockResolvedValue([{ declarationId: "decl-rounding" }]);
+		mockCseWhere.mockResolvedValue([]);
+
+		const { buildExportRows } = await import("../buildExportRows");
+		const rows = await buildExportRows(mockDb as never, 2027);
+
+		expect(rows[0]).toMatchObject({
+			workforce: 99,
+			complianceProcessRequired: false,
+		});
+	});
+
+	it("should keep a declaration whose company is absent from the GIP file, with a null workforce", async () => {
+		const dbRow = makeMinimalDbRow({
+			declarationId: "decl-no-gip",
+			siren: "999999999",
+			workforceEma: null,
+			globalAnnualMeanGap: "0.10",
+		});
+
+		mockWhere.mockResolvedValue([dbRow]);
+		mockJobWhere.mockResolvedValue([{ declarationId: "decl-no-gip" }]);
+		mockCseWhere.mockResolvedValue([]);
+
+		const { buildExportRows } = await import("../buildExportRows");
+		const rows = await buildExportRows(mockDb as never, 2027);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			siren: "999999999",
+			workforce: null,
+			indicatorGRequired: false,
+			complianceProcessRequired: false,
 		});
 	});
 
@@ -610,7 +675,7 @@ function makeMinimalDbRow(overrides: DbRow): DbRow {
 		updatedAt: new Date("2027-03-15T12:00:00Z"),
 		cancelledAt: null,
 		companyName: "ACME",
-		workforce: null,
+		workforceEma: null,
 		nafCode: null,
 		address: null,
 		hasCse: null,

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -233,7 +233,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-01-01T00:00:00Z"),
 				updatedAt: new Date("2027-01-01T00:00:00Z"),
 				companyName: "Test",
-				workforce: 100,
+				workforceEma: "100.00",
 				nafCode: "62.01",
 				address: "1 rue",
 				hasCse: false,
@@ -269,7 +269,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-01-02T00:00:00Z"),
 				updatedAt: new Date("2027-01-02T00:00:00Z"),
 				companyName: "Test2",
-				workforce: 200,
+				workforceEma: "200.00",
 				nafCode: "62.02",
 				address: "2 rue",
 				hasCse: true,
@@ -323,7 +323,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: true,
@@ -367,6 +367,111 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(decl).not.toHaveProperty("Fichier_evaluation_conjointe");
 	});
 
+	it("should send the GIP annual average workforce as Effectif, not the Weez value (#3929)", async () => {
+		mockFetchSubmitted.mockResolvedValue([
+			{
+				declarationId: "decl-1",
+				siren: "432491777",
+				year: 2027,
+				status: "submitted",
+				firstDeclarationPathChoice: null,
+				secondDeclarationPathChoice: null,
+				totalWomen: 30,
+				totalMen: 40,
+				submittedAt: null,
+				firstDeclarationPathChoiceAt: null,
+				secondDeclarationPathChoiceAt: null,
+				secondDeclarationSubmittedAt: null,
+				jointEvaluationSubmittedAt: null,
+				cseOpinionCompletedAt: null,
+				demarcheCompletedAt: null,
+				complianceProcessRequired: false,
+				complianceProcessRevisionRequired: false,
+				cseRequired: false,
+				indicatorGRequired: false,
+				rulesVersion: "2027.1",
+				secondDeclReferencePeriodStart: null,
+				secondDeclReferencePeriodEnd: null,
+				createdAt: new Date("2027-03-15T10:00:00Z"),
+				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				companyName: "ACME Corp",
+				workforceEma: "70.00",
+				nafCode: "62.02",
+				address: "1 rue test",
+				hasCse: null,
+				declarantFirstName: "Jean",
+				declarantLastName: "Dupont",
+				declarantEmail: "jean@acme.fr",
+				declarantPhone: "0612345678",
+				...nullIndicators,
+			},
+		]);
+
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const request = gatewayForwardedRequest(
+			"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+		);
+		const response = await GET(request);
+
+		expect(response.status).toBe(200);
+		const decl = (await response.json()).Declarations[0];
+		expect(decl.Effectif).toBe(70);
+		expect(decl.Indicateur_G_requis).toBe(false);
+	});
+
+	it("should send a null Effectif when the company is absent from the GIP file", async () => {
+		mockFetchSubmitted.mockResolvedValue([
+			{
+				declarationId: "decl-1",
+				siren: "999999999",
+				year: 2027,
+				status: "submitted",
+				firstDeclarationPathChoice: null,
+				secondDeclarationPathChoice: null,
+				totalWomen: 10,
+				totalMen: 10,
+				submittedAt: null,
+				firstDeclarationPathChoiceAt: null,
+				secondDeclarationPathChoiceAt: null,
+				secondDeclarationSubmittedAt: null,
+				jointEvaluationSubmittedAt: null,
+				cseOpinionCompletedAt: null,
+				demarcheCompletedAt: null,
+				complianceProcessRequired: false,
+				complianceProcessRevisionRequired: false,
+				cseRequired: false,
+				indicatorGRequired: false,
+				rulesVersion: "2027.1",
+				secondDeclReferencePeriodStart: null,
+				secondDeclReferencePeriodEnd: null,
+				createdAt: new Date("2027-03-15T10:00:00Z"),
+				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				companyName: "Hors GIP",
+				workforceEma: null,
+				nafCode: "62.02",
+				address: "1 rue test",
+				hasCse: null,
+				declarantFirstName: "Jean",
+				declarantLastName: "Dupont",
+				declarantEmail: "jean@acme.fr",
+				declarantPhone: "0612345678",
+				...nullIndicators,
+			},
+		]);
+
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const request = gatewayForwardedRequest(
+			"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+		);
+		const response = await GET(request);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.Nombre).toBe(1);
+		expect(body.Declarations[0].Effectif).toBeNull();
+		expect(body.Declarations[0].Indicateur_G_requis).toBe(false);
+	});
+
 	it("should expose CSE opinion declarationNumber alongside type", async () => {
 		mockFetchSubmitted.mockResolvedValue([
 			{
@@ -395,7 +500,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: true,
@@ -497,7 +602,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: true,
@@ -576,7 +681,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: true,
@@ -643,7 +748,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: true,
@@ -720,7 +825,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: false,
@@ -781,7 +886,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: false,
@@ -849,7 +954,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: false,
@@ -906,7 +1011,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: false,
@@ -996,7 +1101,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-10-15T14:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: true,
@@ -1095,7 +1200,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-04-01T10:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: false,
@@ -1173,7 +1278,7 @@ describe("GET /api/v1/export/declarations", () => {
 				createdAt: new Date("2027-03-15T10:00:00Z"),
 				updatedAt: new Date("2027-03-15T12:00:00Z"),
 				companyName: "ACME Corp",
-				workforce: 250,
+				workforceEma: "250.00",
 				nafCode: "62.02",
 				address: "1 rue test",
 				hasCse: false,

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -35,7 +35,7 @@ const baseRow = {
 	updatedAt: new Date("2027-03-15T12:00:00Z"),
 	cancelledAt: null as Date | null,
 	companyName: "ACME Corp",
-	workforce: 250,
+	workforceEma: "250.00" as string | null,
 	nafCode: "62.02",
 	address: "1 rue test",
 	hasCse: true,
@@ -307,6 +307,23 @@ describe("assembleDeclaration", () => {
 		expect(result).not.toHaveProperty("Fichiers_CSE");
 		expect(result).not.toHaveProperty("Fichier_evaluation_conjointe");
 		expect(result.Date_creation).toBe("2027-03-15T10:00:00.000Z");
+	});
+
+	it("exposes the GIP annual average workforce as Effectif, floored to the lower integer", () => {
+		expect(
+			assembleDeclaration({ ...baseRow, workforceEma: "99.97" }, [], [])
+				.Effectif,
+		).toBe(99);
+		expect(
+			assembleDeclaration({ ...baseRow, workforceEma: "70.00" }, [], [])
+				.Effectif,
+		).toBe(70);
+	});
+
+	it("exposes a null Effectif when the company is absent from the GIP file", () => {
+		expect(
+			assembleDeclaration({ ...baseRow, workforceEma: null }, [], []).Effectif,
+		).toBeNull();
 	});
 
 	it("should include indicator A–F values with GIP labels", () => {
@@ -795,7 +812,11 @@ describe("assembleDeclaration — compliance flags", () => {
 	];
 
 	it("requires the compliance process for >= 100 employees with indicator G and a gap >= 5%", () => {
-		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0600" };
+		const row = {
+			...baseRow,
+			workforceEma: "300.00",
+			globalAnnualMeanGap: "0.0600",
+		};
 
 		const result = assembleDeclaration(row, indicatorG, []);
 
@@ -803,7 +824,11 @@ describe("assembleDeclaration — compliance flags", () => {
 	});
 
 	it("does not require the compliance process when the gap is below 5%", () => {
-		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0455" };
+		const row = {
+			...baseRow,
+			workforceEma: "300.00",
+			globalAnnualMeanGap: "0.0455",
+		};
 
 		const result = assembleDeclaration(row, indicatorG, []);
 
@@ -812,7 +837,11 @@ describe("assembleDeclaration — compliance flags", () => {
 	});
 
 	it("does not require the compliance process below 100 employees even with a gap", () => {
-		const row = { ...baseRow, workforce: 99, globalAnnualMeanGap: "0.0600" };
+		const row = {
+			...baseRow,
+			workforceEma: "99.00",
+			globalAnnualMeanGap: "0.0600",
+		};
 
 		const result = assembleDeclaration(row, indicatorG, []);
 
@@ -820,7 +849,11 @@ describe("assembleDeclaration — compliance flags", () => {
 	});
 
 	it("does not require the compliance process without indicator G", () => {
-		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "0.0600" };
+		const row = {
+			...baseRow,
+			workforceEma: "300.00",
+			globalAnnualMeanGap: "0.0600",
+		};
 
 		const result = assembleDeclaration(row, [], []);
 
@@ -828,7 +861,11 @@ describe("assembleDeclaration — compliance flags", () => {
 	});
 
 	it("does not require the compliance process when the global gap is null", () => {
-		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: null };
+		const row = {
+			...baseRow,
+			workforceEma: "300.00",
+			globalAnnualMeanGap: null,
+		};
 
 		const result = assembleDeclaration(row, indicatorG, []);
 
@@ -837,26 +874,81 @@ describe("assembleDeclaration — compliance flags", () => {
 
 	it("does not require the compliance process when the gap is negative (women earn more)", () => {
 		// Signed stored gap of -0.06 → |gap| >= 5% but negative, so no obligation.
-		const row = { ...baseRow, workforce: 300, globalAnnualMeanGap: "-0.0600" };
+		const row = {
+			...baseRow,
+			workforceEma: "300.00",
+			globalAnnualMeanGap: "-0.0600",
+		};
 
 		const result = assembleDeclaration(row, indicatorG, []);
 
 		expect(result.Parcours_de_conformite_requis).toBe(false);
 	});
 
-	it("treats a null workforce as 0 for the derived flags", () => {
-		const row = { ...baseRow, workforce: null, globalAnnualMeanGap: "0.0600" };
+	it("treats a company absent from the GIP file as 0 for the derived flags", () => {
+		const row = {
+			...baseRow,
+			workforceEma: null,
+			globalAnnualMeanGap: "0.0600",
+		};
 
 		const result = assembleDeclaration(row, indicatorG, []);
 
+		expect(result.Effectif).toBeNull();
 		expect(result.Parcours_de_conformite_requis).toBe(false);
 		expect(result.Indicateur_G_requis).toBe(false);
+	});
+
+	it("derives the flags from the GIP workforce, never from the Weez value (#3929)", () => {
+		const row = {
+			...baseRow,
+			workforceEma: "70.00",
+			globalAnnualMeanGap: "0.0600",
+		};
+
+		const result = assembleDeclaration(row, indicatorG, []);
+
+		expect(result.Effectif).toBe(70);
+		expect(result.Indicateur_G_requis).toBe(false);
+		expect(result.Parcours_de_conformite_requis).toBe(false);
+	});
+
+	it("compares the indicator G threshold on the exact GIP value", () => {
+		const below = assembleDeclaration(
+			{ ...baseRow, workforceEma: "149.99" },
+			indicatorG,
+			[],
+		);
+		const atThreshold = assembleDeclaration(
+			{ ...baseRow, workforceEma: "150.00" },
+			indicatorG,
+			[],
+		);
+
+		expect(below.Indicateur_G_requis).toBe(false);
+		expect(atThreshold.Indicateur_G_requis).toBe(true);
+	});
+
+	it("compares the compliance threshold on the exact GIP value", () => {
+		const below = assembleDeclaration(
+			{ ...baseRow, workforceEma: "99.97", globalAnnualMeanGap: "0.0600" },
+			indicatorG,
+			[],
+		);
+		const atThreshold = assembleDeclaration(
+			{ ...baseRow, workforceEma: "100.00", globalAnnualMeanGap: "0.0600" },
+			indicatorG,
+			[],
+		);
+
+		expect(below.Parcours_de_conformite_requis).toBe(false);
+		expect(atThreshold.Parcours_de_conformite_requis).toBe(true);
 	});
 
 	it("requires the revision when a second declaration was submitted with a correction gap >= 5%", () => {
 		const row = {
 			...baseRow,
-			workforce: 300,
+			workforceEma: "300.00",
 			globalAnnualMeanGap: "0.0600",
 			variableAnnualMeanGap: "0.0800",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
@@ -871,7 +963,7 @@ describe("assembleDeclaration — compliance flags", () => {
 	it("does not require the revision without a submitted second declaration", () => {
 		const row = {
 			...baseRow,
-			workforce: 300,
+			workforceEma: "300.00",
 			globalAnnualMeanGap: "0.0600",
 			variableAnnualMeanGap: "0.0800",
 			secondDeclarationSubmittedAt: null,
@@ -886,7 +978,7 @@ describe("assembleDeclaration — compliance flags", () => {
 	it("does not require the revision when the correction gap is below 5%", () => {
 		const row = {
 			...baseRow,
-			workforce: 300,
+			workforceEma: "300.00",
 			globalAnnualMeanGap: "0.0600",
 			variableAnnualMeanGap: "0.0400",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
@@ -900,7 +992,7 @@ describe("assembleDeclaration — compliance flags", () => {
 	it("does not require the revision when the correction gap is negative", () => {
 		const row = {
 			...baseRow,
-			workforce: 300,
+			workforceEma: "300.00",
 			globalAnnualMeanGap: "0.0600",
 			variableAnnualMeanGap: "-0.0800",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
@@ -914,7 +1006,7 @@ describe("assembleDeclaration — compliance flags", () => {
 	it("does not require the revision when the correction gap is null", () => {
 		const row = {
 			...baseRow,
-			workforce: 300,
+			workforceEma: "300.00",
 			globalAnnualMeanGap: "0.0600",
 			variableAnnualMeanGap: null,
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -326,6 +326,33 @@ describe("assembleDeclaration", () => {
 		).toBeNull();
 	});
 
+	it("nulls CSE_existant below the CSE threshold even when a legacy hasCse value exists", () => {
+		expect(
+			assembleDeclaration(
+				{ ...baseRow, workforceEma: "70.00", hasCse: true },
+				[],
+				[],
+			).CSE_existant,
+		).toBeNull();
+		expect(
+			assembleDeclaration(
+				{ ...baseRow, workforceEma: null, hasCse: true },
+				[],
+				[],
+			).CSE_existant,
+		).toBeNull();
+	});
+
+	it("keeps CSE_existant at or above the CSE threshold", () => {
+		expect(
+			assembleDeclaration(
+				{ ...baseRow, workforceEma: "100.00", hasCse: false },
+				[],
+				[],
+			).CSE_existant,
+		).toBe(false);
+	});
+
 	it("should include indicator A–F values with GIP labels", () => {
 		const result = assembleDeclaration(baseRow, [], []);
 

--- a/packages/app/src/modules/export/__tests__/gipWorkforceExport.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/gipWorkforceExport.integration.test.ts
@@ -1,0 +1,134 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+
+// The GIP workforce reaches SUIT through a leftJoin on `gip_mds_data`; a unit
+// test mocks the driver and cannot prove the join keeps GIP-less declarations.
+describe("GET /api/v1/export/declarations — GIP workforce integration (#3929)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN_IN_GIP = "111111111";
+	const SIREN_NOT_IN_GIP = "222222222";
+	const SIREN_FRACTIONAL = "333333333";
+	const SIREN_OTHER_YEAR = "444444444";
+	const ALL_SIRENS = [
+		SIREN_IN_GIP,
+		SIREN_NOT_IN_GIP,
+		SIREN_FRACTIONAL,
+		SIREN_OTHER_YEAR,
+	];
+	const YEAR = 2025;
+	const USER_ID = "gip-workforce-integration-user";
+	const DECL_IDS = [
+		"gip-decl-in-gip",
+		"gip-decl-not-in-gip",
+		"gip-decl-fractional",
+		"gip-decl-other-year",
+	];
+
+	async function cleanup() {
+		await sql`DELETE FROM app_declaration WHERE id IN ${sql(DECL_IDS)}`;
+		await sql`DELETE FROM app_gip_mds_data WHERE siren IN ${sql(ALL_SIRENS)}`;
+		await sql`DELETE FROM app_company WHERE siren IN ${sql(ALL_SIRENS)}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+
+		await sql`
+			INSERT INTO app_user (id, email, first_name, last_name)
+			VALUES (${USER_ID}, 'dir.rh@example.fr', 'Dir', 'RH')
+		`;
+		// `workforce` holds the Weez/INSEE value, deliberately different from the GIP one.
+		await sql`
+			INSERT INTO app_company (siren, name, workforce)
+			VALUES
+				(${SIREN_IN_GIP},      'Entreprise Dans GIP',       82),
+				(${SIREN_NOT_IN_GIP},  'Entreprise Absente Du GIP', 1183),
+				(${SIREN_FRACTIONAL},  'Entreprise Arrondi',        250),
+				(${SIREN_OTHER_YEAR},  'Entreprise Autre Annee',    500)
+		`;
+		await sql`
+			INSERT INTO app_gip_mds_data (siren, year, workforce_ema)
+			VALUES
+				(${SIREN_IN_GIP},     ${YEAR},     70.00),
+				(${SIREN_FRACTIONAL}, ${YEAR},     99.97),
+				(${SIREN_OTHER_YEAR}, ${YEAR - 1}, 300.00)
+		`;
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id, status, created_at, updated_at)
+			VALUES
+				('gip-decl-in-gip',      ${SIREN_IN_GIP},     ${YEAR}, ${USER_ID}, 'demarche_completed', '2025-05-01T00:00:00Z', '2025-05-01T00:00:00Z'),
+				('gip-decl-not-in-gip',  ${SIREN_NOT_IN_GIP}, ${YEAR}, ${USER_ID}, 'demarche_completed', '2025-05-01T00:00:00Z', '2025-05-01T00:00:00Z'),
+				('gip-decl-fractional',  ${SIREN_FRACTIONAL}, ${YEAR}, ${USER_ID}, 'demarche_completed', '2025-05-01T00:00:00Z', '2025-05-01T00:00:00Z'),
+				('gip-decl-other-year',  ${SIREN_OTHER_YEAR}, ${YEAR}, ${USER_ID}, 'demarche_completed', '2025-05-01T00:00:00Z', '2025-05-01T00:00:00Z')
+		`;
+	});
+
+	async function fetchExport(): Promise<
+		Array<{
+			SIREN: string;
+			Effectif: number | null;
+			Indicateur_G_requis: boolean;
+		}>
+	> {
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const response = await GET(
+			new Request(
+				"http://localhost/api/v1/export/declarations?date_begin=2025-05-01&date_end=2025-05-02",
+				{ headers: { "x-gateway-forwarded": "test-value" } },
+			),
+		);
+		expect(response.status).toBe(200);
+		return (await response.json()).Declarations;
+	}
+
+	function findBySiren(
+		declarations: Array<{ SIREN: string }>,
+		siren: string,
+	): { SIREN: string; Effectif: number | null; Indicateur_G_requis: boolean } {
+		const found = declarations.find((d) => d.SIREN === siren);
+		if (!found) throw new Error(`declaration for ${siren} missing from export`);
+		return found as never;
+	}
+
+	it("sends the GIP annual average workforce as Effectif, not the Weez company workforce", async () => {
+		const declarations = await fetchExport();
+
+		expect(findBySiren(declarations, SIREN_IN_GIP).Effectif).toBe(70);
+	});
+
+	it("keeps the declaration of a company absent from the GIP file, with a null Effectif", async () => {
+		const declarations = await fetchExport();
+
+		expect(declarations).toHaveLength(4);
+		const notInGip = findBySiren(declarations, SIREN_NOT_IN_GIP);
+		expect(notInGip.Effectif).toBeNull();
+		expect(notInGip.Indicateur_G_requis).toBe(false);
+	});
+
+	it("floors the numeric(9,2) workforce so 99,97 is exported as 99", async () => {
+		const declarations = await fetchExport();
+
+		expect(findBySiren(declarations, SIREN_FRACTIONAL).Effectif).toBe(99);
+	});
+
+	it("does not pick up a GIP row from another campaign year", async () => {
+		const declarations = await fetchExport();
+
+		const otherYear = findBySiren(declarations, SIREN_OTHER_YEAR);
+		expect(otherYear.Effectif).toBeNull();
+		expect(otherYear.Indicateur_G_requis).toBe(false);
+	});
+});

--- a/packages/app/src/modules/export/__tests__/queries.test.ts
+++ b/packages/app/src/modules/export/__tests__/queries.test.ts
@@ -4,7 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockWhere = vi.fn();
 const mockInnerJoin2 = vi.fn(() => ({ where: mockWhere }));
-const mockInnerJoin1 = vi.fn(() => ({ innerJoin: mockInnerJoin2 }));
+const mockLeftJoin = vi.fn(() => ({ innerJoin: mockInnerJoin2 }));
+const mockInnerJoin1 = vi.fn(() => ({ leftJoin: mockLeftJoin }));
 const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin1 }));
 const mockSelect = vi.fn<(fields: Record<string, unknown>) => unknown>(() => ({
 	from: mockFrom,
@@ -14,14 +15,20 @@ vi.mock("~/server/db", () => ({
 	db: { select: (fields: Record<string, unknown>) => mockSelect(fields) },
 }));
 
-function compileWhere(): { sql: string; params: unknown[] } {
-	const condition = mockWhere.mock.calls[0]?.[0] as SQL | undefined;
+function compile(condition: SQL | undefined): {
+	sql: string;
+	params: unknown[];
+} {
 	if (!condition) {
-		throw new Error("where() was not called with a condition");
+		throw new Error("no condition to compile");
 	}
 	const dialect = new PgDialect({ casing: "snake_case" });
 	const built = dialect.sqlToQuery(condition);
 	return { sql: built.sql, params: built.params };
+}
+
+function compileWhere(): { sql: string; params: unknown[] } {
+	return compile(mockWhere.mock.calls[0]?.[0] as SQL | undefined);
 }
 
 describe("fetchSubmittedDeclarations — composite temporal filter", () => {
@@ -37,6 +44,33 @@ describe("fetchSubmittedDeclarations — composite temporal filter", () => {
 		const fields = mockSelect.mock.calls[0]?.[0];
 		expect(fields).toBeDefined();
 		expect(fields).toHaveProperty("cancelledAt");
+	});
+
+	it("should read the SUIT Effectif from gip_mds_data, not from the Weez company workforce (#3929)", async () => {
+		const { fetchSubmittedDeclarations } = await import("../queries");
+		await fetchSubmittedDeclarations("2025-04-01", "2025-05-01");
+
+		const fields = mockSelect.mock.calls[0]?.[0];
+		expect(fields).toHaveProperty("workforceEma");
+		expect(fields).not.toHaveProperty("workforce");
+	});
+
+	it("should left-join gip_mds_data on siren + year so declarations of companies absent from the GIP file are kept", async () => {
+		const { fetchSubmittedDeclarations } = await import("../queries");
+		await fetchSubmittedDeclarations("2025-04-01", "2025-05-01");
+
+		expect(mockLeftJoin).toHaveBeenCalledTimes(1);
+		const joinCall = mockLeftJoin.mock.calls[0] as unknown as
+			| [unknown, SQL]
+			| undefined;
+		const { sql } = compile(joinCall?.[1]);
+
+		expect(sql).toContain(
+			'"app_gip_mds_data"."siren" = "app_declaration"."siren"',
+		);
+		expect(sql).toContain(
+			'"app_gip_mds_data"."year" = "app_declaration"."year"',
+		);
 	});
 
 	it("should compose an OR with two AND branches: cancelled_at-window OR (non-draft + updated_at-window + cancelled_at IS NULL)", async () => {

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -2,13 +2,16 @@ import { and, eq, isNotNull, or } from "drizzle-orm";
 
 import {
 	gapRatioToPercent,
+	getObligationWorkforce,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isIndicatorGRequired,
+	parseGipWorkforce,
+	toDisplayWorkforce,
 } from "~/modules/domain";
 import type { DB } from "~/server/db";
 import { submittedDeclarationCondition } from "~/server/db/declarationConditions";
-import { companies, declarations, users } from "~/server/db/schema";
+import { companies, declarations, gipMdsData, users } from "~/server/db/schema";
 import { mapCseOpinions } from "./mapIndicators";
 import {
 	fetchCseOpinionsByDeclaration,
@@ -45,7 +48,7 @@ export async function buildExportRows(
 			cancelledAt: declarations.cancelledAt,
 			declarationId: declarations.id,
 			companyName: companies.name,
-			workforce: companies.workforce,
+			workforceEma: gipMdsData.workforceEma,
 			nafCode: companies.nafCode,
 			address: companies.address,
 			hasCse: companies.hasCse,
@@ -58,6 +61,13 @@ export async function buildExportRows(
 		})
 		.from(declarations)
 		.innerJoin(companies, eq(declarations.siren, companies.siren))
+		.leftJoin(
+			gipMdsData,
+			and(
+				eq(gipMdsData.siren, declarations.siren),
+				eq(gipMdsData.year, declarations.year),
+			),
+		)
 		.innerJoin(users, eq(declarations.declarantId, users.id))
 		.where(
 			and(
@@ -80,8 +90,9 @@ export async function buildExportRows(
 		const hasIndicatorGForThisDecl = hasIndicatorG.has(row.declarationId);
 		const globalAnnualMeanGap = gapRatioToPercent(row.globalAnnualMeanGap);
 		const variableAnnualMeanGap = gapRatioToPercent(row.variableAnnualMeanGap);
+		const workforce = parseGipWorkforce(row.workforceEma);
 		const complianceInput = {
-			workforce: row.workforce,
+			workforce,
 			hasIndicatorG: hasIndicatorGForThisDecl,
 			gap: globalAnnualMeanGap,
 		};
@@ -105,13 +116,13 @@ export async function buildExportRows(
 							],
 			});
 		const indicatorGRequired = isIndicatorGRequired(
-			row.workforce ?? 0,
+			getObligationWorkforce(workforce),
 			row.year,
 		);
 		return {
 			siren: row.siren,
 			companyName: row.companyName,
-			workforce: row.workforce,
+			workforce: toDisplayWorkforce(workforce),
 			nafCode: row.nafCode,
 			address: row.address,
 			hasCse: row.hasCse,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -15,9 +15,12 @@ export {
 
 import {
 	gapRatioToPercent,
+	getObligationWorkforce,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isIndicatorGRequired,
+	parseGipWorkforce,
+	toDisplayWorkforce,
 } from "~/modules/domain";
 import type { DeclarationRow } from "./queries";
 import {
@@ -54,7 +57,7 @@ function deriveExportFlags(
 	const hasIndicatorG = indicatorGEntries.length > 0;
 	const globalAnnualMeanGap = gapRatioToPercent(row.globalAnnualMeanGap);
 	const variableAnnualMeanGap = gapRatioToPercent(row.variableAnnualMeanGap);
-	const workforce = row.workforce;
+	const workforce = parseGipWorkforce(row.workforceEma);
 	const complianceInput = {
 		workforce,
 		hasIndicatorG,
@@ -80,7 +83,10 @@ function deriveExportFlags(
 						],
 		},
 	);
-	const indicatorGRequiredFlag = isIndicatorGRequired(workforce ?? 0, row.year);
+	const indicatorGRequiredFlag = isIndicatorGRequired(
+		getObligationWorkforce(workforce),
+		row.year,
+	);
 	return {
 		complianceProcessRequired,
 		complianceProcessRevisionRequired,
@@ -313,7 +319,7 @@ export function assembleDeclaration(
 		id: row.declarationId,
 		SIREN: row.siren,
 		Raison_sociale: row.companyName,
-		Effectif: row.workforce,
+		Effectif: toDisplayWorkforce(parseGipWorkforce(row.workforceEma)),
 		Code_NAF: row.nafCode,
 		Adresse: row.address,
 		CSE_existant: row.hasCse,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -18,6 +18,7 @@ import {
 	getObligationWorkforce,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
+	isCseRequired,
 	isIndicatorGRequired,
 	parseGipWorkforce,
 	toDisplayWorkforce,
@@ -322,7 +323,12 @@ export function assembleDeclaration(
 		Effectif: toDisplayWorkforce(parseGipWorkforce(row.workforceEma)),
 		Code_NAF: row.nafCode,
 		Adresse: row.address,
-		CSE_existant: row.hasCse,
+		// The CSE field only exists for companies at or above the CSE threshold; legacy sub-100 values are not exported.
+		CSE_existant: isCseRequired(
+			getObligationWorkforce(parseGipWorkforce(row.workforceEma)),
+		)
+			? row.hasCse
+			: null,
 		Annee: row.year,
 		Statut: row.status,
 		Parcours_apres_declaration_1: row.firstDeclarationPathChoice,

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -198,7 +198,7 @@ const declarationSchema = {
 		},
 		CSE_existant: {
 			type: ["boolean", "null"],
-			description: "Présence d'un CSE (>= 50 salariés)",
+			description: "Présence d'un CSE (>= 100 salariés)",
 		},
 		Annee: {
 			type: "integer",

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -14,6 +14,7 @@ import {
 	declarations,
 	employeeCategories,
 	files,
+	gipMdsData,
 	jobCategories,
 	users,
 } from "~/server/db/schema";
@@ -210,7 +211,7 @@ export async function fetchSubmittedDeclarations(
 			cancelledAt: declarations.cancelledAt,
 			declarationId: declarations.id,
 			companyName: companies.name,
-			workforce: companies.workforce,
+			workforceEma: gipMdsData.workforceEma,
 			nafCode: companies.nafCode,
 			address: companies.address,
 			hasCse: companies.hasCse,
@@ -219,6 +220,13 @@ export async function fetchSubmittedDeclarations(
 		})
 		.from(declarations)
 		.innerJoin(companies, eq(declarations.siren, companies.siren))
+		.leftJoin(
+			gipMdsData,
+			and(
+				eq(gipMdsData.siren, declarations.siren),
+				eq(gipMdsData.year, declarations.year),
+			),
+		)
 		.innerJoin(users, eq(declarations.declarantId, users.id))
 		.where(
 			or(

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -1,5 +1,10 @@
 import type { CampaignDeadlines } from "~/modules/domain";
-import { getCurrentYear, getDeclarationDisplayContext } from "~/modules/domain";
+import {
+	getCurrentYear,
+	getDeclarationDisplayContext,
+	getObligationWorkforce,
+	isCseRequired,
+} from "~/modules/domain";
 
 import { ArchivesSection } from "./ArchivesSection";
 import { CompanyEditModal } from "./CompanyEditModal";
@@ -51,6 +56,9 @@ export function CompanyDeclarationsPage({
 	userPhone,
 }: Props) {
 	const currentYear = getCurrentYear();
+	const cseApplicable = isCseRequired(
+		getObligationWorkforce(company.gipWorkforce),
+	);
 	const lastActionDate = getLastActionDate(declarations, currentYear);
 	const currentDeclaration = declarations.find(
 		(d) => d.type === "remuneration" && d.year === currentYear,
@@ -71,6 +79,7 @@ export function CompanyDeclarationsPage({
 			<CompanyInfoBanner company={company} />
 			<DeclarationsSection
 				campaignDeadlines={campaignDeadlines}
+				cseApplicable={cseApplicable}
 				declarations={declarations}
 				hasCse={company.hasCse}
 				hasNoSanction={hasNoSanction}
@@ -79,6 +88,7 @@ export function CompanyDeclarationsPage({
 			<ArchivesSection />
 			<CompanyEditModal company={company} />
 			<MissingInfoModal
+				cseApplicable={cseApplicable}
 				hasCse={company.hasCse}
 				siren={company.siren}
 				userPhone={userPhone}

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -5,7 +5,7 @@ import { useCallback, useRef } from "react";
 import { Controller } from "react-hook-form";
 
 import {
-	GIP_WORKFORCE_UNKNOWN_LABEL,
+	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getCurrentYear,
 	getObligationWorkforce,
 	isCseRequired,
@@ -199,7 +199,7 @@ function CompanyReadonlySection({ company }: CompanyReadonlySectionProps) {
 						value={
 							toDisplayWorkforce(company.gipWorkforce)?.toLocaleString(
 								"fr-FR",
-							) ?? GIP_WORKFORCE_UNKNOWN_LABEL
+							) ?? GIP_WORKFORCE_ABSENT_DISPLAY
 						}
 					/>
 				</dl>

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -4,7 +4,13 @@ import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
 import { Controller } from "react-hook-form";
 
-import { getCurrentYear } from "~/modules/domain";
+import {
+	GIP_WORKFORCE_UNKNOWN_LABEL,
+	getCurrentYear,
+	getObligationWorkforce,
+	isCseRequired,
+	toDisplayWorkforce,
+} from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import styles from "./CompanyEditModal.module.scss";
@@ -22,7 +28,7 @@ type Props = {
 		name: string;
 		address: string | null;
 		nafCode: string | null;
-		workforce: number | null;
+		gipWorkforce: number | null;
 		hasCse: boolean | null;
 	};
 };
@@ -30,6 +36,9 @@ type Props = {
 export function CompanyEditModal({ company: initialCompany }: Props) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 	const router = useRouter();
+	const cseApplicable = isCseRequired(
+		getObligationWorkforce(initialCompany.gipWorkforce),
+	);
 
 	const form = useZodForm(updateHasCseSchema, {
 		defaultValues: {
@@ -84,9 +93,10 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 									Modifier les informations
 								</h2>
 								<p className="fr-mb-4w">
-									Vérifier les données affichées et compléter l'information
-									manquantes sur l'existence d'un CSE si nécessaire. Si vous
-									constatez une erreur, veuillez{" "}
+									{cseApplicable
+										? "Vérifier les données affichées et compléter l'information manquantes sur l'existence d'un CSE si nécessaire."
+										: "Vérifier les données affichées."}{" "}
+									Si vous constatez une erreur, veuillez{" "}
 									<a
 										className="fr-link fr-icon-external-link-line fr-link--icon-right"
 										href="/aide/nous-contacter"
@@ -108,39 +118,43 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 									onSubmit={onSubmit}
 								>
 									<CompanyReadonlySection company={initialCompany} />
-									<Controller
-										control={form.control}
-										name="hasCse"
-										render={({ field }) => (
-											<CseRadioGroup
-												hasCse={field.value ?? null}
-												setHasCse={field.onChange}
-											/>
-										)}
-									/>
+									{cseApplicable && (
+										<Controller
+											control={form.control}
+											name="hasCse"
+											render={({ field }) => (
+												<CseRadioGroup
+													hasCse={field.value ?? null}
+													setHasCse={field.onChange}
+												/>
+											)}
+										/>
+									)}
 								</form>
 							</div>
 							<div className="fr-modal__footer">
 								<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
-									<li>
-										<button
-											className="fr-btn"
-											disabled={
-												hasCse === undefined || updateHasCseMutation.isPending
-											}
-											form="company-edit-form"
-											type="submit"
-										>
-											Enregistrer
-										</button>
-									</li>
+									{cseApplicable && (
+										<li>
+											<button
+												className="fr-btn"
+												disabled={
+													hasCse === undefined || updateHasCseMutation.isPending
+												}
+												form="company-edit-form"
+												type="submit"
+											>
+												Enregistrer
+											</button>
+										</li>
+									)}
 									<li>
 										<button
 											aria-controls={MODAL_ID}
 											className="fr-btn fr-btn--secondary"
 											type="button"
 										>
-											Annuler
+											{cseApplicable ? "Annuler" : "Fermer"}
 										</button>
 									</li>
 								</ul>
@@ -159,7 +173,7 @@ type CompanyReadonlySectionProps = {
 		name: string;
 		address: string | null;
 		nafCode: string | null;
-		workforce: number | null;
+		gipWorkforce: number | null;
 	};
 };
 
@@ -182,11 +196,15 @@ function CompanyReadonlySection({ company }: CompanyReadonlySectionProps) {
 				<dl className={styles.infoList}>
 					<InfoRow
 						label={`Effectif annuel moyen en ${CURRENT_YEAR} :`}
-						value={company.workforce?.toLocaleString("fr-FR")}
+						value={
+							toDisplayWorkforce(company.gipWorkforce)?.toLocaleString(
+								"fr-FR",
+							) ?? GIP_WORKFORCE_UNKNOWN_LABEL
+						}
 					/>
 				</dl>
 				<p className={`fr-text--sm fr-mb-0 ${styles.sourceText}`}>
-					Source : DSN (Déclarations sociales nominatives).
+					Source : GIP-MDS (DSN — Déclarations sociales nominatives).
 				</p>
 			</div>
 		</>

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -1,4 +1,10 @@
-import { getCurrentYear } from "~/modules/domain";
+import {
+	GIP_WORKFORCE_UNKNOWN_LABEL,
+	getCurrentYear,
+	getObligationWorkforce,
+	isCseRequired,
+	toDisplayWorkforce,
+} from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 
 import { MODAL_ID as COMPANY_EDIT_MODAL_ID } from "./CompanyEditModal";
@@ -14,6 +20,9 @@ type Props = {
 
 export function CompanyInfoBanner({ company }: Props) {
 	const currentYear = getCurrentYear();
+	const cseApplicable = isCseRequired(
+		getObligationWorkforce(company.gipWorkforce),
+	);
 
 	return (
 		<div className={`fr-pt-3w fr-pb-4w ${styles.banner}`}>
@@ -71,24 +80,28 @@ export function CompanyInfoBanner({ company }: Props) {
 							</dd>
 						</div>
 					)}
-					{company.workforce !== null && (
-						<div className={styles.datapoint}>
-							<dt>Effectif annuel moyen en {currentYear} :</dt>
-							<dd>
-								<strong>{company.workforce}</strong>
-							</dd>
-						</div>
-					)}
 					<div className={styles.datapoint}>
-						<dt>Existence d'un CSE :</dt>
+						<dt>Effectif annuel moyen en {currentYear} :</dt>
 						<dd>
-							{company.hasCse !== null ? (
-								<strong>{company.hasCse ? "Oui" : "Non"}</strong>
+							{company.gipWorkforce === null ? (
+								GIP_WORKFORCE_UNKNOWN_LABEL
 							) : (
-								<StatusBadge status="to_complete" />
+								<strong>{toDisplayWorkforce(company.gipWorkforce)}</strong>
 							)}
 						</dd>
 					</div>
+					{cseApplicable && (
+						<div className={styles.datapoint}>
+							<dt>Existence d'un CSE :</dt>
+							<dd>
+								{company.hasCse !== null ? (
+									<strong>{company.hasCse ? "Oui" : "Non"}</strong>
+								) : (
+									<StatusBadge status="to_complete" />
+								)}
+							</dd>
+						</div>
+					)}
 				</dl>
 			</div>
 		</div>

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -1,5 +1,6 @@
 import {
-	GIP_WORKFORCE_UNKNOWN_LABEL,
+	classifyCompanySize,
+	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getCurrentYear,
 	getObligationWorkforce,
 	isCseRequired,
@@ -20,9 +21,11 @@ type Props = {
 
 export function CompanyInfoBanner({ company }: Props) {
 	const currentYear = getCurrentYear();
-	const cseApplicable = isCseRequired(
-		getObligationWorkforce(company.gipWorkforce),
-	);
+	const obligationWorkforce = getObligationWorkforce(company.gipWorkforce);
+	const cseApplicable = isCseRequired(obligationWorkforce);
+	// Below the voluntary threshold nothing is editable (the CSE field starts at 100), so the edit entry point is hidden entirely.
+	const editApplicable =
+		classifyCompanySize(obligationWorkforce) !== "voluntary";
 
 	return (
 		<div className={`fr-pt-3w fr-pb-4w ${styles.banner}`}>
@@ -38,16 +41,18 @@ export function CompanyInfoBanner({ company }: Props) {
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">{company.name}</h1>
 					</div>
-					<div className="fr-col-auto">
-						<button
-							aria-controls={COMPANY_EDIT_MODAL_ID}
-							className="fr-btn fr-btn--tertiary-no-outline fr-icon-edit-line fr-btn--icon-left"
-							data-fr-opened="false"
-							type="button"
-						>
-							Modifier
-						</button>
-					</div>
+					{editApplicable && (
+						<div className="fr-col-auto">
+							<button
+								aria-controls={COMPANY_EDIT_MODAL_ID}
+								className="fr-btn fr-btn--tertiary-no-outline fr-icon-edit-line fr-btn--icon-left"
+								data-fr-opened="false"
+								type="button"
+							>
+								Modifier
+							</button>
+						</div>
+					)}
 				</div>
 
 				<dl className={`${styles.infoRow} fr-mb-1w`}>
@@ -84,7 +89,7 @@ export function CompanyInfoBanner({ company }: Props) {
 						<dt>Effectif annuel moyen en {currentYear} :</dt>
 						<dd>
 							{company.gipWorkforce === null ? (
-								GIP_WORKFORCE_UNKNOWN_LABEL
+								GIP_WORKFORCE_ABSENT_DISPLAY
 							) : (
 								<strong>{toDisplayWorkforce(company.gipWorkforce)}</strong>
 							)}

--- a/packages/app/src/modules/my-space/DeclarationLink.tsx
+++ b/packages/app/src/modules/my-space/DeclarationLink.tsx
@@ -18,14 +18,22 @@ type Props = {
 	type: DeclarationType;
 	userPhone: string | null;
 	hasCse: boolean | null;
+	cseApplicable: boolean;
 	children: React.ReactNode;
 };
 
 /** Link that opens the missing info modal if phone or CSE is missing, or navigates/opens panel directly. */
-export function DeclarationLink({ type, userPhone, hasCse, children }: Props) {
+export function DeclarationLink({
+	type,
+	userPhone,
+	hasCse,
+	cseApplicable,
+	children,
+}: Props) {
 	const isImpersonating = useIsImpersonating();
 	const hasMissingInfo =
-		!isImpersonating && !hasRequiredDeclarationInfo(userPhone, hasCse);
+		!isImpersonating &&
+		!hasRequiredDeclarationInfo(userPhone, hasCse, cseApplicable);
 
 	// When info is missing, open missing-info modal (for both types)
 	if (hasMissingInfo) {

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -33,6 +33,7 @@ type Props = {
 	declarations: DeclarationItem[];
 	userPhone: string | null;
 	hasCse: boolean | null;
+	cseApplicable: boolean;
 	hasNoSanction: boolean;
 };
 
@@ -59,6 +60,7 @@ export function DeclarationsSection({
 	declarations,
 	userPhone,
 	hasCse,
+	cseApplicable,
 	hasNoSanction,
 }: Props) {
 	const currentYear = getCurrentYear();
@@ -118,6 +120,7 @@ export function DeclarationsSection({
 			{visibleCurrentDeclarations.length > 0 && (
 				<DeclarationsTable
 					campaignDeadlines={campaignDeadlines}
+					cseApplicable={cseApplicable}
 					declarations={visibleCurrentDeclarations}
 					hasCse={hasCse}
 					labelledById="demarches-en-cours-title"
@@ -131,6 +134,7 @@ export function DeclarationsSection({
 					</h2>
 					<DeclarationsTable
 						campaignDeadlines={campaignDeadlines}
+						cseApplicable={cseApplicable}
 						declarations={visiblePreviousDeclarations}
 						hasCse={hasCse}
 						labelledById="annees-precedentes-title"
@@ -178,6 +182,7 @@ type DeclarationsTableProps = {
 	labelledById: string;
 	userPhone: string | null;
 	hasCse: boolean | null;
+	cseApplicable: boolean;
 };
 
 function DeclarationsTable({
@@ -186,6 +191,7 @@ function DeclarationsTable({
 	labelledById,
 	userPhone,
 	hasCse,
+	cseApplicable,
 }: DeclarationsTableProps) {
 	return (
 		<div className={`fr-table ${styles.tableNoCaptionOffset}`}>
@@ -210,6 +216,7 @@ function DeclarationsTable({
 										<tr key={`${declaration.type}-${declaration.year}`}>
 											<td>
 												<DeclarationLink
+													cseApplicable={cseApplicable}
 													hasCse={hasCse}
 													type={declaration.type}
 													userPhone={userPhone}

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -21,6 +21,7 @@ type Props = {
 	siren: string;
 	userPhone: string | null;
 	hasCse: boolean | null;
+	cseApplicable: boolean;
 };
 
 function getDescription(needsPhone: boolean, needsCse: boolean): string {
@@ -35,12 +36,17 @@ function getDescription(needsPhone: boolean, needsCse: boolean): string {
 
 type OpenerType = "remuneration" | "representation";
 
-export function MissingInfoModal({ siren, userPhone, hasCse }: Props) {
+export function MissingInfoModal({
+	siren,
+	userPhone,
+	hasCse,
+	cseApplicable,
+}: Props) {
 	const isImpersonating = useIsImpersonating();
 	const dialogRef = useRef<HTMLDialogElement>(null);
 	const openerTypeRef = useRef<OpenerType>("remuneration");
 	const needsPhone = !userPhone;
-	const needsCse = hasCse === null;
+	const needsCse = cseApplicable && hasCse === null;
 
 	const schema = useMemo(
 		() => createMissingInfoSchema(needsPhone, needsCse),

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -34,7 +34,7 @@ const company: CompanyDetail = {
 	address: null,
 	nafCode: null,
 	nafLabel: null,
-	workforce: null,
+	gipWorkforce: null,
 	hasCse: null,
 };
 

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
+import { GIP_WORKFORCE_ABSENT_DISPLAY } from "~/modules/domain";
 
 const mockMutate = vi.fn();
 
@@ -114,7 +114,7 @@ describe("CompanyEditModal", () => {
 			<CompanyEditModal company={{ ...company, gipWorkforce: null }} />,
 		);
 
-		expect(container.textContent).toContain(GIP_WORKFORCE_UNKNOWN_LABEL);
+		expect(container.textContent).toContain(GIP_WORKFORCE_ABSENT_DISPLAY);
 	});
 
 	it("disables submit when no CSE is selected", () => {
@@ -202,7 +202,7 @@ describe("CompanyEditModal", () => {
 			);
 
 			expect(screen.queryByLabelText("Oui", { exact: true })).toBeNull();
-			expect(container.textContent).toContain(GIP_WORKFORCE_UNKNOWN_LABEL);
+			expect(container.textContent).toContain(GIP_WORKFORCE_ABSENT_DISPLAY);
 			expect(container.textContent).not.toContain(
 				"Vérifier les données affichées et compléter",
 			);

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
+
 const mockMutate = vi.fn();
 
 vi.mock("~/modules/analytics", () => ({
@@ -34,7 +36,7 @@ const company = {
 	name: "Alpha Solutions",
 	address: "12 rue des Innovateurs, 75011 Paris",
 	nafCode: "6202A",
-	workforce: 2256,
+	gipWorkforce: 2256,
 	hasCse: null as boolean | null,
 };
 
@@ -95,20 +97,24 @@ describe("CompanyEditModal", () => {
 	it("renders formatted workforce", () => {
 		const { container } = render(<CompanyEditModal company={company} />);
 
-		expect(container.textContent).toMatch(/2\u202f256/);
+		expect(container.textContent).toMatch(/2 256/);
 	});
 
-	it("shows dash when workforce is null", () => {
+	it("floors the workforce display so 99.97 shows as 99", () => {
 		const { container } = render(
-			<CompanyEditModal company={{ ...company, workforce: null }} />,
+			<CompanyEditModal company={{ ...company, gipWorkforce: 99.97 }} />,
 		);
 
-		const dialog = container.querySelector("dialog");
-		const strongElements = dialog?.querySelectorAll("strong") ?? [];
-		const effectifStrong = Array.from(strongElements).find(
-			(el) => el.textContent === "—",
+		expect(container.textContent).toContain("99");
+		expect(container.textContent).not.toContain("100");
+	});
+
+	it("shows the GIP unknown label when gipWorkforce is null", () => {
+		const { container } = render(
+			<CompanyEditModal company={{ ...company, gipWorkforce: null }} />,
 		);
-		expect(effectifStrong).toBeTruthy();
+
+		expect(container.textContent).toContain(GIP_WORKFORCE_UNKNOWN_LABEL);
 	});
 
 	it("disables submit when no CSE is selected", () => {
@@ -158,7 +164,7 @@ describe("CompanyEditModal", () => {
 
 		expect(container.textContent).toContain("Source : INSEE");
 		expect(container.textContent).toContain(
-			"DSN (Déclarations sociales nominatives)",
+			"Source : GIP-MDS (DSN — Déclarations sociales nominatives).",
 		);
 		expect(container.textContent).toContain("élections professionnelles");
 	});
@@ -169,5 +175,37 @@ describe("CompanyEditModal", () => {
 		expect(container.textContent).toContain("Existence d'un CSE (obligatoire)");
 		expect(screen.getByLabelText("Oui", { exact: true })).toBeInTheDocument();
 		expect(screen.getByLabelText("Non", { exact: true })).toBeInTheDocument();
+	});
+
+	describe("when the CSE is not applicable (gipWorkforce below 100 or unknown)", () => {
+		it("hides the CSE fieldset and the Enregistrer button, and shows a Fermer button", () => {
+			const { container } = render(
+				<CompanyEditModal company={{ ...company, gipWorkforce: 45 }} />,
+			);
+
+			expect(screen.queryByLabelText("Oui", { exact: true })).toBeNull();
+			expect(screen.queryByLabelText("Non", { exact: true })).toBeNull();
+			expect(
+				screen.queryByRole("button", { name: "Enregistrer", hidden: true }),
+			).toBeNull();
+
+			const footerButtons = container.querySelectorAll(
+				".fr-modal__footer button",
+			);
+			expect(footerButtons).toHaveLength(1);
+			expect(footerButtons[0]).toHaveTextContent("Fermer");
+		});
+
+		it("hides the CSE fieldset when the company is absent from the GIP file", () => {
+			const { container } = render(
+				<CompanyEditModal company={{ ...company, gipWorkforce: null }} />,
+			);
+
+			expect(screen.queryByLabelText("Oui", { exact: true })).toBeNull();
+			expect(container.textContent).toContain(GIP_WORKFORCE_UNKNOWN_LABEL);
+			expect(container.textContent).not.toContain(
+				"Vérifier les données affichées et compléter",
+			);
+		});
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
+import { GIP_WORKFORCE_ABSENT_DISPLAY } from "~/modules/domain";
 import { CompanyInfoBanner } from "../CompanyInfoBanner";
 import type { CompanyDetail } from "../types";
 
@@ -116,11 +116,11 @@ describe("CompanyInfoBanner", () => {
 		expect(screen.queryByText("Code NAF :")).not.toBeInTheDocument();
 	});
 
-	it("renders the GIP unknown label and hides the CSE row when gipWorkforce is null", () => {
+	it("renders '< 50' and hides the CSE row when gipWorkforce is null", () => {
 		render(
 			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: null }} />,
 		);
-		expect(screen.getByText(GIP_WORKFORCE_UNKNOWN_LABEL)).toBeInTheDocument();
+		expect(screen.getByText(GIP_WORKFORCE_ABSENT_DISPLAY)).toBeInTheDocument();
 		expect(screen.queryByText("Existence d'un CSE :")).not.toBeInTheDocument();
 	});
 
@@ -140,10 +140,37 @@ describe("CompanyInfoBanner", () => {
 		expect(screen.getByText("Existence d'un CSE :")).toBeInTheDocument();
 	});
 
-	it("renders the 'Modifier' button", () => {
+	it("renders the 'Modifier' button at or above the voluntary threshold", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
 		expect(
 			screen.getByRole("button", { name: "Modifier" }),
 		).toBeInTheDocument();
+	});
+
+	it("keeps the 'Modifier' button between 50 and 99 (read-only modal)", () => {
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 70 }} />,
+		);
+		expect(
+			screen.getByRole("button", { name: "Modifier" }),
+		).toBeInTheDocument();
+	});
+
+	it("hides the 'Modifier' button below 50", () => {
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 42 }} />,
+		);
+		expect(
+			screen.queryByRole("button", { name: "Modifier" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("hides the 'Modifier' button when the company is absent from the GIP file", () => {
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: null }} />,
+		);
+		expect(
+			screen.queryByRole("button", { name: "Modifier" }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -1,16 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { GIP_WORKFORCE_UNKNOWN_LABEL } from "~/modules/domain";
 import { CompanyInfoBanner } from "../CompanyInfoBanner";
 import type { CompanyDetail } from "../types";
 
+// gipWorkforce is >= 100 by default so the CSE row is visible in tests
+// exercising the historical CSE badge/value behavior.
 const baseCompany: CompanyDetail = {
 	siren: "532847196",
 	name: "Alpha Solutions",
 	address: null,
 	nafCode: null,
 	nafLabel: null,
-	workforce: null,
+	gipWorkforce: 250,
 	hasCse: null,
 };
 
@@ -82,7 +85,9 @@ describe("CompanyInfoBanner", () => {
 	});
 
 	it("renders the workforce when provided", () => {
-		render(<CompanyInfoBanner company={{ ...baseCompany, workforce: 150 }} />);
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 150 }} />,
+		);
 		expect(screen.getByText("150")).toBeInTheDocument();
 	});
 
@@ -111,9 +116,28 @@ describe("CompanyInfoBanner", () => {
 		expect(screen.queryByText("Code NAF :")).not.toBeInTheDocument();
 	});
 
-	it("does not render workforce section when workforce is null", () => {
-		render(<CompanyInfoBanner company={baseCompany} />);
-		expect(screen.queryByText(/Effectif annuel moyen/)).not.toBeInTheDocument();
+	it("renders the GIP unknown label and hides the CSE row when gipWorkforce is null", () => {
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: null }} />,
+		);
+		expect(screen.getByText(GIP_WORKFORCE_UNKNOWN_LABEL)).toBeInTheDocument();
+		expect(screen.queryByText("Existence d'un CSE :")).not.toBeInTheDocument();
+	});
+
+	it("floors the workforce display and hides the CSE row below the 100 threshold", () => {
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 99.97 }} />,
+		);
+		expect(screen.getByText("99")).toBeInTheDocument();
+		expect(screen.queryByText("Existence d'un CSE :")).not.toBeInTheDocument();
+	});
+
+	it("shows the workforce and the CSE row at or above the 100 threshold", () => {
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 250 }} />,
+		);
+		expect(screen.getByText("250")).toBeInTheDocument();
+		expect(screen.getByText("Existence d'un CSE :")).toBeInTheDocument();
 	});
 
 	it("renders the 'Modifier' button", () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationLink.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationLink.test.tsx
@@ -14,7 +14,12 @@ describe("DeclarationLink", () => {
 
 	it("renders remuneration as a button opening the process panel when info is present", () => {
 		render(
-			<DeclarationLink hasCse={true} type="remuneration" userPhone="0122334455">
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={true}
+				type="remuneration"
+				userPhone="0122334455"
+			>
 				Rémunération
 			</DeclarationLink>,
 		);
@@ -28,7 +33,12 @@ describe("DeclarationLink", () => {
 
 	it("renders as a button opening missing info modal when userPhone is null", () => {
 		render(
-			<DeclarationLink hasCse={true} type="remuneration" userPhone={null}>
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={true}
+				type="remuneration"
+				userPhone={null}
+			>
 				Rémunération
 			</DeclarationLink>,
 		);
@@ -37,20 +47,63 @@ describe("DeclarationLink", () => {
 		expect(button).toHaveAttribute("aria-controls", "missing-info-modal");
 	});
 
-	it("renders as a button opening missing info modal when hasCse is null", () => {
+	it("renders as a button opening missing info modal when hasCse is null and CSE is applicable", () => {
 		render(
-			<DeclarationLink hasCse={null} type="remuneration" userPhone="0122334455">
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={null}
+				type="remuneration"
+				userPhone="0122334455"
+			>
 				Rémunération
 			</DeclarationLink>,
 		);
 		const button = screen.getByRole("button", { name: "Rémunération" });
 		expect(button).toBeInTheDocument();
+		expect(button).toHaveAttribute("aria-controls", "missing-info-modal");
+	});
+
+	it("navigates normally when hasCse is null but CSE is not applicable", () => {
+		render(
+			<DeclarationLink
+				cseApplicable={false}
+				hasCse={null}
+				type="remuneration"
+				userPhone="0122334455"
+			>
+				Rémunération
+			</DeclarationLink>,
+		);
+		const button = screen.getByRole("button", { name: "Rémunération" });
+		expect(button).toHaveAttribute(
+			"aria-controls",
+			"declaration-process-panel",
+		);
+	});
+
+	it("still opens the missing info modal for a missing phone when CSE is not applicable", () => {
+		render(
+			<DeclarationLink
+				cseApplicable={false}
+				hasCse={null}
+				type="remuneration"
+				userPhone={null}
+			>
+				Rémunération
+			</DeclarationLink>,
+		);
+		const button = screen.getByRole("button", { name: "Rémunération" });
 		expect(button).toHaveAttribute("aria-controls", "missing-info-modal");
 	});
 
 	it("stores the declaration type on buttons opening missing info modal", () => {
 		render(
-			<DeclarationLink hasCse={true} type="remuneration" userPhone={null}>
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={true}
+				type="remuneration"
+				userPhone={null}
+			>
 				Rémunération
 			</DeclarationLink>,
 		);
@@ -61,6 +114,7 @@ describe("DeclarationLink", () => {
 	it("renders representation as a button placeholder when info is present", () => {
 		render(
 			<DeclarationLink
+				cseApplicable={true}
 				hasCse={true}
 				type="representation"
 				userPhone="0122334455"
@@ -76,7 +130,12 @@ describe("DeclarationLink", () => {
 		mockImpersonatingSession(mockedUseSession);
 
 		render(
-			<DeclarationLink hasCse={null} type="remuneration" userPhone={null}>
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={null}
+				type="remuneration"
+				userPhone={null}
+			>
 				Rémunération
 			</DeclarationLink>,
 		);

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -57,6 +57,7 @@ function renderSection(
 	return render(
 		<DeclarationsSection
 			campaignDeadlines={campaignDeadlines}
+			cseApplicable={true}
 			declarations={overrides?.declarations ?? declarations}
 			hasCse={true}
 			hasNoSanction={false}

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
@@ -34,7 +34,12 @@ import { MissingInfoModal } from "../MissingInfoModal";
 describe("MissingInfoModal", () => {
 	it("renders the modal with correct id and title", () => {
 		const { container } = render(
-			<MissingInfoModal hasCse={null} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		const dialog = container.querySelector("#missing-info-modal");
 		expect(dialog).toBeInTheDocument();
@@ -45,7 +50,12 @@ describe("MissingInfoModal", () => {
 
 	it("shows both phone and CSE description when both are missing", () => {
 		render(
-			<MissingInfoModal hasCse={null} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		expect(
 			screen.getByText(
@@ -56,7 +66,12 @@ describe("MissingInfoModal", () => {
 
 	it("shows phone-only description when only phone is missing", () => {
 		render(
-			<MissingInfoModal hasCse={true} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={true}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		expect(
 			screen.getByText(
@@ -68,6 +83,7 @@ describe("MissingInfoModal", () => {
 	it("shows CSE-only description when only CSE is missing", () => {
 		render(
 			<MissingInfoModal
+				cseApplicable={true}
 				hasCse={null}
 				siren="532847196"
 				userPhone="0122334455"
@@ -82,7 +98,12 @@ describe("MissingInfoModal", () => {
 
 	it("renders phone field when userPhone is null", () => {
 		render(
-			<MissingInfoModal hasCse={true} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={true}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		expect(screen.getByLabelText(/Numéro de téléphone/)).toBeInTheDocument();
 	});
@@ -90,6 +111,7 @@ describe("MissingInfoModal", () => {
 	it("does not render phone field when userPhone is provided", () => {
 		render(
 			<MissingInfoModal
+				cseApplicable={true}
 				hasCse={null}
 				siren="532847196"
 				userPhone="0122334455"
@@ -100,9 +122,10 @@ describe("MissingInfoModal", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("renders CSE radio buttons when hasCse is null", () => {
+	it("renders CSE radio buttons when hasCse is null and CSE is applicable", () => {
 		render(
 			<MissingInfoModal
+				cseApplicable={true}
 				hasCse={null}
 				siren="532847196"
 				userPhone="0122334455"
@@ -119,7 +142,12 @@ describe("MissingInfoModal", () => {
 
 	it("does not render CSE radio buttons when hasCse is provided", () => {
 		render(
-			<MissingInfoModal hasCse={true} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={true}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		expect(
 			screen.queryByText(
@@ -128,9 +156,37 @@ describe("MissingInfoModal", () => {
 		).not.toBeInTheDocument();
 	});
 
+	it("hides CSE radios and limits the description to the phone when CSE is not applicable", () => {
+		render(
+			<MissingInfoModal
+				cseApplicable={false}
+				hasCse={null}
+				siren="532847196"
+				userPhone={null}
+			/>,
+		);
+		expect(
+			screen.getByText(
+				"Pour continuer, vous devez ajouter un numéro de téléphone à votre profil.",
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				"Un CSE a-t-il été mis en place dans votre entreprise ?",
+			),
+		).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Oui")).not.toBeInTheDocument();
+		expect(screen.queryByLabelText("Non")).not.toBeInTheDocument();
+	});
+
 	it("renders Enregistrer and Retour buttons", () => {
 		render(
-			<MissingInfoModal hasCse={null} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		expect(
 			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
@@ -140,14 +196,24 @@ describe("MissingInfoModal", () => {
 
 	it("renders the close button", () => {
 		render(
-			<MissingInfoModal hasCse={null} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		expect(screen.getByTitle("Fermer")).toBeInTheDocument();
 	});
 
 	it("Enregistrer button is not disabled when mutations are idle", () => {
 		render(
-			<MissingInfoModal hasCse={null} siren="532847196" userPhone={null} />,
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone={null}
+			/>,
 		);
 		expect(
 			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
@@ -163,7 +229,12 @@ describe("MissingInfoModal", () => {
 			mockImpersonatingSession(mockedUseSession);
 
 			const { container } = render(
-				<MissingInfoModal hasCse={null} siren="532847196" userPhone={null} />,
+				<MissingInfoModal
+					cseApplicable={true}
+					hasCse={null}
+					siren="532847196"
+					userPhone={null}
+				/>,
 			);
 			expect(container.querySelector("#missing-info-modal")).toBeNull();
 		});

--- a/packages/app/src/modules/my-space/types.ts
+++ b/packages/app/src/modules/my-space/types.ts
@@ -25,7 +25,7 @@ export type CompanyDetail = {
 	address: string | null;
 	nafCode: string | null;
 	nafLabel: string | null;
-	workforce: number | null;
+	gipWorkforce: number | null;
 	hasCse: boolean | null;
 };
 

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getById.test.ts
@@ -72,6 +72,7 @@ function buildDb(options: {
 			const chain = {
 				from: vi.fn().mockReturnThis(),
 				innerJoin: vi.fn().mockReturnThis(),
+				leftJoin: vi.fn().mockReturnThis(),
 				where: vi.fn().mockReturnThis(),
 				limit: vi.fn().mockImplementation(() => {
 					if (callIndex === 1)

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
@@ -55,7 +55,7 @@ type JoinedRow = {
 	companySiren: string;
 	companyNafCode: string | null;
 	companyAddress: string | null;
-	companyWorkforce: number | null;
+	companyWorkforceEma: string | null;
 	declarantEmail: string;
 	declarantFirstName: string | null;
 	declarantLastName: string | null;
@@ -67,7 +67,7 @@ const baseJoinedRow: JoinedRow = {
 	companySiren: "123456789",
 	companyNafCode: "6201Z",
 	companyAddress: "1 rue de Paris",
-	companyWorkforce: 200,
+	companyWorkforceEma: "200.00",
 	declarantEmail: "alice@example.fr",
 	declarantFirstName: "Alice",
 	declarantLastName: "Dupont",
@@ -105,6 +105,7 @@ function buildDb(options: {
 					return chain;
 				}),
 				innerJoin: vi.fn().mockReturnThis(),
+				leftJoin: vi.fn().mockReturnThis(),
 				where: vi.fn().mockImplementation(resolve),
 			};
 			return chain;
@@ -145,8 +146,9 @@ describe("adminDeclarationsRouter — getRecap", () => {
 			siren: "123456789",
 			nafCode: "6201Z",
 			address: "1 rue de Paris",
-			workforce: 200,
+			gipWorkforce: 200,
 		});
+		expect(result.company).not.toHaveProperty("workforce");
 		expect(result.declarationYear).toBe(2026);
 		expect(result.referencePeriod).toBe("01/01/2026 - 31/12/2026");
 		expect(result.declarantName).toBe("Alice Dupont");
@@ -156,6 +158,38 @@ describe("adminDeclarationsRouter — getRecap", () => {
 		expect(result.totalMen).toBe(50);
 		expect(result.step5Categories).toEqual([]);
 		expect(result.step5Source).toBeNull();
+	});
+
+	it("exposes a null gipWorkforce when the company is absent from the GIP file", async () => {
+		const db = buildDb({
+			row: { ...baseJoinedRow, companyWorkforceEma: null },
+		});
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getRecap({ id: DECL_ID });
+
+		expect(result.company.gipWorkforce).toBeNull();
+	});
+
+	it("keeps the exact fractional GIP workforce", async () => {
+		const db = buildDb({
+			row: { ...baseJoinedRow, companyWorkforceEma: "99.97" },
+		});
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getRecap({ id: DECL_ID });
+
+		expect(result.company.gipWorkforce).toBe(99.97);
 	});
 
 	it("flags isCorrection=true when a second_declaration_submit event exists", async () => {

--- a/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
@@ -10,7 +10,7 @@ function makeCompanyRow() {
 		name: "Test Company",
 		address: "1 rue de Paris",
 		nafCode: "6202A",
-		workforce: 100,
+		workforceEma: "100.00",
 		hasCse: true,
 	};
 }
@@ -22,9 +22,11 @@ function makeSelectMock(declRows: unknown[]) {
 		if (selectCallCount === 1) {
 			return {
 				from: vi.fn().mockReturnValue({
-					innerJoin: vi.fn().mockReturnValue({
-						where: vi.fn().mockReturnValue({
-							limit: vi.fn().mockResolvedValue([makeCompanyRow()]),
+					leftJoin: vi.fn().mockReturnValue({
+						innerJoin: vi.fn().mockReturnValue({
+							where: vi.fn().mockReturnValue({
+								limit: vi.fn().mockResolvedValue([makeCompanyRow()]),
+							}),
 						}),
 					}),
 				}),

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -85,6 +85,7 @@ vi.mock("~/server/db", () => ({
 const mockLimit = vi.fn();
 const mockWhere = vi.fn();
 const mockInnerJoin = vi.fn();
+const mockLeftJoin = vi.fn();
 const mockFrom = vi.fn();
 const mockSelect = vi.fn();
 const mockUpdate = vi.fn();
@@ -95,9 +96,10 @@ function createMockDb(rows: unknown[]) {
 	mockLimit.mockResolvedValue(rows);
 	mockWhere.mockReturnValue({ limit: mockLimit });
 	mockInnerJoin.mockReturnValue({ where: mockWhere });
-	// `where` on the from() result supports the impersonation bypass path
+	// `where` on the leftJoin() result supports the impersonation bypass path
 	// (no innerJoin); `innerJoin` supports the owner path.
-	mockFrom.mockReturnValue({ innerJoin: mockInnerJoin, where: mockWhere });
+	mockLeftJoin.mockReturnValue({ innerJoin: mockInnerJoin, where: mockWhere });
+	mockFrom.mockReturnValue({ leftJoin: mockLeftJoin });
 	mockSelect.mockReturnValue({ from: mockFrom });
 
 	mockUpdateWhere.mockResolvedValue(undefined);
@@ -129,7 +131,7 @@ describe("findUserCompany CSE auto-fetch", () => {
 			name: "Test Company",
 			address: "1 rue de Paris",
 			nafCode: "6202A",
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: null,
 		};
 
@@ -150,6 +152,94 @@ describe("findUserCompany CSE auto-fetch", () => {
 		expect(result.hasCse).toBe(true);
 	});
 
+	it("does not fetch CSE below 100 GIP employees, comparing on the exact value", async () => {
+		const { fetchCseBySiren } = await import("~/server/services/suit");
+		const fetchCseMock = vi.mocked(fetchCseBySiren);
+
+		const mockDb = createMockDb([
+			{
+				siren: "339787277",
+				name: "Test Company",
+				address: "1 rue de Paris",
+				nafCode: "6202A",
+				workforceEma: "99.97",
+				hasCse: null,
+			},
+		]);
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.get({ siren: "339787277" });
+
+		expect(fetchCseMock).not.toHaveBeenCalled();
+		expect(mockUpdate).not.toHaveBeenCalled();
+		expect(result.hasCse).toBeNull();
+		expect(result.gipWorkforce).toBe(99.97);
+	});
+
+	it("does not fetch CSE when the company is absent from the GIP file", async () => {
+		const { fetchCseBySiren } = await import("~/server/services/suit");
+		const fetchCseMock = vi.mocked(fetchCseBySiren);
+
+		const mockDb = createMockDb([
+			{
+				siren: "339787277",
+				name: "Test Company",
+				address: "1 rue de Paris",
+				nafCode: "6202A",
+				workforceEma: null,
+				hasCse: null,
+			},
+		]);
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.get({ siren: "339787277" });
+
+		expect(fetchCseMock).not.toHaveBeenCalled();
+		expect(result.hasCse).toBeNull();
+		expect(result.gipWorkforce).toBeNull();
+	});
+
+	it("exposes the GIP workforce and never the Weez company workforce (#3929)", async () => {
+		const { fetchCseBySiren } = await import("~/server/services/suit");
+		vi.mocked(fetchCseBySiren).mockResolvedValue(null);
+
+		const mockDb = createMockDb([
+			{
+				siren: "123456789",
+				name: "Test Company",
+				address: "1 rue de Paris",
+				nafCode: "6202A",
+				workforceEma: "70.00",
+				hasCse: null,
+			},
+		]);
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.get({ siren: "123456789" });
+
+		expect(result.gipWorkforce).toBe(70);
+		expect(result).not.toHaveProperty("workforce");
+		expect(result).not.toHaveProperty("workforceEma");
+	});
+
 	it("does not fetch CSE when hasCse is already set", async () => {
 		const { fetchCseBySiren } = await import("~/server/services/suit");
 		const fetchCseMock = vi.mocked(fetchCseBySiren);
@@ -159,7 +249,7 @@ describe("findUserCompany CSE auto-fetch", () => {
 			name: "Test Company",
 			address: "1 rue de Paris",
 			nafCode: "6202A",
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: false,
 		};
 
@@ -188,7 +278,7 @@ describe("findUserCompany CSE auto-fetch", () => {
 			name: "Test Company",
 			address: "1 rue de Paris",
 			nafCode: "6202A",
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: null,
 		};
 
@@ -264,7 +354,7 @@ describe("findUserCompany NAF label enrichment", () => {
 			address: null,
 			nafCode: "62.01Z",
 			nafLabel: null,
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: true,
 		});
 
@@ -284,7 +374,7 @@ describe("findUserCompany NAF label enrichment", () => {
 			address: null,
 			nafCode: "62.01Z",
 			nafLabel: "Programmation informatique",
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: true,
 		});
 
@@ -301,7 +391,7 @@ describe("findUserCompany NAF label enrichment", () => {
 			address: null,
 			nafCode: null,
 			nafLabel: null,
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: true,
 		});
 
@@ -319,7 +409,7 @@ describe("findUserCompany NAF label enrichment", () => {
 			address: null,
 			nafCode: "62.01Z",
 			nafLabel: null,
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: true,
 		});
 
@@ -335,7 +425,7 @@ describe("findUserCompany NAF label enrichment", () => {
 				address: null,
 				nafCode: "62.01Z",
 				nafLabel: null,
-				workforce: 100,
+				workforceEma: "100.00",
 				hasCse: true,
 			},
 		]);
@@ -375,14 +465,15 @@ describe("companyRouter.updateHasCse", () => {
 			name: "Test Company",
 			address: "1 rue de Paris",
 			nafCode: "6202A",
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: false,
 		};
 
 		mockLimit.mockResolvedValue([companyRow]);
 		mockWhere.mockReturnValue({ limit: mockLimit });
 		mockInnerJoin.mockReturnValue({ where: mockWhere });
-		mockFrom.mockReturnValue({ innerJoin: mockInnerJoin });
+		mockLeftJoin.mockReturnValue({ innerJoin: mockInnerJoin });
+		mockFrom.mockReturnValue({ leftJoin: mockLeftJoin });
 		mockSelect.mockReturnValue({ from: mockFrom });
 
 		mockUpdateWhere.mockResolvedValue(undefined);
@@ -449,7 +540,7 @@ describe("companyRouter.getSanctionStatus", () => {
 			name: "Test Company",
 			address: "1 rue de Paris",
 			nafCode: "6202A",
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: true,
 		};
 
@@ -478,7 +569,7 @@ describe("companyRouter.getSanctionStatus", () => {
 			name: "Test Company",
 			address: "1 rue de Paris",
 			nafCode: "6202A",
-			workforce: 100,
+			workforceEma: "100.00",
 			hasCse: true,
 		};
 

--- a/packages/app/src/server/api/routers/__tests__/company.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.test.ts
@@ -494,6 +494,70 @@ describe("companyRouter.updateHasCse", () => {
 		expect(mockSet).toHaveBeenCalledWith({ hasCse: true });
 	});
 
+	it("refuses the update below the CSE threshold (GIP workforce < 100)", async () => {
+		const companyRow = {
+			siren: "339787277",
+			name: "Test Company",
+			address: "1 rue de Paris",
+			nafCode: "6202A",
+			workforceEma: "70.00",
+			hasCse: null,
+		};
+
+		mockLimit.mockResolvedValue([companyRow]);
+		mockWhere.mockReturnValue({ limit: mockLimit });
+		mockInnerJoin.mockReturnValue({ where: mockWhere });
+		mockLeftJoin.mockReturnValue({ innerJoin: mockInnerJoin });
+		mockFrom.mockReturnValue({ leftJoin: mockLeftJoin });
+		mockSelect.mockReturnValue({ from: mockFrom });
+
+		const mockDb = { select: mockSelect, update: mockUpdate } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await expect(
+			caller.updateHasCse({ siren: "339787277", hasCse: true }),
+		).rejects.toThrow("réservé aux entreprises de 100 salariés et plus");
+		expect(mockSet).not.toHaveBeenCalled();
+	});
+
+	it("refuses the update when the company is absent from the GIP file", async () => {
+		const companyRow = {
+			siren: "339787277",
+			name: "Test Company",
+			address: "1 rue de Paris",
+			nafCode: "6202A",
+			workforceEma: null,
+			hasCse: null,
+		};
+
+		mockLimit.mockResolvedValue([companyRow]);
+		mockWhere.mockReturnValue({ limit: mockLimit });
+		mockInnerJoin.mockReturnValue({ where: mockWhere });
+		mockLeftJoin.mockReturnValue({ innerJoin: mockInnerJoin });
+		mockFrom.mockReturnValue({ leftJoin: mockLeftJoin });
+		mockSelect.mockReturnValue({ from: mockFrom });
+
+		const mockDb = { select: mockSelect, update: mockUpdate } as unknown;
+
+		const { companyRouter } = await import("../company");
+		const caller = companyRouter.createCaller({
+			db: mockDb,
+			session: { user: { id: "user-1" }, expires: "" },
+			headers: new Headers(),
+		} as never);
+
+		await expect(
+			caller.updateHasCse({ siren: "339787277", hasCse: true }),
+		).rejects.toThrow("réservé aux entreprises de 100 salariés et plus");
+		expect(mockSet).not.toHaveBeenCalled();
+	});
+
 	it("refuses the update when the admin is impersonating the company", async () => {
 		const mockDb = { select: mockSelect, update: mockUpdate } as unknown;
 

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -292,9 +292,17 @@ function createSubmitMockDb(
 	declaration: DeclarationStateRow,
 	company: CompanyRow,
 	employeeCategories: Array<Record<string, unknown>> = [],
+	gipWorkforceEma: string | null = null,
 ) {
 	const joinRows = employeeCategories.map((ec) => ({ employee_category: ec }));
-	const selectQueue = createSelectQueue([[declaration], [company], joinRows]);
+	const gipRows =
+		gipWorkforceEma === null ? [] : [{ workforceEma: gipWorkforceEma }];
+	const selectQueue = createSelectQueue([
+		[declaration],
+		[company],
+		gipRows,
+		joinRows,
+	]);
 
 	const m = createMutationTxMock([declaration]);
 
@@ -534,7 +542,12 @@ describe("declarationRouter", () => {
 			const employeeCategories = [
 				{ annualBaseWomen: "100", annualBaseMen: "100" },
 			];
-			const ctx = createSubmitMockDb(declaration, company, employeeCategories);
+			const ctx = createSubmitMockDb(
+				declaration,
+				company,
+				employeeCategories,
+				"120.00",
+			);
 			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
@@ -553,7 +566,12 @@ describe("declarationRouter", () => {
 			const employeeCategories = [
 				{ annualBaseWomen: "85", annualBaseMen: "100" },
 			];
-			const ctx = createSubmitMockDb(declaration, company, employeeCategories);
+			const ctx = createSubmitMockDb(
+				declaration,
+				company,
+				employeeCategories,
+				"130.00",
+			);
 			const caller = await createLockedCaller(ctx.db);
 
 			await caller.submit();
@@ -564,6 +582,48 @@ describe("declarationRouter", () => {
 				eventType: string;
 			}>;
 			expect(insertedEvents.map((e) => e.eventType)).toEqual(["submit"]);
+		});
+
+		it("drives the FSM from the GIP workforce, not from the Weez company workforce (#3929)", async () => {
+			const declaration = buildDeclaration({ status: "draft" });
+			const company = buildCompany({ workforce: 82, hasCse: true });
+			const employeeCategories = [
+				{ annualBaseWomen: "85", annualBaseMen: "100" },
+			];
+			const ctx = createSubmitMockDb(
+				declaration,
+				company,
+				employeeCategories,
+				"70.00",
+			);
+			const caller = await createLockedCaller(ctx.db);
+
+			await caller.submit();
+
+			const setCall = ctx.set.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(setCall.status).toBe("demarche_completed");
+			expect(setCall.cseRequired).toBe(false);
+		});
+
+		it("treats a company absent from the GIP file as not subject, whatever the Weez workforce says", async () => {
+			const declaration = buildDeclaration({ status: "draft" });
+			const company = buildCompany({ workforce: 1183, hasCse: true });
+			const employeeCategories = [
+				{ annualBaseWomen: "85", annualBaseMen: "100" },
+			];
+			const ctx = createSubmitMockDb(
+				declaration,
+				company,
+				employeeCategories,
+				null,
+			);
+			const caller = await createLockedCaller(ctx.db);
+
+			await caller.submit();
+
+			const setCall = ctx.set.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(setCall.status).toBe("demarche_completed");
+			expect(setCall.cseRequired).toBe(false);
 		});
 
 		it("does not duplicate submit events when called from a non-draft state", async () => {
@@ -685,12 +745,12 @@ describe("declarationRouter", () => {
 
 	describe("submit — cseRequired snapshot", () => {
 		async function submitAndReadSnapshot(
-			workforce: number | null,
+			gipWorkforceEma: string | null,
 			hasCse: boolean | null,
 		): Promise<boolean> {
 			const declaration = buildDeclaration({ status: "draft" });
-			const company = buildCompany({ workforce, hasCse });
-			const ctx = createSubmitMockDb(declaration, company, []);
+			const company = buildCompany({ hasCse });
+			const ctx = createSubmitMockDb(declaration, company, [], gipWorkforceEma);
 			const caller = await createLockedCaller(ctx.db);
 			await caller.submit();
 			const projectionCall = ctx.set.mock.calls
@@ -699,23 +759,27 @@ describe("declarationRouter", () => {
 			return projectionCall?.cseRequired as boolean;
 		}
 
-		it("snapshots true for >= 100 employees with a CSE", async () => {
-			expect(await submitAndReadSnapshot(100, true)).toBe(true);
+		it("snapshots true for >= 100 GIP employees with a CSE", async () => {
+			expect(await submitAndReadSnapshot("100.00", true)).toBe(true);
 		});
 
 		it("snapshots false just below the 100-employee threshold", async () => {
-			expect(await submitAndReadSnapshot(99, true)).toBe(false);
+			expect(await submitAndReadSnapshot("99.00", true)).toBe(false);
 		});
 
-		it("snapshots false for >= 100 employees without a CSE", async () => {
-			expect(await submitAndReadSnapshot(120, false)).toBe(false);
+		it("snapshots false for a fractional GIP workforce just below 100", async () => {
+			expect(await submitAndReadSnapshot("99.97", true)).toBe(false);
+		});
+
+		it("snapshots false for >= 100 GIP employees without a CSE", async () => {
+			expect(await submitAndReadSnapshot("120.00", false)).toBe(false);
 		});
 
 		it("snapshots false when hasCse is null", async () => {
-			expect(await submitAndReadSnapshot(250, null)).toBe(false);
+			expect(await submitAndReadSnapshot("250.00", null)).toBe(false);
 		});
 
-		it("snapshots false when workforce is null", async () => {
+		it("snapshots false when the company is absent from the GIP file", async () => {
 			expect(await submitAndReadSnapshot(null, true)).toBe(false);
 		});
 	});

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -27,6 +27,7 @@ import {
 	getCurrentYear,
 	isCancelled,
 	parseGipWorkforce,
+	toDisplayWorkforce,
 } from "~/modules/domain";
 import {
 	mapToEmployeeCategoryRows,
@@ -169,7 +170,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 					companyName: companies.name,
 					companyAddress: companies.address,
 					companyNafCode: companies.nafCode,
-					companyWorkforce: companies.workforce,
+					companyWorkforceEma: gipMdsData.workforceEma,
 					companyHasCse: companies.hasCse,
 					declarantEmail: users.email,
 					declarantFirstName: users.firstName,
@@ -178,14 +179,23 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				})
 				.from(declarations)
 				.innerJoin(companies, eq(declarations.siren, companies.siren))
+				.leftJoin(
+					gipMdsData,
+					and(
+						eq(gipMdsData.siren, declarations.siren),
+						eq(gipMdsData.year, declarations.year),
+					),
+				)
 				.innerJoin(users, eq(declarations.declarantId, users.id))
 				.where(eq(declarations.id, input.id))
 				.limit(1);
 
-			const declaration = rows[0];
-			if (!declaration) {
+			const row = rows[0];
+			if (!row) {
 				return null;
 			}
+
+			const { companyWorkforceEma, ...declaration } = row;
 
 			const [declarationFiles, opinions, siblingRows, historyRows, activeLock] =
 				await Promise.all([
@@ -248,6 +258,9 @@ export const adminDeclarationsRouter = createTRPCRouter({
 
 			return {
 				...declaration,
+				companyWorkforce: toDisplayWorkforce(
+					parseGipWorkforce(companyWorkforceEma),
+				),
 				files: declarationFiles,
 				cseOpinions: opinions,
 				siblings,

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -23,7 +23,11 @@ import {
 	searchDeclarationsSchema,
 } from "~/modules/admin/declarations/schemas";
 import { releaseLockSchema } from "~/modules/admin/schemas";
-import { getCurrentYear, isCancelled } from "~/modules/domain";
+import {
+	getCurrentYear,
+	isCancelled,
+	parseGipWorkforce,
+} from "~/modules/domain";
 import {
 	mapToEmployeeCategoryRows,
 	mapToStepData,
@@ -36,6 +40,7 @@ import {
 	declarations,
 	employeeCategories,
 	files,
+	gipMdsData,
 	jobCategories,
 	users,
 } from "~/server/db/schema";
@@ -328,13 +333,20 @@ export const adminDeclarationsRouter = createTRPCRouter({
 					companySiren: companies.siren,
 					companyNafCode: companies.nafCode,
 					companyAddress: companies.address,
-					companyWorkforce: companies.workforce,
+					companyWorkforceEma: gipMdsData.workforceEma,
 					declarantEmail: users.email,
 					declarantFirstName: users.firstName,
 					declarantLastName: users.lastName,
 				})
 				.from(declarations)
 				.innerJoin(companies, eq(declarations.siren, companies.siren))
+				.leftJoin(
+					gipMdsData,
+					and(
+						eq(gipMdsData.siren, declarations.siren),
+						eq(gipMdsData.year, declarations.year),
+					),
+				)
 				.innerJoin(users, eq(declarations.declarantId, users.id))
 				.where(eq(declarations.id, input.id))
 				.limit(1);
@@ -412,7 +424,7 @@ export const adminDeclarationsRouter = createTRPCRouter({
 					siren: row.companySiren,
 					nafCode: row.companyNafCode,
 					address: row.companyAddress,
-					workforce: row.companyWorkforce,
+					gipWorkforce: parseGipWorkforce(row.companyWorkforceEma),
 				},
 				declarationYear: d.year,
 				referencePeriod,

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server";
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Session } from "next-auth";
 import {
@@ -289,7 +290,14 @@ export const companyRouter = createTRPCRouter({
 		.input(updateHasCseSchema)
 		.mutation(async ({ ctx, input }) => {
 			assertNotImpersonating(ctx.session);
-			await findUserCompany(ctx.db, ctx.session, input.siren);
+			const company = await findUserCompany(ctx.db, ctx.session, input.siren);
+			if (!isCseRequired(getObligationWorkforce(company.gipWorkforce))) {
+				throw new TRPCError({
+					code: "PRECONDITION_FAILED",
+					message:
+						"Le champ CSE est réservé aux entreprises de 100 salariés et plus.",
+				});
+			}
 			await ctx.db
 				.update(companies)
 				.set({ hasCse: input.hasCse })

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -3,6 +3,8 @@ import type { Session } from "next-auth";
 import {
 	computeDeclarationStatus,
 	getCurrentYear,
+	getObligationWorkforce,
+	isCseRequired,
 	parseGipWorkforce,
 } from "~/modules/domain";
 import { buildDeclarationList } from "~/modules/my-space/buildDeclarationList";
@@ -70,7 +72,11 @@ async function findUserCompany(db: DB, session: Session, siren: string) {
 		gipWorkforce: parseGipWorkforce(workforceEma),
 	};
 
-	if (company.hasCse === null) {
+	// Below 100 the CSE field is out of scope entirely, so `hasCse` stays null.
+	if (
+		company.hasCse === null &&
+		isCseRequired(getObligationWorkforce(company.gipWorkforce))
+	) {
 		const hasCse = await fetchCseBySiren(company.siren);
 		if (hasCse !== null) {
 			await db

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -1,6 +1,10 @@
 import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Session } from "next-auth";
-import { computeDeclarationStatus, getCurrentYear } from "~/modules/domain";
+import {
+	computeDeclarationStatus,
+	getCurrentYear,
+	parseGipWorkforce,
+} from "~/modules/domain";
 import { buildDeclarationList } from "~/modules/my-space/buildDeclarationList";
 import {
 	sirenInputSchema,
@@ -34,10 +38,17 @@ async function findUserCompany(db: DB, session: Session, siren: string) {
 			address: companies.address,
 			nafCode: companies.nafCode,
 			nafLabel: companies.nafLabel,
-			workforce: companies.workforce,
+			workforceEma: gipMdsData.workforceEma,
 			hasCse: companies.hasCse,
 		})
-		.from(companies);
+		.from(companies)
+		.leftJoin(
+			gipMdsData,
+			and(
+				eq(gipMdsData.siren, companies.siren),
+				eq(gipMdsData.year, getCurrentYear()),
+			),
+		);
 
 	const rows = bypassOwnership
 		? await baseQuery.where(eq(companies.siren, siren)).limit(1)
@@ -48,10 +59,16 @@ async function findUserCompany(db: DB, session: Session, siren: string) {
 				)
 				.limit(1);
 
-	const company = rows[0];
-	if (!company) {
+	const row = rows[0];
+	if (!row) {
 		throw new Error("Company not found or access denied");
 	}
+
+	const { workforceEma, ...rest } = row;
+	const company = {
+		...rest,
+		gipWorkforce: parseGipWorkforce(workforceEma),
+	};
 
 	if (company.hasCse === null) {
 		const hasCse = await fetchCseBySiren(company.siren);

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -15,10 +15,12 @@ import {
 import { mapGipToFormData } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import {
 	getCurrentYear,
+	getObligationWorkforce,
 	hasGapsAboveThreshold,
 	isCseRequired,
 	isDraft,
 	isTriennialYear,
+	parseGipWorkforce,
 } from "~/modules/domain";
 import {
 	companyProcedure,
@@ -31,6 +33,7 @@ import {
 	assertNotImpersonating,
 	isImpersonatingSiren,
 } from "~/server/auth/companyAccess";
+import type { DB } from "~/server/db";
 import {
 	companies,
 	declarationStatusHistory,
@@ -82,6 +85,19 @@ type DbLike = {
 	};
 };
 
+async function findGipWorkforce(
+	database: DB,
+	siren: string,
+	year: number,
+): Promise<number | null> {
+	const rows = await database
+		.select({ workforceEma: gipMdsData.workforceEma })
+		.from(gipMdsData)
+		.where(and(eq(gipMdsData.siren, siren), eq(gipMdsData.year, year)))
+		.limit(1);
+	return parseGipWorkforce(rows[0]?.workforceEma);
+}
+
 async function loadEmployeeCategoriesForDeclaration(
 	database: DbLike,
 	declarationId: string,
@@ -106,13 +122,13 @@ async function loadEmployeeCategoriesForDeclaration(
 function buildSubmitFacts(
 	declaration: DeclarationRow,
 	company: CompanyRow,
+	gipWorkforce: number | null,
 	hasIndicatorGData: boolean,
 	hasGap: boolean,
 ): Record<string, unknown> {
-	const workforce = company.workforce ?? 0;
 	return {
 		currentState: declaration.status,
-		workforce,
+		workforce: getObligationWorkforce(gipWorkforce),
 		hasCse: company.hasCse === true,
 		indicatorGCalculated: hasIndicatorGData,
 		gap: hasGap ? 100 : 0,
@@ -663,6 +679,8 @@ export const declarationRouter = createTRPCRouter({
 				message: "Entreprise introuvable",
 			});
 
+		const gipWorkforce = await findGipWorkforce(ctx.db, siren, year);
+
 		const initialCategories = await loadEmployeeCategoriesForDeclaration(
 			ctx.db,
 			declaration.id,
@@ -676,6 +694,7 @@ export const declarationRouter = createTRPCRouter({
 		const facts = buildSubmitFacts(
 			declaration,
 			company,
+			gipWorkforce,
 			hasIndicatorGData,
 			hasGap,
 		);
@@ -693,7 +712,8 @@ export const declarationRouter = createTRPCRouter({
 		// que les transitions FSM aval (saveCompliancePath, submitJointEvaluation,
 		// cseOpinion.finalize) liront comme guard.
 		const cseRequiredSnapshot =
-			isCseRequired(company.workforce ?? 0) && company.hasCse === true;
+			isCseRequired(getObligationWorkforce(gipWorkforce)) &&
+			company.hasCse === true;
 
 		await ctx.db.transaction(async (tx) => {
 			if (isDraft(declaration.status) && historyInserts.length > 0) {

--- a/packages/app/src/server/audit/__tests__/declarationCleanupScript.integration.test.ts
+++ b/packages/app/src/server/audit/__tests__/declarationCleanupScript.integration.test.ts
@@ -24,8 +24,8 @@ import {
 	describe,
 	expect,
 	it,
-	vi,
 	type Mock,
+	vi,
 } from "vitest";
 import { runDeclarationCleanup } from "#scripts/declaration-cleanup.mjs";
 import { env } from "~/env.js";

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -45,6 +45,8 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"cseOpinion.setFileContentTypes": AUDIT_ACTIONS.CSE_OPINION_SET_FILE_TYPES,
 
 	// ── company mutations ──────────────────────────────────
+	"company.get": AUDIT_ACTIONS.COMPANY_READ_GIP_DATA,
+	"company.getWithDeclarations": AUDIT_ACTIONS.COMPANY_READ_GIP_DATA,
 	"company.updateHasCse": AUDIT_ACTIONS.COMPANY_UPDATE_HAS_CSE,
 
 	// ── profile mutations + sensitive read ─────────────────

--- a/packages/app/src/server/db/__tests__/schema-comments.test.ts
+++ b/packages/app/src/server/db/__tests__/schema-comments.test.ts
@@ -110,7 +110,6 @@ describe("SCHEMA_COLUMN_COMMENTS", () => {
 	it("annotates company identity columns exposed by SUIT", () => {
 		const company = SCHEMA_COLUMN_COMMENTS.company;
 		expect(company?.name).toBe("SUIT: Raison_sociale");
-		expect(company?.workforce).toBe("SUIT: Effectif");
 		expect(company?.naf_code).toBe("SUIT: Code_NAF");
 		expect(company?.address).toBe("SUIT: Adresse");
 		expect(company?.has_cse).toBe("SUIT: CSE_existant");
@@ -201,10 +200,20 @@ describe("SCHEMA_COLUMN_COMMENTS", () => {
 		const allComments = t2Tables.flatMap((table) =>
 			Object.values(SCHEMA_COLUMN_COMMENTS[table] ?? {}),
 		);
+		// `Weez/INSEE` is the compound source label of `company.workforce`, which is
+		// no longer the SUIT Effectif since #3929 — still a Weez-first declaration.
 		for (const comment of allComments) {
-			expect(comment).toMatch(/^(SUIT|Weez): /);
+			expect(comment).toMatch(/^(SUIT|Weez|Weez\/INSEE): /);
 			expect(comment).not.toContain("GIP-MDS");
 		}
+	});
+
+	it("no longer presents company.workforce as the SUIT Effectif (#3929)", () => {
+		const workforce = SCHEMA_COLUMN_COMMENTS.company?.workforce;
+		expect(workforce).toBeDefined();
+		expect(workforce).not.toBe("SUIT: Effectif");
+		expect(workforce).toMatch(/^Weez\/INSEE: /);
+		expect(workforce).toContain("gip_mds_data.workforce_ema");
 	});
 
 	it("annotates the Weez-sourced company region/department columns", () => {

--- a/packages/app/src/server/db/schema-comments.ts
+++ b/packages/app/src/server/db/schema-comments.ts
@@ -123,7 +123,8 @@ export const SCHEMA_COLUMN_COMMENTS: SchemaColumnComments = {
 	},
 	company: {
 		name: "SUIT: Raison_sociale",
-		workforce: "SUIT: Effectif",
+		workforce:
+			"Weez/INSEE: effectif de référence (stats admin/publiques). SUIT Effectif provient de gip_mds_data.workforce_ema",
 		naf_code: "SUIT: Code_NAF",
 		address: "SUIT: Adresse",
 		region: "Weez: libellé région (dérivé du code postal établissement)",


### PR DESCRIPTION
Closes #3929

Couvre aussi #3934 (étape « 7ᵉ indicateur » demandée à tort sous les seuils).

## Problème

Partout où « l'effectif moyen annuel » alimentait **l'affichage**, **le parcours de déclaration** et **la transmission SUIT**, le code lisait `companies.workforce` — la valeur Weez/INSEE, réécrite à chaque login ProConnect — au lieu de `gip_mds_data.workforceEma`, le véritable effectif moyen annuel DSN importé par le flux GIP.

D'où les écarts rapportés : 1183 affiché pour une entreprise **absente** du fichier GIP, 97 affiché pour un effectif GIP de 70, et 82 transmis à SUIT au lieu de 70.

Cause directe du #3934 : l'étape 5 du funnel (indicateur G, le « 7ᵉ indicateur ») était **inconditionnelle**. Le domaine `isIndicatorGRequired` existait mais n'était câblé que dans l'export — jamais dans le parcours. Toute entreprise y était promenée, même sous les seuils.

## Correctif

Bascule des 3 volets sur la source GIP via un helper domaine commun (`~/modules/domain/shared/gipWorkforce.ts`), et ajout d'un gate sur l'étape 5.

| Volet | Avant | Après |
|---|---|---|
| Affichage (bandeaux, récapitulatif, avis CSE, espace entreprise) | `companies.workforce` | `gip_mds_data.workforceEma` |
| Parcours (`buildSubmitFacts`, snapshot `cseRequired`, gate étape 5) | `companies.workforce` | `gip_mds_data.workforceEma` |
| SUIT `Effectif` + flags export (`Indicateur_G_requis`, `Parcours_de_conformite_requis`, `Avis_CSE_requis`) | `companies.workforce` | `gip_mds_data.workforceEma` |
| Stats admin / publiques | `companies.workforce` | inchangé (hors périmètre) |

Décisions fonctionnelles appliquées (validées sur le ticket) :

- **Seuils indicateur G** — règle codifiée `isIndicatorGRequired` (150 triennal / 250 annuel). Les cas 70 et 97 du ticket sautent donc l'étape 5. Le « 100 » évoqué dans le rapport est le seuil phase 2 / CSE, distinct.
- **Entreprise absente du GIP** — réputée non assujettie, parcours traité comme `< 50`. Les bandeaux affichent « Effectif non connu du GIP », sans jamais retomber sur la valeur Weez.
- **Arrondi** (`numeric(9,2)`) — comparaison aux seuils sur la valeur **exacte** (99,97 reste `< 100`), affichage à l'entier **inférieur** (99,97 s'affiche « 99 »).
- **Champ « Existence de CSE »** — affiché uniquement à partir de 100 salariés, en lecture comme en édition. En dessous, `hasCse` reste `null` et aucun appel `updateHasCse` n'est possible depuis l'UI.

Le funnel devient dynamique : `shared/funnelSteps.ts` calcule la liste des étapes, les liens précédent/suivant et le libellé du stepper (« Étape 5 sur 5 » quand l'indicateur G ne s'applique pas). Une redirection serveur ferme l'accès direct à `/etape/5`.

Deux corollaires nécessaires du masquage CSE :

- `hasRequiredDeclarationInfo` prend un 3ᵉ argument `cseApplicable`. Sans lui, `MissingInfoModal` aurait bloqué **définitivement** les déclarants sous 100 salariés en réclamant une information devenue non collectable.
- Le complètement automatique de `hasCse` depuis le registre CSE externe est court-circuité sous 100 (économise aussi un appel réseau inutile).

## Test plan

- **Revert-verify** : `src/modules/export/__tests__/gipWorkforceExport.integration.test.ts` reproduit le bug tel que rapporté quand le fix est reverse-appliqué (82 au lieu de 70 · 1183 au lieu de « non connu » · 250 au lieu de 99 sur l'arrondi · fuite d'une ligne GIP d'une autre campagne), et repasse au vert une fois le fix réappliqué.
- **Intégration DB** : les nouveaux `leftJoin` sur `gip_mds_data` préservent bien les déclarations des entreprises absentes du GIP (`Effectif` à `null`, ligne non perdue) et ne croisent pas les campagnes.
- **Unitaires** : 100 % de couverture sur `gipWorkforce.ts`, `funnelSteps.ts`, `declarationPrerequisites.ts`, `buildExportRows.ts`, `fetchDeclarations.ts`. Suite complète 3422 tests verts.

Aucune migration : la colonne `workforce_ema` existait déjà.
