### PR TITLE
fix(dsfr): #3953 — bordures des cases à cocher et des radios invisibles sous Firefox

### DIFF
--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -12,6 +12,9 @@ import {
 import { ProfileModal } from "~/modules/profile";
 import { TRPCReactProvider } from "~/trpc/react";
 
+// Loaded after the DSFR stylesheet links below so these overrides win.
+import "~/modules/layout/dsfrFixes.scss";
+
 export const metadata: Metadata = {
 	title: { template: "%s — Egapro", default: "Egapro" },
 	description: "Indicateurs d'égalité professionnelle femmes‑hommes",

--- a/packages/app/src/modules/layout/dsfrFixes.scss
+++ b/packages/app/src/modules/layout/dsfrFixes.scss
@@ -1,0 +1,74 @@
+// Global DSFR rendering fixes.
+//
+// DSFR 1.14 draws the border of checkboxes and rich radios with stacked
+// background layers — four 1px `linear-gradient` bands for the edges plus
+// `radial-gradient` rings for the corners — and declares no `border` at all.
+// Background layers are not snapped to the device pixel grid the way a border
+// or a box-shadow is, and Firefox drops some of those 1px bands outright: the
+// certification checkbox renders with only its top and right edges (issue 3953)
+// and the Oui/Non tiles lose their bottom edge (issue 3951).
+//
+// Each rule below re-draws the same border as an inset box-shadow, which every
+// engine rasterises as a solid primitive. DSFR's own gradients are left in
+// place underneath (they also carry the checkmark and the radio dot), so this
+// only reinforces the outline — it never changes the design.
+//
+// Colours mirror, state for state, the ones DSFR declares in
+// `@gouvfr/dsfr/dist/component/{checkbox,radio}/*.css`. They are DSFR custom
+// properties, so light and dark themes follow automatically.
+
+.fr-checkbox-group input[type="checkbox"] + label::before {
+	--egapro-control-border: var(--border-action-high-blue-france);
+
+	box-shadow: inset 0 0 0 1px var(--egapro-control-border);
+}
+
+.fr-checkbox-group input[type="checkbox"]:checked + label::before {
+	--egapro-control-border: var(--border-active-blue-france);
+}
+
+.fr-checkbox-group input[type="checkbox"]:disabled + label::before,
+.fr-checkbox-group input[type="checkbox"]:disabled:checked + label::before {
+	--egapro-control-border: var(--background-disabled-grey);
+}
+
+.fr-checkbox-group--error input[type="checkbox"] + label::before,
+.fr-checkbox-group--error input[type="checkbox"]:checked + label::before,
+.fr-fieldset--error .fr-checkbox-group input[type="checkbox"] + label::before {
+	--egapro-control-border: var(--border-plain-error);
+}
+
+.fr-checkbox-group--valid input[type="checkbox"] + label::before,
+.fr-checkbox-group--valid input[type="checkbox"]:checked + label::before,
+.fr-fieldset--valid .fr-checkbox-group input[type="checkbox"] + label::before {
+	--egapro-control-border: var(--border-plain-success);
+}
+
+.fr-radio-rich input[type="radio"] + label {
+	--egapro-control-border: var(--border-default-grey);
+
+	box-shadow: inset 0 0 0 1px var(--egapro-control-border);
+}
+
+.fr-radio-rich input[type="radio"]:checked + label {
+	--egapro-control-border: var(--border-active-blue-france);
+}
+
+.fr-radio-rich input[type="radio"]:checked:disabled + label {
+	--egapro-control-border: var(--text-disabled-grey);
+}
+
+.fr-fieldset--error .fr-radio-rich input[type="radio"]:checked + label,
+.fr-fieldset--valid .fr-radio-rich input[type="radio"]:checked + label,
+.fr-fieldset--info .fr-radio-rich input[type="radio"]:checked + label {
+	--egapro-control-border: var(--background-action-high-blue-france);
+}
+
+// Windows high-contrast mode replaces the drawn box with the native control,
+// so the reinforcement must not paint a stray outline over it.
+@media (forced-colors: active) {
+	.fr-checkbox-group input[type="checkbox"] + label::before,
+	.fr-radio-rich input[type="radio"] + label {
+		box-shadow: none;
+	}
+}


### PR DESCRIPTION
Closes #3953

Couvre aussi le point ③ de #3951 (« les cases à cocher OUI/NON n'ont pas de barre en bas, cadre non fermé en bas, sur Firefox ») — même cause, même correctif. #3951 reste ouvert pour sa partie fonctionnelle, traitée dans une PR distincte.

## Problème

Le DSFR 1.14 ne déclare **aucune propriété `border`** sur ces contrôles. Leur cadre est peint par des couches de fond empilées : quatre bandes `linear-gradient` de 1 px pour les arêtes, des `radial-gradient` pour les angles.

`@gouvfr/dsfr/dist/component/checkbox/checkbox.css` :
```css
.fr-checkbox-group input[type=checkbox] + label::before {
  background-size: .25rem .25rem, calc(100% - .25rem) 1px, …;
  background-position: 0 0, .25rem 0, 100% 0, 0 .25rem, …;
  background-image: radial-gradient(…), linear-gradient(…), …;
}
```

Une couche de fond n'est pas alignée sur la grille de pixels physiques comme le sont une bordure ou une ombre. Firefox en abandonne certaines. En zoomant la capture jointe au ticket, on voit précisément **l'arête haute et l'arête droite dessinées, l'arête basse et l'arête gauche absentes** — d'où la case « fantôme ». Le même mécanisme touche `.fr-radio-rich input[type=radio] + label` (`radio.css:80-96`), dont la bande basse est ancrée à `background-position: 0 100%` sur une hauteur calculée : c'est le « cadre non fermé en bas » de #3951.

Chromium aligne ces bandes, d'où l'absence de symptôme — et l'invisibilité en CI, où Playwright ne tourne que sur `Desktop Chrome`.

## Correctif

Nouvelle feuille **globale** `src/modules/layout/dsfrFixes.scss`, importée par le layout racine. Elle redessine le même cadre en `box-shadow: inset 0 0 0 1px`, une primitive pleine que tous les moteurs rastérisent d'un bloc et qui ne peut pas être amputée arête par arête.

Les dégradés du DSFR restent en place dessous — ils portent aussi la coche et le point du radio : le correctif **consolide** le tracé, il ne le remplace pas et ne change pas le design. Les couleurs reprennent **état par état** celles que le DSFR déclare (`:checked`, `:disabled`, `--error`, `--valid`, `--info`), toutes via ses custom properties, donc le thème sombre suit automatiquement. Un garde `@media (forced-colors: active)` évite de peindre un contour parasite en mode contraste élevé de Windows, où le DSFR rend la main au contrôle natif.

Une feuille globale plutôt que des overrides par composant : le défaut est dans le design system, pas dans un écran. La correction couvre d'un coup les 7 cases à cocher (modale de soumission, matrice de types de contenu, écrans admin) et les 5 groupes `fr-radio-rich` (avis CSE, `MissingInfoModal`, `CompanyEditModal`, `ThemeModal`) — et les futurs.

## Vérification

Correctif purement CSS : pas de test unitaire pertinent, la preuve est au rendu.

Banc de rendu statique (DSFR + le markup exact de `SubmitDeclarationModal` et `GapConsultationCard`) capturé sous Firefox et Chromium :

1. **Non-régression** — rendu strictement identique avec et sans la feuille sur les moteurs qui peignent déjà correctement les dégradés. La consolidation tombe pile sur la bordure existante.
2. **Efficacité** — en neutralisant les dégradés du DSFR (`background-image: none`, ce qui simule l'échec Firefox) : sans la feuille, **aucun cadre n'est peint** ; avec elle, les **quatre arêtes** sont là, sur la case comme sur les tuiles.
3. Build Next.js OK, règles présentes dans le bundle CSS émis.

Honnêteté sur la reproduction : le Firefox **headless** de Playwright n'abandonne pas les bandes (chemin de rastérisation logiciel différent de celui d'un Firefox de bureau sur GPU). Le diagnostic s'appuie donc sur la capture du ticket, qui montre sans ambiguïté deux arêtes sur quatre, et sur le mécanisme CSS. À confirmer sur un vrai Firefox lors de la revue : modale « Soumettre » de l'étape 6, et `/avis-cse/etape/1`.

Suite complète : 3639 tests ✅ · typecheck, lint, format ✅