### PR TITLE
chore(orchestration): #3956 — colonnes Start date / End date du board

### DIFF
--- a/.claude/rules/github-board.md
+++ b/.claude/rules/github-board.md
@@ -18,11 +18,13 @@ Les IDs sont **stables** tant que le board n'est pas recréé. Si un snippet éc
 ## IDs constants
 
 ```
-PROJECT_ID       = PVT_kwDOAh0HH84BFsK7
-STATUS_FIELD_ID  = PVTSSF_lADOAh0HH84BFsK7zg29EI8
-SIZE_FIELD_ID    = PVTSSF_lADOAh0HH84BFsK7zg29ENU   # single-select XS/S/M/L/XL
-ESTIMATE_FIELD_ID= PVTF_lADOAh0HH84BFsK7zg29ENY     # number (points Fibonacci)
-SPRINT_FIELD_ID  = PVTIF_lADOAh0HH84BFsK7zg8pCDM    # iteration
+PROJECT_ID         = PVT_kwDOAh0HH84BFsK7
+STATUS_FIELD_ID    = PVTSSF_lADOAh0HH84BFsK7zg29EI8
+SIZE_FIELD_ID      = PVTSSF_lADOAh0HH84BFsK7zg29ENU   # single-select XS/S/M/L/XL
+ESTIMATE_FIELD_ID  = PVTF_lADOAh0HH84BFsK7zg29ENY     # number (points Fibonacci)
+START_DATE_FIELD_ID= PVTF_lADOAh0HH84BFsK7zg29ENc     # date (implementation start)
+END_DATE_FIELD_ID  = PVTF_lADOAh0HH84BFsK7zg29ENg     # date (PR merge)
+SPRINT_FIELD_ID    = PVTIF_lADOAh0HH84BFsK7zg8pCDM    # iteration
 ```
 
 ### Size options (complexité t-shirt)
@@ -36,6 +38,15 @@ SPRINT_FIELD_ID  = PVTIF_lADOAh0HH84BFsK7zg8pCDM    # iteration
 | XL | `db339eb2` | 8 |
 
 Ne jamais écrire `Size` / `Estimate` en GraphQL brut : passer par `scripts/orchestration/set_ticket_size.sh <ticket> <XS|S|M|L|XL>` (écrit les deux champs d'un coup). Rubrique de sizing : `rules/complexity-estimation.md`. Lecture de la vélocité : `scripts/orchestration/sprint_velocity.sh` (skill `/velocity`).
+
+### Date fields (Start date / End date)
+
+Les deux champs `DATE` donnent une vision de la fenêtre d'implémentation d'un ticket (voir #3956) :
+
+- **Start date** — jour où le ticket entre en implémentation. Écrit automatiquement par `set_ticket_status.sh` sur la transition `→ In progress` (donc via `/implement`, `code-dev` et `epic_loop.sh`), idempotent (le premier passage gagne).
+- **End date** — jour de merge de la PR. Écrit par le workflow `.github/workflows/ticket-end-date.yaml` (résout `<N>` depuis `ticket/<N>-*`).
+
+Ne jamais écrire ces champs en GraphQL brut : passer par `scripts/orchestration/set_ticket_date.sh <ticket> <start|end> [--if-empty] [YYYY-MM-DD]` (write primitive unique). Backfill historique des tickets déjà mergés : `scripts/orchestration/backfill_ticket_dates.sh` (Start = 1ᵉʳ commit de la PR, End = date de merge).
 
 ### Issue types (GitHub native)
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -163,7 +163,7 @@ Pour un single ticket (Task, Bug, ou sub-issue d'epic dispatchée manuellement),
    bash scripts/orchestration/create_linked_branch.sh "$ISSUE_N" "$BASE_BRANCH"
    ```
 
-3. **Status board** : `set_ticket_status.sh "$ISSUE_N" "In progress"`.
+3. **Status board** : `set_ticket_status.sh "$ISSUE_N" "In progress"`. Cette transition **stampe automatiquement la `Start date`** du board (première fois seulement, idempotent) via `set_ticket_date.sh` — c'est le point de passage unique de « implémentation démarrée » pour tous les modes. La `End date` est posée plus tard par le workflow `ticket-end-date.yaml` au merge de la PR.
 
 4. **Lancer `code-dev` en CLI foreground** (PAS via le Task tool) — code-dev DOIT être *main agent* de son propre process pour pouvoir lancer ses sous-agents (`tu-dev` étape 5.5, les 4 quality gates étape 6, `functional-validator` étape 9a) ; un sous-agent ne peut pas en spawner d'autres. Même invocation que `epic_loop.sh` (`spawn_agent`), mais **synchrone/bloquante** pour un seul ticket :
 
@@ -297,5 +297,6 @@ L'utilisateur retire `dispatch=escalate` (et `attempt=3`) après orientation pou
 - Régénération doc (best-effort, après la gate E2E verte) : `scripts/orchestration/run_doc_writer.sh`
 - Computation du plan : `scripts/orchestration/dispatch_plan.sh`
 - Mutations board : `scripts/orchestration/process_tick_result.sh`
-- Helpers : `scripts/orchestration/{cache_gh,log_event,set_ticket_status,epic_state,render_dashboard,create_linked_branch,force_pr_issue_link}.sh`
+- Helpers : `scripts/orchestration/{cache_gh,log_event,set_ticket_status,set_ticket_date,epic_state,render_dashboard,create_linked_branch,force_pr_issue_link}.sh`
+- Colonnes `Start date` / `End date` du board : `scripts/orchestration/{set_ticket_date,backfill_ticket_dates}.sh` + workflow `.github/workflows/ticket-end-date.yaml` (voir `rules/github-board.md` § Date fields)
 - Dashboard : skill `/report`

--- a/.github/workflows/ticket-end-date.yaml
+++ b/.github/workflows/ticket-end-date.yaml
@@ -1,0 +1,58 @@
+name: 🗓️ Ticket end date
+
+# Stamps the "End date" column of the EGAPRO V2 project board when a ticket's
+# PR is merged. The ticket number is parsed from the linked-branch convention
+# `ticket/<N>-*` (created by scripts/orchestration/create_linked_branch.sh), so
+# the final epic PR (`epic/<N>`) and human non-ticket branches are skipped.
+#
+# Auth: GitHub App token minted by SocialGouv/token-bureau (OIDC), same pattern
+# as release.yml / promote-test-env.yaml.
+#
+# PREREQUISITE — the token-bureau token must carry `organization_projects: write`.
+#   Writing an org Project V2 needs the projects scope; the default GITHUB_TOKEN
+#   cannot, and the token-bureau whitelist (infra-apps) must allow it. As of now
+#   the deployed default whitelist is contents/metadata/issues/pull_requests/
+#   deployments — add `organization_projects: write` (default or an egapro
+#   override) in SocialGouv/infra-apps token-bureau values, and ensure the
+#   backing App has "Organization projects: Read and write", or the board write
+#   step 403s.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  id-token: write # required for token-bureau OIDC
+
+jobs:
+  stamp-end-date:
+    # Only merged PRs, only ticket branches.
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'ticket/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Stamp End date
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGED_AT: ${{ github.event.pull_request.merged_at }}
+        run: |
+          N="$(printf '%s' "$HEAD_REF" | sed -nE 's#^ticket/([0-9]+)-.*#\1#p')"
+          if [ -z "$N" ]; then
+            echo "Head ref '$HEAD_REF' is not a ticket branch — skipping."
+            exit 0
+          fi
+          MERGE_DATE="$(printf '%s' "$MERGED_AT" | cut -dT -f1)"
+          echo "Stamping End date=$MERGE_DATE on ticket #$N"
+          bash scripts/orchestration/set_ticket_date.sh "$N" end --if-empty "$MERGE_DATE"

--- a/scripts/orchestration/backfill_ticket_dates.sh
+++ b/scripts/orchestration/backfill_ticket_dates.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
+# backfill_ticket_dates.sh [--dry-run] [--force]
+#
+# One-off (idempotent, re-runnable) backfill of the "Start date" / "End date"
+# columns on the EGAPRO V2 board for tickets that already went through the
+# pipeline, from durable GitHub data:
+#
+#   Start date = date of the FIRST commit on the ticket's merged PR
+#   End date   = date the PR was merged
+#
+# Scope: leaf issues only (type Task / Bug) that are on the project AND have a
+# merged linked PR. Feature/epic issues are skipped (they are not leaves).
+#
+# Options:
+#   --dry-run   Print what would be written, without touching the board.
+#   --force     Overwrite existing values. Default is --if-empty (never clobber
+#               a value already set live by the pipeline).
+#
+# Writes go through set_ticket_date.sh (single write primitive). Uses the local
+# `gh` auth, which already has project write access (same as set_ticket_size.sh
+# / set_ticket_status.sh).
+#
+# Usage:
+#   backfill_ticket_dates.sh --dry-run     # inspect first
+#   backfill_ticket_dates.sh               # apply (if-empty)
+#   backfill_ticket_dates.sh --force       # apply, overwriting
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ID="${EGAPRO_PROJECT_ID:-PVT_kwDOAh0HH84BFsK7}"
+
+DRY_RUN=0
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        --force)   FORCE=1 ;;
+        *) echo "ERROR: unknown argument '$arg'" >&2; exit 2 ;;
+    esac
+done
+
+IF_EMPTY_FLAG="--if-empty"
+[ "$FORCE" = "1" ] && IF_EMPTY_FLAG=""
+
+# 1. Collect leaf ticket numbers (Task / Bug) currently on the project.
+echo "Collecting Task/Bug items on the project..." >&2
+TICKETS=$(gh api graphql --paginate -f project="$PROJECT_ID" -f query='
+query($project:ID!, $endCursor:String) {
+  node(id: $project) {
+    ... on ProjectV2 {
+      items(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          content {
+            __typename
+            ... on Issue { number issueType { name } }
+          }
+        }
+      }
+    }
+  }
+}' --jq '.data.node.items.nodes[]
+          | select(.content.__typename == "Issue")
+          | select(.content.issueType.name == "Task" or .content.issueType.name == "Bug")
+          | .content.number' | sort -un)
+
+if [ -z "$TICKETS" ]; then
+    echo "No Task/Bug items found on the project." >&2
+    exit 0
+fi
+
+COUNT=0
+PROCESSED=0
+SKIPPED=0
+
+# 2. For each ticket, resolve its merged PR and compute the two dates.
+for N in $TICKETS; do
+    COUNT=$((COUNT + 1))
+
+    # Prefer the merged PR whose head branch follows the ticket/<N>-* convention;
+    # otherwise fall back to the most recently merged linked PR.
+    PR_JSON=$(gh api graphql -f query='
+query($owner:String!, $repo:String!, $n:Int!) {
+  repository(owner: $owner, name: $repo) {
+    issue(number: $n) {
+      closedByPullRequestsReferences(first: 20, includeClosedPrs: true) {
+        nodes {
+          number state mergedAt headRefName
+          commits(first: 1) { nodes { commit { committedDate } } }
+        }
+      }
+    }
+  }
+}' -f owner=SocialGouv -f repo=egapro -F n="$N" \
+      --jq '[.data.repository.issue.closedByPullRequestsReferences.nodes[]
+             | select(.state == "MERGED" and .mergedAt != null)]' 2>/dev/null || echo "[]")
+
+    # Pick: ticket/<N>-* branch first, else the latest merged (by mergedAt).
+    PICK=$(echo "$PR_JSON" | jq -c --arg t "ticket/${N}-" '
+        (map(select(.headRefName | startswith($t))) | sort_by(.mergedAt) | last)
+        // (sort_by(.mergedAt) | last)
+        // empty')
+
+    if [ -z "$PICK" ] || [ "$PICK" = "null" ]; then
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    START_DATE=$(echo "$PICK" | jq -r '.commits.nodes[0].commit.committedDate // ""' | cut -dT -f1)
+    END_DATE=$(echo "$PICK" | jq -r '.mergedAt // ""' | cut -dT -f1)
+    PR_NUM=$(echo "$PICK" | jq -r '.number')
+
+    if [ -z "$START_DATE" ] && [ -z "$END_DATE" ]; then
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+
+    if [ "$DRY_RUN" = "1" ]; then
+        echo "[dry-run] #$N (PR #$PR_NUM): start=${START_DATE:-—} end=${END_DATE:-—}"
+        continue
+    fi
+
+    # shellcheck disable=SC2086
+    [ -n "$START_DATE" ] && bash "$SCRIPT_DIR/set_ticket_date.sh" "$N" start $IF_EMPTY_FLAG "$START_DATE" || true
+    # shellcheck disable=SC2086
+    [ -n "$END_DATE" ] && bash "$SCRIPT_DIR/set_ticket_date.sh" "$N" end $IF_EMPTY_FLAG "$END_DATE" || true
+    # Counts tickets with a merged PR that were processed; individual writes may
+    # still be no-ops when --if-empty finds a value already set.
+    PROCESSED=$((PROCESSED + 1))
+done
+
+echo "" >&2
+if [ "$DRY_RUN" = "1" ]; then
+    echo "Dry-run complete: $COUNT ticket(s) inspected." >&2
+else
+    echo "Backfill complete: $COUNT inspected, $PROCESSED processed (had merged PR), $SKIPPED skipped (no merged PR)." >&2
+fi

--- a/scripts/orchestration/set_ticket_date.sh
+++ b/scripts/orchestration/set_ticket_date.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+  for B in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    [ -x "$B" ] && exec "$B" "$0" "$@"
+  done
+  echo "Bash 4+ required. Install via 'brew install bash'." >&2
+  exit 1
+fi
+# set_ticket_date.sh <ticket_number> <start|end> [--if-empty] [YYYY-MM-DD]
+#
+# Writes a DATE field on the EGAPRO V2 GitHub project board:
+#   start -> "Start date"  (implementation start)
+#   end   -> "End date"    (PR merge)
+#
+# Encapsulates the same node-id -> project-item-id resolution as
+# set_ticket_status.sh, then writes the DATE field via
+# updateProjectV2ItemFieldValue { value: { date: "YYYY-MM-DD" } }.
+#
+# This is the single write primitive shared by:
+#   - set_ticket_status.sh   (stamps Start date on the "In progress" transition)
+#   - backfill_ticket_dates.sh (historical backfill, both fields)
+#   - .github/workflows/ticket-end-date.yaml (stamps End date on PR merge)
+#
+# Options:
+#   --if-empty   Skip the write if the field already holds a value. Keeps the
+#                FIRST value that was ever set (e.g. a re-dispatch that goes
+#                To Do -> In progress again does not reset the original start).
+#   YYYY-MM-DD   Explicit date (any positional arg matching the pattern).
+#                Defaults to today (`date +%F`).
+#
+# Exit codes: 0 ok / skipped, 1 resolution error, 2 usage error.
+#
+# Usage:
+#   set_ticket_date.sh 123 start                 # Start date = today
+#   set_ticket_date.sh 123 start --if-empty      # Start date = today, only if empty
+#   set_ticket_date.sh 123 end 2026-07-22        # End date = 2026-07-22
+#
+# Env:
+#   EGAPRO_PROJECT_ID           — override project ID
+#   EGAPRO_START_DATE_FIELD_ID  — override Start date field ID
+#   EGAPRO_END_DATE_FIELD_ID    — override End date field ID
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <ticket_number> <start|end> [--if-empty] [YYYY-MM-DD]" >&2
+    exit 2
+fi
+
+TICKET="$1"
+KIND="$2"
+shift 2
+
+IF_EMPTY=0
+DATE=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --if-empty) IF_EMPTY=1 ;;
+        [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) DATE="$1" ;;
+        *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+[ -z "$DATE" ] && DATE="$(date +%F)"
+
+PROJECT_ID="${EGAPRO_PROJECT_ID:-PVT_kwDOAh0HH84BFsK7}"
+START_FIELD_ID="${EGAPRO_START_DATE_FIELD_ID:-PVTF_lADOAh0HH84BFsK7zg29ENc}"
+END_FIELD_ID="${EGAPRO_END_DATE_FIELD_ID:-PVTF_lADOAh0HH84BFsK7zg29ENg}"
+
+case "$KIND" in
+    start|Start) FIELD_ID="$START_FIELD_ID"; FIELD_NAME="Start date" ;;
+    end|End)     FIELD_ID="$END_FIELD_ID";   FIELD_NAME="End date" ;;
+    *) echo "ERROR: kind must be 'start' or 'end' (got '$KIND')" >&2; exit 2 ;;
+esac
+
+# 1. Resolve issue node ID
+NODE_ID=$(gh api graphql -f query='
+query($owner:String!, $repo:String!, $n:Int!) {
+  repository(owner:$owner, name:$repo) {
+    issue(number:$n) { id }
+  }
+}' -f owner=SocialGouv -f repo=egapro -F n="$TICKET" --jq '.data.repository.issue.id')
+
+if [ -z "$NODE_ID" ] || [ "$NODE_ID" = "null" ]; then
+    echo "ERROR: issue #$TICKET not found in SocialGouv/egapro" >&2
+    exit 1
+fi
+
+# 2. Find existing project item ID, or add the issue to the project
+ITEM_ID=$(gh api graphql -f query='
+query($owner:String!, $repo:String!, $n:Int!) {
+  repository(owner:$owner, name:$repo) {
+    issue(number:$n) {
+      projectItems(first: 5) {
+        nodes { id project { id } }
+      }
+    }
+  }
+}' -f owner=SocialGouv -f repo=egapro -F n="$TICKET" \
+  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" \
+  | head -1 || true)
+
+if [ -z "$ITEM_ID" ]; then
+    ITEM_ID=$(gh api graphql -f query='
+mutation($project:ID!, $content:ID!) {
+  addProjectV2ItemById(input: { projectId: $project, contentId: $content }) {
+    item { id }
+  }
+}' -f project="$PROJECT_ID" -f content="$NODE_ID" --jq '.data.addProjectV2ItemById.item.id')
+fi
+
+if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+    echo "ERROR: failed to resolve project item for issue #$TICKET" >&2
+    exit 1
+fi
+
+# 3. Idempotency guard — skip if the field already holds a value.
+# Read by field ID (same key the write uses) so an EGAPRO_*_FIELD_ID env
+# override stays consistent between the guard and the mutation.
+if [ "$IF_EMPTY" = "1" ]; then
+    CURRENT=$(gh api graphql -f query='
+query($item:ID!) {
+  node(id: $item) {
+    ... on ProjectV2Item {
+      fieldValues(first: 50) {
+        nodes {
+          __typename
+          ... on ProjectV2ItemFieldDateValue {
+            field { ... on ProjectV2FieldCommon { id } }
+            date
+          }
+        }
+      }
+    }
+  }
+}' -f item="$ITEM_ID" \
+      --jq "[.data.node.fieldValues.nodes[] | select(.field.id == \"$FIELD_ID\") | .date] | .[0] // \"\"" \
+      2>/dev/null || echo "")
+    if [ -n "$CURRENT" ] && [ "$CURRENT" != "null" ]; then
+        echo "ticket #$TICKET → $FIELD_NAME already set ($CURRENT), skipping" >&2
+        exit 0
+    fi
+fi
+
+# 4. Write the DATE field
+gh api graphql -f query='
+mutation($project:ID!, $item:ID!, $field:ID!, $date:Date!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $project,
+    itemId: $item,
+    fieldId: $field,
+    value: { date: $date }
+  }) { projectV2Item { id } }
+}' \
+  -f project="$PROJECT_ID" \
+  -f item="$ITEM_ID" \
+  -f field="$FIELD_ID" \
+  -f date="$DATE" \
+  --jq '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null
+
+echo "ticket #$TICKET → $FIELD_NAME = $DATE"

--- a/scripts/orchestration/set_ticket_status.sh
+++ b/scripts/orchestration/set_ticket_status.sh
@@ -38,6 +38,9 @@ fi
 
 set -euo pipefail
 
+# Resolve script dir to locate sibling scripts (set_ticket_date.sh).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ $# -lt 2 ]; then
     echo "Usage: $0 <ticket_number> <status_label>" >&2
     echo "  status_label: Backlog | To Do | In progress | In review" >&2
@@ -133,3 +136,11 @@ mutation($project:ID!, $item:ID!, $field:ID!, $option:String!) {
   --jq '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null
 
 echo "ticket #$TICKET → $STATUS_RAW"
+
+# Stamp the Start date on the first "In progress" transition (idempotent).
+# This is the single choke point for "implementation started" across every mode
+# (/implement task/bug, code-dev, epic_loop), so the board's Start date column
+# is populated automatically. Best-effort: never fail the status move on this.
+if [ "$OPTION_ID" = "47fc9ee4" ]; then
+    bash "$SCRIPT_DIR/set_ticket_date.sh" "$TICKET" start --if-empty >/dev/null 2>&1 || true
+fi


### PR DESCRIPTION
## Contexte

Epic #3956 — donner une vision de la fenêtre d'implémentation d'un ticket via les colonnes natives **Start date** / **End date** du Project EGAPRO V2 (les champs DATE existent déjà sur le board ; ces changements ne font que les **peupler**).

## Contenu

- **#3958** — `scripts/orchestration/set_ticket_date.sh` (primitive de write d'un champ DATE, idempotente `--if-empty`) + stamp automatique de la **Start date** sur la transition `→ In progress` dans `set_ticket_status.sh`, le point de passage unique de « implémentation démarrée » (`/implement`, `code-dev`, `epic_loop`). Le premier passage gagne.
- **#3957** — `scripts/orchestration/backfill_ticket_dates.sh` — backfill historique des feuilles Task/Bug ayant une PR mergée : **Start = 1ᵉʳ commit de la PR**, **End = date de merge**. `--dry-run` (read-only) · `--if-empty` par défaut · `--force`.
- **#3959** — `.github/workflows/ticket-end-date.yaml` — stampe la **End date** au merge de la PR (résolution du ticket depuis `ticket/<N>-*`, skippe la PR finale d'epic et les branches non-ticket). Auth via `SocialGouv/token-bureau` (OIDC), même pattern que `release.yml`.
- **Docs** — `.claude/rules/github-board.md` (IDs des champs DATE + primitive + backfill), `.claude/skills/implement/SKILL.md` (comportement du stamp).

## ⚠️ Prérequis avant que #3959 soit fonctionnel

Le workflow écrit sur un **Project org** → le token token-bureau doit porter le scope **`organization_projects: write`**. Le whitelist déployé (`SocialGouv/infra-apps`) est aujourd'hui `contents / metadata / issues / pull_requests / deployments` (pas de projects). À ajouter côté infra-apps (+ l'App token-bureau doit avoir la permission org Projects Read & write), sinon l'étape de write board renvoie **403**.

> Note : un workflow `pull_request` ne s'exécute qu'à partir de la version présente sur la **branche de base** — il ne stampera donc qu'à partir des PR mergées après l'arrivée de ce workflow sur `alpha`.

## Vérifications

- `bash -n` OK sur tous les scripts ; YAML du workflow validé ; parsing `ticket/<N>-*` + date de merge testés (skippe `epic/<N>`, `chore/*`).
- `backfill --dry-run` exécuté en réel (read-only) sur le board : résolution tickets → PR mergée → Start/End correcte, y compris sous-tickets partageant une PR.
- Requête d'idempotence (lecture par field ID) validée en live sur un vrai item.
- `/code-review` (2 axes) : **0 violation dure**, spec 100 % fidèle ; 2 correctifs appliqués (lecture idempotence par ID, compteur backfill honnête).

Part of #3956
Closes #3957
Closes #3958
Closes #3959
