### PR TITLE
fix(step5): #4008 — accordéons inutilisables après suppression puis ré-import

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -168,7 +168,7 @@ export function CategoryForm({
 		return () => sub.unsubscribe();
 	}, [form, onValuesChange]);
 
-	const { fields, append, remove } = useFieldArray({
+	const { fields, append, remove, replace } = useFieldArray({
 		control: form.control,
 		name: "categories",
 	});
@@ -250,7 +250,7 @@ export function CategoryForm({
 	}
 
 	function handleImportCategories(imported: EmployeeCategory[]) {
-		form.setValue("categories", toFormValues(imported));
+		replace(toFormValues(imported));
 		setHasData(false);
 	}
 
@@ -353,7 +353,7 @@ export function CategoryForm({
 				onDevFill={() => {
 					if (maxWomen == null || maxMen == null) return;
 					const devCats = createDevStep5Categories(nextId, maxWomen, maxMen);
-					form.setValue("categories", toFormValues(devCats));
+					replace(toFormValues(devCats));
 					form.setValue("source", DEV_STEP5_SOURCE);
 					setHasData(false);
 				}}
@@ -451,7 +451,13 @@ export function CategoryForm({
 			<div className="fr-accordions-group" data-fr-group="false">
 				{fields.map((field, index) => {
 					const cat = categories[index];
-					const collapseId = `${baseId}-accordion-${index}`;
+					// Derive the accordion id from the row's stable identity, never from
+					// its position: DSFR's vanilla JS freezes the id at instantiation and
+					// binds its toggle through a literal `[aria-controls="<id>"]` selector.
+					// Renumbering ids in place (after a delete) makes the live instance
+					// stop matching its own selector and DSFR disposes it, which leaves the
+					// accordion unopenable — cf. #4008.
+					const collapseId = `${baseId}-accordion-${field.id}`;
 					const headingId = `${collapseId}-heading`;
 					const categoryNumber = `Catégorie d'emplois n°${index + 1}`;
 					const catName = cat?.name?.trim() ?? "";

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryForm.test.tsx
@@ -1,0 +1,222 @@
+import {
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+	within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
+import type { ImportResult } from "../categoryFileHandler";
+import type { EmployeeCategory } from "../categorySerializer";
+
+const { parseImportFileMock, getDsfrModalMock } = vi.hoisted(() => ({
+	parseImportFileMock: vi.fn(),
+	getDsfrModalMock: vi.fn(() => ({ conceal: vi.fn() })),
+}));
+
+// Stub only getDsfrModal; the DSFR JS that drives the import panel is absent in jsdom.
+vi.mock("~/modules/shared", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("~/modules/shared")>();
+	return { ...actual, getDsfrModal: getDsfrModalMock };
+});
+
+vi.mock("../categoryFileHandler", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../categoryFileHandler")>();
+	return { ...actual, parseImportFile: parseImportFileMock };
+});
+
+vi.mock("../categoryModelTracking", () => ({
+	startCategoryModelTimer: vi.fn(),
+	trackCategoryImportDuration: vi.fn(),
+}));
+
+import { CategoryForm } from "../CategoryForm";
+
+function row(name: string): EmployeeCategoryRow {
+	return {
+		name,
+		womenCount: null,
+		menCount: null,
+		annualBaseWomen: null,
+		annualBaseMen: null,
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+	};
+}
+
+function importedCategory(id: number, name: string): EmployeeCategory {
+	return {
+		id,
+		name,
+		womenCount: "",
+		menCount: "",
+		annualBaseWomen: "",
+		annualBaseMen: "",
+		annualVariableWomen: "",
+		annualVariableMen: "",
+		hourlyBaseWomen: "",
+		hourlyBaseMen: "",
+		hourlyVariableWomen: "",
+		hourlyVariableMen: "",
+	};
+}
+
+/**
+ * The accordion ids DSFR binds its toggles to. DSFR freezes them at
+ * instantiation and matches its buttons through a literal
+ * `[aria-controls="<id>"]` selector, so renumbering them in place silently
+ * kills the toggle — see #4008. Scoped to the category group so the sibling
+ * definitions accordion is left out.
+ */
+function accordionIds(): string[] {
+	return Array.from(
+		document.querySelectorAll<HTMLButtonElement>(
+			'.fr-accordions-group[data-fr-group="false"] button.fr-accordion__btn',
+		),
+	).map((button) => button.getAttribute("aria-controls") ?? "");
+}
+
+function renderForm(initialCategories: EmployeeCategoryRow[]) {
+	return render(
+		<CategoryForm
+			accordionId="accordion-test"
+			initialCategories={initialCategories}
+			instructionText="Renseignez vos catégories."
+			isSubmitting={false}
+			onSubmit={vi.fn()}
+			previousHref="/precedent"
+			referenceYear={2025}
+			stepper={null}
+			title="Catégories de salariés"
+			tooltipPrefix="test"
+		/>,
+	);
+}
+
+async function deleteCategoryAt(index: number) {
+	const user = userEvent.setup();
+	const deleteButtons = screen.getAllByRole("button", { name: /supprimer/i });
+	await user.click(deleteButtons[index] as HTMLElement);
+
+	const dialog = document.querySelector(
+		'dialog[aria-labelledby="delete-category-title"]',
+	) as HTMLElement;
+	// getByText, not getByRole: the <dialog> has no `open` attribute in jsdom,
+	// so its contents are outside the accessibility tree.
+	await user.click(within(dialog).getByText("Supprimer"));
+}
+
+async function importCategories(categories: EmployeeCategory[]) {
+	parseImportFileMock.mockResolvedValue({
+		ok: true,
+		categories,
+	} satisfies ImportResult);
+
+	fireEvent.change(screen.getByLabelText("Sélectionner des fichiers"), {
+		target: { files: [new File(["x"], "import.csv", { type: "text/csv" })] },
+	});
+	fireEvent.click(
+		screen.getByRole("button", { hidden: true, name: "Importer" }),
+	);
+}
+
+beforeEach(() => {
+	parseImportFileMock.mockReset();
+	HTMLDialogElement.prototype.showModal = vi.fn();
+	HTMLDialogElement.prototype.close = vi.fn();
+});
+
+describe("CategoryForm accordion identity", () => {
+	it("gives every accordion a unique id", () => {
+		renderForm([row("Cadres"), row("Employés"), row("Ouvriers")]);
+
+		const ids = accordionIds();
+		expect(ids).toHaveLength(3);
+		expect(new Set(ids).size).toBe(3);
+	});
+
+	it("keeps the surviving accordion ids unchanged when a category is deleted", async () => {
+		renderForm([row("Cadres"), row("Employés"), row("Ouvriers")]);
+		const [, second, third] = accordionIds();
+
+		await deleteCategoryAt(0);
+
+		await waitFor(() => expect(accordionIds()).toHaveLength(2));
+		// Not merely "still 2 ids": the exact ids of the untouched rows must be
+		// byte-identical, otherwise DSFR disposes their live toggle instances.
+		expect(accordionIds()).toEqual([second, third]);
+	});
+
+	it("keeps each id wired to its own panel and heading after a deletion", async () => {
+		renderForm([row("Cadres"), row("Employés")]);
+
+		await deleteCategoryAt(0);
+
+		await waitFor(() => expect(accordionIds()).toHaveLength(1));
+		const button = document.querySelector<HTMLButtonElement>(
+			'.fr-accordions-group[data-fr-group="false"] button.fr-accordion__btn',
+		);
+		const panelId = button?.getAttribute("aria-controls") ?? "";
+		expect(document.getElementById(panelId)).not.toBeNull();
+		expect(button?.id).toBe(`${panelId}-heading`);
+	});
+
+	it("hands out brand-new ids after an import so stale DSFR registrations cannot collide", async () => {
+		renderForm([row("Cadres"), row("Employés")]);
+		const before = accordionIds();
+
+		await importCategories([
+			importedCategory(1, "Techniciens"),
+			importedCategory(2, "Agents de maîtrise"),
+		]);
+
+		await waitFor(() =>
+			expect(
+				screen.getByRole("button", { name: /Techniciens/ }),
+			).toBeInTheDocument(),
+		);
+		const after = accordionIds();
+		expect(after).toHaveLength(2);
+		expect(new Set(after).size).toBe(2);
+		expect(after.filter((id) => before.includes(id))).toEqual([]);
+	});
+
+	it("survives the reported import → delete → import sequence", async () => {
+		renderForm([row("Cadres"), row("Employés"), row("Ouvriers")]);
+
+		await importCategories([
+			importedCategory(1, "Alpha"),
+			importedCategory(2, "Bravo"),
+			importedCategory(3, "Charlie"),
+		]);
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: /Alpha/ })).toBeInTheDocument(),
+		);
+
+		await deleteCategoryAt(0);
+		await waitFor(() => expect(accordionIds()).toHaveLength(2));
+		const afterDelete = accordionIds();
+
+		await importCategories([
+			importedCategory(4, "Delta"),
+			importedCategory(5, "Echo"),
+		]);
+		await waitFor(() =>
+			expect(screen.getByRole("button", { name: /Delta/ })).toBeInTheDocument(),
+		);
+
+		const afterSecondImport = accordionIds();
+		expect(new Set(afterSecondImport).size).toBe(2);
+		expect(afterSecondImport.filter((id) => afterDelete.includes(id))).toEqual(
+			[],
+		);
+	});
+});


### PR DESCRIPTION
Closes #4008

## Problème

Sur l'étape 5 (indicateur G), après la séquence *import → suppression de catégories → nouvel import*, les accordéons ne s'ouvraient plus. L'intuition du rapporteur était la bonne : c'est bien un bug d'`id`.

`CategoryForm` tirait l'id de l'accordéon de la **position** dans le tableau :

```tsx
const collapseId = `${baseId}-accordion-${index}`;
```

La clé React, elle, est stable (`field.id`, l'uuid react-hook-form). L'écart entre les deux est toute la cause.

Le JS vanilla du DSFR :
1. fige l'id du panneau à l'instanciation (`Instance._config`) ;
2. enregistre le bouton associé via un sélecteur **littéral** `[aria-controls="<id>"]` (`Disclosure.init`) ;
3. sur toute mutation d'attribut, vérifie que le nœud correspond encore à ce sélecteur figé — sinon il détruit l'instance (`Instance.examine`), ce qui purge en cascade tous les boutons de l'enregistrement (`Registration.dispose`) ;
4. refuse ensuite toute seconde instance sur un nœud déjà vu (`Element.create`), d'où l'absence de récupération.

Conséquences :

- **Suppression** : `remove(index)` conserve les nœuds survivants et se contente de **renuméroter leurs ids en place**. Chaque accordéon situé après celui supprimé sort de son propre sélecteur → instance détruite, bouton mort ou re-branché sur le panneau voisin.
- **Ré-import** : `form.setValue("categories", …)` fait régénérer tous les `field.id` par react-hook-form, donc démontage/remontage complet — mais avec **exactement les mêmes chaînes d'id** (`…-accordion-0..N`), qui percutent les enregistrements périmés.

Le contournement observé (« repasser sur l'ensemble des accordéons ») correspond au re-parse déclenché par une mutation d'attribut ultérieure.

## Correctif

**`steps/step5/CategoryForm.tsx`**

- `collapseId` dérive de `field.id` (identité stable de la ligne) au lieu de l'index. `headingId`, `aria-controls` et `aria-labelledby` en héritent. Les ids des lignes survivantes ne bougent plus lors d'une suppression ; un import produit des ids **inédits**, hors de portée des enregistrements périmés.
- `form.setValue("categories", …)` → `replace()` de `useFieldArray` (import et remplissage dev), le patron recommandé par react-hook-form pour un tableau de champs.

Les ids internes (`cat-${index}-*`) sont laissés tels quels : ils ne pilotent aucun enregistrement DSFR et servent au focus du champ « Libellé » après ajout.

## Tests

Nouveau `steps/step5/__tests__/CategoryForm.test.tsx` (5 cas), qui verrouille l'invariant au niveau des `aria-controls` :

- unicité des ids ;
- ids des lignes survivantes **strictement identiques** après une suppression ;
- cohérence bouton ↔ panneau ↔ heading après suppression ;
- ids disjoints des précédents après un import ;
- séquence complète du ticket : import → suppression → ré-import.

Vérifié sur le code d'avant le correctif : **3 des 5 cas échouent**, et passent avec.

Suite complète : 3644 tests ✅ · typecheck, lint, format ✅