### PR TITLE
fix: masquer la section CSE quand aucun avis n'est attendu

### DIFF
--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers/db";
 import {
 	completeDeclaration,
+	reachStep6ComplianceRecap,
 	submitStepsThroughQuartiles,
 } from "./helpers/declaration-flows";
 
@@ -562,6 +563,127 @@ test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse
 		await submitCseStep2(page);
 		await expect(
 			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
+	});
+});
+
+// === GROUP H: [#3945] CSE opinion mentions gated by the declared CSE existence ===
+// A company >= 100 that declared it has no CSE (hasCse false or null) must no
+// longer be told to deposit a CSE opinion: the recap "Prochaines étapes" box and
+// the compliance-choice options drop every CSE-opinion mention, while the gap
+// actions and the "Mettre à jour l'existence d'un CSE" escape hatch stay.
+
+const CSE_OPINION_RECAP_TEXT = /avis du CSE devront être transmis/;
+const CSE_JUSTIFY_PARENTHESIS = /avis à transmettre sur le portail/;
+const UPDATE_CSE_BUTTON = /Mettre à jour l.existence d.un CSE/;
+
+test.describe("[#3945] gap + workforce >= 100 + hasCse=false → no CSE opinion mention", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setCompanyHasCse(false);
+		await setCompanyWorkforce(200);
+	});
+
+	test("step 6 recap hides the CSE opinion but keeps the gap actions and the update-CSE button", async ({
+		page,
+	}) => {
+		test.slow(); // Full 5-step declaration up to the recap
+		await reachStep6ComplianceRecap(page);
+
+		await expect(
+			page.getByRole("heading", { name: "Prochaines étapes" }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Informer et consulter le CSE" }),
+		).toHaveCount(0);
+		await expect(page.getByText(CSE_OPINION_RECAP_TEXT)).toHaveCount(0);
+		await expect(
+			page.getByRole("link", { name: /Voir les modèles d.avis CSE/ }),
+		).toHaveCount(0);
+		await expect(page.getByText(CSE_JUSTIFY_PARENTHESIS)).toHaveCount(0);
+
+		// Gap actions stay fully visible
+		await expect(page.getByText("Écarts détectés", { exact: true })).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Actions à engager" }),
+		).toBeVisible();
+		// Escape hatch for a mis-declared CSE flag stays available
+		await expect(
+			page.getByRole("button", { name: UPDATE_CSE_BUTTON }),
+		).toBeVisible();
+	});
+
+	test("compliance choice page drops the CSE opinion bullets", async ({
+		page,
+	}) => {
+		test.slow(); // Full declaration + submission
+		await completeDeclaration(page, { hasGap: true });
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+
+		await expect(
+			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
+				exact: true,
+			}),
+		).toBeVisible();
+		await expect(
+			page.getByText("Transmettre l'avis du CSE", { exact: true }),
+		).toHaveCount(0);
+		await expect(
+			page.getByText(/Transmettre l.avis ou les avis du CSE/),
+		).toHaveCount(0);
+	});
+});
+
+test.describe("[#3945] gap + workforce >= 100 + hasCse=null → no CSE opinion mention", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setCompanyHasCse(null);
+		await setCompanyWorkforce(200);
+	});
+
+	test("step 6 recap treats an unset CSE flag like an absent CSE", async ({
+		page,
+	}) => {
+		test.slow(); // Full 5-step declaration up to the recap
+		await reachStep6ComplianceRecap(page);
+
+		await expect(
+			page.getByRole("heading", { name: "Informer et consulter le CSE" }),
+		).toHaveCount(0);
+		await expect(page.getByText(CSE_OPINION_RECAP_TEXT)).toHaveCount(0);
+		await expect(
+			page.getByRole("button", { name: UPDATE_CSE_BUTTON }),
+		).toBeVisible();
+	});
+});
+
+test.describe("[#3945] gap + workforce >= 100 + hasCse=true → CSE opinion still shown", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setCompanyHasCse(true);
+		await setCompanyWorkforce(200);
+	});
+
+	test("step 6 recap shows the CSE opinion mention", async ({ page }) => {
+		test.slow(); // Full 5-step declaration up to the recap
+		await reachStep6ComplianceRecap(page);
+
+		await expect(
+			page.getByRole("heading", { name: "Informer et consulter le CSE" }),
+		).toBeVisible();
+		await expect(page.getByText(CSE_OPINION_RECAP_TEXT)).toBeVisible();
+		await expect(page.getByText(CSE_JUSTIFY_PARENTHESIS)).toBeVisible();
+	});
+
+	test("compliance choice page keeps the CSE opinion bullet", async ({
+		page,
+	}) => {
+		test.slow(); // Full declaration + submission
+		await completeDeclaration(page, { hasGap: true });
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+
+		await expect(
+			page.getByText("Transmettre l'avis du CSE", { exact: true }),
 		).toBeVisible();
 	});
 });

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -1,7 +1,14 @@
 import type { Page } from "@playwright/test";
 
-/** Fill all pay gap textboxes on steps 2 and 3 with equal values (no gap). */
-async function fillPayGapTable(page: Page) {
+/**
+ * Fill all pay gap textboxes on steps 2 and 3. Every row is equal (no gap) by
+ * default; passing annualMeanMen introduces a gap on the mean annual row, which
+ * is the indicator A annual gap that drives the step 6 recap compliance box.
+ */
+async function fillPayGapTable(
+	page: Page,
+	options: { annualMeanMen?: string } = {},
+) {
 	const rows = [
 		"Annuelle brute moyenne",
 		"Horaire brute moyenne",
@@ -9,8 +16,10 @@ async function fillPayGapTable(page: Page) {
 		"Horaire brute médiane",
 	];
 	for (const row of rows) {
+		const men =
+			row === "Annuelle brute moyenne" ? (options.annualMeanMen ?? "1000") : "1000";
 		await page.getByRole("textbox", { name: `${row} — Femmes` }).fill("1000");
-		await page.getByRole("textbox", { name: `${row} — Hommes` }).fill("1000");
+		await page.getByRole("textbox", { name: `${row} — Hommes` }).fill(men);
 	}
 }
 
@@ -118,7 +127,10 @@ export async function fillStep4Quartiles(
  * Fill and submit steps 1 → 4, then click "Suivant" on the quartile step without
  * asserting the destination: it is step 5 when indicator G applies, step 6 otherwise.
  */
-export async function submitStepsThroughQuartiles(page: Page) {
+export async function submitStepsThroughQuartiles(
+	page: Page,
+	options: { annualMeanGap?: boolean } = {},
+) {
 	// Navigate to create/resume declaration → redirects to step 1
 	await page.goto("/declaration-remuneration");
 	await page.waitForURL("**/declaration-remuneration/etape/1");
@@ -129,8 +141,10 @@ export async function submitStepsThroughQuartiles(page: Page) {
 	await page.getByRole("button", { name: "Suivant" }).click();
 	await page.waitForURL("**/declaration-remuneration/etape/2");
 
-	// Step 2: Pay gap — fill all 8 fields with equal values
-	await fillPayGapTable(page);
+	// Step 2: Pay gap — mean annual row optionally carries the indicator A gap
+	await fillPayGapTable(page, {
+		annualMeanMen: options.annualMeanGap ? "1100" : "1000",
+	});
 	await page.getByRole("button", { name: "Suivant" }).click();
 	await page.waitForURL("**/declaration-remuneration/etape/3");
 
@@ -147,21 +161,11 @@ export async function submitStepsThroughQuartiles(page: Page) {
 }
 
 /**
- * Fill and submit a complete declaration through all 6 steps.
- * Controls whether the employee category data produces a pay gap ≥ 5%.
- * Requires a company subject to indicator G (step 5), i.e. the suite baseline workforce.
+ * Fill step 5 employee categories so the computed indicator G gap lands above or
+ * below the 5% alert threshold. women=1000, men=1100 → 9% gap (triggers
+ * compliance); women=1000, men=1020 → 2% gap (no compliance).
  */
-export async function completeDeclaration(
-	page: Page,
-	options: { hasGap: boolean },
-) {
-	await submitStepsThroughQuartiles(page);
-	await page.waitForURL("**/declaration-remuneration/etape/5");
-
-	// Step 5: Employee categories — fill salary data to control gap
-	// Gap formula: |((men - women) / men) * 100|
-	// women=1000, men=1100 → 9% gap (triggers compliance)
-	// women=1000, men=1020 → 2% gap (no compliance)
+async function fillStep5Categories(page: Page, options: { hasGap: boolean }) {
 	const menSalary = options.hasGap ? "1100" : "1020";
 
 	// If categories are pre-populated (from getOrCreate), the source select
@@ -182,9 +186,48 @@ export async function completeDeclaration(
 
 	// Fill salary data on category 1 (works for both fresh and pre-populated)
 	await fillCategoryPayAmounts(page, { men: menSalary, women: "1000" });
+}
 
+/**
+ * Fill steps 1 → 5 and stop on the step 6 review recap without submitting, so a
+ * caller can assert on the recap ("Prochaines étapes" box) before certification.
+ * Requires a company subject to indicator G (step 5), i.e. the suite baseline workforce.
+ */
+export async function reachStep6Recap(
+	page: Page,
+	options: { hasGap: boolean },
+) {
+	await submitStepsThroughQuartiles(page);
+	await page.waitForURL("**/declaration-remuneration/etape/5");
+	await fillStep5Categories(page, options);
 	await page.getByRole("button", { name: "Suivant" }).click();
 	await page.waitForURL("**/declaration-remuneration/etape/6");
+}
+
+/**
+ * Fill steps 1 → 5 with an indicator A annual gap ≥ 5% and stop on the step 6
+ * review recap. The annual gap makes isComplianceProcessRequired true, so the
+ * recap renders the "Prochaines étapes" (NextStepsBox) compliance box — the
+ * surface that must gate its CSE-opinion mention on the declared CSE existence.
+ */
+export async function reachStep6ComplianceRecap(page: Page) {
+	await submitStepsThroughQuartiles(page, { annualMeanGap: true });
+	await page.waitForURL("**/declaration-remuneration/etape/5");
+	await fillStep5Categories(page, { hasGap: true });
+	await page.getByRole("button", { name: "Suivant" }).click();
+	await page.waitForURL("**/declaration-remuneration/etape/6");
+}
+
+/**
+ * Fill and submit a complete declaration through all 6 steps.
+ * Controls whether the employee category data produces a pay gap ≥ 5%.
+ * Requires a company subject to indicator G (step 5), i.e. the suite baseline workforce.
+ */
+export async function completeDeclaration(
+	page: Page,
+	options: { hasGap: boolean },
+) {
+	await reachStep6Recap(page, options);
 
 	// Step 6: Submit declaration
 	await page.getByRole("button", { name: "Suivant" }).click();

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -7,6 +7,7 @@ import { UpdateCseModal } from "./UpdateCseModal";
 
 type Props = {
 	cseApplicable: boolean;
+	cseOpinionRequired: boolean;
 	hasGapsAboveThreshold: boolean;
 	siren: string;
 	isSecondDeclaration?: boolean;
@@ -15,6 +16,7 @@ type Props = {
 /** Shared "Prochaines étapes" box with CSE consultation info and gap warnings */
 export function NextStepsBox({
 	cseApplicable,
+	cseOpinionRequired,
 	hasGapsAboveThreshold,
 	siren,
 	isSecondDeclaration,
@@ -24,34 +26,51 @@ export function NextStepsBox({
 			<div className={styles.nextSteps}>
 				<h3 className="fr-h4 fr-mb-0">Prochaines étapes</h3>
 
-				<div className={styles.section}>
-					<h4 className="fr-text--bold fr-text--md fr-mb-0">
-						Informer et consulter le CSE
-					</h4>
+				{cseOpinionRequired && (
+					<div className={styles.section}>
+						<h4 className="fr-text--bold fr-text--md fr-mb-0">
+							Informer et consulter le CSE
+						</h4>
 
-					<p className="fr-mb-0">
-						Au cours du temps imparti pour réaliser votre déclaration, vous
-						devez{" "}
-						<strong>
-							obligatoirement informer et consulter le CSE sur l&apos;exactitude
-							des données déclarées
-						</strong>
-						.
-					</p>
-
-					<div className={styles.ctaGroup}>
 						<p className="fr-mb-0">
-							Le ou les avis du CSE devront être transmis sur le portail lors de
-							la dernière étape.
+							Au cours du temps imparti pour réaliser votre déclaration, vous
+							devez{" "}
+							<strong>
+								obligatoirement informer et consulter le CSE sur
+								l&apos;exactitude des données déclarées
+							</strong>
+							.
 						</p>
-						<TrackedLink
-							className="fr-link"
-							href="/avis-cse"
-							trackingId="cse_models"
-						>
-							Voir les modèles d&apos;avis CSE
-						</TrackedLink>
-						{cseApplicable && (
+
+						<div className={styles.ctaGroup}>
+							<p className="fr-mb-0">
+								Le ou les avis du CSE devront être transmis sur le portail lors
+								de la dernière étape.
+							</p>
+							<TrackedLink
+								className="fr-link"
+								href="/avis-cse"
+								trackingId="cse_models"
+							>
+								Voir les modèles d&apos;avis CSE
+							</TrackedLink>
+							{cseApplicable && (
+								<button
+									aria-controls="update-cse-modal"
+									className="fr-btn fr-btn--secondary"
+									data-fr-opened="false"
+									type="button"
+								>
+									Mettre à jour l&apos;existence d&apos;un CSE
+								</button>
+							)}
+						</div>
+					</div>
+				)}
+
+				{!cseOpinionRequired && cseApplicable && (
+					<div className={styles.section}>
+						<div className={styles.ctaGroup}>
 							<button
 								aria-controls="update-cse-modal"
 								className="fr-btn fr-btn--secondary"
@@ -60,9 +79,9 @@ export function NextStepsBox({
 							>
 								Mettre à jour l&apos;existence d&apos;un CSE
 							</button>
-						)}
+						</div>
 					</div>
-				</div>
+				)}
 
 				{hasGapsAboveThreshold && <hr className={styles.separator} />}
 
@@ -93,8 +112,9 @@ export function NextStepsBox({
 									sexistes.
 								</strong>{" "}
 								Si vous choisissez ce parcours, vous devez informer et consulter
-								le CSE (avis à transmettre sur le portail lors de la dernière
-								étape)
+								le CSE
+								{cseOpinionRequired &&
+									" (avis à transmettre sur le portail lors de la dernière étape)"}
 							</li>
 						</ul>
 						<p className="fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -213,6 +213,7 @@ export function CompliancePathChoice({
 								{isSecondRound ? (
 									<SecondRoundOptions
 										disabled={isImpersonating || isReadOnly}
+										hasCse={hasCse}
 										jointEvaluationDeadline={
 											campaignDeadlines.decl2JointEvaluationDeadline
 										}
@@ -228,6 +229,7 @@ export function CompliancePathChoice({
 											campaignDeadlines.decl2ModificationDeadline
 										}
 										disabled={isImpersonating || isReadOnly}
+										hasCse={hasCse}
 										jointEvaluationDeadline={
 											campaignDeadlines.decl1JointEvaluationDeadline
 										}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -38,6 +38,7 @@ type Props = {
 	currentYear: number;
 	declarationSiren: string;
 	declarationYear: number;
+	cseOpinionRequired: boolean;
 	email: string;
 	hasCse: boolean | null;
 	initialPath?: CompliancePathValue;
@@ -48,6 +49,7 @@ type Props = {
 
 export function CompliancePathChoice({
 	campaignDeadlines,
+	cseOpinionRequired,
 	currentYear,
 	declarationSiren,
 	declarationYear,
@@ -212,8 +214,8 @@ export function CompliancePathChoice({
 
 								{isSecondRound ? (
 									<SecondRoundOptions
+										cseOpinionRequired={cseOpinionRequired}
 										disabled={isImpersonating || isReadOnly}
-										hasCse={hasCse}
 										jointEvaluationDeadline={
 											campaignDeadlines.decl2JointEvaluationDeadline
 										}
@@ -228,8 +230,8 @@ export function CompliancePathChoice({
 										correctiveActionDeadline={
 											campaignDeadlines.decl2ModificationDeadline
 										}
+										cseOpinionRequired={cseOpinionRequired}
 										disabled={isImpersonating || isReadOnly}
-										hasCse={hasCse}
 										jointEvaluationDeadline={
 											campaignDeadlines.decl1JointEvaluationDeadline
 										}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -1,8 +1,10 @@
 import { redirect } from "next/navigation";
 import {
 	type DeclarationFsmStatus,
+	getObligationWorkforce,
 	hasGapsAboveThreshold,
 	isComplianceProcessCompleted,
+	isCseOpinionRequired,
 	isDeadlinePassed,
 	isDraft,
 } from "~/modules/domain";
@@ -133,6 +135,10 @@ export async function CompliancePathPage() {
 		<HydrateClient>
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
+				cseOpinionRequired={isCseOpinionRequired(
+					getObligationWorkforce(company.gipWorkforce),
+					company.hasCse,
+				)}
 				currentYear={currentYear}
 				declarationSiren={data.declaration.siren}
 				declarationYear={currentYear}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -9,6 +9,7 @@ import {
 	getCompanySizeRange,
 	getObligationWorkforce,
 	isComplianceProcessRequired,
+	isCseOpinionRequired,
 	isCseRequired,
 } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
@@ -71,6 +72,10 @@ export function Step6Review({
 	const router = useRouter();
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const cseApplicable = isCseRequired(getObligationWorkforce(companyWorkforce));
+	const cseOpinionRequired = isCseOpinionRequired(
+		getObligationWorkforce(companyWorkforce),
+		hasCse,
+	);
 	const submitMutation = api.declaration.submit.useMutation({
 		onSuccess: () => {
 			trackFunnelComplete(
@@ -163,6 +168,7 @@ export function Step6Review({
 					{complianceProcessRequired && declaration.siren && (
 						<NextStepsBox
 							cseApplicable={cseApplicable}
+							cseOpinionRequired={cseOpinionRequired}
 							hasGapsAboveThreshold={complianceProcessRequired}
 							siren={declaration.siren}
 						/>

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -438,6 +438,60 @@ describe("CompliancePathChoice", () => {
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();
 	});
 
+	describe("CSE consultation items gating (issue #3945)", () => {
+		function renderWithHasCse(hasCse: boolean | null) {
+			return render(
+				<CompliancePathChoice
+					campaignDeadlines={campaignDeadlines}
+					currentYear={2026}
+					declarationSiren={DECLARATION_SIREN}
+					declarationYear={DECLARATION_YEAR}
+					email="test@example.fr"
+					hasCse={hasCse}
+				/>,
+			);
+		}
+
+		it("shows the CSE consultation items in both the justify and corrective-action options when hasCse is true", () => {
+			renderWithHasCse(true);
+
+			expect(
+				screen.getByText(
+					"Informer et consulter votre CSE sur cette justification",
+				),
+			).toBeInTheDocument();
+			expect(screen.getByText("Transmettre l'avis du CSE")).toBeInTheDocument();
+			expect(
+				screen.getByText(/Informer et consulter votre CSE sur l'exactitude/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText("Transmettre l'avis ou les avis du CSE"),
+			).toBeInTheDocument();
+		});
+
+		it.each([
+			false,
+			null,
+		] as const)("hides all CSE consultation items when hasCse is %s", (hasCse) => {
+			renderWithHasCse(hasCse);
+
+			expect(
+				screen.queryByText(
+					"Informer et consulter votre CSE sur cette justification",
+				),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText("Transmettre l'avis du CSE"),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/Informer et consulter votre CSE sur l'exactitude/),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText("Transmettre l'avis ou les avis du CSE"),
+			).not.toBeInTheDocument();
+		});
+	});
+
 	describe("draft autosave", () => {
 		it("hydrates the selected path from a persisted draft", () => {
 			draftRef.current = { path: "joint_evaluation" };

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -5,6 +5,7 @@ import {
 	screen,
 	waitFor,
 } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
@@ -68,6 +69,23 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
+function compliancePathChoice(
+	overrides: Partial<ComponentProps<typeof CompliancePathChoice>> = {},
+) {
+	return (
+		<CompliancePathChoice
+			campaignDeadlines={campaignDeadlines}
+			cseOpinionRequired={true}
+			currentYear={2026}
+			declarationSiren={DECLARATION_SIREN}
+			declarationYear={DECLARATION_YEAR}
+			email="test@example.fr"
+			hasCse={true}
+			{...overrides}
+		/>
+	);
+}
+
 beforeEach(() => {
 	mockMutate.mockClear();
 	mockPush.mockClear();
@@ -77,16 +95,7 @@ beforeEach(() => {
 
 describe("CompliancePathChoice", () => {
 	it("renders the page title and success banner", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		expect(
 			screen.getByText(/Déclaration des indicateurs de rémunération/),
 		).toBeInTheDocument();
@@ -96,32 +105,14 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("names the read-only fieldset with a screen-reader-only legend (RGAA 11.6/11.7)", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		expect(
 			screen.getByRole("group", { name: "Choix du parcours de conformité" }),
 		).toBeInTheDocument();
 	});
 
 	it("renders all 3 compliance path options", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		expect(
 			screen.getByText("Justifier les écarts de rémunération ≥ 5 %"),
 		).toBeInTheDocument();
@@ -136,31 +127,13 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("disables next button when no path is selected", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		const nextButton = screen.getByRole("button", { name: /suivant/i });
 		expect(nextButton).toBeDisabled();
 	});
 
 	it("enables next button after selecting a path", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		const radio = screen.getByLabelText(
 			"Actions correctives et seconde déclaration",
 		);
@@ -170,16 +143,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("submits the selected path and navigates to evaluation-conjointe", async () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		const radio = screen.getByLabelText(
 			"Mettre en place une évaluation conjointe des rémunérations",
 		);
@@ -199,16 +163,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("navigates to second declaration when corrective_action is selected", async () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		const radio = screen.getByLabelText(
 			"Actions correctives et seconde déclaration",
 		);
@@ -228,16 +183,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("does not submit when no path is selected", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 
 		const form = screen
 			.getByRole("button", { name: /suivant/i })
@@ -249,16 +195,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("submits justify and navigates to the CSE opinion page", async () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		const radio = screen.getByLabelText(
 			"Justifier les écarts de rémunération ≥ 5 %",
 		);
@@ -275,18 +212,28 @@ describe("CompliancePathChoice", () => {
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
 	});
 
-	it("pre-selects the initial path when provided", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-				initialPath="corrective_action"
-			/>,
+	it("submits justify and navigates to the confirmation page without a CSE", async () => {
+		render(compliancePathChoice({ cseOpinionRequired: false, hasCse: false }));
+		const radio = screen.getByLabelText(
+			"Justifier les écarts de rémunération ≥ 5 %",
 		);
+		fireEvent.click(radio);
+
+		const form = screen
+			.getByRole("button", { name: /suivant/i })
+			.closest("form") as HTMLFormElement;
+		fireEvent.submit(form);
+
+		await waitFor(() => {
+			expect(mockMutate).toHaveBeenCalledWith({ path: "justify" });
+		});
+		expect(mockPush).toHaveBeenCalledWith(
+			"/declaration-remuneration/parcours-conformite/confirmation",
+		);
+	});
+
+	it("pre-selects the initial path when provided", () => {
+		render(compliancePathChoice({ initialPath: "corrective_action" }));
 		const radio = screen.getByLabelText(
 			"Actions correctives et seconde déclaration",
 		) as HTMLInputElement;
@@ -294,17 +241,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders isSecondRound options when isSecondRound is set", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-				isSecondRound={true}
-			/>,
-		);
+		render(compliancePathChoice({ isSecondRound: true }));
 		expect(
 			screen.getByText(
 				"Mettre en place une évaluation conjointe des rémunérations",
@@ -316,16 +253,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders the first-round instruction phrase by default", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		expect(
 			screen.getByText(/Des écarts ≥ 5 % ont été constatés/),
 		).toBeInTheDocument();
@@ -335,17 +263,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders the second-round instruction phrase and intermediate heading", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-				isSecondRound={true}
-			/>,
-		);
+		render(compliancePathChoice({ isSecondRound: true }));
 		expect(
 			screen.getByText(/Des écarts ≥ 5 % ont de nouveau été détectés/),
 		).toBeInTheDocument();
@@ -361,16 +279,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("uses the funnel title as h1 and keeps section headings at level 2", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		expect(
 			screen.getByRole("heading", {
 				level: 1,
@@ -389,16 +298,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders the path choice deadline highlight block", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		expect(
 			screen.getByText(
 				"Date limite pour choisir un parcours de mise en conformité",
@@ -408,16 +308,7 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders previous link pointing to step 6", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice());
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/etape/6",
@@ -425,35 +316,16 @@ describe("CompliancePathChoice", () => {
 	});
 
 	it("renders the email in the success banner", () => {
-		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="john@company.fr"
-				hasCse={true}
-			/>,
-		);
+		render(compliancePathChoice({ email: "john@company.fr" }));
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();
 	});
 
 	describe("CSE consultation items gating (issue #3945)", () => {
-		function renderWithHasCse(hasCse: boolean | null) {
-			return render(
-				<CompliancePathChoice
-					campaignDeadlines={campaignDeadlines}
-					currentYear={2026}
-					declarationSiren={DECLARATION_SIREN}
-					declarationYear={DECLARATION_YEAR}
-					email="test@example.fr"
-					hasCse={hasCse}
-				/>,
-			);
-		}
-
-		it("shows the CSE consultation items in both the justify and corrective-action options when hasCse is true", () => {
-			renderWithHasCse(true);
+		it.each([
+			false,
+			true,
+		])("shows the justify CSE consultation items when a CSE opinion is required (isSecondRound: %s)", (isSecondRound) => {
+			render(compliancePathChoice({ cseOpinionRequired: true, isSecondRound }));
 
 			expect(
 				screen.getByText(
@@ -461,19 +333,19 @@ describe("CompliancePathChoice", () => {
 				),
 			).toBeInTheDocument();
 			expect(screen.getByText("Transmettre l'avis du CSE")).toBeInTheDocument();
-			expect(
-				screen.getByText(/Informer et consulter votre CSE sur l'exactitude/),
-			).toBeInTheDocument();
-			expect(
-				screen.getByText("Transmettre l'avis ou les avis du CSE"),
-			).toBeInTheDocument();
 		});
 
 		it.each([
 			false,
-			null,
-		] as const)("hides all CSE consultation items when hasCse is %s", (hasCse) => {
-			renderWithHasCse(hasCse);
+			true,
+		])("hides the justify CSE consultation items when no CSE opinion is required (isSecondRound: %s)", (isSecondRound) => {
+			render(
+				compliancePathChoice({
+					cseOpinionRequired: false,
+					hasCse: false,
+					isSecondRound,
+				}),
+			);
 
 			expect(
 				screen.queryByText(
@@ -483,6 +355,24 @@ describe("CompliancePathChoice", () => {
 			expect(
 				screen.queryByText("Transmettre l'avis du CSE"),
 			).not.toBeInTheDocument();
+		});
+
+		it("shows the corrective-action CSE consultation items when a CSE opinion is required", () => {
+			render(compliancePathChoice({ cseOpinionRequired: true }));
+
+			expect(
+				screen.getByText(/Informer et consulter votre CSE sur l'exactitude/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText("Transmettre l'avis ou les avis du CSE"),
+			).toBeInTheDocument();
+		});
+
+		it("hides the corrective-action CSE consultation items when no CSE opinion is required", () => {
+			render(
+				compliancePathChoice({ cseOpinionRequired: false, hasCse: false }),
+			);
+
 			expect(
 				screen.queryByText(/Informer et consulter votre CSE sur l'exactitude/),
 			).not.toBeInTheDocument();
@@ -490,22 +380,30 @@ describe("CompliancePathChoice", () => {
 				screen.queryByText("Transmettre l'avis ou les avis du CSE"),
 			).not.toBeInTheDocument();
 		});
+
+		it("keeps the non-CSE corrective-action items when no CSE opinion is required", () => {
+			render(
+				compliancePathChoice({ cseOpinionRequired: false, hasCse: false }),
+			);
+
+			expect(
+				screen.getByText(
+					"Mettre en place des actions correctives par accord ou par plan d'action",
+				),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					"Redéclarer l'indicateur dans un délai de 6 mois après votre première déclaration",
+				),
+			).toBeInTheDocument();
+		});
 	});
 
 	describe("draft autosave", () => {
 		it("hydrates the selected path from a persisted draft", () => {
 			draftRef.current = { path: "joint_evaluation" };
 
-			render(
-				<CompliancePathChoice
-					campaignDeadlines={campaignDeadlines}
-					currentYear={2026}
-					declarationSiren={DECLARATION_SIREN}
-					declarationYear={DECLARATION_YEAR}
-					email="test@example.fr"
-					hasCse={true}
-				/>,
-			);
+			render(compliancePathChoice());
 
 			const radio = screen.getByLabelText(
 				"Mettre en place une évaluation conjointe des rémunérations",
@@ -514,16 +412,7 @@ describe("CompliancePathChoice", () => {
 		});
 
 		it("saves a draft when a path is selected and the lock is inactive", async () => {
-			render(
-				<CompliancePathChoice
-					campaignDeadlines={campaignDeadlines}
-					currentYear={2026}
-					declarationSiren={DECLARATION_SIREN}
-					declarationYear={DECLARATION_YEAR}
-					email="test@example.fr"
-					hasCse={true}
-				/>,
-			);
+			render(compliancePathChoice());
 
 			fireEvent.click(
 				screen.getByLabelText("Actions correctives et seconde déclaration"),
@@ -537,18 +426,7 @@ describe("CompliancePathChoice", () => {
 		});
 
 		it("does not save a draft when the declaration is locked read-only", async () => {
-			render(
-				<LockProvider isReadOnly>
-					<CompliancePathChoice
-						campaignDeadlines={campaignDeadlines}
-						currentYear={2026}
-						declarationSiren={DECLARATION_SIREN}
-						declarationYear={DECLARATION_YEAR}
-						email="test@example.fr"
-						hasCse={true}
-					/>
-				</LockProvider>,
-			);
+			render(<LockProvider isReadOnly>{compliancePathChoice()}</LockProvider>);
 
 			const radio = screen.getByLabelText(
 				"Actions correctives et seconde déclaration",
@@ -561,16 +439,7 @@ describe("CompliancePathChoice", () => {
 
 		it("disables each control while keeping the fieldset enabled when the declaration is locked read-only", () => {
 			const { container } = render(
-				<LockProvider isReadOnly>
-					<CompliancePathChoice
-						campaignDeadlines={campaignDeadlines}
-						currentYear={2026}
-						declarationSiren={DECLARATION_SIREN}
-						declarationYear={DECLARATION_YEAR}
-						email="test@example.fr"
-						hasCse={true}
-					/>
-				</LockProvider>,
+				<LockProvider isReadOnly>{compliancePathChoice()}</LockProvider>,
 			);
 
 			// The outermost fieldset stays enabled so its content remains exposed
@@ -587,16 +456,10 @@ describe("CompliancePathChoice", () => {
 describe("CompliancePathChoice read-only mode", () => {
 	it("renders the read-only alert and disables the radios", () => {
 		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-				initialPath="justify"
-				readOnlyReason="cse_opinion_submitted"
-			/>,
+			compliancePathChoice({
+				initialPath: "justify",
+				readOnlyReason: "cse_opinion_submitted",
+			}),
 		);
 		expect(
 			screen.getByText(/L'avis du CSE a déjà été transmis/),
@@ -608,16 +471,10 @@ describe("CompliancePathChoice read-only mode", () => {
 
 	it("renders Suivant as a navigation link instead of a submit button", () => {
 		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-				initialPath="justify"
-				readOnlyReason="cse_opinion_submitted"
-			/>,
+			compliancePathChoice({
+				initialPath: "justify",
+				readOnlyReason: "cse_opinion_submitted",
+			}),
 		);
 		expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
 			"href",
@@ -630,16 +487,10 @@ describe("CompliancePathChoice read-only mode", () => {
 
 	it("does not call the save mutation when the read-only form is submitted", async () => {
 		render(
-			<CompliancePathChoice
-				campaignDeadlines={campaignDeadlines}
-				currentYear={2026}
-				declarationSiren={DECLARATION_SIREN}
-				declarationYear={DECLARATION_YEAR}
-				email="test@example.fr"
-				hasCse={true}
-				initialPath="justify"
-				readOnlyReason="cse_opinion_submitted"
-			/>,
+			compliancePathChoice({
+				initialPath: "justify",
+				readOnlyReason: "cse_opinion_submitted",
+			}),
 		);
 		const form = screen
 			.getByRole("link", { name: /suivant/i })

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -191,6 +191,7 @@ describe("DraftLoadingGate", () => {
 					decl2JointEvaluationDeadline: new Date("2026-11-01"),
 					pathChoiceDeadline: new Date("2027-01-01"),
 				}}
+				cseOpinionRequired={true}
 				currentYear={2026}
 				declarationSiren="123456789"
 				declarationYear={2026}

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -715,4 +715,80 @@ describe("Step6Review", () => {
 		);
 		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
 	});
+
+	describe("CSE consultation section gating (issue #3945)", () => {
+		// A annual gap 5% at 300 employees → the "Prochaines étapes" callout renders;
+		// only the CSE consultation part is driven by hasCse.
+		const gappedStep2 = () => ({
+			indicatorAAnnualWomen: "95",
+			indicatorAAnnualMen: "100",
+			indicatorAHourlyWomen: "100",
+			indicatorAHourlyMen: "100",
+			indicatorCAnnualWomen: "100",
+			indicatorCAnnualMen: "100",
+			indicatorCHourlyWomen: "100",
+			indicatorCHourlyMen: "100",
+		});
+
+		function renderWithHasCse(hasCse: boolean | null) {
+			return render(
+				<Step6Review
+					companyWorkforce={300}
+					declaration={{ siren: "532847196", status: null }}
+					declarationYear={2025}
+					hasCse={hasCse}
+					indicatorGRequired
+					step2Data={gappedStep2()}
+					step3Data={emptyStep3Data()}
+					step4Data={emptyStep4Data()}
+				/>,
+			);
+		}
+
+		it.each([
+			false,
+			null,
+		] as const)("hides the CSE consultation section but keeps gap actions and the CSE update button when hasCse is %s", (hasCse) => {
+			renderWithHasCse(hasCse);
+
+			expect(
+				screen.queryByRole("heading", {
+					name: "Informer et consulter le CSE",
+				}),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/obligatoirement informer et consulter le CSE/),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/avis du CSE devront être transmis sur le portail/),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/avis à transmettre sur le portail/),
+			).not.toBeInTheDocument();
+
+			expect(screen.getByText("Écarts détectés")).toBeInTheDocument();
+			expect(
+				screen.getByRole("heading", { name: "Actions à engager" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", {
+					name: "Mettre à jour l'existence d'un CSE",
+				}),
+			).toBeInTheDocument();
+		});
+
+		it("shows the CSE consultation section when hasCse is true", () => {
+			renderWithHasCse(true);
+
+			expect(
+				screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/avis du CSE devront être transmis sur le portail/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/avis à transmettre sur le portail/),
+			).toBeInTheDocument();
+		});
+	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
@@ -72,15 +72,15 @@ export function JointEvaluationOption({
 
 export function JustifyOption({
 	checked,
+	cseOpinionRequired,
 	deadline,
 	disabled,
-	hasCse,
 	onChange,
 }: {
 	checked: boolean;
+	cseOpinionRequired: boolean;
 	deadline: Date;
 	disabled?: boolean;
-	hasCse: boolean | null;
 	onChange: () => void;
 }) {
 	return (
@@ -99,27 +99,27 @@ export function JustifyOption({
 					Vous avez la possibilité de justifier vos écarts par des critères
 					objectifs et non sexistes :
 				</p>
-				<ul className="fr-mt-1w fr-mb-0">
-					{hasCse === true && (
+				{cseOpinionRequired && (
+					<ul className="fr-mt-1w fr-mb-0">
 						<li>Informer et consulter votre CSE sur cette justification</li>
-					)}
-					{hasCse === true && <li>Transmettre l&apos;avis du CSE</li>}
-				</ul>
+						<li>Transmettre l&apos;avis du CSE</li>
+					</ul>
+				)}
 			</CompliancePathOption>
 		</div>
 	);
 }
 
 export function SecondRoundOptions({
+	cseOpinionRequired,
 	disabled,
-	hasCse,
 	justificationDeadline,
 	jointEvaluationDeadline,
 	selectedPath,
 	setSelectedPath,
 }: {
+	cseOpinionRequired: boolean;
 	disabled?: boolean;
-	hasCse: boolean | null;
 	justificationDeadline: Date;
 	jointEvaluationDeadline: Date;
 	selectedPath: CompliancePathValue | undefined;
@@ -129,9 +129,9 @@ export function SecondRoundOptions({
 		<>
 			<JustifyOption
 				checked={selectedPath === "justify"}
+				cseOpinionRequired={cseOpinionRequired}
 				deadline={justificationDeadline}
 				disabled={disabled}
-				hasCse={hasCse}
 				onChange={() => setSelectedPath("justify")}
 			/>
 
@@ -153,16 +153,16 @@ export function SecondRoundOptions({
 
 export function FirstRoundOptions({
 	correctiveActionDeadline,
+	cseOpinionRequired,
 	disabled,
-	hasCse,
 	jointEvaluationDeadline,
 	justificationDeadline,
 	selectedPath,
 	setSelectedPath,
 }: {
 	correctiveActionDeadline: Date;
+	cseOpinionRequired: boolean;
 	disabled?: boolean;
-	hasCse: boolean | null;
 	jointEvaluationDeadline: Date;
 	justificationDeadline: Date;
 	selectedPath: CompliancePathValue | undefined;
@@ -172,9 +172,9 @@ export function FirstRoundOptions({
 		<>
 			<JustifyOption
 				checked={selectedPath === "justify"}
+				cseOpinionRequired={cseOpinionRequired}
 				deadline={justificationDeadline}
 				disabled={disabled}
-				hasCse={hasCse}
 				onChange={() => setSelectedPath("justify")}
 			/>
 
@@ -211,13 +211,13 @@ export function FirstRoundOptions({
 							Redéclarer l&apos;indicateur dans un délai de 6 mois après votre
 							première déclaration
 						</li>
-						{hasCse === true && (
+						{cseOpinionRequired && (
 							<li>
 								Informer et consulter votre CSE sur l&apos;exactitude des
 								données et éventuellement, sur la justification des écarts ≥ 5 %
 							</li>
 						)}
-						{hasCse === true && (
+						{cseOpinionRequired && (
 							<li>Transmettre l&apos;avis ou les avis du CSE</li>
 						)}
 					</ul>

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
@@ -1,4 +1,4 @@
-import { getPostComplianceDestination } from "../../shared/complianceNavigation";
+import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { CompliancePathOption } from "./CompliancePathOption";
 import type { CompliancePathValue } from "./constants";
 
@@ -74,11 +74,13 @@ export function JustifyOption({
 	checked,
 	deadline,
 	disabled,
+	hasCse,
 	onChange,
 }: {
 	checked: boolean;
 	deadline: Date;
 	disabled?: boolean;
+	hasCse: boolean | null;
 	onChange: () => void;
 }) {
 	return (
@@ -98,8 +100,10 @@ export function JustifyOption({
 					objectifs et non sexistes :
 				</p>
 				<ul className="fr-mt-1w fr-mb-0">
-					<li>Informer et consulter votre CSE sur cette justification</li>
-					<li>Transmettre l&apos;avis du CSE</li>
+					{hasCse === true && (
+						<li>Informer et consulter votre CSE sur cette justification</li>
+					)}
+					{hasCse === true && <li>Transmettre l&apos;avis du CSE</li>}
 				</ul>
 			</CompliancePathOption>
 		</div>
@@ -108,12 +112,14 @@ export function JustifyOption({
 
 export function SecondRoundOptions({
 	disabled,
+	hasCse,
 	justificationDeadline,
 	jointEvaluationDeadline,
 	selectedPath,
 	setSelectedPath,
 }: {
 	disabled?: boolean;
+	hasCse: boolean | null;
 	justificationDeadline: Date;
 	jointEvaluationDeadline: Date;
 	selectedPath: CompliancePathValue | undefined;
@@ -125,6 +131,7 @@ export function SecondRoundOptions({
 				checked={selectedPath === "justify"}
 				deadline={justificationDeadline}
 				disabled={disabled}
+				hasCse={hasCse}
 				onChange={() => setSelectedPath("justify")}
 			/>
 
@@ -147,6 +154,7 @@ export function SecondRoundOptions({
 export function FirstRoundOptions({
 	correctiveActionDeadline,
 	disabled,
+	hasCse,
 	jointEvaluationDeadline,
 	justificationDeadline,
 	selectedPath,
@@ -154,6 +162,7 @@ export function FirstRoundOptions({
 }: {
 	correctiveActionDeadline: Date;
 	disabled?: boolean;
+	hasCse: boolean | null;
 	jointEvaluationDeadline: Date;
 	justificationDeadline: Date;
 	selectedPath: CompliancePathValue | undefined;
@@ -165,6 +174,7 @@ export function FirstRoundOptions({
 				checked={selectedPath === "justify"}
 				deadline={justificationDeadline}
 				disabled={disabled}
+				hasCse={hasCse}
 				onChange={() => setSelectedPath("justify")}
 			/>
 
@@ -201,11 +211,15 @@ export function FirstRoundOptions({
 							Redéclarer l&apos;indicateur dans un délai de 6 mois après votre
 							première déclaration
 						</li>
-						<li>
-							Informer et consulter votre CSE sur l&apos;exactitude des données
-							et éventuellement, sur la justification des écarts ≥ 5 %
-						</li>
-						<li>Transmettre l&apos;avis ou les avis du CSE</li>
+						{hasCse === true && (
+							<li>
+								Informer et consulter votre CSE sur l&apos;exactitude des
+								données et éventuellement, sur la justification des écarts ≥ 5 %
+							</li>
+						)}
+						{hasCse === true && (
+							<li>Transmettre l&apos;avis ou les avis du CSE</li>
+						)}
 					</ul>
 					<p className="fr-mt-1w fr-mb-0">
 						Si des écarts non justifiés persistent, vous devez engager une

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/__tests__/CompliancePathOptions.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/__tests__/CompliancePathOptions.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	FirstRoundOptions,
+	getCompliancePathHref,
+	JustifyOption,
+	SecondRoundOptions,
+} from "../CompliancePathOptions";
+
+const JUSTIFICATION_DEADLINE = new Date("2027-03-01");
+const JOINT_EVALUATION_DEADLINE = new Date("2027-05-01");
+const CORRECTIVE_ACTION_DEADLINE = new Date("2027-09-01");
+
+const JUSTIFY_CSE_CONSULT =
+	"Informer et consulter votre CSE sur cette justification";
+const JUSTIFY_CSE_OPINION = "Transmettre l'avis du CSE";
+const CORRECTIVE_CSE_CONSULT =
+	/Informer et consulter votre CSE sur l'exactitude/;
+const CORRECTIVE_CSE_OPINION = "Transmettre l'avis ou les avis du CSE";
+
+// An option whose only list items are CSE-gated must drop the whole <ul>:
+// an empty list is invalid content for assistive technologies (RGAA 9.3).
+function expectNoEmptyList(container: HTMLElement) {
+	const emptyLists = Array.from(container.querySelectorAll("ul")).filter(
+		(list) => list.children.length === 0,
+	);
+	expect(emptyLists).toHaveLength(0);
+}
+
+describe("getCompliancePathHref", () => {
+	it.each([
+		true,
+		false,
+		null,
+	])("routes corrective_action to the second declaration funnel (hasCse: %s)", (hasCse) => {
+		expect(getCompliancePathHref("corrective_action", hasCse)).toBe(
+			"/declaration-remuneration/parcours-conformite/etape/1",
+		);
+	});
+
+	it.each([
+		true,
+		false,
+		null,
+	])("routes joint_evaluation to the joint evaluation form (hasCse: %s)", (hasCse) => {
+		expect(getCompliancePathHref("joint_evaluation", hasCse)).toBe(
+			"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
+		);
+	});
+
+	it("routes justify to the CSE opinion page when the company has a CSE", () => {
+		expect(getCompliancePathHref("justify", true)).toBe("/avis-cse");
+	});
+
+	it.each([
+		false,
+		null,
+	])("routes justify to the confirmation page without a CSE (hasCse: %s)", (hasCse) => {
+		expect(getCompliancePathHref("justify", hasCse)).toBe(
+			"/declaration-remuneration/parcours-conformite/confirmation",
+		);
+	});
+});
+
+describe("JustifyOption", () => {
+	function renderJustifyOption(cseOpinionRequired: boolean) {
+		return render(
+			<JustifyOption
+				checked={false}
+				cseOpinionRequired={cseOpinionRequired}
+				deadline={JUSTIFICATION_DEADLINE}
+				onChange={vi.fn()}
+			/>,
+		);
+	}
+
+	it("lists the CSE consultation steps when a CSE opinion is required", () => {
+		renderJustifyOption(true);
+
+		expect(screen.getByText(JUSTIFY_CSE_CONSULT)).toBeInTheDocument();
+		expect(screen.getByText(JUSTIFY_CSE_OPINION)).toBeInTheDocument();
+	});
+
+	it("renders no list at all when no CSE opinion is required", () => {
+		const { container } = renderJustifyOption(false);
+
+		expect(screen.queryByText(JUSTIFY_CSE_CONSULT)).not.toBeInTheDocument();
+		expect(screen.queryByText(JUSTIFY_CSE_OPINION)).not.toBeInTheDocument();
+		expect(container.querySelector("ul")).toBeNull();
+	});
+
+	it.each([
+		true,
+		false,
+	])("keeps the option title and its justification intro (cseOpinionRequired: %s)", (cseOpinionRequired) => {
+		renderJustifyOption(cseOpinionRequired);
+
+		expect(
+			screen.getByText("Justifier les écarts de rémunération ≥ 5 %"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/Vous avez la possibilité de justifier vos écarts/),
+		).toBeInTheDocument();
+	});
+});
+
+describe("SecondRoundOptions", () => {
+	function renderSecondRoundOptions(cseOpinionRequired: boolean) {
+		const setSelectedPath = vi.fn();
+		return {
+			setSelectedPath,
+			...render(
+				<SecondRoundOptions
+					cseOpinionRequired={cseOpinionRequired}
+					jointEvaluationDeadline={JOINT_EVALUATION_DEADLINE}
+					justificationDeadline={JUSTIFICATION_DEADLINE}
+					selectedPath={undefined}
+					setSelectedPath={setSelectedPath}
+				/>,
+			),
+		};
+	}
+
+	it("reports the picked path to the parent", async () => {
+		const user = userEvent.setup();
+		const { setSelectedPath } = renderSecondRoundOptions(true);
+
+		await user.click(
+			screen.getByLabelText("Justifier les écarts de rémunération ≥ 5 %"),
+		);
+		expect(setSelectedPath).toHaveBeenCalledWith("justify");
+
+		await user.click(
+			screen.getByLabelText(
+				"Mettre en place une évaluation conjointe des rémunérations",
+			),
+		);
+		expect(setSelectedPath).toHaveBeenCalledWith("joint_evaluation");
+	});
+
+	it("forwards the CSE requirement to the justify option", () => {
+		renderSecondRoundOptions(true);
+
+		expect(screen.getByText(JUSTIFY_CSE_CONSULT)).toBeInTheDocument();
+		expect(screen.getByText(JUSTIFY_CSE_OPINION)).toBeInTheDocument();
+	});
+
+	it("hides the CSE consultation steps when no CSE opinion is required", () => {
+		const { container } = renderSecondRoundOptions(false);
+
+		expect(screen.queryByText(JUSTIFY_CSE_CONSULT)).not.toBeInTheDocument();
+		expect(screen.queryByText(JUSTIFY_CSE_OPINION)).not.toBeInTheDocument();
+		expectNoEmptyList(container);
+	});
+
+	it.each([
+		true,
+		false,
+	])("keeps the joint evaluation option and its steps (cseOpinionRequired: %s)", (cseOpinionRequired) => {
+		renderSecondRoundOptions(cseOpinionRequired);
+
+		expect(
+			screen.getByText(
+				"Mettre en place une évaluation conjointe des rémunérations",
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Analyse conjointe et définition des actions correctrices",
+			),
+		).toBeInTheDocument();
+	});
+});
+
+describe("FirstRoundOptions", () => {
+	function renderFirstRoundOptions(cseOpinionRequired: boolean) {
+		return render(
+			<FirstRoundOptions
+				correctiveActionDeadline={CORRECTIVE_ACTION_DEADLINE}
+				cseOpinionRequired={cseOpinionRequired}
+				jointEvaluationDeadline={JOINT_EVALUATION_DEADLINE}
+				justificationDeadline={JUSTIFICATION_DEADLINE}
+				selectedPath={undefined}
+				setSelectedPath={vi.fn()}
+			/>,
+		);
+	}
+
+	it("lists every CSE consultation step when a CSE opinion is required", () => {
+		renderFirstRoundOptions(true);
+
+		expect(screen.getByText(JUSTIFY_CSE_CONSULT)).toBeInTheDocument();
+		expect(screen.getByText(JUSTIFY_CSE_OPINION)).toBeInTheDocument();
+		expect(screen.getByText(CORRECTIVE_CSE_CONSULT)).toBeInTheDocument();
+		expect(screen.getByText(CORRECTIVE_CSE_OPINION)).toBeInTheDocument();
+	});
+
+	it("hides every CSE consultation step when no CSE opinion is required", () => {
+		const { container } = renderFirstRoundOptions(false);
+
+		expect(screen.queryByText(JUSTIFY_CSE_CONSULT)).not.toBeInTheDocument();
+		expect(screen.queryByText(JUSTIFY_CSE_OPINION)).not.toBeInTheDocument();
+		expect(screen.queryByText(CORRECTIVE_CSE_CONSULT)).not.toBeInTheDocument();
+		expect(screen.queryByText(CORRECTIVE_CSE_OPINION)).not.toBeInTheDocument();
+		expectNoEmptyList(container);
+	});
+
+	it.each([
+		true,
+		false,
+	])("keeps the non-CSE corrective action steps (cseOpinionRequired: %s)", (cseOpinionRequired) => {
+		renderFirstRoundOptions(cseOpinionRequired);
+
+		expect(
+			screen.getByText("Actions correctives et seconde déclaration"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Mettre en place des actions correctives par accord ou par plan d'action",
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Redéclarer l'indicateur dans un délai de 6 mois après votre première déclaration",
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/Si des écarts non justifiés persistent/),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -21,7 +21,7 @@ import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator
 
 type Props = {
 	cseApplicable: boolean;
-	cseOpinionRequired?: boolean;
+	cseOpinionRequired: boolean;
 	declarationYear: number;
 	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
@@ -30,7 +30,7 @@ type Props = {
 
 export function SecondDeclarationStep3Review({
 	cseApplicable,
-	cseOpinionRequired = true,
+	cseOpinionRequired,
 	declarationYear,
 	hasCse,
 	secondDeclarationCategories,

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -21,6 +21,7 @@ import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator
 
 type Props = {
 	cseApplicable: boolean;
+	cseOpinionRequired?: boolean;
 	declarationYear: number;
 	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
@@ -29,6 +30,7 @@ type Props = {
 
 export function SecondDeclarationStep3Review({
 	cseApplicable,
+	cseOpinionRequired = true,
 	declarationYear,
 	hasCse,
 	secondDeclarationCategories,
@@ -148,6 +150,7 @@ export function SecondDeclarationStep3Review({
 
 			<NextStepsBox
 				cseApplicable={cseApplicable}
+				cseOpinionRequired={cseOpinionRequired}
 				hasGapsAboveThreshold={gapsExist}
 				isSecondDeclaration
 				siren={siren}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -4,6 +4,7 @@ import { campaignYearDimension, FunnelStepTracker } from "~/modules/analytics";
 import {
 	formatShortDate,
 	getObligationWorkforce,
+	isCseOpinionRequired,
 	isCseRequired,
 	shouldRedirectSubmittedToRecap,
 } from "~/modules/domain";
@@ -135,6 +136,10 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 				<SecondDeclarationStep3Review
 					cseApplicable={isCseRequired(
 						getObligationWorkforce(company.gipWorkforce),
+					)}
+					cseOpinionRequired={isCseOpinionRequired(
+						getObligationWorkforce(company.gipWorkforce),
+						company.hasCse,
 					)}
 					declarationYear={currentYear}
 					hasCse={company.hasCse}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -463,6 +463,77 @@ describe("SecondDeclarationStep3Review", () => {
 		expect(screen.getByText("Aucune donnée renseignée.")).toBeInTheDocument();
 	});
 
+	describe("CSE consultation section gating (issue #3945)", () => {
+		const highGapCategories: EmployeeCategoryRow[] = [
+			makeCategory({
+				name: "Ouvriers",
+				womenCount: 10,
+				menCount: 15,
+				annualBaseWomen: "1000",
+				annualBaseMen: "2000",
+				annualVariableWomen: "100",
+				annualVariableMen: "200",
+				hourlyBaseWomen: "10",
+				hourlyBaseMen: "20",
+				hourlyVariableWomen: "1",
+				hourlyVariableMen: "2",
+			}),
+		];
+
+		it("hides the CSE consultation section but keeps gap actions and the CSE update button when cseOpinionRequired is false", () => {
+			render(
+				<SecondDeclarationStep3Review
+					cseApplicable
+					cseOpinionRequired={false}
+					declarationYear={2025}
+					hasCse={false}
+					secondDeclarationCategories={highGapCategories}
+					siren="532847196"
+				/>,
+			);
+
+			expect(
+				screen.queryByRole("heading", { name: "Informer et consulter le CSE" }),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/obligatoirement informer et consulter le CSE/),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/avis à transmettre sur le portail/),
+			).not.toBeInTheDocument();
+
+			expect(screen.getByText("Écarts détectés")).toBeInTheDocument();
+			expect(
+				screen.getByRole("heading", { name: "Actions à engager" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", {
+					name: "Mettre à jour l'existence d'un CSE",
+				}),
+			).toBeInTheDocument();
+		});
+
+		it("shows the CSE consultation section when cseOpinionRequired is true", () => {
+			render(
+				<SecondDeclarationStep3Review
+					cseApplicable
+					cseOpinionRequired={true}
+					declarationYear={2025}
+					hasCse={true}
+					secondDeclarationCategories={highGapCategories}
+					siren="532847196"
+				/>,
+			);
+
+			expect(
+				screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/avis à transmettre sur le portail/),
+			).toBeInTheDocument();
+		});
+	});
+
 	it("closes the modal without submitting when Annuler is clicked", async () => {
 		const user = userEvent.setup();
 		render(

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { SecondDeclarationStep3Review } from "../SecondDeclarationStep3Review";
@@ -72,6 +73,61 @@ const mockCategories: EmployeeCategoryRow[] = [
 	}),
 ];
 
+const highGapCategories: EmployeeCategoryRow[] = [
+	makeCategory({
+		name: "Ouvriers",
+		womenCount: 10,
+		menCount: 15,
+		annualBaseWomen: "1000",
+		annualBaseMen: "2000",
+		annualVariableWomen: "100",
+		annualVariableMen: "200",
+		hourlyBaseWomen: "10",
+		hourlyBaseMen: "20",
+		hourlyVariableWomen: "1",
+		hourlyVariableMen: "2",
+	}),
+];
+
+const noGapCategories: EmployeeCategoryRow[] = [
+	makeCategory({
+		annualBaseWomen: "9800",
+		annualBaseMen: "10000",
+	}),
+];
+
+// Defaults mirror `isCseOpinionRequired(workforce, null)` → false: an unknown
+// CSE flag requires no opinion, exactly like an explicit `false`.
+function renderStep3(
+	overrides: Partial<ComponentProps<typeof SecondDeclarationStep3Review>> = {},
+) {
+	return render(
+		<SecondDeclarationStep3Review
+			cseApplicable
+			cseOpinionRequired={false}
+			declarationYear={2025}
+			hasCse={null}
+			secondDeclarationCategories={mockCategories}
+			siren="532847196"
+			{...overrides}
+		/>,
+	);
+}
+
+async function submitDeclaration() {
+	const user = userEvent.setup();
+	await user.click(screen.getByRole("button", { name: /soumettre/i }));
+	const checkbox = screen.getByLabelText(/Je certifie/, {
+		selector: "input",
+	});
+	await user.click(checkbox);
+	const validerButton = screen.getByRole("button", {
+		name: /valider/i,
+		hidden: true,
+	});
+	await user.click(validerButton);
+}
+
 describe("SecondDeclarationStep3Review", () => {
 	beforeEach(() => {
 		mockMutate.mockClear();
@@ -79,15 +135,7 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("renders the title and step indicator", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(
 			screen.getByText(
 				/Parcours de mise en conformité pour l.indicateur par catégorie de salariés/,
@@ -101,45 +149,21 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("renders category gap card with category name", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(
 			screen.getByText("Catégorie d'emplois n°1 : Ingénieurs"),
 		).toBeInTheDocument();
 	});
 
 	it("does not bracket the category title", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(
 			screen.queryByText(/\[Catégorie d.emplois n°1\]/),
 		).not.toBeInTheDocument();
 	});
 
 	it("renders the card title without the base-and-bonus parenthetical", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(
 			screen.getByText("Écart de rémunération par catégories de salariés"),
 		).toBeInTheDocument();
@@ -148,31 +172,8 @@ describe("SecondDeclarationStep3Review", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("always shows the CSE consultation heading for second declaration", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
-		expect(
-			screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
-		).toBeInTheDocument();
-	});
-
 	it("renders gap columns", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(screen.getAllByText("Annuelle brute").length).toBeGreaterThanOrEqual(
 			1,
 		);
@@ -182,28 +183,12 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("renders the next steps section", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(screen.getByText("Prochaines étapes")).toBeInTheDocument();
 	});
 
 	it("renders the CSE update trigger as a secondary button", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		const cseButton = screen.getByRole("button", {
 			name: "Mettre à jour l'existence d'un CSE",
 		});
@@ -212,15 +197,7 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("hides the CSE update trigger when cseApplicable is false", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable={false}
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3({ cseApplicable: false });
 		expect(
 			screen.queryByRole("button", {
 				name: "Mettre à jour l'existence d'un CSE",
@@ -229,30 +206,14 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("renders Soumettre button", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(
 			screen.getByRole("button", { name: /soumettre/i }),
 		).toBeInTheDocument();
 	});
 
 	it("renders modal with certification checkbox", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(
 			screen.getAllByText(/seconde déclaration des écarts de rémunération/)
 				.length,
@@ -263,15 +224,7 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("renders previous link to step 2", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/parcours-conformite/etape/2",
@@ -279,31 +232,7 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("shows gap warning when gaps >= 5% exist", () => {
-		const categoriesWithHighGaps: EmployeeCategoryRow[] = [
-			makeCategory({
-				name: "Ouvriers",
-				womenCount: 10,
-				menCount: 15,
-				annualBaseWomen: "1000",
-				annualBaseMen: "2000",
-				annualVariableWomen: "100",
-				annualVariableMen: "200",
-				hourlyBaseWomen: "10",
-				hourlyBaseMen: "20",
-				hourlyVariableWomen: "1",
-				hourlyVariableMen: "2",
-			}),
-		];
-
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={categoriesWithHighGaps}
-				siren="532847196"
-			/>,
-		);
+		renderStep3({ secondDeclarationCategories: highGapCategories });
 		expect(screen.getByText("Écarts détectés")).toBeInTheDocument();
 		expect(
 			screen.getByRole("heading", { name: "Actions à engager" }),
@@ -327,15 +256,7 @@ describe("SecondDeclarationStep3Review", () => {
 			}),
 		];
 
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={categoriesWithLowGaps}
-				siren="532847196"
-			/>,
-		);
+		renderStep3({ secondDeclarationCategories: categoriesWithLowGaps });
 		expect(screen.queryByText("Écarts détectés")).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole("heading", { name: "Actions à engager" }),
@@ -343,36 +264,15 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("navigates to compliance path when gaps persist after submit", async () => {
-		const user = userEvent.setup();
-		const categoriesWithHighGaps: EmployeeCategoryRow[] = [
-			makeCategory({
-				annualBaseWomen: "1000",
-				annualBaseMen: "2000",
-			}),
-		];
-
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={true}
-				secondDeclarationCategories={categoriesWithHighGaps}
-				siren="532847196"
-			/>,
-		);
-
-		// Click Soumettre to trigger the modal open (modal stays in DOM but hidden in JSDOM)
-		await user.click(screen.getByRole("button", { name: /soumettre/i }));
-		// Interact with modal elements using hidden option (dialog is not open in JSDOM)
-		const checkbox = screen.getByLabelText(/Je certifie/, {
-			selector: "input",
+		renderStep3({
+			cseOpinionRequired: true,
+			hasCse: true,
+			secondDeclarationCategories: [
+				makeCategory({ annualBaseWomen: "1000", annualBaseMen: "2000" }),
+			],
 		});
-		await user.click(checkbox);
-		const validerButton = screen.getByRole("button", {
-			name: /valider/i,
-			hidden: true,
-		});
-		await user.click(validerButton);
+
+		await submitDeclaration();
 
 		expect(mockMutate).toHaveBeenCalledTimes(1);
 		expect(mockPush).toHaveBeenCalledWith(
@@ -381,68 +281,25 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("navigates to avis-cse when no gaps and hasCse is true", async () => {
-		const user = userEvent.setup();
-		const categoriesNoGaps: EmployeeCategoryRow[] = [
-			makeCategory({
-				annualBaseWomen: "9800",
-				annualBaseMen: "10000",
-			}),
-		];
-
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={true}
-				secondDeclarationCategories={categoriesNoGaps}
-				siren="532847196"
-			/>,
-		);
-
-		await user.click(screen.getByRole("button", { name: /soumettre/i }));
-		const checkbox = screen.getByLabelText(/Je certifie/, {
-			selector: "input",
+		renderStep3({
+			cseOpinionRequired: true,
+			hasCse: true,
+			secondDeclarationCategories: noGapCategories,
 		});
-		await user.click(checkbox);
-		const validerButton = screen.getByRole("button", {
-			name: /valider/i,
-			hidden: true,
-		});
-		await user.click(validerButton);
+
+		await submitDeclaration();
 
 		expect(mockMutate).toHaveBeenCalledTimes(1);
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
 	});
 
 	it("navigates to confirmation when no gaps and no CSE", async () => {
-		const user = userEvent.setup();
-		const categoriesNoGaps: EmployeeCategoryRow[] = [
-			makeCategory({
-				annualBaseWomen: "9800",
-				annualBaseMen: "10000",
-			}),
-		];
-
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={false}
-				secondDeclarationCategories={categoriesNoGaps}
-				siren="532847196"
-			/>,
-		);
-
-		await user.click(screen.getByRole("button", { name: /soumettre/i }));
-		const checkbox = screen.getByLabelText(/Je certifie/, {
-			selector: "input",
+		renderStep3({
+			hasCse: false,
+			secondDeclarationCategories: noGapCategories,
 		});
-		await user.click(checkbox);
-		const validerButton = screen.getByRole("button", {
-			name: /valider/i,
-			hidden: true,
-		});
-		await user.click(validerButton);
+
+		await submitDeclaration();
 
 		expect(mockMutate).toHaveBeenCalledTimes(1);
 		expect(mockPush).toHaveBeenCalledWith(
@@ -451,46 +308,17 @@ describe("SecondDeclarationStep3Review", () => {
 	});
 
 	it("renders empty state when no categories", () => {
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={[]}
-				siren="532847196"
-			/>,
-		);
+		renderStep3({ secondDeclarationCategories: [] });
 		expect(screen.getByText("Aucune donnée renseignée.")).toBeInTheDocument();
 	});
 
 	describe("CSE consultation section gating (issue #3945)", () => {
-		const highGapCategories: EmployeeCategoryRow[] = [
-			makeCategory({
-				name: "Ouvriers",
-				womenCount: 10,
-				menCount: 15,
-				annualBaseWomen: "1000",
-				annualBaseMen: "2000",
-				annualVariableWomen: "100",
-				annualVariableMen: "200",
-				hourlyBaseWomen: "10",
-				hourlyBaseMen: "20",
-				hourlyVariableWomen: "1",
-				hourlyVariableMen: "2",
-			}),
-		];
-
 		it("hides the CSE consultation section but keeps gap actions and the CSE update button when cseOpinionRequired is false", () => {
-			render(
-				<SecondDeclarationStep3Review
-					cseApplicable
-					cseOpinionRequired={false}
-					declarationYear={2025}
-					hasCse={false}
-					secondDeclarationCategories={highGapCategories}
-					siren="532847196"
-				/>,
-			);
+			renderStep3({
+				cseOpinionRequired: false,
+				hasCse: false,
+				secondDeclarationCategories: highGapCategories,
+			});
 
 			expect(
 				screen.queryByRole("heading", { name: "Informer et consulter le CSE" }),
@@ -513,17 +341,24 @@ describe("SecondDeclarationStep3Review", () => {
 			).toBeInTheDocument();
 		});
 
+		it("hides the CSE consultation section when the CSE flag is unknown", () => {
+			renderStep3({
+				cseOpinionRequired: false,
+				hasCse: null,
+				secondDeclarationCategories: highGapCategories,
+			});
+
+			expect(
+				screen.queryByRole("heading", { name: "Informer et consulter le CSE" }),
+			).not.toBeInTheDocument();
+		});
+
 		it("shows the CSE consultation section when cseOpinionRequired is true", () => {
-			render(
-				<SecondDeclarationStep3Review
-					cseApplicable
-					cseOpinionRequired={true}
-					declarationYear={2025}
-					hasCse={true}
-					secondDeclarationCategories={highGapCategories}
-					siren="532847196"
-				/>,
-			);
+			renderStep3({
+				cseOpinionRequired: true,
+				hasCse: true,
+				secondDeclarationCategories: highGapCategories,
+			});
 
 			expect(
 				screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
@@ -531,20 +366,17 @@ describe("SecondDeclarationStep3Review", () => {
 			expect(
 				screen.getByText(/avis à transmettre sur le portail/),
 			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", {
+					name: "Mettre à jour l'existence d'un CSE",
+				}),
+			).toBeInTheDocument();
 		});
 	});
 
 	it("closes the modal without submitting when Annuler is clicked", async () => {
 		const user = userEvent.setup();
-		render(
-			<SecondDeclarationStep3Review
-				cseApplicable
-				declarationYear={2025}
-				hasCse={null}
-				secondDeclarationCategories={mockCategories}
-				siren="532847196"
-			/>,
-		);
+		renderStep3();
 
 		await user.click(screen.getByRole("button", { name: /soumettre/i }));
 		const submitDialog = document.getElementById("submit-declaration-modal");


### PR DESCRIPTION
Closes #3945

## Problème

La section « Informer et consulter le CSE » et la mention « avis à transmettre lors de la dernière étape » s'affichaient dans le récapitulatif de fin de funnel (étape 6), la seconde déclaration et le parcours de conformité, **même quand l'entreprise avait déclaré ne pas avoir de CSE**. Résultat : le récap annonçait une obligation de dépôt d'avis CSE contredite par l'écran `/parcours-conformite/confirmation`.

## Solution

Branchement du helper domaine existant `isCseOpinionRequired(workforce, hasCse)` — déjà utilisé par `declaration.ts`, `ComplianceConfirmation` et mon-espace — dans les 4 surfaces manquantes :

- **`NextStepsBox`** : nouvelle prop `cseOpinionRequired: boolean` conditionne la section entière « Informer et consulter le CSE » (heading + paragraphes + lien modèles) et la parenthèse « (avis à transmettre sur le portail) » dans le bullet « Justifier les écarts ». Le bouton « Mettre à jour l'existence d'un CSE » reste gouverné par `cseApplicable` (≥ 100) — c'est la porte de sortie de l'utilisateur ayant mal déclaré son flag.
- **`Step6Review`** : calcul de `isCseOpinionRequired(getObligationWorkforce(companyWorkforce), hasCse)` et passage à `NextStepsBox`.
- **`SecondDeclarationStep3Review` + `SecondDeclarationStepPage`** : idem, prop threadée depuis la couche serveur.
- **`CompliancePathOptions`** : `hasCse` threadé vers `JustifyOption`, `SecondRoundOptions` et `FirstRoundOptions` ; les bullets CSE des options « justify » et « corrective_action » conditionnés par `hasCse === true`.

## Tests

8 nouveaux tests de non-régression (tu-dev, Opus) :
- `Step6Review.test.tsx` : `hasCse` false/null → section CSE masquée + bouton « Mettre à jour » conservé ; `hasCse` true → section CSE présente.
- `SecondDeclarationStep3Review.test.tsx` : `cseOpinionRequired` false → masqué, true → présent.
- `CompliancePathChoice.test.tsx` : `hasCse` true → bullets CSE visibles dans JustifyOption et corrective_action ; false/null → absents.

Revert-verify (RED→GREEN) prouvé par tu-dev.

Suite complète : 3975 passed, 0 regression.