### PR TITLE
feat(layout): #4020 — numéro de version dans le footer

### DIFF
--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -58,6 +58,7 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+            app_version=${{ github.ref_name }}
           push: true
 
   kontinuous:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -59,6 +59,7 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+            app_version=${{ github.ref_name }}
           push: true
 
   kontinuous:

--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC identity for buildkit-operator /route auth
+      pull-requests: read # resolve the PR number for the footer version link
     environment: build-review-auto
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -22,6 +23,20 @@ jobs:
     steps:
       - name: ⏬ Checkout code repository
         uses: actions/checkout@v4
+
+      # The footer exposes a direct link to the PR on review apps. Review builds
+      # trigger on `push` (not `pull_request`), so the PR number is not in the
+      # event context — resolve it from the commit SHA. Empty on the first push
+      # of a branch (PR not opened yet); the footer then falls back to a
+      # branch-scoped PR search link.
+      - name: 🔍 Resolve pull request number
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          N=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+                --jq '.[0].number // empty' 2>/dev/null || true)
+          echo "number=$N" >> "$GITHUB_OUTPUT"
 
       - name: 📌 Extract metadata (tags, labels) for Docker
         id: meta
@@ -68,6 +83,8 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+            app_version=${{ github.ref_name }}
+            pr_number=${{ steps.pr.outputs.number }}
           push: true
 
   kontinuous:

--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -34,8 +34,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          N=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-                --jq '.[0].number // empty' 2>/dev/null || true)
+          # No PR yet is a normal state and must not fail the build, but an API
+          # error must stay visible: without this, a bad token or a rate limit
+          # is indistinguishable from "branch has no PR".
+          if ERR=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+                     --jq '.[0].number // empty' 2>&1 >pr-number.txt); then
+            N=$(cat pr-number.txt)
+          else
+            N=""
+            echo "::warning::Numéro de PR non résolu (${ERR}) — le pied de page pointera vers une recherche par branche."
+          fi
           echo "number=$N" >> "$GITHUB_OUTPUT"
 
       - name: 📌 Extract metadata (tags, labels) for Docker

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC identity for buildkit-operator /route auth
+      pull-requests: read # resolve the PR number for the footer version link
     environment: build-review
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -20,6 +21,18 @@ jobs:
     steps:
       - name: ⏬ Checkout code repository
         uses: actions/checkout@v4
+
+      # Resolve the PR number from the commit SHA (review builds trigger on
+      # `push`, so it is not in the event context). Empty if no PR is open yet;
+      # the footer then falls back to a branch-scoped PR search link.
+      - name: 🔍 Resolve pull request number
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          N=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+                --jq '.[0].number // empty' 2>/dev/null || true)
+          echo "number=$N" >> "$GITHUB_OUTPUT"
 
       - name: 📌 Extract metadata (tags, labels) for Docker
         id: meta
@@ -64,6 +77,8 @@ jobs:
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
             sentry_release=${{ github.ref_name }}
+            app_version=${{ github.ref_name }}
+            pr_number=${{ steps.pr.outputs.number }}
           push: true
 
   kontinuous:

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -30,8 +30,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          N=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-                --jq '.[0].number // empty' 2>/dev/null || true)
+          # No PR yet is a normal state and must not fail the build, but an API
+          # error must stay visible: without this, a bad token or a rate limit
+          # is indistinguishable from "branch has no PR".
+          if ERR=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+                     --jq '.[0].number // empty' 2>&1 >pr-number.txt); then
+            N=$(cat pr-number.txt)
+          else
+            N=""
+            echo "::warning::Numéro de PR non résolu (${ERR}) — le pied de page pointera vers une recherche par branche."
+          fi
           echo "number=$N" >> "$GITHUB_OUTPUT"
 
       - name: 📌 Extract metadata (tags, labels) for Docker

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -10,6 +10,13 @@ EGAPRO_PROCONNECT_ISSUER=""
 EGAPRO_WEEZ_API_URL=""
 SENTRY_AUTH_TOKEN=""
 NEXT_PUBLIC_SENTRY_DSN=""
+# Release identifier shown in the footer (issue #4020): git tag in production,
+# branch name on review apps. Inlined at build time via a BuildKit secret in the
+# Dockerfile — leave unset for local dev (the footer then hides the version).
+NEXT_PUBLIC_APP_VERSION=""
+# Pull-request number for the footer's PR link on review apps. Resolved from the
+# commit SHA in the review workflows; unset everywhere else.
+NEXT_PUBLIC_PR_NUMBER=""
 # Local Matomo (docker compose) — see scripts/matomo-local/README.md.
 # Points at the local stack on :8080, site 1 (provisioned by `matomo-init`).
 NEXT_PUBLIC_MATOMO_URL="http://localhost:8080"

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -61,12 +61,19 @@ RUN pnpm --filter notifications deploy --prod --legacy /deploy/notifications
 
 # Build with Next.js cache persisted across builds
 # Sentry auth token and release are mounted as BuildKit secrets to avoid leaking in image layers
-# and to preserve build cache (ARG would invalidate cache on every new release)
+# and to preserve build cache (ARG would invalidate cache on every new release).
+# app_version (git tag / branch name) and pr_number (review apps) follow the same
+# secret path for the same reason — they are inlined into the client bundle by
+# the footer, and must NOT be passed as ARG or the cache would bust every release.
 RUN --mount=type=cache,id=next-cache,target=/app/packages/app/.next/cache \
     --mount=type=secret,id=sentry_auth_token \
     --mount=type=secret,id=sentry_release \
+    --mount=type=secret,id=app_version \
+    --mount=type=secret,id=pr_number \
     SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token 2>/dev/null) \
     NEXT_PUBLIC_SENTRY_RELEASE=$(cat /run/secrets/sentry_release 2>/dev/null | tr '/' '-') \
+    NEXT_PUBLIC_APP_VERSION=$(cat /run/secrets/app_version 2>/dev/null) \
+    NEXT_PUBLIC_PR_NUMBER=$(cat /run/secrets/pr_number 2>/dev/null) \
     pnpm --filter app build
 
 

--- a/packages/app/src/env.js
+++ b/packages/app/src/env.js
@@ -129,6 +129,12 @@ export const env = createEnv({
 			.default("dev"),
 		NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
 		NEXT_PUBLIC_SENTRY_RELEASE: z.string().optional(),
+		// Release identifier shown in the footer (git tag in prod, branch name on
+		// review apps). Inlined at build time, so optional — absent in local dev.
+		NEXT_PUBLIC_APP_VERSION: z.string().optional(),
+		// Pull-request number resolved at build time on review apps, for the
+		// footer's PR link. Digits only; absent outside review builds.
+		NEXT_PUBLIC_PR_NUMBER: z.string().regex(/^\d+$/).optional(),
 		NEXT_PUBLIC_MATOMO_URL: z.string().url().optional(),
 		NEXT_PUBLIC_MATOMO_SITE_ID: z.string().optional(),
 	},
@@ -174,6 +180,8 @@ export const env = createEnv({
 		NEXT_PUBLIC_EGAPRO_ENV: process.env.NEXT_PUBLIC_EGAPRO_ENV,
 		NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
 		NEXT_PUBLIC_SENTRY_RELEASE: process.env.NEXT_PUBLIC_SENTRY_RELEASE,
+		NEXT_PUBLIC_APP_VERSION: process.env.NEXT_PUBLIC_APP_VERSION,
+		NEXT_PUBLIC_PR_NUMBER: process.env.NEXT_PUBLIC_PR_NUMBER,
 		NEXT_PUBLIC_MATOMO_URL: process.env.NEXT_PUBLIC_MATOMO_URL,
 		NEXT_PUBLIC_MATOMO_SITE_ID: process.env.NEXT_PUBLIC_MATOMO_SITE_ID,
 	},

--- a/packages/app/src/modules/layout/Footer/AppVersion.tsx
+++ b/packages/app/src/modules/layout/Footer/AppVersion.tsx
@@ -1,0 +1,65 @@
+import { env } from "~/env.js";
+
+import { NewTabNotice } from "../shared/NewTabNotice";
+
+/**
+ * GitHub repository the footer links to. Hard-coded (not env-driven) so a
+ * misconfigured variable can never inject an arbitrary `href` — only the PR
+ * number / branch name / tag, all validated shapes, are interpolated.
+ */
+const REPOSITORY_URL = "https://github.com/SocialGouv/egapro";
+
+/**
+ * Footer release indicator (issue #4020): lets a reviewer know which version
+ * of the code a review app is running.
+ *
+ * - In production: the git tag → links to the release.
+ * - On a review app: the branch name → links to the PR when its number is
+ *   resolved at build time, otherwise to a branch-scoped PR search.
+ * - In local dev / CI without the build var: renders nothing.
+ *
+ * The version comes from `NEXT_PUBLIC_APP_VERSION` (inlined at build time);
+ * the PR number from `NEXT_PUBLIC_PR_NUMBER` (review builds only).
+ */
+export function AppVersion() {
+	const version = env.NEXT_PUBLIC_APP_VERSION;
+	const prNumber = env.NEXT_PUBLIC_PR_NUMBER;
+	if (!version) return null;
+
+	const href = buildHref(version, prNumber);
+
+	return (
+		<p className="fr-footer__bottom-copy">
+			{"Version "}
+			<a
+				href={href}
+				rel="noopener noreferrer"
+				target="_blank"
+				title={`Code source pour la version ${version} - nouvelle fenêtre`}
+			>
+				{version}
+				<NewTabNotice />
+			</a>
+		</p>
+	);
+}
+
+function buildHref(version: string, prNumber: string | undefined): string {
+	// A git release tag (production). Direct link to the release page.
+	if (version.startsWith("v")) {
+		return `${REPOSITORY_URL}/releases/tag/${encodeURIComponent(version)}`;
+	}
+	// A long-lived environment branch (beta, master, alpha, dev…): no slash,
+	// not a tag → link to the branch tree. Feature/ticket branches always
+	// carry a slash (`ticket/4020-…`), so they never take this path.
+	if (!version.includes("/")) {
+		return `${REPOSITORY_URL}/tree/${encodeURIComponent(version)}`;
+	}
+	// A review-app feature branch with a resolved PR number → direct link.
+	if (prNumber) {
+		return `${REPOSITORY_URL}/pull/${prNumber}`;
+	}
+	// A review-app feature branch whose PR is not open yet (first push) → a
+	// search scoped to the branch head.
+	return `${REPOSITORY_URL}/pulls?q=${encodeURIComponent(`is:pr head:${version}`)}`;
+}

--- a/packages/app/src/modules/layout/Footer/FooterBottom.tsx
+++ b/packages/app/src/modules/layout/Footer/FooterBottom.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { NewTabNotice } from "../shared/NewTabNotice";
 
+import { AppVersion } from "./AppVersion";
+
 /** Footer bottom bar: legal links, display settings, license. */
 export function FooterBottom() {
 	return (
@@ -57,6 +59,7 @@ export function FooterBottom() {
 						<NewTabNotice />
 					</a>
 				</p>
+				<AppVersion />
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/layout/Footer/__tests__/AppVersion.test.tsx
+++ b/packages/app/src/modules/layout/Footer/__tests__/AppVersion.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 async function withEnv(env: Record<string, string | undefined>) {
 	vi.resetModules();
 	vi.doMock("~/env", () => ({ env }));
-	const mod = await import("../Footer/AppVersion");
+	const mod = await import("../AppVersion");
 	return mod.AppVersion;
 }
 

--- a/packages/app/src/modules/layout/__tests__/AppVersion.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/AppVersion.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `env` is mocked per-test below. Each test redefines the module mock to set
+// the public env vars the component reads.
+async function withEnv(env: Record<string, string | undefined>) {
+	vi.doMock("~/env", () => ({ env }));
+	vi.resetModules();
+	const mod = await import("../Footer/AppVersion");
+	return mod.AppVersion;
+}
+
+afterEach(() => {
+	vi.doUnmock("~/env");
+	vi.resetModules();
+	cleanup();
+});
+
+describe("AppVersion", () => {
+	it("renders nothing when no version is set (local dev)", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: undefined,
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		const { container } = render(<Comp />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("links to the release page for a git tag (production)", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "v3.14.0-alpha.11",
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		render(<Comp />);
+		const link = screen.getByRole("link", {
+			name: /v3\.14\.0-alpha\.11.*nouvelle fenêtre/,
+		});
+		expect(link).toHaveAttribute(
+			"href",
+			"https://github.com/SocialGouv/egapro/releases/tag/v3.14.0-alpha.11",
+		);
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("links to the PR on a review app when the PR number is resolved", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "ticket/4020-version-footer",
+			NEXT_PUBLIC_PR_NUMBER: "4039",
+		});
+		render(<Comp />);
+		expect(
+			screen.getByRole("link", {
+				name: /ticket\/4020-version-footer.*nouvelle fenêtre/,
+			}),
+		).toHaveAttribute("href", "https://github.com/SocialGouv/egapro/pull/4039");
+	});
+
+	it("falls back to a branch-scoped PR search when no PR is open yet", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "ticket/4020-version-footer",
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		render(<Comp />);
+		const link = screen.getByRole("link");
+		const href = link.getAttribute("href");
+		expect(href).toContain("/pulls?q=");
+		expect(href).toContain(
+			encodeURIComponent("is:pr head:ticket/4020-version-footer"),
+		);
+	});
+
+	it("links to the branch tree for a long-lived environment branch (preprod)", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "beta",
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		render(<Comp />);
+		expect(
+			screen.getByRole("link", { name: /beta.*nouvelle fenêtre/ }),
+		).toHaveAttribute("href", "https://github.com/SocialGouv/egapro/tree/beta");
+	});
+});

--- a/packages/app/src/modules/layout/__tests__/AppVersion.test.tsx
+++ b/packages/app/src/modules/layout/__tests__/AppVersion.test.tsx
@@ -4,8 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 // `env` is mocked per-test below. Each test redefines the module mock to set
 // the public env vars the component reads.
 async function withEnv(env: Record<string, string | undefined>) {
-	vi.doMock("~/env", () => ({ env }));
 	vi.resetModules();
+	vi.doMock("~/env", () => ({ env }));
 	const mod = await import("../Footer/AppVersion");
 	return mod.AppVersion;
 }


### PR DESCRIPTION
Closes #4020

## Contexte — #4020

Avoir le numéro de release sur les branches (notamment les branches de tests) pour savoir la version du code sur lequel le recetage tourne. Sur les branches de tests, le lien de la PR.

## Ce que fait la PR

Le footer affiche désormais la version du code, avec un lien adapté à l'environnement :

| Contexte | Libellé | Cible du lien |
|---|---|---|
| Prod | `v3.14.0-alpha.11` | release GitHub |
| Préprod | `beta` | arbre de la branche |
| Review app (PR ouverte) | `ticket/4020-…` | la PR |
| Review app (PR pas encore ouverte) | idem | recherche de PR par branche |
| Dev local | — | rien (variable absente) |

## Choix techniques

- **`package.json` est inutilisable** : sur `alpha`, `.releaserc.cjs` désactive `@semantic-release/npm` et `@semantic-release/git` (branche protégée) → `version` figé à 3.13.2 alors que le dernier tag est `v3.14.0-alpha.11`. On utilise une variable dédiée `NEXT_PUBLIC_APP_VERSION` alimentée par `github.ref_name`.
- **Le footer est un composant client** (rendu via `PublicChrome` `"use client"`) → obligatoirement une variable `NEXT_PUBLIC_*` (inlinée au build).
- **Secret BuildKit, pas `ARG`** : comme `sentry_release`, la version passe par `--mount=type=secret` dans le Dockerfile — un `ARG` invaliderait le cache Next à chaque release.
- **N° de PR résolu dans le workflow** : les workflows de review se déclenchent sur `push` (pas `pull_request`), donc `github.event.pull_request.number` est vide. Étape `gh api …/commits/{sha}/pulls` avant le build, passée en secret `pr_number`. Vide si la PR n'est pas encore ouverte → le footer bascule sur un lien de recherche par branche.
- **URL GitHub codée en dur** : seule la version (tag / nom de branche / n° PR, formes validées par Zod) est interpolée dans l'URL — jamais une URL arbitraire, pour qu'une variable mal configurée ne puisse pas injecter un `href`.

## Fichiers

- `env.js` : `NEXT_PUBLIC_APP_VERSION` + `NEXT_PUBLIC_PR_NUMBER` (client + runtimeEnv)
- `Dockerfile` : deux `--mount=type=secret`
- 4 workflows de build : `app_version=${{ github.ref_name }}` partout ; résolution PR + `pull-requests: read` sur les 2 workflows de review
- `AppVersion.tsx` (nouveau) + montage dans `FooterBottom.tsx`
- `.env.example` documenté

## Tests & validation

- `AppVersion.test.tsx` : 5 cas (rien si absent, tag → release, review+PR → pull, review sans PR → recherche, branche longue durée → tree). Lien externe RGAA (`target="_blank"` + `rel="noopener noreferrer"` + `<NewTabNotice />`).
- Typecheck ✅ · 3828 tests ✅ · lint/format ✅ · 16 YAML workflows valides ✅

## À valider en review app

Le chemin Docker/workflow n'est pleinement validé qu'au premier build de review app — à vérifier sur la review app de cette PR elle-même (le footer doit afficher `ticket/4020-version-footer` avec le lien vers la PR).

---

_Recrée #4042, fermée automatiquement par GitHub à la suite d'un force-push (une PR dont la branche devient identique à sa base est close et ne peut plus être rouverte). Le code est identique ; l'historique de revue reste consultable sur #4042._
