### PR TITLE
test(e2e): #3986 — couverture complète des 12 cas du cahier de tests

### DIFF
--- a/docs/cahier-de-tests.md
+++ b/docs/cahier-de-tests.md
@@ -331,7 +331,7 @@ Le socle déclaratif (étapes 1–6, brouillon, historique, panneau de démarche
 Ce que les tests E2E ne peuvent pas rejouer tel quel, et comment c'est compensé :
 
 1. **La dimension année de campagne** — les specs E2E tournent sur l'année de campagne courante, pas sur 2027 → 2033. Le *contenu* de chaque cellule de l'Excel (les parcours) est déroulé par les tests du §2 ; le *cadencement* (quelle année déclenche 6 ou 7 indicateurs pour quelle tranche) est verrouillé par les tests unitaires du domaine (`indicatorG.test.ts`, `companyObligation.test.ts`), qui couvrent chaque tranche × année de la matrice.
-2. **La tranche d'effectif** — les parcours de conformité (cas 1 à 12) tournent en 250 et + (effectif GIP 250) ; les variantes 6 indicateurs ([CAS-01-6IND](#cas-01-6ind), [CAS-02-6IND](#cas-02-6ind)) tournent avec un effectif GIP de 120, représentatif de la tranche 100-149.
+2. **La tranche d'effectif** — les parcours de conformité (cas 1 à 12) tournent en 250 et + (effectif GIP 250) ; les variantes 6 indicateurs (`CAS-01-6IND`, `CAS-02-6IND`) tournent avec un effectif GIP de 120, représentatif de la tranche 100-149.
 3. **Avis CSE défavorables** — tous les tests déposent des avis « favorable » ; les variantes « défavorable » (sans impact de routage attendu, mais affichées au récapitulatif) ne sont pas déroulées.
 
 ---

--- a/docs/cahier-de-tests.md
+++ b/docs/cahier-de-tests.md
@@ -86,7 +86,7 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Déclaration des 7 indicateurs
 - Parcours de conformité : justification des écarts
 
-**Test E2E** : `compliance.e2e.ts` — `[CAS-03] Path 5` : l'option « Justifier » est proposée sans CSE ; le flux complet n'est pas déroulé.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-03] Path 5.b` : choix justification sans CSE → fin de démarche directe → `/confirmation`.
 **Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-03\]"`
 
 ---
@@ -100,7 +100,7 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Parcours de conformité : justification des écarts
 - Dépot avis CSE sur l'exactitude des données déclarées et la justification des écarts
 
-**Test E2E** : `compliance.e2e.ts` — `[CAS-04] Path 3` : choix justification → `/avis-cse/etape/1` ; dépôt de l'avis « exactitude + justification » non déroulé.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-04] Path 3` : justification → avis CSE avec colonnes « Exactitude » + « Justification » → confirmation.
 **Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-04\]"`
 
 ---
@@ -114,7 +114,7 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Parcours de conformité : évaluation conjointe
 - Dépôt du rapport de l'évaluation conjointe
 
-**Test E2E** : `compliance.e2e.ts` — `[CAS-03][CAS-05] Path 5` : éval. conjointe → upload du rapport → `/confirmation`.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-05] Path 5` : éval. conjointe → upload du rapport → `/confirmation`.
 **Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-05\]"`
 
 ---
@@ -129,7 +129,7 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Dépôt du rapport de l'évaluation conjointe
 - Dépot avis CSE sur l'exactitude des données déclarées et éventuellement sur la justification des écarts
 
-**Test E2E** : `compliance.e2e.ts` — `[CAS-06] Path 4` : éval. conjointe → upload → `/avis-cse` ; dépôt de l'avis non déroulé.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-06] Path 4` : éval. conjointe → upload du rapport → avis CSE déposé → confirmation.
 **Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-06\]"`
 
 ---
@@ -158,7 +158,7 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Nouvelle déclaration du 7ème indicateur
 - Dépot avis CSE sur l'exactitude des données déclarées pour la 1ère et la 2ème déclaration, et éventuellement sur la justifications des écarts de la 1ère déclaration
 
-**Test E2E** : `compliance.e2e.ts` — `[CAS-08] Path 6` : 2ᵉ déclaration sans écart → `/avis-cse` ; dépôt de l'avis 2-déclarations non déroulé.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-08] Path 6` : 2ᵉ déclaration sans écart → avis CSE en mode 2 déclarations (« Exactitude » 1ʳᵉ + 2ᵉ) → confirmation.
 **Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-08\]"`
 
 ---
@@ -173,7 +173,8 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Nouvelle déclaration du 7ème indicateur
 - Parcours de conformité : justification des écarts
 
-**Test E2E** : **aucun test** — le 2ᵉ tour n'est testé qu'avec CSE (`CAS-10`) ; la CI est rouge tant que ce test n'existe pas.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-09] Path 9` : 2ᵉ tour → justification sans CSE → fin de démarche directe → `/confirmation`.
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-09\]"`
 
 ---
 
@@ -188,7 +189,7 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Parcours de conformité : justification des écarts
 - Dépot avis CSE sur l'exactitude des données déclarées et éventuellement sur la justification des écarts de la 1ère déclaration, sur l'exactitude des données déclarées et la justification des écarts pour la 2ème déclaration
 
-**Test E2E** : `compliance.e2e.ts` — `[CAS-10] Path 8` : 2ᵉ tour, options restreintes, justification → `/avis-cse/etape/1` ; dépôt de l'avis non déroulé.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-10] Path 8` : 2ᵉ tour, options restreintes → justification → avis CSE 2 déclarations avec colonne « Justification » sur la 2ᵉ → confirmation.
 **Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-10\]"`
 
 ---
@@ -221,7 +222,7 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Dépôt du rapport de l'évaluation conjointe
 - Dépot avis CSE sur l'exactitude des données déclarées et éventuellement sur la justification des écarts pour la 1ère et la 2ème déclaration
 
-**Test E2E** : `compliance.e2e.ts` — `[CAS-12] Path 10` : 2ᵉ tour → éval. conjointe → upload → `/avis-cse` ; dépôt de l'avis non déroulé.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-12] Path 10` : 2ᵉ tour → éval. conjointe → avis CSE en mode 2 déclarations → confirmation.
 **Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-12\]"`
 
 ---

--- a/docs/cahier-de-tests.md
+++ b/docs/cahier-de-tests.md
@@ -234,7 +234,8 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - CSE : non
 - Déclaration des 6 premiers indicateurs
 
-**Test E2E** : **aucun test** — la soumission complète en 6 indicateurs (étape catégories masquée, aucun parcours de conformité proposé) n'est pas déroulée ; la CI est rouge tant que ce test n'existe pas.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-01-6IND] Path 14` : effectif GIP 120 (tranche 100-149), funnel en 5 étapes (étape catégories masquée), soumission → fin de démarche directe → `/confirmation`.
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-01-6IND\]"`
 
 ---
 
@@ -246,7 +247,8 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 - Déclaration des 6 premiers indicateurs
 - Dépot avis CSE sur l'exactitude des données déclarées
 
-**Test E2E** : **aucun test** — la soumission complète en 6 indicateurs avec dépôt de l'avis CSE « exactitude » n'est pas déroulée ; la CI est rouge tant que ce test n'existe pas.
+**Test E2E** : `compliance.e2e.ts` — `[CAS-02-6IND] Path 15` : effectif GIP 120, funnel en 5 étapes, soumission → `/avis-cse` → dépôt de l'avis « exactitude » → confirmation.
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-02-6IND\]"`
 
 ---
 
@@ -329,7 +331,7 @@ Le socle déclaratif (étapes 1–6, brouillon, historique, panneau de démarche
 Ce que les tests E2E ne peuvent pas rejouer tel quel, et comment c'est compensé :
 
 1. **La dimension année de campagne** — les specs E2E tournent sur l'année de campagne courante, pas sur 2027 → 2033. Le *contenu* de chaque cellule de l'Excel (les parcours) est déroulé par les tests du §2 ; le *cadencement* (quelle année déclenche 6 ou 7 indicateurs pour quelle tranche) est verrouillé par les tests unitaires du domaine (`indicatorG.test.ts`, `companyObligation.test.ts`), qui couvrent chaque tranche × année de la matrice.
-2. **La tranche d'effectif** — les specs conformité tournent en 250 et + (effectif GIP 250) ; les variantes 6 indicateurs doivent tourner avec un effectif GIP dans la tranche 100-149 pour être représentatives.
+2. **La tranche d'effectif** — les parcours de conformité (cas 1 à 12) tournent en 250 et + (effectif GIP 250) ; les variantes 6 indicateurs ([CAS-01-6IND](#cas-01-6ind), [CAS-02-6IND](#cas-02-6ind)) tournent avec un effectif GIP de 120, représentatif de la tranche 100-149.
 3. **Avis CSE défavorables** — tous les tests déposent des avis « favorable » ; les variantes « défavorable » (sans impact de routage attendu, mais affichées au récapitulatif) ne sont pas déroulées.
 
 ---

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -9,10 +9,15 @@ import {
 } from "./helpers/compliance-flows";
 import {
 	resetDeclarationToDraft,
+	resetGipWorkforce,
 	setCompanyHasCse,
 	setCompanyWorkforce,
+	setGipWorkforce,
 } from "./helpers/db";
-import { completeDeclaration } from "./helpers/declaration-flows";
+import {
+	completeDeclaration,
+	submitStepsThroughQuartiles,
+} from "./helpers/declaration-flows";
 
 test.describe.configure({ mode: "serial" });
 
@@ -489,5 +494,74 @@ test.describe("[ANX-02] Path 12: compliance already completed → redirect", () 
 			{ timeout: 10_000 },
 		);
 		await expect(page).toHaveURL(/avis-cse/);
+	});
+});
+
+// === GROUP G: "6 premiers indicateurs" variant — indicator G not required ===
+// GIP workforce 120 (bracket 100-149, off-cycle year): the funnel drops the
+// categories step and no compliance path can trigger (Excel: cas 1-2 of the
+// "6 premiers indicateurs" columns). resetGipWorkforce restores the suite
+// baseline (>= 250) for any spec running after this one.
+
+test.describe("[CAS-01-6IND] Path 14: 6 indicators (no G) + no hasCse → direct completion", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setGipWorkforce(120);
+		await setCompanyHasCse(false);
+	});
+
+	test.afterAll(async () => {
+		await resetGipWorkforce();
+	});
+
+	test("submits the 5-step funnel and completes the démarche directly", async ({
+		page,
+	}) => {
+		test.slow(); // 5-step declaration + submission
+		await submitStepsThroughQuartiles(page);
+		// No indicator G → the categories step is skipped: quartiles land on review
+		await page.waitForURL("**/declaration-remuneration/etape/6");
+		await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+
+		// Submit — no indicator G and no CSE → demarche completed directly
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.getByText(/Je certifie/).click();
+		await page.getByRole("button", { name: "Valider" }).click();
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
+	});
+});
+
+test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setGipWorkforce(120);
+		await setCompanyHasCse(true);
+	});
+
+	test.afterAll(async () => {
+		await resetGipWorkforce();
+	});
+
+	test("submits the 5-step funnel then deposits the CSE accuracy opinion", async ({
+		page,
+	}) => {
+		test.slow(); // 5-step declaration + submission + CSE flow
+		await submitStepsThroughQuartiles(page);
+		await page.waitForURL("**/declaration-remuneration/etape/6");
+
+		// Submit — no indicator G but a CSE → straight to the CSE opinion
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.getByText(/Je certifie/).click();
+		await page.getByRole("button", { name: "Valider" }).click();
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+
+		await fillCseStep1(page);
+		await submitCseStep2(page);
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
 	});
 });

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -35,7 +35,7 @@ test.describe("[CAS-02] Path 1: no gap + hasCse → /avis-cse → full CSE flow"
 
 		// No gap + hasCse → auto-redirect to /avis-cse
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-		await fillCseStep1(page, false);
+		await fillCseStep1(page);
 		await submitCseStep2(page);
 		await expect(
 			page.getByText(/Votre parcours .* est (désormais )?terminé/),
@@ -98,9 +98,25 @@ test.describe("[CAS-04] Path 3: gap + hasCse → compliance choice → justify",
 		).toBeVisible();
 	});
 
-	test("justify → navigates to /avis-cse/etape/1", async ({ page }) => {
+	test("justify → CSE opinion with accuracy + gap justification columns", async ({
+		page,
+	}) => {
+		test.slow(); // CSE step 1 (gap consulted) + step 2 matrix with 2 columns
 		await selectCompliancePath(page, "path-justify");
 		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+
+		// CSE consulted on gap justification → step 2 requires the
+		// "Justification" column on top of "Exactitude" (Excel: cas 4).
+		await fillCseStep1(page, { firstDeclGapConsulted: true });
+		await submitCseStep2(page, {
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 1, type: "gap" },
+			],
+		});
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
 	});
 });
 
@@ -111,18 +127,26 @@ test.describe("[CAS-06] Path 4: gap + hasCse → joint evaluation → /avis-cse"
 		await setCompanyWorkforce(200);
 	});
 
-	test("complete declaration with gap, joint evaluation → CSE", async ({
+	test("complete declaration with gap, joint evaluation → CSE opinion deposited", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance choice + joint eval upload
+		test.slow(); // Full declaration + compliance choice + joint eval upload + CSE flow
 		await completeDeclaration(page, { hasGap: true });
 		await selectCompliancePath(page, "path-joint");
 		await uploadJointEvalPdf(page);
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+
+		// Complete the CSE opinion after the joint evaluation (Excel: cas 6 —
+		// accuracy opinion, gap justification opinion being optional here).
+		await fillCseStep1(page);
+		await submitCseStep2(page);
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
 	});
 });
 
-test.describe("[CAS-03][CAS-05] Path 5: gap + no hasCse → joint evaluation → /confirmation", () => {
+test.describe("[CAS-05] Path 5: gap + no hasCse → joint evaluation → /confirmation", () => {
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
 		await setCompanyHasCse(false);
@@ -147,6 +171,29 @@ test.describe("[CAS-03][CAS-05] Path 5: gap + no hasCse → joint evaluation →
 	});
 });
 
+test.describe("[CAS-03] Path 5.b: gap + no hasCse → justify → /confirmation", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setCompanyHasCse(false);
+		await setCompanyWorkforce(200);
+	});
+
+	test("justify without CSE completes the démarche directly", async ({
+		page,
+	}) => {
+		test.slow(); // Full declaration + compliance choice
+		await completeDeclaration(page, { hasGap: true });
+
+		// No CSE → the justify path has no opinion to deposit: the FSM goes
+		// straight to demarche_completed (Excel: cas 3).
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
+	});
+});
+
 // === GROUP C: Corrective action — second declaration (no remaining gap) ===
 
 test.describe("[CAS-08] Path 6: gap + corrective action (no gap after) + hasCse → /avis-cse", () => {
@@ -156,14 +203,29 @@ test.describe("[CAS-08] Path 6: gap + corrective action (no gap after) + hasCse 
 		await setCompanyWorkforce(200);
 	});
 
-	test("declaration → corrective action → correct without gap → /avis-cse", async ({
+	test("declaration → corrective action → correct without gap → CSE opinion on both declarations", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance + second declaration
+		test.slow(); // Full declaration + compliance + second declaration + CSE flow
 		await completeDeclaration(page, { hasGap: true });
 		await selectCompliancePath(page, "path-corrective");
 		await completeSecondDeclaration(page, { hasGap: false });
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+
+		// Two declarations submitted → the CSE step asks for both opinions and
+		// the step 2 matrix carries one "Exactitude" column per declaration
+		// (Excel: cas 8).
+		await fillCseStep1(page, { hasSecondDeclaration: true });
+		await submitCseStep2(page, {
+			hasSecondDeclaration: true,
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 2, type: "accuracy" },
+			],
+		});
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
 	});
 });
 
@@ -229,11 +291,58 @@ test.describe("[CAS-10] Path 8: gap + corrective action (gap persists) → secon
 		).not.toBeVisible();
 	});
 
-	test("second round: justify → navigates to /avis-cse/etape/1", async ({
+	test("second round: justify → CSE opinion on both declarations with gap justification", async ({
 		page,
 	}) => {
+		test.slow(); // CSE step 1 (2 declarations) + step 2 matrix with 3 columns
 		await selectCompliancePath(page, "path-justify");
 		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+
+		// Both declarations keep a gap ≥ 5%; the CSE was consulted on justifying
+		// the second one → step 2 requires accuracy ×2 + the second declaration's
+		// "Justification" column (Excel: cas 10).
+		await fillCseStep1(page, {
+			hasSecondDeclaration: true,
+			secondDeclGapConsulted: true,
+		});
+		await submitCseStep2(page, {
+			hasSecondDeclaration: true,
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 2, type: "accuracy" },
+				{ declarationNumber: 2, type: "gap" },
+			],
+		});
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
+	});
+});
+
+test.describe("[CAS-09] Path 9: second round + justify + no hasCse → /confirmation", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setCompanyHasCse(false);
+		await setCompanyWorkforce(200);
+	});
+
+	test("full flow → second round → justify → /confirmation", async ({
+		page,
+	}) => {
+		test.slow(); // Full declaration + compliance + second decl + second round
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await completeSecondDeclaration(page, { hasGap: true });
+		// Gap persists → back to compliance choice for the second round
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+
+		// No CSE → justify has no opinion to deposit: straight to completion
+		// (Excel: cas 9).
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
 	});
 });
 
@@ -245,10 +354,10 @@ test.describe("[CAS-12] Path 10: second round + joint evaluation + hasCse → /a
 		await setCompanyWorkforce(200);
 	});
 
-	test("full flow → second round → joint evaluation → /avis-cse", async ({
+	test("full flow → second round → joint evaluation → CSE opinion on both declarations", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance + second decl + second round
+		test.slow(); // Full declaration + compliance + second decl + second round + CSE flow
 		await completeDeclaration(page, { hasGap: true });
 		await selectCompliancePath(page, "path-corrective");
 		await completeSecondDeclaration(page, { hasGap: true });
@@ -256,6 +365,20 @@ test.describe("[CAS-12] Path 10: second round + joint evaluation + hasCse → /a
 		await selectCompliancePath(page, "path-joint");
 		await uploadJointEvalPdf(page);
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+
+		// Joint evaluation deposited → close the démarche with the CSE opinion
+		// covering both declarations (Excel: cas 12).
+		await fillCseStep1(page, { hasSecondDeclaration: true });
+		await submitCseStep2(page, {
+			hasSecondDeclaration: true,
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 2, type: "accuracy" },
+			],
+		});
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
 	});
 });
 
@@ -356,7 +479,7 @@ test.describe("[ANX-02] Path 12: compliance already completed → redirect", () 
 		// Complete declaration without gap → auto-redirect to CSE → complete CSE
 		await completeDeclaration(page, { hasGap: false });
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-		await fillCseStep1(page, false);
+		await fillCseStep1(page);
 		await submitCseStep2(page);
 
 		// demarcheCompletedAt is now set — navigating back should redirect

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -4,16 +4,55 @@ import { expect, type Page } from "@playwright/test";
 const DUMMY_PDF = path.join(import.meta.dirname, "../fixtures/dummy.pdf");
 export const COMPLIANCE_PATH = "/declaration-remuneration/parcours-conformite";
 
-export async function fillCseStep1(page: Page, hasSecondDeclaration = false) {
+type CseStep1Options = {
+	hasSecondDeclaration?: boolean;
+	/** CSE consulted on justifying the first declaration's gaps ≥ 5% — adds the "Justification" column in step 2 when that declaration has a gap. */
+	firstDeclGapConsulted?: boolean;
+	/** Same, for the corrective (second) declaration. */
+	secondDeclGapConsulted?: boolean;
+};
+
+// Fill one GapConsultationCard: consulted yes/no, and when yes the opinion + date.
+async function fillGapConsultation(
+	page: Page,
+	idPrefix: string,
+	consulted: boolean,
+	date: string,
+) {
+	if (!consulted) {
+		await page.locator(`label[for="${idPrefix}-no"]`).click();
+		return;
+	}
+	await page.locator(`label[for="${idPrefix}-yes"]`).click();
+	await page.locator(`label[for="${idPrefix}-favorable"]`).click();
+	await page.locator(`#${idPrefix}-date`).fill(date);
+}
+
+export async function fillCseStep1(page: Page, options: CseStep1Options = {}) {
+	const {
+		hasSecondDeclaration = false,
+		firstDeclGapConsulted = false,
+		secondDeclGapConsulted = false,
+	} = options;
 	await page.waitForURL("**/avis-cse/etape/1");
 	// DSFR hides native radio inputs — click on the associated label instead
 	await page.locator('label[for="first-decl-accuracy-favorable"]').click();
 	await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
-	await page.locator('label[for="first-decl-gap-no"]').click();
+	await fillGapConsultation(
+		page,
+		"first-decl-gap",
+		firstDeclGapConsulted,
+		"2025-03-15",
+	);
 	if (hasSecondDeclaration) {
 		await page.locator('label[for="second-decl-accuracy-favorable"]').click();
 		await page.locator("#second-decl-accuracy-date").fill("2025-06-15");
-		await page.locator('label[for="second-decl-gap-no"]').click();
+		await fillGapConsultation(
+			page,
+			"second-decl-gap",
+			secondDeclGapConsulted,
+			"2025-06-15",
+		);
 	}
 	await page.getByRole("button", { name: "Suivant" }).click();
 	await page.waitForURL("**/avis-cse/etape/2");

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -17,6 +17,7 @@ import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 
 import common from "../shared/common.module.scss";
+import { getPostComplianceDestination } from "../shared/complianceNavigation";
 import { FormActions } from "../shared/FormActions";
 import { SavedIndicator } from "../shared/SavedIndicator";
 import styles from "./CompliancePathChoice.module.scss";
@@ -38,6 +39,7 @@ type Props = {
 	declarationSiren: string;
 	declarationYear: number;
 	email: string;
+	hasCse: boolean | null;
 	initialPath?: CompliancePathValue;
 	isSecondRound?: boolean;
 	pdfDownloadHref?: string;
@@ -50,6 +52,7 @@ export function CompliancePathChoice({
 	declarationSiren,
 	declarationYear,
 	email,
+	hasCse,
 	initialPath,
 	isSecondRound = false,
 	pdfDownloadHref,
@@ -106,7 +109,9 @@ export function CompliancePathChoice({
 					"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
 				);
 			} else {
-				router.push("/avis-cse");
+				// "justify": with a CSE the opinion remains to be deposited on
+				// /avis-cse; without one the FSM already completed the démarche.
+				router.push(getPostComplianceDestination(hasCse));
 			}
 		},
 	});
@@ -241,12 +246,12 @@ export function CompliancePathChoice({
 				<FormActions
 					isSubmitting={mutation.isPending}
 					mimoquageNextHref={
-						initialPath ? getCompliancePathHref(initialPath) : undefined
+						initialPath ? getCompliancePathHref(initialPath, hasCse) : undefined
 					}
 					nextDisabled={!selectedPath || isReadOnly}
 					nextHref={
 						isReadOnly && initialPath
-							? getCompliancePathHref(initialPath)
+							? getCompliancePathHref(initialPath, hasCse)
 							: undefined
 					}
 					nextLabel="Suivant"

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -137,6 +137,7 @@ export async function CompliancePathPage() {
 				declarationSiren={data.declaration.siren}
 				declarationYear={currentYear}
 				email={email}
+				hasCse={company.hasCse}
 				initialPath={pathChoice ?? undefined}
 				isSecondRound={isSecondRound}
 				pdfDownloadHref={

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -84,6 +84,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(
@@ -102,6 +103,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(
@@ -117,6 +119,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(
@@ -140,6 +143,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		const nextButton = screen.getByRole("button", { name: /suivant/i });
@@ -154,6 +158,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		const radio = screen.getByLabelText(
@@ -172,6 +177,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		const radio = screen.getByLabelText(
@@ -200,6 +206,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		const radio = screen.getByLabelText(
@@ -228,6 +235,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 
@@ -248,6 +256,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		const radio = screen.getByLabelText(
@@ -274,6 +283,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 				initialPath="corrective_action"
 			/>,
 		);
@@ -291,6 +301,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 				isSecondRound={true}
 			/>,
 		);
@@ -312,6 +323,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(
@@ -330,6 +342,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 				isSecondRound={true}
 			/>,
 		);
@@ -355,6 +368,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(
@@ -382,6 +396,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(
@@ -400,6 +415,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
@@ -416,6 +432,7 @@ describe("CompliancePathChoice", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="john@company.fr"
+				hasCse={true}
 			/>,
 		);
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();
@@ -432,6 +449,7 @@ describe("CompliancePathChoice", () => {
 					declarationSiren={DECLARATION_SIREN}
 					declarationYear={DECLARATION_YEAR}
 					email="test@example.fr"
+					hasCse={true}
 				/>,
 			);
 
@@ -449,6 +467,7 @@ describe("CompliancePathChoice", () => {
 					declarationSiren={DECLARATION_SIREN}
 					declarationYear={DECLARATION_YEAR}
 					email="test@example.fr"
+					hasCse={true}
 				/>,
 			);
 
@@ -472,6 +491,7 @@ describe("CompliancePathChoice", () => {
 						declarationSiren={DECLARATION_SIREN}
 						declarationYear={DECLARATION_YEAR}
 						email="test@example.fr"
+						hasCse={true}
 					/>
 				</LockProvider>,
 			);
@@ -494,6 +514,7 @@ describe("CompliancePathChoice", () => {
 						declarationSiren={DECLARATION_SIREN}
 						declarationYear={DECLARATION_YEAR}
 						email="test@example.fr"
+						hasCse={true}
 					/>
 				</LockProvider>,
 			);
@@ -518,6 +539,7 @@ describe("CompliancePathChoice read-only mode", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 				initialPath="justify"
 				readOnlyReason="cse_opinion_submitted"
 			/>,
@@ -538,6 +560,7 @@ describe("CompliancePathChoice read-only mode", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 				initialPath="justify"
 				readOnlyReason="cse_opinion_submitted"
 			/>,
@@ -559,6 +582,7 @@ describe("CompliancePathChoice read-only mode", () => {
 				declarationSiren={DECLARATION_SIREN}
 				declarationYear={DECLARATION_YEAR}
 				email="test@example.fr"
+				hasCse={true}
 				initialPath="justify"
 				readOnlyReason="cse_opinion_submitted"
 			/>,

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -195,6 +195,7 @@ describe("DraftLoadingGate", () => {
 				declarationSiren="123456789"
 				declarationYear={2026}
 				email="user@example.com"
+				hasCse={true}
 			/>,
 		);
 		expectLoadingState();

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
@@ -1,14 +1,21 @@
+import { getPostComplianceDestination } from "../../shared/complianceNavigation";
 import { CompliancePathOption } from "./CompliancePathOption";
 import type { CompliancePathValue } from "./constants";
 
-export function getCompliancePathHref(path: CompliancePathValue): string {
+export function getCompliancePathHref(
+	path: CompliancePathValue,
+	hasCse: boolean | null,
+): string {
 	if (path === "corrective_action") {
 		return "/declaration-remuneration/parcours-conformite/etape/1";
 	}
 	if (path === "joint_evaluation") {
 		return "/declaration-remuneration/parcours-conformite/evaluation-conjointe";
 	}
-	return "/avis-cse";
+	// "justify" has no dedicated page: with a CSE the opinion remains to be
+	// deposited on /avis-cse; without one the FSM already completed the
+	// démarche (choose_path_*_justify_without_cse) → confirmation page.
+	return getPostComplianceDestination(hasCse);
 }
 
 export function JointEvaluationOption({


### PR DESCRIPTION
Suite de #3988 (**basée sur cette PR** — à merger après elle). Ferme le reste de #3986.

## Ce que fait cette PR

Elle écrit les tests E2E manquants identifiés par le cahier de tests : les 12 cas du fichier `Parcours.xlsx` de Laetitia et les variantes « 6 premiers indicateurs » des cas 1-2 sont désormais tous déroulés de bout en bout, dépôts d'avis CSE compris. **C'est cette PR qui fait repasser le job `app-check-cahier` au vert** : sur #3988 il échoue volontairement (CAS-09, CAS-01-6IND et CAS-02-6IND sont au cahier sans test) ; ici les tests arrivent et la vérification passe pour les 17 parcours du référentiel.

### Nouveaux flux couverts

| Scénario | Ce qui est désormais déroulé | Test |
|---|---|---|
| CAS-03 | Justification **sans CSE** au 1ᵉʳ tour : le choix « justifier » clôt la démarche directement (aucun avis à déposer) → page de confirmation | `compliance.e2e.ts` Path 5.b (nouveau) |
| CAS-04 | Dépôt de l'avis CSE avec les **deux colonnes** de la matrice — « Exactitude » et « Justification » — quand le CSE a été consulté sur la justification des écarts | Path 3 (étendu) |
| CAS-06 | Dépôt de l'avis CSE **après l'évaluation conjointe** → confirmation | Path 4 (étendu) |
| CAS-08 | Avis CSE en **mode 2 déclarations** (« Exactitude » 1ʳᵉ + 2ᵉ) après une correction sans écart résiduel | Path 6 (étendu) |
| CAS-09 | 2ᵉ tour **sans CSE** avec justification : clôture directe de la démarche | Path 9 (nouveau) |
| CAS-10 | Avis CSE 2 déclarations avec la colonne « Justification » sur la 2ᵉ (écart persistant, CSE consulté) — la matrice la plus riche : 3 colonnes | Path 8 (étendu) |
| CAS-12 | Avis CSE 2 déclarations après l'évaluation conjointe du 2ᵉ tour | Path 10 (étendu) |
| CAS-01-6IND | Année « 6 premiers indicateurs » sans CSE : effectif GIP 120 (tranche 100-149), funnel en 5 étapes (étape catégories masquée), soumission → clôture directe de la démarche | Path 14 (nouveau) |
| CAS-02-6IND | Idem avec CSE : soumission → `/avis-cse` → dépôt de l'avis « exactitude » (seule colonne exigée : aucune catégorie donc aucun écart possible) → confirmation | Path 15 (nouveau) |

### Pourquoi ces flux étaient les bons à écrire

- Les extensions des Paths 3/4/6/8/10 exercent enfin `computeRequiredContentTypes` côté UI **et** côté garde serveur : consultation « justification » à l'étape 1 → colonne correspondante exigée dans la matrice de l'étape 2 → soumission bloquée tant que chaque colonne n'est pas associée à un fichier. C'était le cœur des cas 4, 8, 10 et 12 de l'Excel, jamais déroulé jusqu'ici.
- Les deux nouveaux describes (CAS-03, CAS-09) verrouillent le comportement « sans CSE, justification » : le FSM va directement à `demarche_completed` (`getPostComplianceDestination`), il n'existe pas de page de dépôt de justification dans ce cas. Si ce comportement change un jour (dépôt de justification exigé même sans CSE), ces tests casseront et forceront la mise à jour du cahier.

### Évolution du helper

`fillCseStep1` prend maintenant des options (`hasSecondDeclaration`, `firstDeclGapConsulted`, `secondDeclGapConsulted`) au lieu d'un booléen positionnel, pour piloter les cartes de consultation « justification » de l'étape 1 (radios oui/non, avis favorable, date). Les deux appels existants sont mis à jour.

### Cahier de tests

`docs/cahier-de-tests.md` : la ligne CAS-09 rejoint le tableau §2, les descriptions « Couverture E2E » décrivent les déroulés complets. La section « Trous de couverture » (§5) ne liste plus que : la variante « 6 indicateurs » (étape catégories masquée), les tranches < 250 (couvertes uniquement en tests unitaires de domaine, en attente des arbitrages métier du §6), et les avis CSE défavorables.

### Bug applicatif détecté et corrigé au passage

Le premier passage du test CAS-03 a révélé une incohérence réelle : après le choix « Justifier les écarts » **sans CSE**, la navigation cliente poussait vers `/avis-cse` inconditionnellement (`CompliancePathChoice.tsx`), alors que le moteur de règles (`v2027.1.json`, transitions `choose_path_*_justify_without_cse`) clôt la démarche — l'utilisateur sans CSE atterrissait sur un formulaire d'avis CSE sans objet. Corrigé en routant le choix « justifier » via `getPostComplianceDestination(hasCse)`, comme le font déjà l'évaluation conjointe et la seconde déclaration (commit dédié ; tsc, 168 tests unitaires du module et biome verts).

## Vérification

`pnpm --filter app check:cahier` passe (15 scénarios, bijection cahier ↔ specs). Le workflow « 🧪 E2E Tests » ne se déclenchant que sur les PRs basées sur `alpha`, il a été lancé manuellement (`workflow_dispatch`) sur cette branche : [run vert](https://github.com/SocialGouv/egapro/actions/runs/29929913688) — 81 tests passés, 0 échec (2 flaky sans rapport, retentés avec succès).

