### PR TITLE
test(declaration): #3978 — élagage des tests subsumés par le verrou FSM et la table de décision

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
@@ -90,57 +90,9 @@ describe("getCseOpinionPreviousHref", () => {
 });
 
 describe("getCurrentStageHref", () => {
-	it("returns /avis-cse for awaiting_cse_opinion", () => {
-		expect(getCurrentStageHref("awaiting_cse_opinion", true)).toBe("/avis-cse");
-	});
-
-	it("returns /avis-cse for demarche_completed when CSE is required", () => {
-		expect(getCurrentStageHref("demarche_completed", true)).toBe("/avis-cse");
-	});
-
-	it("returns the no-CSE confirmation page for demarche_completed without CSE", () => {
-		expect(getCurrentStageHref("demarche_completed", false)).toBe(
-			"/declaration-remuneration/parcours-conformite/confirmation",
-		);
-	});
-
-	it("returns the compliance choice page for awaiting_compliance_path_choice", () => {
-		expect(getCurrentStageHref("awaiting_compliance_path_choice", true)).toBe(
-			"/declaration-remuneration/parcours-conformite",
-		);
-	});
-
-	it("returns the compliance choice page for awaiting_revision_choice", () => {
-		expect(getCurrentStageHref("awaiting_revision_choice", true)).toBe(
-			"/declaration-remuneration/parcours-conformite",
-		);
-	});
-
-	it("returns the corrective actions first step for corrective_actions_chosen", () => {
-		expect(getCurrentStageHref("corrective_actions_chosen", true)).toBe(
-			"/declaration-remuneration/parcours-conformite/etape/1",
-		);
-	});
-
-	it("returns the joint evaluation page for joint_evaluation_chosen", () => {
-		expect(getCurrentStageHref("joint_evaluation_chosen", true)).toBe(
-			"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
-		);
-	});
-
-	it("returns the joint evaluation page for revised_joint_evaluation_chosen", () => {
-		expect(getCurrentStageHref("revised_joint_evaluation_chosen", true)).toBe(
-			"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
-		);
-	});
-
-	it("returns the declaration entry for draft (no more silent parcours-conformite fallback)", () => {
-		expect(getCurrentStageHref("draft", true)).toBe(
-			"/declaration-remuneration",
-		);
-	});
-
-	it("returns the compliance path for a null status", () => {
+	// Per-status destinations live in fsmMirrors.conformance.test.ts (#3975);
+	// only the null status, outside DECLARATION_FSM_STATUSES, is owned here.
+	it("falls back to the compliance path for a declaration without FSM projection (null status)", () => {
 		expect(getCurrentStageHref(null, true)).toBe(
 			"/declaration-remuneration/parcours-conformite",
 		);

--- a/packages/app/src/modules/domain/__tests__/companySize.test.ts
+++ b/packages/app/src/modules/domain/__tests__/companySize.test.ts
@@ -2,38 +2,23 @@ import { describe, expect, it } from "vitest";
 
 import {
 	COMPANY_SIZE_RANGES,
-	classifyCompanySize,
 	getCompanySizeRange,
-	isCseRequired,
 } from "../shared/companySize";
+import {
+	COMPANY_SIZE_ANNUAL_MIN,
+	COMPANY_SIZE_VOLUNTARY_MAX,
+} from "../shared/constants";
 
-describe("classifyCompanySize", () => {
-	it("returns voluntary for workforce below 50", () => {
-		expect(classifyCompanySize(10)).toBe("voluntary");
-		expect(classifyCompanySize(49)).toBe("voluntary");
+describe("regulatory size constants", () => {
+	// Boundary behavior lives symbolically in demarcheDecisionTable.test.ts
+	// (#3975); the literal values are pinned here (COMPANY_SIZE_RANGES below
+	// carries its own literals, independent of these constants).
+	it("pins the voluntary/triennial boundary at 50", () => {
+		expect(COMPANY_SIZE_VOLUNTARY_MAX).toBe(50);
 	});
 
-	it("returns triennial for workforce between 50 and 99", () => {
-		expect(classifyCompanySize(50)).toBe("triennial");
-		expect(classifyCompanySize(75)).toBe("triennial");
-		expect(classifyCompanySize(99)).toBe("triennial");
-	});
-
-	it("returns annual for workforce >= 100", () => {
-		expect(classifyCompanySize(100)).toBe("annual");
-		expect(classifyCompanySize(500)).toBe("annual");
-	});
-});
-
-describe("isCseRequired", () => {
-	it("returns false for workforce below 100", () => {
-		expect(isCseRequired(50)).toBe(false);
-		expect(isCseRequired(99)).toBe(false);
-	});
-
-	it("returns true for workforce at or above 100", () => {
-		expect(isCseRequired(100)).toBe(true);
-		expect(isCseRequired(500)).toBe(true);
+	it("pins the annual-declaration + CSE boundary at 100", () => {
+		expect(COMPANY_SIZE_ANNUAL_MIN).toBe(100);
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
@@ -1,48 +1,22 @@
 import { describe, expect, it } from "vitest";
 
 import {
-	isComplianceProcessRequired,
-	isComplianceProcessRevisionRequired,
-} from "../shared/declarationFlags";
-import type { DeclarationStatusEvent } from "../shared/declarationTrajectory";
+	COMPANY_SIZE_ANNUAL_MIN,
+	GAP_ALERT_THRESHOLD,
+} from "../shared/constants";
+import { isComplianceProcessRequired } from "../shared/declarationFlags";
 
+// Composed behavior (nominal, G guard, gap guard, revision boundaries) lives in
+// demarcheDecisionTable.test.ts / demarcheRevisionAndStatus.test.ts (#3975);
+// only isolated-predicate inputs their composition cannot produce live here.
 describe("isComplianceProcessRequired", () => {
-	it("returns true when workforce ≥ 100, indicator G computed, and gap ≥ 5%", () => {
-		expect(
-			isComplianceProcessRequired({
-				workforce: 300,
-				hasIndicatorG: true,
-				gap: 10,
-			}),
-		).toBe(true);
-	});
-
 	it("returns false when workforce < 100 even if gap is high", () => {
+		// Below 100 the matrix always derives hasIndicatorG=false, so it cannot isolate this guard.
 		expect(
 			isComplianceProcessRequired({
 				workforce: 80,
 				hasIndicatorG: true,
 				gap: 10,
-			}),
-		).toBe(false);
-	});
-
-	it("returns false when no indicator G data", () => {
-		expect(
-			isComplianceProcessRequired({
-				workforce: 300,
-				hasIndicatorG: false,
-				gap: 10,
-			}),
-		).toBe(false);
-	});
-
-	it("returns false when gap < 5%", () => {
-		expect(
-			isComplianceProcessRequired({
-				workforce: 300,
-				hasIndicatorG: true,
-				gap: 3,
 			}),
 		).toBe(false);
 	});
@@ -67,84 +41,13 @@ describe("isComplianceProcessRequired", () => {
 		).toBe(false);
 	});
 
-	it("returns true at the exact 100 / 5 thresholds", () => {
+	it("returns true at the exact workforce and gap alert thresholds", () => {
+		// Forced hasIndicatorG at exactly 100: pre-2030 the composition derives false there.
 		expect(
 			isComplianceProcessRequired({
-				workforce: 100,
+				workforce: COMPANY_SIZE_ANNUAL_MIN,
 				hasIndicatorG: true,
-				gap: 5,
-			}),
-		).toBe(true);
-	});
-});
-
-describe("isComplianceProcessRevisionRequired", () => {
-	const withSecondDecl: DeclarationStatusEvent[] = [
-		{
-			eventType: "second_declaration_submit",
-			value: null,
-			round: 2,
-			actorUserId: null,
-			createdAt: new Date("2027-06-01T00:00:00Z"),
-		},
-	];
-
-	it("returns false when compliance process was not required to start with", () => {
-		expect(
-			isComplianceProcessRevisionRequired({
-				workforce: 80,
-				hasIndicatorG: true,
-				gap: 10,
-				correctionGap: 10,
-				events: withSecondDecl,
-			}),
-		).toBe(false);
-	});
-
-	it("returns false when no second_declaration_submit event exists", () => {
-		expect(
-			isComplianceProcessRevisionRequired({
-				workforce: 300,
-				hasIndicatorG: true,
-				gap: 10,
-				correctionGap: 10,
-				events: [],
-			}),
-		).toBe(false);
-	});
-
-	it("returns false when correctionGap is null", () => {
-		expect(
-			isComplianceProcessRevisionRequired({
-				workforce: 300,
-				hasIndicatorG: true,
-				gap: 10,
-				correctionGap: null,
-				events: withSecondDecl,
-			}),
-		).toBe(false);
-	});
-
-	it("returns false when correctionGap is below 5%", () => {
-		expect(
-			isComplianceProcessRevisionRequired({
-				workforce: 300,
-				hasIndicatorG: true,
-				gap: 10,
-				correctionGap: 2,
-				events: withSecondDecl,
-			}),
-		).toBe(false);
-	});
-
-	it("returns true when compliance process + second decl + gap persists", () => {
-		expect(
-			isComplianceProcessRevisionRequired({
-				workforce: 300,
-				hasIndicatorG: true,
-				gap: 10,
-				correctionGap: 7,
-				events: withSecondDecl,
+				gap: GAP_ALERT_THRESHOLD,
 			}),
 		).toBe(true);
 	});

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -65,71 +65,12 @@ describe("isCancelled", () => {
 });
 
 describe("computeDeclarationStatus", () => {
-	it("returns to_complete when declaration is undefined", () => {
-		expect(computeDeclarationStatus(undefined)).toBe("to_complete");
-	});
-
-	it("returns to_complete for draft with currentStep 0", () => {
-		expect(computeDeclarationStatus({ status: "draft", currentStep: 0 })).toBe(
-			"to_complete",
-		);
-	});
-
+	// The per-status projection is covered exhaustively by
+	// demarcheRevisionAndStatus.test.ts (#3975); only classes it does not iterate live here.
 	it("returns to_complete for draft with null currentStep", () => {
 		expect(
 			computeDeclarationStatus({ status: "draft", currentStep: null }),
 		).toBe("to_complete");
-	});
-
-	it("returns in_progress for awaiting_compliance_path_choice (action still expected)", () => {
-		expect(
-			computeDeclarationStatus({
-				status: "awaiting_compliance_path_choice",
-				currentStep: 6,
-			}),
-		).toBe("in_progress");
-	});
-
-	it("returns in_progress for corrective_actions_chosen (waiting on 2nd decl)", () => {
-		expect(
-			computeDeclarationStatus({
-				status: "corrective_actions_chosen",
-				currentStep: 6,
-			}),
-		).toBe("in_progress");
-	});
-
-	it("returns in_progress for awaiting_revision_choice (revised path pending)", () => {
-		expect(
-			computeDeclarationStatus({
-				status: "awaiting_revision_choice",
-				currentStep: 6,
-			}),
-		).toBe("in_progress");
-	});
-
-	it("returns in_progress for awaiting_cse_opinion (CSE deposit pending)", () => {
-		expect(
-			computeDeclarationStatus({
-				status: "awaiting_cse_opinion",
-				currentStep: 6,
-			}),
-		).toBe("in_progress");
-	});
-
-	it("returns done only for demarche_completed (terminal FSM state)", () => {
-		expect(
-			computeDeclarationStatus({
-				status: "demarche_completed",
-				currentStep: 6,
-			}),
-		).toBe("done");
-	});
-
-	it("returns in_progress for draft with currentStep > 0", () => {
-		expect(computeDeclarationStatus({ status: "draft", currentStep: 3 })).toBe(
-			"in_progress",
-		);
 	});
 
 	it("returns to_complete when cancelledAt is set, regardless of status", () => {
@@ -150,16 +91,6 @@ describe("computeDeclarationStatus", () => {
 				cancelledAt: new Date("2025-04-01"),
 			}),
 		).toBe("to_complete");
-	});
-
-	it("uses existing logic when cancelledAt is null", () => {
-		expect(
-			computeDeclarationStatus({
-				status: "awaiting_compliance_path_choice",
-				currentStep: 6,
-				cancelledAt: null,
-			}),
-		).toBe("in_progress");
 	});
 
 	it("uses existing logic when cancelledAt is undefined", () => {

--- a/packages/app/src/modules/domain/__tests__/gap.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gap.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { GAP_ALERT_THRESHOLD } from "../shared/constants";
 import {
 	computeGap,
 	computeGapBetween,
@@ -13,6 +14,14 @@ import {
 	hasHighGap,
 	isSignificantGap,
 } from "../shared/gap";
+
+describe("regulatory constants", () => {
+	// The decision table (#3975) is fully symbolic — a drifting constant would
+	// silently shift every boundary test, so the literal value is pinned here.
+	it("pins the gap alert threshold at 5%", () => {
+		expect(GAP_ALERT_THRESHOLD).toBe(5);
+	});
+});
 
 describe("computeGapRatio", () => {
 	it("returns positive ratio when men earn more", () => {
@@ -89,26 +98,9 @@ describe("computeGapBetween", () => {
 });
 
 describe("gapLevel", () => {
-	it("returns low for gap below threshold", () => {
-		expect(gapLevel(3)).toBe("low");
-	});
-
-	it("returns high for gap at threshold (5%)", () => {
-		expect(gapLevel(5)).toBe("high");
-	});
-
-	it("returns high for gap above threshold", () => {
-		expect(gapLevel(15)).toBe("high");
-	});
-
-	it("returns null for null input", () => {
-		expect(gapLevel(null)).toBeNull();
-	});
-
-	it("returns low for zero gap", () => {
-		expect(gapLevel(0)).toBe("low");
-	});
-
+	// Positive boundary + null live in demarcheDecisionTable.test.ts (#3975). The
+	// negative case asserts the CURRENT behavior, contested by #3963 (intended
+	// "high" is documented by the table's it.fails) — untouched until that lands.
 	it("returns low for a negative gap (women earn more, no alert)", () => {
 		expect(gapLevel(-6)).toBe("low");
 	});
@@ -204,22 +196,8 @@ describe("hasHighGap", () => {
 });
 
 describe("isSignificantGap", () => {
-	it("returns true for a positive gap at the threshold", () => {
-		expect(isSignificantGap(5)).toBe(true);
-	});
-
-	it("returns true for a significant negative gap (either direction)", () => {
-		expect(isSignificantGap(-6)).toBe(true);
-	});
-
-	it("returns false for a sub-threshold gap", () => {
-		expect(isSignificantGap(3)).toBe(false);
-	});
-
-	it("returns false for null", () => {
-		expect(isSignificantGap(null)).toBe(false);
-	});
-
+	// Default-threshold behavior lives in demarcheDecisionTable.test.ts (#3975);
+	// only the custom-threshold parameter is owned here.
 	it("respects a custom threshold", () => {
 		expect(isSignificantGap(3, 2)).toBe(true);
 	});

--- a/packages/app/src/modules/domain/__tests__/gipWorkforce.test.ts
+++ b/packages/app/src/modules/domain/__tests__/gipWorkforce.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { isCseRequired } from "../shared/companySize";
 import {
 	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getObligationWorkforce,
 	parseGipWorkforce,
 	toDisplayWorkforce,
 } from "../shared/gipWorkforce";
-import { isIndicatorGRequired } from "../shared/indicatorG";
 
 describe("parseGipWorkforce", () => {
 	it("parses the numeric(9,2) string returned by the postgres driver", () => {
@@ -50,23 +48,9 @@ describe("getObligationWorkforce", () => {
 		expect(getObligationWorkforce(null)).toBe(0);
 	});
 
-	it("makes a company absent from the GIP file non-subject to CSE and indicator G", () => {
-		const workforce = getObligationWorkforce(null);
-		expect(isCseRequired(workforce)).toBe(false);
-		expect(isIndicatorGRequired(workforce, 2027)).toBe(false);
-	});
-
-	it("compares thresholds on the exact value, so 99,97 stays below 100", () => {
-		expect(isCseRequired(getObligationWorkforce(99.97))).toBe(false);
-		expect(isCseRequired(getObligationWorkforce(100))).toBe(true);
-	});
-
-	it("does not promote 149,99 to the triennial indicator G threshold", () => {
-		expect(isIndicatorGRequired(getObligationWorkforce(149.99), 2027)).toBe(
-			false,
-		);
-		expect(isIndicatorGRequired(getObligationWorkforce(150), 2027)).toBe(true);
-	});
+	// Downstream obligation consequences (absent company → no obligation;
+	// exact-value comparison for decimal workforces like 99.97) live in the
+	// GIP-workforce describes of demarcheDecisionTable.test.ts (#3975).
 });
 
 describe("toDisplayWorkforce", () => {

--- a/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
+++ b/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
@@ -19,62 +19,21 @@ describe("constants", () => {
 	});
 });
 
-describe("isTriennialYear", () => {
-	it("returns true for the base year 2027", () => {
-		expect(isTriennialYear(2027)).toBe(true);
-	});
-
-	it("returns true for 2030 (2027 + 3)", () => {
-		expect(isTriennialYear(2030)).toBe(true);
-	});
-
-	it("returns true for 2033 (2027 + 6)", () => {
-		expect(isTriennialYear(2033)).toBe(true);
-	});
-
-	it("returns false for 2028 (off-cycle)", () => {
-		expect(isTriennialYear(2028)).toBe(false);
-	});
-
-	it("returns false for 2029 (off-cycle)", () => {
-		expect(isTriennialYear(2029)).toBe(false);
-	});
-
-	it("returns false for years before 2027", () => {
-		expect(isTriennialYear(2026)).toBe(false);
-		expect(isTriennialYear(2024)).toBe(false);
+// The triennial cycle around the base year and every pre-2030 isIndicatorGRequired
+// combination are covered symbolically by demarcheDecisionTable.test.ts (#3975).
+describe("isTriennialYear — pre-base guard", () => {
+	// base − 3 is on-modulo, so only the pre-base guard rejects it — the decision
+	// table's base − 1 case cannot discriminate that guard.
+	it("keeps on-cycle years before the base year out of the triennial cadence", () => {
+		expect(isTriennialYear(INDICATOR_G_TRIENNIAL_BASE_YEAR - 3)).toBe(false);
 	});
 });
 
-describe("isIndicatorGRequired", () => {
-	it("returns true for workforce >= 250 in a normal year", () => {
-		expect(isIndicatorGRequired(300, 2027)).toBe(true);
-		expect(isIndicatorGRequired(250, 2027)).toBe(true);
-	});
-
-	it("returns true for workforce 150-249 in a triennial year (2027)", () => {
-		expect(isIndicatorGRequired(200, 2027)).toBe(true);
-		expect(isIndicatorGRequired(150, 2027)).toBe(true);
-		expect(isIndicatorGRequired(249, 2027)).toBe(true);
-	});
-
-	it("returns false for workforce 150-249 in a non-triennial year (2028)", () => {
-		expect(isIndicatorGRequired(200, 2028)).toBe(false);
-		expect(isIndicatorGRequired(150, 2028)).toBe(false);
-	});
-
-	it("returns false for workforce 150-249 in a non-triennial year (2029)", () => {
-		expect(isIndicatorGRequired(200, 2029)).toBe(false);
-	});
-
+// The decision table (#3975) deliberately keeps its matrix below
+// INDICATOR_G_UNIVERSAL_YEAR, so the 2030+ down-extension regime is owned here.
+describe("isIndicatorGRequired — universal year (2030+) regime", () => {
 	it("returns true for workforce 150-249 in triennial year 2030", () => {
 		expect(isIndicatorGRequired(200, 2030)).toBe(true);
-	});
-
-	it("returns false for workforce < 150 in any year before universal year", () => {
-		expect(isIndicatorGRequired(100, 2027)).toBe(false);
-		expect(isIndicatorGRequired(149, 2027)).toBe(false);
-		expect(isIndicatorGRequired(100, 2029)).toBe(false);
 	});
 
 	it("extends the obligation to every tier >= 50 on triennial years from 2030", () => {
@@ -103,14 +62,6 @@ describe("isIndicatorGRequired", () => {
 
 	it("returns true for workforce >= 250 after universal year", () => {
 		expect(isIndicatorGRequired(300, 2035)).toBe(true);
-	});
-
-	it("boundary: workforce 249 (just below annual min) in 2027 — is triennial year, so required", () => {
-		expect(isIndicatorGRequired(249, 2027)).toBe(true);
-	});
-
-	it("boundary: workforce 149 (just below triennial min) in 2027 — not required", () => {
-		expect(isIndicatorGRequired(149, 2027)).toBe(false);
 	});
 });
 

--- a/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { DeclarationFsmStatus } from "~/modules/domain";
-import type { PanelVariant } from "../DeclarationProcessPanel";
+import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
 import {
 	computeCtaHref,
 	computePanelVariant,
@@ -44,39 +43,8 @@ describe("computePanelVariant", () => {
 		);
 	});
 
-	const fsmCases: Array<{
-		fsm: DeclarationFsmStatus;
-		variant: PanelVariant;
-		overrides?: Partial<DeclarationItem>;
-		label?: string;
-	}> = [
-		{ fsm: "draft", variant: "start" },
-		{ fsm: "awaiting_compliance_path_choice", variant: "compliance_choice" },
-		{ fsm: "corrective_actions_chosen", variant: "compliance" },
-		{ fsm: "awaiting_revision_choice", variant: "compliance_choice" },
-		{ fsm: "joint_evaluation_chosen", variant: "evaluation" },
-		{ fsm: "revised_joint_evaluation_chosen", variant: "evaluation" },
-		{ fsm: "awaiting_cse_opinion", variant: "cse" },
-		{
-			fsm: "demarche_completed",
-			variant: "cse",
-			label: "demarche_completed without CSE opinion deposited",
-		},
-		{
-			fsm: "demarche_completed",
-			variant: "closed",
-			overrides: { hasSubmittedCseOpinion: true },
-			label: "demarche_completed with CSE opinion deposited",
-		},
-	];
-
-	for (const { fsm, variant, overrides, label } of fsmCases) {
-		it(`returns "${variant}" for fsmStatus="${fsm}"${label ? ` (${label})` : ""}`, () => {
-			expect(
-				computePanelVariant(makeDeclaration({ fsmStatus: fsm, ...overrides })),
-			).toBe(variant);
-		});
-	}
+	// Per-status variants live in fsmMirrors.conformance.test.ts (#3975);
+	// only the inputs outside the FSM vocabulary (undefined / null) are owned here.
 });
 
 describe("computeCtaHref", () => {
@@ -92,61 +60,14 @@ describe("computeCtaHref", () => {
 		);
 	});
 
-	const fsmCases: Array<{
-		fsm: DeclarationFsmStatus;
-		href: string;
-		overrides?: Partial<DeclarationItem>;
-		label?: string;
-	}> = [
-		{
-			fsm: "draft",
-			href: `/declaration-remuneration?siren=${SIREN}`,
-		},
-		{
-			fsm: "awaiting_compliance_path_choice",
-			href: `/declaration-remuneration/parcours-conformite?siren=${SIREN}`,
-		},
-		{
-			fsm: "awaiting_revision_choice",
-			href: `/declaration-remuneration/parcours-conformite?siren=${SIREN}`,
-		},
-		{
-			fsm: "corrective_actions_chosen",
-			href: `/declaration-remuneration/parcours-conformite/etape/1?siren=${SIREN}`,
-		},
-		{
-			fsm: "joint_evaluation_chosen",
-			href: `/declaration-remuneration/parcours-conformite/evaluation-conjointe?siren=${SIREN}`,
-		},
-		{
-			fsm: "revised_joint_evaluation_chosen",
-			href: `/declaration-remuneration/parcours-conformite/evaluation-conjointe?siren=${SIREN}`,
-		},
-		{
-			fsm: "awaiting_cse_opinion",
-			href: `/avis-cse?siren=${SIREN}`,
-		},
-		{
-			fsm: "demarche_completed",
-			href: `/avis-cse?siren=${SIREN}`,
-			label: "demarche_completed without CSE opinion deposited",
-		},
-		{
-			fsm: "demarche_completed",
-			href: `/declaration-remuneration?siren=${SIREN}`,
-			overrides: { hasSubmittedCseOpinion: true },
-			label: "demarche_completed with CSE opinion deposited",
-		},
-	];
-
-	for (const { fsm, href, overrides, label } of fsmCases) {
-		it(`returns "${href}" for fsmStatus="${fsm}"${label ? ` (${label})` : ""}`, () => {
-			expect(
-				computeCtaHref(
-					makeDeclaration({ fsmStatus: fsm, ...overrides }),
-					SIREN,
-				),
-			).toBe(href);
-		});
-	}
+	// Per-status destinations live in fsmMirrors.conformance.test.ts (#3975), which
+	// strips the query — the company-scoping contract is pinned here, across every
+	// branch since the implementation repeats the siren template per status.
+	it("keeps every destination scoped to the company via the siren query parameter", () => {
+		for (const fsmStatus of DECLARATION_FSM_STATUSES) {
+			expect(computeCtaHref(makeDeclaration({ fsmStatus }), SIREN)).toContain(
+				`?siren=${SIREN}`,
+			);
+		}
+	});
 });


### PR DESCRIPTION
## Objectif

Sous-ticket de l'epic #3964 — Closes #3978.

Depuis #3974 (verrou compilateur) et #3975 (table de décision + suite de conformité des miroirs), une partie des tests unitaires refait des vérifications que ces nouvelles suites font déjà, en mieux. Cette PR supprime ces doublons. **Elle ne supprime aucune vérification d'un comportement : elle supprime des vérifications en double.** La preuve chiffrée est en bas : la couverture après élagage est identique au pourcentage près à celle d'avant.

**8 fichiers de tests modifiés, −465/+70 lignes. Aucun code de production, aucun fichier `src/e2e/**`.**

## La logique de l'audit, en deux mots

Les suites introduites par #3975 servent de référence :

- **`demarcheDecisionTable.test.ts`** croise effectif × écart × régime (matrice de 100 lignes) et vérifie tous les prédicats du domaine (`isCseRequired`, `isIndicatorGRequired`, `gapLevel`, `isSignificantGap`, `isComplianceProcessRequired`…) **aux frontières réglementaires, via les constantes nommées** (`GAP_ALERT_THRESHOLD`, `COMPANY_SIZE_ANNUAL_MIN`…).
- **`fsmMirrors.conformance.test.ts`** parcourt **tous les états du moteur** (`v2027.1.json`) et vérifie que les deux miroirs d'interface (`getCurrentStageHref` pour la navigation, `computePanelVariant`/`computeCtaHref` pour le panneau « Mon espace ») envoient l'utilisateur vers l'écran que le moteur associe à chaque état.
- **`demarcheRevisionAndStatus.test.ts`** parcourt tous les statuts FSM pour la projection `computeDeclarationStatus`, et toutes les frontières de la révision (`isComplianceProcessRevisionRequired`).

Un ancien test unitaire qui vérifie la même chose qu'une de ces suites, mais avec des valeurs codées en dur et sans garantie d'exhaustivité, n'apporte plus rien : s'il casse, la suite de référence casse aussi ; s'il passe alors que la référence casse, c'est lui qui a tort. On le supprime donc — **sauf** s'il couvre un cas que la référence ne voit pas (entrée `null`, paramètre optionnel, régime hors périmètre de la matrice…) : dans ce cas on le garde, et c'est justifié fichier par fichier ci-dessous.

Un point mérite d'être explicité : la table de décision travaille **uniquement avec les constantes symboliques**. Si quelqu'un modifiait par erreur `GAP_ALERT_THRESHOLD = 5` en `6`, toute la table resterait verte (elle testerait la frontière à 6 %). Les anciens tests aux valeurs en dur (`gapLevel(5)`) auraient détecté cette dérive. Pour ne pas perdre cette protection, la PR ajoute des **tests d'ancrage** qui figent la valeur littérale de chaque constante réglementaire (`expect(GAP_ALERT_THRESHOLD).toBe(5)`). C'est le remplacement « équivalent ou plus fort » exigé par le ticket : table symbolique + valeur figée ⇔ anciens tests littéraux.

## Détail fichier par fichier

### 1. `complianceNavigation.test.ts` (navigation du parcours de conformité)

**Supprimés — les 9 tests « un statut → une URL » de `getCurrentStageHref`** (« returns /avis-cse for awaiting_cse_opinion », « returns the compliance choice page for awaiting_compliance_path_choice », etc., jusqu'à « returns the declaration entry for draft »).

*Pourquoi :* chacun de ces tests affirmait « pour le statut X, la fonction renvoie l'URL Y », avec X et Y écrits à la main. `fsmMirrors.conformance.test.ts` fait la même vérification pour **chaque état déclaré dans le moteur** — y compris les deux valeurs de `hasCse` et le cas terminal `demarche_completed` croisé avec le dépôt d'avis CSE. Elle est plus forte sur deux plans : si on ajoute un état au moteur, elle échoue automatiquement (la liste n'est pas recopiée à la main) ; et l'URL attendue est déduite du `stage` que le moteur lui-même associe à l'état, au lieu d'être re-déclarée dans le test.

**Conservé :** le cas `getCurrentStageHref(null, …)` — une déclaration sans état FSM (données antérieures au moteur). La suite de conformité itère les statuts du moteur, donc ne passe jamais `null`. Le test est renommé pour dire l'intention (« falls back to the compliance path for a declaration without FSM projection »).

**Conservés :** les blocs `getPostComplianceDestination` et `getCseOpinionPreviousHref` (9 tests) — ces fonctions ne sont couvertes par aucune suite de référence.

### 2. `declarationProcessState.test.ts` (panneau « Mon espace »)

**Supprimées — les deux énumérations de 9 cas** : « pour le statut X, le panneau affiche le variant Y » (`computePanelVariant`) et « pour le statut X, le bouton pointe vers l'URL Y » (`computeCtaHref`).

*Pourquoi :* même raisonnement qu'au point 1 — la suite de conformité vérifie variant et URL pour chaque état du moteur, y compris la matrice terminale (avis CSE déposé ou non), dont la branche connue comme fausse est documentée par le `it.fails` #3945.

**Conservés :** les cas `undefined` (pas de déclaration) et `fsmStatus: null`, hors du vocabulaire du moteur.

**Ajouté :** un test qui vérifie que **chaque** URL renvoyée contient bien `?siren=<siren>`. La suite de conformité retire volontairement ce paramètre avant de comparer les URLs (elle ne s'intéresse qu'à l'écran de destination) ; or l'implémentation répète le paramètre branche par branche, donc une branche qui l'oublierait passerait un test portant sur une seule branche. Le test itère donc tous les statuts. C'est la seule information que les 9 cas supprimés portaient en propre, et elle est désormais mieux protégée qu'avant.

### 3. `gap.test.ts` (écarts de rémunération)

**Supprimés — 5 tests de `gapLevel`** : « returns low for gap below threshold » (3 %), « returns high for gap at threshold » (5 %), « returns high for gap above threshold » (15 %), « returns null for null input », « returns low for zero gap ».

*Pourquoi :* la table de décision teste la frontière positive de `gapLevel` des deux côtés et sur la valeur exacte (`GAP_ALERT_THRESHOLD − 1` / `GAP_ALERT_THRESHOLD` / `+ 1`) ainsi que l'entrée `null` ; le cas « 0 % » est en outre une ligne de sa matrice. Les tests supprimés faisaient la même vérification avec 3/5/15 en dur — ce que `rules/testing.md` demande justement d'éviter (« use the domain constant, never a hardcoded 5 »).

**Supprimés — 4 tests d'`isSignificantGap`** : seuil atteint côté positif, côté négatif, sous le seuil, `null`.

*Pourquoi :* la table contient un test dédié « isSignificantGap detects a significant gap in both directions » qui couvre exactement ces quatre classes, aux constantes.

**Conservé :** « respects a custom threshold » — le paramètre de seuil personnalisé n'est exercé nulle part ailleurs.

**Conservé à l'identique (cas contesté, scénario S4 du ticket) :** « returns low for a negative gap (women earn more, no alert) ». Ce comportement est contesté par le bug #3963 (un écart de −5 % devrait être classé « élevé »). Le comportement *voulu* est déjà documenté par le `it.fails` de la table de décision ; cette PR ne tranche pas et n'y touche pas.

**Ajouté :** l'ancrage `GAP_ALERT_THRESHOLD === 5` (voir la logique d'audit ci-dessus).

**Intacts :** tous les autres blocs du fichier (`computeGap`, `computeGapRatio`, `computeGapBetween`, `computeTotal`, `hasGapsAboveThreshold`, `gapMagnitude`, `hasHighGap`, `gapDirection`, `gapRatioToPercent`) — aucune suite de référence ne couvre ces fonctions.

### 4. `companySize.test.ts` (tailles d'entreprise)

**Supprimés — 5 tests** : les 3 de `classifyCompanySize` (« voluntary » sous 50, « triennial » de 50 à 99, « annual » dès 100) et les 2 d'`isCseRequired` (faux sous 100, vrai dès 100).

*Pourquoi :* la table de décision a un bloc « size boundaries (named domain constants) » qui teste ces deux fonctions des deux côtés et sur la valeur exacte de chaque frontière, aux constantes ; et chaque ligne de sa matrice (10 effectifs différents) re-vérifie `isCseRequired`.

**Ajoutés :** les ancrages `COMPANY_SIZE_VOLUNTARY_MAX === 50` et `COMPANY_SIZE_ANNUAL_MIN === 100`. À noter : les bornes de `COMPANY_SIZE_RANGES` (tranches d'affichage des statistiques) sont des littéraux indépendants de ces constantes — leur test existant ne protégeait donc pas ces deux valeurs.

**Intacts :** les blocs `COMPANY_SIZE_RANGES` et `getCompanySizeRange` (tranches statistiques, couvertes nulle part ailleurs).

### 5. `indicatorG.test.ts` (7ᵉ indicateur)

**Supprimé — le bloc `isTriennialYear` entier** (2027/2030/2033 vrais, 2028/2029 faux, années antérieures fausses).

*Pourquoi :* la table teste le cycle aux constantes (année de base − 1 / base / base + 1 / base + 3) — 2033 (base + 6) et 2028/2029 appartiennent aux mêmes classes d'équivalence. La valeur littérale de l'année de base (2027) reste figée par le bloc « constants » conservé.

*Correction apportée pendant la revue de cette PR :* le cas « années antérieures » contenait 2024, qui n'est pas dans la même classe que 2026. 2024 est **sur le cycle modulo 3** (`(2024 − 2027) % 3 === 0`) : c'est le seul type d'entrée qui distingue la garde `year >= INDICATOR_G_TRIENNIAL_BASE_YEAR` du reste de la formule. Sa suppression aurait donc perdu une vérification réelle. Un test dédié, aux constantes, a été (r)ajouté : « keeps on-cycle years before the base year out of the triennial cadence », avec `base − 3`.

**Supprimés — 7 tests d'`isIndicatorGRequired` portant sur le régime antérieur à 2030** : ≥ 250 toute année, 150-249 en année triennale, 150-249 hors année triennale (2028 et 2029), < 150, et deux tests « boundary » qui dupliquaient des assertions déjà présentes deux blocs plus haut dans le même fichier.

*Pourquoi :* la matrice de la table croise 10 effectifs (49/50/99/100/149/150/151/249/250/251) avec les deux régimes et recalcule l'attendu pour chaque ligne ; deux tests dédiés vérifient en plus chaque bascule (150 et 250) des deux côtés ; la régression #3934 (< 100 ne déclenche jamais le 7ᵉ indicateur) y est également.

**Conservés :** le bloc « constants » (fige 250/150/2030/2027 — la table est symbolique) ; **tous les tests du régime 2030+** (extension à tous les paliers ≥ 50 les années triennales à partir de 2030) : la table s'interdit explicitement ce périmètre (son commentaire le dit : « the 2030+ down-extension is out of scope here ») ; et le bloc `getApplicableIndicators` (composition de la liste A-F / A-G, couverte nulle part ailleurs).

### 6. `gipWorkforce.test.ts` (effectif GIP)

**Supprimés — 3 tests** : « makes a company absent from the GIP file non-subject to CSE and indicator G », « compares thresholds on the exact value, so 99,97 stays below 100 », « does not promote 149,99 to the triennial indicator G threshold ».

*Pourquoi :* la table a un bloc dédié « GIP workforce — single source for the obligations » qui vérifie plus complet : entreprise absente du fichier GIP → aucune obligation (CSE, indicateur G **et** parcours de conformité, là où le test supprimé ne vérifiait que les deux premiers) ; et les effectifs décimaux 99,97 / 149,5 / 249,9 comparés sur la valeur exacte, jamais sur l'arrondi d'affichage.

**Intacts :** tout le reste du fichier — en particulier le bloc `parseGipWorkforce` (chaînes numériques du driver postgres, `undefined`, `NaN`, `Infinity`, valeurs négatives), plus riche que ce que la table exerce ; c'est lui la référence sur cette fonction.

### 7. `declarationStatus.test.ts` (statut affiché à l'utilisateur)

**Supprimés — 9 tests du bloc `computeDeclarationStatus`** : déclaration absente → « à compléter » ; brouillon à l'étape 0 → « à compléter » ; brouillon démarré → « en cours » ; quatre tests « statut X → en cours » (choix de parcours attendu, actions correctives, choix de révision, avis CSE attendu) ; « done » seulement pour `demarche_completed` ; et le cas `cancelledAt: null`.

*Pourquoi :* `demarcheRevisionAndStatus.test.ts` fait exactement cette projection en itérant **tous** les statuts FSM (« done » uniquement au terminal, « en cours » partout ailleurs, `cancelledAt: null` passé sur chaque ligne), plus les cas déclaration absente, brouillon étape 0 vs démarré, et l'annulation d'une démarche terminée.

**Conservés :** brouillon avec `currentStep: null` (classe que la suite de référence ne passe pas) ; les deux tests d'**annulation d'une démarche non terminée** (la référence n'annule qu'une démarche terminée) ; et le cas `cancelledAt: undefined` (clé absente ≠ clé à `null` en TypeScript, les deux arrivent en pratique).

**Intacts :** tous les autres blocs du fichier (`isDraft`, `isComplianceProcessCompleted`, `isDeclarationSubmitted`, `isCancelled`, `getCurrentCompliancePath`, `isInComplianceProcess`, `hasStartedSecondDeclaration`).

### 8. `declarationFlags.test.ts` (prédicats du parcours de conformité)

**Supprimé — le bloc `isComplianceProcessRevisionRequired` entier (5 tests)** : parcours initial non requis → pas de révision ; pas de seconde déclaration → pas de révision ; écart corrigé inconnu → pas de révision ; écart corrigé sous le seuil → pas de révision ; écart persistant → révision.

*Pourquoi :* les 7 lignes de `REVISION_ROWS` dans `demarcheRevisionAndStatus.test.ts` couvrent ces cinq cas **plus** deux que le fichier ne testait pas (écart corrigé exactement au seuil, écart corrigé négatif), et ajoutent une assertion de cohérence : une révision ne peut être requise que si le parcours initial l'était.

**Supprimés — 3 tests d'`isComplianceProcessRequired`** : le cas nominal (tout réuni → vrai), « pas de donnée indicateur G → faux », « écart < 5 % → faux ».

*Pourquoi :* la matrice de la table produit ces trois situations : ses lignes 250+ × écart ≥ seuil donnent le nominal ; la ligne 150 hors année triennale × écart élevé isole la condition « indicateur G » (effectif suffisant, écart élevé, mais pas d'indicateur G) ; les lignes 250+ × écart faible isolent la condition « écart ».

**Conservés — 4 tests, qui exercent des entrées que la matrice ne peut pas produire.** Dans la matrice, `hasIndicatorG` est *déduit* de l'effectif et de l'année (comme en production, #3962) ; on ne peut donc pas y tester le prédicat avec des combinaisons « impossibles » mais que la fonction, elle, doit gérer : effectif < 100 **avec** `hasIndicatorG: true` (sous 100, la matrice dérive toujours `false` — c'est le seul moyen d'isoler la condition d'effectif) ; effectif `null` ; écart `null` ; et les seuils exacts avec indicateur G forcé (à 100 salariés, la dérivation donne `false` avant 2030). Ce dernier test est réécrit avec les constantes du domaine au lieu de 100/5 en dur.

## Candidats listés par le ticket mais **non** supprimés

- **`declarationFsmStatus.test.ts`** — conservé tel quel. Le ticket le désignait comme candidat, mais son unique test vérifie que l'enum Drizzle `declarationStatusEnum` (colonne `declarations.status` en base) et la constante domaine `DECLARATION_FSM_STATUSES` contiennent les mêmes valeurs. Ni le `z.enum` de #3974 (qui lie le *moteur de règles* au domaine) ni la suite de conformité (qui lie le *JSON du moteur* au domaine) ne vérifient ce lien avec la *base de données* — et le compilateur ne peut pas le faire, le domaine s'interdisant d'importer Drizzle. C'est le dernier fil qui rattrape une divergence base ↔ domaine avant la production. (L'historique git montre que le fichier n'a jamais contenu autre chose : la « partie devenue redondante » pressentie par le ticket n'existe pas.)
- **`declarationProcessStep.test.ts`** — conservé : il vérifie *quelle deadline* correspond à chaque statut (des valeurs), pas *que tous les statuts sont gérés* (de l'exhaustivité, désormais garantie par le compilateur). Ce mapping n'est testé nulle part ailleurs.
- **`matrix.v2027.1.test.ts`** — conservé : il teste les *transitions* du moteur (`applyAction`), pas les miroirs d'interface ; aucune redondance avec la suite de conformité.
- **Les 11 tests d'intégration** — audités : aucun ne recouvre le périmètre #3974/#3975 (ils testent base de données, services et routeurs). Intouchés.
- **Les fichiers UI et routeurs qui citent des statuts FSM** (`DeclarationStepLabel`, `VerticalStepper`, `StepDropoffTable`, `CompliancePathPage`, `declarationSteps`, routeurs, `admin/declarations/schemas.test.ts`) — conservés : ils testent des valeurs par statut (libellés, positions de stepper) ou dérivent leur vocabulaire de la constante partagée. Aucun ne recompte l'exhaustivité à la main.

## Catégorie 2 du ticket (tests qui recopient l'implémentation → réécrire)

L'exemple historique cité par le ticket (`gap.test.ts`, titres « computes gap as absolute percentage » ayant dérivé de la convention signée) avait déjà été corrigé en amont — les titres actuels disent « signed, GIP convention ». Le balayage du reste de la suite n'a pas trouvé d'autre restatement d'implémentation dans le périmètre audité. Les réécritures effectives de cette PR : le test siren multi-branches (point 2), le renommage du cas `null` (point 1), et le passage aux constantes du test de seuils exacts (point 8).

## Vérifications

- [x] Chaque suppression est justifiée ci-dessus — catégorie unique : **doublon d'une suite de référence #3975** (aucun test d'un code disparu n'a été trouvé)
- [x] Aucun comportement ne perd sa vérification sans remplacement équivalent ou plus fort (ancrages littéraux, test siren multi-branches, garde pré-base du cycle triennal restaurée)
- [x] `pnpm test --coverage` vert : 90,95 % statements / 85,08 % branches en global (seuil 75 %) — **identique avant/après élagage**, preuve que seuls des doublons ont été retirés
- [x] `pnpm test` vert (3 604 tests, dont les 2 échecs attendus `it.fails` #3963/#3945, intacts)
- [x] `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` verts
- [x] Aucun fichier `src/e2e/**` touché, aucun code de production modifié
- [x] Cas contestés non tranchés (scénario S4) : assertion `gapLevel` négatif conservée à l'identique, `it.fails` intacts
