### PR TITLE
fix: prevent duplicate PDF downloads on repeated clicks

### DIFF
--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,57 +1,10 @@
-"use client";
-
 import Link from "next/link";
 import { DsfrPictogram } from "~/modules/layout";
 import { ResendReceiptButton } from "~/modules/mail";
-import { useFileDownload } from "~/modules/shared";
 import { FeedbackBanner } from "~/modules/shared/FeedbackBanner";
 import styles from "./ConfirmationPage.module.scss";
+import { DownloadCard } from "./DownloadCard";
 import formStyles from "./shared/formActions.module.scss";
-
-type DownloadCardProps = {
-	dataYear: number;
-	href: string;
-	title: string;
-	year: number;
-};
-
-function DownloadCard({ dataYear, href, title, year }: DownloadCardProps) {
-	const { state, download } = useFileDownload();
-
-	return (
-		<>
-			<a
-				aria-busy={state === "pending" ? "true" : undefined}
-				aria-disabled={state === "pending" ? "true" : undefined}
-				className={styles.downloadCard}
-				href={href}
-				onClick={(e) => {
-					e.preventDefault();
-					void download(href);
-				}}
-			>
-				<p className="fr-text--bold fr-text--md fr-mb-1w">
-					{state === "pending" ? "Téléchargement en cours…" : title}
-				</p>
-				<p className="fr-text--sm fr-text--default-grey fr-mb-1w">
-					Année {year} au titre des données {dataYear}
-				</p>
-				<div className={styles.downloadFooter}>
-					<span className="fr-text--xs fr-text--mention-grey">PDF</span>
-					<span aria-hidden="true" className="fr-icon-download-line" />
-				</div>
-			</a>
-			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
-				{state === "pending" ? "Téléchargement en cours…" : ""}
-			</p>
-			{state === "error" && (
-				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
-					Le téléchargement a échoué, réessayez.
-				</p>
-			)}
-		</>
-	);
-}
 
 type Props = {
 	dataYear: number;

--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import Link from "next/link";
 import { DsfrPictogram } from "~/modules/layout";
 import { ResendReceiptButton } from "~/modules/mail";
+import { useFileDownload } from "~/modules/shared";
 import { FeedbackBanner } from "~/modules/shared/FeedbackBanner";
 import styles from "./ConfirmationPage.module.scss";
 import formStyles from "./shared/formActions.module.scss";
@@ -13,17 +16,40 @@ type DownloadCardProps = {
 };
 
 function DownloadCard({ dataYear, href, title, year }: DownloadCardProps) {
+	const { state, download } = useFileDownload();
+
 	return (
-		<a className={styles.downloadCard} download={title} href={href}>
-			<p className="fr-text--bold fr-text--md fr-mb-1w">{title}</p>
-			<p className="fr-text--sm fr-text--default-grey fr-mb-1w">
-				Année {year} au titre des données {dataYear}
+		<>
+			<a
+				aria-busy={state === "pending" ? "true" : undefined}
+				aria-disabled={state === "pending" ? "true" : undefined}
+				className={styles.downloadCard}
+				href={href}
+				onClick={(e) => {
+					e.preventDefault();
+					void download(href);
+				}}
+			>
+				<p className="fr-text--bold fr-text--md fr-mb-1w">
+					{state === "pending" ? "Téléchargement en cours…" : title}
+				</p>
+				<p className="fr-text--sm fr-text--default-grey fr-mb-1w">
+					Année {year} au titre des données {dataYear}
+				</p>
+				<div className={styles.downloadFooter}>
+					<span className="fr-text--xs fr-text--mention-grey">PDF</span>
+					<span aria-hidden="true" className="fr-icon-download-line" />
+				</div>
+			</a>
+			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
+				{state === "pending" ? "Téléchargement en cours…" : ""}
 			</p>
-			<div className={styles.downloadFooter}>
-				<span className="fr-text--xs fr-text--mention-grey">PDF</span>
-				<span aria-hidden="true" className="fr-icon-download-line" />
-			</div>
-		</a>
+			{state === "error" && (
+				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
+					Le téléchargement a échoué, réessayez.
+				</p>
+			)}
+		</>
 	);
 }
 

--- a/packages/app/src/modules/cseOpinion/DownloadCard.tsx
+++ b/packages/app/src/modules/cseOpinion/DownloadCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { isNativeClick, useFileDownload } from "~/modules/shared";
+import { DownloadStatusRegion, useDownloadClickGuard } from "~/modules/shared";
 import styles from "./ConfirmationPage.module.scss";
+
+const PENDING_LABEL = "Téléchargement en cours…";
 
 type Props = {
 	dataYear: number;
@@ -11,23 +13,13 @@ type Props = {
 };
 
 export function DownloadCard({ dataYear, href, title, year }: Props) {
-	const { state, download } = useFileDownload();
+	const { anchorProps, state } = useDownloadClickGuard(href);
 
 	return (
 		<>
-			<a
-				aria-busy={state === "pending" ? "true" : undefined}
-				aria-disabled={state === "pending" ? "true" : undefined}
-				className={styles.downloadCard}
-				href={href}
-				onClick={(e) => {
-					if (isNativeClick(e)) return;
-					e.preventDefault();
-					void download(href);
-				}}
-			>
+			<a className={styles.downloadCard} {...anchorProps}>
 				<p className="fr-text--bold fr-text--md fr-mb-1w">
-					{state === "pending" ? "Téléchargement en cours…" : title}
+					{state === "pending" ? PENDING_LABEL : title}
 				</p>
 				<p className="fr-text--sm fr-text--default-grey fr-mb-1w">
 					Année {year} au titre des données {dataYear}
@@ -37,14 +29,7 @@ export function DownloadCard({ dataYear, href, title, year }: Props) {
 					<span aria-hidden="true" className="fr-icon-download-line" />
 				</div>
 			</a>
-			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
-				{state === "pending" ? "Téléchargement en cours…" : ""}
-			</p>
-			{state === "error" && (
-				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
-					Le téléchargement a échoué, réessayez.
-				</p>
-			)}
+			<DownloadStatusRegion pendingLabel={PENDING_LABEL} state={state} />
 		</>
 	);
 }

--- a/packages/app/src/modules/cseOpinion/DownloadCard.tsx
+++ b/packages/app/src/modules/cseOpinion/DownloadCard.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useFileDownload } from "~/modules/shared";
+import styles from "./ConfirmationPage.module.scss";
+
+type Props = {
+	dataYear: number;
+	href: string;
+	title: string;
+	year: number;
+};
+
+export function DownloadCard({ dataYear, href, title, year }: Props) {
+	const { state, download } = useFileDownload();
+
+	return (
+		<>
+			<a
+				aria-busy={state === "pending" ? "true" : undefined}
+				aria-disabled={state === "pending" ? "true" : undefined}
+				className={styles.downloadCard}
+				href={href}
+				onClick={(e) => {
+					e.preventDefault();
+					void download(href);
+				}}
+			>
+				<p className="fr-text--bold fr-text--md fr-mb-1w">
+					{state === "pending" ? "Téléchargement en cours…" : title}
+				</p>
+				<p className="fr-text--sm fr-text--default-grey fr-mb-1w">
+					Année {year} au titre des données {dataYear}
+				</p>
+				<div className={styles.downloadFooter}>
+					<span className="fr-text--xs fr-text--mention-grey">PDF</span>
+					<span aria-hidden="true" className="fr-icon-download-line" />
+				</div>
+			</a>
+			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
+				{state === "pending" ? "Téléchargement en cours…" : ""}
+			</p>
+			{state === "error" && (
+				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
+					Le téléchargement a échoué, réessayez.
+				</p>
+			)}
+		</>
+	);
+}

--- a/packages/app/src/modules/cseOpinion/DownloadCard.tsx
+++ b/packages/app/src/modules/cseOpinion/DownloadCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useFileDownload } from "~/modules/shared";
+import { isNativeClick, useFileDownload } from "~/modules/shared";
 import styles from "./ConfirmationPage.module.scss";
 
 type Props = {
@@ -21,6 +21,7 @@ export function DownloadCard({ dataYear, href, title, year }: Props) {
 				className={styles.downloadCard}
 				href={href}
 				onClick={(e) => {
+					if (isNativeClick(e)) return;
 					e.preventDefault();
 					void download(href);
 				}}

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -140,7 +140,7 @@ describe("ConfirmationPage", () => {
 			"href",
 			`/api/declaration-pdf?year=${DECLARATION_YEAR}`,
 		);
-		expect(declarationLink).toHaveAttribute("download");
+		expect(declarationLink).not.toHaveAttribute("download");
 
 		const transmittedLink = screen
 			.getByText(/récapitulatif des éléments transmis/)
@@ -149,7 +149,7 @@ describe("ConfirmationPage", () => {
 			"href",
 			`/api/transmitted-pdf?year=${DECLARATION_YEAR}`,
 		);
-		expect(transmittedLink).toHaveAttribute("download");
+		expect(transmittedLink).not.toHaveAttribute("download");
 	});
 
 	it("renders second declaration download card with correction href", () => {
@@ -168,7 +168,7 @@ describe("ConfirmationPage", () => {
 			"href",
 			`/api/declaration-pdf?type=correction&year=${DECLARATION_YEAR}`,
 		);
-		expect(secondDeclLink).toHaveAttribute("download");
+		expect(secondDeclLink).not.toHaveAttribute("download");
 	});
 
 	it("renders the feedback banner with the jedonnemonavis link", () => {

--- a/packages/app/src/modules/cseOpinion/__tests__/DownloadCard.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/DownloadCard.test.tsx
@@ -2,25 +2,16 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+	failingFetch,
+	getLiveRegion,
+	pendingFetch,
+} from "~/test/downloadHelpers";
 import { DownloadCard } from "../DownloadCard";
 
 const DATA_YEAR = 2024;
 const DECLARATION_YEAR = 2025;
 const HREF = "/api/cse-opinion-pdf?year=2025";
-
-function pendingFetch() {
-	return vi.fn(() => new Promise<Response>(() => undefined));
-}
-
-function failingFetch() {
-	return vi.fn(() =>
-		Promise.resolve({
-			ok: false,
-			blob: () => Promise.resolve(new Blob(["pdf"])),
-			headers: { get: () => null },
-		} as unknown as Response),
-	);
-}
 
 function renderCard() {
 	return render(
@@ -69,7 +60,7 @@ describe("DownloadCard", () => {
 		expect(link).toHaveAttribute("aria-busy", "true");
 		expect(link).toHaveAttribute("aria-disabled", "true");
 		expect(link).toHaveTextContent("Téléchargement en cours…");
-		const announcement = container.querySelector('[aria-live="polite"]');
+		const announcement = getLiveRegion(container);
 		expect(announcement).toHaveAttribute("aria-atomic", "true");
 		expect(announcement).toHaveTextContent("Téléchargement en cours…");
 	});

--- a/packages/app/src/modules/cseOpinion/__tests__/DownloadCard.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/DownloadCard.test.tsx
@@ -1,0 +1,120 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DownloadCard } from "../DownloadCard";
+
+const DATA_YEAR = 2024;
+const DECLARATION_YEAR = 2025;
+const HREF = "/api/cse-opinion-pdf?year=2025";
+
+function pendingFetch() {
+	return vi.fn(() => new Promise<Response>(() => undefined));
+}
+
+function failingFetch() {
+	return vi.fn(() =>
+		Promise.resolve({
+			ok: false,
+			blob: () => Promise.resolve(new Blob(["pdf"])),
+			headers: { get: () => null },
+		} as unknown as Response),
+	);
+}
+
+function renderCard() {
+	return render(
+		<DownloadCard
+			dataYear={DATA_YEAR}
+			href={HREF}
+			title="Télécharger l'avis du CSE"
+			year={DECLARATION_YEAR}
+		/>,
+	);
+}
+
+beforeEach(() => {
+	vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+		() => undefined,
+	);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("DownloadCard", () => {
+	it("renders the card as a link to the file with its title and years", () => {
+		renderCard();
+
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("href", HREF);
+		expect(link).toHaveTextContent("Télécharger l'avis du CSE");
+		expect(link).toHaveTextContent(
+			`Année ${DECLARATION_YEAR} au titre des données ${DATA_YEAR}`,
+		);
+		expect(link).not.toHaveAttribute("aria-busy");
+		expect(link).not.toHaveAttribute("aria-disabled");
+	});
+
+	it("announces the pending state and marks the link busy while downloading", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", pendingFetch());
+		const { container } = renderCard();
+
+		await user.click(screen.getByRole("link"));
+
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("aria-busy", "true");
+		expect(link).toHaveAttribute("aria-disabled", "true");
+		expect(link).toHaveTextContent("Téléchargement en cours…");
+		const announcement = container.querySelector('[aria-live="polite"]');
+		expect(announcement).toHaveAttribute("aria-atomic", "true");
+		expect(announcement).toHaveTextContent("Téléchargement en cours…");
+	});
+
+	it("triggers a single fetch for a burst of clicks fired before the re-render", async () => {
+		const fetchMock = pendingFetch();
+		vi.stubGlobal("fetch", fetchMock);
+		renderCard();
+
+		const link = screen.getByRole("link");
+		await act(async () => {
+			link.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+			link.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves a modifier click to the browser's native behaviour", () => {
+		const fetchMock = pendingFetch();
+		vi.stubGlobal("fetch", fetchMock);
+		renderCard();
+
+		const notPrevented = fireEvent.click(screen.getByRole("link"), {
+			ctrlKey: true,
+		});
+
+		expect(notPrevented).toBe(true);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(screen.getByRole("link")).not.toHaveAttribute("aria-busy");
+	});
+
+	it("renders an alert message when the download fails", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", failingFetch());
+		renderCard();
+
+		await user.click(screen.getByRole("link"));
+
+		expect(await screen.findByRole("alert")).toHaveTextContent(
+			"Le téléchargement a échoué, réessayez.",
+		);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/DeclarationSuccessBanner.tsx
@@ -1,6 +1,7 @@
 import { formatLongDate } from "~/modules/domain";
 import { DsfrPictogram } from "~/modules/layout/shared/DsfrPictogram";
 import { ResendReceiptButton } from "~/modules/mail";
+import { FileDownloadLink } from "~/modules/shared";
 import styles from "./DeclarationSuccessBanner.module.scss";
 
 type Props = {
@@ -39,15 +40,15 @@ export function DeclarationSuccessBanner({
 						<strong>{formatLongDate(modificationDeadline)}</strong>
 					</p>
 					{pdfDownloadHref && (
-						<a
+						<FileDownloadLink
 							className="fr-link fr-link--download"
-							download
 							href={pdfDownloadHref}
+							pendingLabel="Génération du récapitulatif en cours…"
 						>
 							{isSecondDeclaration
 								? "Télécharger le récapitulatif de la seconde déclaration de l'indicateur de rémunération par catégorie de salariés"
 								: "Télécharger le récapitulatif de la déclaration des indicateurs"}
-						</a>
+						</FileDownloadLink>
 					)}
 				</div>
 			</div>

--- a/packages/app/src/modules/declarationPdf/DownloadDeclarationPdfButton.tsx
+++ b/packages/app/src/modules/declarationPdf/DownloadDeclarationPdfButton.tsx
@@ -6,6 +6,7 @@ import {
 	MATOMO_EVENT_CATEGORY,
 	trackEvent,
 } from "~/modules/analytics";
+import { FileDownloadLink } from "~/modules/shared";
 
 type Props = {
 	year?: number;
@@ -26,7 +27,7 @@ export function DownloadDeclarationPdfButton({
 	const query = params.toString();
 	const href = query ? `/api/declaration-pdf?${query}` : "/api/declaration-pdf";
 
-	function handleClick(): void {
+	function handleBeforeDownload(): void {
 		trackEvent({
 			category: MATOMO_EVENT_CATEGORY.DOCUMENT,
 			action: MATOMO_ACTION.PDF_DOWNLOAD,
@@ -36,13 +37,13 @@ export function DownloadDeclarationPdfButton({
 	}
 
 	return (
-		<a
+		<FileDownloadLink
 			className={`fr-btn fr-btn--${variant} fr-btn--icon-left fr-icon-file-pdf-line`}
-			download
 			href={href}
-			onClick={handleClick}
+			onBeforeDownload={handleBeforeDownload}
+			pendingLabel="Génération du récapitulatif en cours…"
 		>
 			{label}
-		</a>
+		</FileDownloadLink>
 	);
 }

--- a/packages/app/src/modules/declarationPdf/__tests__/DownloadDeclarationPdfButton.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/DownloadDeclarationPdfButton.test.tsx
@@ -10,7 +10,7 @@ describe("DownloadDeclarationPdfButton", () => {
 			name: /Télécharger le récapitulatif/,
 		});
 		expect(link).toHaveAttribute("href", "/api/declaration-pdf?year=2025");
-		expect(link).toHaveAttribute("download");
+		expect(link).not.toHaveAttribute("download");
 	});
 
 	it("renders a download link without year param when year is omitted", () => {

--- a/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
@@ -1,36 +1,57 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const queryResults: unknown[][] = [];
-let callIndex = 0;
+type TableKey =
+	| "declarations"
+	| "companies"
+	| "users"
+	| "gipMdsData"
+	| "jobCategories"
+	| "employeeCategories"
+	| "declarationStatusHistory";
 
-// Records each query in call order and returns the next queued result set.
-// Supports every chain shape used by buildPdfData: `.where().limit()`,
-// `.where().orderBy().limit()` (status history) and awaited `.where()`
-// (jobs / employeeCategories, no `.limit`).
-vi.mock("~/server/db", () => {
-	const settle = () => {
-		const result = queryResults[callIndex++] ?? [];
-		const chain = Object.assign(Promise.resolve(result), {
-			limit: () => Promise.resolve(result),
-			orderBy: () => ({ limit: () => Promise.resolve(result) }),
-		});
-		return chain;
-	};
-	return {
-		db: {
-			select: () => ({ from: () => ({ where: () => settle() }) }),
-		},
-	};
-});
+// Result sets keyed by the queried table. buildPdfData issues most queries via
+// `Promise.all`, so execution order is not stable — the mock keys results by the
+// table passed to `.from()` (via the schema token's `__table` tag) instead of by
+// call order. `declarationStatusHistory` is queried up to twice per build
+// (second_declaration_submit then submit), so it holds a FIFO sub-queue.
+const results = new Map<TableKey, unknown[][]>();
+
+function settle(table: TableKey) {
+	const queued = results.get(table);
+	const result = queued?.shift() ?? [];
+	return Object.assign(Promise.resolve(result), {
+		limit: () => Promise.resolve(result),
+		orderBy: () => ({ limit: () => Promise.resolve(result) }),
+	});
+}
+
+vi.mock("~/server/db", () => ({
+	db: {
+		select: () => ({
+			from: (table: { __table: TableKey }) => ({
+				where: () => settle(table.__table),
+			}),
+		}),
+	},
+}));
 
 vi.mock("~/server/db/schema", () => ({
-	declarations: { id: "id", siren: "siren", year: "year" },
-	companies: { siren: "siren" },
-	users: { id: "id" },
-	gipMdsData: { siren: "siren", year: "year" },
-	jobCategories: { declarationId: "declarationId" },
-	employeeCategories: { jobCategoryId: "jobCategoryId" },
+	declarations: {
+		__table: "declarations",
+		id: "id",
+		siren: "siren",
+		year: "year",
+	},
+	companies: { __table: "companies", siren: "siren" },
+	users: { __table: "users", id: "id" },
+	gipMdsData: { __table: "gipMdsData", siren: "siren", year: "year" },
+	jobCategories: { __table: "jobCategories", declarationId: "declarationId" },
+	employeeCategories: {
+		__table: "employeeCategories",
+		jobCategoryId: "jobCategoryId",
+	},
 	declarationStatusHistory: {
+		__table: "declarationStatusHistory",
 		declarationId: "declarationId",
 		eventType: "eventType",
 		createdAt: "createdAt",
@@ -57,12 +78,24 @@ vi.mock("drizzle-orm", () => ({
 	and: (...args: unknown[]) => args,
 	desc: (col: unknown) => col,
 	eq: (col: unknown, val: unknown) => ({ col, val }),
+	inArray: (col: unknown, values: unknown) => ({ col, values }),
 }));
 
-function queue(...results: unknown[][]) {
-	callIndex = 0;
-	queryResults.length = 0;
-	queryResults.push(...results);
+// One entry per table. `declarationStatusHistory` takes an array of result sets
+// (consumed FIFO) since it can be queried twice within one build.
+type QueueSpec = Partial<
+	Record<Exclude<TableKey, "declarationStatusHistory">, unknown[]>
+> & { declarationStatusHistory?: unknown[][] };
+
+function queue(spec: QueueSpec) {
+	results.clear();
+	for (const [table, value] of Object.entries(spec)) {
+		if (table === "declarationStatusHistory") {
+			results.set(table, value as unknown[][]);
+		} else {
+			results.set(table as TableKey, [value as unknown[]]);
+		}
+	}
 }
 
 const SUBMITTED = new Date("2026-03-05T10:00:00Z");
@@ -76,12 +109,11 @@ async function importBuild() {
 
 describe("buildPdfData", () => {
 	beforeEach(() => {
-		callIndex = 0;
-		queryResults.length = 0;
+		results.clear();
 	});
 
 	it("throws when the declaration is not found", async () => {
-		queue([]);
+		queue({ declarations: [] });
 		const buildPdfData = await importBuild();
 		await expect(buildPdfData("123456789", 2026, NOW)).rejects.toThrow(
 			"Déclaration introuvable",
@@ -89,7 +121,11 @@ describe("buildPdfData", () => {
 	});
 
 	it("throws when the declaration is still a draft", async () => {
-		queue([{ id: "d1", siren: "123456789", year: 2026, status: "draft" }]);
+		queue({
+			declarations: [
+				{ id: "d1", siren: "123456789", year: 2026, status: "draft" },
+			],
+		});
 		const buildPdfData = await importBuild();
 		await expect(buildPdfData("123456789", 2026, NOW)).rejects.toThrow(
 			"La déclaration n'est pas encore soumise",
@@ -97,9 +133,8 @@ describe("buildPdfData", () => {
 	});
 
 	it("assembles declarant, company, GIP workforce, source and transmission date for an initial declaration", async () => {
-		queue(
-			// declarations
-			[
+		queue({
+			declarations: [
 				{
 					id: "d1",
 					siren: "123456789",
@@ -113,8 +148,7 @@ describe("buildPdfData", () => {
 					indicatorEWomen: "80",
 				},
 			],
-			// companies
-			[
+			companies: [
 				{
 					siren: "123456789",
 					name: "Société Démo",
@@ -123,8 +157,7 @@ describe("buildPdfData", () => {
 					nafLabel: "Programmation informatique",
 				},
 			],
-			// users (declarant)
-			[
+			users: [
 				{
 					firstName: "Jean",
 					lastName: "Martin",
@@ -132,10 +165,8 @@ describe("buildPdfData", () => {
 					phone: "0102030405",
 				},
 			],
-			// gipMdsData
-			[{ workforceEma: "250.7" }],
-			// jobCategories
-			[
+			gipMdsData: [{ workforceEma: "250.7" }],
+			jobCategories: [
 				{
 					id: "job-1",
 					name: "Ouvriers",
@@ -143,11 +174,9 @@ describe("buildPdfData", () => {
 					source: "accord-entreprise",
 				},
 			],
-			// employeeCategories for job-1
-			[{ jobCategoryId: "job-1" }],
-			// status history: submit
-			[{ createdAt: SUBMITTED }],
-		);
+			employeeCategories: [{ jobCategoryId: "job-1" }],
+			declarationStatusHistory: [[{ createdAt: SUBMITTED }]],
+		});
 		const buildPdfData = await importBuild();
 		const result = await buildPdfData("123456789", 2026, NOW);
 
@@ -179,8 +208,8 @@ describe("buildPdfData", () => {
 	});
 
 	it("displays the GIP-absent placeholder and a humanised source when GIP data and label are missing", async () => {
-		queue(
-			[
+		queue({
+			declarations: [
 				{
 					id: "d2",
 					siren: "987654321",
@@ -192,10 +221,10 @@ describe("buildPdfData", () => {
 					updatedAt: new Date("2026-03-01T00:00:00Z"),
 				},
 			],
-			[{ siren: "987654321", name: "Autre Démo" }],
-			[{ firstName: "Alice", lastName: null, email: null, phone: null }],
-			[], // gipMdsData absent
-			[
+			companies: [{ siren: "987654321", name: "Autre Démo" }],
+			users: [{ firstName: "Alice", lastName: null, email: null, phone: null }],
+			gipMdsData: [], // GIP data absent
+			jobCategories: [
 				{
 					id: "job-9",
 					name: "Cadres",
@@ -203,9 +232,9 @@ describe("buildPdfData", () => {
 					source: "convention-maison",
 				},
 			],
-			[{ jobCategoryId: "job-9" }],
-			[{ createdAt: SUBMITTED }],
-		);
+			employeeCategories: [{ jobCategoryId: "job-9" }],
+			declarationStatusHistory: [[{ createdAt: SUBMITTED }]],
+		});
 		const buildPdfData = await importBuild();
 		const result = await buildPdfData("987654321", 2026, NOW);
 
@@ -222,8 +251,8 @@ describe("buildPdfData", () => {
 	});
 
 	it("falls back to a synthesized company name and zeroed totals when the company row is missing", async () => {
-		queue(
-			[
+		queue({
+			declarations: [
 				{
 					id: "d3",
 					siren: "111222333",
@@ -235,11 +264,12 @@ describe("buildPdfData", () => {
 					updatedAt: new Date("2026-03-01T00:00:00Z"),
 				},
 			],
-			[], // companies missing
-			[], // gipMdsData (no declarantId → users query is skipped)
-			[], // jobCategories empty
-			[{ createdAt: SUBMITTED }], // status history: submit
-		);
+			companies: [], // company row missing
+			gipMdsData: [],
+			jobCategories: [], // empty → employeeCategories query is skipped
+			// no declarantId → users query is skipped
+			declarationStatusHistory: [[{ createdAt: SUBMITTED }]],
+		});
 		const buildPdfData = await importBuild();
 		const result = await buildPdfData("111222333", 2026, NOW);
 
@@ -252,8 +282,8 @@ describe("buildPdfData", () => {
 	});
 
 	it("uses the second_declaration_submit date for a correction declaration", async () => {
-		queue(
-			[
+		queue({
+			declarations: [
 				{
 					id: "d4",
 					siren: "123456789",
@@ -265,8 +295,8 @@ describe("buildPdfData", () => {
 					updatedAt: new Date("2026-03-01T00:00:00Z"),
 				},
 			],
-			[{ siren: "123456789", name: "Société Démo" }],
-			[
+			companies: [{ siren: "123456789", name: "Société Démo" }],
+			users: [
 				{
 					firstName: "Jean",
 					lastName: "Martin",
@@ -274,8 +304,8 @@ describe("buildPdfData", () => {
 					phone: "",
 				},
 			],
-			[{ workforceEma: "120" }],
-			[
+			gipMdsData: [{ workforceEma: "120" }],
+			jobCategories: [
 				{
 					id: "job-1",
 					name: "Ouvriers",
@@ -283,10 +313,10 @@ describe("buildPdfData", () => {
 					source: "accord-groupe",
 				},
 			],
-			[{ jobCategoryId: "job-1" }],
-			// resolveTransmittedDate for correction: second_declaration_submit first
-			[{ createdAt: SECOND_SUBMIT }],
-		);
+			employeeCategories: [{ jobCategoryId: "job-1" }],
+			// correction: second_declaration_submit event resolves first
+			declarationStatusHistory: [[{ createdAt: SECOND_SUBMIT }]],
+		});
 		const buildPdfData = await importBuild();
 		const result = await buildPdfData("123456789", 2026, NOW, "correction");
 
@@ -295,8 +325,8 @@ describe("buildPdfData", () => {
 	});
 
 	it("falls back through submit then updatedAt when no matching status event exists", async () => {
-		queue(
-			[
+		queue({
+			declarations: [
 				{
 					id: "d5",
 					siren: "123456789",
@@ -308,14 +338,13 @@ describe("buildPdfData", () => {
 					updatedAt: new Date("2026-02-14T00:00:00Z"),
 				},
 			],
-			[{ siren: "123456789", name: "Société Démo" }],
-			[], // gipMdsData
-			[], // jobCategories
-			// resolveTransmittedDate for correction: second_declaration_submit (empty)
-			[],
-			// then submit (empty) → falls back to updatedAt
-			[],
-		);
+			companies: [{ siren: "123456789", name: "Société Démo" }],
+			gipMdsData: [],
+			jobCategories: [],
+			// correction: second_declaration_submit (empty), then submit (empty)
+			// → falls back to updatedAt
+			declarationStatusHistory: [[], []],
+		});
 		const buildPdfData = await importBuild();
 		const result = await buildPdfData("123456789", 2026, NOW, "correction");
 
@@ -323,8 +352,8 @@ describe("buildPdfData", () => {
 	});
 
 	it("falls back to `now` when the declaration has no updatedAt and no submit event", async () => {
-		queue(
-			[
+		queue({
+			declarations: [
 				{
 					id: "d6",
 					siren: "123456789",
@@ -336,11 +365,12 @@ describe("buildPdfData", () => {
 					updatedAt: null,
 				},
 			],
-			[{ siren: "123456789", name: "Société Démo" }],
-			[], // gipMdsData
-			[], // jobCategories
-			[], // status history: submit (empty) → falls back to `now`
-		);
+			companies: [{ siren: "123456789", name: "Société Démo" }],
+			gipMdsData: [],
+			jobCategories: [],
+			// submit event empty → falls back to `now`
+			declarationStatusHistory: [[]],
+		});
 		const buildPdfData = await importBuild();
 		const result = await buildPdfData("123456789", 2026, NOW);
 

--- a/packages/app/src/modules/declarationPdf/buildPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildPdfData.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 
 import { formatCategorySource } from "~/modules/declaration-remuneration";
 import {
@@ -85,51 +85,47 @@ export async function buildPdfData(
 		throw new Error("La déclaration n'est pas encore soumise");
 	}
 
-	const [company] = await db
-		.select()
-		.from(companies)
-		.where(eq(companies.siren, siren))
-		.limit(1);
+	const [[company], [gip], jobs, transmittedDate, declarantRows] =
+		await Promise.all([
+			db.select().from(companies).where(eq(companies.siren, siren)).limit(1),
+			db
+				.select({ workforceEma: gipMdsData.workforceEma })
+				.from(gipMdsData)
+				.where(and(eq(gipMdsData.siren, siren), eq(gipMdsData.year, year)))
+				.limit(1),
+			db
+				.select()
+				.from(jobCategories)
+				.where(eq(jobCategories.declarationId, declaration.id)),
+			resolveTransmittedDate(
+				declaration.id,
+				declaration.updatedAt ?? now,
+				declarationType,
+			),
+			declaration.declarantId
+				? db
+						.select({
+							firstName: users.firstName,
+							lastName: users.lastName,
+							email: users.email,
+							phone: users.phone,
+						})
+						.from(users)
+						.where(eq(users.id, declaration.declarantId))
+						.limit(1)
+				: Promise.resolve([]),
+		]);
 
-	const declarant = declaration.declarantId
-		? (
-				await db
-					.select({
-						firstName: users.firstName,
-						lastName: users.lastName,
-						email: users.email,
-						phone: users.phone,
-					})
-					.from(users)
-					.where(eq(users.id, declaration.declarantId))
-					.limit(1)
-			)[0]
-		: undefined;
-
-	const [gip] = await db
-		.select({ workforceEma: gipMdsData.workforceEma })
-		.from(gipMdsData)
-		.where(and(eq(gipMdsData.siren, siren), eq(gipMdsData.year, year)))
-		.limit(1);
-
-	const jobs = await db
-		.select()
-		.from(jobCategories)
-		.where(eq(jobCategories.declarationId, declaration.id));
+	const declarant = declarantRows[0];
 
 	const jobIds = jobs.map((j) => j.id);
-	let empCats: (typeof employeeCategories.$inferSelect)[] = [];
-	if (jobIds.length > 0) {
-		const results = await Promise.all(
-			jobIds.map((id) =>
-				db
+	const empCats =
+		jobIds.length > 0
+			? await db
 					.select()
 					.from(employeeCategories)
-					.where(eq(employeeCategories.jobCategoryId, id)),
-			),
-		);
-		empCats = results.flat();
-	}
+					.where(inArray(employeeCategories.jobCategoryId, jobIds))
+			: [];
 
 	const categories =
 		jobs.length > 0
@@ -137,12 +133,6 @@ export async function buildPdfData(
 			: [];
 
 	const { step2Data, step3Data, step4Data } = mapToStepData(declaration);
-
-	const transmittedDate = await resolveTransmittedDate(
-		declaration.id,
-		declaration.updatedAt ?? now,
-		declarationType,
-	);
 
 	const displayWorkforce = toDisplayWorkforce(
 		parseGipWorkforce(gip?.workforceEma),

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -10,6 +10,7 @@ import {
 	getRepresentationDeadline,
 } from "~/modules/domain";
 
+import { FileDownloadLink } from "~/modules/shared";
 import { Pagination } from "~/modules/shared/Pagination";
 
 import { DeclarationLink } from "./DeclarationLink";
@@ -107,13 +108,13 @@ export function DeclarationsSection({
 				</div>
 				{hasNoSanction && (
 					<div className="fr-col-auto">
-						<a
+						<FileDownloadLink
 							className="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-download-line"
-							download
 							href="/api/no-sanction-pdf"
+							pendingLabel="Téléchargement en cours…"
 						>
-							Télécharger l'attestation de non sanction (PDF)
-						</a>
+							Télécharger l&apos;attestation de non sanction (PDF)
+						</FileDownloadLink>
 					</div>
 				)}
 			</div>

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { getWorkforceYearFor } from "~/modules/domain";
+import { useFileDownload } from "~/modules/shared";
 import styles from "./DeclarationProcessPanel.module.scss";
 import type { DeclarationItem } from "./types";
 
@@ -20,7 +21,6 @@ function getResources(declaration: DeclarationItem): DocumentResource[] {
 
 	const subtitle = `Année ${declaration.year} au titre des données ${getWorkforceYearFor(declaration.year)}`;
 
-	// Available as soon as the GIP MDS prefill has been loaded for this year.
 	if (declaration.hasPrefillData) {
 		resources.push({
 			title: "Télécharger les données préremplies (issues des données DSN)",
@@ -29,7 +29,6 @@ function getResources(declaration: DeclarationItem): DocumentResource[] {
 		});
 	}
 
-	// Available once the initial declaration has been submitted.
 	if (declaration.status === "done") {
 		resources.push({
 			title: "Télécharger le récapitulatif de la déclaration des indicateurs",
@@ -43,7 +42,6 @@ function getResources(declaration: DeclarationItem): DocumentResource[] {
 		});
 	}
 
-	// Available once the second (corrective) declaration has been submitted.
 	if (declaration.hasSubmittedSecondDeclaration) {
 		resources.push({
 			title: "Télécharger le récapitulatif de la seconde déclaration",
@@ -57,6 +55,52 @@ function getResources(declaration: DeclarationItem): DocumentResource[] {
 
 export function getDocumentResourceCount(declaration: DeclarationItem): number {
 	return getResources(declaration).length;
+}
+
+type DocumentCardItemProps = {
+	resource: DocumentResource;
+};
+
+function DocumentCardItem({ resource }: DocumentCardItemProps) {
+	const { state, download } = useFileDownload();
+
+	return (
+		<li className={styles.documentItem}>
+			<div className="fr-card fr-card--sm fr-card--download fr-enlarge-link">
+				<div className="fr-card__body">
+					<div className="fr-card__content">
+						<h3 className="fr-card__title">
+							<a
+								aria-busy={state === "pending" ? "true" : undefined}
+								aria-disabled={state === "pending" ? "true" : undefined}
+								href={resource.href}
+								onClick={(e) => {
+									e.preventDefault();
+									void download(resource.href);
+								}}
+							>
+								{resource.title}
+							</a>
+						</h3>
+						<p className="fr-card__desc">{resource.subtitle}</p>
+						<div className="fr-card__end">
+							<p className="fr-card__detail">
+								{state === "pending" ? "Téléchargement en cours…" : "PDF"}
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
+				{state === "pending" ? "Téléchargement en cours…" : ""}
+			</p>
+			{state === "error" && (
+				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
+					Le téléchargement a échoué, réessayez.
+				</p>
+			)}
+		</li>
+	);
 }
 
 type Props = {
@@ -97,23 +141,7 @@ export function DocumentsPanel({ declaration }: Props) {
 						</h2>
 						<ul className={styles.documentList}>
 							{resources.map((resource) => (
-								<li className={styles.documentItem} key={resource.href}>
-									<div className="fr-card fr-card--sm fr-card--download fr-enlarge-link">
-										<div className="fr-card__body">
-											<div className="fr-card__content">
-												<h3 className="fr-card__title">
-													<a download href={resource.href}>
-														{resource.title}
-													</a>
-												</h3>
-												<p className="fr-card__desc">{resource.subtitle}</p>
-												<div className="fr-card__end">
-													<p className="fr-card__detail">PDF</p>
-												</div>
-											</div>
-										</div>
-									</div>
-								</li>
+								<DocumentCardItem key={resource.href} resource={resource} />
 							))}
 						</ul>
 					</div>

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { getWorkforceYearFor } from "~/modules/domain";
-import { isNativeClick, useFileDownload } from "~/modules/shared";
+import { DownloadStatusRegion, useDownloadClickGuard } from "~/modules/shared";
 import styles from "./DeclarationProcessPanel.module.scss";
 import type { DeclarationItem } from "./types";
+
+const PENDING_LABEL = "Téléchargement en cours…";
 
 export function getDocumentsPanelId(declaration: DeclarationItem): string {
 	return `documents-panel-${declaration.type}-${declaration.year}`;
@@ -62,7 +64,7 @@ type DocumentCardItemProps = {
 };
 
 function DocumentCardItem({ resource }: DocumentCardItemProps) {
-	const { state, download } = useFileDownload();
+	const { anchorProps, state } = useDownloadClickGuard(resource.href);
 
 	return (
 		<li className={styles.documentItem}>
@@ -70,36 +72,18 @@ function DocumentCardItem({ resource }: DocumentCardItemProps) {
 				<div className="fr-card__body">
 					<div className="fr-card__content">
 						<h3 className="fr-card__title">
-							<a
-								aria-busy={state === "pending" ? "true" : undefined}
-								aria-disabled={state === "pending" ? "true" : undefined}
-								href={resource.href}
-								onClick={(e) => {
-									if (isNativeClick(e)) return;
-									e.preventDefault();
-									void download(resource.href);
-								}}
-							>
-								{resource.title}
-							</a>
+							<a {...anchorProps}>{resource.title}</a>
 						</h3>
 						<p className="fr-card__desc">{resource.subtitle}</p>
 						<div className="fr-card__end">
 							<p className="fr-card__detail">
-								{state === "pending" ? "Téléchargement en cours…" : "PDF"}
+								{state === "pending" ? PENDING_LABEL : "PDF"}
 							</p>
 						</div>
 					</div>
 				</div>
 			</div>
-			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
-				{state === "pending" ? "Téléchargement en cours…" : ""}
-			</p>
-			{state === "error" && (
-				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
-					Le téléchargement a échoué, réessayez.
-				</p>
-			)}
+			<DownloadStatusRegion pendingLabel={PENDING_LABEL} state={state} />
 		</li>
 	);
 }

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { getWorkforceYearFor } from "~/modules/domain";
-import { useFileDownload } from "~/modules/shared";
+import { isNativeClick, useFileDownload } from "~/modules/shared";
 import styles from "./DeclarationProcessPanel.module.scss";
 import type { DeclarationItem } from "./types";
 
@@ -75,6 +75,7 @@ function DocumentCardItem({ resource }: DocumentCardItemProps) {
 								aria-disabled={state === "pending" ? "true" : undefined}
 								href={resource.href}
 								onClick={(e) => {
+									if (isNativeClick(e)) return;
 									e.preventDefault();
 									void download(resource.href);
 								}}

--- a/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
@@ -3,6 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getWorkforceYearFor } from "~/modules/domain";
 import {
+	failingFetch,
+	getLiveRegion,
+	pendingFetch,
+} from "~/test/downloadHelpers";
+import {
 	DocumentsPanel,
 	getDocumentResourceCount,
 	getDocumentsPanelId,
@@ -39,20 +44,6 @@ function makeDeclaration(
 		hasPrefillData: false,
 		...overrides,
 	};
-}
-
-function pendingFetch() {
-	return vi.fn(() => new Promise<Response>(() => undefined));
-}
-
-function failingFetch() {
-	return vi.fn(() =>
-		Promise.resolve({
-			ok: false,
-			blob: () => Promise.resolve(new Blob(["pdf"])),
-			headers: { get: () => null },
-		} as unknown as Response),
-	);
 }
 
 // The panel is a closed <dialog>, so its subtree is display:none and role
@@ -261,7 +252,7 @@ describe("DocumentsPanel", () => {
 		const link = links()[0];
 		expect(link).toHaveAttribute("aria-busy", "true");
 		expect(link).toHaveAttribute("aria-disabled", "true");
-		const announcement = dialog.querySelector('[aria-live="polite"]');
+		const announcement = getLiveRegion(dialog);
 		expect(announcement).toHaveAttribute("aria-atomic", "true");
 		expect(announcement).toHaveTextContent("Téléchargement en cours…");
 		expect(panel.getAllByText("Téléchargement en cours…")).toHaveLength(2);

--- a/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
@@ -1,0 +1,323 @@
+import { act, fireEvent, render, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getWorkforceYearFor } from "~/modules/domain";
+import {
+	DocumentsPanel,
+	getDocumentResourceCount,
+	getDocumentsPanelId,
+} from "../DocumentsPanel";
+import type { DeclarationItem } from "../types";
+
+const DECLARATION_YEAR = 2026;
+const SUBTITLE = `Année ${DECLARATION_YEAR} au titre des données ${getWorkforceYearFor(DECLARATION_YEAR)}`;
+
+const PREFILL_TITLE =
+	"Télécharger les données préremplies (issues des données DSN)";
+const RECAP_TITLE =
+	"Télécharger le récapitulatif de la déclaration des indicateurs";
+const TRANSMITTED_TITLE = "Télécharger le récapitulatif des éléments transmis";
+const SECOND_TITLE = "Télécharger le récapitulatif de la seconde déclaration";
+
+function makeDeclaration(
+	overrides: Partial<DeclarationItem> = {},
+): DeclarationItem {
+	return {
+		type: "remuneration",
+		siren: "123456789",
+		year: DECLARATION_YEAR,
+		status: "done",
+		fsmStatus: null,
+		currentStep: 5,
+		updatedAt: null,
+		firstDeclarationPathChoice: null,
+		secondDeclarationPathChoice: null,
+		hasSubmittedSecondDeclaration: false,
+		hasSubmittedCseOpinion: false,
+		cseRequired: false,
+		hasJointEvaluationFile: false,
+		hasPrefillData: false,
+		...overrides,
+	};
+}
+
+function pendingFetch() {
+	return vi.fn(() => new Promise<Response>(() => undefined));
+}
+
+function failingFetch() {
+	return vi.fn(() =>
+		Promise.resolve({
+			ok: false,
+			blob: () => Promise.resolve(new Blob(["pdf"])),
+			headers: { get: () => null },
+		} as unknown as Response),
+	);
+}
+
+// The panel is a closed <dialog>, so its subtree is display:none and role
+// queries must opt into hidden elements.
+function renderPanel(overrides: Partial<DeclarationItem> = {}) {
+	const { container } = render(
+		<DocumentsPanel declaration={makeDeclaration(overrides)} />,
+	);
+	const dialog = container.querySelector("dialog") as HTMLElement;
+	return {
+		container,
+		dialog,
+		panel: within(dialog),
+		links: () =>
+			within(dialog).queryAllByRole("link", {
+				hidden: true,
+			}) as HTMLAnchorElement[],
+	};
+}
+
+beforeEach(() => {
+	vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+		() => undefined,
+	);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("getDocumentsPanelId", () => {
+	it("builds an id scoped to the declaration type and year", () => {
+		expect(getDocumentsPanelId(makeDeclaration())).toBe(
+			`documents-panel-remuneration-${DECLARATION_YEAR}`,
+		);
+		expect(
+			getDocumentsPanelId(makeDeclaration({ type: "representation" })),
+		).toBe(`documents-panel-representation-${DECLARATION_YEAR}`);
+	});
+});
+
+describe("getDocumentResourceCount", () => {
+	it("counts no resource for a representation declaration", () => {
+		expect(
+			getDocumentResourceCount(
+				makeDeclaration({ type: "representation", hasPrefillData: true }),
+			),
+		).toBe(0);
+	});
+
+	it("counts no resource for a remuneration declaration still in progress", () => {
+		expect(
+			getDocumentResourceCount(makeDeclaration({ status: "in_progress" })),
+		).toBe(0);
+	});
+
+	it("counts the prefill resource as soon as DSN data exists", () => {
+		expect(
+			getDocumentResourceCount(
+				makeDeclaration({ status: "in_progress", hasPrefillData: true }),
+			),
+		).toBe(1);
+	});
+
+	it("counts the recap and transmitted resources once the declaration is done", () => {
+		expect(getDocumentResourceCount(makeDeclaration())).toBe(2);
+	});
+
+	it("counts every resource when the second declaration was submitted", () => {
+		expect(
+			getDocumentResourceCount(
+				makeDeclaration({
+					hasPrefillData: true,
+					hasSubmittedSecondDeclaration: true,
+				}),
+			),
+		).toBe(4);
+	});
+});
+
+describe("DocumentsPanel", () => {
+	it("labels the panel with the remuneration process title", () => {
+		const { dialog, panel } = renderPanel();
+
+		expect(dialog).toHaveAttribute(
+			"id",
+			`documents-panel-remuneration-${DECLARATION_YEAR}`,
+		);
+		expect(dialog).toHaveAttribute(
+			"aria-labelledby",
+			`documents-panel-remuneration-${DECLARATION_YEAR}-title`,
+		);
+		expect(
+			panel.getByText(
+				`Démarche des indicateurs de rémunération ${DECLARATION_YEAR}`,
+			),
+		).toHaveAttribute(
+			"id",
+			`documents-panel-remuneration-${DECLARATION_YEAR}-title`,
+		);
+	});
+
+	it("labels the panel with the representation process title and offers no document", () => {
+		const { panel, links } = renderPanel({ type: "representation" });
+
+		expect(
+			panel.getByText(`Démarche de représentation ${DECLARATION_YEAR}`),
+		).toBeInTheDocument();
+		expect(links()).toHaveLength(0);
+	});
+
+	it("renders one card per available resource, in order", () => {
+		const { links } = renderPanel({
+			hasPrefillData: true,
+			hasSubmittedSecondDeclaration: true,
+		});
+
+		expect(links().map((link) => link.textContent)).toEqual([
+			PREFILL_TITLE,
+			RECAP_TITLE,
+			TRANSMITTED_TITLE,
+			SECOND_TITLE,
+		]);
+	});
+
+	it("points each card at its own PDF route and dates it with the workforce year", () => {
+		const { panel, links } = renderPanel({
+			hasPrefillData: true,
+			hasSubmittedSecondDeclaration: true,
+		});
+
+		expect(links().map((link) => link.getAttribute("href"))).toEqual([
+			`/api/prefill-pdf?year=${DECLARATION_YEAR}`,
+			`/api/declaration-pdf?year=${DECLARATION_YEAR}`,
+			`/api/transmitted-pdf?year=${DECLARATION_YEAR}`,
+			`/api/declaration-pdf?type=correction&year=${DECLARATION_YEAR}`,
+		]);
+		expect(panel.getAllByText(SUBTITLE)).toHaveLength(4);
+		expect(panel.getAllByText("PDF")).toHaveLength(4);
+	});
+
+	it("omits the prefill card when no DSN data is available", () => {
+		const { links } = renderPanel();
+
+		expect(links().map((link) => link.textContent)).toEqual([
+			RECAP_TITLE,
+			TRANSMITTED_TITLE,
+		]);
+	});
+
+	it("omits the recap cards while the declaration is not done", () => {
+		const { links } = renderPanel({
+			status: "in_progress",
+			hasPrefillData: true,
+		});
+
+		expect(links().map((link) => link.textContent)).toEqual([PREFILL_TITLE]);
+	});
+
+	it("triggers a single fetch for a burst of clicks fired before the re-render", async () => {
+		const fetchMock = pendingFetch();
+		vi.stubGlobal("fetch", fetchMock);
+		const { links } = renderPanel();
+
+		const [link] = links();
+		await act(async () => {
+			link?.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+			link?.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+			link?.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith(
+			`/api/declaration-pdf?year=${DECLARATION_YEAR}`,
+		);
+	});
+
+	it("leaves a modifier click to the browser's native behaviour", () => {
+		const fetchMock = pendingFetch();
+		vi.stubGlobal("fetch", fetchMock);
+		const { links } = renderPanel();
+
+		const [link] = links();
+		const notPrevented = fireEvent.click(link as HTMLAnchorElement, {
+			metaKey: true,
+		});
+
+		expect(notPrevented).toBe(true);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(links()[0]).not.toHaveAttribute("aria-busy");
+	});
+
+	it("announces the pending state and marks the card busy while downloading", () => {
+		vi.stubGlobal("fetch", pendingFetch());
+		const { dialog, panel, links } = renderPanel();
+
+		fireEvent.click(links()[0] as HTMLAnchorElement);
+
+		const link = links()[0];
+		expect(link).toHaveAttribute("aria-busy", "true");
+		expect(link).toHaveAttribute("aria-disabled", "true");
+		const announcement = dialog.querySelector('[aria-live="polite"]');
+		expect(announcement).toHaveAttribute("aria-atomic", "true");
+		expect(announcement).toHaveTextContent("Téléchargement en cours…");
+		expect(panel.getAllByText("Téléchargement en cours…")).toHaveLength(2);
+		expect(panel.getAllByText("PDF")).toHaveLength(1);
+	});
+
+	it("keeps each card's download state independent", () => {
+		vi.stubGlobal("fetch", pendingFetch());
+		const { links } = renderPanel();
+
+		fireEvent.click(links()[0] as HTMLAnchorElement);
+
+		expect(links()[0]).toHaveAttribute("aria-busy", "true");
+		expect(links()[1]).not.toHaveAttribute("aria-busy");
+	});
+
+	it("renders an alert message when the download fails", async () => {
+		vi.stubGlobal("fetch", failingFetch());
+		const { panel, links } = renderPanel();
+
+		fireEvent.click(links()[0] as HTMLAnchorElement);
+
+		const alert = await panel.findByRole("alert", { hidden: true });
+		expect(alert).toHaveTextContent("Le téléchargement a échoué, réessayez.");
+	});
+
+	it("accepts a new download after a failed attempt", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: false,
+				blob: () => Promise.resolve(new Blob(["pdf"])),
+				headers: { get: () => null },
+			} as unknown as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				blob: () => Promise.resolve(new Blob(["pdf"])),
+				headers: { get: () => null },
+			} as unknown as Response);
+		vi.stubGlobal("fetch", fetchMock);
+		const { panel, links } = renderPanel();
+
+		fireEvent.click(links()[0] as HTMLAnchorElement);
+		expect(
+			await panel.findByRole("alert", { hidden: true }),
+		).toBeInTheDocument();
+
+		await act(async () => {
+			links()[0]?.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(
+			panel.queryByRole("alert", { hidden: true }),
+		).not.toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/shared/DownloadStatusRegion.tsx
+++ b/packages/app/src/modules/shared/DownloadStatusRegion.tsx
@@ -1,0 +1,22 @@
+import type { DownloadState } from "./useDownloadClickGuard";
+
+type Props = {
+	pendingLabel: string;
+	state: DownloadState;
+};
+
+/** Screen-reader feedback shared by every guarded download link. */
+export function DownloadStatusRegion({ pendingLabel, state }: Props) {
+	return (
+		<>
+			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
+				{state === "pending" ? pendingLabel : ""}
+			</p>
+			{state === "error" && (
+				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
+					Le téléchargement a échoué, réessayez.
+				</p>
+			)}
+		</>
+	);
+}

--- a/packages/app/src/modules/shared/FileDownloadLink.tsx
+++ b/packages/app/src/modules/shared/FileDownloadLink.tsx
@@ -1,14 +1,23 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 type DownloadState = "idle" | "pending" | "error";
 
+// Browsers cancel a download whose blob URL is revoked too early. Keep the
+// URL alive long enough for the click to be picked up by the download
+// manager, then release the memory.
+const OBJECT_URL_TTL_MS = 60_000;
+
 export function useFileDownload() {
 	const [state, setState] = useState<DownloadState>("idle");
+	// Guards against a burst of clicks fired before React re-renders with the
+	// pending state — the very behaviour this component exists to fix.
+	const isDownloading = useRef(false);
 
 	async function download(href: string): Promise<void> {
-		if (state === "pending") return;
+		if (isDownloading.current) return;
+		isDownloading.current = true;
 		setState("pending");
 		try {
 			const response = await fetch(href);
@@ -31,15 +40,27 @@ export function useFileDownload() {
 			const anchor = document.createElement("a");
 			anchor.href = objectUrl;
 			if (filename) anchor.download = filename;
+			document.body.appendChild(anchor);
 			anchor.click();
-			URL.revokeObjectURL(objectUrl);
+			anchor.remove();
+			setTimeout(() => URL.revokeObjectURL(objectUrl), OBJECT_URL_TTL_MS);
 			setState("idle");
 		} catch {
 			setState("error");
+		} finally {
+			isDownloading.current = false;
 		}
 	}
 
 	return { state, download };
+}
+
+/**
+ * A modifier click ("open in a new tab", "save as") must keep the browser's
+ * native behaviour — hijacking it would be a regression on the plain link.
+ */
+export function isNativeClick(event: React.MouseEvent): boolean {
+	return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 }
 
 type Props = {
@@ -67,6 +88,7 @@ export function FileDownloadLink({
 				className={className}
 				href={href}
 				onClick={(e) => {
+					if (isNativeClick(e)) return;
 					e.preventDefault();
 					onBeforeDownload?.();
 					void download(href);

--- a/packages/app/src/modules/shared/FileDownloadLink.tsx
+++ b/packages/app/src/modules/shared/FileDownloadLink.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+
+type DownloadState = "idle" | "pending" | "error";
+
+export function useFileDownload() {
+	const [state, setState] = useState<DownloadState>("idle");
+
+	async function download(href: string): Promise<void> {
+		if (state === "pending") return;
+		setState("pending");
+		try {
+			const response = await fetch(href);
+			if (!response.ok) {
+				setState("error");
+				return;
+			}
+			const blob = await response.blob();
+			const objectUrl = URL.createObjectURL(blob);
+			const disposition = response.headers.get("Content-Disposition");
+			let filename = "";
+			if (disposition) {
+				const utf8Match = /filename\*=UTF-8''([^;\r\n]+)/i.exec(disposition);
+				const asciiMatch = /filename=["']?([^"';\r\n]+)["']?/i.exec(
+					disposition,
+				);
+				const raw = utf8Match?.[1] ?? asciiMatch?.[1];
+				if (raw) filename = decodeURIComponent(raw.trim());
+			}
+			const anchor = document.createElement("a");
+			anchor.href = objectUrl;
+			if (filename) anchor.download = filename;
+			anchor.click();
+			URL.revokeObjectURL(objectUrl);
+			setState("idle");
+		} catch {
+			setState("error");
+		}
+	}
+
+	return { state, download };
+}
+
+type Props = {
+	href: string;
+	className?: string;
+	pendingLabel?: string;
+	onBeforeDownload?: () => void;
+	children: React.ReactNode;
+};
+
+export function FileDownloadLink({
+	href,
+	className,
+	pendingLabel = "Téléchargement en cours…",
+	onBeforeDownload,
+	children,
+}: Props) {
+	const { state, download } = useFileDownload();
+
+	return (
+		<>
+			<a
+				aria-busy={state === "pending" ? "true" : undefined}
+				aria-disabled={state === "pending" ? "true" : undefined}
+				className={className}
+				href={href}
+				onClick={(e) => {
+					e.preventDefault();
+					onBeforeDownload?.();
+					void download(href);
+				}}
+			>
+				{state === "pending" ? pendingLabel : children}
+			</a>
+			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
+				{state === "pending" ? pendingLabel : ""}
+			</p>
+			{state === "error" && (
+				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
+					Le téléchargement a échoué, réessayez.
+				</p>
+			)}
+		</>
+	);
+}

--- a/packages/app/src/modules/shared/FileDownloadLink.tsx
+++ b/packages/app/src/modules/shared/FileDownloadLink.tsx
@@ -1,67 +1,7 @@
 "use client";
 
-import { useRef, useState } from "react";
-
-type DownloadState = "idle" | "pending" | "error";
-
-// Browsers cancel a download whose blob URL is revoked too early. Keep the
-// URL alive long enough for the click to be picked up by the download
-// manager, then release the memory.
-const OBJECT_URL_TTL_MS = 60_000;
-
-export function useFileDownload() {
-	const [state, setState] = useState<DownloadState>("idle");
-	// Guards against a burst of clicks fired before React re-renders with the
-	// pending state — the very behaviour this component exists to fix.
-	const isDownloading = useRef(false);
-
-	async function download(href: string): Promise<void> {
-		if (isDownloading.current) return;
-		isDownloading.current = true;
-		setState("pending");
-		try {
-			const response = await fetch(href);
-			if (!response.ok) {
-				setState("error");
-				return;
-			}
-			const blob = await response.blob();
-			const objectUrl = URL.createObjectURL(blob);
-			const disposition = response.headers.get("Content-Disposition");
-			let filename = "";
-			if (disposition) {
-				const utf8Match = /filename\*=UTF-8''([^;\r\n]+)/i.exec(disposition);
-				const asciiMatch = /filename=["']?([^"';\r\n]+)["']?/i.exec(
-					disposition,
-				);
-				const raw = utf8Match?.[1] ?? asciiMatch?.[1];
-				if (raw) filename = decodeURIComponent(raw.trim());
-			}
-			const anchor = document.createElement("a");
-			anchor.href = objectUrl;
-			if (filename) anchor.download = filename;
-			document.body.appendChild(anchor);
-			anchor.click();
-			anchor.remove();
-			setTimeout(() => URL.revokeObjectURL(objectUrl), OBJECT_URL_TTL_MS);
-			setState("idle");
-		} catch {
-			setState("error");
-		} finally {
-			isDownloading.current = false;
-		}
-	}
-
-	return { state, download };
-}
-
-/**
- * A modifier click ("open in a new tab", "save as") must keep the browser's
- * native behaviour — hijacking it would be a regression on the plain link.
- */
-export function isNativeClick(event: React.MouseEvent): boolean {
-	return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
-}
+import { DownloadStatusRegion } from "./DownloadStatusRegion";
+import { useDownloadClickGuard } from "./useDownloadClickGuard";
 
 type Props = {
 	href: string;
@@ -78,32 +18,14 @@ export function FileDownloadLink({
 	onBeforeDownload,
 	children,
 }: Props) {
-	const { state, download } = useFileDownload();
+	const { anchorProps, state } = useDownloadClickGuard(href, onBeforeDownload);
 
 	return (
 		<>
-			<a
-				aria-busy={state === "pending" ? "true" : undefined}
-				aria-disabled={state === "pending" ? "true" : undefined}
-				className={className}
-				href={href}
-				onClick={(e) => {
-					if (isNativeClick(e)) return;
-					e.preventDefault();
-					onBeforeDownload?.();
-					void download(href);
-				}}
-			>
+			<a className={className} {...anchorProps}>
 				{state === "pending" ? pendingLabel : children}
 			</a>
-			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
-				{state === "pending" ? pendingLabel : ""}
-			</p>
-			{state === "error" && (
-				<p className="fr-text--xs fr-error-text fr-mt-1w fr-mb-0" role="alert">
-					Le téléchargement a échoué, réessayez.
-				</p>
-			)}
+			<DownloadStatusRegion pendingLabel={pendingLabel} state={state} />
 		</>
 	);
 }

--- a/packages/app/src/modules/shared/__tests__/DownloadStatusRegion.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/DownloadStatusRegion.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { getLiveRegion } from "~/test/downloadHelpers";
+import { DownloadStatusRegion } from "../DownloadStatusRegion";
+
+const PENDING_LABEL = "Génération du récapitulatif en cours…";
+const ERROR_MESSAGE = "Le téléchargement a échoué, réessayez.";
+
+describe("DownloadStatusRegion", () => {
+	it("keeps a silent polite region while idle", () => {
+		const { container } = render(
+			<DownloadStatusRegion pendingLabel={PENDING_LABEL} state="idle" />,
+		);
+
+		const liveRegion = getLiveRegion(container);
+		expect(liveRegion).toBeInTheDocument();
+		expect(liveRegion).toBeEmptyDOMElement();
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("announces the pending label politely and atomically", () => {
+		const { container } = render(
+			<DownloadStatusRegion pendingLabel={PENDING_LABEL} state="pending" />,
+		);
+
+		const liveRegion = getLiveRegion(container);
+		expect(liveRegion).toHaveTextContent(PENDING_LABEL);
+		expect(liveRegion).toHaveAttribute("aria-atomic", "true");
+		expect(liveRegion).toHaveClass("fr-sr-only");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("carries no role of its own, so it never double-declares a live region", () => {
+		const { container } = render(
+			<DownloadStatusRegion pendingLabel={PENDING_LABEL} state="pending" />,
+		);
+
+		expect(getLiveRegion(container)).not.toHaveAttribute("role");
+		expect(screen.queryByRole("status")).not.toBeInTheDocument();
+	});
+
+	it("reports a failure in an alert and stops announcing progress", () => {
+		const { container } = render(
+			<DownloadStatusRegion pendingLabel={PENDING_LABEL} state="error" />,
+		);
+
+		expect(screen.getByRole("alert")).toHaveTextContent(ERROR_MESSAGE);
+		expect(getLiveRegion(container)).toBeEmptyDOMElement();
+	});
+});

--- a/packages/app/src/modules/shared/__tests__/FileDownloadLink.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/FileDownloadLink.test.tsx
@@ -2,395 +2,66 @@ import {
 	act,
 	fireEvent,
 	render,
-	renderHook,
 	screen,
 	waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { MouseEvent } from "react";
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	type Mock,
-	vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-	FileDownloadLink,
-	isNativeClick,
-	useFileDownload,
-} from "../FileDownloadLink";
+	getLiveRegion,
+	pdfResponse,
+	pendingFetch,
+} from "~/test/downloadHelpers";
+import { FileDownloadLink } from "../FileDownloadLink";
 
-const createObjectURLMock = URL.createObjectURL as unknown as Mock;
-const revokeObjectURLMock = URL.revokeObjectURL as unknown as Mock;
-
-const NATIVE_CLICK_MODIFIERS = [
-	"altKey",
-	"ctrlKey",
-	"metaKey",
-	"shiftKey",
-] as const;
-
-function pdfResponse(
-	disposition?: string,
-	{ ok = true }: { ok?: boolean } = {},
-): Response {
-	return {
-		ok,
-		blob: () => Promise.resolve(new Blob(["pdf"], { type: "application/pdf" })),
-		headers: {
-			get: (name: string) =>
-				name.toLowerCase() === "content-disposition"
-					? (disposition ?? null)
-					: null,
-		},
-	} as unknown as Response;
-}
-
-function mouseEvent(
-	modifier?: (typeof NATIVE_CLICK_MODIFIERS)[number],
-): MouseEvent {
-	return {
-		altKey: false,
-		ctrlKey: false,
-		metaKey: false,
-		shiftKey: false,
-		...(modifier ? { [modifier]: true } : {}),
-	} as unknown as MouseEvent;
-}
-
-function pendingFetch(): Mock {
-	return vi.fn(() => new Promise<Response>(() => undefined));
-}
+const HREF = "/api/declaration-pdf";
+const PENDING_LABEL = "Génération du récapitulatif en cours…";
+const CHILDREN = "Télécharger le récapitulatif";
 
 // Never lets a real navigation happen (jsdom logs "Not implemented: navigation")
 // and lets us assert the programmatic download click.
 let clickSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
-	createObjectURLMock.mockClear();
-	revokeObjectURLMock.mockClear();
 	clickSpy = vi
 		.spyOn(HTMLAnchorElement.prototype, "click")
 		.mockImplementation(() => undefined);
 });
 
 afterEach(() => {
-	vi.useRealTimers();
 	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
 });
 
-describe("isNativeClick", () => {
-	it.each(NATIVE_CLICK_MODIFIERS)("detects a %s click", (modifier) => {
-		expect(isNativeClick(mouseEvent(modifier))).toBe(true);
-	});
-
-	it("does not detect a plain click", () => {
-		expect(isNativeClick(mouseEvent())).toBe(false);
-	});
-});
-
-describe("useFileDownload", () => {
-	it("fetches the blob, triggers a programmatic download and returns to idle", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() =>
-				Promise.resolve(pdfResponse('attachment; filename="recap.pdf"')),
-			),
-		);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(fetch).toHaveBeenCalledWith("/api/declaration-pdf");
-		expect(createObjectURLMock).toHaveBeenCalledTimes(1);
-		expect(clickSpy).toHaveBeenCalledTimes(1);
-		expect(result.current.state).toBe("idle");
-	});
-
-	it("keeps the object URL alive once the click is handed over to the browser", async () => {
-		vi.useFakeTimers();
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => Promise.resolve(pdfResponse())),
-		);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(clickSpy).toHaveBeenCalledTimes(1);
-		expect(revokeObjectURLMock).not.toHaveBeenCalled();
-	});
-
-	it("revokes the object URL once the retention delay has elapsed", async () => {
-		vi.useFakeTimers();
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => Promise.resolve(pdfResponse())),
-		);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-		act(() => {
-			vi.runAllTimers();
-		});
-
-		expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
-		expect(revokeObjectURLMock).toHaveBeenCalledWith(
-			createObjectURLMock.mock.results[0]?.value,
-		);
-	});
-
-	it("attaches the programmatic anchor to the document and detaches it after the click", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => Promise.resolve(pdfResponse())),
-		);
-		const { result } = renderHook(() => useFileDownload());
-		const anchor = document.createElement("a");
-		const createElementSpy = vi
-			.spyOn(document, "createElement")
-			.mockReturnValue(anchor);
-		let connectedDuringClick: boolean | undefined;
-		clickSpy.mockImplementation(() => {
-			connectedDuringClick = anchor.isConnected;
-		});
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-		createElementSpy.mockRestore();
-
-		expect(connectedDuringClick).toBe(true);
-		expect(anchor.isConnected).toBe(false);
-	});
-
-	it("ignores a burst of calls fired before the pending state is committed", async () => {
-		const fetchMock = pendingFetch();
-		vi.stubGlobal("fetch", fetchMock);
-		const { result } = renderHook(() => useFileDownload());
-		const { download } = result.current;
-
-		await act(async () => {
-			void download("/api/declaration-pdf");
-			void download("/api/declaration-pdf");
-			void download("/api/declaration-pdf");
-		});
-
-		expect(fetchMock).toHaveBeenCalledTimes(1);
-	});
-
-	it("ignores a second call while a download is pending", async () => {
-		let releaseFetch: (response: Response) => void = () => undefined;
-		const fetchMock = vi.fn(
-			() =>
-				new Promise<Response>((resolve) => {
-					releaseFetch = resolve;
-				}),
-		);
-		vi.stubGlobal("fetch", fetchMock);
-		const { result } = renderHook(() => useFileDownload());
-
-		let firstCall: Promise<void> = Promise.resolve();
-		act(() => {
-			firstCall = result.current.download("/api/declaration-pdf");
-		});
-		expect(result.current.state).toBe("pending");
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(fetchMock).toHaveBeenCalledTimes(1);
-
-		await act(async () => {
-			releaseFetch(pdfResponse());
-			await firstCall;
-		});
-		expect(result.current.state).toBe("idle");
-	});
-
-	it("sets error state when the response is not ok", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => Promise.resolve(pdfResponse(undefined, { ok: false }))),
-		);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(result.current.state).toBe("error");
-		expect(clickSpy).not.toHaveBeenCalled();
-		expect(createObjectURLMock).not.toHaveBeenCalled();
-	});
-
-	it("sets error state when fetch rejects", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => Promise.reject(new Error("network down"))),
-		);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(result.current.state).toBe("error");
-	});
-
-	it("accepts a new download after a failed response", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValueOnce(pdfResponse(undefined, { ok: false }))
-			.mockResolvedValueOnce(pdfResponse());
-		vi.stubGlobal("fetch", fetchMock);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-		expect(result.current.state).toBe("error");
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(fetchMock).toHaveBeenCalledTimes(2);
-		expect(result.current.state).toBe("idle");
-	});
-
-	it("accepts a new download after fetch rejected", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockRejectedValueOnce(new Error("network down"))
-			.mockResolvedValueOnce(pdfResponse());
-		vi.stubGlobal("fetch", fetchMock);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-		expect(result.current.state).toBe("error");
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(fetchMock).toHaveBeenCalledTimes(2);
-		expect(result.current.state).toBe("idle");
-	});
-
-	it("extracts the filename from an ASCII Content-Disposition header", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() =>
-				Promise.resolve(pdfResponse('attachment; filename="recap-2026.pdf"')),
-			),
-		);
-		const anchor = document.createElement("a");
-		const createElementSpy = vi
-			.spyOn(document, "createElement")
-			.mockReturnValue(anchor);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(anchor.download).toBe("recap-2026.pdf");
-		createElementSpy.mockRestore();
-	});
-
-	it("prefers the UTF-8 Content-Disposition filename and decodes it", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() =>
-				Promise.resolve(
-					pdfResponse(
-						"attachment; filename=\"fallback.pdf\"; filename*=UTF-8''r%C3%A9capitulatif.pdf",
-					),
-				),
-			),
-		);
-		const anchor = document.createElement("a");
-		const createElementSpy = vi
-			.spyOn(document, "createElement")
-			.mockReturnValue(anchor);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(anchor.download).toBe("récapitulatif.pdf");
-		createElementSpy.mockRestore();
-	});
-
-	it("leaves the download attribute unset when no filename can be parsed", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => Promise.resolve(pdfResponse("attachment"))),
-		);
-		const anchor = document.createElement("a");
-		const createElementSpy = vi
-			.spyOn(document, "createElement")
-			.mockReturnValue(anchor);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(anchor.download).toBe("");
-		createElementSpy.mockRestore();
-	});
-
-	it("leaves the download attribute unset when the header is absent", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => Promise.resolve(pdfResponse())),
-		);
-		const anchor = document.createElement("a");
-		const createElementSpy = vi
-			.spyOn(document, "createElement")
-			.mockReturnValue(anchor);
-		const { result } = renderHook(() => useFileDownload());
-
-		await act(async () => {
-			await result.current.download("/api/declaration-pdf");
-		});
-
-		expect(anchor.download).toBe("");
-		createElementSpy.mockRestore();
-	});
-});
+function renderLink(props: { pendingLabel?: string } = {}) {
+	return render(
+		<FileDownloadLink href={HREF} {...props}>
+			{CHILDREN}
+		</FileDownloadLink>,
+	);
+}
 
 describe("FileDownloadLink", () => {
 	it("renders the children as a link pointing at the real href", () => {
+		renderLink();
+
+		const link = screen.getByRole("link", { name: CHILDREN });
+		expect(link).toHaveAttribute("href", HREF);
+		expect(link).not.toHaveAttribute("aria-busy");
+		expect(link).not.toHaveAttribute("aria-disabled");
+	});
+
+	it("keeps the caller's className alongside the guarded anchor props", () => {
 		render(
-			<FileDownloadLink href="/api/declaration-pdf">
-				Télécharger le récapitulatif
+			<FileDownloadLink className="fr-link fr-link--download" href={HREF}>
+				{CHILDREN}
 			</FileDownloadLink>,
 		);
 
-		const link = screen.getByRole("link", {
-			name: "Télécharger le récapitulatif",
-		});
-		expect(link).toHaveAttribute("href", "/api/declaration-pdf");
-		expect(link).not.toHaveAttribute("aria-busy");
-		expect(link).not.toHaveAttribute("aria-disabled");
+		const link = screen.getByRole("link");
+		expect(link).toHaveClass("fr-link", "fr-link--download");
+		expect(link).toHaveAttribute("href", HREF);
 	});
 
 	it("shows the pending label and sets aria-busy/aria-disabled while downloading", async () => {
@@ -405,26 +76,17 @@ describe("FileDownloadLink", () => {
 					}),
 			),
 		);
-		const { container } = render(
-			<FileDownloadLink
-				href="/api/declaration-pdf"
-				pendingLabel="Génération du récapitulatif en cours…"
-			>
-				Télécharger le récapitulatif
-			</FileDownloadLink>,
-		);
+		const { container } = renderLink({ pendingLabel: PENDING_LABEL });
 
 		await user.click(screen.getByRole("link"));
 
 		const link = screen.getByRole("link");
 		expect(link).toHaveAttribute("aria-busy", "true");
 		expect(link).toHaveAttribute("aria-disabled", "true");
-		expect(link).toHaveTextContent("Génération du récapitulatif en cours…");
-		const announcement = container.querySelector('[aria-live="polite"]');
+		expect(link).toHaveTextContent(PENDING_LABEL);
+		const announcement = getLiveRegion(container);
 		expect(announcement).toHaveAttribute("aria-atomic", "true");
-		expect(announcement).toHaveTextContent(
-			"Génération du récapitulatif en cours…",
-		);
+		expect(announcement).toHaveTextContent(PENDING_LABEL);
 
 		await act(async () => {
 			releaseFetch(pdfResponse());
@@ -435,15 +97,23 @@ describe("FileDownloadLink", () => {
 		expect(announcement).toBeEmptyDOMElement();
 	});
 
+	it("uses the default pending label when none is provided", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal("fetch", pendingFetch());
+		renderLink();
+
+		await user.click(screen.getByRole("link"));
+
+		expect(screen.getByRole("link")).toHaveTextContent(
+			"Téléchargement en cours…",
+		);
+	});
+
 	it("does not trigger a second fetch when clicked again while pending", async () => {
 		const user = userEvent.setup();
 		const fetchMock = pendingFetch();
 		vi.stubGlobal("fetch", fetchMock);
-		render(
-			<FileDownloadLink href="/api/declaration-pdf">
-				Télécharger le récapitulatif
-			</FileDownloadLink>,
-		);
+		renderLink();
 
 		const link = screen.getByRole("link");
 		await user.click(link);
@@ -456,40 +126,25 @@ describe("FileDownloadLink", () => {
 	it("triggers a single fetch for a burst of clicks fired before the re-render", async () => {
 		const fetchMock = pendingFetch();
 		vi.stubGlobal("fetch", fetchMock);
-		render(
-			<FileDownloadLink href="/api/declaration-pdf">
-				Télécharger le récapitulatif
-			</FileDownloadLink>,
-		);
+		renderLink();
 
 		const link = screen.getByRole("link");
 		await act(async () => {
-			link.dispatchEvent(
-				new MouseEvent("click", { bubbles: true, cancelable: true }),
-			);
-			link.dispatchEvent(
-				new MouseEvent("click", { bubbles: true, cancelable: true }),
-			);
-			link.dispatchEvent(
-				new MouseEvent("click", { bubbles: true, cancelable: true }),
-			);
+			for (let i = 0; i < 3; i++) {
+				link.dispatchEvent(
+					new MouseEvent("click", { bubbles: true, cancelable: true }),
+				);
+			}
 		});
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith(HREF);
 	});
 
 	it("leaves a modifier click to the browser's native behaviour", () => {
 		const fetchMock = pendingFetch();
-		const onBeforeDownload = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
-		render(
-			<FileDownloadLink
-				href="/api/declaration-pdf"
-				onBeforeDownload={onBeforeDownload}
-			>
-				Télécharger le récapitulatif
-			</FileDownloadLink>,
-		);
+		renderLink();
 
 		const notPrevented = fireEvent.click(screen.getByRole("link"), {
 			metaKey: true,
@@ -497,7 +152,6 @@ describe("FileDownloadLink", () => {
 
 		expect(notPrevented).toBe(true);
 		expect(fetchMock).not.toHaveBeenCalled();
-		expect(onBeforeDownload).not.toHaveBeenCalled();
 		expect(screen.getByRole("link")).not.toHaveAttribute("aria-busy");
 	});
 
@@ -509,11 +163,8 @@ describe("FileDownloadLink", () => {
 			vi.fn(() => Promise.resolve(pdfResponse())),
 		);
 		render(
-			<FileDownloadLink
-				href="/api/declaration-pdf"
-				onBeforeDownload={onBeforeDownload}
-			>
-				Télécharger le récapitulatif
+			<FileDownloadLink href={HREF} onBeforeDownload={onBeforeDownload}>
+				{CHILDREN}
 			</FileDownloadLink>,
 		);
 
@@ -528,11 +179,7 @@ describe("FileDownloadLink", () => {
 			"fetch",
 			vi.fn(() => Promise.resolve(pdfResponse(undefined, { ok: false }))),
 		);
-		render(
-			<FileDownloadLink href="/api/declaration-pdf">
-				Télécharger le récapitulatif
-			</FileDownloadLink>,
-		);
+		renderLink();
 
 		await user.click(screen.getByRole("link"));
 
@@ -547,11 +194,7 @@ describe("FileDownloadLink", () => {
 			.mockResolvedValueOnce(pdfResponse(undefined, { ok: false }))
 			.mockResolvedValueOnce(pdfResponse());
 		vi.stubGlobal("fetch", fetchMock);
-		render(
-			<FileDownloadLink href="/api/declaration-pdf">
-				Télécharger le récapitulatif
-			</FileDownloadLink>,
-		);
+		renderLink();
 
 		await user.click(screen.getByRole("link"));
 		expect(await screen.findByRole("alert")).toBeInTheDocument();
@@ -563,21 +206,5 @@ describe("FileDownloadLink", () => {
 			expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
 		);
 		expect(clickSpy).toHaveBeenCalledTimes(1);
-	});
-
-	it("uses the default pending label when none is provided", async () => {
-		const user = userEvent.setup();
-		vi.stubGlobal("fetch", pendingFetch());
-		render(
-			<FileDownloadLink href="/api/no-sanction-pdf">
-				Télécharger l&apos;attestation
-			</FileDownloadLink>,
-		);
-
-		await user.click(screen.getByRole("link"));
-
-		expect(screen.getByRole("link")).toHaveTextContent(
-			"Téléchargement en cours…",
-		);
 	});
 });

--- a/packages/app/src/modules/shared/__tests__/FileDownloadLink.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/FileDownloadLink.test.tsx
@@ -1,11 +1,13 @@
 import {
 	act,
+	fireEvent,
 	render,
 	renderHook,
 	screen,
 	waitFor,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { MouseEvent } from "react";
 import {
 	afterEach,
 	beforeEach,
@@ -16,10 +18,21 @@ import {
 	vi,
 } from "vitest";
 
-import { FileDownloadLink, useFileDownload } from "../FileDownloadLink";
+import {
+	FileDownloadLink,
+	isNativeClick,
+	useFileDownload,
+} from "../FileDownloadLink";
 
 const createObjectURLMock = URL.createObjectURL as unknown as Mock;
 const revokeObjectURLMock = URL.revokeObjectURL as unknown as Mock;
+
+const NATIVE_CLICK_MODIFIERS = [
+	"altKey",
+	"ctrlKey",
+	"metaKey",
+	"shiftKey",
+] as const;
 
 function pdfResponse(
 	disposition?: string,
@@ -37,6 +50,22 @@ function pdfResponse(
 	} as unknown as Response;
 }
 
+function mouseEvent(
+	modifier?: (typeof NATIVE_CLICK_MODIFIERS)[number],
+): MouseEvent {
+	return {
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		shiftKey: false,
+		...(modifier ? { [modifier]: true } : {}),
+	} as unknown as MouseEvent;
+}
+
+function pendingFetch(): Mock {
+	return vi.fn(() => new Promise<Response>(() => undefined));
+}
+
 // Never lets a real navigation happen (jsdom logs "Not implemented: navigation")
 // and lets us assert the programmatic download click.
 let clickSpy: ReturnType<typeof vi.spyOn>;
@@ -50,8 +79,19 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	vi.useRealTimers();
 	vi.restoreAllMocks();
 	vi.unstubAllGlobals();
+});
+
+describe("isNativeClick", () => {
+	it.each(NATIVE_CLICK_MODIFIERS)("detects a %s click", (modifier) => {
+		expect(isNativeClick(mouseEvent(modifier))).toBe(true);
+	});
+
+	it("does not detect a plain click", () => {
+		expect(isNativeClick(mouseEvent())).toBe(false);
+	});
 });
 
 describe("useFileDownload", () => {
@@ -71,8 +111,83 @@ describe("useFileDownload", () => {
 		expect(fetch).toHaveBeenCalledWith("/api/declaration-pdf");
 		expect(createObjectURLMock).toHaveBeenCalledTimes(1);
 		expect(clickSpy).toHaveBeenCalledTimes(1);
-		expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
 		expect(result.current.state).toBe("idle");
+	});
+
+	it("keeps the object URL alive once the click is handed over to the browser", async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(clickSpy).toHaveBeenCalledTimes(1);
+		expect(revokeObjectURLMock).not.toHaveBeenCalled();
+	});
+
+	it("revokes the object URL once the retention delay has elapsed", async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+		act(() => {
+			vi.runAllTimers();
+		});
+
+		expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(revokeObjectURLMock).toHaveBeenCalledWith(
+			createObjectURLMock.mock.results[0]?.value,
+		);
+	});
+
+	it("attaches the programmatic anchor to the document and detaches it after the click", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const { result } = renderHook(() => useFileDownload());
+		const anchor = document.createElement("a");
+		const createElementSpy = vi
+			.spyOn(document, "createElement")
+			.mockReturnValue(anchor);
+		let connectedDuringClick: boolean | undefined;
+		clickSpy.mockImplementation(() => {
+			connectedDuringClick = anchor.isConnected;
+		});
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+		createElementSpy.mockRestore();
+
+		expect(connectedDuringClick).toBe(true);
+		expect(anchor.isConnected).toBe(false);
+	});
+
+	it("ignores a burst of calls fired before the pending state is committed", async () => {
+		const fetchMock = pendingFetch();
+		vi.stubGlobal("fetch", fetchMock);
+		const { result } = renderHook(() => useFileDownload());
+		const { download } = result.current;
+
+		await act(async () => {
+			void download("/api/declaration-pdf");
+			void download("/api/declaration-pdf");
+			void download("/api/declaration-pdf");
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
 	it("ignores a second call while a download is pending", async () => {
@@ -133,6 +248,48 @@ describe("useFileDownload", () => {
 		});
 
 		expect(result.current.state).toBe("error");
+	});
+
+	it("accepts a new download after a failed response", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(pdfResponse(undefined, { ok: false }))
+			.mockResolvedValueOnce(pdfResponse());
+		vi.stubGlobal("fetch", fetchMock);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+		expect(result.current.state).toBe("error");
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.current.state).toBe("idle");
+	});
+
+	it("accepts a new download after fetch rejected", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("network down"))
+			.mockResolvedValueOnce(pdfResponse());
+		vi.stubGlobal("fetch", fetchMock);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+		expect(result.current.state).toBe("error");
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.current.state).toBe("idle");
 	});
 
 	it("extracts the filename from an ASCII Content-Disposition header", async () => {
@@ -248,7 +405,7 @@ describe("FileDownloadLink", () => {
 					}),
 			),
 		);
-		render(
+		const { container } = render(
 			<FileDownloadLink
 				href="/api/declaration-pdf"
 				pendingLabel="Génération du récapitulatif en cours…"
@@ -263,7 +420,9 @@ describe("FileDownloadLink", () => {
 		expect(link).toHaveAttribute("aria-busy", "true");
 		expect(link).toHaveAttribute("aria-disabled", "true");
 		expect(link).toHaveTextContent("Génération du récapitulatif en cours…");
-		expect(screen.getByRole("status")).toHaveTextContent(
+		const announcement = container.querySelector('[aria-live="polite"]');
+		expect(announcement).toHaveAttribute("aria-atomic", "true");
+		expect(announcement).toHaveTextContent(
 			"Génération du récapitulatif en cours…",
 		);
 
@@ -273,11 +432,12 @@ describe("FileDownloadLink", () => {
 		await waitFor(() =>
 			expect(screen.getByRole("link")).not.toHaveAttribute("aria-busy"),
 		);
+		expect(announcement).toBeEmptyDOMElement();
 	});
 
 	it("does not trigger a second fetch when clicked again while pending", async () => {
 		const user = userEvent.setup();
-		const fetchMock = vi.fn(() => new Promise<Response>(() => undefined));
+		const fetchMock = pendingFetch();
 		vi.stubGlobal("fetch", fetchMock);
 		render(
 			<FileDownloadLink href="/api/declaration-pdf">
@@ -291,6 +451,54 @@ describe("FileDownloadLink", () => {
 		await user.click(link);
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("triggers a single fetch for a burst of clicks fired before the re-render", async () => {
+		const fetchMock = pendingFetch();
+		vi.stubGlobal("fetch", fetchMock);
+		render(
+			<FileDownloadLink href="/api/declaration-pdf">
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		const link = screen.getByRole("link");
+		await act(async () => {
+			link.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+			link.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+			link.dispatchEvent(
+				new MouseEvent("click", { bubbles: true, cancelable: true }),
+			);
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves a modifier click to the browser's native behaviour", () => {
+		const fetchMock = pendingFetch();
+		const onBeforeDownload = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		render(
+			<FileDownloadLink
+				href="/api/declaration-pdf"
+				onBeforeDownload={onBeforeDownload}
+			>
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		const notPrevented = fireEvent.click(screen.getByRole("link"), {
+			metaKey: true,
+		});
+
+		expect(notPrevented).toBe(true);
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(onBeforeDownload).not.toHaveBeenCalled();
+		expect(screen.getByRole("link")).not.toHaveAttribute("aria-busy");
 	});
 
 	it("invokes onBeforeDownload before starting the download", async () => {
@@ -332,12 +540,34 @@ describe("FileDownloadLink", () => {
 		expect(alert).toHaveTextContent("Le téléchargement a échoué, réessayez.");
 	});
 
+	it("clears the error and downloads again when the user retries", async () => {
+		const user = userEvent.setup();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(pdfResponse(undefined, { ok: false }))
+			.mockResolvedValueOnce(pdfResponse());
+		vi.stubGlobal("fetch", fetchMock);
+		render(
+			<FileDownloadLink href="/api/declaration-pdf">
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		await user.click(screen.getByRole("link"));
+		expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+		await user.click(screen.getByRole("link"));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		await waitFor(() =>
+			expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+		);
+		expect(clickSpy).toHaveBeenCalledTimes(1);
+	});
+
 	it("uses the default pending label when none is provided", async () => {
 		const user = userEvent.setup();
-		vi.stubGlobal(
-			"fetch",
-			vi.fn(() => new Promise<Response>(() => undefined)),
-		);
+		vi.stubGlobal("fetch", pendingFetch());
 		render(
 			<FileDownloadLink href="/api/no-sanction-pdf">
 				Télécharger l&apos;attestation

--- a/packages/app/src/modules/shared/__tests__/FileDownloadLink.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/FileDownloadLink.test.tsx
@@ -1,0 +1,353 @@
+import {
+	act,
+	render,
+	renderHook,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
+
+import { FileDownloadLink, useFileDownload } from "../FileDownloadLink";
+
+const createObjectURLMock = URL.createObjectURL as unknown as Mock;
+const revokeObjectURLMock = URL.revokeObjectURL as unknown as Mock;
+
+function pdfResponse(
+	disposition?: string,
+	{ ok = true }: { ok?: boolean } = {},
+): Response {
+	return {
+		ok,
+		blob: () => Promise.resolve(new Blob(["pdf"], { type: "application/pdf" })),
+		headers: {
+			get: (name: string) =>
+				name.toLowerCase() === "content-disposition"
+					? (disposition ?? null)
+					: null,
+		},
+	} as unknown as Response;
+}
+
+// Never lets a real navigation happen (jsdom logs "Not implemented: navigation")
+// and lets us assert the programmatic download click.
+let clickSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	createObjectURLMock.mockClear();
+	revokeObjectURLMock.mockClear();
+	clickSpy = vi
+		.spyOn(HTMLAnchorElement.prototype, "click")
+		.mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("useFileDownload", () => {
+	it("fetches the blob, triggers a programmatic download and returns to idle", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(pdfResponse('attachment; filename="recap.pdf"')),
+			),
+		);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(fetch).toHaveBeenCalledWith("/api/declaration-pdf");
+		expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(clickSpy).toHaveBeenCalledTimes(1);
+		expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(result.current.state).toBe("idle");
+	});
+
+	it("ignores a second call while a download is pending", async () => {
+		let releaseFetch: (response: Response) => void = () => undefined;
+		const fetchMock = vi.fn(
+			() =>
+				new Promise<Response>((resolve) => {
+					releaseFetch = resolve;
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const { result } = renderHook(() => useFileDownload());
+
+		let firstCall: Promise<void> = Promise.resolve();
+		act(() => {
+			firstCall = result.current.download("/api/declaration-pdf");
+		});
+		expect(result.current.state).toBe("pending");
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			releaseFetch(pdfResponse());
+			await firstCall;
+		});
+		expect(result.current.state).toBe("idle");
+	});
+
+	it("sets error state when the response is not ok", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse(undefined, { ok: false }))),
+		);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(result.current.state).toBe("error");
+		expect(clickSpy).not.toHaveBeenCalled();
+		expect(createObjectURLMock).not.toHaveBeenCalled();
+	});
+
+	it("sets error state when fetch rejects", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.reject(new Error("network down"))),
+		);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(result.current.state).toBe("error");
+	});
+
+	it("extracts the filename from an ASCII Content-Disposition header", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(pdfResponse('attachment; filename="recap-2026.pdf"')),
+			),
+		);
+		const anchor = document.createElement("a");
+		const createElementSpy = vi
+			.spyOn(document, "createElement")
+			.mockReturnValue(anchor);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(anchor.download).toBe("recap-2026.pdf");
+		createElementSpy.mockRestore();
+	});
+
+	it("prefers the UTF-8 Content-Disposition filename and decodes it", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(
+					pdfResponse(
+						"attachment; filename=\"fallback.pdf\"; filename*=UTF-8''r%C3%A9capitulatif.pdf",
+					),
+				),
+			),
+		);
+		const anchor = document.createElement("a");
+		const createElementSpy = vi
+			.spyOn(document, "createElement")
+			.mockReturnValue(anchor);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(anchor.download).toBe("récapitulatif.pdf");
+		createElementSpy.mockRestore();
+	});
+
+	it("leaves the download attribute unset when no filename can be parsed", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse("attachment"))),
+		);
+		const anchor = document.createElement("a");
+		const createElementSpy = vi
+			.spyOn(document, "createElement")
+			.mockReturnValue(anchor);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(anchor.download).toBe("");
+		createElementSpy.mockRestore();
+	});
+
+	it("leaves the download attribute unset when the header is absent", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const anchor = document.createElement("a");
+		const createElementSpy = vi
+			.spyOn(document, "createElement")
+			.mockReturnValue(anchor);
+		const { result } = renderHook(() => useFileDownload());
+
+		await act(async () => {
+			await result.current.download("/api/declaration-pdf");
+		});
+
+		expect(anchor.download).toBe("");
+		createElementSpy.mockRestore();
+	});
+});
+
+describe("FileDownloadLink", () => {
+	it("renders the children as a link pointing at the real href", () => {
+		render(
+			<FileDownloadLink href="/api/declaration-pdf">
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		const link = screen.getByRole("link", {
+			name: "Télécharger le récapitulatif",
+		});
+		expect(link).toHaveAttribute("href", "/api/declaration-pdf");
+		expect(link).not.toHaveAttribute("aria-busy");
+		expect(link).not.toHaveAttribute("aria-disabled");
+	});
+
+	it("shows the pending label and sets aria-busy/aria-disabled while downloading", async () => {
+		const user = userEvent.setup();
+		let releaseFetch: (response: Response) => void = () => undefined;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(
+				() =>
+					new Promise<Response>((resolve) => {
+						releaseFetch = resolve;
+					}),
+			),
+		);
+		render(
+			<FileDownloadLink
+				href="/api/declaration-pdf"
+				pendingLabel="Génération du récapitulatif en cours…"
+			>
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		await user.click(screen.getByRole("link"));
+
+		const link = screen.getByRole("link");
+		expect(link).toHaveAttribute("aria-busy", "true");
+		expect(link).toHaveAttribute("aria-disabled", "true");
+		expect(link).toHaveTextContent("Génération du récapitulatif en cours…");
+		expect(screen.getByRole("status")).toHaveTextContent(
+			"Génération du récapitulatif en cours…",
+		);
+
+		await act(async () => {
+			releaseFetch(pdfResponse());
+		});
+		await waitFor(() =>
+			expect(screen.getByRole("link")).not.toHaveAttribute("aria-busy"),
+		);
+	});
+
+	it("does not trigger a second fetch when clicked again while pending", async () => {
+		const user = userEvent.setup();
+		const fetchMock = vi.fn(() => new Promise<Response>(() => undefined));
+		vi.stubGlobal("fetch", fetchMock);
+		render(
+			<FileDownloadLink href="/api/declaration-pdf">
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		const link = screen.getByRole("link");
+		await user.click(link);
+		await user.click(link);
+		await user.click(link);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("invokes onBeforeDownload before starting the download", async () => {
+		const user = userEvent.setup();
+		const onBeforeDownload = vi.fn();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		render(
+			<FileDownloadLink
+				href="/api/declaration-pdf"
+				onBeforeDownload={onBeforeDownload}
+			>
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		await user.click(screen.getByRole("link"));
+
+		expect(onBeforeDownload).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders an alert message when the download fails", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse(undefined, { ok: false }))),
+		);
+		render(
+			<FileDownloadLink href="/api/declaration-pdf">
+				Télécharger le récapitulatif
+			</FileDownloadLink>,
+		);
+
+		await user.click(screen.getByRole("link"));
+
+		const alert = await screen.findByRole("alert");
+		expect(alert).toHaveTextContent("Le téléchargement a échoué, réessayez.");
+	});
+
+	it("uses the default pending label when none is provided", async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => new Promise<Response>(() => undefined)),
+		);
+		render(
+			<FileDownloadLink href="/api/no-sanction-pdf">
+				Télécharger l&apos;attestation
+			</FileDownloadLink>,
+		);
+
+		await user.click(screen.getByRole("link"));
+
+		expect(screen.getByRole("link")).toHaveTextContent(
+			"Téléchargement en cours…",
+		);
+	});
+});

--- a/packages/app/src/modules/shared/__tests__/useDownloadClickGuard.test.ts
+++ b/packages/app/src/modules/shared/__tests__/useDownloadClickGuard.test.ts
@@ -1,0 +1,373 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	type Mock,
+	vi,
+} from "vitest";
+
+import { pdfResponse, pendingFetch } from "~/test/downloadHelpers";
+import { isNativeClick, useDownloadClickGuard } from "../useDownloadClickGuard";
+
+const HREF = "/api/declaration-pdf";
+const createObjectURLMock = URL.createObjectURL as unknown as Mock;
+const revokeObjectURLMock = URL.revokeObjectURL as unknown as Mock;
+
+const NATIVE_CLICK_MODIFIERS = [
+	"altKey",
+	"ctrlKey",
+	"metaKey",
+	"shiftKey",
+] as const;
+
+type Modifier = (typeof NATIVE_CLICK_MODIFIERS)[number];
+type ClickEvent = ReactMouseEvent<HTMLAnchorElement> & {
+	preventDefault: Mock;
+};
+
+function clickEvent(modifier?: Modifier): ClickEvent {
+	return {
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		shiftKey: false,
+		...(modifier ? { [modifier]: true } : {}),
+		preventDefault: vi.fn(),
+	} as unknown as ClickEvent;
+}
+
+function renderGuard(onBeforeDownload?: () => void) {
+	const { result } = renderHook(() =>
+		useDownloadClickGuard(HREF, onBeforeDownload),
+	);
+	return {
+		result,
+		click: async (event: ClickEvent = clickEvent()) => {
+			await act(async () => {
+				result.current.anchorProps.onClick(event);
+			});
+			return event;
+		},
+		// Captures the handler once, so the whole burst runs against the render
+		// that still believes the link is idle.
+		burst: async (times: number) => {
+			const { onClick } = result.current.anchorProps;
+			await act(async () => {
+				for (let i = 0; i < times; i++) onClick(clickEvent());
+			});
+		},
+	};
+}
+
+function stubAnchor(): HTMLAnchorElement {
+	const anchor = document.createElement("a");
+	vi.spyOn(document, "createElement").mockReturnValue(anchor);
+	return anchor;
+}
+
+let clickSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	createObjectURLMock.mockClear();
+	revokeObjectURLMock.mockClear();
+	clickSpy = vi
+		.spyOn(HTMLAnchorElement.prototype, "click")
+		.mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("isNativeClick", () => {
+	it.each(NATIVE_CLICK_MODIFIERS)("detects a %s click", (modifier) => {
+		expect(isNativeClick(clickEvent(modifier))).toBe(true);
+	});
+
+	it("does not detect a plain click", () => {
+		expect(isNativeClick(clickEvent())).toBe(false);
+	});
+});
+
+describe("useDownloadClickGuard", () => {
+	it("exposes an untouched link while idle", () => {
+		const { result } = renderGuard();
+
+		expect(result.current.state).toBe("idle");
+		expect(result.current.anchorProps.href).toBe(HREF);
+		expect(result.current.anchorProps["aria-busy"]).toBeUndefined();
+		expect(result.current.anchorProps["aria-disabled"]).toBeUndefined();
+	});
+
+	it("fetches the blob, triggers a programmatic download and returns to idle", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(pdfResponse('attachment; filename="recap.pdf"')),
+			),
+		);
+		const { result, click } = renderGuard();
+
+		const event = await click();
+
+		expect(event.preventDefault).toHaveBeenCalledTimes(1);
+		expect(fetch).toHaveBeenCalledWith(HREF);
+		expect(createObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(clickSpy).toHaveBeenCalledTimes(1);
+		expect(result.current.state).toBe("idle");
+	});
+
+	it("marks the link busy and disabled while the file is being generated", async () => {
+		vi.stubGlobal("fetch", pendingFetch());
+		const { result, click } = renderGuard();
+
+		await click();
+
+		expect(result.current.state).toBe("pending");
+		expect(result.current.anchorProps["aria-busy"]).toBe("true");
+		expect(result.current.anchorProps["aria-disabled"]).toBe("true");
+	});
+
+	it("keeps the object URL alive once the click is handed over to the browser", async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const { click } = renderGuard();
+
+		await click();
+
+		expect(clickSpy).toHaveBeenCalledTimes(1);
+		expect(revokeObjectURLMock).not.toHaveBeenCalled();
+	});
+
+	it("revokes the object URL once the retention delay has elapsed", async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const { click } = renderGuard();
+
+		await click();
+		act(() => {
+			vi.runAllTimers();
+		});
+
+		expect(revokeObjectURLMock).toHaveBeenCalledTimes(1);
+		expect(revokeObjectURLMock).toHaveBeenCalledWith(
+			createObjectURLMock.mock.results[0]?.value,
+		);
+	});
+
+	it("attaches the programmatic anchor to the document and detaches it after the click", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const { click } = renderGuard();
+		const anchor = stubAnchor();
+		let connectedDuringClick: boolean | undefined;
+		clickSpy.mockImplementation(() => {
+			connectedDuringClick = anchor.isConnected;
+		});
+
+		await click();
+
+		expect(connectedDuringClick).toBe(true);
+		expect(anchor.isConnected).toBe(false);
+	});
+
+	it("ignores a burst of clicks fired before the pending state is committed", async () => {
+		const fetchMock = pendingFetch();
+		vi.stubGlobal("fetch", fetchMock);
+		const { burst } = renderGuard();
+
+		await burst(3);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores a further click once the pending state is visible", async () => {
+		let releaseFetch: (response: Response) => void = () => undefined;
+		const fetchMock = vi.fn(
+			() =>
+				new Promise<Response>((resolve) => {
+					releaseFetch = resolve;
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const { result, click } = renderGuard();
+
+		await click();
+		expect(result.current.state).toBe("pending");
+
+		await click();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			releaseFetch(pdfResponse());
+		});
+		await waitFor(() => expect(result.current.state).toBe("idle"));
+	});
+
+	it("leaves a modifier click to the browser's native behaviour", async () => {
+		const fetchMock = pendingFetch();
+		const onBeforeDownload = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const { result, click } = renderGuard(onBeforeDownload);
+
+		const event = await click(clickEvent("metaKey"));
+
+		expect(event.preventDefault).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(onBeforeDownload).not.toHaveBeenCalled();
+		expect(result.current.state).toBe("idle");
+	});
+
+	it("invokes onBeforeDownload before firing the request", async () => {
+		const calls: string[] = [];
+		const onBeforeDownload = vi.fn(() => {
+			calls.push("onBeforeDownload");
+		});
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => {
+				calls.push("fetch");
+				return Promise.resolve(pdfResponse());
+			}),
+		);
+		const { click } = renderGuard(onBeforeDownload);
+
+		await click();
+
+		expect(calls).toEqual(["onBeforeDownload", "fetch"]);
+	});
+
+	it("sets error state when the response is not ok", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse(undefined, { ok: false }))),
+		);
+		const { result, click } = renderGuard();
+
+		await click();
+
+		expect(result.current.state).toBe("error");
+		expect(clickSpy).not.toHaveBeenCalled();
+		expect(createObjectURLMock).not.toHaveBeenCalled();
+	});
+
+	it("sets error state when fetch rejects", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.reject(new Error("network down"))),
+		);
+		const { result, click } = renderGuard();
+
+		await click();
+
+		expect(result.current.state).toBe("error");
+	});
+
+	it("accepts a new download after a failed response", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(pdfResponse(undefined, { ok: false }))
+			.mockResolvedValueOnce(pdfResponse());
+		vi.stubGlobal("fetch", fetchMock);
+		const { result, click } = renderGuard();
+
+		await click();
+		expect(result.current.state).toBe("error");
+
+		await click();
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.current.state).toBe("idle");
+	});
+
+	it("accepts a new download after fetch rejected", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("network down"))
+			.mockResolvedValueOnce(pdfResponse());
+		vi.stubGlobal("fetch", fetchMock);
+		const { result, click } = renderGuard();
+
+		await click();
+		expect(result.current.state).toBe("error");
+
+		await click();
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(result.current.state).toBe("idle");
+	});
+
+	it("names the file from an ASCII Content-Disposition header", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(pdfResponse('attachment; filename="recap-2026.pdf"')),
+			),
+		);
+		const { click } = renderGuard();
+		const anchor = stubAnchor();
+
+		await click();
+
+		expect(anchor.download).toBe("recap-2026.pdf");
+	});
+
+	it("prefers the UTF-8 Content-Disposition filename and decodes it", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() =>
+				Promise.resolve(
+					pdfResponse(
+						"attachment; filename=\"fallback.pdf\"; filename*=UTF-8''r%C3%A9capitulatif.pdf",
+					),
+				),
+			),
+		);
+		const { click } = renderGuard();
+		const anchor = stubAnchor();
+
+		await click();
+
+		expect(anchor.download).toBe("récapitulatif.pdf");
+	});
+
+	it("leaves the download attribute unset when no filename can be parsed", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse("attachment"))),
+		);
+		const { click } = renderGuard();
+		const anchor = stubAnchor();
+
+		await click();
+
+		expect(anchor.download).toBe("");
+	});
+
+	it("leaves the download attribute unset when the header is absent", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(() => Promise.resolve(pdfResponse())),
+		);
+		const { click } = renderGuard();
+		const anchor = stubAnchor();
+
+		await click();
+
+		expect(anchor.download).toBe("");
+	});
+});

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -3,6 +3,7 @@ export {
 	CampaignRateTileLoading,
 } from "./CampaignRateTileStates";
 export { CompanySizeFilter } from "./CompanySizeFilter";
+export { FileDownloadLink, useFileDownload } from "./FileDownloadLink";
 export { FileUpload } from "./FileUpload";
 export type { FileNameError } from "./fileNameValidation";
 export {

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -3,11 +3,13 @@ export {
 	CampaignRateTileLoading,
 } from "./CampaignRateTileStates";
 export { CompanySizeFilter } from "./CompanySizeFilter";
+export { DownloadStatusRegion } from "./DownloadStatusRegion";
+export { FileDownloadLink } from "./FileDownloadLink";
 export {
-	FileDownloadLink,
+	type DownloadState,
 	isNativeClick,
-	useFileDownload,
-} from "./FileDownloadLink";
+	useDownloadClickGuard,
+} from "./useDownloadClickGuard";
 export { FileUpload } from "./FileUpload";
 export type { FileNameError } from "./fileNameValidation";
 export {

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -3,7 +3,11 @@ export {
 	CampaignRateTileLoading,
 } from "./CampaignRateTileStates";
 export { CompanySizeFilter } from "./CompanySizeFilter";
-export { FileDownloadLink, useFileDownload } from "./FileDownloadLink";
+export {
+	FileDownloadLink,
+	isNativeClick,
+	useFileDownload,
+} from "./FileDownloadLink";
 export { FileUpload } from "./FileUpload";
 export type { FileNameError } from "./fileNameValidation";
 export {

--- a/packages/app/src/modules/shared/useDownloadClickGuard.ts
+++ b/packages/app/src/modules/shared/useDownloadClickGuard.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { type MouseEvent as ReactMouseEvent, useRef, useState } from "react";
+
+export type DownloadState = "idle" | "pending" | "error";
+
+// Browsers cancel a download whose blob URL is revoked before the download
+// manager has picked the click up.
+const OBJECT_URL_TTL_MS = 60_000;
+
+// A modifier click ("open in a new tab", "save as") must keep its native behaviour.
+export function isNativeClick(event: ReactMouseEvent): boolean {
+	return event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+}
+
+function readFilename(disposition: string | null): string {
+	if (!disposition) return "";
+	const utf8Match = /filename\*=UTF-8''([^;\r\n]+)/i.exec(disposition);
+	const asciiMatch = /filename=["']?([^"';\r\n]+)["']?/i.exec(disposition);
+	const raw = utf8Match?.[1] ?? asciiMatch?.[1];
+	return raw ? decodeURIComponent(raw.trim()) : "";
+}
+
+type AnchorProps = {
+	"aria-busy": "true" | undefined;
+	"aria-disabled": "true" | undefined;
+	href: string;
+	onClick: (event: ReactMouseEvent<HTMLAnchorElement>) => void;
+};
+
+/**
+ * Turns a plain download link into a guarded one: the first click fetches the
+ * file and swaps the anchor to a busy state, and every click fired while that
+ * request is in flight is ignored instead of starting a second generation.
+ */
+export function useDownloadClickGuard(
+	href: string,
+	onBeforeDownload?: () => void,
+): { anchorProps: AnchorProps; state: DownloadState } {
+	const [state, setState] = useState<DownloadState>("idle");
+	// A ref, not the state: a burst of clicks lands before React re-renders.
+	const isDownloading = useRef(false);
+
+	async function download(): Promise<void> {
+		if (isDownloading.current) return;
+		isDownloading.current = true;
+		setState("pending");
+		try {
+			const response = await fetch(href);
+			if (!response.ok) {
+				setState("error");
+				return;
+			}
+			const blob = await response.blob();
+			const objectUrl = URL.createObjectURL(blob);
+			const filename = readFilename(
+				response.headers.get("Content-Disposition"),
+			);
+			const anchor = document.createElement("a");
+			anchor.href = objectUrl;
+			if (filename) anchor.download = filename;
+			document.body.appendChild(anchor);
+			anchor.click();
+			anchor.remove();
+			setTimeout(() => URL.revokeObjectURL(objectUrl), OBJECT_URL_TTL_MS);
+			setState("idle");
+		} catch {
+			setState("error");
+		} finally {
+			isDownloading.current = false;
+		}
+	}
+
+	return {
+		anchorProps: {
+			"aria-busy": state === "pending" ? "true" : undefined,
+			"aria-disabled": state === "pending" ? "true" : undefined,
+			href,
+			onClick: (event) => {
+				if (isNativeClick(event)) return;
+				event.preventDefault();
+				onBeforeDownload?.();
+				void download();
+			},
+		},
+		state,
+	};
+}

--- a/packages/app/src/test/downloadHelpers.ts
+++ b/packages/app/src/test/downloadHelpers.ts
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+
+/**
+ * Fetch stubs and DOM queries shared by every guarded-download test suite
+ * (useDownloadClickGuard, DownloadStatusRegion, FileDownloadLink, DownloadCard,
+ * DocumentsPanel). Kept in one place so the live-region markup and the PDF
+ * response shape have a single definition across the five files.
+ */
+
+/** A PDF response, optionally carrying a `Content-Disposition` header. */
+export function pdfResponse(
+	disposition?: string,
+	{ ok = true }: { ok?: boolean } = {},
+): Response {
+	return {
+		ok,
+		blob: () => Promise.resolve(new Blob(["pdf"], { type: "application/pdf" })),
+		headers: {
+			get: (name: string) =>
+				name.toLowerCase() === "content-disposition"
+					? (disposition ?? null)
+					: null,
+		},
+	} as unknown as Response;
+}
+
+/** A fetch that never settles — pins the download to its pending state. */
+export function pendingFetch() {
+	return vi.fn(() => new Promise<Response>(() => undefined));
+}
+
+/** A fetch resolving to a non-ok response. */
+export function failingFetch() {
+	return vi.fn(() => Promise.resolve(pdfResponse(undefined, { ok: false })));
+}
+
+/**
+ * The polite live region rendered by `DownloadStatusRegion`. It carries no
+ * `role` on purpose (RGAA forbids declaring both), so it cannot be reached
+ * through a role query.
+ */
+export function getLiveRegion(scope: ParentNode): HTMLElement | null {
+	return scope.querySelector('[aria-live="polite"]');
+}


### PR DESCRIPTION
Closes #4015

## Problème

Les liens de téléchargement de PDF (récapitulatif de déclaration, attestation de non-sanction, documents CSE) sont de simples `<a download href>`. La génération du PDF côté serveur n'est pas instantanée (requêtes SQL séquentielles + rendu `@react-pdf/renderer`, sans cache) et, pendant cette attente, **rien ne change dans la page** : l'utilisateur reclique, et chaque clic relance un cycle de génération complet — ce qui allonge encore l'attente.

## Fix

### Mécanique partagée

- **`~/modules/shared/useDownloadClickGuard.ts`** — intercepte le clic (`fetch` → blob → clic programmatique) et renvoie `{ anchorProps, state }`. `anchorProps` porte `href`, `onClick`, `aria-busy` et `aria-disabled`, à spreader sur le `<a>`.
  - Les clics tirés pendant un téléchargement en cours sont **ignorés** — c'est le cœur du fix. La garde est un `useRef`, pas l'état : une rafale de clics arrive avant que React n'ait re-rendu.
  - La révocation de l'URL blob est **différée** : la révoquer immédiatement après le clic fait annuler le téléchargement par certains navigateurs.
  - `isNativeClick` laisse passer les clics avec modificateur (Cmd / Ctrl / Maj / Alt) au comportement natif du navigateur.
  - Nom de fichier extrait de l'en-tête `Content-Disposition`.
- **`~/modules/shared/DownloadStatusRegion.tsx`** — la zone `aria-live="polite"` + `aria-atomic="true"` et le message d'erreur `role="alert"`, partagés par tous les points d'appel.
- **`~/modules/shared/FileDownloadLink.tsx`** — le cas simple (lien texte), consommant les deux modules ci-dessus.

Le `href` réel reste en place : sans JS, le lien fonctionne comme avant.

### Points d'appel câblés

`DeclarationSuccessBanner`, `DownloadDeclarationPdfButton`, `cseOpinion/ConfirmationPage` (3 cartes, via `DownloadCard`), `my-space/DocumentsPanel` (3 cartes), `my-space/DeclarationsSection` (attestation de non-sanction).

### Réduction du temps d'attente

`buildPdfData.ts` : les requêtes indépendantes (company / declarant / gip / jobs / date de transmission) passent en un seul `Promise.all` après la résolution de la déclaration, et la boucle N+1 sur `jobIds` est remplacée par une seule requête `inArray`.

## Tests

- 46 tests sur 6 fichiers, couverture 100 % sur les 5 fichiers de logique du ticket.
- **Revert-verify** : en retirant la garde `useRef` et `isNativeClick`, 8 tests passent au rouge sur les 4 surfaces (rafale de clics + clic avec modificateur) ; restaurés → vert.
- Validation fonctionnelle sur le dev server, authentifié : une rafale de 3 clics ne produit **qu'une seule** requête réseau, sur `Mon espace` → attestation de non-sanction et sur le panneau Documents ; `Content-Disposition` correct sur les deux routes ; Cmd+clic non confisqué.

## Notes de revue

- La mécanique était initialement dupliquée dans les 3 composants, et une régression est passée par là (la garde du clic natif manquait dans `DocumentsPanel`, qui perdait donc le Cmd+clic dont il disposait avant le ticket). D'où la factorisation dans les deux modules partagés : les consommateurs ne portent plus que leur markup.
- Hors périmètre, noté en piste de suivi dans l'analyse du ticket : la mise en cache du buffer PDF rendu (le récapitulatif est immuable tant que la déclaration n'est pas modifiée).
