### PR TITLE
fix(export): filter step_change from SUIT status history and align OpenAPI with FSM

### DIFF
--- a/packages/app/src/e2e/suit-export-declarations.e2e.ts
+++ b/packages/app/src/e2e/suit-export-declarations.e2e.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+import { COMPLIANCE_PATH, selectCompliancePath } from "./helpers/compliance-flows";
+import {
+	resetDeclarationToDraft,
+	setCompanyHasCse,
+	setCompanyWorkforce,
+} from "./helpers/db";
+import { completeDeclaration } from "./helpers/declaration-flows";
+import { TEST_SIREN } from "./constants";
+
+/**
+ * End-to-end contract test for the SUIT declarations export
+ * (`GET /api/v1/export/declarations`), the machine API consumed by the SUIT
+ * gateway (bug #3950 — « choix justification écart sans CSE »).
+ *
+ * The A–F stepper records internal `step_change` rows in the status history;
+ * these must never surface in the exported `Historique_statuts`, and every
+ * exported entry must carry a human-readable `Libelle_statut`. Unit tests cover
+ * the assembly in isolation; this spec proves the full chain — real UI
+ * declaration → real Postgres → SQL projection → gateway auth → JSON contract —
+ * against a running server, which is the only place the `eventType != 'step_change'`
+ * SQL filter actually runs.
+ */
+
+test.describe.configure({ mode: "serial" });
+
+// Dev gateway shared secret — the deterministic local value from `.env.example`.
+// Not a secret. In prod the value is injected into the `X-Gateway-Forwarded`
+// header by the APISIX `proxy-rewrite` plugin; the E2E server runs with the same
+// value so the middleware's constant-time check passes.
+const DEV_GATEWAY_SHARED_SECRET = "dev-gateway-shared-secret-minimum-32-chars";
+const EXPORT_PATH = "/api/v1/export/declarations";
+
+// Mirror of DECLARATION_EVENT_TYPE_LABELS keys — the only status values the
+// public contract is allowed to emit. `step_change` is deliberately absent.
+const PUBLIC_STATUTS = new Set([
+	"submit",
+	"path_choice",
+	"second_declaration_submit",
+	"joint_evaluation_submit",
+	"cse_opinion_submit",
+	"cancel",
+	"demarche_complete",
+]);
+
+const DAY_MS = 86_400_000;
+function dayString(offsetDays: number): string {
+	return new Date(Date.now() + offsetDays * DAY_MS).toISOString().slice(0, 10);
+}
+function exportUrl(): string {
+	return `${EXPORT_PATH}?date_begin=${dayString(-1)}&date_end=${dayString(1)}`;
+}
+
+test.describe("SUIT export declarations — status history contract (bug #3950)", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setCompanyHasCse(false);
+		await setCompanyWorkforce(200);
+	});
+
+	test("completes a declaration with a gap and records the justify path choice", async ({
+		page,
+	}) => {
+		test.slow(); // Full 6-step declaration + compliance choice
+		await completeDeclaration(page, { hasGap: true });
+		// Gap → compliance choice page; the justify option records a path_choice
+		// event and, once the A–F stepper has run, the history carries internal
+		// step_change rows that the export must strip.
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+	});
+
+	test("gateway request without the shared secret is rejected with 403", async ({
+		browser,
+	}) => {
+		const anonCtx = await browser.newContext({ storageState: undefined });
+		try {
+			const response = await anonCtx.request.get(exportUrl());
+			expect(response.status()).toBe(403);
+		} finally {
+			await anonCtx.close();
+		}
+	});
+
+	test("Historique_statuts excludes internal step_change events and always carries a Libelle_statut", async ({
+		browser,
+	}) => {
+		const anonCtx = await browser.newContext({ storageState: undefined });
+		try {
+			const response = await anonCtx.request.get(exportUrl(), {
+				headers: { "X-Gateway-Forwarded": DEV_GATEWAY_SHARED_SECRET },
+			});
+			expect(response.status()).toBe(200);
+
+			const body = await response.json();
+			const declaration = body.Declarations.find(
+				(entry: { SIREN: string }) => entry.SIREN === TEST_SIREN,
+			);
+			expect(
+				declaration,
+				"the freshly completed test declaration is present in the export",
+			).toBeTruthy();
+
+			const history = declaration.Historique_statuts as Array<{
+				Statut: string;
+				Libelle_statut: unknown;
+			}>;
+			expect(Array.isArray(history)).toBe(true);
+			expect(history.length).toBeGreaterThan(0);
+
+			// The internal step_change rows recorded by the A–F stepper must not leak.
+			expect(history.some((entry) => entry.Statut === "step_change")).toBe(
+				false,
+			);
+
+			for (const entry of history) {
+				expect(PUBLIC_STATUTS.has(entry.Statut)).toBe(true);
+				expect(typeof entry.Libelle_statut).toBe("string");
+				expect((entry.Libelle_statut as string).length).toBeGreaterThan(0);
+			}
+
+			// The submission and the justify path choice are materialised in the
+			// machine contract with their public labels.
+			const statuts = history.map((entry) => entry.Statut);
+			expect(statuts).toContain("submit");
+			expect(statuts).toContain("path_choice");
+
+			const pathChoice = history.find((entry) => entry.Statut === "path_choice");
+			expect(pathChoice?.Libelle_statut).toBe(
+				"Choix du parcours — Justification de l'écart",
+			);
+		} finally {
+			await anonCtx.close();
+		}
+	});
+});

--- a/packages/app/src/e2e/suit-export-declarations.e2e.ts
+++ b/packages/app/src/e2e/suit-export-declarations.e2e.ts
@@ -1,12 +1,15 @@
 import { expect, test } from "@playwright/test";
-import { COMPLIANCE_PATH, selectCompliancePath } from "./helpers/compliance-flows";
+import { TEST_SIREN } from "./constants";
+import {
+	COMPLIANCE_PATH,
+	selectCompliancePath,
+} from "./helpers/compliance-flows";
 import {
 	resetDeclarationToDraft,
 	setCompanyHasCse,
 	setCompanyWorkforce,
 } from "./helpers/db";
 import { completeDeclaration } from "./helpers/declaration-flows";
-import { TEST_SIREN } from "./constants";
 
 /**
  * End-to-end contract test for the SUIT declarations export
@@ -68,7 +71,12 @@ test.describe("SUIT export declarations — status history contract (bug #3950)"
 		// step_change rows that the export must strip.
 		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
 		await selectCompliancePath(page, "path-justify");
-		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+		// Without a CSE the justify choice completes the démarche immediately
+		// (FSM transition choose_path_*_justify_without_cse) — the user lands on
+		// the confirmation page, not on the /avis-cse deposit flow.
+		await page.waitForURL(`**${COMPLIANCE_PATH}/confirmation`, {
+			timeout: 10_000,
+		});
 	});
 
 	test("gateway request without the shared secret is rejected with 403", async ({
@@ -126,7 +134,9 @@ test.describe("SUIT export declarations — status history contract (bug #3950)"
 			expect(statuts).toContain("submit");
 			expect(statuts).toContain("path_choice");
 
-			const pathChoice = history.find((entry) => entry.Statut === "path_choice");
+			const pathChoice = history.find(
+				(entry) => entry.Statut === "path_choice",
+			);
 			expect(pathChoice?.Libelle_statut).toBe(
 				"Choix du parcours — Justification de l'écart",
 			);

--- a/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
@@ -126,8 +126,6 @@ describe("GET /api/v1/export/declarations — Date_annulation integration", () =
 		const body = await response.json();
 		expect(body.Nombre).toBe(1);
 		const decl = body.Declarations[0];
-		// The active declaration is seeded with a step_change row between submit and
-		// demarche_complete; the SQL filter drops it, so only the two public events remain.
 		expect(decl.Historique_statuts).toEqual([
 			{
 				Statut: "submit",

--- a/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.integration.test.ts
@@ -48,8 +48,9 @@ describe("GET /api/v1/export/declarations — Date_annulation integration", () =
 		await sql`
 			INSERT INTO app_declaration_status_history (id, declaration_id, event_type, value, round, created_at)
 			VALUES
-				('hist-active-submit',       'export-decl-active', 'submit',            NULL, NULL, '2025-04-30T09:00:00Z'),
-				('hist-active-demarche',     'export-decl-active', 'demarche_complete', NULL, NULL, '2025-04-30T11:00:00Z')
+				('hist-active-submit',       'export-decl-active', 'submit',            NULL,          NULL, '2025-04-30T09:00:00Z'),
+				('hist-active-step',         'export-decl-active', 'step_change',       'from:1|to:2', 2,    '2025-04-30T10:00:00Z'),
+				('hist-active-demarche',     'export-decl-active', 'demarche_complete', NULL,          NULL, '2025-04-30T11:00:00Z')
 		`;
 	});
 
@@ -115,7 +116,7 @@ describe("GET /api/v1/export/declarations — Date_annulation integration", () =
 		}
 	});
 
-	it("returns Historique_statuts as an ASC-ordered list of FR-labelled events (S1)", async () => {
+	it("returns Historique_statuts as an ASC-ordered list of FR-labelled events, excluding the seeded internal step_change (S1)", async () => {
 		const { GET } = await import("~/app/api/v1/export/declarations/route");
 		const response = await GET(
 			gatewayRequest({ date_begin: "2025-05-01", date_end: "2025-05-02" }),
@@ -125,6 +126,8 @@ describe("GET /api/v1/export/declarations — Date_annulation integration", () =
 		const body = await response.json();
 		expect(body.Nombre).toBe(1);
 		const decl = body.Declarations[0];
+		// The active declaration is seeded with a step_change row between submit and
+		// demarche_complete; the SQL filter drops it, so only the two public events remain.
 		expect(decl.Historique_statuts).toEqual([
 			{
 				Statut: "submit",
@@ -137,6 +140,27 @@ describe("GET /api/v1/export/declarations — Date_annulation integration", () =
 				Date: "2025-04-30T11:00:00.000Z",
 			},
 		]);
+	});
+
+	it("filters step_change out of Historique_statuts while every returned entry carries a Libelle_statut (#3950)", async () => {
+		const { GET } = await import("~/app/api/v1/export/declarations/route");
+		const response = await GET(
+			gatewayRequest({ date_begin: "2025-05-01", date_end: "2025-05-02" }),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		const decl = body.Declarations[0];
+		const statuts = decl.Historique_statuts as Array<{
+			Statut: string;
+			Libelle_statut: string;
+		}>;
+
+		expect(statuts.map((entry) => entry.Statut)).not.toContain("step_change");
+		for (const entry of statuts) {
+			expect(entry.Libelle_statut).toBeTypeOf("string");
+			expect(entry.Libelle_statut.length).toBeGreaterThan(0);
+		}
 	});
 
 	it("returns Historique_statuts as [] when the declaration has no history rows (S7)", async () => {

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -6,6 +6,7 @@ import {
 	buildIndicatorG,
 	buildIndicators,
 } from "../fetchDeclarations";
+import type { RawHistoryEntry } from "../queries";
 
 // Minimal DeclarationRow used by buildIndicators / assembleDeclaration
 const baseRow = {
@@ -120,13 +121,15 @@ const baseRow = {
 	hourlyQuartile3ProportionMen: "0.5410",
 	hourlyQuartile4ProportionWomen: "0.3509",
 	hourlyQuartile4ProportionMen: "0.6491",
-	statusHistoryArray: [] as Array<{
-		eventType: string;
-		value: string | null;
-		round: number | null;
-		createdAt: string;
-	}>,
+	statusHistoryArray: [] as RawHistoryEntry[],
 };
+
+function withHistory(
+	statusHistoryArray: RawHistoryEntry[],
+	overrides: Partial<typeof baseRow> = {},
+): typeof baseRow {
+	return { ...baseRow, ...overrides, statusHistoryArray };
+}
 
 describe("buildIndicators", () => {
 	it("should map indicator A with GIP labels", () => {
@@ -584,23 +587,20 @@ describe("assembleDeclaration", () => {
 	});
 
 	it("should expose Historique_statuts with FR labels for submit + demarche_complete (S1)", () => {
-		const row = {
-			...baseRow,
-			statusHistoryArray: [
-				{
-					eventType: "submit",
-					value: null,
-					round: null,
-					createdAt: "2027-03-15T10:00:00.123Z",
-				},
-				{
-					eventType: "demarche_complete",
-					value: null,
-					round: null,
-					createdAt: "2027-10-15T14:00:00.456Z",
-				},
-			],
-		};
+		const row = withHistory([
+			{
+				eventType: "submit",
+				value: null,
+				round: null,
+				createdAt: "2027-03-15T10:00:00.123Z",
+			},
+			{
+				eventType: "demarche_complete",
+				value: null,
+				round: null,
+				createdAt: "2027-10-15T14:00:00.456Z",
+			},
+		]);
 
 		const result = assembleDeclaration(row, [], []);
 
@@ -619,17 +619,14 @@ describe("assembleDeclaration", () => {
 	});
 
 	it("should expose Numero_declaration and Libelle for path_choice corrective_action (S2)", () => {
-		const row = {
-			...baseRow,
-			statusHistoryArray: [
-				{
-					eventType: "path_choice",
-					value: "corrective_action",
-					round: 1,
-					createdAt: "2027-04-01T10:00:00.000Z",
-				},
-			],
-		};
+		const row = withHistory([
+			{
+				eventType: "path_choice",
+				value: "corrective_action",
+				round: 1,
+				createdAt: "2027-04-01T10:00:00.000Z",
+			},
+		]);
 
 		const result = assembleDeclaration(row, [], []);
 
@@ -644,41 +641,38 @@ describe("assembleDeclaration", () => {
 	});
 
 	it("should expose all 5 lifecycle entries with FR labels (S3)", () => {
-		const row = {
-			...baseRow,
-			statusHistoryArray: [
-				{
-					eventType: "submit",
-					value: null,
-					round: null,
-					createdAt: "2027-03-15T10:00:00.000Z",
-				},
-				{
-					eventType: "path_choice",
-					value: "joint_evaluation",
-					round: 1,
-					createdAt: "2027-04-01T10:00:00.000Z",
-				},
-				{
-					eventType: "joint_evaluation_submit",
-					value: null,
-					round: null,
-					createdAt: "2027-09-01T12:00:00.000Z",
-				},
-				{
-					eventType: "cse_opinion_submit",
-					value: null,
-					round: null,
-					createdAt: "2027-10-01T13:00:00.000Z",
-				},
-				{
-					eventType: "demarche_complete",
-					value: null,
-					round: null,
-					createdAt: "2027-10-15T14:00:00.000Z",
-				},
-			],
-		};
+		const row = withHistory([
+			{
+				eventType: "submit",
+				value: null,
+				round: null,
+				createdAt: "2027-03-15T10:00:00.000Z",
+			},
+			{
+				eventType: "path_choice",
+				value: "joint_evaluation",
+				round: 1,
+				createdAt: "2027-04-01T10:00:00.000Z",
+			},
+			{
+				eventType: "joint_evaluation_submit",
+				value: null,
+				round: null,
+				createdAt: "2027-09-01T12:00:00.000Z",
+			},
+			{
+				eventType: "cse_opinion_submit",
+				value: null,
+				round: null,
+				createdAt: "2027-10-01T13:00:00.000Z",
+			},
+			{
+				eventType: "demarche_complete",
+				value: null,
+				round: null,
+				createdAt: "2027-10-15T14:00:00.000Z",
+			},
+		]);
 
 		const result = assembleDeclaration(row, [], []);
 
@@ -705,23 +699,20 @@ describe("assembleDeclaration", () => {
 	});
 
 	it("should expose two path_choice entries with their own Numero_declaration (S4)", () => {
-		const row = {
-			...baseRow,
-			statusHistoryArray: [
-				{
-					eventType: "path_choice",
-					value: "justify",
-					round: 1,
-					createdAt: "2027-04-01T10:00:00.000Z",
-				},
-				{
-					eventType: "path_choice",
-					value: "corrective_action",
-					round: 2,
-					createdAt: "2027-08-01T10:00:00.000Z",
-				},
-			],
-		};
+		const row = withHistory([
+			{
+				eventType: "path_choice",
+				value: "justify",
+				round: 1,
+				createdAt: "2027-04-01T10:00:00.000Z",
+			},
+			{
+				eventType: "path_choice",
+				value: "corrective_action",
+				round: 2,
+				createdAt: "2027-08-01T10:00:00.000Z",
+			},
+		]);
 
 		const result = assembleDeclaration(row, [], []);
 
@@ -739,10 +730,8 @@ describe("assembleDeclaration", () => {
 	});
 
 	it("should expose cancel entry with FR label while keeping Date_annulation (S5)", () => {
-		const row = {
-			...baseRow,
-			cancelledAt: new Date("2027-04-15T08:00:00Z"),
-			statusHistoryArray: [
+		const row = withHistory(
+			[
 				{
 					eventType: "submit",
 					value: null,
@@ -756,7 +745,8 @@ describe("assembleDeclaration", () => {
 					createdAt: "2027-04-15T08:00:00.000Z",
 				},
 			],
-		};
+			{ cancelledAt: new Date("2027-04-15T08:00:00Z") },
+		);
 
 		const result = assembleDeclaration(row, [], []);
 
@@ -770,23 +760,20 @@ describe("assembleDeclaration", () => {
 	});
 
 	it("should preserve the order returned by the query without re-sorting", () => {
-		const row = {
-			...baseRow,
-			statusHistoryArray: [
-				{
-					eventType: "demarche_complete",
-					value: null,
-					round: null,
-					createdAt: "2027-10-15T14:00:00.000Z",
-				},
-				{
-					eventType: "submit",
-					value: null,
-					round: null,
-					createdAt: "2027-03-15T10:00:00.000Z",
-				},
-			],
-		};
+		const row = withHistory([
+			{
+				eventType: "demarche_complete",
+				value: null,
+				round: null,
+				createdAt: "2027-10-15T14:00:00.000Z",
+			},
+			{
+				eventType: "submit",
+				value: null,
+				round: null,
+				createdAt: "2027-03-15T10:00:00.000Z",
+			},
+		]);
 
 		const result = assembleDeclaration(row, [], []);
 
@@ -797,17 +784,14 @@ describe("assembleDeclaration", () => {
 	});
 
 	it("should not add Numero_declaration key when path_choice round is null", () => {
-		const row = {
-			...baseRow,
-			statusHistoryArray: [
-				{
-					eventType: "path_choice",
-					value: null,
-					round: null,
-					createdAt: "2027-04-01T10:00:00.000Z",
-				},
-			],
-		};
+		const row = withHistory([
+			{
+				eventType: "path_choice",
+				value: null,
+				round: null,
+				createdAt: "2027-04-01T10:00:00.000Z",
+			},
+		]);
 
 		const result = assembleDeclaration(row, [], []);
 

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
 import { openApiSpec } from "../openapi";
 
 describe("openApiSpec", () => {
@@ -60,6 +61,29 @@ describe("openApiSpec", () => {
 		expect(details.type).toBe("array");
 		expect(details.items).toBeDefined();
 		expect(details.items.type).toBe("object");
+	});
+
+	describe("Statut field (declaration FSM status)", () => {
+		const declarationSchema =
+			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]
+				.content["application/json"].schema.properties.Declarations.items;
+		const statutSchema = declarationSchema.properties.Statut;
+
+		it("declares Statut as a string enum", () => {
+			expect(statutSchema.type).toBe("string");
+			expect(Array.isArray(statutSchema.enum)).toBe(true);
+		});
+
+		it("mirrors the enum exactly on DECLARATION_FSM_STATUSES", () => {
+			expect([...statutSchema.enum].sort()).toEqual(
+				[...DECLARATION_FSM_STATUSES].sort(),
+			);
+			expect(statutSchema.enum).toHaveLength(DECLARATION_FSM_STATUSES.length);
+		});
+
+		it("uses a valid FSM status as its example", () => {
+			expect(DECLARATION_FSM_STATUSES).toContain(statutSchema.example);
+		});
 	});
 
 	describe("Historique_statuts schema", () => {

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -42,10 +42,7 @@ import {
 	INDICATOR_F_HOURLY_THRESHOLD_LABELS,
 	INDICATOR_F_HOURLY_WOMEN_LABELS,
 } from "./shared/apiLabels";
-import {
-	type DeclarationEventType,
-	getStatusHistoryLabel,
-} from "./shared/statusHistoryLabels";
+import { getStatusHistoryLabel } from "./shared/statusHistoryLabels";
 
 function deriveExportFlags(
 	row: DeclarationRow,
@@ -356,10 +353,7 @@ export function assembleDeclaration(
 		Historique_statuts: row.statusHistoryArray.map((entry) => {
 			const base = {
 				Statut: entry.eventType,
-				Libelle_statut: getStatusHistoryLabel(
-					entry.eventType as DeclarationEventType,
-					entry.value,
-				),
+				Libelle_statut: getStatusHistoryLabel(entry.eventType, entry.value),
 				Date: entry.createdAt,
 			};
 			return entry.eventType === "path_choice" && entry.round !== null

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -1,5 +1,7 @@
 // OpenAPI 3.1 specification for the declarations export API.
 
+import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
+
 const declarantSchema = {
 	type: "object",
 	description: "Personne physique ayant réalisé la déclaration.",
@@ -207,8 +209,10 @@ const declarationSchema = {
 		},
 		Statut: {
 			type: "string",
-			description: "Statut de la déclaration",
-			example: "submitted",
+			description:
+				"Statut courant de la déclaration dans le moteur FSM. Dérivé de l'autorité DECLARATION_FSM_STATUSES — toute évolution du vocabulaire FSM se répercute ici automatiquement. Sémantique : « demarche_completed » signifie qu'aucune action supplémentaire n'est attendue sur Egapro ; il peut être atteint dès le choix du parcours « justify » lorsque l'entreprise n'a pas de CSE (la justification des écarts ne donne lieu à aucun dépôt sur la plateforme).",
+			enum: [...DECLARATION_FSM_STATUSES],
+			example: "demarche_completed",
 		},
 		Parcours_apres_declaration_1: {
 			type: ["string", "null"],
@@ -223,7 +227,7 @@ const declarationSchema = {
 		Parcours_de_conformite_requis: {
 			type: "boolean",
 			description:
-				"Indique si le parcours de conformité (mesures correctives après déclaration 1) est requis.",
+				"Prédicat statique : indique si l'entreprise est soumise au parcours de conformité (effectif ≥ 100, indicateur G calculé, écart ≥ 5 %). Calculé à la soumission et figé — ne change jamais au fil de l'avancement de la démarche. Ne pas confondre avec « Statut » qui, lui, évolue à chaque transition FSM.",
 		},
 		Parcours_de_conformite_revision_requis: {
 			type: "boolean",

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -19,6 +19,7 @@ import {
 	users,
 } from "~/server/db/schema";
 import type { CseRow, FileRow, IndicatorGEntry } from "./fetchDeclarations";
+import type { DeclarationEventType } from "./shared/statusHistoryLabels";
 import type { IndicatorGRow } from "./types";
 
 // postgres.js returns ISO strings (not Date) for raw `sql<>` aggregations like
@@ -28,7 +29,7 @@ const toDate = (value: unknown): Date | null =>
 	value == null ? null : new Date(value as string | number | Date);
 
 export type RawHistoryEntry = {
-	eventType: string;
+	eventType: DeclarationEventType;
 	value: string | null;
 	round: number | null;
 	createdAt: string;
@@ -72,6 +73,7 @@ function statusHistoryArray() {
 		)
 		FROM ${declarationStatusHistory}
 		WHERE ${declarationStatusHistory.declarationId} = ${declarations.id}
+		AND ${declarationStatusHistory.eventType} != ${"step_change"}
 	)`.mapWith((value: unknown) =>
 		Array.isArray(value) ? (value as RawHistoryEntry[]) : [],
 	);

--- a/packages/app/src/modules/export/shared/__tests__/statusHistoryLabels.test.ts
+++ b/packages/app/src/modules/export/shared/__tests__/statusHistoryLabels.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { declarationEventTypeEnum } from "~/server/db/schema";
 import {
 	DECLARATION_EVENT_TYPE_LABELS,
 	getStatusHistoryLabel,
@@ -54,5 +55,20 @@ describe("getStatusHistoryLabel", () => {
 			const result = getStatusHistoryLabel(key, null);
 			expect(result.length).toBeGreaterThan(0);
 		}
+	});
+
+	// The public SUIT vocabulary must expose every DB event type except step_change,
+	// which is an internal stepper-transition event (indicators A–F) that must not
+	// leak into the export (#3950).
+	it("exposes exactly the declaration_event_type DB values minus the internal step_change", () => {
+		const publicVocabulary = Object.keys(DECLARATION_EVENT_TYPE_LABELS).sort();
+		const dbEventTypesExceptInternal = declarationEventTypeEnum.enumValues
+			.filter((value) => value !== "step_change")
+			.sort();
+
+		expect(publicVocabulary).toEqual(dbEventTypesExceptInternal);
+		expect(Object.keys(DECLARATION_EVENT_TYPE_LABELS)).not.toContain(
+			"step_change",
+		);
 	});
 });

--- a/packages/app/src/modules/export/shared/__tests__/statusHistoryLabels.test.ts
+++ b/packages/app/src/modules/export/shared/__tests__/statusHistoryLabels.test.ts
@@ -57,9 +57,6 @@ describe("getStatusHistoryLabel", () => {
 		}
 	});
 
-	// The public SUIT vocabulary must expose every DB event type except step_change,
-	// which is an internal stepper-transition event (indicators A–F) that must not
-	// leak into the export (#3950).
 	it("exposes exactly the declaration_event_type DB values minus the internal step_change", () => {
 		const publicVocabulary = Object.keys(DECLARATION_EVENT_TYPE_LABELS).sort();
 		const dbEventTypesExceptInternal = declarationEventTypeEnum.enumValues


### PR DESCRIPTION
Closes #3950

## Résumé

Trois défauts actionnables identifiés lors de l'analyse du bug SUIT :

1. **Fuite d'events `step_change` dans `Historique_statuts`** — `queries.ts` ne filtrait pas les events de télémétrie interne (stepper A–F) ; ils apparaissaient dans l'API SUIT avec un `Libelle_statut` absent (violation du contrat `required`).
2. **`Libelle_statut` manquant** — `statusHistoryLabels.ts` n'avait pas de clé `step_change`, et le cast `as DeclarationEventType` dans `fetchDeclarations.ts` masquait le trou au typecheck.
3. **OpenAPI non aligné** — `Statut` était documenté avec `example: "submitted"` (valeur impossible) et sans enum ; les consommateurs SUIT ne pouvaient pas déduire les 8 états FSM ni comprendre que `demarche_completed` peut être atteint dès le choix de parcours (cas justify-sans-CSE).

## Changements

- `queries.ts` : exclure `step_change` de `statusHistoryArray` (filtre SQL `WHERE event_type != 'step_change'`)
- `fetchDeclarations.ts` : supprimer le cast `as DeclarationEventType` devenu inutile
- `openapi.ts` : dériver l'enum `Statut` de `DECLARATION_FSM_STATUSES` (source d'autorité) + description sémantique + example valide (`demarche_completed`)

## Exemple avant / après — `GET /api/v1/export/declarations`

Scénario du bug (données fictives) : entreprise ≥ 100 salariés, écart ≥ 5 % sur l'indicateur G, `CSE_existant: false`, choix « Justification des écarts ».

**Avant** (défauts visibles) :

```jsonc
{
  "SIREN": "123456789",
  "Parcours_de_conformite_requis": true,
  "Parcours_apres_declaration_1": "justify",
  "Date_parcours_apres_declaration_1": "2026-07-16T09:14:52.123Z",
  "Date_fin_demarche": "2026-07-16T09:14:52.123Z",
  "Statut": "demarche_completed",
  "Historique_statuts": [
    { "Statut": "step_change", "Date": "2026-07-16T09:02:41.507Z" },
    // ^ event de télémétrie interne (stepper A–F) : hors vocabulaire documenté,
    //   et `Libelle_statut` absent — violation du contrat required
    { "Statut": "submit", "Libelle_statut": "Soumission de la déclaration", "Date": "2026-07-16T09:11:03.882Z" },
    { "Statut": "path_choice", "Libelle_statut": "Choix du parcours — Justification de l'écart", "Date": "2026-07-16T09:14:52.123Z" },
    { "Statut": "demarche_complete", "Libelle_statut": "Démarche terminée", "Date": "2026-07-16T09:14:52.123Z" }
  ]
}
```

De plus, l'OpenAPI documentait `Statut` avec `example: "submitted"` — valeur qui n'existe pas (l'enum réel = les 8 états FSM).

**Après** (cette PR) :

```jsonc
{
  "SIREN": "123456789",
  "Parcours_de_conformite_requis": true,
  "Parcours_apres_declaration_1": "justify",
  "Date_parcours_apres_declaration_1": "2026-07-16T09:14:52.123Z",
  "Date_fin_demarche": "2026-07-16T09:14:52.123Z",
  "Statut": "demarche_completed",
  "Historique_statuts": [
    { "Statut": "submit", "Libelle_statut": "Soumission de la déclaration", "Date": "2026-07-16T09:11:03.882Z" },
    { "Statut": "path_choice", "Libelle_statut": "Choix du parcours — Justification de l'écart", "Date": "2026-07-16T09:14:52.123Z" },
    { "Statut": "demarche_complete", "Libelle_statut": "Démarche terminée", "Date": "2026-07-16T09:14:52.123Z" }
  ]
}
```

- `step_change` n'apparaît plus ; chaque entrée porte un `Libelle_statut` (contrat `required` respecté).
- L'OpenAPI documente désormais l'enum complet de `Statut` (dérivé de `DECLARATION_FSM_STATUSES`) avec un exemple valide, et précise que `Parcours_de_conformite_requis` est un prédicat figé.
- Note : `Statut: "demarche_completed"` et `Date_fin_demarche` posée dès le choix « justify » **sans CSE** restent inchangés — c'est le comportement spécifié à date (arbitrage Q12). Son évolution éventuelle (écran de justification dédié) relève d'une feature produit séparée, hors périmètre de ce fix.

## Tests

- `openapi.test.ts` : 3 nouveaux tests (enum string, miroir exact `DECLARATION_FSM_STATUSES`, example valide)
- `statusHistoryLabels.test.ts` : 1 nouveau test (vocabulaire public = enum DB moins `step_change`)
- `exportApi.integration.test.ts` : 2 nouveaux tests d'intégration avec seed `step_change` (filtre SQL + contrat `Libelle_statut`)
- Revert-verify prouvé : fix inverse → RED sur les 3 défauts, fix réappliqué → GREEN
- Suite complète : 3786/3786 passed
