### PR TITLE
fix(export): expose Source_categories_emplois dans l'API SUIT

### DIFF
--- a/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
@@ -174,3 +174,100 @@ describe("GET /api/v1/export/declarations — Date_annulation integration", () =
 		expect(decl.Historique_statuts).toEqual([]);
 	});
 });
+
+describe("GET /api/v1/export/declarations — Source_categories_emplois integration (#3944)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN = "987654321";
+	const YEAR = 2025;
+	const USER_ID = "export-source-integration-test-user";
+	const DECL_G_ID = "export-decl-with-g";
+	const DECL_NO_G_ID = "export-decl-without-g";
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	async function cleanup() {
+		await sql`DELETE FROM app_employee_category WHERE job_category_id IN (SELECT id FROM app_job_category WHERE declaration_id IN (${DECL_G_ID}, ${DECL_NO_G_ID}))`;
+		await sql`DELETE FROM app_job_category WHERE declaration_id IN (${DECL_G_ID}, ${DECL_NO_G_ID})`;
+		await sql`DELETE FROM app_declaration WHERE id IN (${DECL_G_ID}, ${DECL_NO_G_ID})`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+	}
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+
+		await sql`
+			INSERT INTO app_user (id, email, first_name, last_name)
+			VALUES (${USER_ID}, 'dir.rh@example.fr', 'Dir', 'RH')
+			ON CONFLICT DO NOTHING
+		`;
+		await sql`
+			INSERT INTO app_company (siren, name, workforce)
+			VALUES (${SIREN}, 'Entreprise Source Test', 250)
+			ON CONFLICT DO NOTHING
+		`;
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id, status, created_at, updated_at)
+			VALUES
+				(${DECL_G_ID},    ${SIREN}, ${YEAR}, ${USER_ID}, 'demarche_completed', '2025-05-01T00:00:00Z', '2025-05-01T00:00:00Z'),
+				(${DECL_NO_G_ID}, ${SIREN}, ${YEAR + 1}, ${USER_ID}, 'demarche_completed', '2025-05-01T00:00:00Z', '2025-05-01T00:00:00Z')
+		`;
+		await sql`
+			INSERT INTO app_job_category (id, declaration_id, category_index, name, source)
+			VALUES ('jobcat-1', ${DECL_G_ID}, 0, 'Cadres', 'accord-branche')
+		`;
+		await sql`
+			INSERT INTO app_employee_category (id, job_category_id, declaration_type, women_count, men_count)
+			VALUES ('empcat-1', 'jobcat-1', 'initial', 10, 12)
+		`;
+	});
+
+	it("surfaces the job-category source through the real Drizzle query as Source_categories_emplois", async () => {
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const response = await GET(
+			gatewayRequest({ date_begin: "2025-05-01", date_end: "2025-05-02" }),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		const decl = body.Declarations.find(
+			(d: { id: string }) => d.id === DECL_G_ID,
+		);
+		expect(decl).toBeDefined();
+		expect(decl.Source_categories_emplois).toBe("accord-branche");
+		expect(decl.Indicateurs.G).toHaveLength(1);
+	});
+
+	it("returns Source_categories_emplois null for a declaration without any job category", async () => {
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const response = await GET(
+			gatewayRequest({ date_begin: "2025-05-01", date_end: "2025-05-02" }),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		const decl = body.Declarations.find(
+			(d: { id: string }) => d.id === DECL_NO_G_ID,
+		);
+		expect(decl).toBeDefined();
+		expect(decl.Source_categories_emplois).toBeNull();
+		expect(decl.Indicateurs.G).toBeNull();
+	});
+
+	function gatewayRequest(params: Record<string, string>): Request {
+		const searchParams = new URLSearchParams(params);
+		return new Request(
+			`http://localhost/api/v1/export/declarations?${searchParams}`,
+			{ headers: { "x-gateway-forwarded": "test-value" } },
+		);
+	}
+});

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -1172,6 +1172,132 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(decl.Seconde_declaration.Statut).toBe(true);
 	});
 
+	it("should thread the job-category source into Source_categories_emplois (#3944)", async () => {
+		mockFetchSubmitted.mockResolvedValue([
+			{
+				declarationId: "decl-1",
+				siren: "123456789",
+				year: 2027,
+				status: "submitted",
+				firstDeclarationPathChoice: null,
+				secondDeclarationPathChoice: null,
+				totalWomen: 100,
+				totalMen: 150,
+				submittedAt: null,
+				firstDeclarationPathChoiceAt: null,
+				secondDeclarationPathChoiceAt: null,
+				secondDeclarationSubmittedAt: null,
+				jointEvaluationSubmittedAt: null,
+				cseOpinionCompletedAt: null,
+				demarcheCompletedAt: null,
+				complianceProcessRequired: false,
+				complianceProcessRevisionRequired: false,
+				cseRequired: false,
+				indicatorGRequired: false,
+				rulesVersion: "2027.1",
+				secondDeclReferencePeriodStart: null,
+				secondDeclReferencePeriodEnd: null,
+				createdAt: new Date("2027-03-15T10:00:00Z"),
+				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				companyName: "ACME Corp",
+				workforceEma: "250.00",
+				nafCode: "62.02",
+				address: "1 rue test",
+				hasCse: true,
+				declarantFirstName: "Jean",
+				declarantLastName: "Dupont",
+				declarantEmail: "jean@acme.fr",
+				declarantPhone: "0612345678",
+				...nullIndicators,
+			},
+		]);
+		mockFetchIndicatorG.mockResolvedValueOnce(
+			new Map([
+				[
+					"decl-1",
+					[
+						{
+							categoryName: "cadres",
+							source: "accord-branche",
+							declarationType: "initial",
+							womenCount: 10,
+							menCount: 10,
+							annualBaseWomen: "100",
+							annualBaseMen: "100",
+							annualVariableWomen: null,
+							annualVariableMen: null,
+							hourlyBaseWomen: null,
+							hourlyBaseMen: null,
+							hourlyVariableWomen: null,
+							hourlyVariableMen: null,
+						},
+					],
+				],
+			]),
+		);
+
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const request = gatewayForwardedRequest(
+			"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+		);
+		const response = await GET(request);
+
+		expect(response.status).toBe(200);
+		const decl = (await response.json()).Declarations[0];
+		expect(decl.Source_categories_emplois).toBe("accord-branche");
+	});
+
+	it("should expose Source_categories_emplois=null when the declaration has no indicator G (#3944)", async () => {
+		mockFetchSubmitted.mockResolvedValue([
+			{
+				declarationId: "decl-1",
+				siren: "123456789",
+				year: 2027,
+				status: "submitted",
+				firstDeclarationPathChoice: null,
+				secondDeclarationPathChoice: null,
+				totalWomen: 100,
+				totalMen: 150,
+				submittedAt: null,
+				firstDeclarationPathChoiceAt: null,
+				secondDeclarationPathChoiceAt: null,
+				secondDeclarationSubmittedAt: null,
+				jointEvaluationSubmittedAt: null,
+				cseOpinionCompletedAt: null,
+				demarcheCompletedAt: null,
+				complianceProcessRequired: false,
+				complianceProcessRevisionRequired: false,
+				cseRequired: false,
+				indicatorGRequired: false,
+				rulesVersion: "2027.1",
+				secondDeclReferencePeriodStart: null,
+				secondDeclReferencePeriodEnd: null,
+				createdAt: new Date("2027-03-15T10:00:00Z"),
+				updatedAt: new Date("2027-03-15T12:00:00Z"),
+				companyName: "ACME Corp",
+				workforceEma: "250.00",
+				nafCode: "62.02",
+				address: "1 rue test",
+				hasCse: true,
+				declarantFirstName: "Jean",
+				declarantLastName: "Dupont",
+				declarantEmail: "jean@acme.fr",
+				declarantPhone: "0612345678",
+				...nullIndicators,
+			},
+		]);
+
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const request = gatewayForwardedRequest(
+			"http://localhost/api/v1/export/declarations?date_begin=2027-03-15",
+		);
+		const response = await GET(request);
+
+		expect(response.status).toBe(200);
+		const decl = (await response.json()).Declarations[0];
+		expect(decl.Source_categories_emplois).toBeNull();
+	});
+
 	it("should include Historique_statuts with FR labels and Numero_declaration on path_choice entries", async () => {
 		mockFetchSubmitted.mockResolvedValue([
 			{

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -244,6 +244,7 @@ describe("buildIndicatorG", () => {
 		const entries: IndicatorGEntry[] = [
 			{
 				categoryName: "Ouvriers",
+				source: null,
 				declarationType: "initial",
 				womenCount: 40,
 				menCount: 45,
@@ -258,6 +259,7 @@ describe("buildIndicatorG", () => {
 			},
 			{
 				categoryName: "Ouvriers",
+				source: null,
 				declarationType: "correction",
 				womenCount: 42,
 				menCount: 44,
@@ -450,6 +452,7 @@ describe("assembleDeclaration", () => {
 		const indicatorG: IndicatorGEntry[] = [
 			{
 				categoryName: "Cadres",
+				source: null,
 				declarationType: "initial",
 				womenCount: 50,
 				menCount: 60,
@@ -464,6 +467,7 @@ describe("assembleDeclaration", () => {
 			},
 			{
 				categoryName: "Cadres",
+				source: null,
 				declarationType: "correction",
 				womenCount: 52,
 				menCount: 58,
@@ -555,10 +559,50 @@ describe("assembleDeclaration", () => {
 		expect(result.Source_categories_emplois).toBeNull();
 	});
 
+	it("should read Source_categories_emplois from the first initial entry even when correction entries appear first (#3944)", () => {
+		const indicatorG: IndicatorGEntry[] = [
+			{
+				categoryName: "Cadres",
+				source: "accord-entreprise",
+				declarationType: "correction",
+				womenCount: 50,
+				menCount: 60,
+				annualBaseWomen: "52000",
+				annualBaseMen: "56000",
+				annualVariableWomen: null,
+				annualVariableMen: null,
+				hourlyBaseWomen: null,
+				hourlyBaseMen: null,
+				hourlyVariableWomen: null,
+				hourlyVariableMen: null,
+			},
+			{
+				categoryName: "Cadres",
+				source: "accord-branche",
+				declarationType: "initial",
+				womenCount: 50,
+				menCount: 60,
+				annualBaseWomen: "52000",
+				annualBaseMen: "56000",
+				annualVariableWomen: null,
+				annualVariableMen: null,
+				hourlyBaseWomen: null,
+				hourlyBaseMen: null,
+				hourlyVariableWomen: null,
+				hourlyVariableMen: null,
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, indicatorG, []);
+
+		expect(result.Source_categories_emplois).toBe("accord-branche");
+	});
+
 	it("should fall back to null when the first indicator G entry carries no source (#3944)", () => {
 		const indicatorG: IndicatorGEntry[] = [
 			{
 				categoryName: "Cadres",
+				source: null,
 				declarationType: "initial",
 				womenCount: 50,
 				menCount: 60,
@@ -729,6 +773,7 @@ describe("assembleDeclaration", () => {
 		const indicatorG: IndicatorGEntry[] = [
 			{
 				categoryName: "Cadres",
+				source: null,
 				declarationType: "initial",
 				womenCount: 12,
 				menCount: 18,
@@ -981,6 +1026,7 @@ describe("assembleDeclaration — compliance flags", () => {
 	const indicatorG: IndicatorGEntry[] = [
 		{
 			categoryName: "Cadres",
+			source: null,
 			declarationType: "initial",
 			womenCount: 50,
 			menCount: 60,

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -293,6 +293,7 @@ describe("buildIndicatorG", () => {
 
 	const gEntry = (overrides: Partial<IndicatorGEntry>): IndicatorGEntry => ({
 		categoryName: "Cadres",
+		source: null,
 		declarationType: "initial",
 		womenCount: 50,
 		menCount: 60,

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -486,6 +486,98 @@ describe("assembleDeclaration", () => {
 		expect(result.Seconde_declaration.Correction?.[0]?.Effectif_F).toBe(52);
 	});
 
+	it("should expose the job-category source as Source_categories_emplois (#3944)", () => {
+		const indicatorG: IndicatorGEntry[] = [
+			{
+				categoryName: "Cadres",
+				source: "accord-branche",
+				declarationType: "initial",
+				womenCount: 50,
+				menCount: 60,
+				annualBaseWomen: "52000",
+				annualBaseMen: "56000",
+				annualVariableWomen: null,
+				annualVariableMen: null,
+				hourlyBaseWomen: null,
+				hourlyBaseMen: null,
+				hourlyVariableWomen: null,
+				hourlyVariableMen: null,
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, indicatorG, []);
+
+		expect(result.Source_categories_emplois).toBe("accord-branche");
+	});
+
+	it("should read Source_categories_emplois from the first entry, all entries sharing the same source (#3944)", () => {
+		const indicatorG: IndicatorGEntry[] = [
+			{
+				categoryName: "Cadres",
+				source: "decision-unilaterale",
+				declarationType: "initial",
+				womenCount: 50,
+				menCount: 60,
+				annualBaseWomen: "52000",
+				annualBaseMen: "56000",
+				annualVariableWomen: null,
+				annualVariableMen: null,
+				hourlyBaseWomen: null,
+				hourlyBaseMen: null,
+				hourlyVariableWomen: null,
+				hourlyVariableMen: null,
+			},
+			{
+				categoryName: "Employés",
+				source: "decision-unilaterale",
+				declarationType: "initial",
+				womenCount: 30,
+				menCount: 20,
+				annualBaseWomen: "30000",
+				annualBaseMen: "31000",
+				annualVariableWomen: null,
+				annualVariableMen: null,
+				hourlyBaseWomen: null,
+				hourlyBaseMen: null,
+				hourlyVariableWomen: null,
+				hourlyVariableMen: null,
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, indicatorG, []);
+
+		expect(result.Source_categories_emplois).toBe("decision-unilaterale");
+	});
+
+	it("should set Source_categories_emplois to null when the declaration has no indicator G (#3944)", () => {
+		const result = assembleDeclaration(baseRow, [], []);
+
+		expect(result.Source_categories_emplois).toBeNull();
+	});
+
+	it("should fall back to null when the first indicator G entry carries no source (#3944)", () => {
+		const indicatorG: IndicatorGEntry[] = [
+			{
+				categoryName: "Cadres",
+				declarationType: "initial",
+				womenCount: 50,
+				menCount: 60,
+				annualBaseWomen: "52000",
+				annualBaseMen: "56000",
+				annualVariableWomen: null,
+				annualVariableMen: null,
+				hourlyBaseWomen: null,
+				hourlyBaseMen: null,
+				hourlyVariableWomen: null,
+				hourlyVariableMen: null,
+			},
+		];
+
+		const result = assembleDeclaration(baseRow, indicatorG, []);
+
+		expect(result.Source_categories_emplois).toBeNull();
+	});
+
 	it("should map CSE opinions when at least one CSE file is present", () => {
 		const opinions: CseRow[] = [
 			{

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -86,6 +86,38 @@ describe("openApiSpec", () => {
 		});
 	});
 
+	describe("Source_categories_emplois schema (#3944)", () => {
+		const declarationSchema =
+			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]
+				.content["application/json"].schema.properties.Declarations.items;
+		const sourceSchema = declarationSchema.properties.Source_categories_emplois;
+		const hasEnum = (v: {
+			type: string;
+		}): v is { type: string; enum: readonly string[] } => "enum" in v;
+
+		it("declares Source_categories_emplois as a nullable string enum", () => {
+			expect(sourceSchema).toBeDefined();
+			expect(sourceSchema.oneOf).toHaveLength(2);
+			const stringVariant = sourceSchema.oneOf.find((v) => v.type === "string");
+			const nullVariant = sourceSchema.oneOf.find((v) => v.type === "null");
+			expect(stringVariant).toBeDefined();
+			expect(nullVariant).toBeDefined();
+		});
+
+		it("lists the 4 job-category source values in the string enum", () => {
+			const stringVariant = sourceSchema.oneOf.find((v) => v.type === "string");
+			expect(stringVariant && hasEnum(stringVariant)).toBe(true);
+			expect(
+				stringVariant && hasEnum(stringVariant) && stringVariant.enum,
+			).toEqual([
+				"accord-entreprise",
+				"accord-groupe",
+				"accord-branche",
+				"decision-unilaterale",
+			]);
+		});
+	});
+
 	describe("Historique_statuts schema", () => {
 		const declarationSchema =
 			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -98,6 +98,7 @@ function deriveExportFlags(
 
 export type IndicatorGEntry = {
 	categoryName: string;
+	source?: string | null;
 	declarationType: string;
 	womenCount: number | null;
 	menCount: number | null;
@@ -404,6 +405,7 @@ export function assembleDeclaration(
 		}),
 		Effectif_F_rem_annuelle_globale: row.totalWomen,
 		Effectif_H_rem_annuelle_globale: row.totalMen,
+		Source_categories_emplois: indicatorGEntries[0]?.source ?? null,
 		Indicateurs: {
 			...buildIndicators(row),
 			G: initial.length > 0 ? initial : null,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -98,7 +98,7 @@ function deriveExportFlags(
 
 export type IndicatorGEntry = {
 	categoryName: string;
-	source?: string | null;
+	source: string | null;
 	declarationType: string;
 	womenCount: number | null;
 	menCount: number | null;
@@ -405,7 +405,9 @@ export function assembleDeclaration(
 		}),
 		Effectif_F_rem_annuelle_globale: row.totalWomen,
 		Effectif_H_rem_annuelle_globale: row.totalMen,
-		Source_categories_emplois: indicatorGEntries[0]?.source ?? null,
+		Source_categories_emplois:
+			indicatorGEntries.find((e) => e.declarationType === "initial")?.source ??
+			null,
 		Indicateurs: {
 			...buildIndicators(row),
 			G: initial.length > 0 ? initial : null,

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -374,6 +374,22 @@ const declarationSchema = {
 			description:
 				"Effectif hommes pris en compte pour la rémunération globale annuelle",
 		},
+		Source_categories_emplois: {
+			oneOf: [
+				{
+					type: "string",
+					enum: [
+						"accord-entreprise",
+						"accord-groupe",
+						"accord-branche",
+						"decision-unilaterale",
+					],
+					description:
+						"Source de détermination des catégories d'emplois pour l'indicateur G. `null` si aucun indicateur G déclaré.",
+				},
+				{ type: "null" },
+			],
+		},
 		Indicateurs: indicatorsSchema,
 		Seconde_declaration: {
 			type: "object",

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -375,6 +375,8 @@ const declarationSchema = {
 				"Effectif hommes pris en compte pour la rémunération globale annuelle",
 		},
 		Source_categories_emplois: {
+			description:
+				"Source de détermination des catégories d'emplois pour l'indicateur G. `null` si aucun indicateur G déclaré.",
 			oneOf: [
 				{
 					type: "string",
@@ -384,8 +386,6 @@ const declarationSchema = {
 						"accord-branche",
 						"decision-unilaterale",
 					],
-					description:
-						"Source de détermination des catégories d'emplois pour l'indicateur G. `null` si aucun indicateur G déclaré.",
 				},
 				{ type: "null" },
 			],

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -257,6 +257,7 @@ export async function fetchIndicatorGByDeclaration(
 		.select({
 			declarationId: jobCategories.declarationId,
 			categoryName: jobCategories.name,
+			source: jobCategories.source,
 			declarationType: employeeCategories.declarationType,
 			womenCount: employeeCategories.womenCount,
 			menCount: employeeCategories.menCount,


### PR DESCRIPTION
Closes #3944

## Résumé

La source de détermination des catégories d'emplois (`job_category.source`, saisie à l'étape 5 et persistée NOT NULL) était absente du payload SUIT `GET /api/v1/export/declarations`. Ce fix expose un champ déclaration-level `Source_categories_emplois` (valeur brute, ex. `accord-branche`) dans le payload, `null` si aucun indicateur G déclaré.

## Changements

- **`queries.ts`** — `fetchIndicatorGByDeclaration` : ajout de `source: jobCategories.source` dans le select Drizzle
- **`fetchDeclarations.ts`** — `IndicatorGEntry` : nouveau champ optionnel `source?`; `assembleDeclaration` : exposition de `Source_categories_emplois: indicatorGEntries[0]?.source ?? null`
- **`openapi.ts`** — documentation du nouveau champ avec enum des 4 valeurs (`accord-entreprise`, `accord-groupe`, `accord-branche`, `decision-unilaterale`) + `null`

## Tests (tu-dev)

- 12 nouveaux tests (8 TU + 4 intégration) — revert-verify prouvé : les tests passent RED sans le fix, GREEN avec
- `fetchDeclarations.test.ts` : 4 scénarios (source transmise, source partagée entre entrées, null sans G, null si source absente)
- `exportApi.test.ts` : 2 scénarios end-to-end via route mock
- `openapi.test.ts` : 2 scénarios de validation du schéma
- `exportApi.integration.test.ts` : 2 tests DB réelle (Postgres jetable)

## Plan de test

- [ ] Vérifier que `Source_categories_emplois` apparaît dans le payload SUIT pour une déclaration avec indicateur G
- [ ] Vérifier que `Source_categories_emplois` est `null` pour une déclaration sans indicateur G
- [ ] Confirmer que les 4 valeurs enum sont bien acceptées