### PR TITLE
fix(pdf): affiche la source des catégories d'emplois en libellé lisible

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -71,7 +71,7 @@ export {
 	SecondDeclarationStep3Review,
 	SecondDeclarationStepPage,
 } from "./steps/secondDeclaration";
-export { SOURCE_LABELS } from "./steps/step5/sources";
+export { formatCategorySource } from "./steps/step5/sources";
 export { parseEmployeeCategories } from "./steps/step6";
 export type {
 	EmployeeCategoryRow,

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -4,6 +4,7 @@ import {
 	toDisplayWorkforce,
 } from "~/modules/domain";
 import common from "../shared/common.module.scss";
+import { formatCategorySource } from "../steps/step5/sources";
 import type {
 	EmployeeCategoryRow,
 	Step2Data,
@@ -13,16 +14,6 @@ import type {
 import { CategoryRecapTable } from "./CategoryRecapTable";
 import { EmptyNotice, IndicatorTables } from "./IndicatorTables";
 import styles from "./RecapitulatifPage.module.scss";
-
-const SOURCE_LABELS: Record<string, string> = {
-	"convention-collective": "Convention collective",
-	"accord-entreprise": "Accord d'entreprise",
-	"accord-groupe": "Accord de groupe",
-	"accord-branche": "Accord de branche",
-	"decision-unilaterale": "Décision unilatérale",
-	"classification-interne": "Classification interne",
-	autre: "Autre",
-};
 
 type CompanyInfo = {
 	name: string;
@@ -116,9 +107,7 @@ export function RecapitulatifPage({
 			GIP_WORKFORCE_ABSENT_DISPLAY,
 	});
 
-	const sourceLabel = step5Source
-		? (SOURCE_LABELS[step5Source] ?? step5Source)
-		: null;
+	const sourceLabel = step5Source ? formatCategorySource(step5Source) : null;
 
 	const indexedCategories = step5Categories.map((cat, i) => ({
 		...cat,

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -371,11 +371,23 @@ describe("RecapitulatifPage", () => {
 		expect(screen.getByText("marie@acme.fr")).toBeInTheDocument();
 	});
 
-	it("falls back to the raw source key when it is not a known label", () => {
+	it("humanises the source key when it is not a known label", () => {
 		render(
 			<RecapitulatifPage {...defaultProps()} step5Source="source-inconnue" />,
 		);
-		expect(screen.getByText("source-inconnue")).toBeInTheDocument();
+		expect(screen.getByText("Source inconnue")).toBeInTheDocument();
+		expect(screen.queryByText("source-inconnue")).not.toBeInTheDocument();
+	});
+
+	// Regression #4014: legacy values must render identically here and in the PDF.
+	it("labels a legacy source value saved before the step 5 options changed", () => {
+		render(
+			<RecapitulatifPage
+				{...defaultProps()}
+				step5Source="convention-collective"
+			/>,
+		);
+		expect(screen.getByText("Convention collective")).toBeInTheDocument();
 	});
 
 	it("shows '< 50' when company.gipWorkforce is null", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -16,7 +16,7 @@ import { StepTitleRow } from "~/modules/declaration-remuneration/shared/StepTitl
 import { TooltipButton } from "~/modules/declaration-remuneration/shared/TooltipButton";
 import {
 	CATEGORY_SOURCES,
-	SOURCE_LABELS,
+	formatCategorySource,
 } from "~/modules/declaration-remuneration/steps/step5/sources";
 import type {
 	EmployeeCategoryRow,
@@ -385,7 +385,7 @@ export function CategoryForm({
 					<p className="fr-mb-0">
 						Source utilisée pour déterminer les catégories d&apos;emplois :{" "}
 						<span className="fr-text--bold">
-							{SOURCE_LABELS[form.watch("source")] ?? form.watch("source")}
+							{formatCategorySource(form.watch("source"))}
 						</span>
 					</p>
 				) : (

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/sources.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/sources.test.ts
@@ -30,9 +30,37 @@ describe("formatCategorySource", () => {
 		expect(formatCategorySource("accord_local")).toBe("Accord local");
 	});
 
-	it("returns the value unchanged when it holds no readable characters", () => {
+	it("falls back to the raw value when humanising would leave it empty", () => {
 		expect(formatCategorySource("")).toBe("");
 		expect(formatCategorySource("-")).toBe("-");
+		expect(formatCategorySource("__")).toBe("__");
+	});
+
+	it("labels a known value even if its label were falsy", () => {
+		expect(formatCategorySource("autre")).toBe("Autre");
+		expect(Object.keys(SOURCE_LABELS)).toContain("autre");
+	});
+});
+
+describe("SOURCE_LABELS", () => {
+	it("maps exactly the selectable and legacy values, and nothing else", () => {
+		expect(Object.keys(SOURCE_LABELS).sort()).toEqual(
+			[
+				"accord-branche",
+				"accord-entreprise",
+				"accord-groupe",
+				"autre",
+				"classification-interne",
+				"convention-collective",
+				"decision-unilaterale",
+			].sort(),
+		);
+	});
+
+	it("never maps a value to an empty label", () => {
+		for (const [key, label] of Object.entries(SOURCE_LABELS)) {
+			expect(label, `label for ${key}`).not.toBe("");
+		}
 	});
 });
 

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/sources.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/sources.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+	CATEGORY_SOURCES,
+	formatCategorySource,
+	SOURCE_LABELS,
+} from "../sources";
+
+describe("formatCategorySource", () => {
+	it.each([
+		["accord-entreprise", "Accord d'entreprise"],
+		["accord-groupe", "Accord de groupe"],
+		["accord-branche", "Accord de branche"],
+		["decision-unilaterale", "Décision unilatérale"],
+	])("labels the selectable source %s", (value, expected) => {
+		expect(formatCategorySource(value)).toBe(expected);
+	});
+
+	// Regression #4014: declarations saved before #3361 carry these values and
+	// used to render as raw slugs in the récapitulatif PDF.
+	it.each([
+		["convention-collective", "Convention collective"],
+		["classification-interne", "Classification interne"],
+		["autre", "Autre"],
+	])("labels the legacy source %s", (value, expected) => {
+		expect(formatCategorySource(value)).toBe(expected);
+	});
+
+	it("humanises an unknown value instead of exposing the raw slug", () => {
+		expect(formatCategorySource("convention-maison")).toBe("Convention maison");
+		expect(formatCategorySource("accord_local")).toBe("Accord local");
+	});
+
+	it("returns the value unchanged when it holds no readable characters", () => {
+		expect(formatCategorySource("")).toBe("");
+		expect(formatCategorySource("-")).toBe("-");
+	});
+});
+
+describe("CATEGORY_SOURCES", () => {
+	it("only offers the four currently selectable values", () => {
+		expect(CATEGORY_SOURCES.map((s) => s.value)).toEqual([
+			"accord-entreprise",
+			"accord-groupe",
+			"accord-branche",
+			"decision-unilaterale",
+		]);
+	});
+
+	it("never offers a legacy value as a selectable option", () => {
+		const selectable = CATEGORY_SOURCES.map((s) => s.value) as string[];
+		for (const legacy of [
+			"convention-collective",
+			"classification-interne",
+			"autre",
+		]) {
+			expect(selectable).not.toContain(legacy);
+			expect(SOURCE_LABELS[legacy]).toBeDefined();
+		}
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/sources.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/sources.ts
@@ -10,36 +10,24 @@ export const CATEGORY_SOURCES = [
 	{ value: "decision-unilaterale", label: "Décision unilatérale" },
 ] as const;
 
-/**
- * Values the step 5 select offered before #3361. They are no longer
- * selectable, but declarations saved back then still carry them in
- * `app_job.source` (free-form varchar), so every read-only surface must
- * still be able to label them.
- */
+// Dropped from the select in #3361, but declarations saved before then still
+// carry these in app_job.source (free varchar, never migrated).
 const LEGACY_SOURCE_LABELS: Record<string, string> = {
 	"convention-collective": "Convention collective",
 	"classification-interne": "Classification interne",
 	autre: "Autre",
 };
 
-/**
- * Every source value we know how to label — the currently selectable ones
- * plus the historical ones. Wider than CATEGORY_SOURCES on purpose: adding
- * a legacy value here must never make it selectable again.
- */
+// Wider than CATEGORY_SOURCES on purpose: labelling a legacy value must never
+// make it selectable again.
 export const SOURCE_LABELS: Record<string, string> = {
 	...Object.fromEntries(CATEGORY_SOURCES.map((s) => [s.value, s.label])),
 	...LEGACY_SOURCE_LABELS,
 };
 
-/**
- * Single source of truth for rendering a stored source value to the user,
- * on every surface (recap page, step 5 read-only, récapitulatif PDF).
- * An unknown value is humanised rather than printed as a raw slug.
- */
 export function formatCategorySource(value: string): string {
 	const known = SOURCE_LABELS[value];
-	if (known) return known;
+	if (known !== undefined) return known;
 
 	const humanised = value.replace(/[-_]+/g, " ").trim();
 	if (humanised.length === 0) return value;

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/sources.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/sources.ts
@@ -1,7 +1,7 @@
 /**
  * Allowed values for the "source de détermination des catégories d'emplois"
  * select on step 5. The order in this array drives the rendered <option>
- * order; the value/label split lets the read-only recap reuse the same labels.
+ * order.
  */
 export const CATEGORY_SOURCES = [
 	{ value: "accord-entreprise", label: "Accord d'entreprise" },
@@ -10,6 +10,39 @@ export const CATEGORY_SOURCES = [
 	{ value: "decision-unilaterale", label: "Décision unilatérale" },
 ] as const;
 
-export const SOURCE_LABELS: Record<string, string> = Object.fromEntries(
-	CATEGORY_SOURCES.map((s) => [s.value, s.label]),
-);
+/**
+ * Values the step 5 select offered before #3361. They are no longer
+ * selectable, but declarations saved back then still carry them in
+ * `app_job.source` (free-form varchar), so every read-only surface must
+ * still be able to label them.
+ */
+const LEGACY_SOURCE_LABELS: Record<string, string> = {
+	"convention-collective": "Convention collective",
+	"classification-interne": "Classification interne",
+	autre: "Autre",
+};
+
+/**
+ * Every source value we know how to label — the currently selectable ones
+ * plus the historical ones. Wider than CATEGORY_SOURCES on purpose: adding
+ * a legacy value here must never make it selectable again.
+ */
+export const SOURCE_LABELS: Record<string, string> = {
+	...Object.fromEntries(CATEGORY_SOURCES.map((s) => [s.value, s.label])),
+	...LEGACY_SOURCE_LABELS,
+};
+
+/**
+ * Single source of truth for rendering a stored source value to the user,
+ * on every surface (recap page, step 5 read-only, récapitulatif PDF).
+ * An unknown value is humanised rather than printed as a raw slug.
+ */
+export function formatCategorySource(value: string): string {
+	const known = SOURCE_LABELS[value];
+	if (known) return known;
+
+	const humanised = value.replace(/[-_]+/g, " ").trim();
+	if (humanised.length === 0) return value;
+
+	return humanised.charAt(0).toUpperCase() + humanised.slice(1);
+}

--- a/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
@@ -178,7 +178,7 @@ describe("buildPdfData", () => {
 		expect(result.source).toBe("Accord d'entreprise");
 	});
 
-	it("displays the GIP-absent placeholder and a bare source when GIP data and label are missing", async () => {
+	it("displays the GIP-absent placeholder and a humanised source when GIP data and label are missing", async () => {
 		queue(
 			[
 				{
@@ -217,8 +217,8 @@ describe("buildPdfData", () => {
 			email: "",
 			phone: "",
 		});
-		// Unknown source value falls back to its raw string.
-		expect(result.source).toBe("convention-maison");
+		// Unknown source value is humanised rather than printed as a raw slug.
+		expect(result.source).toBe("Convention maison");
 	});
 
 	it("falls back to a synthesized company name and zeroed totals when the company row is missing", async () => {

--- a/packages/app/src/modules/declarationPdf/buildPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildPdfData.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { and, desc, eq } from "drizzle-orm";
 
-import { SOURCE_LABELS } from "~/modules/declaration-remuneration";
+import { formatCategorySource } from "~/modules/declaration-remuneration";
 import {
 	formatCount,
 	formatShortDate,
@@ -150,7 +150,7 @@ export async function buildPdfData(
 
 	const rawSource = jobs.sort((a, b) => a.categoryIndex - b.categoryIndex)[0]
 		?.source;
-	const source = rawSource ? (SOURCE_LABELS[rawSource] ?? rawSource) : null;
+	const source = rawSource ? formatCategorySource(rawSource) : null;
 
 	return {
 		year,


### PR DESCRIPTION
Closes #4014

## Problème

Le PDF récapitulatif affichait la valeur technique brute de la source des catégories d'emplois (`convention-collective`) au lieu du libellé lisible (`Convention collective`).

## Cause

`SOURCE_LABELS` était dérivé de `CATEGORY_SOURCES`, que #3361 a réduit à 4 valeurs. Or le select de l'étape 5 proposait auparavant `convention-collective`, `classification-interne` et `autre` — valeurs toujours présentes en base (`app_job.source` est un `varchar(50)` libre, Zod `z.string().min(1)`, aucune migration). Le repli `?? rawSource` de `buildPdfData.ts` les imprimait donc telles quelles.

La page web du récapitulatif n'avait pas le bug parce qu'elle maintenait sa **propre copie** de la table de libellés, avec les 7 valeurs. C'est cette divergence qui explique que les deux surfaces ne rendaient pas la même chose.

## Correctif

- `SOURCE_LABELS` couvre désormais aussi les valeurs historiques, **sans** les réintroduire dans `CATEGORY_SOURCES` (le select de l'étape 5 propose toujours exactement les 4 mêmes options).
- Nouveau helper `formatCategorySource()` : source unique de vérité pour l'affichage, qui humanise une valeur inconnue au lieu d'exposer un slug.
- Les 3 points d'appel (PDF, page récap, étape 5 en lecture seule) passent par ce helper ; la copie locale de `RecapitulatifPage` est supprimée.

Le PDF joint à l'accusé de réception bénéficie du correctif, il partage le même builder.

Aucune migration de données : seul l'affichage change.

## Vérification

Rendu de deux PDF réels via `@react-pdf/renderer`, avec la même donnée d'entrée `convention-collective` :

| | Ligne « Source » du PDF |
|---|---|
| avant | `convention-collective` |
| après | `Convention collective` |

- `pnpm test` — 353 fichiers, 3649 tests ✅
- `pnpm typecheck` ✅ · `pnpm lint:check` ✅ · `pnpm format:check` ✅
- Nouveau `sources.test.ts` : couvre les 4 valeurs actuelles, les 3 historiques, l'humanisation d'une valeur inconnue, et verrouille le fait qu'aucune valeur historique ne redevient sélectionnable.
- Les 2 tests qui figeaient l'ancien repli sur le slug brut ont été mis à jour (évolution légitime, c'est le comportement corrigé).
