### PR TITLE
refactor(declaration): #3974 — verrou compilateur du moteur d'étapes FSM

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { useFunnelTracking } from "~/modules/analytics";
+import type { DeclarationFsmStatus } from "~/modules/domain";
 import {
 	getCompanySizeRange,
 	getObligationWorkforce,
@@ -37,7 +38,7 @@ type StepPageClientProps = {
 		year: number;
 		totalWomen: number | null;
 		totalMen: number | null;
-		status: string | null;
+		status: DeclarationFsmStatus | null;
 	};
 	// GIP-MDS annual average workforce; `null` = absent from the GIP file, i.e. not subject to the declaration.
 	companyWorkforce: number | null;

--- a/packages/app/src/modules/declaration-remuneration/__tests__/StepPageClient.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/StepPageClient.test.tsx
@@ -60,7 +60,7 @@ const baseProps = {
 		year: 2025,
 		totalWomen: null,
 		totalMen: null,
-		status: "submitted" as string | null,
+		status: "awaiting_compliance_path_choice" as const,
 	},
 	companyWorkforce: 120,
 	step1Data: {} as never,

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
@@ -134,11 +134,14 @@ describe("getCurrentStageHref", () => {
 		);
 	});
 
-	it("falls back to the compliance path for unknown or null status", () => {
-		expect(getCurrentStageHref(null, true)).toBe(
-			"/declaration-remuneration/parcours-conformite",
-		);
+	it("returns the declaration entry for draft (no more silent parcours-conformite fallback)", () => {
 		expect(getCurrentStageHref("draft", true)).toBe(
+			"/declaration-remuneration",
+		);
+	});
+
+	it("returns the compliance path for a null status", () => {
+		expect(getCurrentStageHref(null, true)).toBe(
 			"/declaration-remuneration/parcours-conformite",
 		);
 	});

--- a/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
@@ -1,5 +1,7 @@
+import type { DeclarationFsmStatus } from "~/modules/domain";
 import type { CompliancePathValue } from "../steps/compliancePath/constants";
 
+const DECLARATION_ENTRY_PATH = "/declaration-remuneration";
 const COMPLIANCE_CONFIRMATION_PATH =
 	"/declaration-remuneration/parcours-conformite/confirmation";
 const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
@@ -52,10 +54,16 @@ type CseOpinionPreviousContext = {
  * event-sourced history (FSM final state).
  */
 export function getCurrentStageHref(
-	status: string | null,
+	status: DeclarationFsmStatus | null,
 	hasCse: boolean | null,
 ): string {
+	if (status === null) {
+		return COMPLIANCE_PATH;
+	}
+
 	switch (status) {
+		case "draft":
+			return DECLARATION_ENTRY_PATH;
 		case "awaiting_compliance_path_choice":
 		case "awaiting_revision_choice":
 			return COMPLIANCE_PATH;
@@ -68,8 +76,6 @@ export function getCurrentStageHref(
 			return CSE_OPINION_PATH;
 		case "demarche_completed":
 			return hasCse === true ? CSE_OPINION_PATH : COMPLIANCE_CONFIRMATION_PATH;
-		default:
-			return COMPLIANCE_PATH;
 	}
 }
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
 import { trackFunnelComplete } from "~/modules/analytics";
+import type { DeclarationFsmStatus } from "~/modules/domain";
 import {
 	computeGap,
 	getCompanySizeRange,
@@ -36,7 +37,7 @@ import { IndicatorSections } from "./step6/IndicatorSections";
 type Props = {
 	declaration: {
 		siren: string;
-		status: string | null;
+		status: DeclarationFsmStatus | null;
 	};
 	// Official GIP/DSN workforce — canonical source for the Matomo size bucket
 	// (see StepPageClient), kept consistent with all business decisions.

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -229,3 +229,4 @@ export type {
 	GapDirection,
 	GapLevel,
 } from "./types";
+export { DECLARATION_FSM_STATUSES } from "./types";

--- a/packages/app/src/modules/domain/types.ts
+++ b/packages/app/src/modules/domain/types.ts
@@ -7,16 +7,19 @@ export type GapDirection = "women" | "men" | "balanced";
 /** Lifecycle state of a declaration from the user's perspective. */
 export type DeclarationStatus = "to_complete" | "in_progress" | "done";
 
-/** FSM status persisted in `declarations.status`; mirrors `declarationStatusEnum` (kept in sync by `declarationFsmStatus.test.ts` — domain layer stays isomorphic, no Drizzle import). */
-export type DeclarationFsmStatus =
-	| "draft"
-	| "awaiting_compliance_path_choice"
-	| "corrective_actions_chosen"
-	| "joint_evaluation_chosen"
-	| "awaiting_revision_choice"
-	| "revised_joint_evaluation_chosen"
-	| "awaiting_cse_opinion"
-	| "demarche_completed";
+/** FSM status persisted in `declarations.status`; mirrors `declarationStatusEnum` (kept in sync by `declarationFsmStatus.test.ts` — domain layer stays isomorphic, no Drizzle import). Single source for the FSM state vocabulary: the rule-engine schema (`server/rules/schema.ts`) and every UI mirror derive from this const, so adding/renaming a state surfaces as a `tsc` or Zod error, never a silent production bug. */
+export const DECLARATION_FSM_STATUSES = [
+	"draft",
+	"awaiting_compliance_path_choice",
+	"corrective_actions_chosen",
+	"joint_evaluation_chosen",
+	"awaiting_revision_choice",
+	"revised_joint_evaluation_chosen",
+	"awaiting_cse_opinion",
+	"demarche_completed",
+] as const;
+
+export type DeclarationFsmStatus = (typeof DECLARATION_FSM_STATUSES)[number];
 
 /** The two types of declarations a company must file each year. */
 export type DeclarationType = "remuneration" | "representation";

--- a/packages/app/src/server/api/routers/statusHistoryHelpers.ts
+++ b/packages/app/src/server/api/routers/statusHistoryHelpers.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, inArray } from "drizzle-orm";
+import type { DeclarationFsmStatus } from "~/modules/domain";
 import type { DB } from "~/server/db";
 import {
 	declarationStatusHistory,
@@ -80,10 +81,10 @@ export type ProjectionUpdate = Partial<typeof declarations.$inferInsert>;
 
 export function computeProjectionUpdates(
 	events: ReadonlyArray<RuleEvent>,
-	nextStatus: string,
+	nextStatus: DeclarationFsmStatus,
 ): ProjectionUpdate {
 	const projection: ProjectionUpdate = {
-		status: nextStatus as typeof declarations.$inferInsert.status,
+		status: nextStatus,
 	};
 
 	for (const event of events) {

--- a/packages/app/src/server/rules/__tests__/schema.test.ts
+++ b/packages/app/src/server/rules/__tests__/schema.test.ts
@@ -52,4 +52,31 @@ describe("RulesSchema", () => {
 			expect(typeof s.stage).toBe("number");
 		}
 	});
+
+	// schema.ts binds the engine JSON to DECLARATION_FSM_STATUSES via z.enum, so an out-of-union state fails the parse.
+	it("rejects a state id outside the FSM union", () => {
+		const bad = {
+			...rawV20271,
+			states: [...rawV20271.states, { id: "not_a_real_state", stage: null }],
+		};
+		expect(() => RulesSchema.parse(bad)).toThrow();
+	});
+
+	it("rejects a transition targeting a state outside the FSM union", () => {
+		const [first, ...rest] = rawV20271.transitions;
+		const bad = {
+			...rawV20271,
+			transitions: [{ ...first, to: "not_a_real_state" }, ...rest],
+		};
+		expect(() => RulesSchema.parse(bad)).toThrow();
+	});
+
+	it("rejects a transition whose from references a state outside the FSM union", () => {
+		const [first, ...rest] = rawV20271.transitions;
+		const bad = {
+			...rawV20271,
+			transitions: [{ ...first, from: ["not_a_real_state"] }, ...rest],
+		};
+		expect(() => RulesSchema.parse(bad)).toThrow();
+	});
 });

--- a/packages/app/src/server/rules/engine.ts
+++ b/packages/app/src/server/rules/engine.ts
@@ -1,3 +1,4 @@
+import type { DeclarationFsmStatus } from "~/modules/domain";
 import { type RuleEvent, type Rules, RulesSchema } from "./schema";
 import rawV20271 from "./v2027.1.json";
 
@@ -207,7 +208,7 @@ export function applyAction(
 	facts: Facts,
 	action: string,
 	rules: Rules,
-): { nextStatus: string; events: RuleEvent[] } {
+): { nextStatus: DeclarationFsmStatus; events: RuleEvent[] } {
 	const currentState = facts.currentState as string | undefined;
 	const computations = (rules.computations ?? {}) as Record<
 		string,
@@ -217,7 +218,9 @@ export function applyAction(
 
 	for (const transition of rules.transitions) {
 		if (transition.action !== action) continue;
-		if (currentState && !transition.from.includes(currentState)) continue;
+		// `from` is DeclarationFsmStatus[]; `.some(===)` compares the wider `string` currentState without a cast.
+		if (currentState && !transition.from.some((from) => from === currentState))
+			continue;
 
 		if (!matchesPayload(transition.matchPayload, facts)) continue;
 

--- a/packages/app/src/server/rules/schema.ts
+++ b/packages/app/src/server/rules/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
 
 const JsonScalarSchema = z.union([
 	z.string(),
@@ -65,11 +66,11 @@ export type RuleEvent = z.infer<typeof EventSchema>;
 
 export const TransitionSchema = z.object({
 	id: z.string(),
-	from: z.array(z.string()).min(1),
+	from: z.array(z.enum(DECLARATION_FSM_STATUSES)).min(1),
 	action: z.string(),
 	matchPayload: z.record(z.string(), z.unknown()).optional(),
 	guard: PredicateSchema.optional(),
-	to: z.string(),
+	to: z.enum(DECLARATION_FSM_STATUSES),
 	events: z.array(EventSchema),
 });
 
@@ -81,7 +82,7 @@ export const StageSchema = z.object({
 });
 
 export const StateSchema = z.object({
-	id: z.string(),
+	id: z.enum(DECLARATION_FSM_STATUSES),
 	stage: z.number().nullable(),
 	terminal: z.boolean().optional(),
 });


### PR DESCRIPTION
## Objectif

Sous-ticket de l'epic #3964. Étend le **verrou compilateur** au moteur d'étapes (FSM) de la démarche de déclaration : ajouter/renommer/supprimer un état devient une **erreur `tsc` ou une erreur de parse Zod**, plus jamais un bug silencieux en production.

Closes #3974

## Changements

- **Source unique** — `DECLARATION_FSM_STATUSES` (const `as const`) dans `modules/domain/types.ts`, dont l'union `DeclarationFsmStatus` est désormais dérivée. C'est le vocabulaire unique des 8 états.
- **Moteur relié au type** — `server/rules/schema.ts` : `states[].id`, `transitions[].from`, `transitions[].to` passent de `z.string()` à `z.enum(DECLARATION_FSM_STATUSES)`. Le parse de `v2027.1.json` échoue désormais si le JSON invente un état hors union.
- **Navigation exhaustive** — `getCurrentStageHref` retypé `DeclarationFsmStatus | null`, `default:` supprimé, cas `draft` explicite. Sans `default` et avec une union fermée, le type de retour `string` force l'exhaustivité : un état ajouté sans être géré casse la compilation.
- **Propagation jusqu'au write DB** — `applyAction` retourne `DeclarationFsmStatus` ; `computeProjectionUpdates` accepte ce type et **un cast `as` est supprimé** (`statusHistoryHelpers.ts`).
- **Frontière typée sans cast** — le prop `declaration.status` de `Step6Review` et `StepPageClient` passe de `string | null` à `DeclarationFsmStatus | null` (valeur DB isomorphe à l'enum Drizzle).

## Changement de comportement (encadré)

La suppression du `default:` révèle qu'un **seul** état y tombait : `draft`. Les 7 autres avaient déjà un `case` explicite. `draft` renvoie désormais `/declaration-remuneration` (entrée du parcours, aligné sur `computeCtaHref`) au lieu du fallback `/parcours-conformite`. Chemin défensif : au call site (`Step6Review`), `getCurrentStageHref` n'est appelé que si `isSubmitted`, donc `draft` y est en pratique inatteignable. Le comportement `null` est préservé. **Aucune autre divergence** → rien à signaler contre les bugs ouverts #3934/#3939/#3945/#3949.

## Tests

- `schema.test.ts` : 3 tests de rejet Zod (état, `from`, `to` hors union).
- `complianceNavigation.test.ts` : split `draft` (→ entrée déclaration) / `null` (→ parcours-conformité).
- Suite complète verte : 342 fichiers / 3452 tests · typecheck + lint + format OK.

## Suivi (hors périmètre de ce ticket)

L'audit structurel a repéré **3 copies supplémentaires** de la liste d'états, non reliées à `DECLARATION_FSM_STATUSES` : `admin/declarations/schemas.ts` (2× `z.enum([...])`) et `admin/declarations/SearchForm.tsx` (union TS inline). Elles ajoutent une valeur `"cancelled"` absente de l'union FSM — la consolidation demande donc une décision (union élargie vs type dédié). Candidat naturel pour l'epic #3964 (à rattacher à #3976 « autorité du moteur » ou en nouvelle feuille).
