### PR TITLE
fix(conformite): boucle de redirection infinie sur /avis-cse sous 100 salariés

### DIFF
--- a/docs/cahier-de-tests.md
+++ b/docs/cahier-de-tests.md
@@ -17,7 +17,7 @@ Audience : équipe métier / PO (référence d'acceptance et suivi des tests) et
 3. [Les feuilles de l'Excel, année par année](#3-les-feuilles-de-lexcel-année-par-année)
 4. [Scénarios complémentaires hors Excel](#4-scénarios-complémentaires-hors-excel)
 5. [Limites de l'automatisation](#5-limites-de-lautomatisation)
-6. [Divergences Excel ↔ code à arbitrer](#6-divergences-excel--code-à-arbitrer)
+6. [Arbitrages métier (divergences résolues)](#6-arbitrages-métier-divergences-résolues)
 
 ---
 
@@ -284,6 +284,51 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 
 ---
 
+<a name="cas-13"></a>
+
+### CAS-13 : 7 indicateurs · tranche < 100 (sans CSE ni obligations d'écart) · aucun écart ≥ 5 % → fin de démarche directe
+
+**Libellé Excel** : « Déclaration des 7 indicateurs » *(feuille « <50 et 50-99 » — cellules sans numéro de cas)*
+
+- CSE : non applicable (pas de question CSE dans le parcours sous 100 salariés)
+- Déclaration des 7 indicateurs (étape 5 incluse)
+- Soumission → fin de démarche directe
+
+**Test E2E** : `compliance.e2e.ts` — `[CAS-13]` : effectif GIP 30 (représentatif < 50), 7 indicateurs sans écart ≥ 5 %, soumission → fin de démarche directe → `/confirmation`.
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-13\]"`
+
+---
+
+<a name="cas-14"></a>
+
+### CAS-14 : 7 indicateurs · tranche < 100 · au moins un écart ≥ 5 % → fin de démarche directe (aucune obligation déclenchée)
+
+**Libellé Excel** : « Déclaration des 7 indicateurs » *(feuille « <50 et 50-99 » — parcours issu de l'arbitrage n° 3 : sous 100 salariés un écart ≥ 5 % ne déclenche aucune obligation)*
+
+- CSE : non applicable
+- Déclaration des 7 indicateurs avec au moins un écart ≥ 5 % sur l'indicateur G
+- Ni parcours de conformité, ni seconde déclaration, ni évaluation conjointe, ni avis CSE → fin de démarche directe
+
+**Test E2E** : `compliance.e2e.ts` — `[CAS-14]` : effectif GIP 30, écart ≥ 5 % à l'étape 5, soumission → aucune proposition de conformité → `/confirmation`.
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-14\]"`
+
+---
+
+<a name="cas-13-6ind"></a>
+
+### CAS-13-6IND : 6 premiers indicateurs · 50-99 → fin de démarche directe
+
+**Libellé Excel** : « Déclaration des 6 premiers indicateurs » *(feuille « <50 et 50-99 » — ligne 50 à 99 salariés)*
+
+- CSE : non applicable (différence avec `CAS-01-6IND` qui tourne en 100-149 avec la question CSE)
+- Funnel sans étape 5 (indicateur G non applicable)
+- Soumission → fin de démarche directe
+
+**Test E2E** : `compliance.e2e.ts` — `[CAS-13-6IND]` : effectif GIP 75 (représentatif 50-99), funnel sans étape 5, soumission → fin de démarche directe → `/confirmation`.
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-13-6IND\]"`
+
+---
+
 ## 3. Les feuilles de l'Excel, année par année
 
 Miroir des quatre onglets du fichier. Placez-vous sur votre feuille et votre année : la cellule liste les cas à dérouler, chacun désigné par une **coordonnée autoportante** (cliquable vers sa fiche §2).
@@ -304,6 +349,7 @@ La coordonnée est **au-dessus des tests** : elle pointe vers la **fiche du parc
 
 - **Année « 7 indicateurs » (les 12 cas)** : `pnpm --filter app test:e2e --grep "\[CAS-(0[1-9]|1[0-2])\]"`
 - **Année « 6 premiers indicateurs » (cas 1-2)** : `pnpm --filter app test:e2e --grep "\[CAS-0[12]-6IND\]"`
+- **Tranches < 100** : `pnpm --filter app test:e2e --grep "\[CAS-1[34](-6IND)?\]"`
 
 ### Feuille « <50 et 50-99 »
 
@@ -314,7 +360,31 @@ Restitution verbatim (cette feuille ne prévoit ni cas CSE ni parcours de confor
 | Moins de 50 salariés (sur la base du volontariat) | Déclaration des 7 indicateurs | Déclaration des 7 indicateurs | Déclaration des 7 indicateurs | Déclaration des 7 indicateurs | Déclaration des 7 indicateurs | Déclaration des 7 indicateurs | Déclaration des 7 indicateurs |
 | 50 à 99 salariés | Déclaration des 6 premiers indicateurs | Déclaration des 6 premiers indicateurs | Déclaration des 6 premiers indicateurs | **Déclaration des 7 indicateurs** | Déclaration des 6 premiers indicateurs | Déclaration des 6 premiers indicateurs | **Déclaration des 7 indicateurs** |
 
-⚠️ Ces deux lignes sont **suspendues aux arbitrages métier du §6** (divergences 1 à 3 : volontariat < 50 avec ou sans indicateur G, assujettissement des 50-99 hors années triennales, parcours de conformité des 50-99 en année 7 indicateurs). Elles n'ont ni coordonnée ni fiche testable tant que ces points ne sont pas tranchés — les trancher, puis créer les fiches et les tests. Pour désigner un point de cette feuille en attendant, « 50-99, 2030 » suffit (un seul contenu par cellule).
+Les arbitrages du §6 étant rendus, chaque cellule porte désormais ses coordonnées et pointe vers une fiche du §2. Sous 100 salariés, il n'y a jamais de CSE ni de parcours de conformité : un écart ≥ 5 % ne déclenche aucune obligation, la démarche se termine directement (arbitrage n° 3).
+
+*Ligne « Moins de 50 salariés »* — coordonnées préfixées `AAAA-49-…`, les 7 années identiques (7 indicateurs sur la base du volontariat).
+
+| Année | Déclaration | Cas à dérouler (coordonnée — rappel) |
+|---|---|---|
+| 2027 | 7 indicateurs | Les 2 cas :<br>[2027-49-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2027-49-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+| 2028 | 7 indicateurs | Les 2 cas :<br>[2028-49-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2028-49-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+| 2029 | 7 indicateurs | Les 2 cas :<br>[2029-49-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2029-49-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+| 2030 | 7 indicateurs | Les 2 cas :<br>[2030-49-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2030-49-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+| 2031 | 7 indicateurs | Les 2 cas :<br>[2031-49-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2031-49-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+| 2032 | 7 indicateurs | Les 2 cas :<br>[2032-49-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2032-49-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+| 2033 | 7 indicateurs | Les 2 cas :<br>[2033-49-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2033-49-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+
+*Ligne « 50 à 99 salariés »* — coordonnées préfixées `AAAA-99-…`. Assujetties chaque année dès 2027 : 6 premiers indicateurs, sauf en 2030 et 2033 (7 indicateurs).
+
+| Année | Déclaration | Cas à dérouler (coordonnée — rappel) |
+|---|---|---|
+| 2027 | 6 premiers indicateurs | Le cas :<br>[2027-99-CAS13](#cas-13-6ind) : 6 premiers indicateurs → fin de démarche directe |
+| 2028 | 6 premiers indicateurs | Le cas :<br>[2028-99-CAS13](#cas-13-6ind) : 6 premiers indicateurs → fin de démarche directe |
+| 2029 | 6 premiers indicateurs | Le cas :<br>[2029-99-CAS13](#cas-13-6ind) : 6 premiers indicateurs → fin de démarche directe |
+| **2030** | **7 indicateurs** | Les 2 cas :<br>[2030-99-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2030-99-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
+| 2031 | 6 premiers indicateurs | Le cas :<br>[2031-99-CAS13](#cas-13-6ind) : 6 premiers indicateurs → fin de démarche directe |
+| 2032 | 6 premiers indicateurs | Le cas :<br>[2032-99-CAS13](#cas-13-6ind) : 6 premiers indicateurs → fin de démarche directe |
+| **2033** | **7 indicateurs** | Les 2 cas :<br>[2033-99-CAS13](#cas-13) : aucun écart → fin de démarche directe<br>[2033-99-CAS14](#cas-14) : écart ≥ 5 % → fin de démarche directe (aucune obligation) |
 
 ### Feuille « 100-149 »
 
@@ -358,7 +428,7 @@ Coordonnées préfixées `AAAA-250P-…`. Toutes les années suivent le même sc
 | **2032** | **7 indicateurs** | Les 12 cas :<br>[2032-250P-CAS01](#cas-01) : sans CSE · aucun écart → fin de démarche<br>[2032-250P-CAS02](#cas-02) : avec CSE · aucun écart → avis CSE « exactitude »<br>[2032-250P-CAS03](#cas-03) : sans CSE · écart ≥ 5 % → justification des écarts<br>[2032-250P-CAS04](#cas-04) : avec CSE · écart ≥ 5 % → justification + avis CSE<br>[2032-250P-CAS05](#cas-05) : sans CSE · écart ≥ 5 % → évaluation conjointe<br>[2032-250P-CAS06](#cas-06) : avec CSE · écart ≥ 5 % → évaluation conjointe + avis CSE<br>[2032-250P-CAS07](#cas-07) : sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. sans écart<br>[2032-250P-CAS08](#cas-08) : avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. sans écart + avis CSE<br>[2032-250P-CAS09](#cas-09) : sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → justification<br>[2032-250P-CAS10](#cas-10) : avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → justification + avis CSE<br>[2032-250P-CAS11](#cas-11) : sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → évaluation conjointe<br>[2032-250P-CAS12](#cas-12) : avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → évaluation conjointe + avis CSE |
 | **2033** | **7 indicateurs** | Les 12 cas :<br>[2033-250P-CAS01](#cas-01) : sans CSE · aucun écart → fin de démarche<br>[2033-250P-CAS02](#cas-02) : avec CSE · aucun écart → avis CSE « exactitude »<br>[2033-250P-CAS03](#cas-03) : sans CSE · écart ≥ 5 % → justification des écarts<br>[2033-250P-CAS04](#cas-04) : avec CSE · écart ≥ 5 % → justification + avis CSE<br>[2033-250P-CAS05](#cas-05) : sans CSE · écart ≥ 5 % → évaluation conjointe<br>[2033-250P-CAS06](#cas-06) : avec CSE · écart ≥ 5 % → évaluation conjointe + avis CSE<br>[2033-250P-CAS07](#cas-07) : sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. sans écart<br>[2033-250P-CAS08](#cas-08) : avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. sans écart + avis CSE<br>[2033-250P-CAS09](#cas-09) : sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → justification<br>[2033-250P-CAS10](#cas-10) : avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → justification + avis CSE<br>[2033-250P-CAS11](#cas-11) : sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → évaluation conjointe<br>[2033-250P-CAS12](#cas-12) : avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → évaluation conjointe + avis CSE |
 
-**Règles de cadencement sous-jacentes** (implémentées dans `packages/app/src/modules/domain/shared/indicatorG.ts` et `companyObligation.ts`, couvertes par les tests unitaires `indicatorG.test.ts` et `companyObligation.test.ts`) : indicateur G requis chaque année dès 250 salariés ; les années triennales (2027, 2030, 2033) dès 150 salariés avant 2030 puis dès 50 salariés à partir de 2030.
+**Règles de cadencement sous-jacentes** (implémentées dans `packages/app/src/modules/domain/shared/indicatorG.ts` et `companyObligation.ts`, couvertes par les tests unitaires `indicatorG.test.ts` et `companyObligation.test.ts`) : indicateur G requis chaque année sous 50 salariés (volontariat, 7 indicateurs) et dès 250 salariés ; les années triennales (2027, 2030, 2033) dès 150 salariés avant 2030 puis dès 50 salariés à partir de 2030 ; assujettissement annuel dès 50 salariés à partir de 2027 (6 premiers indicateurs pour les 50-99 hors années « indicateur G »).
 
 
 ---
@@ -382,15 +452,15 @@ Le socle déclaratif (étapes 1–6, brouillon, historique, panneau de démarche
 Ce que les tests E2E ne peuvent pas rejouer tel quel, et comment c'est compensé :
 
 1. **La dimension année de campagne** — les specs E2E tournent sur l'année de campagne courante, pas sur 2027 → 2033. Le *contenu* de chaque cellule de l'Excel (les parcours) est déroulé par les tests du §2 ; le *cadencement* (quelle année déclenche 6 ou 7 indicateurs pour quelle tranche) est verrouillé par les tests unitaires du domaine (`indicatorG.test.ts`, `companyObligation.test.ts`), qui couvrent chaque tranche × année de la matrice.
-2. **La tranche d'effectif** — les parcours de conformité (cas 1 à 12) tournent en 250 et + (effectif GIP 250) ; les variantes 6 indicateurs (`CAS-01-6IND`, `CAS-02-6IND`) tournent avec un effectif GIP de 120, représentatif de la tranche 100-149.
+2. **La tranche d'effectif** — les parcours de conformité (cas 1 à 12) tournent en 250 et + (effectif GIP 250) ; les variantes 6 indicateurs (`CAS-01-6IND`, `CAS-02-6IND`) tournent avec un effectif GIP de 120, représentatif de la tranche 100-149 ; les nouveaux parcours < 100 tournent avec un effectif GIP de 30 (représentatif < 50) pour `CAS-13`/`CAS-14` et de 75 (représentatif 50-99) pour `CAS-13-6IND`.
 3. **Avis CSE défavorables** — tous les tests déposent des avis « favorable » ; les variantes « défavorable » (sans impact de routage attendu, mais affichées au récapitulatif) ne sont pas déroulées.
 
 ---
 
-## 6. Divergences Excel ↔ code à arbitrer
+## 6. Arbitrages métier (divergences résolues)
 
-Constats faits en transcrivant le fichier (état du code : branche `alpha`, juillet 2026). À trancher avec le métier, puis répercuter ici **et** dans le code/les tests :
+Les 3 divergences relevées en transcrivant le fichier Excel ont été arbitrées par le métier (juillet 2026) et répercutées dans le code, les miroirs SQL et le moteur de règles par #4043.
 
-1. **< 50 salariés** : l'Excel affiche « Déclaration des 7 indicateurs » (volontariat) chaque année ; le code n'inclut jamais l'indicateur G sous 50 salariés (`isIndicatorGRequired` → false, donc `getApplicableIndicators` renvoie 6 indicateurs). Un déclarant volontaire n'aurait donc que 6 indicateurs.
-2. **50 – 99, années hors cadence** (2028, 2029, 2031, 2032) : l'Excel affiche « Déclaration des 6 premiers indicateurs » ; le code ne les assujettit pas du tout ces années-là (`isObligatedForYear` → false hors 2027/2030/2033). S'agit-il d'une déclaration volontaire possible chaque année ?
-3. **50 – 99 en 2030/2033 avec écart ≥ 5 %** : l'Excel ne prévoit aucun parcours de conformité pour cette tranche ; côté code, le parcours se déclenche dès que l'indicateur G est requis et qu'un écart ≥ 5 % existe, sans condition de tranche (`Step6Review.tsx` → `isComplianceProcessRequired`). Confirmer le comportement attendu pour une 50-99 en année « 7 indicateurs ».
+1. **Moins de 50 salariés (volontariat)** — déclarent **les 7 indicateurs chaque année**, indicateur G compris. La déclaration reste volontaire ; c'est son *contenu* qui change. *Statut : répercutée dans le code par #4043 (`isIndicatorGRequired` renvoie `true` sous 50 salariés, toutes années).*
+2. **50 à 99 salariés** — sont assujetties **chaque année** dès 2027 : les **6 premiers indicateurs** en 2027, 2028, 2029, 2031 et 2032, et les **7 indicateurs** en **2030 et 2033**. *Statut : répercutée dans le code par #4043 (`isObligatedForYear` assujettit les 50-99 chaque année dès `V2_FIRST_CAMPAIGN_YEAR`).*
+3. **Sous 100 salariés en année « 7 indicateurs »** — les tranches < 100 (50-99 comprises en 2030/2033, et les < 50 volontaires) ne sont **pas** concernées par les obligations déclenchées par un écart ≥ 5 % : pas de parcours de conformité, pas de seconde déclaration, pas de rapport d'évaluation conjointe, pas d'avis CSE. Le seuil de ces obligations reste **100 salariés**. *Statut : le code était déjà conforme — le seuil 100 vit dans `isComplianceProcessRequired`/`isCseOpinionRequired` (domaine) et `phase2Required`/`cseRequired` (moteur de règles) ; la divergence décrivait un état antérieur du code (« sans condition de tranche ») qui n'existe plus. Verrouillée par des tests, sans changement de comportement.*

--- a/packages/app/src/app/avis-cse/layout.tsx
+++ b/packages/app/src/app/avis-cse/layout.tsx
@@ -29,17 +29,17 @@ export default async function CseOpinionRootLayout({
 		api.declaration.getOrCreate(),
 	]);
 
-	// Without a CSE there is no opinion to transmit, and this funnel's fields are
-	// all required — landing here is a dead end. Reads the company's live answer
-	// rather than the declaration snapshot, so a démarche already parked here by
-	// a stale snapshot recovers on its own.
-	if (
-		!isCseOpinionRequired({
-			workforce: getObligationWorkforce(company.gipWorkforce),
-			hasCse: company.hasCse,
-		})
-	) {
-		redirect(getPostComplianceDestination(company.hasCse));
+	// Reads the company's live answer rather than the declaration snapshot, so a
+	// démarche parked here by a stale snapshot recovers on its own.
+	const cseOpinionRequired = isCseOpinionRequired({
+		workforce: getObligationWorkforce(company.gipWorkforce),
+		hasCse: company.hasCse,
+	});
+
+	// This funnel's fields are all required, so landing here with no opinion to
+	// transmit is a dead end.
+	if (!cseOpinionRequired) {
+		redirect(getPostComplianceDestination(cseOpinionRequired));
 	}
 
 	const declaration = declarationData.declaration;

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -16,9 +16,15 @@ import {
 } from "./helpers/db";
 import {
 	completeDeclaration,
+	reachRecapWithoutGap,
 	reachStep6ComplianceRecap,
-	submitStepsThroughQuartiles,
+	reachStep6Recap,
+	submitFromStep6Recap,
 } from "./helpers/declaration-flows";
+import {
+	indicatorGRequiredForGip,
+	recapStepperLabel,
+} from "./helpers/indicator-g";
 
 test.describe.configure({ mode: "serial" });
 
@@ -508,13 +514,15 @@ test.describe("[ANX-02] Path 12: compliance already completed → redirect", () 
 	});
 });
 
-// === GROUP G: "6 premiers indicateurs" variant — indicator G not required ===
-// GIP workforce 120 (bracket 100-149, off-cycle year): the funnel drops the
-// categories step and no compliance path can trigger (Excel: cas 1-2 of the
-// "6 premiers indicateurs" columns). resetGipWorkforce restores the suite
-// baseline (>= 250) for any spec running after this one.
+// === GROUP G: "6 premiers indicateurs" variant — the 100-149 bracket ===
+// GIP workforce 120 (bracket 100-149): the funnel drops the categories step and no
+// compliance path can trigger (Excel: cas 1-2 of the "6 premiers indicateurs" columns).
+// That bracket owes indicator G on the triennial years from 2030, so the funnel shape
+// is read from the domain — the submission outcome under test is the same either way.
+// resetGipWorkforce restores the suite baseline (>= 250) for any spec running after this one.
+const GIP_120_INDICATOR_G = indicatorGRequiredForGip(120);
 
-test.describe("[CAS-01-6IND] Path 14: 6 indicators (no G) + no hasCse → direct completion", () => {
+test.describe("[CAS-01-6IND] Path 14: GIP 120 (100-149) + no hasCse → direct completion", () => {
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
 		await setGipWorkforce(120);
@@ -525,19 +533,19 @@ test.describe("[CAS-01-6IND] Path 14: 6 indicators (no G) + no hasCse → direct
 		await resetGipWorkforce();
 	});
 
-	test("submits the 5-step funnel and completes the démarche directly", async ({
+	test("submits the tier's funnel and completes the démarche directly", async ({
 		page,
 	}) => {
-		test.slow(); // 5-step declaration + submission
-		await submitStepsThroughQuartiles(page);
-		// No indicator G → the categories step is skipped: quartiles land on review
-		await page.waitForURL("**/declaration-remuneration/etape/6");
-		await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+		test.slow(); // Full declaration + submission
+		await reachRecapWithoutGap(page, {
+			indicatorGRequired: GIP_120_INDICATOR_G,
+		});
+		await expect(
+			page.getByText(recapStepperLabel(GIP_120_INDICATOR_G), { exact: true }),
+		).toBeVisible();
 
-		// Submit — no indicator G and no CSE → demarche completed directly
-		await page.getByRole("button", { name: "Suivant" }).click();
-		await page.getByText(/Je certifie/).click();
-		await page.getByRole("button", { name: "Valider" }).click();
+		// Submit — no gap and no CSE → demarche completed directly
+		await submitFromStep6Recap(page);
 		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
 		await expect(
 			page.getByText(/Votre parcours .* est (désormais )?terminé/),
@@ -545,7 +553,7 @@ test.describe("[CAS-01-6IND] Path 14: 6 indicators (no G) + no hasCse → direct
 	});
 });
 
-test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse", () => {
+test.describe("[CAS-02-6IND] Path 15: GIP 120 (100-149) + hasCse → /avis-cse", () => {
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
 		await setGipWorkforce(120);
@@ -556,17 +564,16 @@ test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse
 		await resetGipWorkforce();
 	});
 
-	test("submits the 5-step funnel then deposits the CSE accuracy opinion", async ({
+	test("submits the tier's funnel then deposits the CSE accuracy opinion", async ({
 		page,
 	}) => {
-		test.slow(); // 5-step declaration + submission + CSE flow
-		await submitStepsThroughQuartiles(page);
-		await page.waitForURL("**/declaration-remuneration/etape/6");
+		test.slow(); // Full declaration + submission + CSE flow
+		await reachRecapWithoutGap(page, {
+			indicatorGRequired: GIP_120_INDICATOR_G,
+		});
 
-		// Submit — no indicator G but a CSE → straight to the CSE opinion
-		await page.getByRole("button", { name: "Suivant" }).click();
-		await page.getByText(/Je certifie/).click();
-		await page.getByRole("button", { name: "Valider" }).click();
+		// Submit — no gap but a CSE → straight to the CSE opinion
+		await submitFromStep6Recap(page);
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
 
 		await fillCseStep1(page);
@@ -696,6 +703,176 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=true → CSE opinion stil
 
 		await expect(
 			page.getByText("Transmettre l'avis du CSE", { exact: true }),
+		).toBeVisible();
+	});
+});
+
+// === GROUP I: tranches < 100 — the gap ≥ 5 % obligations stop at 100 salariés ===
+// Arbitrage 2026-07 (#4043, cahier de tests §6): the voluntary tier (< 50) declares
+// all 7 indicators every year, the 50-99 tier declares the 6 first ones outside its
+// own indicator G years, and neither owes anything when a gap ≥ 5 % shows up — the
+// compliance process, the second declaration, the joint evaluation and the CSE
+// opinion all stay gated at 100 salariés (Excel sheet "<50 et 50-99").
+// `hasCse` starts unset, as the question is never asked below 100 — but the CSE
+// probe of [CAS-14] declares one on purpose: `isCseOpinionRequired` is an AND of
+// the effectif and the CSE, so leaving `hasCse` unset would keep that probe green
+// even with no threshold at all, and [CAS-01] already covers the absent CSE. Each
+// describe restores the file's exit state (GIP >= 250 + hasCse true) after it.
+
+test.describe("[CAS-13] 7 indicators + GIP 30 (< 50) + no gap → direct completion", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setGipWorkforce(30);
+		await setCompanyHasCse(null);
+	});
+
+	test.afterAll(async () => {
+		await resetGipWorkforce();
+		await setCompanyHasCse(true);
+	});
+
+	test("declares the 7 indicators and completes the démarche directly", async ({
+		page,
+	}) => {
+		test.slow(); // 6-step declaration + submission
+		await reachStep6Recap(page, { hasGap: false });
+
+		// Step 5 was presented: 6-step funnel + indicator G block on the recap.
+		// `exact` scopes to the stepper — the Next.js route announcer repeats the
+		// label followed by the step title.
+		await expect(
+			page.getByText("Étape 6 sur 6", { exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", {
+				name: "Indicateurs par catégorie de salariés",
+			}),
+		).toBeVisible();
+
+		await submitFromStep6Recap(page);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
+	});
+});
+
+test.describe("[CAS-14] 7 indicators + GIP 30 (< 50) + gap ≥ 5 % → no obligation triggered", () => {
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setGipWorkforce(30);
+		await setCompanyHasCse(null);
+	});
+
+	test.afterAll(async () => {
+		await resetGipWorkforce();
+		await setCompanyHasCse(true);
+	});
+
+	test("the recap proposes no compliance action despite the gap", async ({
+		page,
+	}) => {
+		test.slow(); // 6-step declaration up to the recap
+		await reachStep6ComplianceRecap(page);
+
+		// Same gap inputs that render the "Prochaines étapes" box at 200 salariés
+		// (GROUP H): below 100 nothing is due, so the box is absent altogether.
+		await expect(
+			page.getByRole("heading", { name: "Prochaines étapes" }),
+		).toHaveCount(0);
+		await expect(
+			page.getByText("Écarts détectés", { exact: true }),
+		).toHaveCount(0);
+		await expect(
+			page.getByRole("heading", { name: "Actions à engager" }),
+		).toHaveCount(0);
+	});
+
+	test("submits into a direct completion, with every compliance surface out of reach", async ({
+		page,
+	}) => {
+		await page.goto("/declaration-remuneration/etape/6");
+		await submitFromStep6Recap(page);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
+
+		// The compliance path choice, which carries the second declaration and the
+		// joint evaluation, is unreachable even by URL: below 100 salariés a gap
+		// ≥ 5 % opens none of them.
+		await page.goto(COMPLIANCE_PATH);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+
+		// Declaring a CSE leaves the effectif as the only unmet term of
+		// `isCseOpinionRequired`, so this probe fails if the 100-salarié gate goes
+		// away — which an unset `hasCse` would have hidden.
+		await setCompanyHasCse(true);
+		const cseFunnelResponse = await page.goto("/avis-cse/etape/1");
+
+		// Read off the settled navigation instead of polling for the URL: a gate
+		// bouncing this company back into /avis-cse loops, and must surface as a
+		// redirect error or as the funnel pathname, never as a silent timeout.
+		expect(cseFunnelResponse?.ok()).toBe(true);
+		expect(new URL(page.url()).pathname).toBe(CONFIRMATION_PATH);
+		await expect(
+			page.getByRole("heading", {
+				name: "Transmettre l'avis ou les avis du CSE",
+			}),
+		).toHaveCount(0);
+		await expect(page.locator("#first-decl-accuracy-favorable")).toHaveCount(0);
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
+		).toBeVisible();
+	});
+});
+
+// The cahier describes this case on the 6-indicator variant, which is what the 50-99
+// tier declares outside its own indicator G years. On those years (2030, 2033, …) the
+// same company declares the 7 indicators instead, so the funnel shape is read from the
+// domain — what is under test either way is the outcome: below 100 salariés a gap-free
+// declaration completes the démarche directly, with no compliance obligation.
+test.describe("[CAS-13-6IND] GIP 75 (50-99) → direct completion", () => {
+	const indicatorGRequired = indicatorGRequiredForGip(75);
+
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setGipWorkforce(75);
+		await setCompanyHasCse(null);
+	});
+
+	test.afterAll(async () => {
+		await resetGipWorkforce();
+		await setCompanyHasCse(true);
+	});
+
+	test("submits the tier's funnel and completes the démarche directly", async ({
+		page,
+	}) => {
+		test.slow(); // Full declaration + submission
+		await page.goto("/declaration-remuneration/etape/5");
+		if (indicatorGRequired) {
+			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/5$/);
+			await expect(
+				page.getByRole("heading", {
+					name: /Écart de rémunération par catégories de salariés/,
+				}),
+			).toBeVisible();
+		} else {
+			// Off those years step 5 is out of reach even by URL — unlike the < 50
+			// tier, which always carries it.
+			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/6$/);
+		}
+
+		await reachRecapWithoutGap(page, { indicatorGRequired });
+		await expect(
+			page.getByText(recapStepperLabel(indicatorGRequired), { exact: true }),
+		).toBeVisible();
+
+		await submitFromStep6Recap(page);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await expect(
+			page.getByText(/Votre parcours .* est (désormais )?terminé/),
 		).toBeVisible();
 	});
 });

--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { getCurrentYear } from "~/modules/domain";
 import {
 	deleteCseOpinions,
 	deleteJointEvaluationFiles,
@@ -14,12 +15,14 @@ import {
 	setUserPhone,
 } from "./helpers/db";
 import { clickAndExpectDialogOpen, waitForDsfrModal } from "./helpers/dsfr";
+import { indicatorGRequiredForGip } from "./helpers/indicator-g";
 import { loginWithProConnect } from "./helpers/login";
 
 // Per-variant panel rendering is covered by my-space/__tests__/DeclarationProcessPanel.test.tsx.
 
 const PANEL_ID = "declaration-process-panel";
-const CURRENT_YEAR = 2026;
+// Matches the year the panel renders and the year ensureCurrentYearDeclaration inserts.
+const CURRENT_YEAR = getCurrentYear();
 
 test.describe("Declaration process panel", () => {
 	test.describe.configure({ mode: "serial" });
@@ -108,14 +111,15 @@ test.describe("Declaration process panel", () => {
 	});
 
 	// Regression #3939: a GIP-derived < 100 company without CSE must never see the
-	// indicator-G path step nor the "déposer l'avis CSE" step — neither during the
-	// démarche nor after completion (where the panel used to stay stuck on "avis CSE
-	// en cours" with a /avis-cse CTA). Gating is driven by the GIP workforce (79 here),
-	// not the WEEZ headcount or the has_cse flag.
-	test.describe("GIP < 100 without CSE: indicator-G and CSE steps are hidden", () => {
+	// "déposer l'avis CSE" step — neither during the démarche nor after completion (where
+	// the panel used to stay stuck on "avis CSE en cours" with a /avis-cse CTA). The
+	// indicator-G path step follows the same GIP workforce (79 here), not the WEEZ headcount
+	// or the has_cse flag, so it is hidden except on the tier's own indicator G years.
+	test.describe("GIP < 100 without CSE: the CSE step is hidden, the indicator-G step follows the obligation", () => {
 		const STEP2_TITLE =
 			"Parcours de mise en conformité pour l'indicateur par catégorie de salariés";
 		const STEP3_TITLE = "Déposer le ou les avis du CSE";
+		const indicatorGRequired = indicatorGRequiredForGip(79);
 
 		test.afterAll(async () => {
 			await resetDeclarationToDraft();
@@ -141,14 +145,20 @@ test.describe("Declaration process panel", () => {
 				await resetDeclarationToDraft();
 			});
 
-			test("only the declaration step is announced", async ({ page }) => {
+			test("announces the declaration step, and the indicator-G step only when owed", async ({
+				page,
+			}) => {
 				await openPanel(page);
 				const panel = page.locator(`#${PANEL_ID}`);
 
 				await expect(
 					panel.getByText("Déclaration des indicateurs de rémunération"),
 				).toBeVisible();
-				await expect(panel.getByText(STEP2_TITLE)).toHaveCount(0);
+				if (indicatorGRequired) {
+					await expect(panel.getByText(STEP2_TITLE)).toBeVisible();
+				} else {
+					await expect(panel.getByText(STEP2_TITLE)).toHaveCount(0);
+				}
 				await expect(panel.getByText(STEP3_TITLE)).toHaveCount(0);
 			});
 		});

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -5,7 +5,16 @@ import {
 	resetGipWorkforce,
 	setGipWorkforce,
 } from "./helpers/db";
-import { submitStepsThroughQuartiles } from "./helpers/declaration-flows";
+import {
+	submitFromStep6Recap,
+	submitIndicatorGStep,
+	submitStepsThroughQuartiles,
+} from "./helpers/declaration-flows";
+import {
+	funnelStepCount,
+	indicatorGRequiredForGip,
+	recapStepperLabel,
+} from "./helpers/indicator-g";
 
 // Render-structure assertions are covered by the step component tests in declaration-remuneration/**/__tests__.
 
@@ -239,12 +248,7 @@ test.describe("Declaration workflow", () => {
 	test("step 6 submit leaves declaration page", async ({ page }) => {
 		await goToStep(page, 6);
 
-		// Click the "Suivant" submit button to open the confirmation modal
-		await page.getByRole("button", { name: "Suivant" }).click();
-
-		// Check the certification checkbox (click on the label, as DSFR checkbox label intercepts pointer events)
-		await page.getByText(/Je certifie/).click();
-		await page.getByRole("button", { name: "Valider" }).click();
+		await submitFromStep6Recap(page);
 
 		// After submission, compliance path kicks in. Destination depends on hasCse
 		// and gap state — exact routing is tested in compliance.e2e.ts.
@@ -297,15 +301,28 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 			).toHaveCount(0);
 		});
 
-		test("the funnel drops the indicator G step", async ({ page }) => {
+		// #4043: absent from the GIP file → obligation workforce 0 → voluntary tier,
+		// which declares all 7 indicators every year. Step 5 is therefore presented
+		// (it used to be skipped), and the funnel keeps its 6 steps.
+		test("the funnel keeps the indicator G step", async ({ page }) => {
 			await page.goto("/declaration-remuneration/etape/5");
-			await page.waitForURL("**/declaration-remuneration/etape/6");
 
-			await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/5$/);
+			await expect(page.getByText("Étape 5 sur 6")).toBeVisible();
+			await expect(
+				page.getByRole("heading", {
+					name: /Écart de rémunération par catégories de salariés/,
+				}),
+			).toBeVisible();
 		});
 	});
 
-	test.describe("GIP workforce of 70 — below every indicator G threshold", () => {
+	// The 50-99 tier declares the 6 first indicators, except on its own indicator G
+	// years (2030, 2033, …) where the categories step joins the funnel. Both the step
+	// count and the quartile landing are therefore read from the domain.
+	test.describe("GIP workforce of 70 — the 50-99 mandatory tier", () => {
+		const indicatorGRequired = indicatorGRequiredForGip(70);
+
 		test.beforeAll(async () => {
 			await setGipWorkforce(70);
 			await resetDeclarationToDraft();
@@ -328,20 +345,36 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 			).toHaveCount(0);
 
 			await page.goto("/declaration-remuneration/etape/1");
-			await expect(page.getByText("Étape 1 sur 5")).toBeVisible();
+			await expect(
+				page.getByText(`Étape 1 sur ${funnelStepCount(indicatorGRequired)}`, {
+					exact: true,
+				}),
+			).toBeVisible();
 			await expect(
 				page.getByText(`Effectif annuel moyen en ${currentYear - 1} :`),
 			).toBeVisible();
 			await expect(page.getByText("Existence d'un CSE :")).toHaveCount(0);
 		});
 
-		test("submitting the quartile step lands on the review step (S1 of #3934)", async ({
+		test("submitting the quartile step lands on the next step of the tier's funnel (S1 of #3934)", async ({
 			page,
 		}) => {
 			await submitStepsThroughQuartiles(page);
 
-			await page.waitForURL("**/declaration-remuneration/etape/6");
-			await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+			// Without indicator G the quartiles flow straight into the review step;
+			// on the tier's indicator G years the categories step sits in between.
+			if (indicatorGRequired) {
+				await page.waitForURL("**/declaration-remuneration/etape/5");
+				await expect(
+					page.getByText("Étape 5 sur 6", { exact: true }),
+				).toBeVisible();
+				await submitIndicatorGStep(page, { hasGap: false });
+			} else {
+				await page.waitForURL("**/declaration-remuneration/etape/6");
+			}
+			await expect(
+				page.getByText(recapStepperLabel(indicatorGRequired), { exact: true }),
+			).toBeVisible();
 		});
 	});
 });

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -191,6 +191,19 @@ async function fillStep5Categories(page: Page, options: { hasGap: boolean }) {
 }
 
 /**
+ * Fill the indicator G categories step and submit it, landing on the review step.
+ * Only reachable when the company's tier owes indicator G on the campaign year.
+ */
+export async function submitIndicatorGStep(
+	page: Page,
+	options: { hasGap: boolean },
+) {
+	await fillStep5Categories(page, options);
+	await page.getByRole("button", { name: "Suivant" }).click();
+	await page.waitForURL("**/declaration-remuneration/etape/6");
+}
+
+/**
  * Fill steps 1 → 5 and stop on the step 6 review recap without submitting, so a
  * caller can assert on the recap ("Prochaines étapes" box) before certification.
  * Requires a company subject to indicator G (step 5), i.e. the suite baseline workforce.
@@ -201,8 +214,24 @@ export async function reachStep6Recap(
 ) {
 	await submitStepsThroughQuartiles(page);
 	await page.waitForURL("**/declaration-remuneration/etape/5");
-	await fillStep5Categories(page, options);
-	await page.getByRole("button", { name: "Suivant" }).click();
+	await submitIndicatorGStep(page, options);
+}
+
+/**
+ * Fill a gap-free funnel up to the review step, whatever shape the campaign year gives
+ * it: the categories step is only presented when the tier owes indicator G that year, so
+ * the quartiles land either on it or straight on the review. Callers pass the expectation
+ * derived from the domain (`indicatorGRequiredForGip`).
+ */
+export async function reachRecapWithoutGap(
+	page: Page,
+	options: { indicatorGRequired: boolean },
+) {
+	if (options.indicatorGRequired) {
+		await reachStep6Recap(page, { hasGap: false });
+		return;
+	}
+	await submitStepsThroughQuartiles(page);
 	await page.waitForURL("**/declaration-remuneration/etape/6");
 }
 
@@ -215,9 +244,18 @@ export async function reachStep6Recap(
 export async function reachStep6ComplianceRecap(page: Page) {
 	await submitStepsThroughQuartiles(page, { annualMeanGap: true });
 	await page.waitForURL("**/declaration-remuneration/etape/5");
-	await fillStep5Categories(page, { hasGap: true });
+	await submitIndicatorGStep(page, { hasGap: true });
+}
+
+/**
+ * Certify and submit from the step 6 recap, leaving the destination to the caller:
+ * post-submission routing depends on the workforce, the gap and the CSE.
+ */
+export async function submitFromStep6Recap(page: Page) {
 	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL("**/declaration-remuneration/etape/6");
+	// Click the label, as the DSFR checkbox label intercepts pointer events.
+	await page.getByText(/Je certifie/).click();
+	await page.getByRole("button", { name: "Valider" }).click();
 }
 
 /**
@@ -230,12 +268,7 @@ export async function completeDeclaration(
 	options: { hasGap: boolean },
 ) {
 	await reachStep6Recap(page, options);
-
-	// Step 6: Submit declaration
-	await page.getByRole("button", { name: "Suivant" }).click();
-	// Certification modal
-	await page.getByText(/Je certifie/).click();
-	await page.getByRole("button", { name: "Valider" }).click();
+	await submitFromStep6Recap(page);
 
 	// Wait for post-submission routing (compliance path or CSE or confirmation)
 	await page.waitForURL(

--- a/packages/app/src/e2e/helpers/indicator-g.ts
+++ b/packages/app/src/e2e/helpers/indicator-g.ts
@@ -1,0 +1,34 @@
+import {
+	getCurrentYear,
+	getObligationWorkforce,
+	isIndicatorGRequired,
+} from "~/modules/domain";
+
+/**
+ * Whether the funnel presents the indicator G step for a GIP-MDS workforce, on the
+ * campaign year the app itself uses (`declaration.year` is `getCurrentYear()`).
+ *
+ * The mandatory tiers below 250 owe indicator G only on the triennial cadence, and from
+ * 2030 that cadence reaches every tier >= 50 — so their funnel shape flips with the
+ * calendar (5 steps in 2029, 6 in 2030, 5 again in 2031, 6 in 2033). Reading the
+ * expectation from the domain pins a spec to the arbitrage rather than to the year it
+ * was written in, which is what makes it survive the cadence instead of turning red for
+ * a whole year and reading like a flake.
+ */
+export function indicatorGRequiredForGip(gipWorkforce: number | null): boolean {
+	return isIndicatorGRequired(
+		getObligationWorkforce(gipWorkforce),
+		getCurrentYear(),
+	);
+}
+
+/** Steps the funnel presents: the indicator G categories step is dropped when not owed. */
+export function funnelStepCount(indicatorGRequired: boolean): number {
+	return indicatorGRequired ? 6 : 5;
+}
+
+/** Stepper label of the review step, always the last one of the funnel. */
+export function recapStepperLabel(indicatorGRequired: boolean): string {
+	const total = funnelStepCount(indicatorGRequired);
+	return `Étape ${total} sur ${total}`;
+}

--- a/packages/app/src/modules/cseOpinion/__tests__/CseOpinionRootLayout.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/CseOpinionRootLayout.test.tsx
@@ -1,0 +1,143 @@
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedirect, mockAuth, mockGetEffectiveSiren } = vi.hoisted(() => ({
+	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
+		throw new Error("NEXT_REDIRECT");
+	}),
+	mockAuth: vi.fn(),
+	mockGetEffectiveSiren: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+	redirect: mockRedirect,
+}));
+
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+
+vi.mock("~/server/auth/companyAccess", () => ({
+	getEffectiveSiren: mockGetEffectiveSiren,
+}));
+
+vi.mock("~/server/db", () => ({ db: {} }));
+
+vi.mock("~/server/services/declarationLockService", () => ({
+	getLockReadState: vi
+		.fn()
+		.mockResolvedValue({ isReadOnly: false, lockHolder: null }),
+}));
+
+vi.mock("~/trpc/server", () => ({
+	api: {
+		company: { get: vi.fn() },
+		declaration: { getOrCreate: vi.fn() },
+	},
+}));
+
+// The funnel chrome is irrelevant here and pulls the module's client components
+// through the barrel; this suite only judges the layout's redirect decision.
+vi.mock("~/modules/cseOpinion", () => ({
+	CseOpinionLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import CseOpinionRootLayout from "~/app/avis-cse/layout";
+import { COMPANY_SIZE_ANNUAL_MIN } from "~/modules/domain";
+import { api } from "~/trpc/server";
+
+const SIREN = "123456789";
+const CSE_OPINION_PATH = "/avis-cse";
+const CONFIRMATION_PATH =
+	"/declaration-remuneration/parcours-conformite/confirmation";
+
+function mockCompany(gipWorkforce: number | null, hasCse: boolean | null) {
+	mockAuth.mockResolvedValue({ user: { id: "u1", siret: `${SIREN}00015` } });
+	mockGetEffectiveSiren.mockReturnValue(SIREN);
+	vi.mocked(api.company.get).mockResolvedValue({
+		name: "Société Démo",
+		siren: SIREN,
+		gipWorkforce,
+		hasCse,
+	} as never);
+	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
+		declaration: { id: "d1", year: 2026, siren: SIREN },
+	} as never);
+}
+
+function renderLayout() {
+	return CseOpinionRootLayout({
+		children: "child" as unknown as React.ReactNode,
+	});
+}
+
+describe("CseOpinionRootLayout", () => {
+	beforeEach(() => {
+		mockRedirect.mockClear();
+		mockAuth.mockReset();
+		mockGetEffectiveSiren.mockReset();
+	});
+
+	it("redirects unauthenticated users to /login", async () => {
+		mockAuth.mockResolvedValue(null);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/login");
+	});
+
+	it("redirects to the home page when no company is in scope", async () => {
+		mockAuth.mockResolvedValue({ user: { id: "u1" } });
+		mockGetEffectiveSiren.mockReturnValue(null);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/");
+	});
+
+	it("serves the funnel to a company that owes an opinion", async () => {
+		mockCompany(COMPANY_SIZE_ANNUAL_MIN, true);
+
+		await expect(renderLayout()).resolves.toBeDefined();
+		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+
+	// `has_cse` persists across years while the workforce is re-read from the
+	// current GIP row, so a company that shrinks under the threshold keeps
+	// hasCse=true. Deciding on hasCse alone sent it back to /avis-cse — this very
+	// layout — and the redirect looped until the browser gave up.
+	it("does not bounce a company with a CSE back into the funnel once it falls under the threshold", async () => {
+		mockCompany(COMPANY_SIZE_ANNUAL_MIN - 25, true);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(CONFIRMATION_PATH);
+		expect(mockRedirect).not.toHaveBeenCalledWith(CSE_OPINION_PATH);
+	});
+
+	it("sends a company just under the threshold to the confirmation page", async () => {
+		mockCompany(COMPANY_SIZE_ANNUAL_MIN - 1, true);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(CONFIRMATION_PATH);
+	});
+
+	it("sends a company absent from the GIP file to the confirmation page", async () => {
+		mockCompany(null, true);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(CONFIRMATION_PATH);
+	});
+
+	it.each([
+		false,
+		null,
+	])("sends a large company owing no opinion to the confirmation page (hasCse: %s)", async (hasCse) => {
+		mockCompany(COMPANY_SIZE_ANNUAL_MIN + 150, hasCse);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(CONFIRMATION_PATH);
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
@@ -5,21 +5,26 @@ import {
 	getPostComplianceDestination,
 } from "../complianceNavigation";
 
+const CONFIRMATION_PATH =
+	"/declaration-remuneration/parcours-conformite/confirmation";
+const CSE_OPINION_PATH = "/avis-cse";
+
 describe("getPostComplianceDestination", () => {
-	it("returns /avis-cse when hasCse is true", () => {
-		expect(getPostComplianceDestination(true)).toBe("/avis-cse");
+	it("sends a démarche that still owes an opinion to the CSE funnel", () => {
+		expect(getPostComplianceDestination(true)).toBe(CSE_OPINION_PATH);
 	});
 
-	it("returns confirmation path when hasCse is false", () => {
-		expect(getPostComplianceDestination(false)).toBe(
-			"/declaration-remuneration/parcours-conformite/confirmation",
-		);
+	it("sends a démarche that owes no opinion to the confirmation page", () => {
+		expect(getPostComplianceDestination(false)).toBe(CONFIRMATION_PATH);
 	});
 
-	it("returns confirmation path when hasCse is null", () => {
-		expect(getPostComplianceDestination(null)).toBe(
-			"/declaration-remuneration/parcours-conformite/confirmation",
-		);
+	// The /avis-cse layout redirects here once it establishes no opinion is due,
+	// so any destination under /avis-cse makes that layout redirect onto itself.
+	it("never sends a démarche that owes no opinion into the CSE funnel", () => {
+		const destination = getPostComplianceDestination(false);
+
+		expect(destination).not.toBe(CSE_OPINION_PATH);
+		expect(destination.startsWith(`${CSE_OPINION_PATH}/`)).toBe(false);
 	});
 });
 
@@ -90,11 +95,25 @@ describe("getCseOpinionPreviousHref", () => {
 });
 
 describe("getCurrentStageHref", () => {
-	// Per-status destinations live in fsmMirrors.conformance.test.ts (#3975);
-	// only the null status, outside DECLARATION_FSM_STATUSES, is owned here.
+	// Engine-stage-driven destinations live in fsmMirrors.conformance.test.ts
+	// (#3975). Owned here: the null status, outside DECLARATION_FSM_STATUSES, and
+	// the terminal status, whose destination branches on a caller-supplied flag
+	// the engine does not model.
 	it("falls back to the compliance path for a declaration without FSM projection (null status)", () => {
 		expect(getCurrentStageHref(null, true)).toBe(
 			"/declaration-remuneration/parcours-conformite",
+		);
+	});
+
+	it("keeps a completed démarche that still owes an opinion on the CSE funnel", () => {
+		expect(getCurrentStageHref("demarche_completed", true)).toBe(
+			CSE_OPINION_PATH,
+		);
+	});
+
+	it("sends a completed démarche that owes no opinion to the confirmation page", () => {
+		expect(getCurrentStageHref("demarche_completed", false)).toBe(
+			CONFIRMATION_PATH,
 		);
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
@@ -11,15 +11,12 @@ const SECOND_DECLARATION_RECAP_PATH = `${COMPLIANCE_PATH}/etape/3`;
 const CSE_OPINION_PATH = "/avis-cse";
 const CORRECTIVE_ACTIONS_FIRST_STEP_PATH = `${COMPLIANCE_PATH}/etape/1`;
 
-/**
- * Returns the destination URL after completing a compliance path step,
- * based on whether the company has a CSE (works council).
- *
- * - Has CSE → redirect to CSE opinion page
- * - No CSE or unknown → redirect to the compliance confirmation page
- */
-export function getPostComplianceDestination(hasCse: boolean | null): string {
-	return hasCse === true ? "/avis-cse" : COMPLIANCE_CONFIRMATION_PATH;
+// Takes the decision, not its inputs: on `hasCse` alone this sent a company
+// under 100 salariés into /avis-cse, whose layout bounced it straight back here.
+export function getPostComplianceDestination(
+	cseOpinionRequired: boolean,
+): string {
+	return cseOpinionRequired ? CSE_OPINION_PATH : COMPLIANCE_CONFIRMATION_PATH;
 }
 
 type CseOpinionPreviousContext = {
@@ -55,7 +52,7 @@ type CseOpinionPreviousContext = {
  */
 export function getCurrentStageHref(
 	status: DeclarationFsmStatus | null,
-	hasCse: boolean | null,
+	cseOpinionRequired: boolean,
 ): string {
 	if (status === null) {
 		return COMPLIANCE_PATH;
@@ -75,7 +72,7 @@ export function getCurrentStageHref(
 		case "awaiting_cse_opinion":
 			return CSE_OPINION_PATH;
 		case "demarche_completed":
-			return hasCse === true ? CSE_OPINION_PATH : COMPLIANCE_CONFIRMATION_PATH;
+			return getPostComplianceDestination(cseOpinionRequired);
 	}
 }
 

--- a/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import { DownloadDeclarationPdfButton } from "~/modules/declarationPdf";
-import { COMPANY_SIZE_ANNUAL_MIN } from "~/modules/domain";
+import {
+	COMPANY_SIZE_ANNUAL_MIN,
+	getObligationWorkforce,
+	isCseRequired,
+} from "~/modules/domain";
 import { DsfrPictogram } from "~/modules/layout";
 import { FeedbackBanner } from "~/modules/shared/FeedbackBanner";
 import { api } from "~/trpc/server";
@@ -11,11 +15,14 @@ export async function ComplianceConfirmation() {
 	const currentYear = data.declaration.year;
 	const company = await api.company.get({ siren: data.declaration.siren });
 
-	// A company with a CSE also lands here, whenever its workforce is sub-threshold.
-	const noOpinionReason =
-		company.hasCse === true
-			? `Votre effectif est inférieur à ${COMPANY_SIZE_ANNUAL_MIN} salariés.`
-			: "Votre entreprise ne dispose pas de CSE.";
+	// Branches on the workforce, not on hasCse: below the threshold no opinion is
+	// ever due whatever the company answered, so that reason takes precedence —
+	// and above it, the only way to land here is having no CSE.
+	const noOpinionReason = isCseRequired(
+		getObligationWorkforce(company.gipWorkforce),
+	)
+		? "Votre entreprise ne dispose pas de CSE."
+		: `Votre effectif est inférieur à ${COMPANY_SIZE_ANNUAL_MIN} salariés.`;
 
 	return (
 		<div className={common.flexColumnGap2}>

--- a/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { DownloadDeclarationPdfButton } from "~/modules/declarationPdf";
+import { COMPANY_SIZE_ANNUAL_MIN } from "~/modules/domain";
 import { DsfrPictogram } from "~/modules/layout";
 import { FeedbackBanner } from "~/modules/shared/FeedbackBanner";
 import { api } from "~/trpc/server";
@@ -8,6 +9,13 @@ import common from "../shared/common.module.scss";
 export async function ComplianceConfirmation() {
 	const data = await api.declaration.getOrCreate();
 	const currentYear = data.declaration.year;
+	const company = await api.company.get({ siren: data.declaration.siren });
+
+	// A company with a CSE also lands here, whenever its workforce is sub-threshold.
+	const noOpinionReason =
+		company.hasCse === true
+			? `Votre effectif est inférieur à ${COMPANY_SIZE_ANNUAL_MIN} salariés.`
+			: "Votre entreprise ne dispose pas de CSE.";
 
 	return (
 		<div className={common.flexColumnGap2}>
@@ -28,8 +36,7 @@ export async function ComplianceConfirmation() {
 			</p>
 
 			<p className="fr-mb-0">
-				Votre entreprise ne dispose pas de CSE. Aucun avis CSE n&apos;est
-				requis.
+				{noOpinionReason} Aucun avis CSE n&apos;est requis.
 			</p>
 
 			<DownloadDeclarationPdfButton year={currentYear} />

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -40,7 +40,6 @@ type Props = {
 	declarationYear: number;
 	cseOpinionRequired: boolean;
 	email: string;
-	hasCse: boolean | null;
 	initialPath?: CompliancePathValue;
 	isSecondRound?: boolean;
 	pdfDownloadHref?: string;
@@ -54,7 +53,6 @@ export function CompliancePathChoice({
 	declarationSiren,
 	declarationYear,
 	email,
-	hasCse,
 	initialPath,
 	isSecondRound = false,
 	pdfDownloadHref,
@@ -111,9 +109,9 @@ export function CompliancePathChoice({
 					"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
 				);
 			} else {
-				// "justify": with a CSE the opinion remains to be deposited on
-				// /avis-cse; without one the FSM already completed the démarche.
-				router.push(getPostComplianceDestination(hasCse));
+				// "justify": when an opinion is due it remains to be deposited on
+				// /avis-cse; otherwise the FSM already completed the démarche.
+				router.push(getPostComplianceDestination(cseOpinionRequired));
 			}
 		},
 	});
@@ -250,12 +248,14 @@ export function CompliancePathChoice({
 				<FormActions
 					isSubmitting={mutation.isPending}
 					mimoquageNextHref={
-						initialPath ? getCompliancePathHref(initialPath, hasCse) : undefined
+						initialPath
+							? getCompliancePathHref(initialPath, cseOpinionRequired)
+							: undefined
 					}
 					nextDisabled={!selectedPath || isReadOnly}
 					nextHref={
 						isReadOnly && initialPath
-							? getCompliancePathHref(initialPath, hasCse)
+							? getCompliancePathHref(initialPath, cseOpinionRequired)
 							: undefined
 					}
 					nextLabel="Suivant"

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -101,6 +101,11 @@ export async function CompliancePathPage() {
 
 	const hasChosenPath = data.declaration.firstDeclarationPathChoice !== null;
 
+	const cseOpinionRequired = isCseOpinionRequired({
+		workforce: getObligationWorkforce(company.gipWorkforce),
+		hasCse: company.hasCse,
+	});
+
 	// Skip the choice page only when the user has nothing to (re-)choose:
 	// no current gap and they never picked a path, or they finalised the
 	// procedure without one. When firstDeclarationPathChoice is set, render
@@ -111,7 +116,7 @@ export async function CompliancePathPage() {
 		(state.type === "no_gap" ||
 			isComplianceProcessCompleted(data.declaration.status))
 	) {
-		redirect(getPostComplianceDestination(company.hasCse));
+		redirect(getPostComplianceDestination(cseOpinionRequired));
 	}
 
 	const email = session?.user?.email ?? "";
@@ -135,15 +140,11 @@ export async function CompliancePathPage() {
 		<HydrateClient>
 			<CompliancePathChoice
 				campaignDeadlines={campaignDeadlines}
-				cseOpinionRequired={isCseOpinionRequired({
-					workforce: getObligationWorkforce(company.gipWorkforce),
-					hasCse: company.hasCse,
-				})}
+				cseOpinionRequired={cseOpinionRequired}
 				currentYear={currentYear}
 				declarationSiren={data.declaration.siren}
 				declarationYear={currentYear}
 				email={email}
-				hasCse={company.hasCse}
 				initialPath={pathChoice ?? undefined}
 				isSecondRound={isSecondRound}
 				pdfDownloadHref={

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -177,7 +177,7 @@ export function Step6Review({
 				<FormActions
 					nextHref={
 						isSubmitted
-							? getCurrentStageHref(declaration.status, hasCse)
+							? getCurrentStageHref(declaration.status, cseOpinionRequired)
 							: undefined
 					}
 					nextLabel="Suivant"

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
@@ -19,27 +19,41 @@ import { ComplianceConfirmation } from "../ComplianceConfirmation";
 const DECLARATION_YEAR = 2025;
 const SIREN = "123456789";
 
+const AT_THRESHOLD = COMPANY_SIZE_ANNUAL_MIN;
+const UNDER_THRESHOLD = COMPANY_SIZE_ANNUAL_MIN - 1;
+
 const NO_CSE_REASON = /Votre entreprise ne dispose pas de CSE/;
 const UNDER_THRESHOLD_REASON = new RegExp(
 	`Votre effectif est inférieur à ${COMPANY_SIZE_ANNUAL_MIN} salariés`,
 );
 const NO_OPINION_REQUIRED = /Aucun avis CSE n'est requis/;
 
-async function renderConfirmation(hasCse: boolean | null) {
+type CompanyShape = {
+	gipWorkforce: number | null;
+	hasCse: boolean | null;
+};
+
+// The reason is not what these tests are about; any landing company will do.
+const ANY_COMPANY: CompanyShape = {
+	gipWorkforce: UNDER_THRESHOLD,
+	hasCse: false,
+};
+
+async function renderConfirmation(company: CompanyShape) {
 	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
 		declaration: { year: DECLARATION_YEAR, siren: SIREN },
 		jobCategories: [],
 		employeeCategories: [],
 		gipPrefillData: null,
 	} as never);
-	vi.mocked(api.company.get).mockResolvedValue({ hasCse } as never);
+	vi.mocked(api.company.get).mockResolvedValue(company as never);
 
 	render(await ComplianceConfirmation());
 }
 
 describe("ComplianceConfirmation", () => {
 	it("renders the confirmation title", async () => {
-		await renderConfirmation(false);
+		await renderConfirmation(ANY_COMPANY);
 
 		expect(
 			screen.getByRole("heading", {
@@ -49,7 +63,7 @@ describe("ComplianceConfirmation", () => {
 	});
 
 	it("displays the completion message with declaration year", async () => {
-		await renderConfirmation(false);
+		await renderConfirmation(ANY_COMPANY);
 
 		expect(
 			screen.getByText(
@@ -61,14 +75,14 @@ describe("ComplianceConfirmation", () => {
 	});
 
 	it("has a link to mon espace", async () => {
-		await renderConfirmation(false);
+		await renderConfirmation(ANY_COMPANY);
 
 		const link = screen.getByRole("link", { name: "Mon espace" });
 		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
 	it("has a download PDF button with year", async () => {
-		await renderConfirmation(false);
+		await renderConfirmation(ANY_COMPANY);
 
 		const link = screen.getByRole("link", {
 			name: /Télécharger le récapitulatif/,
@@ -80,7 +94,7 @@ describe("ComplianceConfirmation", () => {
 	});
 
 	it("renders the feedback banner", async () => {
-		await renderConfirmation(false);
+		await renderConfirmation(ANY_COMPANY);
 
 		expect(
 			screen.getByText("Comment s'est passée votre démarche ?"),
@@ -91,28 +105,38 @@ describe("ComplianceConfirmation", () => {
 	});
 
 	describe("reason why no CSE opinion is required", () => {
-		it("looks the reason up on the declaration's own company", async () => {
-			await renderConfirmation(false);
+		it("looks the workforce up on the declaration's own company", async () => {
+			await renderConfirmation(ANY_COMPANY);
 
 			expect(api.company.get).toHaveBeenCalledWith({ siren: SIREN });
 		});
 
-		it("blames the workforce threshold when the company does have a CSE", async () => {
-			await renderConfirmation(true);
+		// Under the threshold no opinion is ever due, whatever the CSE answer — so
+		// the headcount is the operative reason and the CSE answer must not show
+		// through. hasCse:true is the case the redirect-loop fix makes reachable.
+		it.each([
+			true,
+			false,
+			null,
+		])("blames the workforce below the threshold whatever the CSE answer (hasCse: %s)", async (hasCse) => {
+			await renderConfirmation({ gipWorkforce: UNDER_THRESHOLD, hasCse });
 
 			expect(screen.getByText(UNDER_THRESHOLD_REASON)).toBeInTheDocument();
-		});
-
-		// A company with a CSE reaches this page whenever its workforce drops under
-		// the threshold, so claiming it has no CSE would state a plain falsehood.
-		it("never denies the CSE of a company that has one", async () => {
-			await renderConfirmation(true);
-
 			expect(screen.queryByText(NO_CSE_REASON)).not.toBeInTheDocument();
 		});
 
-		it("blames the missing CSE when the company has none", async () => {
-			await renderConfirmation(false);
+		it("blames the workforce for a company absent from the GIP file", async () => {
+			await renderConfirmation({ gipWorkforce: null, hasCse: true });
+
+			expect(screen.getByText(UNDER_THRESHOLD_REASON)).toBeInTheDocument();
+			expect(screen.queryByText(NO_CSE_REASON)).not.toBeInTheDocument();
+		});
+
+		it.each([
+			false,
+			null,
+		])("blames the missing CSE at or above the threshold (hasCse: %s)", async (hasCse) => {
+			await renderConfirmation({ gipWorkforce: AT_THRESHOLD, hasCse });
 
 			expect(screen.getByText(NO_CSE_REASON)).toBeInTheDocument();
 			expect(
@@ -120,18 +144,22 @@ describe("ComplianceConfirmation", () => {
 			).not.toBeInTheDocument();
 		});
 
-		it("falls back to the missing-CSE wording when the question is unanswered", async () => {
-			await renderConfirmation(null);
+		// Unreachable through routing: at this size with a CSE an opinion is due, so
+		// /avis-cse owns the démarche. Only the headcount claim is pinned — asserting
+		// the CSE-denial text would enshrine a statement that is false for it.
+		it("never claims a sub-threshold headcount for a large company with a CSE", async () => {
+			await renderConfirmation({ gipWorkforce: AT_THRESHOLD, hasCse: true });
 
-			expect(screen.getByText(NO_CSE_REASON)).toBeInTheDocument();
+			expect(
+				screen.queryByText(UNDER_THRESHOLD_REASON),
+			).not.toBeInTheDocument();
 		});
 
 		it.each([
-			true,
-			false,
-			null,
-		])("states that no opinion is required (hasCse: %s)", async (hasCse) => {
-			await renderConfirmation(hasCse);
+			{ gipWorkforce: UNDER_THRESHOLD, hasCse: true },
+			{ gipWorkforce: AT_THRESHOLD, hasCse: false },
+		])("states that no opinion is required (gipWorkforce: $gipWorkforce, hasCse: $hasCse)", async (company) => {
+			await renderConfirmation(company);
 
 			expect(screen.getByText(NO_OPINION_REQUIRED)).toBeInTheDocument();
 		});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
@@ -3,24 +3,43 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("~/trpc/server", () => ({
 	api: {
+		company: {
+			get: vi.fn(),
+		},
 		declaration: {
-			getOrCreate: vi.fn().mockResolvedValue({
-				declaration: { year: 2025 },
-				jobCategories: [],
-				employeeCategories: [],
-				gipPrefillData: null,
-			}),
+			getOrCreate: vi.fn(),
 		},
 	},
 }));
 
-const DECLARATION_YEAR = 2025;
-
+import { COMPANY_SIZE_ANNUAL_MIN } from "~/modules/domain";
+import { api } from "~/trpc/server";
 import { ComplianceConfirmation } from "../ComplianceConfirmation";
+
+const DECLARATION_YEAR = 2025;
+const SIREN = "123456789";
+
+const NO_CSE_REASON = /Votre entreprise ne dispose pas de CSE/;
+const UNDER_THRESHOLD_REASON = new RegExp(
+	`Votre effectif est inférieur à ${COMPANY_SIZE_ANNUAL_MIN} salariés`,
+);
+const NO_OPINION_REQUIRED = /Aucun avis CSE n'est requis/;
+
+async function renderConfirmation(hasCse: boolean | null) {
+	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
+		declaration: { year: DECLARATION_YEAR, siren: SIREN },
+		jobCategories: [],
+		employeeCategories: [],
+		gipPrefillData: null,
+	} as never);
+	vi.mocked(api.company.get).mockResolvedValue({ hasCse } as never);
+
+	render(await ComplianceConfirmation());
+}
 
 describe("ComplianceConfirmation", () => {
 	it("renders the confirmation title", async () => {
-		render(await ComplianceConfirmation());
+		await renderConfirmation(false);
 
 		expect(
 			screen.getByRole("heading", {
@@ -30,7 +49,7 @@ describe("ComplianceConfirmation", () => {
 	});
 
 	it("displays the completion message with declaration year", async () => {
-		render(await ComplianceConfirmation());
+		await renderConfirmation(false);
 
 		expect(
 			screen.getByText(
@@ -41,23 +60,15 @@ describe("ComplianceConfirmation", () => {
 		).toBeInTheDocument();
 	});
 
-	it("shows the no CSE message", async () => {
-		render(await ComplianceConfirmation());
-
-		expect(
-			screen.getByText(/Votre entreprise ne dispose pas de CSE/),
-		).toBeInTheDocument();
-	});
-
 	it("has a link to mon espace", async () => {
-		render(await ComplianceConfirmation());
+		await renderConfirmation(false);
 
 		const link = screen.getByRole("link", { name: "Mon espace" });
 		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
 	it("has a download PDF button with year", async () => {
-		render(await ComplianceConfirmation());
+		await renderConfirmation(false);
 
 		const link = screen.getByRole("link", {
 			name: /Télécharger le récapitulatif/,
@@ -69,7 +80,7 @@ describe("ComplianceConfirmation", () => {
 	});
 
 	it("renders the feedback banner", async () => {
-		render(await ComplianceConfirmation());
+		await renderConfirmation(false);
 
 		expect(
 			screen.getByText("Comment s'est passée votre démarche ?"),
@@ -77,5 +88,52 @@ describe("ComplianceConfirmation", () => {
 		expect(
 			screen.getByRole("link", { name: /Je donne mon avis/ }),
 		).toBeInTheDocument();
+	});
+
+	describe("reason why no CSE opinion is required", () => {
+		it("looks the reason up on the declaration's own company", async () => {
+			await renderConfirmation(false);
+
+			expect(api.company.get).toHaveBeenCalledWith({ siren: SIREN });
+		});
+
+		it("blames the workforce threshold when the company does have a CSE", async () => {
+			await renderConfirmation(true);
+
+			expect(screen.getByText(UNDER_THRESHOLD_REASON)).toBeInTheDocument();
+		});
+
+		// A company with a CSE reaches this page whenever its workforce drops under
+		// the threshold, so claiming it has no CSE would state a plain falsehood.
+		it("never denies the CSE of a company that has one", async () => {
+			await renderConfirmation(true);
+
+			expect(screen.queryByText(NO_CSE_REASON)).not.toBeInTheDocument();
+		});
+
+		it("blames the missing CSE when the company has none", async () => {
+			await renderConfirmation(false);
+
+			expect(screen.getByText(NO_CSE_REASON)).toBeInTheDocument();
+			expect(
+				screen.queryByText(UNDER_THRESHOLD_REASON),
+			).not.toBeInTheDocument();
+		});
+
+		it("falls back to the missing-CSE wording when the question is unanswered", async () => {
+			await renderConfirmation(null);
+
+			expect(screen.getByText(NO_CSE_REASON)).toBeInTheDocument();
+		});
+
+		it.each([
+			true,
+			false,
+			null,
+		])("states that no opinion is required (hasCse: %s)", async (hasCse) => {
+			await renderConfirmation(hasCse);
+
+			expect(screen.getByText(NO_OPINION_REQUIRED)).toBeInTheDocument();
+		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -80,7 +80,6 @@ function compliancePathChoice(
 			declarationSiren={DECLARATION_SIREN}
 			declarationYear={DECLARATION_YEAR}
 			email="test@example.fr"
-			hasCse={true}
 			{...overrides}
 		/>
 	);
@@ -212,8 +211,8 @@ describe("CompliancePathChoice", () => {
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
 	});
 
-	it("submits justify and navigates to the confirmation page without a CSE", async () => {
-		render(compliancePathChoice({ cseOpinionRequired: false, hasCse: false }));
+	it("submits justify and navigates to the confirmation page when no CSE opinion is due", async () => {
+		render(compliancePathChoice({ cseOpinionRequired: false }));
 		const radio = screen.getByLabelText(
 			"Justifier les écarts de rémunération ≥ 5 %",
 		);
@@ -342,7 +341,6 @@ describe("CompliancePathChoice", () => {
 			render(
 				compliancePathChoice({
 					cseOpinionRequired: false,
-					hasCse: false,
 					isSecondRound,
 				}),
 			);
@@ -369,9 +367,7 @@ describe("CompliancePathChoice", () => {
 		});
 
 		it("hides the corrective-action CSE consultation items when no CSE opinion is required", () => {
-			render(
-				compliancePathChoice({ cseOpinionRequired: false, hasCse: false }),
-			);
+			render(compliancePathChoice({ cseOpinionRequired: false }));
 
 			expect(
 				screen.queryByText(/Informer et consulter votre CSE sur l'exactitude/),
@@ -382,9 +378,7 @@ describe("CompliancePathChoice", () => {
 		});
 
 		it("keeps the non-CSE corrective-action items when no CSE opinion is required", () => {
-			render(
-				compliancePathChoice({ cseOpinionRequired: false, hasCse: false }),
-			);
+			render(compliancePathChoice({ cseOpinionRequired: false }));
 
 			expect(
 				screen.getByText(

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.redirect.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.redirect.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedirect, mockAuth } = vi.hoisted(() => ({
+	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
+		throw new Error("NEXT_REDIRECT");
+	}),
+	mockAuth: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+	redirect: mockRedirect,
+}));
+
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+
+vi.mock("~/server/db/getCampaignDeadlines", async () => {
+	const { getDefaultCampaignDeadlines } = await import("~/modules/domain");
+	return {
+		getCampaignDeadlines: vi
+			.fn()
+			.mockResolvedValue(getDefaultCampaignDeadlines(2026)),
+	};
+});
+
+vi.mock("~/trpc/server", () => ({
+	HydrateClient: ({ children }: { children: React.ReactNode }) => children,
+	api: {
+		company: { get: vi.fn() },
+		declaration: { getOrCreate: vi.fn() },
+	},
+}));
+
+vi.mock("../CompliancePathChoice", () => ({
+	CompliancePathChoice: vi.fn(() => <div data-testid="path-choice" />),
+}));
+
+import { COMPANY_SIZE_ANNUAL_MIN } from "~/modules/domain";
+import { api } from "~/trpc/server";
+import { CompliancePathChoice } from "../CompliancePathChoice";
+import { CompliancePathPage } from "../CompliancePathPage";
+
+const SIREN = "123456789";
+const CSE_OPINION_PATH = "/avis-cse";
+const CONFIRMATION_PATH =
+	"/declaration-remuneration/parcours-conformite/confirmation";
+
+const HIGH_GAP_CATEGORY = {
+	declarationType: "initial",
+	annualBaseWomen: "25000",
+	annualBaseMen: "35000",
+};
+
+function mockPage({
+	gipWorkforce,
+	hasCse,
+	status = "awaiting_compliance_path_choice",
+	employeeCategories = [],
+	firstDeclarationPathChoice = null,
+}: {
+	gipWorkforce: number | null;
+	hasCse: boolean | null;
+	status?: string;
+	employeeCategories?: Array<Record<string, unknown>>;
+	firstDeclarationPathChoice?: string | null;
+}) {
+	mockAuth.mockResolvedValue({ user: { email: "user@example.fr" } });
+	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
+		declaration: {
+			siren: SIREN,
+			year: 2026,
+			status,
+			firstDeclarationPathChoice,
+			secondDeclarationPathChoice: null,
+		},
+		employeeCategories,
+		hasSubmittedSecondDeclaration: false,
+		hasSubmittedCseOpinion: false,
+		hasSubmittedJointEvaluation: false,
+	} as never);
+	vi.mocked(api.company.get).mockResolvedValue({
+		gipWorkforce,
+		hasCse,
+	} as never);
+}
+
+describe("CompliancePathPage — skipping the choice page", () => {
+	beforeEach(() => {
+		mockRedirect.mockClear();
+		mockAuth.mockReset();
+		vi.mocked(CompliancePathChoice).mockClear();
+	});
+
+	it("sends a still-draft declaration back to the last declaration step", async () => {
+		mockPage({ gipWorkforce: 250, hasCse: true, status: "draft" });
+
+		await expect(CompliancePathPage()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(
+			"/declaration-remuneration/etape/6",
+		);
+	});
+
+	it("skips to the CSE funnel when nothing is left to choose and an opinion is due", async () => {
+		mockPage({ gipWorkforce: COMPANY_SIZE_ANNUAL_MIN, hasCse: true });
+
+		await expect(CompliancePathPage()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(CSE_OPINION_PATH);
+	});
+
+	// Same latent loop as the /avis-cse layout: this page also skips straight to
+	// the CSE funnel, whose own layout bounces a sub-threshold company back here.
+	it("skips to the confirmation page for a company with a CSE under the threshold", async () => {
+		mockPage({ gipWorkforce: COMPANY_SIZE_ANNUAL_MIN - 25, hasCse: true });
+
+		await expect(CompliancePathPage()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(CONFIRMATION_PATH);
+		expect(mockRedirect).not.toHaveBeenCalledWith(CSE_OPINION_PATH);
+	});
+
+	it.each([
+		false,
+		null,
+	])("skips to the confirmation page when the company owes no opinion (hasCse: %s)", async (hasCse) => {
+		mockPage({ gipWorkforce: 250, hasCse });
+
+		await expect(CompliancePathPage()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(CONFIRMATION_PATH);
+	});
+
+	it("renders the choice page and forwards the CSE decision when a gap remains", async () => {
+		mockPage({
+			gipWorkforce: 250,
+			hasCse: true,
+			employeeCategories: [HIGH_GAP_CATEGORY],
+		});
+
+		render(await CompliancePathPage());
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(screen.getByTestId("path-choice")).toBeInTheDocument();
+		expect(vi.mocked(CompliancePathChoice).mock.calls[0]?.[0]).toMatchObject({
+			cseOpinionRequired: true,
+		});
+	});
+
+	it("keeps the choice page reviewable once a path has been picked", async () => {
+		mockPage({
+			gipWorkforce: 250,
+			hasCse: true,
+			status: "demarche_completed",
+			firstDeclarationPathChoice: "justify",
+		});
+
+		render(await CompliancePathPage());
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(screen.getByTestId("path-choice")).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -196,7 +196,6 @@ describe("DraftLoadingGate", () => {
 				declarationSiren="123456789"
 				declarationYear={2026}
 				email="user@example.com"
-				hasCse={true}
 			/>,
 		);
 		expectLoadingState();
@@ -231,10 +230,10 @@ describe("DraftLoadingGate", () => {
 		mockLoadingDraft();
 		const { container } = render(
 			<JointEvaluationForm
+				cseOpinionRequired={false}
 				declarationDate="01/01/2026"
 				declarationSiren="123456789"
 				declarationYear={2026}
-				hasCse={null}
 				jointEvaluationDeadline={new Date("2026-05-01")}
 			/>,
 		);

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/CompliancePathOptions.tsx
@@ -4,7 +4,7 @@ import type { CompliancePathValue } from "./constants";
 
 export function getCompliancePathHref(
 	path: CompliancePathValue,
-	hasCse: boolean | null,
+	cseOpinionRequired: boolean,
 ): string {
 	if (path === "corrective_action") {
 		return "/declaration-remuneration/parcours-conformite/etape/1";
@@ -12,10 +12,10 @@ export function getCompliancePathHref(
 	if (path === "joint_evaluation") {
 		return "/declaration-remuneration/parcours-conformite/evaluation-conjointe";
 	}
-	// "justify" has no dedicated page: with a CSE the opinion remains to be
-	// deposited on /avis-cse; without one the FSM already completed the
+	// "justify" has no dedicated page: when an opinion is due it remains to be
+	// deposited on /avis-cse; otherwise the FSM already completed the
 	// démarche (choose_path_*_justify_without_cse) → confirmation page.
-	return getPostComplianceDestination(hasCse);
+	return getPostComplianceDestination(cseOpinionRequired);
 }
 
 export function JointEvaluationOption({

--- a/packages/app/src/modules/declaration-remuneration/steps/compliancePath/__tests__/CompliancePathOptions.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/compliancePath/__tests__/CompliancePathOptions.test.tsx
@@ -33,9 +33,8 @@ describe("getCompliancePathHref", () => {
 	it.each([
 		true,
 		false,
-		null,
-	])("routes corrective_action to the second declaration funnel (hasCse: %s)", (hasCse) => {
-		expect(getCompliancePathHref("corrective_action", hasCse)).toBe(
+	])("routes corrective_action to the second declaration funnel (cseOpinionRequired: %s)", (cseOpinionRequired) => {
+		expect(getCompliancePathHref("corrective_action", cseOpinionRequired)).toBe(
 			"/declaration-remuneration/parcours-conformite/etape/1",
 		);
 	});
@@ -43,22 +42,18 @@ describe("getCompliancePathHref", () => {
 	it.each([
 		true,
 		false,
-		null,
-	])("routes joint_evaluation to the joint evaluation form (hasCse: %s)", (hasCse) => {
-		expect(getCompliancePathHref("joint_evaluation", hasCse)).toBe(
+	])("routes joint_evaluation to the joint evaluation form (cseOpinionRequired: %s)", (cseOpinionRequired) => {
+		expect(getCompliancePathHref("joint_evaluation", cseOpinionRequired)).toBe(
 			"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
 		);
 	});
 
-	it("routes justify to the CSE opinion page when the company has a CSE", () => {
+	it("routes justify to the CSE opinion page when an opinion is due", () => {
 		expect(getCompliancePathHref("justify", true)).toBe("/avis-cse");
 	});
 
-	it.each([
-		false,
-		null,
-	])("routes justify to the confirmation page without a CSE (hasCse: %s)", (hasCse) => {
-		expect(getCompliancePathHref("justify", hasCse)).toBe(
+	it("routes justify to the confirmation page when no opinion is due", () => {
+		expect(getCompliancePathHref("justify", false)).toBe(
 			"/declaration-remuneration/parcours-conformite/confirmation",
 		);
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -20,18 +20,18 @@ import { JointEvaluationSubmitModal } from "./JointEvaluationSubmitModal";
 const EMPTY_DB_VALUES = {} as Record<string, never>;
 
 type Props = {
+	cseOpinionRequired: boolean;
 	declarationDate: string;
 	declarationSiren: string;
 	declarationYear: number;
-	hasCse: boolean | null;
 	jointEvaluationDeadline: Date;
 };
 
 export function JointEvaluationForm({
+	cseOpinionRequired,
 	declarationDate,
 	declarationSiren,
 	declarationYear,
-	hasCse,
 	jointEvaluationDeadline,
 }: Props) {
 	const router = useRouter();
@@ -58,10 +58,10 @@ export function JointEvaluationForm({
 		// recorded and the "Mon espace" panel + table reflect the new step.
 		submitJointEvaluationMutation.mutate(undefined, {
 			onSettled: () => {
-				router.push(getPostComplianceDestination(hasCse));
+				router.push(getPostComplianceDestination(cseOpinionRequired));
 			},
 		});
-	}, [clearDraft, hasCse, router, submitJointEvaluationMutation]);
+	}, [clearDraft, cseOpinionRequired, router, submitJointEvaluationMutation]);
 
 	const {
 		closeModal,

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationPage.tsx
@@ -1,6 +1,10 @@
 import { redirect } from "next/navigation";
 
-import { formatLongDate } from "~/modules/domain";
+import {
+	formatLongDate,
+	getObligationWorkforce,
+	isCseOpinionRequired,
+} from "~/modules/domain";
 import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { api } from "~/trpc/server";
 
@@ -29,10 +33,13 @@ export async function JointEvaluationPage() {
 
 	return (
 		<JointEvaluationForm
+			cseOpinionRequired={isCseOpinionRequired({
+				workforce: getObligationWorkforce(company.gipWorkforce),
+				hasCse: company.hasCse,
+			})}
 			declarationDate={declarationDate}
 			declarationSiren={data.declaration.siren}
 			declarationYear={currentYear}
-			hasCse={company.hasCse}
 			jointEvaluationDeadline={campaignDeadlines.decl1JointEvaluationDeadline}
 		/>
 	);

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -46,10 +46,10 @@ const { uploadFile: uploadFileMock } = (await import(
 )) as unknown as { uploadFile: ReturnType<typeof vi.fn> };
 
 const defaultProps = {
+	cseOpinionRequired: false,
 	declarationDate: "01/06/2026",
 	declarationSiren: "123456789",
 	declarationYear: 2026,
-	hasCse: null as boolean | null,
 	jointEvaluationDeadline: new Date("2026-08-01T00:00:00"),
 };
 
@@ -170,8 +170,7 @@ describe("JointEvaluationForm", () => {
 	it.each([
 		[true, "/avis-cse"],
 		[false, "/declaration-remuneration/parcours-conformite/confirmation"],
-		[null, "/declaration-remuneration/parcours-conformite/confirmation"],
-	])("uploads the file and redirects after confirmation when hasCse=%s", async (hasCse, expectedRedirect) => {
+	])("uploads the file and redirects after confirmation when cseOpinionRequired=%s", async (cseOpinionRequired, expectedRedirect) => {
 		const user = userEvent.setup();
 		uploadFileMock.mockResolvedValue({
 			ok: true,
@@ -180,7 +179,10 @@ describe("JointEvaluationForm", () => {
 		});
 
 		const { container } = render(
-			<JointEvaluationForm {...defaultProps} hasCse={hasCse} />,
+			<JointEvaluationForm
+				{...defaultProps}
+				cseOpinionRequired={cseOpinionRequired}
+			/>,
 		);
 
 		const input = container.querySelector(

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -23,7 +23,6 @@ type Props = {
 	cseApplicable: boolean;
 	cseOpinionRequired: boolean;
 	declarationYear: number;
-	hasCse: boolean | null;
 	secondDeclarationCategories: EmployeeCategoryRow[];
 	siren: string;
 };
@@ -32,7 +31,6 @@ export function SecondDeclarationStep3Review({
 	cseApplicable,
 	cseOpinionRequired,
 	declarationYear,
-	hasCse,
 	secondDeclarationCategories,
 	siren,
 }: Props) {
@@ -54,7 +52,7 @@ export function SecondDeclarationStep3Review({
 			if (gapsExist) {
 				router.push(BASE_PATH);
 			} else {
-				router.push(getPostComplianceDestination(hasCse));
+				router.push(getPostComplianceDestination(cseOpinionRequired));
 			}
 		},
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -142,7 +142,6 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 						hasCse: company.hasCse,
 					})}
 					declarationYear={currentYear}
-					hasCse={company.hasCse}
 					secondDeclarationCategories={reviewCategories}
 					siren={data.declaration.siren}
 				/>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -96,8 +96,6 @@ const noGapCategories: EmployeeCategoryRow[] = [
 	}),
 ];
 
-// Defaults mirror `isCseOpinionRequired(workforce, null)` → false: an unknown
-// CSE flag requires no opinion, exactly like an explicit `false`.
 function renderStep3(
 	overrides: Partial<ComponentProps<typeof SecondDeclarationStep3Review>> = {},
 ) {
@@ -106,7 +104,6 @@ function renderStep3(
 			cseApplicable
 			cseOpinionRequired={false}
 			declarationYear={2025}
-			hasCse={null}
 			secondDeclarationCategories={mockCategories}
 			siren="532847196"
 			{...overrides}
@@ -266,7 +263,6 @@ describe("SecondDeclarationStep3Review", () => {
 	it("navigates to compliance path when gaps persist after submit", async () => {
 		renderStep3({
 			cseOpinionRequired: true,
-			hasCse: true,
 			secondDeclarationCategories: [
 				makeCategory({ annualBaseWomen: "1000", annualBaseMen: "2000" }),
 			],
@@ -280,10 +276,9 @@ describe("SecondDeclarationStep3Review", () => {
 		);
 	});
 
-	it("navigates to avis-cse when no gaps and hasCse is true", async () => {
+	it("navigates to avis-cse when no gaps remain and a CSE opinion is due", async () => {
 		renderStep3({
 			cseOpinionRequired: true,
-			hasCse: true,
 			secondDeclarationCategories: noGapCategories,
 		});
 
@@ -293,9 +288,9 @@ describe("SecondDeclarationStep3Review", () => {
 		expect(mockPush).toHaveBeenCalledWith("/avis-cse");
 	});
 
-	it("navigates to confirmation when no gaps and no CSE", async () => {
+	it("navigates to confirmation when no gaps remain and no CSE opinion is due", async () => {
 		renderStep3({
-			hasCse: false,
+			cseOpinionRequired: false,
 			secondDeclarationCategories: noGapCategories,
 		});
 
@@ -316,7 +311,6 @@ describe("SecondDeclarationStep3Review", () => {
 		it("hides the CSE consultation section but keeps gap actions and the CSE update button when cseOpinionRequired is false", () => {
 			renderStep3({
 				cseOpinionRequired: false,
-				hasCse: false,
 				secondDeclarationCategories: highGapCategories,
 			});
 
@@ -341,22 +335,9 @@ describe("SecondDeclarationStep3Review", () => {
 			).toBeInTheDocument();
 		});
 
-		it("hides the CSE consultation section when the CSE flag is unknown", () => {
-			renderStep3({
-				cseOpinionRequired: false,
-				hasCse: null,
-				secondDeclarationCategories: highGapCategories,
-			});
-
-			expect(
-				screen.queryByRole("heading", { name: "Informer et consulter le CSE" }),
-			).not.toBeInTheDocument();
-		});
-
 		it("shows the CSE consultation section when cseOpinionRequired is true", () => {
 			renderStep3({
 				cseOpinionRequired: true,
-				hasCse: true,
 				secondDeclarationCategories: highGapCategories,
 			});
 

--- a/packages/app/src/modules/domain/__tests__/companyObligation.test.ts
+++ b/packages/app/src/modules/domain/__tests__/companyObligation.test.ts
@@ -8,7 +8,7 @@ describe("isObligatedForYear", () => {
 			expect(isObligatedForYear(10, 2026)).toBe(false);
 		});
 
-		it("returns false for 49 employees in 2027 (triennial)", () => {
+		it("returns false for 49 employees in 2027", () => {
 			expect(isObligatedForYear(49, 2027)).toBe(false);
 		});
 
@@ -18,26 +18,27 @@ describe("isObligatedForYear", () => {
 		});
 	});
 
-	describe("triennial tier (50 ≤ workforce < 100)", () => {
-		it("returns true on the triennial base year 2027", () => {
-			expect(isObligatedForYear(50, 2027)).toBe(true);
-			expect(isObligatedForYear(75, 2027)).toBe(true);
-			expect(isObligatedForYear(99, 2027)).toBe(true);
+	describe("mandatory tier (50 ≤ workforce < 100)", () => {
+		it("is subject every year from V2_FIRST_CAMPAIGN_YEAR (2027 → 2033)", () => {
+			for (let year = 2027; year <= 2033; year++) {
+				expect(isObligatedForYear(50, year)).toBe(true);
+				expect(isObligatedForYear(75, year)).toBe(true);
+				expect(isObligatedForYear(99, year)).toBe(true);
+			}
 		});
 
-		it("returns true on triennial-aligned years (2030, 2033)", () => {
-			expect(isObligatedForYear(60, 2030)).toBe(true);
-			expect(isObligatedForYear(60, 2033)).toBe(true);
+		it("is subject on the years that used to be off-cycle (2028, 2029)", () => {
+			expect(isObligatedForYear(60, 2028)).toBe(true);
+			expect(isObligatedForYear(60, 2029)).toBe(true);
 		});
 
-		it("returns false on off-cycle years (2026, 2028, 2029)", () => {
+		it("is not subject before the V2 scheme (2026, pinned 2018)", () => {
 			expect(isObligatedForYear(60, 2026)).toBe(false);
-			expect(isObligatedForYear(60, 2028)).toBe(false);
-			expect(isObligatedForYear(60, 2029)).toBe(false);
+			expect(isObligatedForYear(60, 2018)).toBe(false);
 		});
 	});
 
-	describe("annual tier (workforce ≥ 100)", () => {
+	describe("mandatory-with-compliance tier (workforce ≥ 100)", () => {
 		it("returns true regardless of the triennial cycle", () => {
 			expect(isObligatedForYear(100, 2026)).toBe(true);
 			expect(isObligatedForYear(100, 2027)).toBe(true);

--- a/packages/app/src/modules/domain/__tests__/companySize.test.ts
+++ b/packages/app/src/modules/domain/__tests__/companySize.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	COMPANY_SIZE_RANGES,
+	classifyCompanySize,
 	getCompanySizeRange,
 	isCseRequired,
 } from "../shared/companySize";
@@ -14,12 +15,26 @@ describe("regulatory size constants", () => {
 	// Boundary behavior lives symbolically in demarcheDecisionTable.test.ts
 	// (#3975); the literal values are pinned here (COMPANY_SIZE_RANGES below
 	// carries its own literals, independent of these constants).
-	it("pins the voluntary/triennial boundary at 50", () => {
+	it("pins the voluntary/mandatory boundary at 50", () => {
 		expect(COMPANY_SIZE_VOLUNTARY_MAX).toBe(50);
 	});
 
-	it("pins the annual-declaration + CSE boundary at 100", () => {
+	it("pins the compliance-obligation + CSE boundary at 100", () => {
 		expect(COMPANY_SIZE_ANNUAL_MIN).toBe(100);
+	});
+});
+
+describe("classifyCompanySize", () => {
+	it("classifies each obligation package by its workforce band", () => {
+		expect(classifyCompanySize(COMPANY_SIZE_VOLUNTARY_MAX - 1)).toBe(
+			"voluntary",
+		);
+		expect(classifyCompanySize(COMPANY_SIZE_VOLUNTARY_MAX)).toBe("mandatory");
+		expect(classifyCompanySize(COMPANY_SIZE_ANNUAL_MIN - 1)).toBe("mandatory");
+		expect(classifyCompanySize(COMPANY_SIZE_ANNUAL_MIN)).toBe(
+			"mandatory_with_compliance",
+		);
+		expect(classifyCompanySize(300)).toBe("mandatory_with_compliance");
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
@@ -51,6 +51,23 @@ describe("isComplianceProcessRequired", () => {
 			}),
 		).toBe(true);
 	});
+
+	// Rule 3 lock (#4043): a company under 100 employees owes no gap-alert
+	// obligation even with a computed indicator G carrying a significant gap. The
+	// < 50 and 50-99 bands now file 7 / 6 indicators, but the compliance package
+	// still gates at COMPANY_SIZE_ANNUAL_MIN — unchanged behavior, pinned so the
+	// arbitrage does not silently pull it below 100.
+	it("stays false under 100 employees even with a computed indicator G carrying a significant gap (rule 3)", () => {
+		for (const workforce of [30, 75]) {
+			expect(
+				isComplianceProcessRequired({
+					workforce,
+					hasIndicatorG: true,
+					hasSignificantIndicatorGGap: true,
+				}),
+			).toBe(false);
+		}
+	});
 });
 
 describe("isCseOpinionRequired", () => {
@@ -74,6 +91,12 @@ describe("isCseOpinionRequired", () => {
 				hasCse: true,
 			}),
 		).toBe(false);
+	});
+
+	it("owes no opinion for a 50-99 company with a CSE (rule 3, #4043)", () => {
+		// The 50-99 band is mandatory yearly since the arbitrage, but the CSE
+		// opinion is a compliance-package obligation that still starts at 100.
+		expect(isCseOpinionRequired({ workforce: 75, hasCse: true })).toBe(false);
 	});
 
 	it("is true at the exact threshold", () => {

--- a/packages/app/src/modules/domain/__tests__/demarcheDecisionTable.test.ts
+++ b/packages/app/src/modules/domain/__tests__/demarcheDecisionTable.test.ts
@@ -133,9 +133,11 @@ describe("decision table — workforce × gap × regime", () => {
 		const cseBySize = workforce >= COMPANY_SIZE_ANNUAL_MIN;
 		expect(isCseRequired(workforce)).toBe(cseBySize);
 
-		// Indicator G applies in the annual regime from 250 every year, and in the
+		// Indicator G applies to the voluntary tier (< 50, 7-indicator volunteering,
+		// #4043) every year, in the annual regime from 250 every year, and in the
 		// triennial band 150-249 only during a triennial year.
 		const expectedIndicatorG =
+			workforce < COMPANY_SIZE_VOLUNTARY_MAX ||
 			workforce >= INDICATOR_G_ANNUAL_MIN ||
 			(workforce >= INDICATOR_G_TRIENNIAL_MIN && regime.isTriennial);
 		const hasIndicatorG = isIndicatorGRequired(workforce, regime.year);
@@ -174,13 +176,15 @@ describe("size boundaries (named domain constants)", () => {
 		expect(isCseRequired(COMPANY_SIZE_ANNUAL_MIN + 1)).toBe(true);
 	});
 
-	it("classifyCompanySize: voluntary / triennial / annual boundaries", () => {
+	it("classifyCompanySize: voluntary / mandatory / mandatory_with_compliance boundaries", () => {
 		expect(classifyCompanySize(COMPANY_SIZE_VOLUNTARY_MAX - 1)).toBe(
 			"voluntary",
 		);
-		expect(classifyCompanySize(COMPANY_SIZE_VOLUNTARY_MAX)).toBe("triennial");
-		expect(classifyCompanySize(COMPANY_SIZE_ANNUAL_MIN - 1)).toBe("triennial");
-		expect(classifyCompanySize(COMPANY_SIZE_ANNUAL_MIN)).toBe("annual");
+		expect(classifyCompanySize(COMPANY_SIZE_VOLUNTARY_MAX)).toBe("mandatory");
+		expect(classifyCompanySize(COMPANY_SIZE_ANNUAL_MIN - 1)).toBe("mandatory");
+		expect(classifyCompanySize(COMPANY_SIZE_ANNUAL_MIN)).toBe(
+			"mandatory_with_compliance",
+		);
 	});
 
 	it("isIndicatorGRequired: annual regime flips at INDICATOR_G_ANNUAL_MIN (250)", () => {
@@ -228,10 +232,10 @@ describe("size boundaries (named domain constants)", () => {
 		expect(isTriennialYear(INDICATOR_G_TRIENNIAL_BASE_YEAR + 3)).toBe(true);
 	});
 
-	it("#3934 (CLOSED) — a workforce < 100 never triggers the 7th indicator", () => {
-		// Regression guard: 97 and 70 are below both COMPANY_SIZE_ANNUAL_MIN and
-		// INDICATOR_G_TRIENNIAL_MIN, so indicator G must never be required, even in
-		// a triennial year.
+	it("#3934 (CLOSED) — the 50-99 band does not trigger the 7th indicator before the 2030 down-extension", () => {
+		// Regression guard: 97 and 70 are in the mandatory 50-99 band, below
+		// INDICATOR_G_TRIENNIAL_MIN, so indicator G stays excluded in a pre-2030
+		// triennial year (the < 50 volunteering branch does not reach up here).
 		expect(isIndicatorGRequired(97, INDICATOR_G_TRIENNIAL_BASE_YEAR)).toBe(
 			false,
 		);
@@ -242,13 +246,12 @@ describe("size boundaries (named domain constants)", () => {
 });
 
 describe("GIP workforce — single source for the obligations (#3929/#3962)", () => {
-	it("company absent from the GIP file (null) → no obligation", () => {
+	it("company absent from the GIP file (null) → no legal obligation but a 7-indicator voluntary declaration", () => {
 		const workforce = getObligationWorkforce(null);
 		expect(workforce).toBe(0);
+		// Obligation predicates stay false: a company with no GIP workforce owes
+		// nothing (no CSE, no compliance process).
 		expect(isCseRequired(workforce)).toBe(false);
-		expect(
-			isIndicatorGRequired(workforce, INDICATOR_G_TRIENNIAL_BASE_YEAR),
-		).toBe(false);
 		expect(
 			isComplianceProcessRequired({
 				workforce,
@@ -256,6 +259,11 @@ describe("GIP workforce — single source for the obligations (#3929/#3962)", ()
 				hasSignificantIndicatorGGap: true,
 			}),
 		).toBe(false);
+		// But indicator G is still part of the funnel: a workforce-0 declarant is in
+		// the voluntary (< 50) tier, which carries all 7 indicators (#4043).
+		expect(
+			isIndicatorGRequired(workforce, INDICATOR_G_TRIENNIAL_BASE_YEAR),
+		).toBe(true);
 	});
 
 	it("decimal GIP workforce: thresholds compare the exact value, never the display rounding", () => {

--- a/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
+++ b/packages/app/src/modules/domain/__tests__/indicatorG.test.ts
@@ -50,9 +50,16 @@ describe("isIndicatorGRequired — universal year (2030+) regime", () => {
 		expect(isIndicatorGRequired(249, 2032)).toBe(false);
 	});
 
-	it("keeps the voluntary tier (< 50) out of the obligation even from 2030", () => {
-		expect(isIndicatorGRequired(49, 2030)).toBe(false);
-		expect(isIndicatorGRequired(0, 2033)).toBe(false);
+	it("requires the voluntary tier (< 50) every year — 7-indicator volunteering (2026-07 arbitrage)", () => {
+		for (let year = 2027; year <= 2033; year++) {
+			expect(isIndicatorGRequired(0, year)).toBe(true);
+			expect(isIndicatorGRequired(49, year)).toBe(true);
+		}
+		// Pinned: the < 50 tier carries all 7 indicators with no year cadence, like
+		// the >= 250 branch. The V2 scheme starts fresh in March 2027 with no
+		// pre-2027 declarations, so these pre-campaign pins may never be "corrected".
+		expect(isIndicatorGRequired(0, 2018)).toBe(true);
+		expect(isIndicatorGRequired(49, 2026)).toBe(true);
 	});
 
 	it("returns true for workforce >= 250 at universal year (2030)", () => {

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -39,6 +39,7 @@ export {
 	QUARTILE_COUNT,
 	QUARTILE_MIN_INCREMENT,
 	QUARTILE_THRESHOLD_COUNT,
+	V2_FIRST_CAMPAIGN_YEAR,
 } from "./shared/constants";
 // Declaration display context
 export type {

--- a/packages/app/src/modules/domain/shared/companyObligation.ts
+++ b/packages/app/src/modules/domain/shared/companyObligation.ts
@@ -1,11 +1,13 @@
 import {
 	COMPANY_SIZE_ANNUAL_MIN,
 	COMPANY_SIZE_VOLUNTARY_MAX,
+	V2_FIRST_CAMPAIGN_YEAR,
 } from "./constants";
-import { isTriennialYear } from "./indicatorG";
 
 export function isObligatedForYear(workforce: number, year: number): boolean {
 	if (workforce < COMPANY_SIZE_VOLUNTARY_MAX) return false;
-	if (workforce < COMPANY_SIZE_ANNUAL_MIN) return isTriennialYear(year);
+	// 50-99: annual obligation since the V2 scheme (2026-07 arbitrage). Pre-V2 years keep the historical behavior.
+	if (workforce < COMPANY_SIZE_ANNUAL_MIN)
+		return year >= V2_FIRST_CAMPAIGN_YEAR;
 	return true;
 }

--- a/packages/app/src/modules/domain/shared/companySize.ts
+++ b/packages/app/src/modules/domain/shared/companySize.ts
@@ -4,11 +4,16 @@ import {
 	COMPANY_SIZE_VOLUNTARY_MAX,
 } from "./constants";
 
-/** Classify a company by workforce size into its declaration obligation tier. */
+/**
+ * Classify a company by workforce size into its obligation package.
+ * `voluntary` (< 50): voluntary declaration; `mandatory` (50-99): annual declaration
+ * without gap-alert obligations; `mandatory_with_compliance` (>= 100): annual
+ * declaration + CSE opinion + gap-alert (>= 5%) obligations.
+ */
 export function classifyCompanySize(workforce: number): CompanySize {
 	if (workforce < COMPANY_SIZE_VOLUNTARY_MAX) return "voluntary";
-	if (workforce < COMPANY_SIZE_ANNUAL_MIN) return "triennial";
-	return "annual";
+	if (workforce < COMPANY_SIZE_ANNUAL_MIN) return "mandatory";
+	return "mandatory_with_compliance";
 }
 
 /** Returns true if the company is large enough to require CSE opinions (>= 100 employees). */

--- a/packages/app/src/modules/domain/shared/constants.ts
+++ b/packages/app/src/modules/domain/shared/constants.ts
@@ -8,8 +8,11 @@ export const GAP_DISPLAY_DECIMALS = 2;
 /** Workforce below this: voluntary declaration only. */
 export const COMPANY_SIZE_VOLUNTARY_MAX = 50;
 
-/** Workforce at or above this: annual declaration + CSE opinion required. */
+/** Workforce at or above this: CSE opinion + gap-alert obligations. Every mandatory tier (>= 50) declares annually since the 2026-07 business arbitrage, so this threshold marks the compliance-obligation package, not the annual cadence. */
 export const COMPANY_SIZE_ANNUAL_MIN = 100;
+
+/** First campaign year of the V2 scheme (7-indicator regime). The 50-99 annual declaration obligation starts here; earlier years keep their historical behavior. */
+export const V2_FIRST_CAMPAIGN_YEAR = 2027;
 
 // Declaration types expected each year
 /** Every company must file these two declaration types annually. */

--- a/packages/app/src/modules/domain/shared/indicatorG.ts
+++ b/packages/app/src/modules/domain/shared/indicatorG.ts
@@ -12,11 +12,19 @@ export function isTriennialYear(year: number): boolean {
 	);
 }
 
+/**
+ * Whether indicator G is required within a declaration for this workforce and campaign year.
+ * Whether the company must declare at all is `isObligatedForYear` — a voluntary (< 50)
+ * declaration still carries all 7 indicators (2026-07 business arbitrage).
+ */
 export function isIndicatorGRequired(workforce: number, year: number): boolean {
+	// Voluntary tier (< 50): the declaration always carries all 7 indicators
+	// (2026-07 arbitrage). Scheme property with no year cadence, like the >= 250 branch.
+	if (workforce < COMPANY_SIZE_VOLUNTARY_MAX) return true;
 	if (workforce >= INDICATOR_G_ANNUAL_MIN) return true;
 	if (year >= INDICATOR_G_UNIVERSAL_YEAR) {
 		// From 2030 the obligation extends down to every mandatory tier (>= 50), on the triennial cadence.
-		return workforce >= COMPANY_SIZE_VOLUNTARY_MAX && isTriennialYear(year);
+		return isTriennialYear(year);
 	}
 	return workforce >= INDICATOR_G_TRIENNIAL_MIN && isTriennialYear(year);
 }

--- a/packages/app/src/modules/domain/types.ts
+++ b/packages/app/src/modules/domain/types.ts
@@ -24,8 +24,16 @@ export type DeclarationFsmStatus = (typeof DECLARATION_FSM_STATUSES)[number];
 /** The two types of declarations a company must file each year. */
 export type DeclarationType = "remuneration" | "representation";
 
-/** Company size classification for declaration obligations. */
-export type CompanySize = "voluntary" | "triennial" | "annual";
+/**
+ * Company size classification by obligation package.
+ * `voluntary` (< 50): voluntary declaration; `mandatory` (50-99): annual declaration
+ * without gap-alert obligations; `mandatory_with_compliance` (>= 100): annual
+ * declaration + CSE opinion + gap-alert (>= 5%) obligations.
+ */
+export type CompanySize =
+	| "voluntary"
+	| "mandatory"
+	| "mandatory_with_compliance";
 
 /** Workforce range buckets used by admin/public statistics filters. */
 export type CompanySizeRange = "<50" | "50-99" | "100-149" | "150-249" | "250+";

--- a/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
+++ b/packages/app/src/modules/export/__tests__/buildExportRows.test.ts
@@ -683,10 +683,13 @@ describe("buildExportRows", () => {
 		const rows = await buildExportRows(mockDb as never, 2027);
 
 		expect(rows).toHaveLength(1);
+		// No GIP workforce → obligation flags stay false, but the workforce-0
+		// declarant is in the voluntary (< 50) tier, so indicator G is required
+		// (7-indicator volunteering, #4043).
 		expect(rows[0]).toMatchObject({
 			siren: "999999999",
 			workforce: null,
-			indicatorGRequired: false,
+			indicatorGRequired: true,
 			complianceProcessRequired: false,
 		});
 	});

--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -469,7 +469,9 @@ describe("GET /api/v1/export/declarations", () => {
 		const body = await response.json();
 		expect(body.Nombre).toBe(1);
 		expect(body.Declarations[0].Effectif).toBeNull();
-		expect(body.Declarations[0].Indicateur_G_requis).toBe(false);
+		// Workforce-0 (absent from GIP) is in the voluntary (< 50) tier → 7-indicator
+		// volunteering, so indicator G is required (#4043).
+		expect(body.Declarations[0].Indicateur_G_requis).toBe(true);
 	});
 
 	it("should expose CSE opinion declarationNumber alongside type", async () => {

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -1114,7 +1114,9 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		expect(result.Effectif).toBeNull();
 		expect(result.Parcours_de_conformite_requis).toBe(false);
-		expect(result.Indicateur_G_requis).toBe(false);
+		// Workforce-0 derives from the missing GIP effectif; it lands in the
+		// voluntary (< 50) tier, which files all 7 indicators (#4043).
+		expect(result.Indicateur_G_requis).toBe(true);
 	});
 
 	it("derives the flags from the GIP workforce, never from the Weez value (#3929)", () => {

--- a/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminStats.test.ts
@@ -1330,17 +1330,13 @@ describe("adminStatsRouter.getCampaignStats", () => {
 		expect(result.previousYearRate).toBeNull();
 	});
 
-	it("computes the obligation predicate differently for triennial vs non-triennial years (smoke check via call wiring)", async () => {
-		const { result: triennial } = await callStats(
-			{ year: 2027 },
-			[100, 80, 0, 0],
-		);
-		const { result: nonTriennial } = await callStats(
-			{ year: 2026 },
-			[100, 80, 0, 0],
-		);
-		expect(triennial.totalObligated).toBe(100);
-		expect(nonTriennial.totalObligated).toBe(100);
+	it("computes the obligation predicate differently pre/post the V2 scheme year (smoke check via call wiring)", async () => {
+		// From 2027 the SQL predicate widens to ema >= 50 (50-99 become subject);
+		// before 2027 it stays ema >= 100. Both branches must wire the four queries.
+		const { result: postV2 } = await callStats({ year: 2028 }, [100, 80, 0, 0]);
+		const { result: preV2 } = await callStats({ year: 2026 }, [100, 80, 0, 0]);
+		expect(postV2.totalObligated).toBe(100);
+		expect(preV2.totalObligated).toBe(100);
 	});
 
 	it("inflates the size filter when sizeRange covers the voluntary-only bucket (still computes a result)", async () => {

--- a/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/publicStats.test.ts
@@ -112,15 +112,17 @@ describe("publicStatsRouter.getCurrentCampaignRate", () => {
 		expect(result.year).toBe(2027);
 	});
 
-	it("computes the obligation predicate differently for triennial vs non-triennial years (smoke check via call wiring)", async () => {
-		const { result: triennial } = await callRate([100, 80, 0, 0], {
-			year: 2027,
+	it("computes the obligation predicate differently pre/post the V2 scheme year (smoke check via call wiring)", async () => {
+		// From 2027 the SQL predicate widens to ema >= 50 (50-99 become subject);
+		// before 2027 it stays ema >= 100. Both branches must wire the four queries.
+		const { result: postV2 } = await callRate([100, 80, 0, 0], {
+			year: 2028,
 		});
-		const { result: nonTriennial } = await callRate([100, 80, 0, 0], {
+		const { result: preV2 } = await callRate([100, 80, 0, 0], {
 			year: 2026,
 		});
-		expect(triennial.totalObligated).toBe(100);
-		expect(nonTriennial.totalObligated).toBe(100);
+		expect(postV2.totalObligated).toBe(100);
+		expect(preV2.totalObligated).toBe(100);
 	});
 
 	it("defaults to 0 when a count query returns no row at all", async () => {

--- a/packages/app/src/server/api/routers/adminStats.ts
+++ b/packages/app/src/server/api/routers/adminStats.ts
@@ -35,12 +35,12 @@ import {
 	FUNNEL_MAIN_KEY_STEPS,
 	FUNNEL_REVISION_KEY_STEPS,
 	getStepLabel,
-	isTriennialYear,
 	POST_SUBMIT_DROPOFF_PHASES,
 	POST_SUBMIT_MILESTONES,
 	type PostSubmitMilestoneKey,
 	percentageOf,
 	roundOneDecimal,
+	V2_FIRST_CAMPAIGN_YEAR,
 } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
 import {
@@ -93,19 +93,18 @@ function buildSeries(rows: AggregatedRow[]): CampaignProgressionSeries[] {
 		.map(([year, points]) => ({ year, points }));
 }
 
-// Mirrors `isObligatedForYear` (domain) as a SQL predicate so the workforce
-// bracket is enforced server-side and stays symmetric between numerator and denominator.
+// Mirrors `isObligatedForYear` (domain) as a SQL predicate: mandatory from >= 50
+// since the V2 scheme (V2_FIRST_CAMPAIGN_YEAR), >= 100 for earlier years. Kept
+// symmetric between numerator and denominator by construction.
 function obligationWorkforceFilter(
 	year: number,
 	sizeRange: CompanySizeRange | undefined,
 ): SQL {
 	const ema = sql<number>`floor(${gipMdsData.workforceEma})`;
-	const triennialActive = isTriennialYear(year);
-	const triennialClause = triennialActive
-		? sql`${ema} >= ${COMPANY_SIZE_VOLUNTARY_MAX} AND ${ema} < ${COMPANY_SIZE_ANNUAL_MIN}`
-		: sql`false`;
-	const annualClause = sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
-	const baseObligation = sql`((${triennialClause}) OR (${annualClause}))`;
+	const baseObligation =
+		year >= V2_FIRST_CAMPAIGN_YEAR
+			? sql`${ema} >= ${COMPANY_SIZE_VOLUNTARY_MAX}`
+			: sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
 
 	if (!sizeRange) return baseObligation;
 

--- a/packages/app/src/server/api/routers/declaration.ts
+++ b/packages/app/src/server/api/routers/declaration.ts
@@ -133,6 +133,7 @@ function buildSubmitFacts(
 		hasCse: company.hasCse === true,
 		indicatorGCalculated: hasIndicatorGData,
 		gap: hasGap ? 100 : 0,
+		year: declaration.year,
 		isTriennialYear: isTriennialYear(declaration.year),
 	};
 }

--- a/packages/app/src/server/api/routers/publicStats.ts
+++ b/packages/app/src/server/api/routers/publicStats.ts
@@ -5,10 +5,10 @@ import {
 	COMPANY_SIZE_VOLUNTARY_MAX,
 	computeRate,
 	getCurrentYear,
-	isTriennialYear,
 	roundOneDecimal,
 	SCORE_BRACKETS,
 	type ScoreBracketId,
+	V2_FIRST_CAMPAIGN_YEAR,
 } from "~/modules/domain";
 import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { declarations, gipMdsData } from "~/server/db/schema";
@@ -34,13 +34,13 @@ type ScoreDistribution = {
 	year: number;
 };
 
+// Mirrors `isObligatedForYear` (domain) as a SQL predicate: mandatory from >= 50
+// since the V2 scheme (V2_FIRST_CAMPAIGN_YEAR), >= 100 for earlier years.
 function buildObligationFilter(year: number): SQL {
 	const ema = sql<number>`floor(${gipMdsData.workforceEma})`;
-	const triennialClause = isTriennialYear(year)
-		? sql`${ema} >= ${COMPANY_SIZE_VOLUNTARY_MAX} AND ${ema} < ${COMPANY_SIZE_ANNUAL_MIN}`
-		: sql`false`;
-	const annualClause = sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
-	return sql`((${triennialClause}) OR (${annualClause}))`;
+	return year >= V2_FIRST_CAMPAIGN_YEAR
+		? sql`${ema} >= ${COMPANY_SIZE_VOLUNTARY_MAX}`
+		: sql`${ema} >= ${COMPANY_SIZE_ANNUAL_MIN}`;
 }
 
 export const publicStatsRouter = createTRPCRouter({

--- a/packages/app/src/server/rules/__tests__/computationParity.test.ts
+++ b/packages/app/src/server/rules/__tests__/computationParity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isIndicatorGRequired, isTriennialYear } from "~/modules/domain";
+import { evaluateComputation, loadRules } from "../engine";
+
+// Anti-drift lock (#4043): the versioned ruleset (v2027.1.json) carries a JSON
+// mirror of `isIndicatorGRequired`. The single-source-of-truth rule forbids two
+// diverging copies of a business rule, so this test evaluates the JSON
+// computation over a workforce × year matrix and requires it to equal the domain
+// function. It fails if either copy evolves without the other.
+const rules = loadRules("2027.1");
+
+const WORKFORCES = [0, 30, 49, 50, 75, 99, 100, 149, 150, 249, 250, 300];
+const YEARS = [2018, 2026, 2027, 2028, 2029, 2030, 2031, 2032, 2033];
+
+const CASES = WORKFORCES.flatMap((workforce) =>
+	YEARS.map((year) => ({ workforce, year })),
+);
+
+describe("indicatorGRequired parity — engine ruleset ↔ domain function", () => {
+	it.each(CASES)("workforce $workforce · year $year", ({ workforce, year }) => {
+		// Facts assembled exactly like buildSubmitFacts in production: `year` plus
+		// the pre-computed `isTriennialYear` boolean.
+		const facts = {
+			workforce,
+			year,
+			isTriennialYear: isTriennialYear(year),
+		};
+		expect(evaluateComputation(rules, "indicatorGRequired", facts)).toBe(
+			isIndicatorGRequired(workforce, year),
+		);
+	});
+});

--- a/packages/app/src/server/rules/__tests__/fsmMirrors.conformance.test.ts
+++ b/packages/app/src/server/rules/__tests__/fsmMirrors.conformance.test.ts
@@ -87,8 +87,8 @@ describe("mirror conformance — engine states (non-terminal)", () => {
 		const expected = STAGE_SCREEN[String(state.stage)];
 		if (!expected)
 			throw new Error(`No screen mapping for stage ${state.stage}`);
-		// hasCse is only consulted by the nav mirror in the terminal state, so a
-		// non-terminal state must resolve to the same screen for both hasCse values.
+		// cseOpinionRequired is only consulted by the nav mirror in the terminal
+		// state, so a non-terminal state resolves to the same screen either way.
 		expect(getCurrentStageHref(state.id, true)).toBe(expected.screen);
 		expect(getCurrentStageHref(state.id, false)).toBe(expected.screen);
 		const decl = makeDeclaration({ fsmStatus: state.id });
@@ -104,7 +104,7 @@ describe("mirror conformance — engine transition destinations", () => {
 		const to = transition.to;
 		if (to === "demarche_completed") {
 			// Terminal state: only the healthy hasSubmittedCseOpinion:true branch is asserted here —
-			// the full hasCse × hasSubmittedCseOpinion matrix, incl. the no-CSE closed branch (#3939), lives in the dedicated describe below.
+			// the full cseOpinionRequired × hasSubmittedCseOpinion matrix, incl. the no-opinion closed branch (#3939), lives in the dedicated describe below.
 			expect(getCurrentStageHref(to, true)).toBe(CSE);
 			expect(getCurrentStageHref(to, false)).toBe(CONFIRMATION);
 			expect(
@@ -141,8 +141,8 @@ describe("exhaustiveness — every FSM status is covered by both mirrors", () =>
 	});
 });
 
-describe("demarche_completed — mirror coherence × (hasCse × hasSubmittedCseOpinion)", () => {
-	it('with CSE, opinion not yet deposited: panel "cse" and nav → /avis-cse (coherent)', () => {
+describe("demarche_completed — mirror coherence × (cseOpinionRequired × hasSubmittedCseOpinion)", () => {
+	it('opinion due, not yet deposited: panel "cse" and nav → /avis-cse (coherent)', () => {
 		const decl = makeDeclaration({
 			fsmStatus: "demarche_completed",
 			hasSubmittedCseOpinion: false,
@@ -153,7 +153,7 @@ describe("demarche_completed — mirror coherence × (hasCse × hasSubmittedCseO
 		expect(getCurrentStageHref("demarche_completed", true)).toBe(CSE);
 	});
 
-	it('with CSE, opinion deposited: panel "closed"; nav keeps /avis-cse (CSE deposit re-submittable)', () => {
+	it('opinion due and deposited: panel "closed"; nav keeps /avis-cse (CSE deposit re-submittable)', () => {
 		const decl = makeDeclaration({
 			fsmStatus: "demarche_completed",
 			hasSubmittedCseOpinion: true,
@@ -167,19 +167,20 @@ describe("demarche_completed — mirror coherence × (hasCse × hasSubmittedCseO
 		expect(getCurrentStageHref("demarche_completed", true)).toBe(CSE);
 	});
 
-	it('without CSE, opinion not deposited: the panel should be "closed", not "cse" (#3939)', () => {
+	it('no opinion due, none deposited: the panel should be "closed", not "cse" (#3939)', () => {
 		const decl = makeDeclaration({
 			fsmStatus: "demarche_completed",
 			hasSubmittedCseOpinion: false,
 		});
-		// The nav mirror is correct: a no-CSE company lands on /confirmation, never
-		// on the CSE page. computePanelVariant now consumes cseRequired (false by
-		// default in makeDeclaration) and returns "closed" for this case (#3939).
+		// The nav mirror is correct: a démarche owing no opinion lands on
+		// /confirmation, never on the CSE page. computePanelVariant now consumes
+		// cseRequired (false by default in makeDeclaration) and returns "closed"
+		// for this case (#3939).
 		expect(getCurrentStageHref("demarche_completed", false)).toBe(CONFIRMATION);
 		expect(computePanelVariant(decl)).toBe("closed");
 	});
 
-	it('without CSE, opinion "deposited": panel "closed" and nav → /confirmation (coherent, démarche closed)', () => {
+	it('no opinion due, one "deposited": panel "closed" and nav → /confirmation (coherent, démarche closed)', () => {
 		const decl = makeDeclaration({
 			fsmStatus: "demarche_completed",
 			hasSubmittedCseOpinion: true,

--- a/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
+++ b/packages/app/src/server/rules/__tests__/matrix.v2027.1.test.ts
@@ -30,6 +30,9 @@ function base(currentState: string, overrides: Partial<Facts> = {}): Facts {
 		indicatorGCalculated: true,
 		gap: 10,
 		hasCse: true,
+		// `year` mirrors the fact now assembled by buildSubmitFacts (#4043); it feeds
+		// the indicatorGRequired computation's 2030 down-extension branch.
+		year: 2027,
 		isTriennialYear: true,
 		...overrides,
 	};
@@ -74,6 +77,38 @@ const MATRIX: Case[] = [
 			gap: 2,
 			indicatorGCalculated: false,
 			hasCse: false,
+		}),
+		expectedTo: "demarche_completed",
+		expectedEvents: [{ type: "submit" }, { type: "demarche_complete" }],
+	},
+	{
+		// #4043 rule 3: a < 50 company with a computed indicator G and a gap >= 5%
+		// still completes directly — no compliance process, no CSE below 100.
+		label:
+			"submit_to_demarche_completed_directly: voluntary tier (workforce 30) with indicator G gap >= 5%",
+		from: "draft",
+		action: "submit",
+		facts: base("draft", {
+			workforce: 30,
+			gap: 10,
+			indicatorGCalculated: true,
+			hasCse: true,
+		}),
+		expectedTo: "demarche_completed",
+		expectedEvents: [{ type: "submit" }, { type: "demarche_complete" }],
+	},
+	{
+		// #4043 rule 3: same for the 50-99 band — mandatory yearly, but a gap >= 5%
+		// triggers no obligation below 100.
+		label:
+			"submit_to_demarche_completed_directly: 50-99 band (workforce 75) with indicator G gap >= 5%",
+		from: "draft",
+		action: "submit",
+		facts: base("draft", {
+			workforce: 75,
+			gap: 10,
+			indicatorGCalculated: true,
+			hasCse: true,
 		}),
 		expectedTo: "demarche_completed",
 		expectedEvents: [{ type: "submit" }, { type: "demarche_complete" }],

--- a/packages/app/src/server/rules/engine.ts
+++ b/packages/app/src/server/rules/engine.ts
@@ -239,6 +239,23 @@ export function applyAction(
 	);
 }
 
+/** Evaluates a named computation of a ruleset against a facts object (parity locks between the versioned ruleset and the domain functions). */
+export function evaluateComputation(
+	rules: Rules,
+	name: string,
+	facts: Facts,
+): boolean {
+	const computations = (rules.computations ?? {}) as Record<
+		string,
+		ComputationNode
+	>;
+	const computation = computations[name];
+	if (computation === undefined) {
+		throw new Error(`Unknown computation: "${name}"`);
+	}
+	return evaluatePredicate(computation, facts, computations, rules.thresholds);
+}
+
 export function _resetCacheForTests(): void {
 	cache.clear();
 }

--- a/packages/app/src/server/rules/v2027.1.json
+++ b/packages/app/src/server/rules/v2027.1.json
@@ -1,14 +1,14 @@
 {
 	"version": "2027.1",
 	"effectiveFrom": "2027-03-01",
-	"effectiveUntil": "2028-02-28",
-	"description": "Entrée en vigueur V2 — 6 ind A-F obligatoires 50+, 7e ind G obligatoire 150+ (triennal an 1 pour 150-249, annuel 250+). FSM avec convergence : 8 états. Modèle event-sourced (T8) : applyAction émet des events typés persistés dans declaration_status_history. La projection declarations.status / first|second_declaration_path_choice est dérivée du dernier event de chaque type.",
+	"description": "7 indicateurs pour les < 50 (volontariat) et assujettissement annuel dès 50 salariés (arbitrage 2026-07) ; indicateur G étendu aux ≥ 50 les années triennales à partir de 2030 ; Entrée en vigueur V2 — 6 ind A-F obligatoires 50+, 7e ind G obligatoire 150+ (triennal an 1 pour 150-249, annuel 250+). FSM avec convergence : 8 états. Modèle event-sourced (T8) : applyAction émet des events typés persistés dans declaration_status_history. La projection declarations.status / first|second_declaration_path_choice est dérivée du dernier event de chaque type.",
 
 	"thresholds": {
 		"gapAlertPercent": 5,
 		"phase2SizeMin": 100,
 		"indicatorGAnnualSizeMin": 250,
 		"indicatorGTriennialSizeMin": 150,
+		"indicatorGUniversalYear": 2030,
 		"voluntarySizeMax": 50,
 		"mandatorySizeMin": 50
 	},
@@ -59,6 +59,7 @@
 		},
 		"indicatorGRequired": {
 			"any": [
+				{ "fact": "workforce", "op": "<", "threshold": "voluntarySizeMax" },
 				{
 					"fact": "workforce",
 					"op": ">=",
@@ -69,12 +70,22 @@
 						{
 							"fact": "workforce",
 							"op": ">=",
-							"threshold": "indicatorGTriennialSizeMin"
+							"threshold": "mandatorySizeMin"
 						},
 						{
+							"fact": "year",
+							"op": ">=",
+							"threshold": "indicatorGUniversalYear"
+						},
+						{ "fact": "isTriennialYear", "op": "==", "value": true }
+					]
+				},
+				{
+					"all": [
+						{
 							"fact": "workforce",
-							"op": "<",
-							"threshold": "indicatorGAnnualSizeMin"
+							"op": ">=",
+							"threshold": "indicatorGTriennialSizeMin"
 						},
 						{ "fact": "isTriennialYear", "op": "==", "value": true }
 					]


### PR DESCRIPTION
Corrige une **boucle de redirection infinie** sur `/avis-cse`, trouvée en auditant les tests E2E de la #4050 (elle explique pourquoi les fiches `CAS-13`/`CAS-14` y fixent `hasCse` à `null` : la combinaison discriminante était inexploitable).

## Le bug

`getPostComplianceDestination` décidait sur le seul `hasCse` et renvoyait `/avis-cse` dès que `hasCse` valait `true`. Or le layout de `/avis-cse` redirige précisément vers cette destination quand aucun avis n'est dû :

```
/avis-cse  →  isCseOpinionRequired({ workforce: 75, hasCse: true }) === false
           →  redirect(getPostComplianceDestination(true))
           →  /avis-cse  →  …
```

`isCseOpinionRequired` est un **ET** entre l'effectif (`>= 100`) et `hasCse`. Sous 100 salariés il est donc toujours faux, quelle que soit la réponse à la question CSE — et le helper, aveugle à l'effectif, renvoyait quand même vers le tunnel. Chaque tour rejouait `auth()` plus deux appels tRPC avant de rediriger à nouveau.

**Le cas est atteignable en production**, pas seulement par URL forgée : `app_company.has_cse` est une colonne persistante hors année, alors que l'effectif provient de la ligne GIP de l'année courante. Une entreprise à 250 salariés (`has_cse = true`) qui tombe à 75 l'année suivante conserve `true`.

## Le correctif

**Le helper prend la décision, plus ses entrées.** `getPostComplianceDestination(cseOpinionRequired: boolean)` : le compilateur force ainsi chaque appelant à passer `isCseOpinionRequired` du domaine au lieu de reconstruire la règle métier depuis `hasCse`. `getCurrentStageHref` suit la même bascule, et sa branche `demarche_completed` délègue au helper plutôt que de dupliquer le ternaire.

Les 8 appelants sont alignés. Trois d'entre eux (`CompliancePathChoice`, `SecondDeclarationStep3Review`, `Step6Review`) disposaient **déjà** de `cseOpinionRequired` — ils s'en servaient pour l'affichage tout en naviguant sur `hasCse`, à quelques lignes d'écart. C'était l'incohérence de fond. Les props `hasCse` devenues mortes sont retirées de `CompliancePathChoice` et `SecondDeclarationStep3Review` (et de leurs deux parents).

**Une seconde instance de la même boucle** vivait dans `CompliancePathPage`, qui saute lui aussi directement vers le tunnel CSE. Son corps async n'avait aucune couverture (44,7 %) ; il est désormais à 100 % lignes.

**Le message de confirmation ne mentait plus qu'à moitié.** La page affirmait « Votre entreprise ne dispose pas de CSE » — faux pour le cas que ce correctif rend justement atteignable. Elle énonce maintenant la vraie raison : effectif sous `COMPANY_SIZE_ANNUAL_MIN`, ou absence de CSE.

## Preuve de reproduction

Le fix a été retiré (`git apply -R`) pour vérifier que les tests mordent, puis réappliqué :

| Test | Sans le fix | Avec le fix |
|---|---|---|
| layout `/avis-cse`, `hasCse=true` + effectif 75 | 🔴 redirige `/avis-cse` → `/avis-cse` | ✅ confirmation |
| `CompliancePathPage`, `hasCse=true` + effectif < 100 | 🔴 saute vers `/avis-cse` | ✅ confirmation |
| `ComplianceConfirmation`, `hasCse=true` | 🔴 « ne dispose pas de CSE » | ✅ raison d'effectif |

Le cas nominal (≥ 100 avec CSE) est inchangé, verrouillé par les mêmes fichiers de test.

## Validation

`pnpm typecheck` ✅ · `pnpm test` ✅ (3915 tests, 370 fichiers) · `pnpm lint:check` ✅ · `pnpm format:check` ✅

9 tests corrigés (évolution légitime de l'intention : `hasCse` → « un avis est-il dû »), 22 ajoutés dont 2 fichiers reproduisant la boucle, 1 doublon fusionné. Couverture à 100 % sur `layout.tsx`, `complianceNavigation.ts`, `ComplianceConfirmation.tsx`, `CompliancePathChoice.tsx`, `CompliancePathOptions.tsx`, `JointEvaluationForm.tsx`, `JointEvaluationPage.tsx`.

Gates : `validator` PASS · `security-auditor` SECURE (garde d'accès préservé, pas d'open redirect, le fix réduit même ce qui traverse la frontière serveur → client) · `rgaa-auditor` PASS · `structural-auditor` MINOR.

## Reste à faire, hors périmètre

La sonde `/avis-cse` de `[CAS-14]` (PR #4050) reste non discriminante sur le seuil de 100 : son fixture falsifie les deux termes du ET. Une fois ce correctif mergé, la combinaison effectif < 100 **et** `hasCse = true` devient exerçable et la sonde peut être renforcée.
