### PR TITLE
fix(indicateur-g): borner le libellé catégorie d'emploi à 255 caractères

### DIFF
--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -375,9 +375,7 @@ test.describe("Indicator G — category label is bounded to 255 characters (#394
 		const sourceSelect = page.getByRole("combobox", {
 			name: /source utilisée pour déterminer les catégories/i,
 		});
-		if (
-			await sourceSelect.isVisible({ timeout: 1_000 }).catch(() => false)
-		) {
+		if (await sourceSelect.isVisible({ timeout: 1_000 }).catch(() => false)) {
 			await sourceSelect.selectOption("accord-entreprise");
 		}
 

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -345,3 +345,59 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 		});
 	});
 });
+
+// Regression guard for #3943: the indicator G category label maps to a
+// varchar(255) column. Before the fix the field accepted unbounded input, so an
+// over-long label made Postgres reject the insert and surfaced the raw Drizzle
+// SQL query to the user (broken UX + technical disclosure). The fix bounds the
+// input client-side and documents the limit with a DSFR hint.
+test.describe("Indicator G — category label is bounded to 255 characters (#3943)", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test.beforeAll(async () => {
+		// >= 250 workforce → the funnel keeps step 5 / indicator G.
+		await resetGipWorkforce();
+		await resetDeclarationToDraft();
+	});
+
+	test.afterAll(async () => {
+		await resetDeclarationToDraft();
+	});
+
+	test("caps the label input at 255 chars and exposes the DSFR hint", async ({
+		page,
+	}) => {
+		await submitStepsThroughQuartiles(page);
+		await page.waitForURL("**/declaration-remuneration/etape/5");
+
+		// Pick a source when categories aren't pre-populated, so the editable
+		// category form (with its label input) is rendered.
+		const sourceSelect = page.getByRole("combobox", {
+			name: /source utilisée pour déterminer les catégories/i,
+		});
+		if (
+			await sourceSelect.isVisible({ timeout: 1_000 }).catch(() => false)
+		) {
+			await sourceSelect.selectOption("accord-entreprise");
+		}
+
+		const nameInput = page.locator("#cat-0-name");
+		await expect(nameInput).toBeVisible();
+
+		// Hint added by the fix, wired to the field for assistive tech.
+		await expect(page.locator("#cat-0-name-hint")).toHaveText(
+			"255 caractères maximum",
+		);
+		await expect(nameInput).toHaveAttribute(
+			"aria-describedby",
+			/cat-0-name-hint/,
+		);
+
+		// The guard that prevents the varchar(255) overflow (and thus the raw SQL
+		// error at submit) is the maxLength cap on the native input.
+		await expect(nameInput).toHaveAttribute("maxlength", "255");
+
+		await nameInput.fill("a".repeat(300));
+		await expect(nameInput).toHaveJSProperty("value.length", 255);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	CATEGORY_NAME_MAX_LENGTH,
+	CATEGORY_NAME_MAX_LENGTH_MESSAGE,
 	categoryFormSchema,
 	PAY_FIELDS_MEN,
 	PAY_FIELDS_WOMEN,
@@ -318,7 +319,6 @@ describe("updateEmployeeCategoriesSchema — remuneration completeness (#3948)",
 	});
 });
 
-const CATEGORY_NAME_TOO_LONG_MESSAGE = `${CATEGORY_NAME_MAX_LENGTH} caractères maximum`;
 const NAME_AT_MAX = "a".repeat(CATEGORY_NAME_MAX_LENGTH);
 const NAME_OVER_MAX = "a".repeat(CATEGORY_NAME_MAX_LENGTH + 1);
 
@@ -372,7 +372,7 @@ describe("category name length cap (#3943)", () => {
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.error.issues.map((i) => i.message)).toContain(
-				CATEGORY_NAME_TOO_LONG_MESSAGE,
+				CATEGORY_NAME_MAX_LENGTH_MESSAGE,
 			);
 		}
 	});
@@ -387,7 +387,7 @@ describe("category name length cap (#3943)", () => {
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.error.issues.map((i) => i.message)).toContain(
-				CATEGORY_NAME_TOO_LONG_MESSAGE,
+				CATEGORY_NAME_MAX_LENGTH_MESSAGE,
 			);
 		}
 	});

--- a/packages/app/src/modules/declaration-remuneration/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/schemas.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+	CATEGORY_NAME_MAX_LENGTH,
+	categoryFormSchema,
 	PAY_FIELDS_MEN,
 	PAY_FIELDS_WOMEN,
 	updateEmployeeCategoriesSchema,
@@ -311,6 +313,81 @@ describe("updateEmployeeCategoriesSchema — remuneration completeness (#3948)",
 		if (!result.success) {
 			expect(result.error.issues.map((i) => i.message)).toContain(
 				INCOMPLETE_REMUNERATION_MESSAGE,
+			);
+		}
+	});
+});
+
+const CATEGORY_NAME_TOO_LONG_MESSAGE = `${CATEGORY_NAME_MAX_LENGTH} caractères maximum`;
+const NAME_AT_MAX = "a".repeat(CATEGORY_NAME_MAX_LENGTH);
+const NAME_OVER_MAX = "a".repeat(CATEGORY_NAME_MAX_LENGTH + 1);
+
+function parseCategoryWithName(name: string) {
+	return updateEmployeeCategoriesSchema.safeParse({
+		declarationType: "initial",
+		source: "dads",
+		categories: [
+			{
+				name,
+				data: {
+					womenCount: 2,
+					menCount: 2,
+					...WOMEN_PAY_VALUES,
+					...MEN_PAY_VALUES,
+				},
+			},
+		],
+	});
+}
+
+function parseCategoryForm(name: string) {
+	return categoryFormSchema.safeParse({
+		source: "dads",
+		categories: [
+			{
+				name,
+				womenCount: "",
+				menCount: "",
+				annualBaseWomen: "",
+				annualBaseMen: "",
+				annualVariableWomen: "",
+				annualVariableMen: "",
+				hourlyBaseWomen: "",
+				hourlyBaseMen: "",
+				hourlyVariableWomen: "",
+				hourlyVariableMen: "",
+			},
+		],
+	});
+}
+
+describe("category name length cap (#3943)", () => {
+	it("updateEmployeeCategoriesSchema accepts a name of exactly 255 characters", () => {
+		const result = parseCategoryWithName(NAME_AT_MAX);
+		expect(result.success).toBe(true);
+	});
+
+	it("updateEmployeeCategoriesSchema rejects a name of 256 characters with the max-length message", () => {
+		const result = parseCategoryWithName(NAME_OVER_MAX);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.map((i) => i.message)).toContain(
+				CATEGORY_NAME_TOO_LONG_MESSAGE,
+			);
+		}
+	});
+
+	it("categoryFormSchema accepts a name of exactly 255 characters", () => {
+		const result = parseCategoryForm(NAME_AT_MAX);
+		expect(result.success).toBe(true);
+	});
+
+	it("categoryFormSchema rejects a name of 256 characters with the max-length message", () => {
+		const result = parseCategoryForm(NAME_OVER_MAX);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.map((i) => i.message)).toContain(
+				CATEGORY_NAME_TOO_LONG_MESSAGE,
 			);
 		}
 	});

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -3,6 +3,8 @@ export { MissingSiret } from "./MissingSiret";
 export { RecapitulatifPage } from "./recapitulatif";
 export { StepPageClient } from "./StepPageClient";
 export {
+	CATEGORY_NAME_MAX_LENGTH,
+	CATEGORY_NAME_MAX_LENGTH_MESSAGE,
 	categoryFormEntrySchema,
 	categoryFormSchema,
 	saveCompliancePathSchema,

--- a/packages/app/src/modules/declaration-remuneration/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/schemas.ts
@@ -4,6 +4,7 @@ import { isSexRemunerationComplete } from "~/modules/domain";
 import { COMPLIANCE_PATHS } from "./steps/compliancePath/constants";
 
 export const CATEGORY_NAME_MAX_LENGTH = 255;
+export const CATEGORY_NAME_MAX_LENGTH_MESSAGE = `${CATEGORY_NAME_MAX_LENGTH} caractères maximum`;
 
 export const updateStep1Schema = z.object({
 	totalWomen: z.number().int().min(0),
@@ -131,10 +132,7 @@ export const updateEmployeeCategoriesSchema = z.object({
 				name: z
 					.string()
 					.min(1)
-					.max(
-						CATEGORY_NAME_MAX_LENGTH,
-						`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`,
-					),
+					.max(CATEGORY_NAME_MAX_LENGTH, CATEGORY_NAME_MAX_LENGTH_MESSAGE),
 				data: employeeCategoryDataSchema,
 			}),
 		)
@@ -146,10 +144,7 @@ export const updateEmployeeCategoriesSchema = z.object({
 export const categoryFormEntrySchema = z.object({
 	name: z
 		.string()
-		.max(
-			CATEGORY_NAME_MAX_LENGTH,
-			`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`,
-		),
+		.max(CATEGORY_NAME_MAX_LENGTH, CATEGORY_NAME_MAX_LENGTH_MESSAGE),
 	womenCount: z.string(),
 	menCount: z.string(),
 	annualBaseWomen: z.string(),

--- a/packages/app/src/modules/declaration-remuneration/schemas.ts
+++ b/packages/app/src/modules/declaration-remuneration/schemas.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 import { isSexRemunerationComplete } from "~/modules/domain";
 import { COMPLIANCE_PATHS } from "./steps/compliancePath/constants";
 
+export const CATEGORY_NAME_MAX_LENGTH = 255;
+
 export const updateStep1Schema = z.object({
 	totalWomen: z.number().int().min(0),
 	totalMen: z.number().int().min(0),
@@ -126,7 +128,13 @@ export const updateEmployeeCategoriesSchema = z.object({
 	categories: z
 		.array(
 			z.object({
-				name: z.string().min(1),
+				name: z
+					.string()
+					.min(1)
+					.max(
+						CATEGORY_NAME_MAX_LENGTH,
+						`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`,
+					),
 				data: employeeCategoryDataSchema,
 			}),
 		)
@@ -136,7 +144,12 @@ export const updateEmployeeCategoriesSchema = z.object({
 });
 
 export const categoryFormEntrySchema = z.object({
-	name: z.string(),
+	name: z
+		.string()
+		.max(
+			CATEGORY_NAME_MAX_LENGTH,
+			`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`,
+		),
 	womenCount: z.string(),
 	menCount: z.string(),
 	annualBaseWomen: z.string(),

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step5EmployeeCategories.test.tsx
@@ -248,7 +248,7 @@ describe("Step5EmployeeCategories", () => {
 			/>,
 		);
 		expect(
-			screen.getByLabelText("Libellé de la catégorie d'emploi", {
+			screen.getByLabelText(/^Libellé de la catégorie d'emploi/, {
 				selector: "#cat-0-name",
 			}),
 		).toBeInTheDocument();
@@ -469,7 +469,7 @@ describe("Step5EmployeeCategories", () => {
 		);
 
 		const nameInput = screen.getByLabelText(
-			"Libellé de la catégorie d'emploi",
+			/^Libellé de la catégorie d'emploi/,
 			{
 				selector: "#cat-0-name",
 			},
@@ -488,7 +488,7 @@ describe("Step5EmployeeCategories", () => {
 		);
 
 		const nameInput = screen.getByLabelText(
-			"Libellé de la catégorie d'emploi",
+			/^Libellé de la catégorie d'emploi/,
 			{
 				selector: "#cat-0-name",
 			},
@@ -526,7 +526,7 @@ describe("Step5EmployeeCategories", () => {
 		);
 
 		const nameInput = screen.getByLabelText(
-			"Libellé de la catégorie d'emploi",
+			/^Libellé de la catégorie d'emploi/,
 			{
 				selector: "#cat-0-name",
 			},

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryAccordionItem.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryAccordionItem.tsx
@@ -1,6 +1,9 @@
 import type React from "react";
 
-import { CATEGORY_NAME_MAX_LENGTH } from "~/modules/declaration-remuneration/schemas";
+import {
+	CATEGORY_NAME_MAX_LENGTH,
+	CATEGORY_NAME_MAX_LENGTH_MESSAGE,
+} from "~/modules/declaration-remuneration/schemas";
 import stepStyles from "~/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss";
 
 import { CategoryDataTable } from "./CategoryDataTable";
@@ -85,7 +88,7 @@ export function CategoryAccordionItem({
 							<label className="fr-label" htmlFor={`cat-${index}-name`}>
 								Libellé de la catégorie d&apos;emploi
 								<span className="fr-hint-text" id={`cat-${index}-name-hint`}>
-									{CATEGORY_NAME_MAX_LENGTH} caractères maximum
+									{CATEGORY_NAME_MAX_LENGTH_MESSAGE}
 								</span>
 							</label>
 							<input

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryAccordionItem.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryAccordionItem.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 
+import { CATEGORY_NAME_MAX_LENGTH } from "~/modules/declaration-remuneration/schemas";
 import stepStyles from "~/modules/declaration-remuneration/steps/Step5EmployeeCategories.module.scss";
 
 import { CategoryDataTable } from "./CategoryDataTable";
@@ -14,6 +15,7 @@ type Props = {
 	readOnlyLabel: boolean;
 	showDelete: boolean;
 	nameProps: React.ComponentPropsWithRef<"input">;
+	nameError?: string;
 	onAccordionToggle: (e: React.MouseEvent<HTMLButtonElement>) => void;
 	headerRef: (node: HTMLButtonElement | null) => void;
 	collapseRef: (node: HTMLDivElement | null) => void;
@@ -35,6 +37,7 @@ export function CategoryAccordionItem({
 	readOnlyLabel,
 	showDelete,
 	nameProps,
+	nameError,
 	onAccordionToggle,
 	headerRef,
 	collapseRef,
@@ -72,17 +75,38 @@ export function CategoryAccordionItem({
 			>
 				<div className={stepStyles.categoryBlock}>
 					{!readOnlyLabel && (
-						<div className="fr-input-group fr-mb-0">
+						<div
+							className={
+								nameError
+									? "fr-input-group fr-mb-0 fr-input-group--error"
+									: "fr-input-group fr-mb-0"
+							}
+						>
 							<label className="fr-label" htmlFor={`cat-${index}-name`}>
 								Libellé de la catégorie d&apos;emploi
+								<span className="fr-hint-text" id={`cat-${index}-name-hint`}>
+									{CATEGORY_NAME_MAX_LENGTH} caractères maximum
+								</span>
 							</label>
 							<input
-								className="fr-input"
+								aria-describedby={
+									nameError
+										? `cat-${index}-name-hint cat-${index}-name-error`
+										: `cat-${index}-name-hint`
+								}
+								aria-invalid={nameError ? true : undefined}
+								className={nameError ? "fr-input fr-input--error" : "fr-input"}
 								disabled={disabled}
 								id={`cat-${index}-name`}
+								maxLength={CATEGORY_NAME_MAX_LENGTH}
 								{...nameProps}
 								type="text"
 							/>
+							{nameError && (
+								<p className="fr-error-text" id={`cat-${index}-name-error`}>
+									{nameError}
+								</p>
+							)}
 						</div>
 					)}
 					<CategoryDataTable

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -503,6 +503,9 @@ export function CategoryForm({
 							index={index}
 							isExpanded={expandedByFieldId[field.id] ?? true}
 							key={field.id}
+							nameError={
+								form.formState.errors.categories?.[index]?.name?.message
+							}
 							nameProps={{
 								...form.register(`categories.${index}.name`),
 								onChange: (e) => {

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { CATEGORY_NAME_MAX_LENGTH } from "~/modules/declaration-remuneration/schemas";
+import {
+	CATEGORY_NAME_MAX_LENGTH,
+	CATEGORY_NAME_MAX_LENGTH_MESSAGE,
+} from "~/modules/declaration-remuneration/schemas";
 import { CategoryAccordionItem } from "../CategoryAccordionItem";
 import type { EmployeeCategory } from "../categorySerializer";
 
@@ -51,7 +54,7 @@ describe("CategoryAccordionItem — name length cap (#3943)", () => {
 	it("shows the max-length hint and caps the input with maxLength", () => {
 		renderItem();
 		expect(
-			screen.getByText(`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`),
+			screen.getByText(CATEGORY_NAME_MAX_LENGTH_MESSAGE),
 		).toBeInTheDocument();
 		const input = document.getElementById("cat-0-name") as HTMLInputElement;
 		expect(input).toHaveAttribute(
@@ -66,7 +69,7 @@ describe("CategoryAccordionItem — name length cap (#3943)", () => {
 		expect(input).not.toHaveAttribute("aria-invalid");
 		expect(input).toHaveAttribute("aria-describedby", "cat-0-name-hint");
 		expect(
-			screen.queryByText(`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`, {
+			screen.queryByText(CATEGORY_NAME_MAX_LENGTH_MESSAGE, {
 				selector: ".fr-error-text",
 			}),
 		).not.toBeInTheDocument();
@@ -80,7 +83,7 @@ describe("CategoryAccordionItem — name length cap (#3943)", () => {
 	});
 
 	it("renders the error text and wires aria-invalid/aria-describedby when nameError is set", () => {
-		const message = `${CATEGORY_NAME_MAX_LENGTH} caractères maximum`;
+		const message = CATEGORY_NAME_MAX_LENGTH_MESSAGE;
 		renderItem({ nameError: message });
 		const error = document.getElementById("cat-0-name-error");
 		expect(error).toHaveClass("fr-error-text");

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
@@ -35,6 +35,7 @@ function renderItem(
 			category={categoryOverride ?? category}
 			collapseRef={vi.fn()}
 			disabled={false}
+			fieldId="field-1"
 			headerRef={vi.fn()}
 			index={0}
 			isExpanded

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CATEGORY_NAME_MAX_LENGTH } from "~/modules/declaration-remuneration/schemas";
+import { CategoryAccordionItem } from "../CategoryAccordionItem";
+import type { EmployeeCategory } from "../categorySerializer";
+
+const category: EmployeeCategory & { id: number } = {
+	id: 1,
+	name: "",
+	womenCount: "",
+	menCount: "",
+	annualBaseWomen: "",
+	annualBaseMen: "",
+	annualVariableWomen: "",
+	annualVariableMen: "",
+	hourlyBaseWomen: "",
+	hourlyBaseMen: "",
+	hourlyVariableWomen: "",
+	hourlyVariableMen: "",
+};
+
+function renderItem(
+	overrides: {
+		nameError?: string;
+		category?: EmployeeCategory & { id: number };
+	} = {},
+) {
+	const { category: categoryOverride, ...rest } = overrides;
+	return render(
+		<CategoryAccordionItem
+			baseId="cat-form"
+			category={categoryOverride ?? category}
+			collapseRef={vi.fn()}
+			disabled={false}
+			headerRef={vi.fn()}
+			index={0}
+			isExpanded
+			nameProps={{}}
+			onAccordionToggle={vi.fn()}
+			onAskRemove={vi.fn()}
+			onDecimalBlur={() => vi.fn()}
+			onPositiveNumberChange={() => vi.fn()}
+			readOnlyLabel={false}
+			showDelete={false}
+			{...rest}
+		/>,
+	);
+}
+
+describe("CategoryAccordionItem — name length cap (#3943)", () => {
+	it("shows the max-length hint and caps the input with maxLength", () => {
+		renderItem();
+		expect(
+			screen.getByText(`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`),
+		).toBeInTheDocument();
+		const input = document.getElementById("cat-0-name") as HTMLInputElement;
+		expect(input).toHaveAttribute(
+			"maxlength",
+			String(CATEGORY_NAME_MAX_LENGTH),
+		);
+	});
+
+	it("renders no error and marks the input valid when nameError is absent", () => {
+		renderItem();
+		const input = document.getElementById("cat-0-name") as HTMLInputElement;
+		expect(input).not.toHaveAttribute("aria-invalid");
+		expect(input).toHaveAttribute("aria-describedby", "cat-0-name-hint");
+		expect(
+			screen.queryByText(`${CATEGORY_NAME_MAX_LENGTH} caractères maximum`, {
+				selector: ".fr-error-text",
+			}),
+		).not.toBeInTheDocument();
+	});
+
+	it("labels the accordion header with the trimmed category name when present", () => {
+		renderItem({ category: { ...category, name: "  Cadres  " } });
+		expect(
+			screen.getByRole("button", { name: "Catégorie d'emplois n°1 : Cadres" }),
+		).toBeInTheDocument();
+	});
+
+	it("renders the error text and wires aria-invalid/aria-describedby when nameError is set", () => {
+		const message = `${CATEGORY_NAME_MAX_LENGTH} caractères maximum`;
+		renderItem({ nameError: message });
+		const error = document.getElementById("cat-0-name-error");
+		expect(error).toHaveClass("fr-error-text");
+		expect(error).toHaveTextContent(message);
+		const input = document.getElementById("cat-0-name") as HTMLInputElement;
+		expect(input).toHaveAttribute("aria-invalid", "true");
+		expect(input).toHaveAttribute(
+			"aria-describedby",
+			"cat-0-name-hint cat-0-name-error",
+		);
+	});
+});


### PR DESCRIPTION
Closes #3943

## Résumé

L'input « Libellé de la catégorie d'emploi » (step 5 / indicateur G) n'était pas borné à 255 caractères, provoquant une erreur SQL brute de Drizzle à la soumission quand la valeur dépassait la contrainte `varchar(255)` de `app_job_category.name`.

**Fix** :
- Constante partagée `CATEGORY_NAME_MAX_LENGTH = 255` dans `schemas.ts`
- `.max(255, "255 caractères maximum")` sur les schémas Zod client (`categoryFormEntrySchema`) et serveur (`updateEmployeeCategoriesSchema`)
- Attribut `maxLength={255}` sur l'input
- Hint DSFR « 255 caractères maximum » dans le label (`fr-hint-text`) relié par `aria-describedby`
- Erreur Zod affichée sous le champ en `fr-error-text` avec `aria-invalid` et `aria-describedby`

## Plan de test

- [ ] Saisir plus de 255 caractères dans un libellé de catégorie → saisie bloquée à 255 par `maxLength`
- [ ] Le hint « 255 caractères maximum » est visible sous le label
- [ ] Via import de fichier avec un nom > 255 chars → message d'erreur FR clair sous le champ (pas de SQL brut)
- [ ] Un libellé de 255 caractères passe la validation et s'enregistre correctement

## Tests

- 4 tests Zod (cap 255/256 sur les deux schémas)
- 3 tests composant (hint, état sans erreur, état avec erre
ur + a11y)
- 4 tests existants corrigés (évolution légitime : `getByLabelText` prefix regex)

<img width="839" height="376" alt="Capture d’écran 2026-07-28 à 14 17 09" src="https://github.com/user-attachments/assets/41debed4-c8f1-4c32-a251-3eca367ed44e" />