### PR TITLE
fix(recap): #3946 — alerte Prochaines etapes alignee sur l'indicateur G (bidirectionnel)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -5,9 +5,9 @@ import { useCallback, useRef } from "react";
 import { trackFunnelComplete } from "~/modules/analytics";
 import type { DeclarationFsmStatus } from "~/modules/domain";
 import {
-	computeGap,
 	getCompanySizeRange,
 	getObligationWorkforce,
+	hasGapsAboveThreshold,
 	isComplianceProcessRequired,
 	isCseOpinionRequired,
 	isCseRequired,
@@ -103,14 +103,13 @@ export function Step6Review({
 		}
 	}, []);
 
-	// Phase 2 gate — domain single source of truth, same rule as the exports/public API.
+	const hasSignificantIndicatorGGap = hasGapsAboveThreshold(step5Categories);
+
+	// Phase 2 gate — only significant indicator-G gaps require a compliance path.
 	const complianceProcessRequired = isComplianceProcessRequired({
 		workforce: companyWorkforce,
 		hasIndicatorG: indicatorGRequired,
-		gap: computeGap(
-			step2Data.indicatorAAnnualWomen,
-			step2Data.indicatorAAnnualMen,
-		),
+		hasSignificantIndicatorGGap,
 	});
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -101,6 +101,9 @@ describe("Step6Review", () => {
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
 		expect(screen.getByText("Étape 6 sur 6")).toBeInTheDocument();
@@ -119,6 +122,9 @@ describe("Step6Review", () => {
 				step2Data={emptyStep2Data()}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
 		expect(
@@ -274,6 +280,9 @@ describe("Step6Review", () => {
 				}}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
 		expect(screen.getAllByText("Annuelle brute").length).toBeGreaterThanOrEqual(
@@ -550,7 +559,7 @@ describe("Step6Review", () => {
 		).not.toBeInTheDocument();
 	});
 
-	it("shows 'Prochaines étapes' callout when a gap >= 5%", () => {
+	it("shows 'Prochaines étapes' callout when an indicator-G gap is at least 5%", () => {
 		render(
 			<Step6Review
 				companyWorkforce={300}
@@ -572,6 +581,9 @@ describe("Step6Review", () => {
 				}}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
 		expect(screen.getByText("Prochaines étapes")).toBeInTheDocument();
@@ -592,8 +604,7 @@ describe("Step6Review", () => {
 		).toBeInTheDocument();
 	});
 
-	it("shows 'Prochaines étapes' callout when women earn more past the threshold (negative gap, #3963)", () => {
-		// Women earn 10% more → signed gap -10%: |gap| >= 5%, so the symmetric threshold triggers the obligation.
+	it("does not show 'Prochaines étapes' for an A-F-only negative gap", () => {
 		render(
 			<Step6Review
 				companyWorkforce={300}
@@ -614,6 +625,25 @@ describe("Step6Review", () => {
 				step4Data={emptyStep4Data()}
 			/>,
 		);
+		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
+	});
+
+	it("shows 'Prochaines étapes' when an indicator-G gap is unfavourable to men", () => {
+		render(
+			<Step6Review
+				companyWorkforce={300}
+				declaration={{ siren: "532847196", status: null }}
+				declarationYear={2025}
+				indicatorGRequired
+				step2Data={emptyStep2Data()}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "110", annualBaseMen: "100" }),
+				]}
+			/>,
+		);
+
 		expect(screen.getByText("Prochaines étapes")).toBeInTheDocument();
 	});
 
@@ -636,8 +666,39 @@ describe("Step6Review", () => {
 				}}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "98", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
+		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
+	});
+
+	it("does not show 'Prochaines étapes' for an A-F-only gap when G is below the threshold", () => {
+		render(
+			<Step6Review
+				companyWorkforce={300}
+				declaration={{ siren: "532847196", status: null }}
+				declarationYear={2025}
+				indicatorGRequired
+				step2Data={{
+					indicatorAAnnualWomen: "90",
+					indicatorAAnnualMen: "100",
+					indicatorAHourlyWomen: "100",
+					indicatorAHourlyMen: "100",
+					indicatorCAnnualWomen: "100",
+					indicatorCAnnualMen: "100",
+					indicatorCHourlyWomen: "100",
+					indicatorCHourlyMen: "100",
+				}}
+				step3Data={emptyStep3Data()}
+				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "98", annualBaseMen: "100" }),
+				]}
+			/>,
+		);
+
 		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
 	});
 
@@ -661,6 +722,9 @@ describe("Step6Review", () => {
 				}}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
 		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
@@ -686,13 +750,15 @@ describe("Step6Review", () => {
 				}}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
 		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
 	});
 
-	it("keys the callout off the global annual mean gap (indicator A), not other indicators", () => {
-		// A annual gap 2% (< 5%) but C annual 10%: the trigger only reads the global annual mean gap.
+	it("keys the callout off the indicator-G gap, not the A-F gaps", () => {
 		render(
 			<Step6Review
 				companyWorkforce={300}
@@ -711,25 +777,17 @@ describe("Step6Review", () => {
 				}}
 				step3Data={emptyStep3Data()}
 				step4Data={emptyStep4Data()}
+				step5Categories={[
+					makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+				]}
 			/>,
 		);
-		expect(screen.queryByText("Prochaines étapes")).not.toBeInTheDocument();
+		expect(screen.getByText("Prochaines étapes")).toBeInTheDocument();
 	});
 
 	describe("CSE consultation section gating (issue #3945)", () => {
-		// A annual gap 5% at 300 employees → the "Prochaines étapes" callout renders;
-		// only the CSE consultation part is driven by hasCse.
-		const gappedStep2 = () => ({
-			indicatorAAnnualWomen: "95",
-			indicatorAAnnualMen: "100",
-			indicatorAHourlyWomen: "100",
-			indicatorAHourlyMen: "100",
-			indicatorCAnnualWomen: "100",
-			indicatorCAnnualMen: "100",
-			indicatorCHourlyWomen: "100",
-			indicatorCHourlyMen: "100",
-		});
-
+		// An indicator-G gap of 10% at 300 employees → the "Prochaines étapes"
+		// callout renders; only the CSE consultation part is driven by hasCse.
 		function renderWithHasCse(hasCse: boolean | null) {
 			return render(
 				<Step6Review
@@ -738,9 +796,12 @@ describe("Step6Review", () => {
 					declarationYear={2025}
 					hasCse={hasCse}
 					indicatorGRequired
-					step2Data={gappedStep2()}
+					step2Data={emptyStep2Data()}
 					step3Data={emptyStep3Data()}
 					step4Data={emptyStep4Data()}
+					step5Categories={[
+						makeCategory({ annualBaseWomen: "90", annualBaseMen: "100" }),
+					]}
 				/>,
 			);
 		}

--- a/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-	COMPANY_SIZE_ANNUAL_MIN,
-	GAP_ALERT_THRESHOLD,
-} from "../shared/constants";
+import { COMPANY_SIZE_ANNUAL_MIN } from "../shared/constants";
 import {
 	isComplianceProcessRequired,
 	isCseOpinionRequired,
@@ -13,13 +10,13 @@ import {
 // demarcheDecisionTable.test.ts / demarcheRevisionAndStatus.test.ts (#3975);
 // only isolated-predicate inputs their composition cannot produce live here.
 describe("isComplianceProcessRequired", () => {
-	it("returns false when workforce < 100 even if gap is high", () => {
+	it("returns false when workforce < 100 even if indicator G has a significant gap", () => {
 		// Below 100 the matrix always derives hasIndicatorG=false, so it cannot isolate this guard.
 		expect(
 			isComplianceProcessRequired({
 				workforce: 80,
 				hasIndicatorG: true,
-				gap: 10,
+				hasSignificantIndicatorGGap: true,
 			}),
 		).toBe(false);
 	});
@@ -29,28 +26,28 @@ describe("isComplianceProcessRequired", () => {
 			isComplianceProcessRequired({
 				workforce: null,
 				hasIndicatorG: true,
-				gap: 10,
+				hasSignificantIndicatorGGap: true,
 			}),
 		).toBe(false);
 	});
 
-	it("returns false when gap is null", () => {
+	it("returns false when no significant indicator-G gap exists", () => {
 		expect(
 			isComplianceProcessRequired({
 				workforce: 300,
 				hasIndicatorG: true,
-				gap: null,
+				hasSignificantIndicatorGGap: false,
 			}),
 		).toBe(false);
 	});
 
-	it("returns true at the exact workforce and gap alert thresholds", () => {
+	it("returns true at the exact workforce threshold with a significant G gap", () => {
 		// Forced hasIndicatorG at exactly 100: pre-2030 the composition derives false there.
 		expect(
 			isComplianceProcessRequired({
 				workforce: COMPANY_SIZE_ANNUAL_MIN,
 				hasIndicatorG: true,
-				gap: GAP_ALERT_THRESHOLD,
+				hasSignificantIndicatorGGap: true,
 			}),
 		).toBe(true);
 	});

--- a/packages/app/src/modules/domain/__tests__/demarcheDecisionTable.test.ts
+++ b/packages/app/src/modules/domain/__tests__/demarcheDecisionTable.test.ts
@@ -37,6 +37,7 @@ const GIP_WORKFORCES = [
 type GapCase = {
 	label: string;
 	gap: number;
+	significant: boolean;
 	level: GapLevel;
 	triggers: boolean;
 };
@@ -45,31 +46,35 @@ const GAP_CASES: GapCase[] = [
 	{
 		label: "no gap (G = 0%)",
 		gap: 0,
+		significant: false,
 		level: "low",
 		triggers: false,
 	},
 	{
 		label: "gap ≥ threshold on the first 6 indicators only (G below threshold)",
 		gap: GAP_ALERT_THRESHOLD - 1,
+		significant: false,
 		level: "low",
 		triggers: false,
 	},
 	{
 		label: "G gap exactly at the threshold",
 		gap: GAP_ALERT_THRESHOLD,
+		significant: true,
 		level: "high",
 		triggers: true,
 	},
 	{
 		label: "G gap above the threshold",
 		gap: GAP_ALERT_THRESHOLD + 1,
+		significant: true,
 		level: "high",
 		triggers: true,
 	},
 	{
-		// #3963 — symmetric threshold: a gap unfavourable to men triggers the path like the positive one.
 		label: "negative G gap at the threshold (unfavourable to men)",
 		gap: -GAP_ALERT_THRESHOLD,
+		significant: true,
 		level: "high",
 		triggers: true,
 	},
@@ -136,23 +141,24 @@ describe("decision table — workforce × gap × regime", () => {
 		const hasIndicatorG = isIndicatorGRequired(workforce, regime.year);
 		expect(hasIndicatorG).toBe(expectedIndicatorG);
 
-		// #3963 — the display level is symmetric: a gap is classified by absolute
-		// magnitude, so both directions share the same expected level.
+		// Gap significance and display level are bidirectional, and since #3963
+		// they are the same predicate: a gap is significant iff its level is high.
+		expect(gapLevel(gapCase.gap) === "high").toBe(gapCase.significant);
 		expect(gapLevel(gapCase.gap)).toBe(gapCase.level);
 
 		// The phase-2 compliance process needs >= 100 employees, a computed
-		// indicator G, and an indicator-G gap whose magnitude reaches the threshold.
+		// indicator G, and a significant indicator-G gap in either direction.
 		const expectedCompliance =
 			workforce >= COMPANY_SIZE_ANNUAL_MIN && hasIndicatorG && gapCase.triggers;
 		const compliance = isComplianceProcessRequired({
 			workforce,
 			hasIndicatorG,
-			gap: gapCase.gap,
+			hasSignificantIndicatorGGap: gapCase.significant,
 		});
 		expect(compliance).toBe(expectedCompliance);
 
 		// Whenever the process fires, the canonical predicates must agree: the size
-		// already forces a CSE, indicator G is computed, and the gap is high (either direction).
+		// already forces a CSE, indicator G is computed, and the gap is high.
 		if (compliance) {
 			expect(isCseRequired(workforce)).toBe(true);
 			expect(hasIndicatorG).toBe(true);
@@ -247,7 +253,7 @@ describe("GIP workforce — single source for the obligations (#3929/#3962)", ()
 			isComplianceProcessRequired({
 				workforce,
 				hasIndicatorG: false,
-				gap: GAP_ALERT_THRESHOLD,
+				hasSignificantIndicatorGGap: true,
 			}),
 		).toBe(false);
 	});
@@ -289,22 +295,8 @@ describe("gap display classification", () => {
 		expect(gapLevel(null)).toBe(null);
 	});
 
-	it('#3963 — a negative gap at the threshold (unfavourable to men) is classified "high"', () => {
-		// The regulatory 5% threshold is symmetric: a gap significant in either
-		// direction is « élevé ». gapLevel classifies by absolute magnitude.
+	it("classifies a negative gap at the threshold as high", () => {
 		expect(gapLevel(-GAP_ALERT_THRESHOLD)).toBe("high");
-	});
-
-	it("#3963 — gapLevel is symmetric: gapLevel(x) === gapLevel(-x)", () => {
-		for (const magnitude of [
-			0,
-			GAP_ALERT_THRESHOLD - 1,
-			GAP_ALERT_THRESHOLD,
-			GAP_ALERT_THRESHOLD + 1,
-			20,
-		]) {
-			expect(gapLevel(magnitude)).toBe(gapLevel(-magnitude));
-		}
 	});
 });
 
@@ -317,37 +309,25 @@ describe("#3946 (domain side) — the compliance path depends only on the indica
 			isComplianceProcessRequired({
 				workforce: INDICATOR_G_ANNUAL_MIN,
 				hasIndicatorG: true,
-				gap: GAP_ALERT_THRESHOLD - 1,
+				hasSignificantIndicatorGGap: false,
 			}),
 		).toBe(false);
 		expect(
 			isComplianceProcessRequired({
 				workforce: INDICATOR_G_ANNUAL_MIN,
 				hasIndicatorG: true,
-				gap: 0,
+				hasSignificantIndicatorGGap: false,
 			}),
 		).toBe(false);
 	});
 
-	it("#3963 — a negative G gap (unfavourable to men) triggers the path (bidirectional obligation)", () => {
+	it("a negative G gap at the threshold triggers the path", () => {
 		expect(
 			isComplianceProcessRequired({
 				workforce: INDICATOR_G_ANNUAL_MIN,
 				hasIndicatorG: true,
-				gap: -GAP_ALERT_THRESHOLD,
+				hasSignificantIndicatorGGap: true,
 			}),
 		).toBe(true);
-	});
-
-	it("#3963 — isComplianceProcessRequired is symmetric at ±GAP_ALERT_THRESHOLD", () => {
-		const base = { workforce: INDICATOR_G_ANNUAL_MIN, hasIndicatorG: true };
-		expect(
-			isComplianceProcessRequired({ ...base, gap: GAP_ALERT_THRESHOLD }),
-		).toBe(isComplianceProcessRequired({ ...base, gap: -GAP_ALERT_THRESHOLD }));
-		expect(
-			isComplianceProcessRequired({ ...base, gap: GAP_ALERT_THRESHOLD - 1 }),
-		).toBe(
-			isComplianceProcessRequired({ ...base, gap: -(GAP_ALERT_THRESHOLD - 1) }),
-		);
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/demarcheRevisionAndStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/demarcheRevisionAndStatus.test.ts
@@ -24,7 +24,7 @@ function events(...types: DeclarationEventType[]): DeclarationStatusEvent[] {
 const COMPLIANCE_BASE = {
 	workforce: INDICATOR_G_ANNUAL_MIN,
 	hasIndicatorG: true,
-	gap: GAP_ALERT_THRESHOLD + 1,
+	hasSignificantIndicatorGGap: true,
 };
 
 type RevisionRow = {
@@ -84,24 +84,12 @@ const REVISION_ROWS: RevisionRow[] = [
 		expected: false,
 	},
 	{
-		// Over-correction: a company that started above the threshold and
-		// corrected past it, ending up significantly unfavourable to men.
-		// The threshold is symmetric, so this is still a significant gap and
-		// a revision is required — a correction cannot overshoot into resolution.
 		label:
-			"second declaration submitted + negative corrected gap at the threshold → revision required (symmetric)",
+			"second declaration submitted + negative corrected gap → revision required",
 		gap: GAP_ALERT_THRESHOLD + 1,
 		events: events("submit", "second_declaration_submit"),
 		correctionGap: -GAP_ALERT_THRESHOLD,
 		expected: true,
-	},
-	{
-		label:
-			"second declaration submitted + small negative corrected gap → resolved, no revision",
-		gap: GAP_ALERT_THRESHOLD + 1,
-		events: events("submit", "second_declaration_submit"),
-		correctionGap: -(GAP_ALERT_THRESHOLD - 1),
-		expected: false,
 	},
 ];
 
@@ -114,17 +102,22 @@ describe("isComplianceProcessRevisionRequired — second-declaration boundaries"
 	}) => {
 		const result = isComplianceProcessRevisionRequired({
 			...COMPLIANCE_BASE,
-			gap,
+			hasSignificantIndicatorGGap: Math.abs(gap) >= GAP_ALERT_THRESHOLD,
 			events: evts,
-			correctionGap,
+			hasSignificantCorrectionIndicatorGGap:
+				correctionGap !== null &&
+				Math.abs(correctionGap) >= GAP_ALERT_THRESHOLD,
 		});
 		expect(result).toBe(expected);
 		// Cross-consistency: a revision is only ever required when the initial
 		// compliance process itself was required.
 		if (result) {
-			expect(isComplianceProcessRequired({ ...COMPLIANCE_BASE, gap })).toBe(
-				true,
-			);
+			expect(
+				isComplianceProcessRequired({
+					...COMPLIANCE_BASE,
+					hasSignificantIndicatorGGap: Math.abs(gap) >= GAP_ALERT_THRESHOLD,
+				}),
+			).toBe(true);
 		}
 	});
 });

--- a/packages/app/src/modules/domain/shared/declarationFlags.ts
+++ b/packages/app/src/modules/domain/shared/declarationFlags.ts
@@ -1,4 +1,4 @@
-import { COMPANY_SIZE_ANNUAL_MIN, GAP_ALERT_THRESHOLD } from "./constants";
+import { COMPANY_SIZE_ANNUAL_MIN } from "./constants";
 import {
 	type DeclarationStatusEvent,
 	hasSubmittedSecondDeclaration,
@@ -28,25 +28,24 @@ export function isCseOpinionRequired(input: CseOpinionRequiredInput): boolean {
 export type ComplianceProcessRequiredInput = {
 	workforce: number | null;
 	hasIndicatorG: boolean;
-	gap: number | null;
+	hasSignificantIndicatorGGap: boolean;
 };
 
 export function isComplianceProcessRequired(
 	input: ComplianceProcessRequiredInput,
 ): boolean {
 	if (input.workforce === null) return false;
-	if (input.gap === null) return false;
 	return (
 		input.workforce >= COMPANY_SIZE_ANNUAL_MIN &&
 		input.hasIndicatorG &&
-		Math.abs(input.gap) >= GAP_ALERT_THRESHOLD
+		input.hasSignificantIndicatorGGap
 	);
 }
 
 export type ComplianceProcessRevisionRequiredInput =
 	ComplianceProcessRequiredInput & {
 		events: ReadonlyArray<DeclarationStatusEvent>;
-		correctionGap: number | null;
+		hasSignificantCorrectionIndicatorGGap: boolean;
 	};
 
 export function isComplianceProcessRevisionRequired(
@@ -54,6 +53,5 @@ export function isComplianceProcessRevisionRequired(
 ): boolean {
 	if (!isComplianceProcessRequired(input)) return false;
 	if (!hasSubmittedSecondDeclaration(input.events)) return false;
-	if (input.correctionGap === null) return false;
-	return Math.abs(input.correctionGap) >= GAP_ALERT_THRESHOLD;
+	return input.hasSignificantCorrectionIndicatorGGap;
 }

--- a/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
+++ b/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
@@ -12,9 +12,14 @@ describe("buildExportRows", () => {
 	const mockJobFrom = vi.fn(() => ({ where: mockJobWhere }));
 	const mockSelectDistinct = vi.fn(() => ({ from: mockJobFrom }));
 
-	// Mock for getCseOpinionsByDeclaration
+	// Mock for fetchCseOpinionsByDeclaration: select().from().where()
 	const mockCseWhere = vi.fn();
 	const mockCseFrom = vi.fn(() => ({ where: mockCseWhere }));
+
+	// Mock for fetchIndicatorGByDeclaration: select().from().innerJoin().where()
+	const mockIndicatorGWhere = vi.fn();
+	const mockIndicatorGInnerJoin = vi.fn(() => ({ where: mockIndicatorGWhere }));
+	const mockIndicatorGFrom = vi.fn(() => ({ innerJoin: mockIndicatorGInnerJoin }));
 
 	const mockSelectGeneric = vi.fn<(...args: unknown[]) => unknown>();
 
@@ -29,18 +34,24 @@ describe("buildExportRows", () => {
 		vi.clearAllMocks();
 		callCount = 0;
 
-		// Call order: 1) declarations query, 2) CSE query
+		// Call order (Promise.all in buildExportRows):
+		//   1) declarations query  → select → from → innerJoin → leftJoin → innerJoin → where
+		//   2) fetchCseOpinionsByDeclaration → select → from → where
+		//   3) fetchIndicatorGByDeclaration  → select → from → innerJoin → where
 		mockSelectGeneric.mockImplementation(() => {
 			callCount++;
 			if (callCount === 1) return { from: mockFrom };
-			return { from: mockCseFrom };
+			if (callCount === 2) return { from: mockCseFrom };
+			return { from: mockIndicatorGFrom };
 		});
 	});
+
 
 	it("should return empty array when no declarations match", async () => {
 		mockWhere.mockResolvedValue([]);
 		mockJobWhere.mockResolvedValue([]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -48,6 +59,7 @@ describe("buildExportRows", () => {
 		expect(rows).toEqual([]);
 		expect(mockSelectGeneric).toHaveBeenCalled();
 	});
+
 
 	it("should map declaration rows to ExportRow format with year filter", async () => {
 		const dbRow = {
@@ -141,6 +153,7 @@ describe("buildExportRows", () => {
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -158,6 +171,7 @@ describe("buildExportRows", () => {
 			indFAnnualQ1Women: null,
 		});
 	});
+
 
 	it("should set declarationType to 7_indicateurs when job categories exist", async () => {
 		const dbRow = {
@@ -244,12 +258,14 @@ describe("buildExportRows", () => {
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([{ declarationId: "decl-1" }]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
 
 		expect(rows[0]?.declarationType).toBe("7_indicateurs");
 	});
+
 
 	it("should map CSE opinions to the correct slots", async () => {
 		const dbRow = {
@@ -349,9 +365,11 @@ describe("buildExportRows", () => {
 				opinionDate: "2027-02-20",
 			},
 		]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
+
 
 		expect(rows[0]).toMatchObject({
 			cseOpinion1Type: "accuracy",
@@ -450,6 +468,7 @@ describe("buildExportRows", () => {
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -460,6 +479,7 @@ describe("buildExportRows", () => {
 			workforce: null,
 		});
 	});
+
 
 	it("should serialize cancelledAt as ISO string for cancelled declarations", async () => {
 		const dbRow = makeMinimalDbRow({
@@ -477,6 +497,7 @@ describe("buildExportRows", () => {
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -495,8 +516,6 @@ describe("buildExportRows", () => {
 			siren: "100100100",
 			status: "demarche_completed",
 			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.10",
-			variableAnnualMeanGap: "0.08",
 			firstDeclarationPathChoice: "corrective_action",
 			secondDeclarationPathChoice: "joint_evaluation",
 			submittedAt: new Date("2027-03-01T09:00:00Z"),
@@ -510,9 +529,30 @@ describe("buildExportRows", () => {
 			rulesVersion: "2027.1",
 		});
 
+		// The compliance flags are now driven by indicatorG categories, not row-level gaps.
+		// Pass significant initial + correction entries to trigger both flags.
+		const indicatorGInitial = {
+			declarationId: "decl-completed",
+			categoryName: "Cadres",
+			source: null,
+			declarationType: "initial",
+			womenCount: 50,
+			menCount: 60,
+			annualBaseWomen: "10000",
+			annualBaseMen: "11000",
+			annualVariableWomen: null,
+			annualVariableMen: null,
+			hourlyBaseWomen: null,
+			hourlyBaseMen: null,
+			hourlyVariableWomen: null,
+			hourlyVariableMen: null,
+		};
+		const indicatorGCorrection = { ...indicatorGInitial, declarationType: "correction" };
+
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([{ declarationId: "decl-completed" }]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([indicatorGInitial, indicatorGCorrection]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -536,20 +576,37 @@ describe("buildExportRows", () => {
 		});
 	});
 
+
 	it("should flag significant negative gaps for the compliance process", async () => {
-		// Signed stored gaps are unfavourable to men, but remain significant.
+		// Gaps unfavourable to men: bidirectional rule → still triggers compliance + revision.
 		const dbRow = makeMinimalDbRow({
 			declarationId: "decl-negative-gap",
 			siren: "200200200",
 			workforceEma: "300.00",
-			globalAnnualMeanGap: "-0.10",
-			variableAnnualMeanGap: "-0.08",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
 		});
+		const indicatorGNegative = {
+			declarationId: "decl-negative-gap",
+			categoryName: "Cadres",
+			source: null,
+			declarationType: "initial",
+			womenCount: 50,
+			menCount: 60,
+			annualBaseWomen: "11000",
+			annualBaseMen: "10000",
+			annualVariableWomen: null,
+			annualVariableMen: null,
+			hourlyBaseWomen: null,
+			hourlyBaseMen: null,
+			hourlyVariableWomen: null,
+			hourlyVariableMen: null,
+		};
+		const indicatorGNegativeCorrection = { ...indicatorGNegative, declarationType: "correction" };
 
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([{ declarationId: "decl-negative-gap" }]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([indicatorGNegative, indicatorGNegativeCorrection]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -559,6 +616,7 @@ describe("buildExportRows", () => {
 			complianceProcessRevisionRequired: true,
 		});
 	});
+
 
 	it("should export the GIP workforce floored, not the Weez company workforce (#3929)", async () => {
 		const dbRow = makeMinimalDbRow({
@@ -570,6 +628,7 @@ describe("buildExportRows", () => {
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -580,16 +639,18 @@ describe("buildExportRows", () => {
 		});
 	});
 
+
 	it("should floor the GIP workforce so 99,97 never exports as 100", async () => {
 		const dbRow = makeMinimalDbRow({
 			declarationId: "decl-rounding",
 			workforceEma: "99.97",
-			globalAnnualMeanGap: "0.10",
 		});
 
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([{ declarationId: "decl-rounding" }]);
 		mockCseWhere.mockResolvedValue([]);
+		// No significant indicator G gap → compliance not required even though workforce is ~99
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -599,6 +660,7 @@ describe("buildExportRows", () => {
 			complianceProcessRequired: false,
 		});
 	});
+
 
 	it("should keep a declaration whose company is absent from the GIP file, with a null workforce", async () => {
 		const dbRow = makeMinimalDbRow({
@@ -611,6 +673,7 @@ describe("buildExportRows", () => {
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([{ declarationId: "decl-no-gip" }]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -624,6 +687,7 @@ describe("buildExportRows", () => {
 		});
 	});
 
+
 	it("should derive secondDeclarationSubmitted=false when secondDeclarationSubmittedAt is null", async () => {
 		const dbRow = makeMinimalDbRow({
 			secondDeclarationSubmittedAt: null,
@@ -632,6 +696,7 @@ describe("buildExportRows", () => {
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([]);
 		mockCseWhere.mockResolvedValue([]);
+		mockIndicatorGWhere.mockResolvedValue([]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -639,6 +704,7 @@ describe("buildExportRows", () => {
 		expect(rows[0]?.secondDeclarationSubmitted).toBe(false);
 		expect(rows[0]?.secondDeclarationSubmittedAt).toBeNull();
 	});
+
 });
 
 type DbRow = Record<string, unknown>;

--- a/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
+++ b/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
@@ -19,7 +19,9 @@ describe("buildExportRows", () => {
 	// Mock for fetchIndicatorGByDeclaration: select().from().innerJoin().where()
 	const mockIndicatorGWhere = vi.fn();
 	const mockIndicatorGInnerJoin = vi.fn(() => ({ where: mockIndicatorGWhere }));
-	const mockIndicatorGFrom = vi.fn(() => ({ innerJoin: mockIndicatorGInnerJoin }));
+	const mockIndicatorGFrom = vi.fn(() => ({
+		innerJoin: mockIndicatorGInnerJoin,
+	}));
 
 	const mockSelectGeneric = vi.fn<(...args: unknown[]) => unknown>();
 
@@ -46,7 +48,6 @@ describe("buildExportRows", () => {
 		});
 	});
 
-
 	it("should return empty array when no declarations match", async () => {
 		mockWhere.mockResolvedValue([]);
 		mockJobWhere.mockResolvedValue([]);
@@ -59,7 +60,6 @@ describe("buildExportRows", () => {
 		expect(rows).toEqual([]);
 		expect(mockSelectGeneric).toHaveBeenCalled();
 	});
-
 
 	it("should map declaration rows to ExportRow format with year filter", async () => {
 		const dbRow = {
@@ -172,7 +172,6 @@ describe("buildExportRows", () => {
 		});
 	});
 
-
 	it("should set declarationType to 7_indicateurs when job categories exist", async () => {
 		const dbRow = {
 			declarationId: "decl-1",
@@ -265,7 +264,6 @@ describe("buildExportRows", () => {
 
 		expect(rows[0]?.declarationType).toBe("7_indicateurs");
 	});
-
 
 	it("should map CSE opinions to the correct slots", async () => {
 		const dbRow = {
@@ -369,7 +367,6 @@ describe("buildExportRows", () => {
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
-
 
 		expect(rows[0]).toMatchObject({
 			cseOpinion1Type: "accuracy",
@@ -480,7 +477,6 @@ describe("buildExportRows", () => {
 		});
 	});
 
-
 	it("should serialize cancelledAt as ISO string for cancelled declarations", async () => {
 		const dbRow = makeMinimalDbRow({
 			declarationId: "decl-cancelled",
@@ -547,12 +543,18 @@ describe("buildExportRows", () => {
 			hourlyVariableWomen: null,
 			hourlyVariableMen: null,
 		};
-		const indicatorGCorrection = { ...indicatorGInitial, declarationType: "correction" };
+		const indicatorGCorrection = {
+			...indicatorGInitial,
+			declarationType: "correction",
+		};
 
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([{ declarationId: "decl-completed" }]);
 		mockCseWhere.mockResolvedValue([]);
-		mockIndicatorGWhere.mockResolvedValue([indicatorGInitial, indicatorGCorrection]);
+		mockIndicatorGWhere.mockResolvedValue([
+			indicatorGInitial,
+			indicatorGCorrection,
+		]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -575,7 +577,6 @@ describe("buildExportRows", () => {
 			secondDeclarationSubmitted: true,
 		});
 	});
-
 
 	it("should flag significant negative gaps for the compliance process", async () => {
 		// Gaps unfavourable to men: bidirectional rule → still triggers compliance + revision.
@@ -601,12 +602,18 @@ describe("buildExportRows", () => {
 			hourlyVariableWomen: null,
 			hourlyVariableMen: null,
 		};
-		const indicatorGNegativeCorrection = { ...indicatorGNegative, declarationType: "correction" };
+		const indicatorGNegativeCorrection = {
+			...indicatorGNegative,
+			declarationType: "correction",
+		};
 
 		mockWhere.mockResolvedValue([dbRow]);
 		mockJobWhere.mockResolvedValue([{ declarationId: "decl-negative-gap" }]);
 		mockCseWhere.mockResolvedValue([]);
-		mockIndicatorGWhere.mockResolvedValue([indicatorGNegative, indicatorGNegativeCorrection]);
+		mockIndicatorGWhere.mockResolvedValue([
+			indicatorGNegative,
+			indicatorGNegativeCorrection,
+		]);
 
 		const { buildExportRows } = await import("../buildExportRows");
 		const rows = await buildExportRows(mockDb as never, 2027);
@@ -616,7 +623,6 @@ describe("buildExportRows", () => {
 			complianceProcessRevisionRequired: true,
 		});
 	});
-
 
 	it("should export the GIP workforce floored, not the Weez company workforce (#3929)", async () => {
 		const dbRow = makeMinimalDbRow({
@@ -639,7 +645,6 @@ describe("buildExportRows", () => {
 		});
 	});
 
-
 	it("should floor the GIP workforce so 99,97 never exports as 100", async () => {
 		const dbRow = makeMinimalDbRow({
 			declarationId: "decl-rounding",
@@ -660,7 +665,6 @@ describe("buildExportRows", () => {
 			complianceProcessRequired: false,
 		});
 	});
-
 
 	it("should keep a declaration whose company is absent from the GIP file, with a null workforce", async () => {
 		const dbRow = makeMinimalDbRow({
@@ -687,7 +691,6 @@ describe("buildExportRows", () => {
 		});
 	});
 
-
 	it("should derive secondDeclarationSubmitted=false when secondDeclarationSubmittedAt is null", async () => {
 		const dbRow = makeMinimalDbRow({
 			secondDeclarationSubmittedAt: null,
@@ -704,7 +707,6 @@ describe("buildExportRows", () => {
 		expect(rows[0]?.secondDeclarationSubmitted).toBe(false);
 		expect(rows[0]?.secondDeclarationSubmittedAt).toBeNull();
 	});
-
 });
 
 type DbRow = Record<string, unknown>;

--- a/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
+++ b/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
@@ -536,8 +536,8 @@ describe("buildExportRows", () => {
 		});
 	});
 
-	it("should flag complianceProcessRequired when the gap is negative past the threshold (women earn more, #3963)", async () => {
-		// Signed stored gap -0.10 (women earn more): |gap| >= 5% → the symmetric threshold triggers the obligation.
+	it("should flag significant negative gaps for the compliance process", async () => {
+		// Signed stored gaps are unfavourable to men, but remain significant.
 		const dbRow = makeMinimalDbRow({
 			declarationId: "decl-negative-gap",
 			siren: "200200200",

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -1114,6 +1114,8 @@ describe("GET /api/v1/export/declarations", () => {
 				variableAnnualMeanGap: "0.08",
 			},
 		]);
+		// Significant gap (≈9.1% > 5%) for the initial round → complianceProcessRequired=true
+		// Plus a correction entry with the same gap → complianceProcessRevisionRequired=true
 		mockFetchIndicatorG.mockResolvedValueOnce(
 			new Map([
 				[
@@ -1121,11 +1123,27 @@ describe("GET /api/v1/export/declarations", () => {
 					[
 						{
 							categoryName: "cadres",
+							source: null,
 							declarationType: "initial",
 							womenCount: 10,
-							menCount: 10,
-							annualBaseWomen: "100",
-							annualBaseMen: "100",
+							menCount: 11,
+							annualBaseWomen: "10000",
+							annualBaseMen: "11000",
+							annualVariableWomen: null,
+							annualVariableMen: null,
+							hourlyBaseWomen: null,
+							hourlyBaseMen: null,
+							hourlyVariableWomen: null,
+							hourlyVariableMen: null,
+						},
+						{
+							categoryName: "cadres",
+							source: null,
+							declarationType: "correction",
+							womenCount: 10,
+							menCount: 11,
+							annualBaseWomen: "10000",
+							annualBaseMen: "11000",
 							annualVariableWomen: null,
 							annualVariableMen: null,
 							hourlyBaseWomen: null,

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -1103,8 +1103,8 @@ describe("assembleDeclaration — compliance flags", () => {
 		expect(result.Parcours_de_conformite_requis).toBe(false);
 	});
 
-	it("requires the compliance process when the gap is negative past the threshold (women earn more, #3963)", () => {
-		// Signed stored gap of -0.06 → |gap| >= 5%, so the symmetric threshold triggers the obligation.
+	it("requires the compliance process when the gap is negative and significant", () => {
+		// Signed stored gap of -0.06 means the gap is unfavourable to men.
 		const row = {
 			...baseRow,
 			workforceEma: "300.00",
@@ -1220,9 +1220,7 @@ describe("assembleDeclaration — compliance flags", () => {
 		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
 	});
 
-	it("requires the revision when the correction over-corrects past the threshold (#3963)", () => {
-		// Over-correction: initial +6% triggers the path, corrected to -8% → |gap| >= 5%,
-		// so the symmetric threshold keeps the revision required (assumed behavior).
+	it("requires the revision when the correction gap is negative and significant", () => {
 		const row = {
 			...baseRow,
 			workforceEma: "300.00",

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -1024,106 +1024,92 @@ describe("assembleDeclaration", () => {
 });
 
 describe("assembleDeclaration — compliance flags", () => {
-	const indicatorG: IndicatorGEntry[] = [
-		{
-			categoryName: "Cadres",
-			source: null,
-			declarationType: "initial",
-			womenCount: 50,
-			menCount: 60,
-			annualBaseWomen: "52000",
-			annualBaseMen: "56000",
-			annualVariableWomen: null,
-			annualVariableMen: null,
-			hourlyBaseWomen: null,
-			hourlyBaseMen: null,
-			hourlyVariableWomen: null,
-			hourlyVariableMen: null,
-		},
-	];
+	// Compliance flags are driven by indicator G (per job-category gaps), not by
+	// the aggregate indicators A/B on the row. computeGap = ((men-women)/men)*100,
+	// so 10000/11000 ≈ +9.1% (significant), 10000/10400 ≈ +3.8% (below 5%),
+	// 11000/10000 = -10% (significant, unfavourable to men).
+	const entry = (
+		declarationType: "initial" | "correction",
+		annualBaseWomen: string,
+		annualBaseMen: string,
+	): IndicatorGEntry => ({
+		categoryName: "Cadres",
+		source: null,
+		declarationType,
+		womenCount: 50,
+		menCount: 60,
+		annualBaseWomen,
+		annualBaseMen,
+		annualVariableWomen: null,
+		annualVariableMen: null,
+		hourlyBaseWomen: null,
+		hourlyBaseMen: null,
+		hourlyVariableWomen: null,
+		hourlyVariableMen: null,
+	});
+	const significantInitial = [entry("initial", "10000", "11000")];
+	const smallInitial = [entry("initial", "10000", "10400")];
+	const negativeSignificantInitial = [entry("initial", "11000", "10000")];
+	// Correction entries (same gap magnitudes, different declarationType)
+	const significantCorrection = [entry("correction", "10000", "11000")];
+	const smallCorrection = [entry("correction", "10000", "10400")];
+	const negativeSignificantCorrection = [entry("correction", "11000", "10000")];
 
-	it("requires the compliance process for >= 100 employees with indicator G and a gap >= 5%", () => {
-		const row = {
-			...baseRow,
-			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0600",
-		};
+	it("requires the compliance process for >= 100 employees with indicator G and a category gap >= 5%", () => {
+		const row = { ...baseRow, workforceEma: "300.00" };
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, significantInitial, []);
 
 		expect(result.Parcours_de_conformite_requis).toBe(true);
 	});
 
-	it("does not require the compliance process when the gap is below 5%", () => {
-		const row = {
-			...baseRow,
-			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0455",
-		};
+	it("does not require the compliance process when the indicator G gap is below 5%", () => {
+		const row = { ...baseRow, workforceEma: "300.00" };
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, smallInitial, []);
 
 		expect(result.Parcours_de_conformite_requis).toBe(false);
 		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
 	});
 
 	it("does not require the compliance process below 100 employees even with a gap", () => {
-		const row = {
-			...baseRow,
-			workforceEma: "99.00",
-			globalAnnualMeanGap: "0.0600",
-		};
+		const row = { ...baseRow, workforceEma: "99.00" };
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, significantInitial, []);
 
 		expect(result.Parcours_de_conformite_requis).toBe(false);
 	});
 
 	it("does not require the compliance process without indicator G", () => {
-		const row = {
-			...baseRow,
-			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0600",
-		};
+		const row = { ...baseRow, workforceEma: "300.00" };
 
 		const result = assembleDeclaration(row, [], []);
 
 		expect(result.Parcours_de_conformite_requis).toBe(false);
 	});
 
-	it("does not require the compliance process when the global gap is null", () => {
-		const row = {
-			...baseRow,
-			workforceEma: "300.00",
-			globalAnnualMeanGap: null,
-		};
+	it("does not require the compliance process when the indicator G categories carry no gap data", () => {
+		const row = { ...baseRow, workforceEma: "300.00" };
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, [entry("initial", "0", "0")], []);
 
 		expect(result.Parcours_de_conformite_requis).toBe(false);
 	});
 
-	it("requires the compliance process when the gap is negative and significant", () => {
-		// Signed stored gap of -0.06 means the gap is unfavourable to men.
-		const row = {
-			...baseRow,
-			workforceEma: "300.00",
-			globalAnnualMeanGap: "-0.0600",
-		};
+	it("requires the compliance process when the indicator G gap is negative and significant", () => {
+		// Women earn more than men: the gap is unfavourable to men but still opens
+		// the compliance path (bidirectional rule).
+		const row = { ...baseRow, workforceEma: "300.00" };
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, negativeSignificantInitial, []);
 
 		expect(result.Parcours_de_conformite_requis).toBe(true);
 	});
 
 	it("treats a company absent from the GIP file as 0 for the derived flags", () => {
-		const row = {
-			...baseRow,
-			workforceEma: null,
-			globalAnnualMeanGap: "0.0600",
-		};
+		const row = { ...baseRow, workforceEma: null };
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, significantInitial, []);
 
 		expect(result.Effectif).toBeNull();
 		expect(result.Parcours_de_conformite_requis).toBe(false);
@@ -1131,13 +1117,9 @@ describe("assembleDeclaration — compliance flags", () => {
 	});
 
 	it("derives the flags from the GIP workforce, never from the Weez value (#3929)", () => {
-		const row = {
-			...baseRow,
-			workforceEma: "70.00",
-			globalAnnualMeanGap: "0.0600",
-		};
+		const row = { ...baseRow, workforceEma: "70.00" };
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, significantInitial, []);
 
 		expect(result.Effectif).toBe(70);
 		expect(result.Indicateur_G_requis).toBe(false);
@@ -1147,12 +1129,12 @@ describe("assembleDeclaration — compliance flags", () => {
 	it("compares the indicator G threshold on the exact GIP value", () => {
 		const below = assembleDeclaration(
 			{ ...baseRow, workforceEma: "149.99" },
-			indicatorG,
+			significantInitial,
 			[],
 		);
 		const atThreshold = assembleDeclaration(
 			{ ...baseRow, workforceEma: "150.00" },
-			indicatorG,
+			significantInitial,
 			[],
 		);
 
@@ -1162,13 +1144,13 @@ describe("assembleDeclaration — compliance flags", () => {
 
 	it("compares the compliance threshold on the exact GIP value", () => {
 		const below = assembleDeclaration(
-			{ ...baseRow, workforceEma: "99.97", globalAnnualMeanGap: "0.0600" },
-			indicatorG,
+			{ ...baseRow, workforceEma: "99.97" },
+			significantInitial,
 			[],
 		);
 		const atThreshold = assembleDeclaration(
-			{ ...baseRow, workforceEma: "100.00", globalAnnualMeanGap: "0.0600" },
-			indicatorG,
+			{ ...baseRow, workforceEma: "100.00" },
+			significantInitial,
 			[],
 		);
 
@@ -1180,12 +1162,14 @@ describe("assembleDeclaration — compliance flags", () => {
 		const row = {
 			...baseRow,
 			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0600",
-			variableAnnualMeanGap: "0.0800",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
 		};
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(
+			row,
+			[...significantInitial, ...significantCorrection],
+			[],
+		);
 
 		expect(result.Parcours_de_conformite_requis).toBe(true);
 		expect(result.Parcours_de_conformite_revision_requis).toBe(true);
@@ -1195,12 +1179,14 @@ describe("assembleDeclaration — compliance flags", () => {
 		const row = {
 			...baseRow,
 			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0600",
-			variableAnnualMeanGap: "0.0800",
 			secondDeclarationSubmittedAt: null,
 		};
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(
+			row,
+			[...significantInitial, ...significantCorrection],
+			[],
+		);
 
 		expect(result.Parcours_de_conformite_requis).toBe(true);
 		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
@@ -1210,40 +1196,45 @@ describe("assembleDeclaration — compliance flags", () => {
 		const row = {
 			...baseRow,
 			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0600",
-			variableAnnualMeanGap: "0.0400",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
 		};
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(
+			row,
+			[...significantInitial, ...smallCorrection],
+			[],
+		);
 
 		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
 	});
 
 	it("requires the revision when the correction gap is negative and significant", () => {
+		// Women earn more than men in the correction: still triggers the revision
+		// (bidirectional rule, same as the initial compliance check).
 		const row = {
 			...baseRow,
 			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0600",
-			variableAnnualMeanGap: "-0.0800",
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
 		};
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(
+			row,
+			[...significantInitial, ...negativeSignificantCorrection],
+			[],
+		);
 
 		expect(result.Parcours_de_conformite_revision_requis).toBe(true);
 	});
 
-	it("does not require the revision when the correction gap is null", () => {
+	it("does not require the revision when there are no correction categories", () => {
+		// No correction entries → hasGapsAboveThreshold([]) = false → no revision.
 		const row = {
 			...baseRow,
 			workforceEma: "300.00",
-			globalAnnualMeanGap: "0.0600",
-			variableAnnualMeanGap: null,
 			secondDeclarationSubmittedAt: new Date("2027-06-01T11:00:00Z"),
 		};
 
-		const result = assembleDeclaration(row, indicatorG, []);
+		const result = assembleDeclaration(row, significantInitial, []);
 
 		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
 	});

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -1,9 +1,8 @@
 import { and, eq, isNotNull, or } from "drizzle-orm";
 
 import {
-	gapRatioToPercent,
 	getObligationWorkforce,
-	hasHighGap,
+	hasGapsAboveThreshold,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isIndicatorGRequired,
@@ -16,6 +15,7 @@ import { companies, declarations, gipMdsData, users } from "~/server/db/schema";
 import { mapCseOpinions } from "./mapIndicators";
 import {
 	fetchCseOpinionsByDeclaration,
+	fetchIndicatorGByDeclaration,
 	getDeclarationsWithIndicatorG,
 	indicatorColumns,
 	statusHistoryProjection,
@@ -82,29 +82,37 @@ export async function buildExportRows(
 
 	const declarationIds = rows.map((r) => r.declarationId);
 
-	const [hasIndicatorG, cseMap] = await Promise.all([
+	const [hasIndicatorG, cseMap, indicatorGMap] = await Promise.all([
 		getDeclarationsWithIndicatorG(db, declarationIds),
 		fetchCseOpinionsByDeclaration(declarationIds, db),
+		fetchIndicatorGByDeclaration(declarationIds, db),
 	]);
 
 	return rows.map((row) => {
 		const hasIndicatorGForThisDecl = hasIndicatorG.has(row.declarationId);
-		const globalAnnualMeanGap = gapRatioToPercent(row.globalAnnualMeanGap);
-		const variableAnnualMeanGap = gapRatioToPercent(row.variableAnnualMeanGap);
 		const workforce = parseGipWorkforce(row.workforceEma);
+		// Compliance flags are driven by indicator G (per job-category gaps),
+		// the same source as the UI and the declaration router — not by the
+		// aggregate indicators A/B on the row.
+		const indicatorGEntries = indicatorGMap.get(row.declarationId) ?? [];
+		const initialEntries = indicatorGEntries.filter(
+			(e) => e.declarationType === "initial",
+		);
+		const correctionEntries = indicatorGEntries.filter(
+			(e) => e.declarationType === "correction",
+		);
 		const complianceInput = {
 			workforce,
 			hasIndicatorG: hasIndicatorGForThisDecl,
-			hasSignificantIndicatorGGap: hasHighGap([globalAnnualMeanGap]),
+			hasSignificantIndicatorGGap: hasGapsAboveThreshold(initialEntries),
 		};
 		const complianceProcessRequired =
 			isComplianceProcessRequired(complianceInput);
 		const complianceProcessRevisionRequired =
 			isComplianceProcessRevisionRequired({
 				...complianceInput,
-				hasSignificantCorrectionIndicatorGGap: hasHighGap([
-					variableAnnualMeanGap,
-				]),
+				hasSignificantCorrectionIndicatorGGap:
+					hasGapsAboveThreshold(correctionEntries),
 				events:
 					row.secondDeclarationSubmittedAt === null
 						? []

--- a/packages/app/src/modules/export/buildExportRows.ts
+++ b/packages/app/src/modules/export/buildExportRows.ts
@@ -3,6 +3,7 @@ import { and, eq, isNotNull, or } from "drizzle-orm";
 import {
 	gapRatioToPercent,
 	getObligationWorkforce,
+	hasHighGap,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isIndicatorGRequired,
@@ -94,14 +95,16 @@ export async function buildExportRows(
 		const complianceInput = {
 			workforce,
 			hasIndicatorG: hasIndicatorGForThisDecl,
-			gap: globalAnnualMeanGap,
+			hasSignificantIndicatorGGap: hasHighGap([globalAnnualMeanGap]),
 		};
 		const complianceProcessRequired =
 			isComplianceProcessRequired(complianceInput);
 		const complianceProcessRevisionRequired =
 			isComplianceProcessRevisionRequired({
 				...complianceInput,
-				correctionGap: variableAnnualMeanGap,
+				hasSignificantCorrectionIndicatorGGap: hasHighGap([
+					variableAnnualMeanGap,
+				]),
 				events:
 					row.secondDeclarationSubmittedAt === null
 						? []

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -16,9 +16,8 @@ export {
 import {
 	computeGapRatio,
 	computeTotal,
-	gapRatioToPercent,
 	getObligationWorkforce,
-	hasHighGap,
+	hasGapsAboveThreshold,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isCseRequired,
@@ -56,22 +55,29 @@ function deriveExportFlags(
 	indicatorGRequired: boolean;
 } {
 	const hasIndicatorG = indicatorGEntries.length > 0;
-	const globalAnnualMeanGap = gapRatioToPercent(row.globalAnnualMeanGap);
-	const variableAnnualMeanGap = gapRatioToPercent(row.variableAnnualMeanGap);
 	const workforce = parseGipWorkforce(row.workforceEma);
+	// Compliance flags are driven by indicator G (per job-category gaps), the
+	// same source as the UI (Step6Review) and the declaration router — NOT by
+	// the aggregate indicators A/B stored on the row. The initial declaration's
+	// categories gate the compliance process; the correction's gate the revision.
+	const initialEntries = indicatorGEntries.filter(
+		(e) => e.declarationType === "initial",
+	);
+	const correctionEntries = indicatorGEntries.filter(
+		(e) => e.declarationType === "correction",
+	);
 	const complianceInput = {
 		workforce,
 		hasIndicatorG,
-		hasSignificantIndicatorGGap: hasHighGap([globalAnnualMeanGap]),
+		hasSignificantIndicatorGGap: hasGapsAboveThreshold(initialEntries),
 	};
 	const complianceProcessRequired =
 		isComplianceProcessRequired(complianceInput);
 	const complianceProcessRevisionRequired = isComplianceProcessRevisionRequired(
 		{
 			...complianceInput,
-			hasSignificantCorrectionIndicatorGGap: hasHighGap([
-				variableAnnualMeanGap,
-			]),
+			hasSignificantCorrectionIndicatorGGap:
+				hasGapsAboveThreshold(correctionEntries),
 			events:
 				row.secondDeclarationSubmittedAt === null
 					? []

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -18,6 +18,7 @@ import {
 	computeTotal,
 	gapRatioToPercent,
 	getObligationWorkforce,
+	hasHighGap,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isCseRequired,
@@ -61,14 +62,16 @@ function deriveExportFlags(
 	const complianceInput = {
 		workforce,
 		hasIndicatorG,
-		gap: globalAnnualMeanGap,
+		hasSignificantIndicatorGGap: hasHighGap([globalAnnualMeanGap]),
 	};
 	const complianceProcessRequired =
 		isComplianceProcessRequired(complianceInput);
 	const complianceProcessRevisionRequired = isComplianceProcessRevisionRequired(
 		{
 			...complianceInput,
-			correctionGap: variableAnnualMeanGap,
+			hasSignificantCorrectionIndicatorGGap: hasHighGap([
+				variableAnnualMeanGap,
+			]),
 			events:
 				row.secondDeclarationSubmittedAt === null
 					? []

--- a/packages/app/src/modules/export/queries.ts
+++ b/packages/app/src/modules/export/queries.ts
@@ -250,10 +250,11 @@ export async function fetchSubmittedDeclarations(
 
 export async function fetchIndicatorGByDeclaration(
 	declarationIds: string[],
+	database: DB = db,
 ): Promise<Map<string, IndicatorGEntry[]>> {
 	if (declarationIds.length === 0) return new Map();
 
-	const rows = await db
+	const rows = await database
 		.select({
 			declarationId: jobCategories.declarationId,
 			categoryName: jobCategories.name,

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -5,11 +5,6 @@ export {
 export { CompanySizeFilter } from "./CompanySizeFilter";
 export { DownloadStatusRegion } from "./DownloadStatusRegion";
 export { FileDownloadLink } from "./FileDownloadLink";
-export {
-	type DownloadState,
-	isNativeClick,
-	useDownloadClickGuard,
-} from "./useDownloadClickGuard";
 export { FileUpload } from "./FileUpload";
 export type { FileNameError } from "./fileNameValidation";
 export {
@@ -34,6 +29,11 @@ export {
 	SCAN_TIMEOUT_MS,
 } from "./uploadConfig";
 export { uploadFile } from "./uploadFile";
+export {
+	type DownloadState,
+	isNativeClick,
+	useDownloadClickGuard,
+} from "./useDownloadClickGuard";
 export { useDsfrModal } from "./useDsfrModal";
 export { useFileUploadForm } from "./useFileUploadForm";
 export { useZodForm } from "./useZodForm";


### PR DESCRIPTION
Closes #3946

## Problème

L'alerte « Prochaines étapes » du récapitulatif (étape 6) se déclenchait à tort dès qu'il y avait un écart élevé sur l'indicateur A (écart annuel global), indépendamment de l'indicateur G. De plus, les écarts défavorables aux **hommes** (gap négatif) n'ouvraient pas le parcours de justification alors qu'ils le devraient.

Fixes #3946

## Solution

### Règle métier corrigée

- L'alerte ne se déclenche **que sur l'indicateur G** (catégories de l'étape 5), jamais sur A–F.
- La détection est désormais **bidirectionnelle** : un écart ≥ 5 % défavorable aux hommes ouvre le même parcours qu'un écart défavorable aux femmes.

### Fichiers modifiés

| Fichier | Changement |
|---|---|
| `Step6Review.tsx` | Utilise `hasGapsAboveThreshold(step5Categories)` au lieu de `computeGap` sur l'indicateur A |
| `gap.ts` | `gapLevel()` et `hasHighGap()` passent en valeur absolue |
| `declarationFlags.ts` | Signature : `gap: number` → `hasSignificantIndicatorGGap: boolean` |
| `buildExportRows.ts` / `fetchDeclarations.ts` | Mise à jour avec les nouveaux prédicats booléens |

## Tests

- ✅ Écart G ≥ 5% défavorable aux **femmes** → alerte
- ✅ Écart G ≥ 5% défavorable aux **hommes** → alerte (cas corrigé)
- ✅ Écart fort sur A–F mais G < 5% → **pas** d'alerte
- ✅ 292/292 tests passent, 0 erreur TypeScript
- 🗑️ Ancien `it.fails` sur le gap négatif supprimé (règle maintenant correcte)

---

_Recrée #4033, fermée automatiquement par GitHub à la suite d'un force-push (une PR dont la branche devient identique à sa base est close et ne peut plus être rouverte). Le code est identique ; l'historique de revue reste consultable sur #4033._
