### PR TITLE
fix(dev-env): l'import GIP attend la fin du rollout avant d'importer

### DIFF
--- a/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
+++ b/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
@@ -1,3 +1,46 @@
+# GIP MDS import trigger, fired on every deploy (post-upgrade hook).
+#
+# The job MUST wait for the `app` Deployment rollout to complete before
+# triggering the import: during a rolling update the `app` Service still
+# routes to the previous pods, so both the trigger call and the server-side
+# fetch of EGAPRO_GIP_MDS_API_URL (which also goes through the Service) can
+# hit the old version and import its outdated bundled mock CSV. A healthz
+# check is not enough — the old pods answer it too. The init container below
+# gates the import on `kubectl rollout status`, which only returns once the
+# new ReplicaSet is fully ready and the old one is scaled down. The
+# ServiceAccount/Role/RoleBinding grant the read-only access this watch
+# requires, scoped to the single `app` Deployment.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gip-mds-import
+  namespace: {{ .Values.global.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gip-mds-import
+  namespace: {{ .Values.global.namespace }}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["app"]
+    verbs: ["get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gip-mds-import
+  namespace: {{ .Values.global.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gip-mds-import
+subjects:
+  - kind: ServiceAccount
+    name: gip-mds-import
+    namespace: {{ .Values.global.namespace }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -14,9 +57,35 @@ spec:
         app: gip-mds-import
     spec:
       restartPolicy: OnFailure
+      serviceAccountName: gip-mds-import
       securityContext:
         runAsUser: 100
         runAsNonRoot: true
+      initContainers:
+        - name: wait-app-rollout
+          image: alpine/kubectl:1.33.3
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            # kubectl needs a writable HOME for its cache when running as a
+            # non-root arbitrary uid
+            - name: HOME
+              value: /tmp
+          command:
+            - kubectl
+            - rollout
+            - status
+            - deployment/app
+            - --namespace
+            - {{ .Values.global.namespace }}
+            - --timeout=600s
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
       containers:
         - name: trigger
           image: curlimages/curl:8.12.1

--- a/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
+++ b/.kontinuous/env/dev/templates/gip-mds-import-job.yaml
@@ -22,10 +22,17 @@ metadata:
   name: gip-mds-import
   namespace: {{ .Values.global.namespace }}
 rules:
+  # `get` can be scoped to the deployment name, but `list`/`watch` cannot:
+  # RBAC resourceNames never match collection requests, and `kubectl rollout
+  # status` sets up its watch through list+watch on the deployments
+  # collection (with a fieldSelector). The rule stays namespace-scoped.
   - apiGroups: ["apps"]
     resources: ["deployments"]
     resourceNames: ["app"]
-    verbs: ["get", "watch"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -101,23 +108,19 @@ spec:
             - /bin/sh
             - -c
             - |
-              echo "Waiting for app to be ready..."
-              for i in $(seq 1 60); do
-                if curl -sf "http://app/api/healthz" > /dev/null 2>&1; then
-                  echo "App is ready, importing GIP MDS data..."
-                  curl -X POST "http://app/api/gip-mds/import" \
-                    -H "Authorization: Bearer ${EGAPRO_GIP_MDS_API_TOKEN}" \
-                    --connect-timeout 10 \
-                    --max-time 60 \
-                    --fail \
-                    --show-error
-                  exit $?
-                fi
-                echo "App not ready yet, retrying in 5s... ($i/60)"
-                sleep 5
-              done
-              echo "App did not become ready in time"
-              exit 1
+              # The rollout gate (init container) guarantees the app is ready;
+              # retries only cover transient Service endpoint propagation. The
+              # import endpoint is safe to retry (delete+insert transaction).
+              echo "Importing GIP MDS data..."
+              curl -X POST "http://app/api/gip-mds/import" \
+                -H "Authorization: Bearer ${EGAPRO_GIP_MDS_API_TOKEN}" \
+                --retry 10 \
+                --retry-delay 5 \
+                --retry-all-errors \
+                --connect-timeout 10 \
+                --max-time 60 \
+                --fail \
+                --show-error
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
## Problème

Le job `gip-mds-import` (hook Helm `post-upgrade`) se déclenche dès que `http://app/api/healthz` répond. Pendant un rolling update, le Service `app` route encore vers les **anciens pods** — le healthz répond donc avant que la nouvelle version ne serve. L'import récupère alors le CSV mock **de la version précédente** (le fetch server-side de `EGAPRO_GIP_MDS_API_URL` passe lui aussi par le Service, la course existe donc aux deux niveaux).

Cas constaté sur `egapro-rgaa-persist` : pendant la promotion `v3.14.0-alpha.2` → `v3.14.0-alpha.12`, l'import a lu le mock du pod `alpha.2` encore vivant et a écrit `workforce_ema = 150` pour le SIREN de test, alors que le mock d'`alpha.12` (commit 72ab1576, bucket 100–149) donne `133`. L'env `alpha` affichait 133, `rgaa-persist` 150.

## Correctif

Un initContainer `kubectl rollout status deployment/app --timeout=600s` bloque l'import tant que le rollout n'est pas terminé (nouveau ReplicaSet prêt **et** ancien éteint). À ce moment-là, le Service ne route plus que vers la nouvelle version, pour le trigger comme pour le fetch interne du mock.

RBAC minimal ajouté pour ce watch : ServiceAccount + Role/RoleBinding read-only (`get`/`watch`), scopés au seul Deployment `app` du namespace.

## Notes

- Périmètre : template `env/dev` uniquement (le job d'import n'existe que sur les review apps / envs persistants).
- `alpine/kubectl:1.33.3` : plus ancien tag disponible ; client 1.33 sur serveur 1.31, sans impact pour un `rollout status` (API `apps/v1` gelée).
- Vérifiable en re-promouvant une release sur `rgaa-persist` ou `perf-persist` : le job doit rester en `Init` jusqu'à la fin du rollout, puis importer les données de la version promue.