### PR TITLE
fix(banner): retirer le code NAF et restaurer le libellé de l'effectif dans CompanyBanner

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx
@@ -14,8 +14,6 @@ type CompanyBannerProps = {
 	company: {
 		name: string;
 		siren: string;
-		nafCode: string | null;
-		nafLabel: string | null;
 		gipWorkforce: number | null;
 		hasCse: boolean | null;
 	};
@@ -49,28 +47,15 @@ export function CompanyBanner({
 						<strong>{formatSiren(company.siren)}</strong>
 					</div>
 
-					{company.nafCode && (
-						<div className={styles.datapoint}>
-							<span>{"Code NAF :"}</span>
-							<strong>
-								{company.nafLabel
-									? `${company.nafCode} — ${company.nafLabel}`
-									: company.nafCode}
-							</strong>
-						</div>
-					)}
-
 					<div className={styles.datapoint}>
-						{company.gipWorkforce === null ? (
-							<span>{GIP_WORKFORCE_ABSENT_DISPLAY}</span>
-						) : (
-							<>
-								<span>
-									{"Effectif annuel moyen en"} {getWorkforceYear()} {":"}
-								</span>
-								<strong>{toDisplayWorkforce(company.gipWorkforce)}</strong>
-							</>
-						)}
+						<span>
+							{"Effectif annuel moyen en"} {getWorkforceYear()} {":"}
+						</span>
+						<strong>
+							{company.gipWorkforce !== null
+								? toDisplayWorkforce(company.gipWorkforce)
+								: GIP_WORKFORCE_ABSENT_DISPLAY}
+						</strong>
 					</div>
 
 					{cseApplicable && (

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/CompanyBanner.test.tsx
@@ -7,8 +7,6 @@ import { CompanyBanner } from "../CompanyBanner";
 const defaultCompany = {
 	name: "Alpha Solutions",
 	siren: "123456789",
-	nafCode: "62.01Z",
-	nafLabel: "Programmation informatique",
 	gipWorkforce: 256,
 	hasCse: true,
 };
@@ -49,43 +47,6 @@ describe("CompanyBanner", () => {
 		expect(boldName).toHaveClass("fr-text--bold");
 	});
 
-	it("renders NAF code with its activity label", () => {
-		render(
-			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
-		);
-
-		expect(screen.getByText("Code NAF :")).toBeInTheDocument();
-		expect(
-			screen.getByText("62.01Z — Programmation informatique"),
-		).toBeInTheDocument();
-	});
-
-	it("renders NAF code alone when the label is null", () => {
-		render(
-			<CompanyBanner
-				company={{ ...defaultCompany, nafLabel: null }}
-				currentPageLabel="Déclaration"
-			/>,
-		);
-
-		expect(screen.getByText("Code NAF :")).toBeInTheDocument();
-		expect(screen.getByText("62.01Z")).toBeInTheDocument();
-		expect(
-			screen.queryByText(/Programmation informatique/),
-		).not.toBeInTheDocument();
-	});
-
-	it("hides the NAF datapoint when nafCode is null", () => {
-		render(
-			<CompanyBanner
-				company={{ ...defaultCompany, nafCode: null, nafLabel: null }}
-				currentPageLabel="Déclaration"
-			/>,
-		);
-
-		expect(screen.queryByText("Code NAF :")).not.toBeInTheDocument();
-	});
-
 	it("renders workforce and CSE values", () => {
 		render(
 			<CompanyBanner company={defaultCompany} currentPageLabel="Déclaration" />,
@@ -95,7 +56,7 @@ describe("CompanyBanner", () => {
 		expect(screen.getByText("Oui")).toBeInTheDocument();
 	});
 
-	it("shows '< 50' and hides the CSE datapoint when gipWorkforce is null", () => {
+	it("keeps the workforce label and shows '< 50' as value when gipWorkforce is null, hiding the CSE datapoint", () => {
 		render(
 			<CompanyBanner
 				company={{ ...defaultCompany, gipWorkforce: null }}
@@ -103,10 +64,8 @@ describe("CompanyBanner", () => {
 			/>,
 		);
 
+		expect(screen.getByText(/Effectif annuel moyen en/)).toBeInTheDocument();
 		expect(screen.getByText(GIP_WORKFORCE_ABSENT_DISPLAY)).toBeInTheDocument();
-		expect(
-			screen.queryByText(/Effectif annuel moyen en/),
-		).not.toBeInTheDocument();
 		expect(screen.queryByText("Existence d'un CSE :")).not.toBeInTheDocument();
 	});
 


### PR DESCRIPTION
Closes #4011

## Problème

Le bandeau entreprise de la démarche des indicateurs de rémunération présentait deux écarts par rapport au node Figma courant (`9235-223992`) :

1. **Datapoint « Code NAF » en trop** — introduit par #3532 sur un node Figma désormais obsolète (`9235-223932`). La maquette courante ne comporte pas ce datapoint.
2. **Libellé de l'effectif absent** quand `gipWorkforce = null` — seule la valeur `< 50` était affichée, sans le label « Effectif annuel moyen en \<année\> : ».

## Fix

Fichier unique : `packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.tsx`

- **Suppression** du bloc `{company.nafCode && ...}` (datapoint NAF)
- **Nettoyage** de `nafCode` / `nafLabel` dans `CompanyBannerProps`
- **Séparation** label/valeur pour l'effectif : le `<span>` label est rendu inconditionnellement ; seule la `<strong>` bascule entre la valeur numérique et `GIP_WORKFORCE_ABSENT_DISPLAY`

Les autres consommateurs du code NAF (récapitulatif, Mon espace, admin, PDF) ne sont **pas touchés**.

## Bandeau attendu

> **Nom entreprise** · SIREN : **XXX XXX XXX** · Effectif annuel moyen en 2026 : **\<valeur\>** · Existence d'un CSE : **Oui/Non** *(si applicable)*

## Test plan

- [ ] Vérifier le rendu état 1 : `gipWorkforce` connu → valeur numérique avec label
- [ ] Vérifier le rendu état 2 : `gipWorkforce = null` → `< 50` **avec** label (régression corrigée)
- [ ] Vérifier que le datapoint « Code NAF » n'apparaît plus
- [ ] Vérifier que le datapoint CSE reste présent pour les effectifs ≥ 50
- [ ] Vérifier les autres écrans NAF (Mon espace, récapitulatif) — non impactés

## Vérification visuelle

Rapport complet du gate `design-validator` (mesures DOM vs node Figma `9235-223992`, 2 viewports, 2 états) : https://github.com/SocialGouv/egapro/issues/4011#issuecomment-5090133423 — verdict **PASS**.

⚠️ **Limite de la vérification** : la route `/declaration-remuneration` est authentifiée (ProConnect) et n'était pas atteignable en local ; le gate a donc mesuré le bandeau **injecté dans la page publique** (CSS DSFR réellement chargé). Les mesures de style — gaps 24px / 4px, `font-size` 16px, poids 400/700, couleurs `#3A3A3A` / `#F5F5FE`, ordre des datapoints — sont donc fiables, mais **le rendu de la page authentifiée réelle n'a pas été capturé**. Le comportement corrigé est en revanche couvert par les tests unitaires (`CompanyBanner.test.tsx`, 9/9), notamment `keeps the workforce label and shows '< 50' as value when gipWorkforce is null`.

À vérifier de visu sur la review app avant merge (états effectif connu / absent).
