### PR TITLE
fix(my-space): message d'erreur CSE explicite en français dans le bandeau informations manquantes

### DIFF
--- a/packages/app/src/e2e/missing-info-modal.e2e.ts
+++ b/packages/app/src/e2e/missing-info-modal.e2e.ts
@@ -122,4 +122,50 @@ test.describe("Missing info modal", () => {
 			expect(page.url()).toContain("/mon-espace");
 		});
 	});
+
+	test.describe("Validation error on empty CSE", () => {
+		test.beforeAll(async () => {
+			await setUserPhone("0122334455");
+			await setCompanyHasCse(null);
+		});
+
+		test.afterAll(async () => {
+			await setCompanyHasCse(true);
+		});
+
+		test("shows explicit French error when CSE choice is empty", async ({
+			page,
+		}) => {
+			await page.context().clearCookies();
+			await loginWithProConnect(page);
+			await waitForDsfrModal(page, MISSING_INFO_MODAL_ID);
+
+			const modal = page.locator(`#${MISSING_INFO_MODAL_ID}`);
+
+			const declarationButton = page.getByRole("button", {
+				name: "Rémunération",
+			});
+			await expect(declarationButton).toBeVisible();
+			await clickAndExpectDialogOpen(
+				page,
+				declarationButton,
+				MISSING_INFO_MODAL_ID,
+			);
+			await expect(
+				modal.getByText("Un CSE a-t-il été mis en place"),
+			).toBeVisible();
+
+			await modal.getByRole("button", { name: "Enregistrer" }).click();
+
+			// Regression guard for #3970: an unanswered CSE radio must surface the
+			// explicit French message, not Zod's default "Invalid input: expected
+			// boolean, received null".
+			await expect(
+				modal.locator(".fr-message--error", {
+					hasText: "Veuillez renseigner si un CSE a été mis en place.",
+				}),
+			).toBeVisible();
+			expect(page.url()).toContain("/mon-espace");
+		});
+	});
 });

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useSession } from "next-auth/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -6,13 +6,17 @@ import { mockImpersonatingSession } from "~/test/impersonationMock";
 
 const mockedUseSession = vi.mocked(useSession);
 
+const { updateHasCseAsync } = vi.hoisted(() => ({
+	updateHasCseAsync: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("~/trpc/react", () => ({
 	api: {
 		company: {
 			updateHasCse: {
 				useMutation: vi.fn().mockReturnValue({
 					mutate: vi.fn(),
-					mutateAsync: vi.fn(),
+					mutateAsync: updateHasCseAsync,
 					isPending: false,
 				}),
 			},
@@ -21,7 +25,7 @@ vi.mock("~/trpc/react", () => ({
 			updatePhone: {
 				useMutation: vi.fn().mockReturnValue({
 					mutate: vi.fn(),
-					mutateAsync: vi.fn(),
+					mutateAsync: vi.fn().mockResolvedValue(undefined),
 					isPending: false,
 				}),
 			},
@@ -218,6 +222,86 @@ describe("MissingInfoModal", () => {
 		expect(
 			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
 		).not.toBeDisabled();
+	});
+
+	it("shows the explicit CSE error when submitting without selecting a radio", async () => {
+		render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+		await waitFor(() => {
+			const error = document.querySelector(
+				"#missing-info-cse-error .fr-message--error",
+			);
+			expect(error).toHaveTextContent(
+				"Veuillez renseigner si un CSE a été mis en place.",
+			);
+		});
+	});
+
+	it("parses the selected CSE radio to a boolean and clears the error on resubmit", async () => {
+		updateHasCseAsync.mockClear();
+		render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+		const enregistrer = screen.getByRole("button", {
+			name: "Enregistrer",
+			hidden: true,
+		});
+
+		fireEvent.click(enregistrer);
+		await waitFor(() => {
+			expect(
+				document.querySelector("#missing-info-cse-error .fr-message--error"),
+			).toBeInTheDocument();
+		});
+
+		fireEvent.click(screen.getByLabelText("Non"));
+		fireEvent.click(enregistrer);
+		await waitFor(() => {
+			expect(updateHasCseAsync).toHaveBeenCalledWith({
+				siren: "532847196",
+				hasCse: false,
+			});
+		});
+		expect(
+			document.querySelector("#missing-info-cse-error"),
+		).not.toBeInTheDocument();
+	});
+
+	it("parses the Oui CSE radio to true on submit", async () => {
+		updateHasCseAsync.mockClear();
+		render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+
+		fireEvent.click(screen.getByLabelText("Oui"));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+		await waitFor(() => {
+			expect(updateHasCseAsync).toHaveBeenCalledWith({
+				siren: "532847196",
+				hasCse: true,
+			});
+		});
 	});
 
 	describe("admin impersonation", () => {

--- a/packages/app/src/modules/my-space/index.ts
+++ b/packages/app/src/modules/my-space/index.ts
@@ -6,5 +6,9 @@ export {
 export { extractSiren, formatSiren } from "./formatSiren";
 export { MonEspacePage } from "./MonEspacePage";
 export { MyCompaniesPage } from "./MyCompaniesPage";
-export { sirenInputSchema, updateHasCseSchema } from "./schemas";
+export {
+	createMissingInfoSchema,
+	sirenInputSchema,
+	updateHasCseSchema,
+} from "./schemas";
 export { useUpdateHasCse } from "./useUpdateHasCse";

--- a/packages/app/src/modules/my-space/schemas.ts
+++ b/packages/app/src/modules/my-space/schemas.ts
@@ -11,10 +11,14 @@ export const updateHasCseSchema = z.object({
 	hasCse: z.boolean(),
 });
 
-/** Radio buttons always produce strings — transform "true"/"false" to boolean. */
-const hasCseFromRadio = z
-	.union([z.boolean(), z.literal("true"), z.literal("false")])
-	.transform((v): boolean => (typeof v === "string" ? v === "true" : v));
+const CSE_RADIO_ERROR = "Veuillez renseigner si un CSE a été mis en place.";
+
+const hasCseFromRadio = z.unknown().transform((v, ctx) => {
+	if (v === true || v === "true") return true;
+	if (v === false || v === "false") return false;
+	ctx.addIssue({ code: "custom", message: CSE_RADIO_ERROR });
+	return z.NEVER;
+});
 
 export function createMissingInfoSchema(
 	needsPhone: boolean,


### PR DESCRIPTION
Closes #3970

## Problème

Dans le bandeau latéral « Informations manquantes », si l'utilisateur soumet le formulaire sans sélectionner de réponse à la question CSE, le message d'erreur affiché était le message anglais par défaut de Zod v4 : « Invalid input: expected boolean, received null ».

**Cause** : le schéma `hasCseFromRadio` utilisait une `z.union()` sans message d'erreur personnalisé. Quand react-hook-form soumet `null` (aucun radio coché), `zodResolver` remontait le message de la première branche de l'union.

## Fix

Remplacement de l'union `z.union([z.boolean(), z.literal("true"), z.literal("false")])` par un `z.unknown().transform((v, ctx) => …)` avec `ctx.addIssue({ code: "custom", message: "Veuillez renseigner si un CSE a été mis en place." })` — même pattern que `phoneSchema` dans `~/modules/profile/phone.ts`.

- `true` / `"true"` → `true`
- `false` / `"false"` → `false`
- tout autre cas (null, undefined sur la branche non-optionnelle) → message français
- branche `.optional()` (question CSE non affichée) : comportement inchangé

Ajout de `createMissingInfoSchema` dans le barrel `index.ts` (manquait depuis l'introduction de la fonction).

## Test plan

- [ ] Ouvrir le bandeau « Informations manquantes » pour une entreprise nécessitant un CSE
- [ ] Cliquer « Enregistrer » sans sélectionner « Oui » ou « Non »
- [ ] Vérifier que le message « Veuillez renseigner si un CSE a été mis en place. » s'affiche sous le champ radio
- [ ] Sélectionner « Oui » ou « Non » et soumettre → pas d'erreur, mise à jour enregistrée