### PR TITLE
fix(my-space): #3969 — bandeau entreprise et libellé d'étape de la démarche Représentation

### DIFF
--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -322,6 +322,10 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 				.first();
 			await expect(companyInfo).toContainText("70");
 			await expect(companyInfo).not.toContainText("Existence d'un CSE");
+			// Nothing is editable below 100, so the edit entry point is dropped too.
+			await expect(
+				page.getByRole("button", { exact: true, name: "Modifier" }),
+			).toHaveCount(0);
 
 			await page.goto("/declaration-remuneration/etape/1");
 			await expect(page.getByText("Étape 1 sur 5")).toBeVisible();

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -1,5 +1,4 @@
 import {
-	classifyCompanySize,
 	GIP_WORKFORCE_ABSENT_DISPLAY,
 	getCurrentYear,
 	getObligationWorkforce,
@@ -22,10 +21,9 @@ type Props = {
 export function CompanyInfoBanner({ company }: Props) {
 	const currentYear = getCurrentYear();
 	const obligationWorkforce = getObligationWorkforce(company.gipWorkforce);
+	// The CSE field is the only editable datapoint and it starts at 100, so below
+	// that threshold the modal has nothing to offer and the entry point is hidden.
 	const cseApplicable = isCseRequired(obligationWorkforce);
-	// Below the voluntary threshold nothing is editable (the CSE field starts at 100), so the edit entry point is hidden entirely.
-	const editApplicable =
-		classifyCompanySize(obligationWorkforce) !== "voluntary";
 
 	return (
 		<div className={`fr-pt-3w fr-pb-4w ${styles.banner}`}>
@@ -41,7 +39,7 @@ export function CompanyInfoBanner({ company }: Props) {
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">{company.name}</h1>
 					</div>
-					{editApplicable && (
+					{cseApplicable && (
 						<div className="fr-col-auto">
 							<button
 								aria-controls={COMPANY_EDIT_MODAL_ID}

--- a/packages/app/src/modules/my-space/DeclarationStepLabel.ts
+++ b/packages/app/src/modules/my-space/DeclarationStepLabel.ts
@@ -18,6 +18,8 @@ export function getDeclarationProcessStepLabel(d: {
 	type: DeclarationType;
 	fsmStatus: DeclarationFsmStatus | null;
 }): string {
-	if (d.type === "representation") return "Non commencée";
+	// The représentation équilibrée journey has no state machine yet, so every row
+	// sits on its first step: checking whether the company is in scope.
+	if (d.type === "representation") return "Vérification de l'assujettissement";
 	return PROCESS_STEP_LABELS[d.fsmStatus ?? "draft"];
 }

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -140,20 +140,29 @@ describe("CompanyInfoBanner", () => {
 		expect(screen.getByText("Existence d'un CSE :")).toBeInTheDocument();
 	});
 
-	it("renders the 'Modifier' button at or above the voluntary threshold", () => {
+	it("renders the 'Modifier' button at or above the 100 threshold", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
 		expect(
 			screen.getByRole("button", { name: "Modifier" }),
 		).toBeInTheDocument();
 	});
 
-	it("keeps the 'Modifier' button between 50 and 99 (read-only modal)", () => {
+	it("hides the 'Modifier' button between 50 and 99 (nothing is editable)", () => {
 		render(
 			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 70 }} />,
 		);
 		expect(
-			screen.getByRole("button", { name: "Modifier" }),
-		).toBeInTheDocument();
+			screen.queryByRole("button", { name: "Modifier" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("hides the 'Modifier' button just below the 100 threshold", () => {
+		render(
+			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 99.97 }} />,
+		);
+		expect(
+			screen.queryByRole("button", { name: "Modifier" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("hides the 'Modifier' button below 50", () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
@@ -10,22 +10,22 @@ describe("getDeclarationProcessStepLabel", () => {
 		).toBe("Déclaration des indicateurs de rémunération");
 	});
 
-	it("returns 'Non commencée' for a representation declaration", () => {
+	it("returns the first representation step for a representation declaration", () => {
 		expect(
 			getDeclarationProcessStepLabel({
 				type: "representation",
 				fsmStatus: null,
 			}),
-		).toBe("Non commencée");
+		).toBe("Vérification de l'assujettissement");
 	});
 
-	it("returns 'Non commencée' for representation even when fsmStatus is set", () => {
+	it("returns the first representation step even when fsmStatus is set", () => {
 		expect(
 			getDeclarationProcessStepLabel({
 				type: "representation",
 				fsmStatus: "draft",
 			}),
-		).toBe("Non commencée");
+		).toBe("Vérification de l'assujettissement");
 	});
 
 	const cases: Array<{ fsm: DeclarationFsmStatus; label: string }> = [

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -140,6 +140,13 @@ describe("DeclarationsSection", () => {
 		expect(represButtons).toHaveLength(1);
 	});
 
+	it("shows the first representation step in the 'Étape' column", () => {
+		renderSection();
+		expect(
+			screen.getByText("Vérification de l'assujettissement"),
+		).toBeInTheDocument();
+	});
+
 	it("does not render the page size selector when there are 20 rows or fewer", () => {
 		renderSection();
 		expect(


### PR DESCRIPTION
Closes #3969

## Problème

**1. Bandeau entreprise (Mon espace)**

Le bouton « Modifier » s'affichait dès 50 salariés (`classifyCompanySize(...) !== "voluntary"`). Or le seul champ réellement modifiable de `CompanyEditModal` est l'existence d'un CSE, qui ne concerne que les entreprises de 100 salariés et plus : sous ce seuil la modale s'ouvrait en lecture seule sur des données INSEE/GIP non modifiables, et le serveur refusait de toute façon l'écriture (`company.updateHasCse` renvoie `PRECONDITION_FAILED` sous 100).

Le champ « Existence d'un CSE » du bandeau était, lui, **déjà** conditionné au seuil de 100 — rien à changer de ce côté.

**2. Démarche en cours**

La colonne « Étape » de la ligne Représentation affichait « Non commencée », qui n'est pas une étape.

## Correctif

**`my-space/CompanyInfoBanner.tsx`**
Le bouton « Modifier » est gouverné par le même prédicat que le champ CSE (`isCseRequired`, ≥ 100). La variable `editApplicable` et l'import `classifyCompanySize` disparaissent.

**`my-space/DeclarationStepLabel.ts`**
`"Non commencée"` → `"Vérification de l'assujettissement"`, la 1re étape du parcours.

Le parcours Représentation n'ayant encore ni route ni machine à états, la constante littérale reste la bonne réponse : pas de 3e miroir FSM (cf. `rules/demarche-state-machine.md`).

`CompanyEditModal` reste monté dans `CompanyDeclarationsPage` (simplement plus atteignable sous 100) pour ne pas entrer en conflit avec la PR #4000, ouverte sur ce fichier.

## Tests

- `CompanyInfoBanner.test.tsx` : le cas 50–99 passe de « garde le bouton » à « masque le bouton », plus un cas de bord à 99,97
- `DeclarationStepLabel.test.ts` : les deux assertions sur le libellé Représentation
- `DeclarationsSection.test.tsx` : nouvelle assertion sur la colonne « Étape »
- `declaration.e2e.ts` : absence du bouton « Modifier » sur le cas GIP = 70
- Suite complète : 3641 tests ✅ · typecheck, lint, format ✅