### PR TITLE
fix(export): add 6 *_ecart fields to indicator G category in SUIT export API

### DIFF
--- a/packages/app/src/e2e/export-declarations.e2e.ts
+++ b/packages/app/src/e2e/export-declarations.e2e.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+import { TEST_SIREN } from "./constants";
+import { resetDeclarationToDraft } from "./helpers/db";
+import { completeDeclaration } from "./helpers/declaration-flows";
+
+/**
+ * End-to-end test for the SUIT declarations export contract
+ * (`GET /api/v1/export/declarations`).
+ *
+ * Non-regression guard for #3942: the indicator G (indicateur 7) categories
+ * used to serialize only the raw declared amounts, never the computed pay
+ * gaps. This exercises the full HTTP + gateway auth + DB + serialization
+ * chain against a real running server to prove the six `*_ecart` fields are
+ * now emitted per category — something the DB-mocking unit tests cannot.
+ *
+ * A declaration is submitted through the real 6-step funnel so the indicator
+ * G category carries known base amounts (women 1000 / men 1100), then read
+ * back through the SUIT branch (triggered by the `X-Gateway-Forwarded`
+ * header, the same edge-auth path covered by `fileUpload.e2e.ts`).
+ */
+
+test.describe.configure({ mode: "serial" });
+
+// Dev gateway shared secret — the deterministic local value from
+// `.env.example`, injected in prod by the APISIX `proxy-rewrite` plugin into
+// the `X-Gateway-Forwarded` header. Not a secret.
+const DEV_GATEWAY_SHARED_SECRET = "dev-gateway-shared-secret-minimum-32-chars";
+
+// The six computed gap fields the export must expose per indicator G category.
+const ECART_KEYS = [
+	"Rem_annuelle_base_ecart",
+	"Rem_annuelle_variable_ecart",
+	"Rem_annuelle_total_ecart",
+	"Taux_horaire_base_ecart",
+	"Taux_horaire_variable_ecart",
+	"Taux_horaire_total_ecart",
+] as const;
+
+// updatedAt (submission date) is filtered in UTC; a [yesterday, tomorrow)
+// window brackets "now" regardless of the UTC day boundary.
+function isoDate(offsetDays: number): string {
+	const d = new Date();
+	d.setUTCDate(d.getUTCDate() + offsetDays);
+	return d.toISOString().slice(0, 10);
+}
+
+test.describe("SUIT declarations export — indicator G computed gaps", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+	});
+
+	test.afterAll(async () => {
+		await resetDeclarationToDraft();
+	});
+
+	test("emits the six *_ecart fields per indicator G category with the signed (H−F)/H convention", async ({
+		page,
+		browser,
+	}) => {
+		test.slow(); // Full 6-step declaration funnel + submission.
+		await completeDeclaration(page, { hasGap: true });
+
+		const anonCtx = await browser.newContext({ storageState: undefined });
+		try {
+			const response = await anonCtx.request.get(
+				`/api/v1/export/declarations?date_begin=${isoDate(-1)}&date_end=${isoDate(1)}`,
+				{ headers: { "X-Gateway-Forwarded": DEV_GATEWAY_SHARED_SECRET } },
+			);
+			expect(response.status()).toBe(200);
+
+			const body = await response.json();
+			const declaration = body.Declarations.find(
+				(d: { SIREN: string }) => d.SIREN === TEST_SIREN,
+			);
+			expect(declaration).toBeDefined();
+
+			const categories = declaration.Indicateurs.G;
+			expect(Array.isArray(categories)).toBe(true);
+			expect(categories.length).toBeGreaterThan(0);
+
+			// Every category must carry the six computed-gap fields (the bug: absent).
+			for (const category of categories) {
+				for (const key of ECART_KEYS) {
+					expect(category).toHaveProperty(key);
+				}
+			}
+
+			// The funnel fills category 1's annual base at women 1000 / men 1100,
+			// leaving variable and hourly amounts empty. Numeric strings keep their
+			// DB scale ("1100.00"), so compare on the parsed value.
+			const filled = categories.find(
+				(c: { Rem_annuelle_base_H: string | null }) =>
+					c.Rem_annuelle_base_H !== null &&
+					Number(c.Rem_annuelle_base_H) === 1100,
+			);
+			expect(filled).toBeDefined();
+
+			// (1100 − 1000) / 1100 = 0.0909, rounded to 4 decimals.
+			expect(filled.Rem_annuelle_base_ecart).toBe(0.0909);
+			// No variable amount → total equals base.
+			expect(filled.Rem_annuelle_total_ecart).toBe(0.0909);
+			// Null-safe: variable and hourly amounts were never entered.
+			expect(filled.Rem_annuelle_variable_ecart).toBeNull();
+			expect(filled.Taux_horaire_base_ecart).toBeNull();
+			expect(filled.Taux_horaire_variable_ecart).toBeNull();
+			expect(filled.Taux_horaire_total_ecart).toBeNull();
+		} finally {
+			await anonCtx.close();
+		}
+	});
+});

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -285,6 +285,87 @@ describe("buildIndicatorG", () => {
 		expect(result.initial).toEqual([]);
 		expect(result.correction).toEqual([]);
 	});
+
+	const gEntry = (overrides: Partial<IndicatorGEntry>): IndicatorGEntry => ({
+		categoryName: "Cadres",
+		declarationType: "initial",
+		womenCount: 50,
+		menCount: 60,
+		annualBaseWomen: "10000",
+		annualBaseMen: "11000",
+		annualVariableWomen: "1000",
+		annualVariableMen: "1010",
+		hourlyBaseWomen: "20",
+		hourlyBaseMen: "22",
+		hourlyVariableWomen: "2",
+		hourlyVariableMen: "2.5",
+		...overrides,
+	});
+
+	it("should compute the six signed gap ratios rounded to 4 decimals", () => {
+		const [category] = buildIndicatorG([gEntry({})]).initial;
+
+		expect(category?.Rem_annuelle_base_ecart).toBe(0.0909);
+		expect(category?.Rem_annuelle_variable_ecart).toBe(0.0099);
+		expect(category?.Rem_annuelle_total_ecart).toBe(0.0841);
+		expect(category?.Taux_horaire_base_ecart).toBe(0.0909);
+		expect(category?.Taux_horaire_variable_ecart).toBe(0.2);
+		expect(category?.Taux_horaire_total_ecart).toBe(0.102);
+	});
+
+	it("nulls a component gap when one of its salary values is missing", () => {
+		const [category] = buildIndicatorG([
+			gEntry({ annualBaseWomen: null }),
+		]).initial;
+
+		expect(category?.Rem_annuelle_base_ecart).toBeNull();
+		expect(category?.Rem_annuelle_variable_ecart).toBe(0.0099);
+	});
+
+	it("nulls a component gap when the men value is zero", () => {
+		const [category] = buildIndicatorG([
+			gEntry({ annualBaseMen: "0" }),
+		]).initial;
+
+		expect(category?.Rem_annuelle_base_ecart).toBeNull();
+	});
+
+	it("nulls the total gap when the men total is zero", () => {
+		const [category] = buildIndicatorG([
+			gEntry({ annualBaseMen: "0", annualVariableMen: "0" }),
+		]).initial;
+
+		expect(category?.Rem_annuelle_total_ecart).toBeNull();
+	});
+
+	it("nulls the total gap when both men components are missing", () => {
+		const [category] = buildIndicatorG([
+			gEntry({ annualBaseMen: null, annualVariableMen: null }),
+		]).initial;
+
+		expect(category?.Rem_annuelle_total_ecart).toBeNull();
+	});
+
+	it("nulls the total gap when both women components are missing", () => {
+		const [category] = buildIndicatorG([
+			gEntry({ annualBaseWomen: null, annualVariableWomen: null }),
+		]).initial;
+
+		expect(category?.Rem_annuelle_total_ecart).toBeNull();
+	});
+
+	it("computes the total gap from a single present component (null-safe sum)", () => {
+		const [category] = buildIndicatorG([
+			gEntry({
+				annualBaseWomen: "10000",
+				annualVariableWomen: null,
+				annualBaseMen: "11000",
+				annualVariableMen: null,
+			}),
+		]).initial;
+
+		expect(category?.Rem_annuelle_total_ecart).toBe(0.0909);
+	});
 });
 
 describe("assembleDeclaration", () => {

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -14,6 +14,8 @@ export {
 } from "./queries";
 
 import {
+	computeGapRatio,
+	computeTotal,
 	gapRatioToPercent,
 	getObligationWorkforce,
 	isComplianceProcessRequired,
@@ -229,19 +231,55 @@ export function buildIndicators(row: DeclarationRow) {
 
 // ── Indicator G entries ─────────────────────────────────────────────
 
+function roundRatio(r: number | null): number | null {
+	return r === null ? null : Math.round(r * 10000) / 10000;
+}
+
+function computeTotalGapRatio(
+	baseW: string | null,
+	varW: string | null,
+	baseM: string | null,
+	varM: string | null,
+): number | null {
+	const w = computeTotal(baseW ?? "", varW ?? "");
+	const m = computeTotal(baseM ?? "", varM ?? "");
+	if (w === null || m === null || m === 0) return null;
+	return roundRatio((m - w) / m);
+}
+
 function toIndicatorGCategory(entry: IndicatorGEntry) {
+	const {
+		annualBaseWomen: abW,
+		annualBaseMen: abM,
+		annualVariableWomen: avW,
+		annualVariableMen: avM,
+		hourlyBaseWomen: hbW,
+		hourlyBaseMen: hbM,
+		hourlyVariableWomen: hvW,
+		hourlyVariableMen: hvM,
+	} = entry;
 	return {
 		Nom_categorie: entry.categoryName,
 		Effectif_F: entry.womenCount,
 		Effectif_H: entry.menCount,
-		Rem_annuelle_base_F: entry.annualBaseWomen,
-		Rem_annuelle_base_H: entry.annualBaseMen,
-		Rem_annuelle_variable_F: entry.annualVariableWomen,
-		Rem_annuelle_variable_H: entry.annualVariableMen,
-		Taux_horaire_base_F: entry.hourlyBaseWomen,
-		Taux_horaire_base_H: entry.hourlyBaseMen,
-		Taux_horaire_variable_F: entry.hourlyVariableWomen,
-		Taux_horaire_variable_H: entry.hourlyVariableMen,
+		Rem_annuelle_base_F: abW,
+		Rem_annuelle_base_H: abM,
+		Rem_annuelle_variable_F: avW,
+		Rem_annuelle_variable_H: avM,
+		Taux_horaire_base_F: hbW,
+		Taux_horaire_base_H: hbM,
+		Taux_horaire_variable_F: hvW,
+		Taux_horaire_variable_H: hvM,
+		Rem_annuelle_base_ecart: roundRatio(computeGapRatio(abW ?? "", abM ?? "")),
+		Rem_annuelle_variable_ecart: roundRatio(
+			computeGapRatio(avW ?? "", avM ?? ""),
+		),
+		Rem_annuelle_total_ecart: computeTotalGapRatio(abW, avW, abM, avM),
+		Taux_horaire_base_ecart: roundRatio(computeGapRatio(hbW ?? "", hbM ?? "")),
+		Taux_horaire_variable_ecart: roundRatio(
+			computeGapRatio(hvW ?? "", hvM ?? ""),
+		),
+		Taux_horaire_total_ecart: computeTotalGapRatio(hbW, hvW, hbM, hvM),
 	};
 }
 

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -244,7 +244,7 @@ function computeTotalGapRatio(
 	const w = computeTotal(baseW ?? "", varW ?? "");
 	const m = computeTotal(baseM ?? "", varM ?? "");
 	if (w === null || m === null || m === 0) return null;
-	return roundRatio((m - w) / m);
+	return (m - w) / m;
 }
 
 function toIndicatorGCategory(entry: IndicatorGEntry) {
@@ -274,12 +274,16 @@ function toIndicatorGCategory(entry: IndicatorGEntry) {
 		Rem_annuelle_variable_ecart: roundRatio(
 			computeGapRatio(avW ?? "", avM ?? ""),
 		),
-		Rem_annuelle_total_ecart: computeTotalGapRatio(abW, avW, abM, avM),
+		Rem_annuelle_total_ecart: roundRatio(
+			computeTotalGapRatio(abW, avW, abM, avM),
+		),
 		Taux_horaire_base_ecart: roundRatio(computeGapRatio(hbW ?? "", hbM ?? "")),
 		Taux_horaire_variable_ecart: roundRatio(
 			computeGapRatio(hvW ?? "", hvM ?? ""),
 		),
-		Taux_horaire_total_ecart: computeTotalGapRatio(hbW, hvW, hbM, hvM),
+		Taux_horaire_total_ecart: roundRatio(
+			computeTotalGapRatio(hbW, hvW, hbM, hvM),
+		),
 	};
 }
 

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -30,6 +30,36 @@ const indicatorGCategorySchema = {
 		Taux_horaire_base_H: { type: ["string", "null"] },
 		Taux_horaire_variable_F: { type: ["string", "null"] },
 		Taux_horaire_variable_H: { type: ["string", "null"] },
+		Rem_annuelle_base_ecart: {
+			type: ["number", "null"],
+			description:
+				"Écart de rémunération annuelle de base : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
+		},
+		Rem_annuelle_variable_ecart: {
+			type: ["number", "null"],
+			description:
+				"Écart de rémunération annuelle variable : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
+		},
+		Rem_annuelle_total_ecart: {
+			type: ["number", "null"],
+			description:
+				"Écart de rémunération annuelle totale (base + variable) : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
+		},
+		Taux_horaire_base_ecart: {
+			type: ["number", "null"],
+			description:
+				"Écart de taux horaire de base : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
+		},
+		Taux_horaire_variable_ecart: {
+			type: ["number", "null"],
+			description:
+				"Écart de taux horaire variable : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
+		},
+		Taux_horaire_total_ecart: {
+			type: ["number", "null"],
+			description:
+				"Écart de taux horaire total (base + variable) : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
+		},
 	},
 } as const;
 


### PR DESCRIPTION
Closes #3942

## Problème

L'API d'export SUIT (`GET /api/v1/export/declarations`) ne renvoyait pas les écarts calculés pour les catégories de l'indicateur G. Les champs `*_ecart` étaient absents, contrairement aux indicateurs A–D qui exposent déjà leurs écarts.

## Solution

Ajout de 6 champs dans le serializer `toIndicatorGCategory` de `fetchDeclarations.ts` :

| Champ | Calcul |
|---|---|
| `Rem_annuelle_base_ecart` | `(H−F)/H` sur `annualBase` |
| `Rem_annuelle_variable_ecart` | `(H−F)/H` sur `annualVariable` |
| `Rem_annuelle_total_ecart` | `(H−F)/H` sur `annualBase+annualVariable` |
| `Taux_horaire_base_ecart` | `(H−F)/H` sur `hourlyBase` |
| `Taux_horaire_variable_ecart` | `(H−F)/H` sur `hourlyVariable` |
| `Taux_horaire_total_ecart` | `(H−F)/H` sur `hourlyBase+hourlyVariable` |

Convention : ratio signé `(H−F)/H` arrondi à 4 décimales, homogène avec les champs `_ecart` des indicateurs A–D. Null-safe : valeur manquante ou H = 0 → `null`. Schéma OpenAPI mis à jour en conséquence.

## Fichiers modifiés

- `packages/app/src/modules/export/fetchDeclarations.ts` — helpers `roundRatio`, `computeTotalGapRatio` + 6 champs `*_ecart` dans `toIndicatorGCategory`
- `packages/app/src/modules/export/openapi.ts` — 6 nouveaux champs dans `indicatorGCategorySchema`
- `packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts` — 7 nouveaux cas de test (nominal, null-safety, H=0, totaux)

## Test plan

- [x] Typecheck : 0 erreurs
- [x] Tests vitest : 3633 passed (incluant 7 nouveaux cas couvrant les 6 champs)
- [x] Lint + format : clean
- [x] Structural audit : MINOR (file-size warnings pré-existants uniquement)
- [x] Security audit : SECURE
- [x] RGAA : PASS — no UI files