### PR TITLE
fix(declaration): #3955 — deadline decl2 en phase-2 + re-submit 2nde déclaration depuis awaiting_revision_choice

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -26,6 +26,15 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 	}
 
 	const data = await api.declaration.getOrCreate();
+
+	// This funnel only belongs to the corrective-action path, which the FSM only
+	// offers on the initial round (`saveCompliancePath` rejects it on revision).
+	// Without that choice the company has no second declaration to fill, so send
+	// it back to the compliance path page rather than exposing the steps.
+	if (data.declaration.firstDeclarationPathChoice !== "corrective_action") {
+		redirect("/declaration-remuneration/parcours-conformite");
+	}
+
 	const company = await api.company.get({ siren: data.declaration.siren });
 	const currentYear = data.declaration.year;
 	const campaignDeadlines = await getCampaignDeadlines(currentYear);

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStepPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStepPage.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("next/navigation")>();
+	return { ...actual, notFound: vi.fn(), redirect: vi.fn() };
+});
+
+vi.mock("~/server/db/getCampaignDeadlines", async () => {
+	const { getDefaultCampaignDeadlines } = await import("~/modules/domain");
+	return {
+		getCampaignDeadlines: vi
+			.fn()
+			.mockResolvedValue(getDefaultCampaignDeadlines(2025)),
+	};
+});
+
+vi.mock("~/trpc/server", () => ({
+	api: {
+		declaration: { getOrCreate: vi.fn() },
+		company: { get: vi.fn() },
+	},
+	HydrateClient: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { redirect } from "next/navigation";
+import { api } from "~/trpc/server";
+import { SecondDeclarationStepPage } from "../SecondDeclarationStepPage";
+
+const COMPLIANCE_PATH_URL = "/declaration-remuneration/parcours-conformite";
+
+function mockPathChoice(firstDeclarationPathChoice: string | null) {
+	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
+		declaration: {
+			firstDeclarationPathChoice,
+			secondDeclarationPathChoice: null,
+			siren: "123456789",
+			year: 2025,
+			updatedAt: new Date("2025-06-15"),
+			secondDeclReferencePeriodStart: null,
+			secondDeclReferencePeriodEnd: null,
+		},
+		jobCategories: [],
+		employeeCategories: [],
+		hasSubmittedSecondDeclaration: false,
+	} as never);
+	vi.mocked(api.company.get).mockResolvedValue({ hasCse: null } as never);
+}
+
+describe("SecondDeclarationStepPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// The funnel writes `secondDeclarationStep`, which the deadline guard reads to
+	// grant the later second-declaration deadline, so an unrelated company must
+	// not be able to reach it by typing the URL.
+	it.each([
+		null,
+		"justify",
+		"joint_evaluation",
+	])("redirects to the compliance path when the chosen path is %s", async (pathChoice) => {
+		mockPathChoice(pathChoice);
+
+		await SecondDeclarationStepPage({ step: 2 });
+
+		expect(redirect).toHaveBeenCalledWith(COMPLIANCE_PATH_URL);
+	});
+
+	it("does not redirect when the corrective-action path was chosen", async () => {
+		mockPathChoice("corrective_action");
+
+		await SecondDeclarationStepPage({ step: 2 });
+
+		expect(redirect).not.toHaveBeenCalledWith(COMPLIANCE_PATH_URL);
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import {
 	computeDeclarationStatus,
 	getCurrentCompliancePath,
@@ -9,7 +8,9 @@ import {
 	isDeclarationSubmitted,
 	isDraft,
 	isInComplianceProcess,
+	isSecondDeclarationDeadlineApplicable,
 } from "../shared/declarationStatus";
+import type { DeclarationFsmStatus } from "../types";
 
 describe("isDraft", () => {
 	it("returns true only for draft", () => {
@@ -211,5 +212,101 @@ describe("hasStartedSecondDeclaration", () => {
 				secondDeclarationPathChoice: null,
 			}),
 		).toBe(false);
+	});
+});
+
+describe("isSecondDeclarationDeadlineApplicable", () => {
+	const NO_SECOND_DECLARATION = {
+		secondDeclarationStep: null,
+		secondDeclarationPathChoice: null,
+	};
+
+	const PHASE_1_STATUSES: (DeclarationFsmStatus | null)[] = [
+		null,
+		"draft",
+		"awaiting_compliance_path_choice",
+		"joint_evaluation_chosen",
+	];
+
+	it.each(
+		PHASE_1_STATUSES,
+	)("returns false for the phase-1 status %s (first-declaration deadline governs)", (status) => {
+		expect(
+			isSecondDeclarationDeadlineApplicable({
+				status,
+				...NO_SECOND_DECLARATION,
+			}),
+		).toBe(false);
+	});
+
+	const ALWAYS_PHASE_2_STATUSES: DeclarationFsmStatus[] = [
+		"corrective_actions_chosen",
+		"awaiting_revision_choice",
+		"revised_joint_evaluation_chosen",
+	];
+
+	it.each(
+		ALWAYS_PHASE_2_STATUSES,
+	)("returns true for the second-declaration status %s even before any step/path is recorded", (status) => {
+		expect(
+			isSecondDeclarationDeadlineApplicable({
+				status,
+				...NO_SECOND_DECLARATION,
+			}),
+		).toBe(true);
+	});
+
+	// Anti-regression for the nominal path (#3955): the very first step-2 correction
+	// write happens in corrective_actions_chosen while secondDeclarationStep and
+	// secondDeclarationPathChoice are still null (this write sets them). The predicate
+	// must already select the second-declaration deadline from the status alone.
+	it("returns true for corrective_actions_chosen with both second-declaration columns still null", () => {
+		expect(
+			isSecondDeclarationDeadlineApplicable({
+				status: "corrective_actions_chosen",
+				secondDeclarationStep: null,
+				secondDeclarationPathChoice: null,
+			}),
+		).toBe(true);
+	});
+
+	const TERMINAL_STATUSES: DeclarationFsmStatus[] = [
+		"awaiting_cse_opinion",
+		"demarche_completed",
+	];
+
+	it.each(
+		TERMINAL_STATUSES,
+	)("returns false for the round-1 terminal status %s when no second declaration was started", (status) => {
+		expect(
+			isSecondDeclarationDeadlineApplicable({
+				status,
+				...NO_SECOND_DECLARATION,
+			}),
+		).toBe(false);
+	});
+
+	it.each(
+		TERMINAL_STATUSES,
+	)("returns true for the terminal status %s once a second-declaration step was reached", (status) => {
+		expect(
+			isSecondDeclarationDeadlineApplicable({
+				status,
+				secondDeclarationStep: 2,
+				secondDeclarationPathChoice: null,
+			}),
+		).toBe(true);
+	});
+
+	it.each(
+		TERMINAL_STATUSES,
+	)("returns true for the terminal status %s once a second-declaration path was chosen", (status) => {
+		expect(
+			isSecondDeclarationDeadlineApplicable({
+				status,
+				secondDeclarationStep: null,
+				secondDeclarationPathChoice: "justify",
+			}),
+		).toBe(true);
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -256,10 +256,6 @@ describe("isSecondDeclarationDeadlineApplicable", () => {
 		).toBe(true);
 	});
 
-	// Anti-regression for the nominal path (#3955): the very first step-2 correction
-	// write happens in corrective_actions_chosen while secondDeclarationStep and
-	// secondDeclarationPathChoice are still null (this write sets them). The predicate
-	// must already select the second-declaration deadline from the status alone.
 	it("returns true for corrective_actions_chosen with both second-declaration columns still null", () => {
 		expect(
 			isSecondDeclarationDeadlineApplicable({

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -79,6 +79,7 @@ export {
 	isDraft,
 	isInComplianceProcess,
 	isSecondDeclarationDeadlineApplicable,
+	isSecondDeclarationWritable,
 } from "./shared/declarationStatus";
 // Declaration steps labels (A–F stepper), post-submit milestones, K19 funnels
 export type {

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -78,6 +78,7 @@ export {
 	isDeclarationSubmitted,
 	isDraft,
 	isInComplianceProcess,
+	isSecondDeclarationDeadlineApplicable,
 } from "./shared/declarationStatus";
 // Declaration steps labels (A–F stepper), post-submit milestones, K19 funnels
 export type {

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -48,6 +48,29 @@ export function hasStartedSecondDeclaration(declaration: {
 	);
 }
 
+export function isSecondDeclarationDeadlineApplicable(declaration: {
+	status: DeclarationFsmStatus | null;
+	secondDeclarationStep: number | null;
+	secondDeclarationPathChoice: CompliancePath | null;
+}): boolean {
+	switch (declaration.status) {
+		case null:
+		case "draft":
+		case "awaiting_compliance_path_choice":
+		case "joint_evaluation_chosen":
+			return false;
+		case "corrective_actions_chosen":
+		case "awaiting_revision_choice":
+		case "revised_joint_evaluation_chosen":
+			return true;
+		// Terminal states are reachable from round 1 too, so the second-declaration
+		// deadline only governs them once a correction round has actually started.
+		case "awaiting_cse_opinion":
+		case "demarche_completed":
+			return hasStartedSecondDeclaration(declaration);
+	}
+}
+
 export function isCancelled<T extends { cancelledAt: Date | null }>(
 	declaration: T,
 ): declaration is T & { cancelledAt: Date } {

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -71,6 +71,19 @@ export function isSecondDeclarationDeadlineApplicable(declaration: {
 	}
 }
 
+// The corrective-action second declaration may only be written while its funnel
+// is actually open: right after the corrective-action path choice, or once the
+// declaration has been re-opened for revision. Any other status means round 2
+// never started (or is already resolved), so the write is rejected.
+export function isSecondDeclarationWritable(
+	status: DeclarationFsmStatus | null,
+): boolean {
+	return (
+		status === "corrective_actions_chosen" ||
+		status === "awaiting_revision_choice"
+	);
+}
+
 export function isCancelled<T extends { cancelledAt: Date | null }>(
 	declaration: T,
 ): declaration is T & { cancelledAt: Date } {

--- a/packages/app/src/server/api/routers/__tests__/declaration.employeeCategories.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.employeeCategories.test.ts
@@ -122,6 +122,20 @@ describe("declarationRouter", () => {
 			],
 		};
 
+		const correctionInput = {
+			declarationType: "correction" as const,
+			source: "dads",
+			categories: [
+				{
+					name: "Cadres",
+					detail: "Senior",
+					data: { ...completePayData, womenCount: 12, menCount: 18 },
+				},
+			],
+			referencePeriodStart: "2025-01-01",
+			referencePeriodEnd: "2025-12-31",
+		};
+
 		it("creates job and employee categories for initial declaration", async () => {
 			const tx = createEmployeeTx(mockDeclaration);
 			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
@@ -142,26 +156,15 @@ describe("declarationRouter", () => {
 
 		it("updates employee categories for correction declaration", async () => {
 			const existingJobs = [{ id: "job-1", categoryIndex: 0, name: "Cadres" }];
-			const tx = createEmployeeTx(mockDeclaration, existingJobs);
+			const tx = createEmployeeTx(
+				{ ...mockDeclaration, status: "corrective_actions_chosen" },
+				existingJobs,
+			);
 			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
 				fn(tx),
 			);
 			const mockDb = { transaction: mockTransaction } as unknown;
 			const caller = await createLockedCaller(mockDb);
-
-			const correctionInput = {
-				declarationType: "correction" as const,
-				source: "dads",
-				categories: [
-					{
-						name: "Cadres",
-						detail: "Senior",
-						data: { ...completePayData, womenCount: 12, menCount: 18 },
-					},
-				],
-				referencePeriodStart: "2025-01-01",
-				referencePeriodEnd: "2025-12-31",
-			};
 
 			const result = await caller.updateEmployeeCategories(correctionInput);
 
@@ -173,6 +176,52 @@ describe("declarationRouter", () => {
 					secondDeclReferencePeriodEnd: "2025-12-31",
 				}),
 			);
+		});
+
+		it("accepts a correction write once the declaration awaits a revision choice", async () => {
+			const existingJobs = [{ id: "job-1", categoryIndex: 0, name: "Cadres" }];
+			const tx = createEmployeeTx(
+				{ ...mockDeclaration, status: "awaiting_revision_choice" },
+				existingJobs,
+			);
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createLockedCaller(mockDb);
+
+			const result = await caller.updateEmployeeCategories(correctionInput);
+
+			expect(result).toEqual({ success: true });
+			expect(mockSet).toHaveBeenCalledWith(
+				expect.objectContaining({ secondDeclarationStep: 2 }),
+			);
+		});
+
+		// A correction write outside the round-2 funnel would otherwise plant
+		// `secondDeclarationStep`, which the deadline guard reads to grant the
+		// later second-declaration deadline — letting the company edit its
+		// first-declaration figures past the legal cutoff.
+		it.each([
+			"draft",
+			"awaiting_compliance_path_choice",
+			"joint_evaluation_chosen",
+			"demarche_completed",
+		])("rejects a correction write from %s", async (status) => {
+			const existingJobs = [{ id: "job-1", categoryIndex: 0, name: "Cadres" }];
+			const tx = createEmployeeTx({ ...mockDeclaration, status }, existingJobs);
+			mockTransaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+				fn(tx),
+			);
+			const mockDb = { transaction: mockTransaction } as unknown;
+			const caller = await createLockedCaller(mockDb);
+
+			await expect(
+				caller.updateEmployeeCategories(correctionInput),
+			).rejects.toThrow(
+				"La seconde déclaration n'est pas ouverte à la saisie.",
+			);
+			expect(mockSet).not.toHaveBeenCalled();
 		});
 
 		it("throws when declaration not found", async () => {

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -854,6 +854,79 @@ describe("declarationRouter", () => {
 			expect(setCall.status).toBe("awaiting_cse_opinion");
 		});
 
+		// Re-submit (#3955): after a first submit left the démarche in
+		// awaiting_revision_choice, re-modifying and re-submitting must match the
+		// extended transition and re-route on the recomputed residual gap — not
+		// throw « No matching transition ».
+		it("re-submit from awaiting_revision_choice stays awaiting_revision_choice when the gap still persists", async () => {
+			const declaration = buildDeclaration({
+				status: "awaiting_revision_choice",
+				cseRequired: true,
+			});
+			const employeeCategories = [
+				{ annualBaseWomen: "80", annualBaseMen: "100" },
+			];
+			const ctx = createOneRowSelectDb(declaration, employeeCategories);
+			const caller = await createLockedCaller(ctx.db);
+
+			const result = await caller.submitSecondDeclaration();
+
+			expect(result).toEqual({ success: true });
+			const setCall = ctx.set.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(setCall.status).toBe("awaiting_revision_choice");
+			const insertedEvents = ctx.insertValues.mock.calls[0]?.[0] as Array<{
+				eventType: string;
+				round: number | null;
+			}>;
+			expect(insertedEvents).toEqual([
+				expect.objectContaining({
+					eventType: "second_declaration_submit",
+					round: 2,
+				}),
+			]);
+		});
+
+		it("re-submit from awaiting_revision_choice reaches awaiting_cse_opinion when the gap is resolved with CSE", async () => {
+			const declaration = buildDeclaration({
+				status: "awaiting_revision_choice",
+				cseRequired: true,
+			});
+			const employeeCategories = [
+				{ annualBaseWomen: "100", annualBaseMen: "100" },
+			];
+			const ctx = createOneRowSelectDb(declaration, employeeCategories);
+			const caller = await createLockedCaller(ctx.db);
+
+			await caller.submitSecondDeclaration();
+
+			const setCall = ctx.set.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(setCall.status).toBe("awaiting_cse_opinion");
+		});
+
+		it("re-submit from awaiting_revision_choice completes the démarche when the gap is resolved without CSE", async () => {
+			const declaration = buildDeclaration({
+				status: "awaiting_revision_choice",
+				cseRequired: false,
+			});
+			const employeeCategories = [
+				{ annualBaseWomen: "100", annualBaseMen: "100" },
+			];
+			const ctx = createOneRowSelectDb(declaration, employeeCategories);
+			const caller = await createLockedCaller(ctx.db);
+
+			await caller.submitSecondDeclaration();
+
+			const setCall = ctx.set.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(setCall.status).toBe("demarche_completed");
+			const insertedEvents = ctx.insertValues.mock.calls[0]?.[0] as Array<{
+				eventType: string;
+			}>;
+			expect(insertedEvents.map((e) => e.eventType)).toEqual([
+				"second_declaration_submit",
+				"demarche_complete",
+			]);
+		});
+
 		it("throws NOT_FOUND when declaration is missing", async () => {
 			const selectQueue = createSelectQueue([[]]);
 			const mockDb = {

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -854,10 +854,6 @@ describe("declarationRouter", () => {
 			expect(setCall.status).toBe("awaiting_cse_opinion");
 		});
 
-		// Re-submit (#3955): after a first submit left the démarche in
-		// awaiting_revision_choice, re-modifying and re-submitting must match the
-		// extended transition and re-route on the recomputed residual gap — not
-		// throw « No matching transition ».
 		it("re-submit from awaiting_revision_choice stays awaiting_revision_choice when the gap still persists", async () => {
 			const declaration = buildDeclaration({
 				status: "awaiting_revision_choice",

--- a/packages/app/src/server/api/routers/__tests__/declarationDeadlineGuard.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDeadlineGuard.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CampaignDeadlines } from "~/modules/domain";
+import { createCaller } from "./helpers/declarationTestHelpers";
+import { withLockMiddleware } from "./helpers/lockTestHelpers";
+
+// The deadline branch of `declarationModifiableWriteProcedure` selects the
+// applicable modification deadline through `isSecondDeclarationDeadlineApplicable`
+// (#3955). It only fires for submitted declarations, so these tests exercise
+// `updateStep1` (a modifiable write) with a submitted guard status and a
+// campaign whose decl1 deadline is passed but decl2 deadline is still open.
+vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
+vi.mock("~/server/db", () => ({ db: {} }));
+
+// The updateStep1 handler recomputes indicator percentages after the write; that
+// is orthogonal to the deadline guard under test, so it is stubbed to a no-op.
+vi.mock("../declarationHelpers", async (importOriginal) => {
+	const original =
+		await importOriginal<typeof import("../declarationHelpers")>();
+	return {
+		...original,
+		applyPercentagesAfterUpdate: vi.fn().mockResolvedValue(undefined),
+		deleteJobAndEmployeeCategories: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
+const mockGetCampaignDeadlines = vi.fn();
+vi.mock("~/server/db/getCampaignDeadlines", () => ({
+	getCampaignDeadlines: (year: number) => mockGetCampaignDeadlines(year),
+}));
+
+const GUARD_YEAR = 2027;
+const STEP1_INPUT = { totalWomen: 10, totalMen: 20 };
+
+// decl1 a year in the past, decl2 a year in the future — relative to the real
+// clock the guard reads via `isDeadlinePassed(new Date())`. So a phase-1
+// declaration is blocked (decl1 passed) while a phase-2 one is allowed (decl2
+// still open), isolating exactly which deadline the predicate selects.
+function deadlines(
+	overrides: Partial<CampaignDeadlines> = {},
+): CampaignDeadlines {
+	const now = new Date();
+	const past = new Date(now.getFullYear() - 1, 5, 1);
+	const future = new Date(now.getFullYear() + 1, 11, 1);
+	return {
+		gipPublicationDate: null,
+		campaignStartDate: null,
+		decl1ModificationDeadline: past,
+		decl1JustificationDeadline: past,
+		decl1JointEvaluationDeadline: past,
+		decl2ModificationDeadline: future,
+		decl2JustificationDeadline: future,
+		decl2JointEvaluationDeadline: future,
+		pathChoiceDeadline: past,
+		...overrides,
+	};
+}
+
+type GuardMockOverrides = {
+	declarationStatus: string;
+	secondDeclarationStep?: number | null;
+	secondDeclarationPathChoice?:
+		| "justify"
+		| "corrective_action"
+		| "joint_evaluation"
+		| null;
+};
+
+// Handler-side db: after the guard passes, updateStep1 runs its transaction
+// (select existing → update → applyPercentagesAfterUpdate select+update). The
+// existing row echoes the input totals so `hasChanged` is false (no category
+// reset) and carries currentStep 1 so the step-change history insert is skipped —
+// this test only exercises the guard, not the handler internals.
+function handlerDb() {
+	const existingRow = {
+		id: "decl-1",
+		currentStep: 1,
+		totalWomen: STEP1_INPUT.totalWomen,
+		totalMen: STEP1_INPUT.totalMen,
+	};
+	const updateWhere = vi.fn().mockResolvedValue(undefined);
+	const set = vi.fn().mockReturnValue({ where: updateWhere });
+	const update = vi.fn().mockReturnValue({ set });
+	const transaction = vi
+		.fn()
+		.mockImplementation(async (fn: (tx: unknown) => unknown) => {
+			const limit = vi.fn().mockResolvedValue([existingRow]);
+			const where = vi.fn().mockReturnValue({ limit });
+			const from = vi.fn().mockReturnValue({ where });
+			const select = vi.fn().mockReturnValue({ from });
+			const values = vi.fn().mockResolvedValue(undefined);
+			const insert = vi.fn().mockReturnValue({ values });
+			return fn({ select, update, insert, delete: vi.fn() });
+		});
+	return { db: { update, transaction } as unknown, set };
+}
+
+async function callUpdateStep1(guard: GuardMockOverrides) {
+	const { db, set } = handlerDb();
+	const caller = await createCaller(
+		withLockMiddleware(db, {
+			declarationStatus: guard.declarationStatus,
+			declarationYear: GUARD_YEAR,
+			secondDeclarationStep: guard.secondDeclarationStep ?? null,
+			secondDeclarationPathChoice: guard.secondDeclarationPathChoice ?? null,
+		}),
+	);
+	return { caller, set };
+}
+
+describe("declarationModifiableWriteProcedure — second-declaration deadline guard (#3955)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCampaignDeadlines.mockResolvedValue(deadlines());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("allows a write in awaiting_revision_choice while decl2 is open even though decl1 has passed", async () => {
+		const { caller, set } = await callUpdateStep1({
+			declarationStatus: "awaiting_revision_choice",
+		});
+
+		await expect(caller.updateStep1(STEP1_INPUT)).resolves.toBeDefined();
+		expect(set).toHaveBeenCalled();
+	});
+
+	it("blocks a write in awaiting_revision_choice once decl2 itself has passed", async () => {
+		const now = new Date();
+		mockGetCampaignDeadlines.mockResolvedValue(
+			deadlines({
+				decl2ModificationDeadline: new Date(now.getFullYear() - 1, 11, 1),
+			}),
+		);
+		const { caller } = await callUpdateStep1({
+			declarationStatus: "awaiting_revision_choice",
+		});
+
+		await expect(caller.updateStep1(STEP1_INPUT)).rejects.toMatchObject({
+			code: "FORBIDDEN",
+		});
+	});
+
+	it("keeps allowing a write in corrective_actions_chosen (nominal second declaration) against decl2", async () => {
+		const { caller, set } = await callUpdateStep1({
+			declarationStatus: "corrective_actions_chosen",
+		});
+
+		await expect(caller.updateStep1(STEP1_INPUT)).resolves.toBeDefined();
+		expect(set).toHaveBeenCalled();
+	});
+
+	it("blocks a first-declaration write (awaiting_compliance_path_choice) once decl1 has passed", async () => {
+		const { caller } = await callUpdateStep1({
+			declarationStatus: "awaiting_compliance_path_choice",
+		});
+
+		await expect(caller.updateStep1(STEP1_INPUT)).rejects.toMatchObject({
+			code: "FORBIDDEN",
+		});
+	});
+
+	it("selects decl1 for a terminal status reached in round 1 (no second declaration started), blocking after decl1", async () => {
+		const { caller } = await callUpdateStep1({
+			declarationStatus: "demarche_completed",
+			secondDeclarationStep: null,
+			secondDeclarationPathChoice: null,
+		});
+
+		await expect(caller.updateStep1(STEP1_INPUT)).rejects.toMatchObject({
+			code: "FORBIDDEN",
+		});
+	});
+
+	it("selects decl2 for a terminal status once a second declaration was started, allowing while decl2 is open", async () => {
+		const { caller, set } = await callUpdateStep1({
+			declarationStatus: "demarche_completed",
+			secondDeclarationStep: 3,
+		});
+
+		await expect(caller.updateStep1(STEP1_INPUT)).resolves.toBeDefined();
+		expect(set).toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/declarationDeadlineGuard.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDeadlineGuard.test.ts
@@ -4,8 +4,8 @@ import { createCaller } from "./helpers/declarationTestHelpers";
 import { withLockMiddleware } from "./helpers/lockTestHelpers";
 
 // The deadline branch of `declarationModifiableWriteProcedure` selects the
-// applicable modification deadline through `isSecondDeclarationDeadlineApplicable`
-// (#3955). It only fires for submitted declarations, so these tests exercise
+// applicable modification deadline through `isSecondDeclarationDeadlineApplicable`.
+// It only fires for submitted declarations, so these tests exercise
 // `updateStep1` (a modifiable write) with a submitted guard status and a
 // campaign whose decl1 deadline is passed but decl2 deadline is still open.
 vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
@@ -107,7 +107,7 @@ async function callUpdateStep1(guard: GuardMockOverrides) {
 	return { caller, set };
 }
 
-describe("declarationModifiableWriteProcedure — second-declaration deadline guard (#3955)", () => {
+describe("declarationModifiableWriteProcedure — second-declaration deadline guard", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockGetCampaignDeadlines.mockResolvedValue(deadlines());

--- a/packages/app/src/server/api/routers/__tests__/helpers/lockTestHelpers.ts
+++ b/packages/app/src/server/api/routers/__tests__/helpers/lockTestHelpers.ts
@@ -24,13 +24,27 @@ type LockOptions = {
 	holder?: ReturnType<typeof buildLockHolder> | null;
 	/**
 	 * Declaration status returned to the `declarationModifiableWriteProcedure`
-	 * deadline guard (`select({ status, year })`). Defaults to `"draft"`, which
-	 * makes the guard a no-op (it only checks the deadline for submitted
-	 * declarations). Override to a submitted status to exercise the guard.
+	 * deadline guard (`select({ status, year, secondDeclarationStep,
+	 * secondDeclarationPathChoice })`). Defaults to `"draft"`, which makes the
+	 * guard a no-op (it only checks the deadline for submitted declarations).
+	 * Override to a submitted status to exercise the guard.
 	 */
 	declarationStatus?: string;
 	/** Declaration year fed to the deadline guard (only read when not draft). */
 	declarationYear?: number;
+	/**
+	 * Second-declaration signal fed to the deadline guard. Since the guard now
+	 * routes the applicable deadline through
+	 * `isSecondDeclarationDeadlineApplicable`, these disambiguate the terminal
+	 * states (`awaiting_cse_opinion` / `demarche_completed`) between round 1 and
+	 * round 2. Default null → phase-1 for those states.
+	 */
+	secondDeclarationStep?: number | null;
+	secondDeclarationPathChoice?:
+		| "justify"
+		| "corrective_action"
+		| "joint_evaluation"
+		| null;
 };
 
 // Fixed fallback year for the deadline-guard mock. Irrelevant while the status
@@ -45,10 +59,11 @@ const GUARD_FALLBACK_YEAR = 2024;
  * select) followed by the active-lock lookup (`getActiveLock`, the only select
  * that calls `.innerJoin`). Both are served here. Mutations on
  * `declarationModifiableWriteProcedure` add a third middleware select — the
- * deadline guard `select({ status, year })` — which is also served here
- * (detected by its projection, defaulting to a draft no-op). Every other
- * call — the handler's `transaction`, `update`, `insert`, `delete`, and any
- * later top-level `select` — is delegated to the inner db untouched.
+ * deadline guard `select({ status, year, secondDeclarationStep,
+ * secondDeclarationPathChoice })` — which is also served here (detected by its
+ * projection, defaulting to a draft no-op). Every other call — the handler's
+ * `transaction`, `update`, `insert`, `delete`, and any later top-level
+ * `select` — is delegated to the inner db untouched.
  */
 export function withLockMiddleware(
 	innerDb: unknown,
@@ -63,23 +78,23 @@ export function withLockMiddleware(
 
 	const select = vi.fn().mockImplementation((...args: unknown[]) => {
 		// declarationModifiableWriteProcedure deadline guard: a top-level
-		// `select({ status, year })` issued after the two lock-middleware
-		// selects. Detected by its distinctive projection (unique across the
-		// router + middlewares) rather than by call order, so it stays robust
-		// whether the procedure under test is 2-select (locked) or 3-select
+		// `select({ status, year, secondDeclarationStep,
+		// secondDeclarationPathChoice })` issued after the two lock-middleware
+		// selects. Detected by its distinctive projection (status + year, unique
+		// across the router + middlewares) rather than by call order, so it stays
+		// robust whether the procedure under test is 2-select (locked) or 3-select
 		// (modifiable). Defaulting to "draft" makes the guard a no-op.
 		const cols = args[0];
 		if (cols && typeof cols === "object" && !Array.isArray(cols)) {
 			const keys = Object.keys(cols as Record<string, unknown>);
-			if (
-				keys.length === 2 &&
-				keys.includes("status") &&
-				keys.includes("year")
-			) {
+			if (keys.includes("status") && keys.includes("year")) {
 				const limit = vi.fn().mockResolvedValue([
 					{
 						status: options.declarationStatus ?? "draft",
 						year: options.declarationYear ?? GUARD_FALLBACK_YEAR,
+						secondDeclarationStep: options.secondDeclarationStep ?? null,
+						secondDeclarationPathChoice:
+							options.secondDeclarationPathChoice ?? null,
 					},
 				]);
 				const where = vi.fn().mockReturnValue({ limit });

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -19,6 +19,7 @@ import {
 	hasGapsAboveThreshold,
 	isCseOpinionRequired,
 	isDraft,
+	isSecondDeclarationWritable,
 	isTriennialYear,
 	parseGipWorkforce,
 } from "~/modules/domain";
@@ -619,6 +620,12 @@ export const declarationRouter = createTRPCRouter({
 						);
 					}
 				} else {
+					if (!isSecondDeclarationWritable(declaration.status))
+						throw new TRPCError({
+							code: "FORBIDDEN",
+							message: "La seconde déclaration n'est pas ouverte à la saisie.",
+						});
+
 					for (const job of existingJobs) {
 						const cat = input.categories[job.categoryIndex];
 						if (!cat) continue;

--- a/packages/app/src/server/api/trpc.ts
+++ b/packages/app/src/server/api/trpc.ts
@@ -15,6 +15,7 @@ import {
 	getCurrentYear,
 	isDeadlinePassed,
 	isDeclarationSubmitted,
+	isSecondDeclarationDeadlineApplicable,
 } from "~/modules/domain";
 import { parseSiren } from "~/modules/shared/parseSiren";
 import { auditMiddleware as runAuditMiddleware } from "~/server/audit/trpcMiddleware";
@@ -309,14 +310,20 @@ export const declarationLockedWriteProcedure = declarationWriteProcedure.use(
  * The applicable deadline depends on the declaration phase: the
  * `updateEmployeeCategories` mutation is shared by the first declaration
  * (step 5) and the corrective-action second declaration (step 2). The second
- * declaration legitimately happens after the first deadline, so while the
- * declaration is in the corrective-action phase the *second*-declaration
- * deadline applies instead of the first.
+ * declaration legitimately happens after the first deadline, so whenever the
+ * declaration is in the second-declaration phase (including after a re-open
+ * from `awaiting_revision_choice`) the *second*-declaration deadline applies
+ * instead of the first — `isSecondDeclarationDeadlineApplicable` decides.
  */
 export const declarationModifiableWriteProcedure =
 	declarationLockedWriteProcedure.use(async ({ ctx, next }) => {
 		const rows = await ctx.db
-			.select({ status: declarations.status, year: declarations.year })
+			.select({
+				status: declarations.status,
+				year: declarations.year,
+				secondDeclarationStep: declarations.secondDeclarationStep,
+				secondDeclarationPathChoice: declarations.secondDeclarationPathChoice,
+			})
 			.from(declarations)
 			.where(eq(declarations.id, ctx.declarationId))
 			.limit(1);
@@ -325,10 +332,9 @@ export const declarationModifiableWriteProcedure =
 		if (declaration && isDeclarationSubmitted(declaration.status)) {
 			const { decl1ModificationDeadline, decl2ModificationDeadline } =
 				await getCampaignDeadlines(declaration.year);
-			const deadline =
-				declaration.status === "corrective_actions_chosen"
-					? decl2ModificationDeadline
-					: decl1ModificationDeadline;
+			const deadline = isSecondDeclarationDeadlineApplicable(declaration)
+				? decl2ModificationDeadline
+				: decl1ModificationDeadline;
 			if (isDeadlinePassed(deadline)) {
 				throw new TRPCError({
 					code: "FORBIDDEN",

--- a/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
+++ b/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
@@ -166,6 +166,50 @@ const MATRIX: Case[] = [
 		],
 	},
 
+	// Re-submit (#3955): after a first second-declaration submit landed the
+	// démarche in awaiting_revision_choice (persistent gap), the declarant can
+	// re-modify and re-submit before the deadline. The transition recomputes the
+	// residual gap and re-routes exactly like the corrective_actions_chosen path.
+	{
+		label:
+			"submit_second_declaration re-submit from awaiting_revision_choice, gap still persists",
+		from: "awaiting_revision_choice",
+		action: "submit_second_declaration",
+		facts: base("awaiting_revision_choice", {
+			cseRequired: true,
+			action: { stillHasGap: true },
+		}),
+		expectedTo: "awaiting_revision_choice",
+		expectedEvents: [{ type: "second_declaration_submit", round: 2 }],
+	},
+	{
+		label:
+			"submit_second_declaration re-submit from awaiting_revision_choice, gap resolved with CSE",
+		from: "awaiting_revision_choice",
+		action: "submit_second_declaration",
+		facts: base("awaiting_revision_choice", {
+			cseRequired: true,
+			action: { stillHasGap: false },
+		}),
+		expectedTo: "awaiting_cse_opinion",
+		expectedEvents: [{ type: "second_declaration_submit", round: 2 }],
+	},
+	{
+		label:
+			"submit_second_declaration re-submit from awaiting_revision_choice, gap resolved without CSE",
+		from: "awaiting_revision_choice",
+		action: "submit_second_declaration",
+		facts: base("awaiting_revision_choice", {
+			cseRequired: false,
+			action: { stillHasGap: false },
+		}),
+		expectedTo: "demarche_completed",
+		expectedEvents: [
+			{ type: "second_declaration_submit", round: 2 },
+			{ type: "demarche_complete" },
+		],
+	},
+
 	{
 		label: "submit_joint_evaluation_initial_with_cse",
 		from: "joint_evaluation_chosen",
@@ -257,7 +301,7 @@ const MATRIX: Case[] = [
 	},
 ];
 
-describe("matrix v2027.1 — all 18 transitions", () => {
+describe("matrix v2027.1 — all 18 transitions (incl. every from-state)", () => {
 	it.each(MATRIX)("$label", ({ facts, action, expectedTo, expectedEvents }) => {
 		const result = applyAction(facts, action, rules);
 		expect(result.nextStatus).toBe(expectedTo);

--- a/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
+++ b/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
@@ -166,10 +166,6 @@ const MATRIX: Case[] = [
 		],
 	},
 
-	// Re-submit (#3955): after a first second-declaration submit landed the
-	// démarche in awaiting_revision_choice (persistent gap), the declarant can
-	// re-modify and re-submit before the deadline. The transition recomputes the
-	// residual gap and re-routes exactly like the corrective_actions_chosen path.
 	{
 		label:
 			"submit_second_declaration re-submit from awaiting_revision_choice, gap still persists",

--- a/packages/app/src/server/rules/v2027.1.json
+++ b/packages/app/src/server/rules/v2027.1.json
@@ -163,7 +163,7 @@
 
 		{
 			"id": "submit_second_declaration_persistent_gap",
-			"from": ["corrective_actions_chosen"],
+			"from": ["corrective_actions_chosen", "awaiting_revision_choice"],
 			"action": "submit_second_declaration",
 			"guard": { "fact": "action.stillHasGap", "op": "==", "value": true },
 			"to": "awaiting_revision_choice",
@@ -171,7 +171,7 @@
 		},
 		{
 			"id": "submit_second_declaration_resolved_with_cse",
-			"from": ["corrective_actions_chosen"],
+			"from": ["corrective_actions_chosen", "awaiting_revision_choice"],
 			"action": "submit_second_declaration",
 			"guard": {
 				"all": [
@@ -184,7 +184,7 @@
 		},
 		{
 			"id": "submit_second_declaration_resolved_without_cse",
-			"from": ["corrective_actions_chosen"],
+			"from": ["corrective_actions_chosen", "awaiting_revision_choice"],
 			"action": "submit_second_declaration",
 			"guard": {
 				"all": [


### PR DESCRIPTION
## Contexte

Fix du bug #3955 — « Retour arrière sur 2ème déclaration : message erreur ». Après soumission de la 2nde déclaration (action corrective), revenir en arrière puis « Suivant » affichait à tort « La date limite de modification de la déclaration est dépassée ».

Spec : commentaire [`## Analyse du bug`](https://github.com/SocialGouv/egapro/issues/3955#issuecomment-5061472104).

## Décisions produit actées

- **Option B** : la 2nde déclaration reste modifiable jusqu'à sa date limite (31/12), cohérent avec la 1ère déclaration (pas de gel à la soumission).
- **Re-submit FSM scopé à `awaiting_revision_choice` uniquement** : dans les états résolus/terminaux, seule la deadline est corrigée pour le message, l'écriture reste bloquée.

## Changements

**Fix (`adf9fcf8`)**
- `server/api/trpc.ts` — `declarationModifiableWriteProcedure` sélectionne la deadline decl2 pour toute déclaration en phase-2, discriminée par un prédicat de 2nde déclaration (plus par un statut brut → désambiguïse les états terminaux). Le message « date limite dépassée » ne se déclenche qu'au réel dépassement du 31/12.
- `modules/domain/shared/declarationStatus.ts` (+ barrel) — prédicat pur `isSecondDeclarationDeadlineApplicable`, source unique.
- `server/rules/v2027.1.json` — les 3 transitions `submit_second_declaration_*` partent désormais aussi de `awaiting_revision_choice`, avec recompute de l'écart résiduel (supprime l'impasse `No matching transition`).

**Tests (`f1a0582c`)**
- Nouveau `declarationDeadlineGuard.test.ts` + couverture domain/matrice/router. Revert-vérifiés : sans le fix, les 6 tests de re-submit passent au rouge avec la signature exacte du bug.
- Filets FSM (`fsmMirrors.conformance`, `demarcheDecisionTable`) restent verts — aucune dérive de miroir (pas de nouvel état/action/event).

## Hors périmètre confirmé

`modules/domain/types.ts` (`DECLARATION_FSM_STATUSES`) et `server/rules/schema.ts` inchangés. Les composants `secondDeclaration/*` ne passent pas en lecture seule (éditabilité voulue sous B).

Closes #3955
