### PR TITLE
fix(ci): la promotion d'un env de test audite et étiquette la bonne version

### DIFF
--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -25,6 +25,10 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      # Fallback only: this derives the subdomain from the deployment ref, which
+      # is wrong for a deployment whose environment is not named after its ref
+      # (a promoted test env is deployed from `alpha`). Kept for the deployments
+      # that declare no environment URL.
       - name: Load SocialGouv variables
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
@@ -33,7 +37,7 @@ jobs:
         continue-on-error: true
         id: lighthouse
         env:
-          LIGHTHOUSE_URL: https://${{ steps.env.outputs.subdomain }}.ovh.fabrique.social.gouv.fr
+          LIGHTHOUSE_URL: ${{ github.event.deployment_status.environment_url || format('https://{0}.ovh.fabrique.social.gouv.fr', steps.env.outputs.subdomain) }}
       - name: Show Lighthouse scores
         if: always()
         working-directory: packages/app

--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -55,10 +55,10 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_MATOMO_URL=${{ vars.NEXT_PUBLIC_MATOMO_URL }}
             NEXT_PUBLIC_MATOMO_SITE_ID=${{ vars.NEXT_PUBLIC_MATOMO_SITE_ID_DEV }}
+            APP_VERSION=${{ github.ref_name }}
+            SENTRY_RELEASE=${{ github.ref_name }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
-            sentry_release=${{ github.ref_name }}
-            app_version=${{ github.ref_name }}
           push: true
 
   kontinuous:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -56,10 +56,10 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_MATOMO_URL=${{ vars.NEXT_PUBLIC_MATOMO_URL }}
             NEXT_PUBLIC_MATOMO_SITE_ID=${{ vars.NEXT_PUBLIC_MATOMO_SITE_ID_PROD }}
+            APP_VERSION=${{ github.ref_name }}
+            SENTRY_RELEASE=${{ github.ref_name }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
-            sentry_release=${{ github.ref_name }}
-            app_version=${{ github.ref_name }}
           push: true
 
   kontinuous:

--- a/.github/workflows/promote-test-env.yaml
+++ b/.github/workflows/promote-test-env.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: "Release tag to deploy (e.g. v3.4.0-alpha.2)"
+        description: "Release tag to deploy (e.g. v3.14.0-alpha.12)"
         required: true
         type: string
       target:
@@ -57,7 +57,9 @@ jobs:
               ;;
           esac
           if ! git rev-parse --verify --quiet "refs/tags/$TAG^{commit}" > /dev/null; then
-            echo "::error::Tag '$TAG' does not exist on this repository"
+            # Listing the latest tags turns the most common failure — a typo in
+            # the version series — into a one-glance fix.
+            echo "::error::Tag '$TAG' does not exist on this repository. Latest tags: $(git tag --sort=-creatordate | head -5 | tr '\n' ' ')"
             exit 1
           fi
           if ! IS_DRAFT=$(gh release view "$TAG" --json isDraft --jq '.isDraft' 2>/dev/null); then
@@ -115,17 +117,25 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_MATOMO_URL=${{ vars.NEXT_PUBLIC_MATOMO_URL }}
             NEXT_PUBLIC_MATOMO_SITE_ID=${{ vars.NEXT_PUBLIC_MATOMO_SITE_ID_DEV }}
+            APP_VERSION=${{ inputs.release }}
+            SENTRY_RELEASE=${{ inputs.release }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
-            sentry_release=${{ inputs.release }}
-            app_version=${{ inputs.release }}
           push: true
 
   deploy:
     name: "🐳 Deploy ${{ inputs.release }} → ${{ inputs.target }}-persist"
     needs: build-app
     runs-on: ubuntu-latest
-    environment: review-auto
+    # `name` carries the deploy secrets (KUBECONFIG, KS_*). `url` is what makes
+    # the promotion auditable: the workflow runs on `alpha`, so the deployment
+    # record GitHub writes is `review-auto @ alpha` and any downstream job that
+    # recomputes an URL from that ref targets the alpha env. Declaring the URL
+    # here propagates it as `deployment_status.environment_url`, which the
+    # Lighthouse workflow prefers over its own computation.
+    environment:
+      name: review-auto
+      url: https://egapro-${{ inputs.target }}-persist.ovh.fabrique.social.gouv.fr
     permissions:
       contents: read
     steps:

--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -57,9 +57,7 @@ jobs:
               github.ref_name == 'develop' ||
               github.ref_name == 'preprod' ||
               github.ref_name == 'main' ||
-              github.ref_name == 'master' ||
-              github.ref_name == 'rgaa-persist' ||
-              github.ref_name == 'perf-persist'
+              github.ref_name == 'master'
             }},priority=840
             type=sha,prefix=sha-,format=long,priority=890
             type=ref,event=branch,priority=600
@@ -88,11 +86,11 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_MATOMO_URL=${{ vars.NEXT_PUBLIC_MATOMO_URL }}
             NEXT_PUBLIC_MATOMO_SITE_ID=${{ vars.NEXT_PUBLIC_MATOMO_SITE_ID_DEV }}
+            APP_VERSION=${{ github.ref_name }}
+            SENTRY_RELEASE=${{ github.ref_name }}
+            PR_NUMBER=${{ steps.pr.outputs.number }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
-            sentry_release=${{ github.ref_name }}
-            app_version=${{ github.ref_name }}
-            pr_number=${{ steps.pr.outputs.number }}
           push: true
 
   kontinuous:

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -82,11 +82,11 @@ jobs:
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
             NEXT_PUBLIC_MATOMO_URL=${{ vars.NEXT_PUBLIC_MATOMO_URL }}
             NEXT_PUBLIC_MATOMO_SITE_ID=${{ vars.NEXT_PUBLIC_MATOMO_SITE_ID_DEV }}
+            APP_VERSION=${{ github.ref_name }}
+            SENTRY_RELEASE=${{ github.ref_name }}
+            PR_NUMBER=${{ steps.pr.outputs.number }}
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
-            sentry_release=${{ github.ref_name }}
-            app_version=${{ github.ref_name }}
-            pr_number=${{ steps.pr.outputs.number }}
           push: true
 
   kontinuous:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,8 +251,20 @@ GitHub Actions workflows are in `.github/workflows/` :
 | File | Trigger | Role |
 |---|---|---|
 | `ci.yaml` | each push | build · lint · format · typecheck · tests |
+| `a11y.yaml` | push `alpha`/`beta`/`master`, PR, cron hebdo, manual | gate RGAA 4.1.2 / WCAG 2.2 AA statique (ultra11y) |
+| `e2e.yaml` | PR → `alpha`, manual | suite Playwright complète |
+| `lighthouse.yaml` | `deployment_status` (success, hors env `build-*`) | audit Lighthouse sur l'URL déployée |
+| `review-auto.yaml` | push sur toute branche sauf `dependabot/**` et `master` | **déploiement des review apps** |
+| `review.yaml` | push `dependabot/**` | review app des branches Dependabot |
+| `deactivate.yaml` | PR closed, `delete` de branche | destruction de la review app |
+| `preproduction.yaml` | push `beta` | preprod deployment |
+| `production.yaml` | push tag `v*` | prod deployment |
+| `promote-test-env.yaml` | manual (inputs `release`, `target`) | déploie une release publiée sur un env de test persistant (`rgaa` / `perf`) |
 | `release.yml` | manual (branch `beta`) | semantic-release |
 | `release-alpha.yaml` | manual (branch `alpha`) | semantic-release — prerelease `-alpha.N` (remplace l'ancien auto `push: alpha`) |
-| `review.yaml` | PR | review app deployment |
-| `preproduction.yaml` | push `beta` | preprod deployment |
-| `production.yaml` | push `master` | prod deployment |
+| `release-alpha-reminder.yaml` | cron lun–ven, manual | alerte sur les commits livrables non releasés |
+| `release-changelog.yaml` | `release: published`, manual | changelog IA FR injecté dans le corps de la release |
+| `db-schema.yaml` | push `alpha`/`master` sur le schéma, manual | publie la doc de schéma DB sur le wiki |
+| `sync-docs-to-wiki.yaml` | push `alpha`/`master` sur `docs/**`, manual | miroir `docs/` → wiki |
+| `ticket-end-date.yaml` | PR closed | estampille « End date » sur le board |
+| `claude-question.yml` | issue labellisée `question` | réponse automatique |

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,7 +34,11 @@ Le workflow est **découplé** : un échec du changelog ne bloque jamais la rele
 
 ## Env de test
 
-`promote-test-env.yaml` (manuel) déploie une release **existante** sur un env de test persistant (`rgaa-persist` / `perf-persist`). Il ne crée pas de release.
+`promote-test-env.yaml` (manuel) déploie une release **existante** sur un env de test persistant. Il ne crée pas de release.
+
+Le workflow prend un tag (`release`) et une cible (`target` : `rgaa` ou `perf`), vérifie que le tag correspond bien à une release GitHub publiée, construit l'image `app:<tag>` **depuis le tag**, puis la déploie avec `deploy-via-github`. `KS_GIT_BRANCH=<target>-persist` pilote le nommage kontinuous — namespace `egapro-<target>-persist`, labels `kontinuous/ref` et exemption janitor (convention `*-persist`) — et `inlineSet: global.imageTag` force les pods sur le tag promu plutôt que sur le `persist-<sha>` calculé par défaut.
+
+**Aucune branche git n'intervient** : `rgaa` et `perf` ne sont que des refs de nommage pour les préreleases. Le job `deploy` déclare l'URL de l'environnement, ce qui la propage dans `deployment_status.environment_url` — sans quoi l'audit Lighthouse, déclenché sur cet événement, ciblerait l'env de la branche du workflow (`alpha`) au lieu de l'env promu.
 
 ## Canal beta / master
 

--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -59,21 +59,23 @@ RUN pnpm --filter notifications build
 # don't use injected workspace packages).
 RUN pnpm --filter notifications deploy --prod --legacy /deploy/notifications
 
-# Build with Next.js cache persisted across builds
-# Sentry auth token and release are mounted as BuildKit secrets to avoid leaking in image layers
-# and to preserve build cache (ARG would invalidate cache on every new release).
-# app_version (git tag / branch name) and pr_number (review apps) follow the same
-# secret path for the same reason — they are inlined into the client bundle by
-# the footer, and must NOT be passed as ARG or the cache would bust every release.
+# Build with Next.js cache persisted across builds.
+# The Sentry auth token stays a BuildKit secret: it is a credential and must never
+# land in an image layer. The three public values below are ARGs on purpose — they
+# are inlined into the client bundle by the footer, and a secret is NOT part of the
+# layer cache key. As a secret, promoting a release would reuse the bundle Review
+# Auto already built for the same commit and ship the branch name instead of the
+# tag. Declaring them here, right before the build, keeps the dependency layers
+# shared: this layer is already invalidated by the source tree itself.
+ARG APP_VERSION
+ARG PR_NUMBER
+ARG SENTRY_RELEASE
 RUN --mount=type=cache,id=next-cache,target=/app/packages/app/.next/cache \
     --mount=type=secret,id=sentry_auth_token \
-    --mount=type=secret,id=sentry_release \
-    --mount=type=secret,id=app_version \
-    --mount=type=secret,id=pr_number \
     SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token 2>/dev/null) \
-    NEXT_PUBLIC_SENTRY_RELEASE=$(cat /run/secrets/sentry_release 2>/dev/null | tr '/' '-') \
-    NEXT_PUBLIC_APP_VERSION=$(cat /run/secrets/app_version 2>/dev/null) \
-    NEXT_PUBLIC_PR_NUMBER=$(cat /run/secrets/pr_number 2>/dev/null) \
+    NEXT_PUBLIC_SENTRY_RELEASE=$(echo "$SENTRY_RELEASE" | tr '/' '-') \
+    NEXT_PUBLIC_APP_VERSION=$APP_VERSION \
+    NEXT_PUBLIC_PR_NUMBER=$PR_NUMBER \
     pnpm --filter app build
 
 


### PR DESCRIPTION
## Contexte

La refonte de `promote-test-env.yaml` (build de l'image depuis le tag + deploy kontinuous direct, au lieu du force-push sur `<target>-persist`) fonctionne : le dernier run a bien déployé `app:v3.14.0-alpha.12` dans le namespace de l'env RGAA, 8/8 ressources ready, `/api/healthz` OK.

Mais elle a introduit une régression silencieuse et laissé un piège armé.

## 1. Lighthouse auditait le mauvais environnement (régression)

`KS_GIT_BRANCH` n'override que le nommage kontinuous, pas le contexte GitHub. Le workflow tournant sur `alpha` (`workflow_dispatch`), l'enregistrement de déploiement écrit par GitHub est `review-auto @ alpha`. `lighthouse.yaml`, déclenché sur ce `deployment_status`, recalculait son URL depuis ce ref.

Constaté sur le run déclenché par la promotion de `v3.14.0-alpha.12` :

```
LIGHTHOUSE_URL: https://egapro-alpha.ovh.fabrique.social.gouv.fr
```

Sous l'ancien modèle le deploy tournait avec `GITHUB_REF` sur la branche persist, et Lighthouse visait le bon env — le dernier audit correct date du 29/07 09:16. **L'environnement dédié aux audits RGAA n'était donc plus audité du tout**, sans que rien ne le signale.

**Correctif** — le job `deploy` déclare l'URL de son environnement, ce que GitHub propage dans `deployment_status.environment_url` ; `lighthouse.yaml` la préfère à son propre calcul, avec repli sur le comportement actuel pour les déploiements qui n'en déclarent pas (review apps, preprod, prod : inchangés).

## 2. L'étiquette de version allait se figer sur le nom de branche

`app_version`, `pr_number` et `sentry_release` étaient montés en **secrets BuildKit**, précisément pour ne pas invalider le cache — or un secret ne fait **pas** partie de la clé de cache de la couche. Un tag de release pointe toujours sur un commit que Review Auto a déjà buildé avec `app_version=alpha` : la prochaine promotion aurait été un `CACHED` hit et l'image aurait embarqué `alpha` au lieu du tag.

> Le footer vide sur l'env RGAA aujourd'hui n'est **pas** ce bug : `v3.14.0-alpha.12` (28/07) est antérieure à la fonctionnalité de footer (#4047, 29/07).

**Correctif** — les trois valeurs, qui sont publiques, passent en `ARG` déclarés juste avant le build. Le token Sentry reste un secret (c'est un credential). Coût cache quasi nul : les `ARG` sont déclarés tardivement, donc les couches de dépendances restent partagées et seule la couche de build est concernée — or elle est de toute façon invalidée par le source tree.

Vérifié localement :

```
$ docker build --build-arg APP_VERSION=v9.9.9-test --target builder ...
$ docker run --rm egapro-argtest sh -c 'grep -rl "v9.9.9-test" .next/static'
/app/packages/app/.next/static/chunks/0.t8i54d6z56i.js
/app/packages/app/.next/static/chunks/0cu_m8_c~8p2z.js
```

## 3. Ménage

- L'exemple du champ `release` citait `v3.4.0-alpha.2`, une série de tags qui n'existe pas dans ce repo — cause directe d'un run en échec. Corrigé, et le message d'erreur liste désormais les 5 derniers tags.
- `review-auto.yaml` : suppression des entrées `rgaa-persist` / `perf-persist` du tag `persist-<sha>`, devenues inatteignables.
- `docs/release.md` : la section « Env de test » décrivait encore l'ancien flux force-push.
- `CLAUDE.md` : le tableau CI annonçait `review.yaml | PR` (c'est `push dependabot/**`) et `production.yaml | push master` (c'est `push tag v*`), et omettait 12 workflows.

## Point ouvert — les branches `*-persist`

`origin/rgaa-persist` et `origin/perf-persist` sont désormais des refs mortes : le nouveau modèle n'en a plus besoin. Leur suppression n'est **pas** dans cette PR, car elle est risquée en l'état :

- un workflow déclenché par `delete` ne tourne que dans sa version présente sur la **branche par défaut** ;
- la version de `deactivate.yaml` sur `master` ne contient **pas** l'exclusion `!**-persist` (elle n'existe que sur `alpha`, et n'a jamais été mergée vers `master`) ;
- de plus, GitHub ne documente le filtre `branches` que pour `push` / `pull_request` — il est vraisemblablement ignoré sur `delete`.

Supprimer ces branches aujourd'hui détruirait donc très probablement les deux namespaces. C'est récupérable (une promotion les recrée, la base d'un env de review est éphémère), mais autant le faire en connaissance de cause.

## Tests

- `pnpm format:check` OK ; les 6 workflows modifiés parsent.
- Build Docker local avec les nouveaux `ARG` : succès, valeur inlinée dans le bundle client (ci-dessus).
- Reste à valider en conditions réelles à la prochaine prérelease : le job build ne doit pas être `CACHED`, le footer doit afficher le tag, et le run Lighthouse doit porter l'URL de l'env promu.
