### PR TITLE
chore(orchestration): gate E2E sur le port 3000 + overrides env des worktrees

### DIFF
--- a/.claude/agents/e2e-dev/AGENT.md
+++ b/.claude/agents/e2e-dev/AGENT.md
@@ -26,7 +26,7 @@ Tu es invoqué à deux moments selon le type de ticket :
   - **epic** `#<N>` (Feature) — la couverture porte sur la feature complète intégrée dans `epic/<N>`
   - **ticket** `#<N>` (Task ou Bug) — la couverture porte sur ce seul ticket
 - Worktree path + branche de travail (déjà checkout par l'orchestrateur — tu opères dans ce worktree)
-- Worktree index → dev server port (`3001 + index`, lu depuis `packages/app/.env.local`)
+- Worktree index → ports docker de la stack (DB, minio, maildev, valkey). Le dev server E2E tourne **toujours sur le port 3000** — contrainte ProConnect, cf. Workflow étape 2
 - Base de comparaison au format remote-tracking ref :
   - epic → `origin/alpha` (le diff = toute la feature : `origin/alpha...HEAD`)
   - ticket → `origin/epic/<EPIC_N>` ou `origin/alpha` (le diff = ce ticket)
@@ -51,7 +51,11 @@ Là où `tu-dev` vise **100% de couverture** avec des TU ciblés et nombreux, l'
    - **Task** → commentaire `## Analyse architecte`
    - **Bug** → commentaire `## Analyse du bug` (root cause + criticité)
 
-2. **Démarrer le dev server** sur le port du worktree — lire `PORT` dans `packages/app/.env.local` (= `3001 + index`). Lancer le serveur en background (`pnpm --filter app dev` ou `pnpm dev:app`), attendre qu'il réponde, puis exporter `PLAYWRIGHT_BASE_URL=http://localhost:<PORT>` pour que Playwright cible **ce** serveur (et non `:3000`). La stack docker (DB jetable, minio, maildev, valkey) + migrations ont déjà été provisionnées par `setup-worktree.sh`.
+2. **Démarrer le dev server sur le port 3000 — obligatoire.** La passerelle ProConnect de test n'enregistre que le callback `http://localhost:3000/api/auth/callback/proconnect` : tout autre port échoue en 404 dès l'étape authorize, donc `auth.setup.ts` ne peut pas authentifier la suite. Concrètement :
+   - **Mode epic** : `run_e2e_dev.sh` a déjà forcé `PORT=3000` dans `packages/app/.env.local` (les ports docker restent index-dérivés). Lance simplement le serveur.
+   - **Mode ticket** (worktree partagé avec `code-dev`) : vérifie d'abord que le port 3000 est libre (`lsof -nP -iTCP:3000 -sTCP:LISTEN`). S'il est occupé, retourne `{"status":"failed","reason":"port 3000 occupé — requis pour le callback ProConnect"}` sans préempter le process qui l'occupe. Sinon lance le serveur avec `PORT=3000` (override de la valeur du `.env.local`).
+
+   Lancer le serveur en background (`pnpm --filter app dev` ou `pnpm dev:app`), attendre qu'il réponde, puis exporter `PLAYWRIGHT_BASE_URL=http://localhost:3000`. La stack docker (DB jetable, minio, maildev, valkey) + migrations ont déjà été provisionnées par `setup-worktree.sh` sur les ports index-dérivés.
 
 3. **Lancer la suite E2E actuelle** — `pnpm --filter app test:e2e` (Playwright, `workers:1`). Capturer précisément la liste des tests/projets en échec (`test-results/`, trace `retain-on-failure`).
 

--- a/.claude/rules/e2e.md
+++ b/.claude/rules/e2e.md
@@ -31,7 +31,7 @@ E2E tests must cover at minimum:
 - Key content/headings are visible
 - Error pages (404, 500, 503) display correct status and messaging
 
-Run `pnpm test:e2e` to execute all E2E tests (requires the dev server running — `e2e-dev` runs it against its worktree's port via `PLAYWRIGHT_BASE_URL`, the default being port 3000). E2E is **not** part of the CI pipeline, so `e2e-dev`'s local run is the authoritative E2E gate before the reviewable PR.
+Run `pnpm test:e2e` to execute all E2E tests (requires the dev server running on **port 3000** — the ProConnect test gateway only registers the `:3000` callback, so `auth.setup.ts` fails on any other port; worktree E2E runs must bind the dev server to `PORT=3000` while the docker stack keeps its index-derived ports). Port 3000 being a single global resource, all E2E runs are effectively serialized repo-wide: do not run an epic-end E2E gate (background) and a ticket-mode `e2e-dev` (foreground) at the same time — both fail closed on a busy port, but one of them will have to be re-run. E2E is **not** part of the CI pipeline, so `e2e-dev`'s local run is the authoritative E2E gate before the reviewable PR.
 
 **Checklist for `e2e-dev` before completing any page-related coverage:**
 1. List all routes in `src/app/**/page.tsx`

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -201,7 +201,7 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
      "$E2E_PROMPT" 2>&1 | tee "/tmp/e2e-dev-${ISSUE_N}.json"
    ```
 
-   - `$E2E_PROMPT` : unité = ticket `#<N>` (+ type Task/Bug), worktree path, index → port `3001+index`, base de comparaison `origin/...` (la même que `code-dev`), branche de la PR déjà checkout, « suivre STRICTEMENT `e2e-dev/AGENT.md` », push sur `HEAD` (la branche de la PR), retour JSON strict en dernier message. Pour un Bug, rappeler le critère de **criticité** (`e2e-dev` décide s'il vaut un E2E).
+   - `$E2E_PROMPT` : unité = ticket `#<N>` (+ type Task/Bug), worktree path, index → ports docker de la stack ; **dev server port 3000 imposé** (la passerelle ProConnect de test n'enregistre que le callback `:3000` — vérifier que le port est libre avant de lancer `e2e-dev`, sinon le signaler à l'utilisateur au lieu de préempter), base de comparaison `origin/...` (la même que `code-dev`), branche de la PR déjà checkout, « suivre STRICTEMENT `e2e-dev/AGENT.md` », push sur `HEAD` (la branche de la PR), retour JSON strict en dernier message. Pour un Bug, rappeler le critère de **criticité** (`e2e-dev` décide s'il vaut un E2E).
    - **Récupérer le verdict JSON** (dernier objet `{"status":...}`) et l'afficher :
 
      | `.status` e2e-dev | Action skill | Markdown affiché |

--- a/scripts/orchestration/run_e2e_dev.sh
+++ b/scripts/orchestration/run_e2e_dev.sh
@@ -64,7 +64,11 @@ BRANCH="epic/${EPIC_N}"
 BUDGET="${EPIC_LOOP_BUDGET_E2E:-15}"
 AGENT_TIMEOUT="${E2E_DEV_TIMEOUT:-3600}"
 INDEX="${E2E_WORKTREE_INDEX:-${EPIC_MAX_PARALLEL:-5}}"
-PORT=$((3001 + INDEX))
+# The dev server must bind :3000 — the ProConnect test gateway only registers
+# the http://localhost:3000 callback; any other port 404s at the authorize step
+# and auth.setup.ts cannot authenticate the suite. The docker stack keeps its
+# index-derived ports.
+PORT=3000
 WT_PATH="${REPO_ROOT}/../egapro-epic${EPIC_N}-e2e"
 
 # ---- Pre-flight: the integration branch must exist on origin ----
@@ -73,6 +77,13 @@ git fetch origin alpha "$BRANCH" --quiet 2>/dev/null || true
 if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
     echo "ERROR: $BRANCH does not exist on origin — nothing to test" >&2
     bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "no_epic_branch=$BRANCH"
+    exit 1
+fi
+
+# ---- Pre-flight: port 3000 must be free (ProConnect callback constraint) ----
+if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "ERROR: port $PORT is busy — the E2E dev server must bind :3000 (ProConnect callback). Stop the process holding it and re-run." >&2
+    bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "port_3000_busy"
     exit 1
 fi
 
@@ -111,6 +122,10 @@ if [ ! -f "$WT_PATH/packages/app/.env.local" ]; then
     (cd "$WT_PATH" && bash "$REPO_ROOT/scripts/setup-worktree.sh" "$INDEX") >/dev/null 2>&1 \
         || { bash "$SCRIPT_DIR/log_event.sh" "$AID" STACK_FAIL "setup-worktree.sh failed (index=$INDEX)"; exit 1; }
 fi
+# setup-worktree.sh writes PORT=3001+index; the E2E run overrides it to 3000
+# (ProConnect callback constraint). Idempotent across re-runs.
+perl -pi -e "s/^PORT=.*/PORT=$PORT/" "$WT_PATH/packages/app/.env.local"
+
 bash "$SCRIPT_DIR/log_event.sh" "$AID" STACK_READY "wt=$WT_PATH index=$INDEX port=$PORT"
 
 # ---- Build the prompt for the agent ----
@@ -118,7 +133,7 @@ PROMPT="Tu es invoqué par la pipeline d'orchestration en fin d'epic #${EPIC_N},
 
 Unité à couvrir : epic #${EPIC_N} (Feature)
 Worktree : ${WT_PATH} (détaché sur origin/${BRANCH})
-Worktree index : ${INDEX} (dev server port = ${PORT})
+Worktree index : ${INDEX} (ports docker) — dev server port = ${PORT} (imposé par le callback ProConnect)
 Base de comparaison : origin/alpha  (le diff de la feature = origin/alpha...HEAD)
 
 L'orchestrateur a déjà :
@@ -127,7 +142,7 @@ L'orchestrateur a déjà :
 
 Suivre STRICTEMENT le workflow de .claude/agents/e2e-dev/AGENT.md :
 1. Lire le diff intégré (origin/alpha...HEAD) + le body de l'epic et de ses sous-tickets.
-2. Démarrer le dev server sur le port ${PORT} (lire PORT dans packages/app/.env.local) et exporter PLAYWRIGHT_BASE_URL=http://localhost:${PORT}.
+2. Démarrer le dev server sur le port ${PORT} (PORT déjà forcé dans packages/app/.env.local) et exporter PLAYWRIGHT_BASE_URL=http://localhost:${PORT}. Le port 3000 est imposé : la passerelle ProConnect de test n'enregistre que le callback :3000 — ne le change pas.
 3. Lancer la suite E2E actuelle (pnpm --filter app test:e2e), trier les échecs (régression vs évolution légitime).
 4. Sur >=1 régression réelle : commenter \`e2e-dev:\` sur l'epic #${EPIC_N}, NE RIEN corriger côté source, retourner {\"status\":\"regression\",...}.
 5. Sinon : corriger les E2E en échec légitime, puis décider de la couverture de la feature (imbriquer de préférence dans un scénario global existant ; nouveau fichier seulement pour un parcours/page réellement nouveaux).

--- a/scripts/orchestration/run_e2e_dev.sh
+++ b/scripts/orchestration/run_e2e_dev.sh
@@ -81,7 +81,23 @@ if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
 fi
 
 # ---- Pre-flight: port 3000 must be free (ProConnect callback constraint) ----
-if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+# Probe with whatever listener-inspection tool exists (lsof isn't guaranteed on
+# minimal Linux hosts). If none is available, skip the check rather than
+# fail-closed on the absence of tooling — the dev server boot would then surface
+# a bind error itself.
+port_in_use() {
+    local port="$1"
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+    elif command -v ss >/dev/null 2>&1; then
+        ss -ltnH "sport = :$port" 2>/dev/null | grep -q .
+    elif command -v nc >/dev/null 2>&1; then
+        nc -z 127.0.0.1 "$port" >/dev/null 2>&1
+    else
+        return 1
+    fi
+}
+if port_in_use "$PORT"; then
     echo "ERROR: port $PORT is busy — the E2E dev server must bind :3000 (ProConnect callback). Stop the process holding it and re-run." >&2
     bash "$SCRIPT_DIR/log_event.sh" "$AID" FAILED "port_3000_busy"
     exit 1
@@ -123,8 +139,15 @@ if [ ! -f "$WT_PATH/packages/app/.env.local" ]; then
         || { bash "$SCRIPT_DIR/log_event.sh" "$AID" STACK_FAIL "setup-worktree.sh failed (index=$INDEX)"; exit 1; }
 fi
 # setup-worktree.sh writes PORT=3001+index; the E2E run overrides it to 3000
-# (ProConnect callback constraint). Idempotent across re-runs.
-perl -pi -e "s/^PORT=.*/PORT=$PORT/" "$WT_PATH/packages/app/.env.local"
+# (ProConnect callback constraint). Rewrite the line if present, otherwise
+# append it — a silent no-op here would let the dev server bind the wrong port
+# and break ProConnect auth. Idempotent across re-runs.
+E2E_ENV_FILE="$WT_PATH/packages/app/.env.local"
+if grep -qE '^PORT=' "$E2E_ENV_FILE"; then
+    perl -pi -e "s/^PORT=.*/PORT=$PORT/" "$E2E_ENV_FILE"
+else
+    printf '\nPORT=%s\n' "$PORT" >> "$E2E_ENV_FILE"
+fi
 
 bash "$SCRIPT_DIR/log_event.sh" "$AID" STACK_READY "wt=$WT_PATH index=$INDEX port=$PORT"
 

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -82,6 +82,14 @@ VALKEY_HOST_PORT=$VALKEY_HOST_PORT
 PORT=$APP_DEV_PORT
 DATABASE_URL=postgresql://postgres:postgres@localhost:$POSTGRES_HOST_PORT/egapro
 CLAMAV_PORT=$CLAMAV_HOST_PORT
+
+# Service endpoints must follow the index-derived host ports above — the
+# repo-level .env targets the standard single-checkout ports, and a stale
+# endpoint crashes the dev-server boot (instrumentation runs ensureBucket
+# against S3 on startup).
+S3_ENDPOINT=http://localhost:$MINIO_API_PORT
+SMTP_PORT=$MAILDEV_SMTP_PORT
+VALKEY_URL=redis://localhost:$VALKEY_HOST_PORT
 EOF
 
 echo "[setup-worktree] Wrote $ENV_FILE"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -88,6 +88,7 @@ CLAMAV_PORT=$CLAMAV_HOST_PORT
 # endpoint crashes the dev-server boot (instrumentation runs ensureBucket
 # against S3 on startup).
 S3_ENDPOINT=http://localhost:$MINIO_API_PORT
+SMTP_HOST=localhost
 SMTP_PORT=$MAILDEV_SMTP_PORT
 VALKEY_URL=redis://localhost:$VALKEY_HOST_PORT
 EOF


### PR DESCRIPTION
## Contexte

Lors de la gate E2E du ticket #3853, l'agent e2e-dev a diagnostiqué deux blocages d'infra du pipeline d'orchestration (détail : https://github.com/SocialGouv/egapro/issues/3853#issuecomment-5024110124) :

1. La passerelle ProConnect de test n'enregistre que le callback `http://localhost:3000/api/auth/callback/proconnect` — tout autre port échoue en 404 à l'étape authorize. Les worktrees tournant sur `3001 + index`, **aucun worktree ne pouvait authentifier la suite E2E**.
2. `scripts/setup-worktree.sh` n'écrivait que les surcharges Postgres/ClamAV dans `.env.local` : `S3_ENDPOINT`, `SMTP_PORT` et `VALKEY_URL` restaient sur les ports par défaut, faisant planter le boot du dev server (`ensureBucket` dans l'instrumentation) dans chaque worktree.

## Changements

- **`scripts/orchestration/run_e2e_dev.sh`** : le dev server de la gate E2E tourne désormais sur le **port 3000** (pre-flight `lsof` fail-fast si le port est occupé, `PORT=3000` forcé dans le `.env.local` du worktree E2E — les ports docker gardent leurs offsets d'index), brief agent ajusté.
- **`scripts/setup-worktree.sh`** : ajout de `S3_ENDPOINT`, `SMTP_PORT`, `VALKEY_URL` alignés sur les ports index-dérivés dans le `.env.local` généré.
- **Doc pipeline alignée** (`e2e-dev/AGENT.md`, `rules/e2e.md`, `skills/implement/SKILL.md`) : contrainte port 3000 documentée, y compris la sérialisation de facto de tous les runs E2E du repo (ressource globale unique, fail-closed des deux côtés).

## Validation

- `bash -n` + shellcheck : aucune régression sur les lignes modifiées
- Typecheck / tests (3513/3513) / lint / format : verts (aucun fichier TS touché)

Piste complémentaire hors repo, non traitée ici : enregistrer les callbacks `3001..3005` côté passerelle ProConnect de test pour ré-autoriser les runs E2E parallèles.