### PR TITLE
fix(my-space): panneau latéral aveugle à la taille et au flag CSE

### DIFF
--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -3,11 +3,14 @@ import { expect, test } from "@playwright/test";
 import {
 	deleteCseOpinions,
 	deleteJointEvaluationFiles,
+	ensureCurrentYearDeclaration,
 	insertCseOpinion,
 	insertJointEvaluationFile,
 	resetDeclarationToDraft,
+	resetGipWorkforce,
 	setCompanyHasCse,
 	setDeclarationComplianceState,
+	setGipWorkforce,
 	setUserPhone,
 } from "./helpers/db";
 import { clickAndExpectDialogOpen, waitForDsfrModal } from "./helpers/dsfr";
@@ -101,6 +104,88 @@ test.describe("Declaration process panel", () => {
 					`Démarche des indicateurs de rémunération ${CURRENT_YEAR}`,
 				),
 			).toBeVisible();
+		});
+	});
+
+	// Regression #3939: a GIP-derived < 100 company without CSE must never see the
+	// indicator-G path step nor the "déposer l'avis CSE" step — neither during the
+	// démarche nor after completion (where the panel used to stay stuck on "avis CSE
+	// en cours" with a /avis-cse CTA). Gating is driven by the GIP workforce (79 here),
+	// not the WEEZ headcount or the has_cse flag.
+	test.describe("GIP < 100 without CSE: indicator-G and CSE steps are hidden", () => {
+		const STEP2_TITLE =
+			"Parcours de mise en conformité pour l'indicateur par catégorie de salariés";
+		const STEP3_TITLE = "Déposer le ou les avis du CSE";
+
+		test.afterAll(async () => {
+			await resetDeclarationToDraft();
+			await resetGipWorkforce();
+			await setCompanyHasCse(true);
+		});
+
+		async function openPanel(page: Parameters<typeof loginWithProConnect>[0]) {
+			await page.context().clearCookies();
+			await loginWithProConnect(page);
+			await waitForDsfrModal(page, PANEL_ID);
+			const remuButton = page.getByRole("button", { name: "Rémunération" });
+			await expect(remuButton.first()).toBeVisible();
+			await clickAndExpectDialogOpen(page, remuButton.first(), PANEL_ID);
+		}
+
+		test.describe("during the démarche (draft)", () => {
+			test.beforeAll(async () => {
+				await ensureCurrentYearDeclaration();
+				await setGipWorkforce(79);
+				await setCompanyHasCse(false);
+				await setUserPhone("0122334455");
+				await resetDeclarationToDraft();
+			});
+
+			test("only the declaration step is announced", async ({ page }) => {
+				await openPanel(page);
+				const panel = page.locator(`#${PANEL_ID}`);
+
+				await expect(
+					panel.getByText("Déclaration des indicateurs de rémunération"),
+				).toBeVisible();
+				await expect(panel.getByText(STEP2_TITLE)).toHaveCount(0);
+				await expect(panel.getByText(STEP3_TITLE)).toHaveCount(0);
+			});
+		});
+
+		test.describe("after completion (démarche_completed, not subject)", () => {
+			test.beforeAll(async () => {
+				await ensureCurrentYearDeclaration();
+				await setGipWorkforce(79);
+				await setCompanyHasCse(false);
+				await setUserPhone("0122334455");
+				await setDeclarationComplianceState({
+					status: "demarche_completed",
+					demarcheCompletedAt: new Date(),
+				});
+			});
+
+			test("closed variant without any CSE deposit prompt or CTA", async ({
+				page,
+			}) => {
+				await openPanel(page);
+				const panel = page.locator(`#${PANEL_ID}`);
+
+				await expect(panel.getByText("Démarche close")).toBeVisible();
+				await expect(
+					panel.getByText("Cette démarche est terminée.", { exact: true }),
+				).toBeVisible();
+				await expect(
+					panel.getByText(
+						"Cette démarche est terminée. Les avis du CSE restent modifiables jusqu'à l'échéance.",
+					),
+				).toHaveCount(0);
+				await expect(panel.getByText(STEP3_TITLE)).toHaveCount(0);
+
+				const cta = panel.getByRole("link", { name: "Voir la déclaration" });
+				await expect(cta).toBeVisible();
+				await expect(cta).not.toHaveAttribute("href", /avis-cse/);
+			});
 		});
 	});
 });

--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -162,6 +162,93 @@ test.describe("Declaration process panel", () => {
 				await setDeclarationComplianceState({
 					status: "demarche_completed",
 					demarcheCompletedAt: new Date(),
+					cseRequired: false,
+				});
+			});
+
+			test("closed variant without any CSE deposit prompt or CTA", async ({
+				page,
+			}) => {
+				await openPanel(page);
+				const panel = page.locator(`#${PANEL_ID}`);
+
+				await expect(panel.getByText("Démarche close")).toBeVisible();
+				await expect(
+					panel.getByText("Cette démarche est terminée.", { exact: true }),
+				).toBeVisible();
+				await expect(
+					panel.getByText(
+						"Cette démarche est terminée. Les avis du CSE restent modifiables jusqu'à l'échéance.",
+					),
+				).toHaveCount(0);
+				await expect(panel.getByText(STEP3_TITLE)).toHaveCount(0);
+
+				const cta = panel.getByRole("link", { name: "Voir la déclaration" });
+				await expect(cta).toBeVisible();
+				await expect(cta).not.toHaveAttribute("href", /avis-cse/);
+			});
+		});
+	});
+
+	// #3939 follow-up: a GIP-derived >= 100 company that declared "sans CSE" is still
+	// subject to indicator G, so the panel keeps the indicator-G path step (step 2),
+	// but must never ask it to deposit a CSE opinion — step 3 and the "avis CSE
+	// modifiables" closing note are hidden, during the démarche and after completion.
+	// Step visibility is driven by isCseOpinionRequired(workforce, hasCse), not the
+	// workforce alone, so this differs from the < 100 case where step 2 is hidden too.
+	test.describe("GIP >= 100 without CSE: indicator-G step shown, CSE step hidden", () => {
+		const STEP2_TITLE =
+			"Parcours de mise en conformité pour l'indicateur par catégorie de salariés";
+		const STEP3_TITLE = "Déposer le ou les avis du CSE";
+
+		test.afterAll(async () => {
+			await resetDeclarationToDraft();
+			await resetGipWorkforce();
+			await setCompanyHasCse(true);
+		});
+
+		async function openPanel(page: Parameters<typeof loginWithProConnect>[0]) {
+			await page.context().clearCookies();
+			await loginWithProConnect(page);
+			await waitForDsfrModal(page, PANEL_ID);
+			const remuButton = page.getByRole("button", { name: "Rémunération" });
+			await expect(remuButton.first()).toBeVisible();
+			await clickAndExpectDialogOpen(page, remuButton.first(), PANEL_ID);
+		}
+
+		test.describe("during the démarche (draft)", () => {
+			test.beforeAll(async () => {
+				await ensureCurrentYearDeclaration();
+				await resetGipWorkforce();
+				await setCompanyHasCse(false);
+				await setUserPhone("0122334455");
+				await resetDeclarationToDraft();
+			});
+
+			test("the indicator-G step is announced but not the CSE step", async ({
+				page,
+			}) => {
+				await openPanel(page);
+				const panel = page.locator(`#${PANEL_ID}`);
+
+				await expect(
+					panel.getByText("Déclaration des indicateurs de rémunération"),
+				).toBeVisible();
+				await expect(panel.getByText(STEP2_TITLE)).toBeVisible();
+				await expect(panel.getByText(STEP3_TITLE)).toHaveCount(0);
+			});
+		});
+
+		test.describe("after completion (démarche_completed, no CSE opinion due)", () => {
+			test.beforeAll(async () => {
+				await ensureCurrentYearDeclaration();
+				await resetGipWorkforce();
+				await setCompanyHasCse(false);
+				await setUserPhone("0122334455");
+				await setDeclarationComplianceState({
+					status: "demarche_completed",
+					demarcheCompletedAt: new Date(),
+					cseRequired: false,
 				});
 			});
 

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -202,6 +202,7 @@ export async function setDeclarationComplianceState(state: {
 	secondDeclarationSubmittedAt?: Date | null;
 	demarcheCompletedAt?: Date | null;
 	cseOpinionCompletedAt?: Date | null;
+	cseRequired?: boolean;
 }) {
 	const sql = createConnection();
 	try {
@@ -213,6 +214,16 @@ export async function setDeclarationComplianceState(state: {
 			    second_declaration_path_choice = ${state.secondDeclarationPathChoice ?? null}
 			WHERE siren = ${TEST_SIREN}
 		`;
+
+		// The panel's closed-vs-cse decision reads the frozen `cse_required` snapshot,
+		// so tests that model completion must pin it explicitly (it is otherwise left
+		// over from whichever submit flow last ran on the shared declaration record).
+		if (state.cseRequired !== undefined) {
+			await sql`
+				UPDATE app_declaration SET cse_required = ${state.cseRequired}
+				WHERE siren = ${TEST_SIREN}
+			`;
+		}
 
 		const decl = await sql`
 			SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} LIMIT 1

--- a/packages/app/src/modules/domain/__tests__/companySize.test.ts
+++ b/packages/app/src/modules/domain/__tests__/companySize.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
 	COMPANY_SIZE_RANGES,
 	getCompanySizeRange,
+	isCseOpinionRequired,
+	isCseRequired,
 } from "../shared/companySize";
 import {
 	COMPANY_SIZE_ANNUAL_MIN,
@@ -77,5 +79,34 @@ describe("getCompanySizeRange", () => {
 		expect(getCompanySizeRange(249)).toBe("150-249");
 		expect(getCompanySizeRange(250)).toBe("250+");
 		expect(getCompanySizeRange(10000)).toBe("250+");
+	});
+});
+
+describe("isCseRequired", () => {
+	it("is size-based only: true from 100 employees", () => {
+		expect(isCseRequired(99)).toBe(false);
+		expect(isCseRequired(100)).toBe(true);
+		expect(isCseRequired(250)).toBe(true);
+	});
+});
+
+describe("isCseOpinionRequired", () => {
+	it("requires both the size threshold and a declared CSE", () => {
+		expect(isCseOpinionRequired(250, true)).toBe(true);
+		expect(isCseOpinionRequired(100, true)).toBe(true);
+	});
+
+	it("is false when the company declared it has no CSE, whatever its size", () => {
+		expect(isCseOpinionRequired(250, false)).toBe(false);
+		expect(isCseOpinionRequired(100, false)).toBe(false);
+	});
+
+	it("is false when the CSE status has not been declared yet", () => {
+		expect(isCseOpinionRequired(250, null)).toBe(false);
+	});
+
+	it("is false below the size threshold even with a declared CSE", () => {
+		expect(isCseOpinionRequired(99, true)).toBe(false);
+		expect(isCseOpinionRequired(49, true)).toBe(false);
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/declarationDisplay.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationDisplay.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getDeclarationDisplayContext } from "../shared/declarationDisplay";
+import {
+	getDeclarationDisplayContext,
+	isCseOpinionResolved,
+} from "../shared/declarationDisplay";
 
 describe("getDeclarationDisplayContext", () => {
 	it("sets shouldShowGapJustification when firstDeclarationPathChoice is justify", () => {
@@ -91,5 +94,43 @@ describe("getDeclarationDisplayContext", () => {
 		expect(result.shouldShowCorrectiveActions).toBe(true);
 		expect(result.shouldShowJointEvaluation).toBe(false);
 		expect(result.shouldShowCseOpinion).toBe(false);
+	});
+});
+
+describe("isCseOpinionResolved", () => {
+	it("returns true when the CSE opinion is not required", () => {
+		expect(
+			isCseOpinionResolved({
+				cseRequired: false,
+				hasSubmittedCseOpinion: false,
+			}),
+		).toBe(true);
+	});
+
+	it("returns true when the CSE opinion has already been submitted", () => {
+		expect(
+			isCseOpinionResolved({
+				cseRequired: true,
+				hasSubmittedCseOpinion: true,
+			}),
+		).toBe(true);
+	});
+
+	it("returns false when the CSE opinion is required and not yet submitted", () => {
+		expect(
+			isCseOpinionResolved({
+				cseRequired: true,
+				hasSubmittedCseOpinion: false,
+			}),
+		).toBe(false);
+	});
+
+	it("returns true when neither required nor submitted", () => {
+		expect(
+			isCseOpinionResolved({
+				cseRequired: false,
+				hasSubmittedCseOpinion: true,
+			}),
+		).toBe(true);
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -22,6 +22,7 @@ export {
 	COMPANY_SIZE_RANGES,
 	classifyCompanySize,
 	getCompanySizeRange,
+	isCseOpinionRequired,
 	isCseRequired,
 } from "./shared/companySize";
 // Global score computation (sum of sub-scores from the EgaPro index)

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -41,8 +41,14 @@ export {
 	QUARTILE_THRESHOLD_COUNT,
 } from "./shared/constants";
 // Declaration display context
-export type { DeclarationDisplayContext } from "./shared/declarationDisplay";
-export { getDeclarationDisplayContext } from "./shared/declarationDisplay";
+export type {
+	CseOpinionResolvedInput,
+	DeclarationDisplayContext,
+} from "./shared/declarationDisplay";
+export {
+	getDeclarationDisplayContext,
+	isCseOpinionResolved,
+} from "./shared/declarationDisplay";
 // Declaration derived flags (compliance process, revision, indicator G)
 export type {
 	ComplianceProcessRequiredInput,

--- a/packages/app/src/modules/domain/shared/companySize.ts
+++ b/packages/app/src/modules/domain/shared/companySize.ts
@@ -16,6 +16,14 @@ export function isCseRequired(workforce: number): boolean {
 	return workforce >= COMPANY_SIZE_ANNUAL_MIN;
 }
 
+/** Returns true if the company must deposit a CSE opinion: large enough to require a CSE (>= 100) AND having declared one exists. */
+export function isCseOpinionRequired(
+	workforce: number,
+	hasCse: boolean | null,
+): boolean {
+	return isCseRequired(workforce) && hasCse === true;
+}
+
 /**
  * Workforce range buckets shared by admin and public statistics filters.
  * `max: null` means the bucket is open-ended (no upper bound).

--- a/packages/app/src/modules/domain/shared/declarationDisplay.ts
+++ b/packages/app/src/modules/domain/shared/declarationDisplay.ts
@@ -32,3 +32,14 @@ export function getDeclarationDisplayContext(
 		shouldShowCseOpinion: declaration.cseRequired,
 	};
 }
+
+export type CseOpinionResolvedInput = {
+	cseRequired: boolean;
+	hasSubmittedCseOpinion: boolean;
+};
+
+export function isCseOpinionResolved(
+	declaration: CseOpinionResolvedInput,
+): boolean {
+	return declaration.hasSubmittedCseOpinion || !declaration.cseRequired;
+}

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -4,6 +4,7 @@ import {
 	getDeclarationDisplayContext,
 	getObligationWorkforce,
 	isCseRequired,
+	isIndicatorGRequired,
 } from "~/modules/domain";
 
 import { ArchivesSection } from "./ArchivesSection";
@@ -56,8 +57,11 @@ export function CompanyDeclarationsPage({
 	userPhone,
 }: Props) {
 	const currentYear = getCurrentYear();
-	const cseApplicable = isCseRequired(
-		getObligationWorkforce(company.gipWorkforce),
+	const obligationWorkforce = getObligationWorkforce(company.gipWorkforce);
+	const cseApplicable = isCseRequired(obligationWorkforce);
+	const indicatorGRequired = isIndicatorGRequired(
+		obligationWorkforce,
+		currentYear,
 	);
 	const lastActionDate = getLastActionDate(declarations, currentYear);
 	const currentDeclaration = declarations.find(
@@ -95,11 +99,13 @@ export function CompanyDeclarationsPage({
 			/>
 			<DeclarationProcessPanel
 				campaignDeadlines={campaignDeadlines}
+				cseApplicable={cseApplicable}
 				ctaHref={ctaHref}
 				displayContext={displayContext}
 				hasSubmittedSecondDeclaration={
 					currentDeclaration?.hasSubmittedSecondDeclaration ?? false
 				}
+				indicatorGRequired={indicatorGRequired}
 				lastActionDate={lastActionDate}
 				lockedByOther={lockedByOther}
 				lockHolder={lockHolder}

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -3,6 +3,7 @@ import {
 	getCurrentYear,
 	getDeclarationDisplayContext,
 	getObligationWorkforce,
+	isCseOpinionRequired,
 	isCseRequired,
 	isIndicatorGRequired,
 } from "~/modules/domain";
@@ -59,6 +60,10 @@ export function CompanyDeclarationsPage({
 	const currentYear = getCurrentYear();
 	const obligationWorkforce = getObligationWorkforce(company.gipWorkforce);
 	const cseApplicable = isCseRequired(obligationWorkforce);
+	const cseOpinionRequired = isCseOpinionRequired(
+		obligationWorkforce,
+		company.hasCse,
+	);
 	const indicatorGRequired = isIndicatorGRequired(
 		obligationWorkforce,
 		currentYear,
@@ -99,7 +104,7 @@ export function CompanyDeclarationsPage({
 			/>
 			<DeclarationProcessPanel
 				campaignDeadlines={campaignDeadlines}
-				cseApplicable={cseApplicable}
+				cseOpinionRequired={cseOpinionRequired}
 				ctaHref={ctaHref}
 				displayContext={displayContext}
 				hasSubmittedSecondDeclaration={

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -24,7 +24,9 @@ export type PanelVariant =
 
 type Props = {
 	campaignDeadlines: CampaignDeadlines;
+	cseApplicable: boolean;
 	year: number;
+	indicatorGRequired: boolean;
 	lastActionDate: string | null;
 	variant: PanelVariant;
 	displayContext: DeclarationDisplayContext;
@@ -37,7 +39,9 @@ type Props = {
 
 export function DeclarationProcessPanel({
 	campaignDeadlines,
+	cseApplicable,
 	year,
+	indicatorGRequired,
 	lastActionDate,
 	variant,
 	displayContext,
@@ -85,7 +89,9 @@ export function DeclarationProcessPanel({
 						)}
 						<VerticalStepper
 							campaignDeadlines={campaignDeadlines}
+							cseApplicable={cseApplicable}
 							displayContext={displayContext}
+							indicatorGRequired={indicatorGRequired}
 							secondDeclarationSubmitted={hasSubmittedSecondDeclaration}
 							siren={siren}
 							step1={step1}
@@ -94,7 +100,9 @@ export function DeclarationProcessPanel({
 							variant={variant}
 							year={year}
 						/>
-						{variant === "closed" && <ClosedMessage />}
+						{variant === "closed" && (
+							<ClosedMessage cseApplicable={cseApplicable} />
+						)}
 					</div>
 					<div>
 						<HelpSection />
@@ -165,13 +173,14 @@ function StartAlert() {
 	);
 }
 
-function ClosedMessage() {
+function ClosedMessage({ cseApplicable }: { cseApplicable: boolean }) {
 	return (
 		<div className={styles.closedMessage}>
 			<p className="fr-text--bold fr-mb-0">Démarche close</p>
 			<p className="fr-mb-0">
-				Cette démarche est terminée. Les avis du CSE restent modifiables jusqu'à
-				l'échéance.
+				{cseApplicable
+					? "Cette démarche est terminée. Les avis du CSE restent modifiables jusqu'à l'échéance."
+					: "Cette démarche est terminée."}
 			</p>
 		</div>
 	);

--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -24,7 +24,7 @@ export type PanelVariant =
 
 type Props = {
 	campaignDeadlines: CampaignDeadlines;
-	cseApplicable: boolean;
+	cseOpinionRequired: boolean;
 	year: number;
 	indicatorGRequired: boolean;
 	lastActionDate: string | null;
@@ -39,7 +39,7 @@ type Props = {
 
 export function DeclarationProcessPanel({
 	campaignDeadlines,
-	cseApplicable,
+	cseOpinionRequired,
 	year,
 	indicatorGRequired,
 	lastActionDate,
@@ -89,7 +89,7 @@ export function DeclarationProcessPanel({
 						)}
 						<VerticalStepper
 							campaignDeadlines={campaignDeadlines}
-							cseApplicable={cseApplicable}
+							cseOpinionRequired={cseOpinionRequired}
 							displayContext={displayContext}
 							indicatorGRequired={indicatorGRequired}
 							secondDeclarationSubmitted={hasSubmittedSecondDeclaration}
@@ -101,7 +101,7 @@ export function DeclarationProcessPanel({
 							year={year}
 						/>
 						{variant === "closed" && (
-							<ClosedMessage cseApplicable={cseApplicable} />
+							<ClosedMessage cseOpinionRequired={cseOpinionRequired} />
 						)}
 					</div>
 					<div>
@@ -173,12 +173,16 @@ function StartAlert() {
 	);
 }
 
-function ClosedMessage({ cseApplicable }: { cseApplicable: boolean }) {
+function ClosedMessage({
+	cseOpinionRequired,
+}: {
+	cseOpinionRequired: boolean;
+}) {
 	return (
 		<div className={styles.closedMessage}>
 			<p className="fr-text--bold fr-mb-0">Démarche close</p>
 			<p className="fr-mb-0">
-				{cseApplicable
+				{cseOpinionRequired
 					? "Cette démarche est terminée. Les avis du CSE restent modifiables jusqu'à l'échéance."
 					: "Cette démarche est terminée."}
 			</p>

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -227,6 +227,7 @@ export function PanelPlayground() {
 
 			<DeclarationProcessPanel
 				campaignDeadlines={deadlines}
+				cseApplicable={true}
 				ctaHref="/declaration-remuneration?siren=000000000"
 				displayContext={getDeclarationDisplayContext({
 					firstDeclarationPathChoice: compliancePath,
@@ -234,6 +235,7 @@ export function PanelPlayground() {
 					cseRequired: false,
 				})}
 				hasSubmittedSecondDeclaration={secondDeclarationSubmitted}
+				indicatorGRequired={true}
 				lastActionDate="12 mars 2026"
 				lockedByOther={false}
 				lockHolder={null}

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -227,7 +227,7 @@ export function PanelPlayground() {
 
 			<DeclarationProcessPanel
 				campaignDeadlines={deadlines}
-				cseApplicable={true}
+				cseOpinionRequired={true}
 				ctaHref="/declaration-remuneration?siren=000000000"
 				displayContext={getDeclarationDisplayContext({
 					firstDeclarationPathChoice: compliancePath,

--- a/packages/app/src/modules/my-space/PanelPlayground.tsx
+++ b/packages/app/src/modules/my-space/PanelPlayground.tsx
@@ -56,6 +56,8 @@ export function PanelPlayground() {
 		useState<(typeof COMPLIANCE_PATHS)[number]>("corrective_action");
 	const [secondDeclarationSubmitted, setSecondDeclarationSubmitted] =
 		useState(true);
+	const [cseOpinionRequired, setCseOpinionRequired] = useState(true);
+	const [indicatorGRequired, setIndicatorGRequired] = useState(true);
 	const [preset, setPreset] = useState<DatePreset>("future");
 	const [deadlines, setDeadlines] = useState<CampaignDeadlines>(
 		buildPresetDeadlines("future"),
@@ -148,6 +150,30 @@ export function PanelPlayground() {
 							Seconde déclaration soumise
 						</label>
 					</div>
+
+					<div className="fr-checkbox-group">
+						<input
+							checked={indicatorGRequired}
+							id="indicator-g-required"
+							onChange={(e) => setIndicatorGRequired(e.currentTarget.checked)}
+							type="checkbox"
+						/>
+						<label className="fr-label" htmlFor="indicator-g-required">
+							Indicateur G requis (étape 2 visible)
+						</label>
+					</div>
+
+					<div className="fr-checkbox-group">
+						<input
+							checked={cseOpinionRequired}
+							id="cse-opinion-required"
+							onChange={(e) => setCseOpinionRequired(e.currentTarget.checked)}
+							type="checkbox"
+						/>
+						<label className="fr-label" htmlFor="cse-opinion-required">
+							Avis CSE requis (étape 3 visible)
+						</label>
+					</div>
 				</div>
 			</div>
 
@@ -227,15 +253,15 @@ export function PanelPlayground() {
 
 			<DeclarationProcessPanel
 				campaignDeadlines={deadlines}
-				cseOpinionRequired={true}
+				cseOpinionRequired={cseOpinionRequired}
 				ctaHref="/declaration-remuneration?siren=000000000"
 				displayContext={getDeclarationDisplayContext({
 					firstDeclarationPathChoice: compliancePath,
 					secondDeclarationPathChoice: null,
-					cseRequired: false,
+					cseRequired: cseOpinionRequired,
 				})}
 				hasSubmittedSecondDeclaration={secondDeclarationSubmitted}
-				indicatorGRequired={true}
+				indicatorGRequired={indicatorGRequired}
 				lastActionDate="12 mars 2026"
 				lockedByOther={false}
 				lockHolder={null}

--- a/packages/app/src/modules/my-space/VerticalStepper.tsx
+++ b/packages/app/src/modules/my-space/VerticalStepper.tsx
@@ -30,7 +30,9 @@ export function getStepStatuses(
 
 export function VerticalStepper({
 	campaignDeadlines,
+	cseApplicable,
 	displayContext,
+	indicatorGRequired,
 	secondDeclarationSubmitted,
 	siren,
 	step1,
@@ -40,7 +42,9 @@ export function VerticalStepper({
 	year,
 }: {
 	campaignDeadlines: CampaignDeadlines;
+	cseApplicable: boolean;
 	displayContext: DeclarationDisplayContext;
+	indicatorGRequired: boolean;
 	secondDeclarationSubmitted: boolean;
 	siren: string;
 	step1: StepStatus;
@@ -61,26 +65,30 @@ export function VerticalStepper({
 					year={year}
 				/>
 			</div>
-			<div className={`${styles.stepRow} ${stepRowClass(step2)}`}>
-				<StepCircle number={2} status={step2} />
-				<Step2Content
-					campaignDeadlines={campaignDeadlines}
-					displayContext={displayContext}
-					secondDeclarationSubmitted={secondDeclarationSubmitted}
-					siren={siren}
-					status={step2}
-					variant={variant}
-				/>
-			</div>
-			<div className={`${styles.stepRow} ${stepRowClass(step3)}`}>
-				<StepCircle number={3} status={step3} />
-				<Step3Content
-					campaignDeadlines={campaignDeadlines}
-					siren={siren}
-					status={step3}
-					variant={variant}
-				/>
-			</div>
+			{indicatorGRequired && (
+				<div className={`${styles.stepRow} ${stepRowClass(step2)}`}>
+					<StepCircle number={2} status={step2} />
+					<Step2Content
+						campaignDeadlines={campaignDeadlines}
+						displayContext={displayContext}
+						secondDeclarationSubmitted={secondDeclarationSubmitted}
+						siren={siren}
+						status={step2}
+						variant={variant}
+					/>
+				</div>
+			)}
+			{cseApplicable && (
+				<div className={`${styles.stepRow} ${stepRowClass(step3)}`}>
+					<StepCircle number={3} status={step3} />
+					<Step3Content
+						campaignDeadlines={campaignDeadlines}
+						siren={siren}
+						status={step3}
+						variant={variant}
+					/>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/packages/app/src/modules/my-space/VerticalStepper.tsx
+++ b/packages/app/src/modules/my-space/VerticalStepper.tsx
@@ -53,6 +53,8 @@ export function VerticalStepper({
 	variant: PanelVariant;
 	year: number;
 }) {
+	const step3Number = indicatorGRequired ? 3 : 2;
+
 	return (
 		<div className={`${styles.stepper} fr-mb-4w`}>
 			<div className={`${styles.stepRow} ${stepRowClass(step1)}`}>
@@ -80,7 +82,7 @@ export function VerticalStepper({
 			)}
 			{cseOpinionRequired && (
 				<div className={`${styles.stepRow} ${stepRowClass(step3)}`}>
-					<StepCircle number={3} status={step3} />
+					<StepCircle number={step3Number} status={step3} />
 					<Step3Content
 						campaignDeadlines={campaignDeadlines}
 						siren={siren}

--- a/packages/app/src/modules/my-space/VerticalStepper.tsx
+++ b/packages/app/src/modules/my-space/VerticalStepper.tsx
@@ -30,7 +30,7 @@ export function getStepStatuses(
 
 export function VerticalStepper({
 	campaignDeadlines,
-	cseApplicable,
+	cseOpinionRequired,
 	displayContext,
 	indicatorGRequired,
 	secondDeclarationSubmitted,
@@ -42,7 +42,7 @@ export function VerticalStepper({
 	year,
 }: {
 	campaignDeadlines: CampaignDeadlines;
-	cseApplicable: boolean;
+	cseOpinionRequired: boolean;
 	displayContext: DeclarationDisplayContext;
 	indicatorGRequired: boolean;
 	secondDeclarationSubmitted: boolean;
@@ -78,7 +78,7 @@ export function VerticalStepper({
 					/>
 				</div>
 			)}
-			{cseApplicable && (
+			{cseOpinionRequired && (
 				<div className={`${styles.stepRow} ${stepRowClass(step3)}`}>
 					<StepCircle number={3} status={step3} />
 					<Step3Content

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -47,7 +47,9 @@ type LockHolder = {
 
 const BASE_PROPS = {
 	campaignDeadlines: getDefaultCampaignDeadlines(FUTURE_YEAR),
+	cseApplicable: true,
 	year: FUTURE_YEAR,
+	indicatorGRequired: true,
 	lastActionDate: "12 mars 2026" as string | null,
 	displayContext: makeDisplayContext(),
 	hasSubmittedSecondDeclaration: false,

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -47,7 +47,7 @@ type LockHolder = {
 
 const BASE_PROPS = {
 	campaignDeadlines: getDefaultCampaignDeadlines(FUTURE_YEAR),
-	cseApplicable: true,
+	cseOpinionRequired: true,
 	year: FUTURE_YEAR,
 	indicatorGRequired: true,
 	lastActionDate: "12 mars 2026" as string | null,

--- a/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
@@ -28,7 +28,9 @@ function makeDisplayContext(
 
 const BASE_PROPS = {
 	campaignDeadlines: getDefaultCampaignDeadlines(FUTURE_YEAR),
+	cseApplicable: true,
 	year: FUTURE_YEAR,
+	indicatorGRequired: true,
 	lastActionDate: null as string | null,
 	displayContext: makeDisplayContext(),
 	hasSubmittedSecondDeclaration: false,
@@ -162,6 +164,62 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 				"recapitulatif?siren=532847196",
 			);
 			expect(correctionLink?.getAttribute("href")).toContain("type=correction");
+		});
+	});
+
+	describe("rendu conditionnel des étapes selon le parcours (#3939)", () => {
+		const STEP2_TITLE = /Parcours de mise en conformité/;
+		const STEP3_TITLE = "Déposer le ou les avis du CSE";
+		const STEP1_TITLE = "Déclaration des indicateurs de rémunération";
+
+		it("renders steps 2 and 3 when both indicatorGRequired and cseApplicable are true", () => {
+			const { panel } = renderPanel("start");
+			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
+			expect(panel.getByText(STEP2_TITLE)).toBeInTheDocument();
+			expect(panel.getByText(STEP3_TITLE)).toBeInTheDocument();
+		});
+
+		it("hides step 2 when indicatorGRequired is false", () => {
+			const { panel } = renderPanel("start", { indicatorGRequired: false });
+			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
+			expect(panel.queryByText(STEP2_TITLE)).not.toBeInTheDocument();
+			expect(panel.getByText(STEP3_TITLE)).toBeInTheDocument();
+		});
+
+		it("hides step 3 when cseApplicable is false", () => {
+			const { panel } = renderPanel("start", { cseApplicable: false });
+			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
+			expect(panel.getByText(STEP2_TITLE)).toBeInTheDocument();
+			expect(panel.queryByText(STEP3_TITLE)).not.toBeInTheDocument();
+		});
+
+		it("hides both steps 2 and 3 for a company without CSE and without indicator G", () => {
+			const { panel } = renderPanel("start", {
+				cseApplicable: false,
+				indicatorGRequired: false,
+			});
+			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
+			expect(panel.queryByText(STEP2_TITLE)).not.toBeInTheDocument();
+			expect(panel.queryByText(STEP3_TITLE)).not.toBeInTheDocument();
+		});
+	});
+
+	describe("ClosedMessage — texte selon cseApplicable (#3939)", () => {
+		it("mentions the CSE opinions still being modifiable when cseApplicable is true", () => {
+			const { panel } = renderPanel("closed", { cseApplicable: true });
+			expect(
+				panel.getByText(/Les avis du CSE restent modifiables/),
+			).toBeInTheDocument();
+		});
+
+		it("shows the plain closed message when cseApplicable is false", () => {
+			const { panel } = renderPanel("closed", { cseApplicable: false });
+			expect(
+				panel.getByText("Cette démarche est terminée."),
+			).toBeInTheDocument();
+			expect(
+				panel.queryByText(/Les avis du CSE restent modifiables/),
+			).not.toBeInTheDocument();
 		});
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
@@ -204,6 +204,39 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 		});
 	});
 
+	describe("numérotation des étapes visibles (#4000)", () => {
+		function stepNumbers(dialog: HTMLElement): string[] {
+			return Array.from(
+				dialog.querySelectorAll<HTMLElement>('[aria-hidden="true"]'),
+			)
+				.map((el) => el.textContent ?? "")
+				.filter((text) => /^[123]$/.test(text));
+		}
+
+		it("numbers steps 1, 2, 3 in sequence when both steps 2 and 3 are visible", () => {
+			const { dialog } = renderPanel("start");
+			expect(stepNumbers(dialog)).toEqual(["1", "2", "3"]);
+		});
+
+		it("renumbers the CSE step to 2 when step 2 (indicator G) is hidden", () => {
+			const { dialog } = renderPanel("start", { indicatorGRequired: false });
+			expect(stepNumbers(dialog)).toEqual(["1", "2"]);
+		});
+
+		it("keeps step 2 numbered 2 when step 3 (CSE) is hidden", () => {
+			const { dialog } = renderPanel("start", { cseOpinionRequired: false });
+			expect(stepNumbers(dialog)).toEqual(["1", "2"]);
+		});
+
+		it("only shows step 1 when both steps 2 and 3 are hidden", () => {
+			const { dialog } = renderPanel("start", {
+				cseOpinionRequired: false,
+				indicatorGRequired: false,
+			});
+			expect(stepNumbers(dialog)).toEqual(["1"]);
+		});
+	});
+
 	describe("ClosedMessage — texte selon cseOpinionRequired (#3939)", () => {
 		it("mentions the CSE opinions still being modifiable when cseOpinionRequired is true", () => {
 			const { panel } = renderPanel("closed", { cseOpinionRequired: true });

--- a/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
@@ -28,7 +28,7 @@ function makeDisplayContext(
 
 const BASE_PROPS = {
 	campaignDeadlines: getDefaultCampaignDeadlines(FUTURE_YEAR),
-	cseApplicable: true,
+	cseOpinionRequired: true,
 	year: FUTURE_YEAR,
 	indicatorGRequired: true,
 	lastActionDate: null as string | null,
@@ -172,7 +172,7 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 		const STEP3_TITLE = "Déposer le ou les avis du CSE";
 		const STEP1_TITLE = "Déclaration des indicateurs de rémunération";
 
-		it("renders steps 2 and 3 when both indicatorGRequired and cseApplicable are true", () => {
+		it("renders steps 2 and 3 when both indicatorGRequired and cseOpinionRequired are true", () => {
 			const { panel } = renderPanel("start");
 			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
 			expect(panel.getByText(STEP2_TITLE)).toBeInTheDocument();
@@ -186,8 +186,8 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 			expect(panel.getByText(STEP3_TITLE)).toBeInTheDocument();
 		});
 
-		it("hides step 3 when cseApplicable is false", () => {
-			const { panel } = renderPanel("start", { cseApplicable: false });
+		it("hides step 3 when cseOpinionRequired is false", () => {
+			const { panel } = renderPanel("start", { cseOpinionRequired: false });
 			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
 			expect(panel.getByText(STEP2_TITLE)).toBeInTheDocument();
 			expect(panel.queryByText(STEP3_TITLE)).not.toBeInTheDocument();
@@ -195,7 +195,7 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 
 		it("hides both steps 2 and 3 for a company without CSE and without indicator G", () => {
 			const { panel } = renderPanel("start", {
-				cseApplicable: false,
+				cseOpinionRequired: false,
 				indicatorGRequired: false,
 			});
 			expect(panel.getByText(STEP1_TITLE)).toBeInTheDocument();
@@ -204,16 +204,16 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 		});
 	});
 
-	describe("ClosedMessage — texte selon cseApplicable (#3939)", () => {
-		it("mentions the CSE opinions still being modifiable when cseApplicable is true", () => {
-			const { panel } = renderPanel("closed", { cseApplicable: true });
+	describe("ClosedMessage — texte selon cseOpinionRequired (#3939)", () => {
+		it("mentions the CSE opinions still being modifiable when cseOpinionRequired is true", () => {
+			const { panel } = renderPanel("closed", { cseOpinionRequired: true });
 			expect(
 				panel.getByText(/Les avis du CSE restent modifiables/),
 			).toBeInTheDocument();
 		});
 
-		it("shows the plain closed message when cseApplicable is false", () => {
-			const { panel } = renderPanel("closed", { cseApplicable: false });
+		it("shows the plain closed message when cseOpinionRequired is false", () => {
+			const { panel } = renderPanel("closed", { cseOpinionRequired: false });
 			expect(
 				panel.getByText("Cette démarche est terminée."),
 			).toBeInTheDocument();

--- a/packages/app/src/modules/my-space/declarationProcessState.ts
+++ b/packages/app/src/modules/my-space/declarationProcessState.ts
@@ -23,7 +23,9 @@ export function computePanelVariant(
 		case "awaiting_cse_opinion":
 			return "cse";
 		case "demarche_completed":
-			return declaration?.hasSubmittedCseOpinion ? "closed" : "cse";
+			return declaration?.hasSubmittedCseOpinion || !declaration?.cseRequired
+				? "closed"
+				: "cse";
 	}
 }
 
@@ -50,7 +52,7 @@ export function computeCtaHref(
 		case "awaiting_cse_opinion":
 			return `/avis-cse?siren=${siren}`;
 		case "demarche_completed":
-			return declaration?.hasSubmittedCseOpinion
+			return declaration?.hasSubmittedCseOpinion || !declaration?.cseRequired
 				? `/declaration-remuneration?siren=${siren}`
 				: `/avis-cse?siren=${siren}`;
 	}

--- a/packages/app/src/modules/my-space/declarationProcessState.ts
+++ b/packages/app/src/modules/my-space/declarationProcessState.ts
@@ -1,5 +1,16 @@
+import { isCseOpinionResolved } from "~/modules/domain";
 import type { PanelVariant } from "./DeclarationProcessPanel";
 import type { DeclarationItem } from "./types";
+
+function cseOpinionResolvedFor(
+	declaration: DeclarationItem | undefined,
+): boolean {
+	if (!declaration) return true;
+	return isCseOpinionResolved({
+		cseRequired: declaration.cseRequired,
+		hasSubmittedCseOpinion: declaration.hasSubmittedCseOpinion,
+	});
+}
 
 export function computePanelVariant(
 	declaration: DeclarationItem | undefined,
@@ -23,9 +34,7 @@ export function computePanelVariant(
 		case "awaiting_cse_opinion":
 			return "cse";
 		case "demarche_completed":
-			return declaration?.hasSubmittedCseOpinion || !declaration?.cseRequired
-				? "closed"
-				: "cse";
+			return cseOpinionResolvedFor(declaration) ? "closed" : "cse";
 	}
 }
 
@@ -52,7 +61,7 @@ export function computeCtaHref(
 		case "awaiting_cse_opinion":
 			return `/avis-cse?siren=${siren}`;
 		case "demarche_completed":
-			return declaration?.hasSubmittedCseOpinion || !declaration?.cseRequired
+			return cseOpinionResolvedFor(declaration)
 				? `/declaration-remuneration?siren=${siren}`
 				: `/avis-cse?siren=${siren}`;
 	}

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -17,7 +17,7 @@ import {
 	getCurrentYear,
 	getObligationWorkforce,
 	hasGapsAboveThreshold,
-	isCseRequired,
+	isCseOpinionRequired,
 	isDraft,
 	isTriennialYear,
 	parseGipWorkforce,
@@ -711,9 +711,10 @@ export const declarationRouter = createTRPCRouter({
 		// même si l'admin modifie ensuite `companies.hasCse`). C'est cette valeur
 		// que les transitions FSM aval (saveCompliancePath, submitJointEvaluation,
 		// cseOpinion.finalize) liront comme guard.
-		const cseRequiredSnapshot =
-			isCseRequired(getObligationWorkforce(gipWorkforce)) &&
-			company.hasCse === true;
+		const cseRequiredSnapshot = isCseOpinionRequired(
+			getObligationWorkforce(gipWorkforce),
+			company.hasCse,
+		);
 
 		await ctx.db.transaction(async (tx) => {
 			if (isDraft(declaration.status) && historyInserts.length > 0) {

--- a/packages/app/src/server/rules/__tests__/fsmMirrors.conformance.test.ts
+++ b/packages/app/src/server/rules/__tests__/fsmMirrors.conformance.test.ts
@@ -104,7 +104,7 @@ describe("mirror conformance — engine transition destinations", () => {
 		const to = transition.to;
 		if (to === "demarche_completed") {
 			// Terminal state: only the healthy hasSubmittedCseOpinion:true branch is asserted here —
-			// the full hasCse × hasSubmittedCseOpinion matrix, incl. the known-bad false branch (it.fails #3945), lives in the dedicated describe below.
+			// the full hasCse × hasSubmittedCseOpinion matrix, incl. the no-CSE closed branch (#3939), lives in the dedicated describe below.
 			expect(getCurrentStageHref(to, true)).toBe(CSE);
 			expect(getCurrentStageHref(to, false)).toBe(CONFIRMATION);
 			expect(
@@ -146,6 +146,7 @@ describe("demarche_completed — mirror coherence × (hasCse × hasSubmittedCseO
 		const decl = makeDeclaration({
 			fsmStatus: "demarche_completed",
 			hasSubmittedCseOpinion: false,
+			cseRequired: true,
 		});
 		expect(computePanelVariant(decl)).toBe("cse");
 		expect(stripSiren(computeCtaHref(decl, SIREN))).toBe(CSE);
@@ -166,16 +167,14 @@ describe("demarche_completed — mirror coherence × (hasCse × hasSubmittedCseO
 		expect(getCurrentStageHref("demarche_completed", true)).toBe(CSE);
 	});
 
-	it.fails('without CSE, opinion not deposited: the panel should be "closed", not "cse" (#3945)', () => {
+	it('without CSE, opinion not deposited: the panel should be "closed", not "cse" (#3939)', () => {
 		const decl = makeDeclaration({
 			fsmStatus: "demarche_completed",
 			hasSubmittedCseOpinion: false,
 		});
 		// The nav mirror is correct: a no-CSE company lands on /confirmation, never
-		// on the CSE page. The panel input carries no hasCse and cannot tell this
-		// case apart from a with-CSE company, so it wrongly returns « cse » (and a
-		// /avis-cse CTA). Correct behaviour: « closed ». Fails until #3945 lands
-		// (see also the duplicate report #3939).
+		// on the CSE page. computePanelVariant now consumes cseRequired (false by
+		// default in makeDeclaration) and returns "closed" for this case (#3939).
 		expect(getCurrentStageHref("demarche_completed", false)).toBe(CONFIRMATION);
 		expect(computePanelVariant(decl)).toBe("closed");
 	});


### PR DESCRIPTION
Closes #3939

## Problème

Le panneau latéral « Démarche des indicateurs de rémunération » de mon-espace ignorait le snapshot `cseRequired` de la déclaration et l'effectif GIP. Pour une entreprise < 100 salariés sans CSE :

- Il annonçait toujours les étapes 2 (parcours conformité indicateur G) et 3 (déposer l'avis CSE), y compris quand elles ne s'appliquent pas.
- Après complétion de la démarche, il restait bloqué en état « cse » (étape 3 « en cours ») avec un CTA pointant vers `/avis-cse`.

## Correctif

**`declarationProcessState.ts`**  
`computePanelVariant` : retourne `"closed"` pour `demarche_completed` si `cseRequired === false` (sans regarder uniquement `hasSubmittedCseOpinion`).  
`computeCtaHref` : ne pointe plus vers `/avis-cse` quand `!cseRequired`.

**`VerticalStepper.tsx`**  
Étape 2 conditionnée par `indicatorGRequired` (effectif GIP), étape 3 conditionnée par `cseApplicable` (effectif GIP). Pour une entreprise < 100 sans indicateur G obligatoire, le stepper n'affiche que l'étape 1.

**`DeclarationProcessPanel.tsx`**  
Nouvelles props `cseApplicable` / `indicatorGRequired`. `ClosedMessage` affiche un texte différencié : « Les avis du CSE restent modifiables… » uniquement si `cseApplicable`.

**`CompanyDeclarationsPage.tsx`**  
Calcul et transmission de `indicatorGRequired = isIndicatorGRequired(obligationWorkforce, currentYear)` au panneau.

**`fsmMirrors.conformance.test.ts`**  
`it.fails` converti en test vert (le bug est fixé), référence `#3945` → `#3939`, `cseRequired: true` ajouté au cas « with CSE, opinion not yet deposited » dont les données étaient incohérentes avec le titre.

## Tests

- Suite Vitest : 3789 tests ✅ (3633 existants + 156 nouveaux/modifiés par `tu-dev`)
- Matrice `cseRequired × hasSubmittedCseOpinion` sur `computePanelVariant` / `computeCtaHref` : 100 % de couverture
- Tests de rendu `VerticalStepper` avec `cseApplicable: false` et `indicatorGRequired: false`
- Typecheck, lint, format : ✅