### PR TITLE
Fixture E2E « année de campagne » + isolation inter-runs (#4067)

### DIFF
--- a/docs/cahier-de-tests.md
+++ b/docs/cahier-de-tests.md
@@ -284,6 +284,35 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 
 ---
 
+<a name="cas-01-7ind"></a>
+
+### CAS-01-7IND : 7 indicateurs · l'indicateur G revient en année triennale ≥ 2030
+
+**Libellé Excel** : *(contre-branche des variantes « 6 premiers indicateurs » — colonnes « 7 indicateurs » pour la tranche 100-149)*
+
+- Effectif GIP 120 (tranche 100-149), année épinglée sur une année triennale ≥ 2030
+- L'indicateur G redevient obligatoire → funnel en 6 étapes (étape catégories présente)
+
+**Test E2E** : `compliance.e2e.ts` — `[CAS-01-7IND] Path 14bis` : épinglé sur 2030 via `withCampaignYear`, le funnel porte l'étape 5 (« Étape 5 sur 6 »). C'est l'assertion qui basculerait silencieusement au rouge en 2030 sans l'épinglage (#4067). Le parcours complet 7 indicateurs est couvert par les cas baseline ≥ 250.
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-01-7IND\]"`
+
+---
+
+<a name="cas-13-6ind"></a>
+
+### CAS-13-6IND : tranche 50-99 · indicateur G gouverné par l'année épinglée
+
+**Libellé Excel** : *(colonnes « 6 premiers indicateurs » — tranche 50-99, scénarios S1/S2 de #4067)*
+
+- Effectif GIP 75 (tranche 50-99)
+- Année « 6 indicateurs » (< 2030) : étape catégories absente et inatteignable par URL directe (redirection vers le récapitulatif)
+- Année « 7 indicateurs » (triennale ≥ 2030) : étape catégories présente, stepper « sur 6 »
+
+**Test E2E** : `compliance.e2e.ts` — `[CAS-13-6IND] Path 13` : deux branches épinglées via `withCampaignYear` — 2029 (funnel 5 étapes, `/etape/5` redirige vers `/etape/6`) et 2030 (funnel 6 étapes, « Étape 5 sur 6 »).
+**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-13-6IND\]"`
+
+---
+
 ## 3. Les feuilles de l'Excel, année par année
 
 Miroir des quatre onglets du fichier. Placez-vous sur votre feuille et votre année : la cellule liste les cas à dérouler, chacun désigné par une **coordonnée autoportante** (cliquable vers sa fiche §2).

--- a/docs/cahier-de-tests.md
+++ b/docs/cahier-de-tests.md
@@ -284,35 +284,6 @@ Correspondances de vocabulaire (Excel → application) : « 7ᵉ indicateur » =
 
 ---
 
-<a name="cas-01-7ind"></a>
-
-### CAS-01-7IND : 7 indicateurs · l'indicateur G revient en année triennale ≥ 2030
-
-**Libellé Excel** : *(contre-branche des variantes « 6 premiers indicateurs » — colonnes « 7 indicateurs » pour la tranche 100-149)*
-
-- Effectif GIP 120 (tranche 100-149), année épinglée sur une année triennale ≥ 2030
-- L'indicateur G redevient obligatoire → funnel en 6 étapes (étape catégories présente)
-
-**Test E2E** : `compliance.e2e.ts` — `[CAS-01-7IND] Path 14bis` : épinglé sur 2030 via `withCampaignYear`, le funnel porte l'étape 5 (« Étape 5 sur 6 »). C'est l'assertion qui basculerait silencieusement au rouge en 2030 sans l'épinglage (#4067). Le parcours complet 7 indicateurs est couvert par les cas baseline ≥ 250.
-**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-01-7IND\]"`
-
----
-
-<a name="cas-13-6ind"></a>
-
-### CAS-13-6IND : tranche 50-99 · indicateur G gouverné par l'année épinglée
-
-**Libellé Excel** : *(colonnes « 6 premiers indicateurs » — tranche 50-99, scénarios S1/S2 de #4067)*
-
-- Effectif GIP 75 (tranche 50-99)
-- Année « 6 indicateurs » (< 2030) : étape catégories absente et inatteignable par URL directe (redirection vers le récapitulatif)
-- Année « 7 indicateurs » (triennale ≥ 2030) : étape catégories présente, stepper « sur 6 »
-
-**Test E2E** : `compliance.e2e.ts` — `[CAS-13-6IND] Path 13` : deux branches épinglées via `withCampaignYear` — 2029 (funnel 5 étapes, `/etape/5` redirige vers `/etape/6`) et 2030 (funnel 6 étapes, « Étape 5 sur 6 »).
-**Exécuter** : `pnpm --filter app test:e2e --grep "\[CAS-13-6IND\]"`
-
----
-
 ## 3. Les feuilles de l'Excel, année par année
 
 Miroir des quatre onglets du fichier. Placez-vous sur votre feuille et votre année : la cellule liste les cas à dérouler, chacun désigné par une **coordonnée autoportante** (cliquable vers sa fiche §2).
@@ -401,6 +372,8 @@ Comportements testés en E2E qui ne figurent pas dans le fichier de Laetitia mai
 | ANX-01 | Tâtonnement : changer de parcours de conformité avant toute action aval (le dernier choix gagne, les deux événements sont historisés) | `compliance-path-change.e2e.ts` |
 | ANX-02 | Démarche terminée → toute navigation vers le parcours de conformité redirige | `compliance.e2e.ts` — `[ANX-02] Path 12` |
 | ANX-03 | Bouton « Précédent » sur `/avis-cse` : retour contextuel selon l'état (récap étape 6, choix de parcours, récap 2ᵉ déclaration) | `compliance.e2e.ts` — `[ANX-03] Paths 13.a / 13.b / 13.c` |
+| ANX-04 | Tranche 100-149, année triennale ≥ 2030 : l'indicateur G redevient obligatoire, le funnel repasse à 6 étapes. Contre-branche de `CAS-01-6IND` / `CAS-02-6IND`, qui n'exerceraient sinon qu'une seule de leurs deux branches — et basculeraient silencieusement au rouge en 2030 | `compliance.e2e.ts` — `[ANX-04] Path 14bis` (effectif GIP 120, année épinglée 2030) |
+| ANX-05 | Tranche 50-99 : la composition du funnel suit l'année épinglée — étape catégories absente et inatteignable par URL directe en année « 6 indicateurs » (2029), présente en année triennale ≥ 2030 | `compliance.e2e.ts` — `[ANX-05] Path 13` (effectif GIP 75, années épinglées 2029 et 2030) |
 
 Le socle déclaratif (étapes 1–6, brouillon, historique, panneau de démarche, deadlines de campagne, annulation, saut de l'étape 5 quand l'indicateur G ne s'applique pas…) est couvert par les autres specs (`declaration.e2e.ts`, `declarationDraft.e2e.ts`, `declaration-history.e2e.ts`, `declaration-process-panel.e2e.ts`, `campaign-deadlines-gating.e2e.ts`, `declaration-cancellation.e2e.ts`) — hors périmètre de ce cahier, qui trace les parcours du fichier Excel.
 

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -572,11 +572,11 @@ test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse
 	});
 });
 
-// The OTHER branch of CAS-01/02-6IND: the very same 100-149 company gains step 5
+// ANX-04 — the OTHER branch of CAS-01/02-6IND: the same 100-149 company gains step 5
 // in a triennial year from 2030 — the assertion that would have silently broken
 // without #4067. Kept lightweight (funnel shape only): the full compliance flows
 // for a 7-indicator company are already covered by the >= 250 baseline cases.
-test.describe("[CAS-01-7IND] Path 14bis: 100-149 company regains indicator G in a triennial year >= 2030", () => {
+test.describe("[ANX-04] Path 14bis: 100-149 company regains indicator G in a triennial year >= 2030", () => {
 	test("the funnel carries the indicator-G step (6 steps)", async ({
 		page,
 	}) => {
@@ -592,9 +592,9 @@ test.describe("[CAS-01-7IND] Path 14bis: 100-149 company regains indicator G in 
 	});
 });
 
-// CAS-13-6IND — the 50-99 tranche (scenarios S1/S2 of #4067): indicator G is
+// ANX-05 — the 50-99 tranche (scenarios S1/S2 of #4067): indicator G is
 // absent below 2030 and returns only in a triennial year from 2030.
-test.describe("[CAS-13-6IND] Path 13: 50-99 tranche — indicator G gated by the pinned year", () => {
+test.describe("[ANX-05] Path 13: 50-99 tranche — indicator G gated by the pinned year", () => {
 	test.describe.configure({ mode: "serial" });
 
 	test("6-indicator year (2029): step 5 is absent and unreachable by direct URL", async ({

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { withCampaignYear } from "./helpers/campaign-year";
 import {
 	COMPLIANCE_PATH,
 	completeSecondDeclaration,
@@ -9,10 +10,8 @@ import {
 } from "./helpers/compliance-flows";
 import {
 	resetDeclarationToDraft,
-	resetGipWorkforce,
 	setCompanyHasCse,
 	setCompanyWorkforce,
-	setGipWorkforce,
 } from "./helpers/db";
 import {
 	completeDeclaration,
@@ -508,72 +507,125 @@ test.describe("[ANX-02] Path 12: compliance already completed → redirect", () 
 	});
 });
 
-// === GROUP G: "6 premiers indicateurs" variant — indicator G not required ===
-// GIP workforce 120 (bracket 100-149, off-cycle year): the funnel drops the
-// categories step and no compliance path can trigger (Excel: cas 1-2 of the
-// "6 premiers indicateurs" columns). resetGipWorkforce restores the suite
-// baseline (>= 250) for any spec running after this one.
+// === GROUP G: indicator G gated by the campaign year (#4022 / #4067) ===
+// Whether the funnel carries the categories step (step 5 / indicator G) is
+// decided by isIndicatorGRequired(workforce, year): below 250 it only applies on
+// the triennial cadence (base 2027), and — from 2030 — down to every mandatory
+// 50+ company. Every spec here PINS its campaign year through withCampaignYear so
+// both branches stay exercised instead of silently flipping when the calendar
+// reaches 2030; the fixture also tears the coordinate down, leaving no residue.
+
+// 2029: < 2030 and off the triennial cadence → indicator G not required for < 250.
+const SIX_INDICATOR_YEAR = 2029;
+// 2030: triennial ((2030-2027) % 3 === 0) and >= 2030 → indicator G required for 50+.
+const SEVEN_INDICATOR_YEAR = 2030;
 
 test.describe("[CAS-01-6IND] Path 14: 6 indicators (no G) + no hasCse → direct completion", () => {
-	test.beforeAll(async () => {
-		await resetDeclarationToDraft();
-		await setGipWorkforce(120);
-		await setCompanyHasCse(false);
-	});
-
-	test.afterAll(async () => {
-		await resetGipWorkforce();
-	});
-
 	test("submits the 5-step funnel and completes the démarche directly", async ({
 		page,
 	}) => {
 		test.slow(); // 5-step declaration + submission
-		await submitStepsThroughQuartiles(page);
-		// No indicator G → the categories step is skipped: quartiles land on review
-		await page.waitForURL("**/declaration-remuneration/etape/6");
-		await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+		await withCampaignYear(
+			{ page, year: SIX_INDICATOR_YEAR, workforce: 120 },
+			async () => {
+				await setCompanyHasCse(false);
+				await submitStepsThroughQuartiles(page);
+				await page.waitForURL("**/declaration-remuneration/etape/6");
+				await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
 
-		// Submit — no indicator G and no CSE → demarche completed directly
-		await page.getByRole("button", { name: "Suivant" }).click();
-		await page.getByText(/Je certifie/).click();
-		await page.getByRole("button", { name: "Valider" }).click();
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+				await page.getByRole("button", { name: "Suivant" }).click();
+				await page.getByText(/Je certifie/).click();
+				await page.getByRole("button", { name: "Valider" }).click();
+				await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+				await expect(
+					page.getByText(/Votre parcours .* est (désormais )?terminé/),
+				).toBeVisible();
+			},
+		);
 	});
 });
 
 test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse", () => {
-	test.beforeAll(async () => {
-		await resetDeclarationToDraft();
-		await setGipWorkforce(120);
-		await setCompanyHasCse(true);
-	});
-
-	test.afterAll(async () => {
-		await resetGipWorkforce();
-	});
-
 	test("submits the 5-step funnel then deposits the CSE accuracy opinion", async ({
 		page,
 	}) => {
 		test.slow(); // 5-step declaration + submission + CSE flow
-		await submitStepsThroughQuartiles(page);
-		await page.waitForURL("**/declaration-remuneration/etape/6");
+		await withCampaignYear(
+			{ page, year: SIX_INDICATOR_YEAR, workforce: 120 },
+			async () => {
+				await setCompanyHasCse(true);
+				await submitStepsThroughQuartiles(page);
+				await page.waitForURL("**/declaration-remuneration/etape/6");
 
-		// Submit — no indicator G but a CSE → straight to the CSE opinion
-		await page.getByRole("button", { name: "Suivant" }).click();
-		await page.getByText(/Je certifie/).click();
-		await page.getByRole("button", { name: "Valider" }).click();
-		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+				await page.getByRole("button", { name: "Suivant" }).click();
+				await page.getByText(/Je certifie/).click();
+				await page.getByRole("button", { name: "Valider" }).click();
+				await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
 
-		await fillCseStep1(page);
-		await submitCseStep2(page);
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+				await fillCseStep1(page);
+				await submitCseStep2(page);
+				await expect(
+					page.getByText(/Votre parcours .* est (désormais )?terminé/),
+				).toBeVisible();
+			},
+		);
+	});
+});
+
+// The OTHER branch of CAS-01/02-6IND: the very same 100-149 company gains step 5
+// in a triennial year from 2030 — the assertion that would have silently broken
+// without #4067. Kept lightweight (funnel shape only): the full compliance flows
+// for a 7-indicator company are already covered by the >= 250 baseline cases.
+test.describe("[CAS-01-7IND] Path 14bis: 100-149 company regains indicator G in a triennial year >= 2030", () => {
+	test("the funnel carries the indicator-G step (6 steps)", async ({
+		page,
+	}) => {
+		await withCampaignYear(
+			{ page, year: SEVEN_INDICATOR_YEAR, workforce: 120 },
+			async () => {
+				await page.goto("/declaration-remuneration/etape/1");
+				await expect(page.getByText("Étape 1 sur 6")).toBeVisible();
+				await page.goto("/declaration-remuneration/etape/5");
+				await expect(page.getByText("Étape 5 sur 6")).toBeVisible();
+			},
+		);
+	});
+});
+
+// CAS-13-6IND — the 50-99 tranche (scenarios S1/S2 of #4067): indicator G is
+// absent below 2030 and returns only in a triennial year from 2030.
+test.describe("[CAS-13-6IND] Path 13: 50-99 tranche — indicator G gated by the pinned year", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test("6-indicator year (2029): step 5 is absent and unreachable by direct URL", async ({
+		page,
+	}) => {
+		await withCampaignYear(
+			{ page, year: SIX_INDICATOR_YEAR, workforce: 75 },
+			async () => {
+				await page.goto("/declaration-remuneration/etape/1");
+				await expect(page.getByText("Étape 1 sur 5")).toBeVisible();
+				// The categories step is out of reach even by URL: it redirects to the recap.
+				await page.goto("/declaration-remuneration/etape/5");
+				await page.waitForURL("**/declaration-remuneration/etape/6");
+				await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+			},
+		);
+	});
+
+	test("7-indicator year (2030): step 5 is present and the stepper counts 6", async ({
+		page,
+	}) => {
+		await withCampaignYear(
+			{ page, year: SEVEN_INDICATOR_YEAR, workforce: 75 },
+			async () => {
+				// Initialise the declaration first so the step 5 URL is reachable.
+				await page.goto("/declaration-remuneration/etape/1");
+				await expect(page.getByText("Étape 1 sur 6")).toBeVisible();
+				await page.goto("/declaration-remuneration/etape/5");
+				await expect(page.getByText("Étape 5 sur 6")).toBeVisible();
+			},
+		);
 	});
 });
 

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { EXPECTED_DECLARATION_TYPES } from "~/modules/domain";
 import { withCampaignYear } from "./helpers/campaign-year";
 import {
 	getCurrentDbYear,
@@ -359,15 +360,21 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 	});
 });
 
-// #4067 — withCampaignYear isolates one coordinate from the next. After a full
+// #4067 — withCampaignYear isolates one coordinate from the next. After a
 // declaration is built under year N, moving to year N+1 must leave no trace of N
 // (declaration, files, CSE opinion, has_cse). This proves it at the /mon-espace
 // listing, which aggregates every year's declaration for the SIREN — the very
 // surface interference #1 of the spec warns would otherwise show 7 rows after a
 // grid run. The rigorous, row-count proof of resetCampaignYear lives in
-// db-campaign.integration.test.ts.
+// db-campaign.resetCampaignYear.integration.test.ts.
+//
+// Two things make the assertion narrower than it looks. The listing carries one
+// row per expected declaration type (rémunération + représentation), so a bare
+// row count would encode that arity instead of the isolation property. And a row
+// cannot be matched on its text: a campaign-year row legitimately mentions N-1,
+// the reference year its figures describe. Only the Année cell discriminates.
 test.describe("withCampaignYear leaves no residue between two year coordinates (#4067)", () => {
-	test("a run pinned on 2033 lists exactly one declaration", async ({
+	test("a run pinned on 2033 leaves no trace of the 2032 coordinate", async ({
 		page,
 	}) => {
 		test.slow();
@@ -377,7 +384,7 @@ test.describe("withCampaignYear leaves no residue between two year coordinates (
 			await page.waitForURL("**/declaration-remuneration/etape/**");
 		});
 
-		// Coordinate B: only 2033's declaration may exist — A left no residue.
+		// Coordinate B: 2033 is listed, 2032 is gone — A left no residue.
 		await withCampaignYear({ page, year: 2033, workforce: 250 }, async () => {
 			await page.goto("/declaration-remuneration");
 			await page.waitForURL("**/declaration-remuneration/etape/**");
@@ -386,8 +393,15 @@ test.describe("withCampaignYear leaves no residue between two year coordinates (
 			const currentDeclarations = page.locator(
 				'table[aria-labelledby="demarches-en-cours-title"] tbody tr',
 			);
-			await expect(currentDeclarations).toHaveCount(1);
-			await expect(page.getByText("2032")).toHaveCount(0);
+			const rowsForYear = (year: string) =>
+				currentDeclarations.filter({
+					has: page.getByRole("cell", { name: year, exact: true }),
+				});
+
+			await expect(rowsForYear("2032")).toHaveCount(0);
+			await expect(rowsForYear("2033")).toHaveCount(
+				EXPECTED_DECLARATION_TYPES.length,
+			);
 		});
 	});
 });

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from "@playwright/test";
+import { withCampaignYear } from "./helpers/campaign-year";
 import {
 	getCurrentDbYear,
 	resetDeclarationToDraft,
@@ -305,43 +306,88 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 		});
 	});
 
-	test.describe("GIP workforce of 70 — below every indicator G threshold", () => {
-		test.beforeAll(async () => {
-			await setGipWorkforce(70);
-			await resetDeclarationToDraft();
-		});
+	// GIP workforce of 70 (bracket 50-99): whether indicator G / step 5 applies
+	// flips on the campaign year via isIndicatorGRequired(70, year) — never below
+	// 2030, and only in a triennial year from 2030. Pinning both years keeps the
+	// two branches exercised instead of letting the assertion silently flip red
+	// when the calendar reaches 2030 (#4067). withCampaignYear seeds the GIP row
+	// for the pinned year and tears the coordinate down afterwards.
+	test.describe("GIP workforce of 70 — indicator G gated by the pinned year", () => {
+		test.describe.configure({ mode: "serial" });
 
-		test("banners display the GIP workforce and drop the CSE field", async ({
+		test("6-indicator year (2029): banners show the workforce and the funnel drops step 5", async ({
 			page,
 		}) => {
+			await withCampaignYear({ page, year: 2029, workforce: 70 }, async () => {
+				await page.goto("/mon-espace");
+
+				const companyInfo = page
+					.locator("dl")
+					.filter({ hasText: "Effectif annuel moyen" })
+					.first();
+				await expect(companyInfo).toContainText("70");
+				await expect(companyInfo).not.toContainText("Existence d'un CSE");
+				// Nothing is editable below 100, so the edit entry point is dropped too.
+				await expect(
+					page.getByRole("button", { exact: true, name: "Modifier" }),
+				).toHaveCount(0);
+
+				await page.goto("/declaration-remuneration/etape/1");
+				await expect(page.getByText("Étape 1 sur 5")).toBeVisible();
+				// 2029 campaign → workforce reference year N-1 = 2028 (getWorkforceYear).
+				await expect(
+					page.getByText("Effectif annuel moyen en 2028 :"),
+				).toBeVisible();
+				await expect(page.getByText("Existence d'un CSE :")).toHaveCount(0);
+
+				await submitStepsThroughQuartiles(page);
+				await page.waitForURL("**/declaration-remuneration/etape/6");
+				await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+			});
+		});
+
+		test("7-indicator year (2030): the funnel regains the indicator-G step", async ({
+			page,
+		}) => {
+			await withCampaignYear({ page, year: 2030, workforce: 70 }, async () => {
+				await page.goto("/declaration-remuneration/etape/1");
+				await expect(page.getByText("Étape 1 sur 6")).toBeVisible();
+				await page.goto("/declaration-remuneration/etape/5");
+				await expect(page.getByText("Étape 5 sur 6")).toBeVisible();
+			});
+		});
+	});
+});
+
+// #4067 — withCampaignYear isolates one coordinate from the next. After a full
+// declaration is built under year N, moving to year N+1 must leave no trace of N
+// (declaration, files, CSE opinion, has_cse). This proves it at the /mon-espace
+// listing, which aggregates every year's declaration for the SIREN — the very
+// surface interference #1 of the spec warns would otherwise show 7 rows after a
+// grid run. The rigorous, row-count proof of resetCampaignYear lives in
+// db-campaign.integration.test.ts.
+test.describe("withCampaignYear leaves no residue between two year coordinates (#4067)", () => {
+	test("a run pinned on 2033 lists exactly one declaration", async ({
+		page,
+	}) => {
+		test.slow();
+		// Coordinate A: create a declaration under 2032, then let the fixture tear it down.
+		await withCampaignYear({ page, year: 2032, workforce: 250 }, async () => {
+			await page.goto("/declaration-remuneration");
+			await page.waitForURL("**/declaration-remuneration/etape/**");
+		});
+
+		// Coordinate B: only 2033's declaration may exist — A left no residue.
+		await withCampaignYear({ page, year: 2033, workforce: 250 }, async () => {
+			await page.goto("/declaration-remuneration");
+			await page.waitForURL("**/declaration-remuneration/etape/**");
+
 			await page.goto("/mon-espace");
-
-			const companyInfo = page
-				.locator("dl")
-				.filter({ hasText: "Effectif annuel moyen" })
-				.first();
-			await expect(companyInfo).toContainText("70");
-			await expect(companyInfo).not.toContainText("Existence d'un CSE");
-			// Nothing is editable below 100, so the edit entry point is dropped too.
-			await expect(
-				page.getByRole("button", { exact: true, name: "Modifier" }),
-			).toHaveCount(0);
-
-			await page.goto("/declaration-remuneration/etape/1");
-			await expect(page.getByText("Étape 1 sur 5")).toBeVisible();
-			await expect(
-				page.getByText(`Effectif annuel moyen en ${currentYear - 1} :`),
-			).toBeVisible();
-			await expect(page.getByText("Existence d'un CSE :")).toHaveCount(0);
-		});
-
-		test("submitting the quartile step lands on the review step (S1 of #3934)", async ({
-			page,
-		}) => {
-			await submitStepsThroughQuartiles(page);
-
-			await page.waitForURL("**/declaration-remuneration/etape/6");
-			await expect(page.getByText("Étape 5 sur 5")).toBeVisible();
+			const currentDeclarations = page.locator(
+				'table[aria-labelledby="demarches-en-cours-title"] tbody tr',
+			);
+			await expect(currentDeclarations).toHaveCount(1);
+			await expect(page.getByText("2032")).toHaveCount(0);
 		});
 	});
 });

--- a/packages/app/src/e2e/global-setup.ts
+++ b/packages/app/src/e2e/global-setup.ts
@@ -1,10 +1,19 @@
 import {
 	pushCampaignDeadlinesFarFuture,
 	resetDeclarationToDraft,
+	resetGipWorkforce,
 } from "./helpers/db";
 
-/** Reset DB state before E2E tests so runs are idempotent. */
+/**
+ * Reset DB state before E2E tests so runs are idempotent.
+ *
+ * Re-asserts the calendar-year baseline the unpinned suite relies on: far-future
+ * deadlines and the >= 250 GIP workforce. This also heals the coordinate a
+ * hard-interrupted campaign-year grid run (#4022) may have left flattened, since
+ * `withCampaignYear`'s safety net resets the calendar year too.
+ */
 export default async function globalSetup() {
 	await pushCampaignDeadlinesFarFuture();
+	await resetGipWorkforce();
 	await resetDeclarationToDraft();
 }

--- a/packages/app/src/e2e/global-setup.ts
+++ b/packages/app/src/e2e/global-setup.ts
@@ -1,19 +1,24 @@
 import {
 	pushCampaignDeadlinesFarFuture,
 	resetDeclarationToDraft,
-	resetGipWorkforce,
 } from "./helpers/db";
 
 /**
  * Reset DB state before E2E tests so runs are idempotent.
  *
- * Re-asserts the calendar-year baseline the unpinned suite relies on: far-future
- * deadlines and the >= 250 GIP workforce. This also heals the coordinate a
- * hard-interrupted campaign-year grid run (#4022) may have left flattened, since
- * `withCampaignYear`'s safety net resets the calendar year too.
+ * Re-asserts the far-future campaign deadlines the unpinned suite relies on and
+ * clears any leftover declaration. Both touch only year-scoped rows that carry no
+ * FK on `app_company`, so they are safe on a pristine database.
+ *
+ * The >= 250 GIP baseline is deliberately NOT re-asserted here: `app_gip_mds_data`
+ * references `app_company`, whose row only exists once the first ProConnect login
+ * has run — and `globalSetup` runs before the `setup` project that performs it.
+ * Seeding it here would violate the FK and abort the whole suite on a fresh DB.
+ * `auth.setup.ts` re-asserts the GIP baseline right after that login (and so also
+ * heals a company a hard-interrupted campaign-year grid run (#4022/#4067) may have
+ * left flattened), which is the correct — and only viable — place for it.
  */
 export default async function globalSetup() {
 	await pushCampaignDeadlinesFarFuture();
-	await resetGipWorkforce();
 	await resetDeclarationToDraft();
 }

--- a/packages/app/src/e2e/helpers/__tests__/db-campaign.resetCampaignYear.integration.test.ts
+++ b/packages/app/src/e2e/helpers/__tests__/db-campaign.resetCampaignYear.integration.test.ts
@@ -1,0 +1,260 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { TEST_SIREN } from "~/e2e/constants";
+import { resetCampaignYear } from "~/e2e/helpers/db-campaign";
+
+// Runnable proof of the #4067 isolation guarantee (ticket criterion 4).
+//
+// `resetCampaignYear(year)` is the DB core of the campaign-year grid (#4022): it
+// must wipe EVERY year-scoped row of one (siren, year) coordinate — declaration,
+// its dependents, the declaration lock, GIP data and the campaign deadline — while
+// leaving a DIFFERENT year's coordinate completely untouched, and flatten the two
+// non-year-scoped `app_company` columns that would otherwise bleed across years.
+//
+// Unit tests mock the driver and cannot prove this; the whole point is real row
+// counts against a real Postgres. This runs under `pnpm test:integration` against
+// the disposable container from `integration-setup.ts`, which exposes its URI via
+// `process.env.DATABASE_URL` — the exact env var `resetCampaignYear` reads to
+// connect, so the seed and the reset hit the same database.
+
+const TARGET_YEAR = 2099;
+const BYSTANDER_YEAR = 2088;
+const USER_ID = "resetcy-it-user";
+const LOCK_EXPIRES_AT = new Date("2099-12-31T00:00:00Z");
+const FAR_FUTURE = "2099-12-31";
+
+// The ten year-scoped tables `resetCampaignYear` purges, in the order it walks
+// them (children first). Each count is taken for a single (TEST_SIREN, year)
+// coordinate; the campaign deadline is keyed on `year` alone.
+type CoordinateCounts = {
+	employeeCategory: number;
+	jobCategory: number;
+	cseOpinionFile: number;
+	cseOpinion: number;
+	file: number;
+	statusHistory: number;
+	declarationLock: number;
+	declaration: number;
+	gipMdsData: number;
+	campaignDeadline: number;
+};
+
+describe("resetCampaignYear (real Postgres) — #4067 coordinate isolation", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	async function seedCampaignYear(year: number) {
+		// `id` is a Drizzle `$defaultFn` (app-side crypto.randomUUID), NOT a DB
+		// default — raw INSERTs must supply it with gen_random_uuid(), exactly as
+		// the production fixture helpers do.
+		const [declaration] = await sql<[{ id: string }]>`
+			INSERT INTO app_declaration (id, siren, year, declarant_id, status)
+			VALUES (gen_random_uuid(), ${TEST_SIREN}, ${year}, ${USER_ID}, 'draft')
+			RETURNING id
+		`;
+		const declarationId = declaration?.id;
+		await sql`
+			INSERT INTO app_declaration_lock (
+				id, declaration_id, locked_by_user_id, locked_at, last_heartbeat_at, expires_at
+			)
+			VALUES (gen_random_uuid(), ${declarationId}, ${USER_ID}, NOW(), NOW(), ${LOCK_EXPIRES_AT})
+		`;
+		await sql`
+			INSERT INTO app_declaration_status_history (id, declaration_id, event_type, round, created_at)
+			VALUES (gen_random_uuid(), ${declarationId}, 'path_choice', 1, NOW())
+		`;
+		const [jobCategory] = await sql<[{ id: string }]>`
+			INSERT INTO app_job_category (id, declaration_id, category_index, name, source)
+			VALUES (gen_random_uuid(), ${declarationId}, 0, 'Ouvriers', 'user')
+			RETURNING id
+		`;
+		await sql`
+			INSERT INTO app_employee_category (id, job_category_id, declaration_type, women_count, men_count)
+			VALUES (gen_random_uuid(), ${jobCategory?.id}, 'initial', 3, 4)
+		`;
+		const [file] = await sql<[{ id: string }]>`
+			INSERT INTO app_file (id, declaration_id, file_name, file_path, uploaded_at, type)
+			VALUES (gen_random_uuid(), ${declarationId}, 'avis.pdf', '/tmp/avis.pdf', NOW(), 'cse_opinion')
+			RETURNING id
+		`;
+		await sql`
+			INSERT INTO app_cse_opinion (id, declaration_id, declaration_number, type)
+			VALUES (gen_random_uuid(), ${declarationId}, 1, 'remuneration')
+		`;
+		await sql`
+			INSERT INTO app_cse_opinion_file (id, declaration_id, declaration_number, type, file_id)
+			VALUES (gen_random_uuid(), ${declarationId}, 1, 'remuneration', ${file?.id})
+		`;
+		await sql`
+			INSERT INTO app_gip_mds_data (siren, year, workforce_ema)
+			VALUES (${TEST_SIREN}, ${year}, 250)
+		`;
+		await sql`
+			INSERT INTO app_campaign_deadline (
+				year,
+				decl1_modification_deadline, decl1_justification_deadline, decl1_joint_evaluation_deadline,
+				decl2_modification_deadline, decl2_justification_deadline, decl2_joint_evaluation_deadline
+			)
+			VALUES (
+				${year},
+				${FAR_FUTURE}, ${FAR_FUTURE}, ${FAR_FUTURE},
+				${FAR_FUTURE}, ${FAR_FUTURE}, ${FAR_FUTURE}
+			)
+		`;
+	}
+
+	async function countCoordinate(year: number): Promise<CoordinateCounts> {
+		const rows = await sql<[Record<keyof CoordinateCounts, number>]>`
+			SELECT
+				(SELECT count(*)::int FROM app_employee_category ec
+					JOIN app_job_category jc ON jc.id = ec.job_category_id
+					JOIN app_declaration d ON d.id = jc.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "employeeCategory",
+				(SELECT count(*)::int FROM app_job_category jc
+					JOIN app_declaration d ON d.id = jc.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "jobCategory",
+				(SELECT count(*)::int FROM app_cse_opinion_file cof
+					JOIN app_declaration d ON d.id = cof.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "cseOpinionFile",
+				(SELECT count(*)::int FROM app_cse_opinion co
+					JOIN app_declaration d ON d.id = co.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "cseOpinion",
+				(SELECT count(*)::int FROM app_file f
+					JOIN app_declaration d ON d.id = f.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "file",
+				(SELECT count(*)::int FROM app_declaration_status_history h
+					JOIN app_declaration d ON d.id = h.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "statusHistory",
+				(SELECT count(*)::int FROM app_declaration_lock l
+					JOIN app_declaration d ON d.id = l.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "declarationLock",
+				(SELECT count(*)::int FROM app_declaration d
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}) AS "declaration",
+				(SELECT count(*)::int FROM app_gip_mds_data g
+					WHERE g.siren = ${TEST_SIREN} AND g.year = ${year}) AS "gipMdsData",
+				(SELECT count(*)::int FROM app_campaign_deadline cd
+					WHERE cd.year = ${year}) AS "campaignDeadline"
+		`;
+		return rows[0];
+	}
+
+	async function purgeAll() {
+		// Full teardown for the test SIREN across both years and the shared rows
+		// (company + user) so nothing leaks to another integration file that
+		// happens to reuse this SIREN in the shared container.
+		await resetCampaignYear(TARGET_YEAR);
+		await resetCampaignYear(BYSTANDER_YEAR);
+		await sql`DELETE FROM app_user_company WHERE siren = ${TEST_SIREN}`;
+		await sql`DELETE FROM app_company WHERE siren = ${TEST_SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+	}
+
+	beforeAll(() => {
+		sql = postgres(process.env.DATABASE_URL ?? "", { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await purgeAll();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await purgeAll();
+		await sql`
+			INSERT INTO app_user (id, email, first_name, last_name)
+			VALUES (${USER_ID}, 'resetcy-it@example.fr', 'Reset', 'CampaignYear')
+		`;
+		await sql`
+			INSERT INTO app_company (siren, name, has_cse, workforce)
+			VALUES (${TEST_SIREN}, 'Coordinate Test Company', true, 300)
+		`;
+		await seedCampaignYear(TARGET_YEAR);
+		await seedCampaignYear(BYSTANDER_YEAR);
+	});
+
+	it("wipes every year-scoped row of the target coordinate", async () => {
+		const before = await countCoordinate(TARGET_YEAR);
+		expect(before).toStrictEqual({
+			employeeCategory: 1,
+			jobCategory: 1,
+			cseOpinionFile: 1,
+			cseOpinion: 1,
+			file: 1,
+			statusHistory: 1,
+			declarationLock: 1,
+			declaration: 1,
+			gipMdsData: 1,
+			campaignDeadline: 1,
+		});
+
+		await resetCampaignYear(TARGET_YEAR);
+
+		expect(await countCoordinate(TARGET_YEAR)).toStrictEqual({
+			employeeCategory: 0,
+			jobCategory: 0,
+			cseOpinionFile: 0,
+			cseOpinion: 0,
+			file: 0,
+			statusHistory: 0,
+			declarationLock: 0,
+			declaration: 0,
+			gipMdsData: 0,
+			campaignDeadline: 0,
+		});
+	});
+
+	it("releases the target coordinate's declaration lock", async () => {
+		expect((await countCoordinate(TARGET_YEAR)).declarationLock).toBe(1);
+
+		await resetCampaignYear(TARGET_YEAR);
+
+		const remainingLocks = await sql<[{ n: number }]>`
+			SELECT count(*)::int AS n FROM app_declaration_lock WHERE locked_by_user_id = ${USER_ID}
+		`;
+		// Only the bystander year's lock survives the target reset.
+		expect(remainingLocks[0]?.n).toBe(1);
+		expect((await countCoordinate(TARGET_YEAR)).declarationLock).toBe(0);
+	});
+
+	it("leaves a different year's coordinate completely intact", async () => {
+		const bystanderBefore = await countCoordinate(BYSTANDER_YEAR);
+
+		await resetCampaignYear(TARGET_YEAR);
+
+		expect(await countCoordinate(BYSTANDER_YEAR)).toStrictEqual(
+			bystanderBefore,
+		);
+		expect(bystanderBefore).toStrictEqual({
+			employeeCategory: 1,
+			jobCategory: 1,
+			cseOpinionFile: 1,
+			cseOpinion: 1,
+			file: 1,
+			statusHistory: 1,
+			declarationLock: 1,
+			declaration: 1,
+			gipMdsData: 1,
+			campaignDeadline: 1,
+		});
+	});
+
+	it("flattens the shared app_company has_cse and workforce columns to NULL", async () => {
+		const before = await sql<
+			[{ hasCse: boolean | null; workforce: number | null }]
+		>`
+			SELECT has_cse AS "hasCse", workforce FROM app_company WHERE siren = ${TEST_SIREN}
+		`;
+		expect(before[0]?.hasCse).toBe(true);
+		expect(before[0]?.workforce).toBe(300);
+
+		await resetCampaignYear(TARGET_YEAR);
+
+		const after = await sql<
+			[{ hasCse: boolean | null; workforce: number | null }]
+		>`
+			SELECT has_cse AS "hasCse", workforce FROM app_company WHERE siren = ${TEST_SIREN}
+		`;
+		expect(after[0]?.hasCse).toBeNull();
+		expect(after[0]?.workforce).toBeNull();
+	});
+});

--- a/packages/app/src/e2e/helpers/campaign-year.ts
+++ b/packages/app/src/e2e/helpers/campaign-year.ts
@@ -106,6 +106,11 @@ export async function withCampaignYear(
 	try {
 		await fn();
 	} finally {
+		// Clear the SERVER clock override first: pinCampaignYear pins it on the Node
+		// process (a global that survives across tests, unlike the per-page browser
+		// init script), so without this every later unpinned spec would keep reading
+		// this coordinate's year and lose its GIP row / funnel shape (#4067).
+		await setServerCampaignYear(null);
 		await resetCampaignYearData(year);
 		const calendarYear = await getCurrentDbYear();
 		if (calendarYear !== year) {

--- a/packages/app/src/e2e/helpers/campaign-year.ts
+++ b/packages/app/src/e2e/helpers/campaign-year.ts
@@ -1,4 +1,11 @@
 import type { Page } from "@playwright/test";
+import {
+	getCurrentDbYear,
+	pushCampaignDeadlinesFarFuture,
+	resetGipWorkforce,
+	setGipWorkforce,
+} from "./db";
+import { resetCampaignYear as resetCampaignYearData } from "./db-campaign";
 
 // Drives the campaign-year seam of issue #4022 from a Playwright run. The year
 // is read by getCurrentYear() through globalThis.__egaproCampaignYear, a value
@@ -62,4 +69,49 @@ export async function resetCampaignYear(page: Page): Promise<void> {
 		(globalThis as { __egaproCampaignYear?: number }).__egaproCampaignYear =
 			undefined;
 	});
+}
+
+/** One campaign-year coordinate of the E2E grid (#4022): a pinned year and the
+ * GIP workforce that decides the funnel shape (indicator G / step 5 gating). */
+export type CampaignCoordinate = {
+	page: Page;
+	year: number;
+	workforce: number;
+};
+
+/**
+ * Run `fn` under a fully isolated campaign-year coordinate (#4067).
+ *
+ * Pins the clock on both surfaces, wipes any residue of the target year, seeds
+ * its deadlines (never a `campaign_start_date` — see pushCampaignDeadlinesFarFuture)
+ * and its GIP workforce, then runs the body. The teardown always runs (even when
+ * `fn` throws) and double-resets: the coordinate's own year, plus the calendar
+ * year as a safety net for any residue a default-year helper wrote inside `fn`
+ * (`setCompanyHasCse`, an unpinned `setGipWorkforce`, …). The calendar year is
+ * then restored to the baseline the unpinned suite depends on (far-future
+ * deadlines + the >= 250 GIP workforce), so a pinned spec never leaves the shared
+ * company GIP-less for the next spec file. It leaves no declaration, file, CSE
+ * opinion, lock or `has_cse` flag of the coordinate behind — the invariant the
+ * grid relies on to chain 185 coordinates without cross-contamination.
+ */
+export async function withCampaignYear(
+	coordinate: CampaignCoordinate,
+	fn: () => Promise<void>,
+): Promise<void> {
+	const { page, year, workforce } = coordinate;
+	await pinCampaignYear(page, year);
+	await resetCampaignYearData(year);
+	await pushCampaignDeadlinesFarFuture(year);
+	await setGipWorkforce(workforce, year);
+	try {
+		await fn();
+	} finally {
+		await resetCampaignYearData(year);
+		const calendarYear = await getCurrentDbYear();
+		if (calendarYear !== year) {
+			await resetCampaignYearData(calendarYear);
+			await pushCampaignDeadlinesFarFuture();
+			await resetGipWorkforce();
+		}
+	}
 }

--- a/packages/app/src/e2e/helpers/db-campaign.ts
+++ b/packages/app/src/e2e/helpers/db-campaign.ts
@@ -1,10 +1,96 @@
 import postgres from "postgres";
+import { TEST_SIREN } from "../constants";
 
 const DEFAULT_DB_URL = "postgresql://postgres:postgres@localhost:5438/egapro";
 
 function createConnection() {
 	const url = process.env.DATABASE_URL ?? DEFAULT_DB_URL;
 	return postgres(url, { max: 1 });
+}
+
+/**
+ * Full teardown of one campaign-year coordinate for the test SIREN (#4067).
+ *
+ * The E2E grid (#4022) runs 185 declarations across 7 campaign years on a single
+ * test company, so residue between two coordinates would surface as erratic,
+ * undiagnosable failures on a multi-hour nightly run. This purges every
+ * year-scoped row for (siren, year) in foreign-key dependency order (children
+ * first), then flattens the two `app_company` columns that are shared across all
+ * years and would otherwise leak from one coordinate to the next.
+ *
+ * The declaration lock is released explicitly (before the declaration it hangs
+ * off) so a coordinate never inherits the lock of the previous one — even though
+ * the FK would cascade — because the guarantee must be verifiable, not incidental.
+ * The whole sequence runs in one transaction: a mid-teardown failure must never
+ * leave a half-purged coordinate behind.
+ */
+export async function resetCampaignYear(year: number) {
+	const sql = createConnection();
+	try {
+		await sql.begin(async (tx) => {
+			await tx`
+				DELETE FROM app_employee_category
+				WHERE job_category_id IN (
+					SELECT jc.id FROM app_job_category jc
+					INNER JOIN app_declaration d ON d.id = jc.declaration_id
+					WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}
+				)
+			`;
+			await tx`
+				DELETE FROM app_job_category
+				WHERE declaration_id IN (
+					SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				)
+			`;
+			// cse_opinion_file references both cse_opinion and file, so it goes first.
+			await tx`
+				DELETE FROM app_cse_opinion_file
+				WHERE declaration_id IN (
+					SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				)
+			`;
+			await tx`
+				DELETE FROM app_cse_opinion
+				WHERE declaration_id IN (
+					SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				)
+			`;
+			await tx`
+				DELETE FROM app_file
+				WHERE declaration_id IN (
+					SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				)
+			`;
+			await tx`
+				DELETE FROM app_declaration_status_history
+				WHERE declaration_id IN (
+					SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				)
+			`;
+			await tx`
+				DELETE FROM app_declaration_lock
+				WHERE declaration_id IN (
+					SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				)
+			`;
+			await tx`
+				DELETE FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+			`;
+			await tx`
+				DELETE FROM app_gip_mds_data WHERE siren = ${TEST_SIREN} AND year = ${year}
+			`;
+			await tx`
+				DELETE FROM app_campaign_deadline WHERE year = ${year}
+			`;
+			// app_company is NOT year-scoped: flatten the columns a coordinate mutates
+			// (setCompanyHasCse / setCompanyWorkforce) so they cannot bleed forward.
+			await tx`
+				UPDATE app_company SET has_cse = NULL, workforce = NULL WHERE siren = ${TEST_SIREN}
+			`;
+		});
+	} finally {
+		await sql.end();
+	}
 }
 
 type CampaignDeadlineDates = {

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -8,7 +8,22 @@ function createConnection() {
 	return postgres(url, { max: 1 });
 }
 
-export async function ensureCurrentYearDeclaration() {
+type Connection = ReturnType<typeof createConnection>;
+
+// The fixture layer runs in the Playwright runner process, which cannot read the
+// campaign-year override the app honours (that lives on the dev-server process,
+// issue #4022). Year-scoped helpers therefore take the year explicitly and fall
+// back to the database calendar year — the single EXTRACT(YEAR FROM CURRENT_DATE)
+// of this module — so unpinned specs keep their pre-#4067 behaviour untouched.
+async function effectiveYear(sql: Connection, year?: number): Promise<number> {
+	if (year !== undefined) return year;
+	const rows = await sql<[{ year: number }]>`
+		SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS year
+	`;
+	return rows[0]?.year ?? 2026;
+}
+
+export async function ensureCurrentYearDeclaration(year?: number) {
 	const sql = createConnection();
 	try {
 		const users = await sql`
@@ -16,6 +31,7 @@ export async function ensureCurrentYearDeclaration() {
 		`;
 		const userId = users[0]?.user_id as string | undefined;
 		if (!userId) return;
+		const targetYear = await effectiveYear(sql, year);
 		await sql`
 			INSERT INTO app_declaration (
 				id, siren, year, declarant_id, current_step, status,
@@ -24,7 +40,7 @@ export async function ensureCurrentYearDeclaration() {
 			VALUES (
 				gen_random_uuid(),
 				${TEST_SIREN},
-				EXTRACT(YEAR FROM CURRENT_DATE)::int,
+				${targetYear},
 				${userId},
 				1,
 				'draft',
@@ -95,14 +111,23 @@ export async function resetDeclarationToDraft() {
 }
 
 /**
- * Inserts (or refreshes) a app_campaign_deadline row for the current year with all
- * deadlines pushed far into the future. Prevents date-sensitive business rules
- * (e.g. `isDraftExpired` in declarationDraftRouter.get) from breaking e2e tests
- * when CI happens to run on or after the default deadline of June 1.
+ * Inserts (or refreshes) a app_campaign_deadline row for the given year (calendar
+ * year by default) with all deadlines pushed far into the future. Prevents
+ * date-sensitive business rules (e.g. `isDraftExpired` in
+ * declarationDraftRouter.get) from breaking e2e tests when CI happens to run on
+ * or after the default deadline of June 1.
+ *
+ * Deliberately leaves `campaign_start_date` NULL — do NOT "fix" this by seeding
+ * it. `getActiveCampaignYear()` (`~/server/db/getGlobalSettings.ts`) only keeps
+ * rows whose `campaign_start_date` is non-null and past, then takes their max; a
+ * seeded date here would make every pinned year resolve to the latest one and
+ * collapse the whole 7-year grid onto a single campaign. Left null, that query
+ * falls back to `getCurrentYear()` — i.e. the piloted campaign year (#4022/#4067).
  */
-export async function pushCampaignDeadlinesFarFuture() {
+export async function pushCampaignDeadlinesFarFuture(year?: number) {
 	const sql = createConnection();
 	try {
+		const targetYear = await effectiveYear(sql, year);
 		await sql`
 			INSERT INTO app_campaign_deadline (
 				year,
@@ -114,7 +139,7 @@ export async function pushCampaignDeadlinesFarFuture() {
 				decl2_joint_evaluation_deadline
 			)
 			SELECT
-				EXTRACT(YEAR FROM CURRENT_DATE)::int,
+				${targetYear},
 				'2099-12-31'::date,
 				'2099-12-31'::date,
 				'2099-12-31'::date,
@@ -152,14 +177,18 @@ export async function setCompanyHasCse(hasCse: boolean | null) {
  * field, indicator G / step 5 gating, SUIT export). Passing `null` deletes the row,
  * which models a company absent from the GIP file — treated as "< 50", not subject.
  */
-export async function setGipWorkforce(workforceEma: number | null) {
+export async function setGipWorkforce(
+	workforceEma: number | null,
+	year?: number,
+) {
 	const sql = createConnection();
 	try {
+		const targetYear = await effectiveYear(sql, year);
 		if (workforceEma === null) {
 			await sql`
 				DELETE FROM app_gip_mds_data
 				WHERE siren = ${TEST_SIREN}
-				  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
+				  AND year = ${targetYear}
 			`;
 			return;
 		}
@@ -167,7 +196,7 @@ export async function setGipWorkforce(workforceEma: number | null) {
 			INSERT INTO app_gip_mds_data (siren, year, workforce_ema, imported_at)
 			VALUES (
 				${TEST_SIREN},
-				EXTRACT(YEAR FROM CURRENT_DATE)::int,
+				${targetYear},
 				${workforceEma},
 				NOW()
 			)
@@ -345,16 +374,17 @@ export async function deleteCseOpinions() {
 	}
 }
 
-export async function deleteCurrentYearCategories() {
+export async function deleteCurrentYearCategories(year?: number) {
 	const sql = createConnection();
 	try {
+		const targetYear = await effectiveYear(sql, year);
 		await sql`
 			DELETE FROM app_employee_category
 			WHERE job_category_id IN (
 				SELECT jc.id FROM app_job_category jc
 				INNER JOIN app_declaration d ON d.id = jc.declaration_id
 				WHERE d.siren = ${TEST_SIREN}
-				  AND d.year = EXTRACT(YEAR FROM CURRENT_DATE)::int
+				  AND d.year = ${targetYear}
 			)
 		`;
 		await sql`
@@ -362,7 +392,7 @@ export async function deleteCurrentYearCategories() {
 			WHERE declaration_id IN (
 				SELECT id FROM app_declaration
 				WHERE siren = ${TEST_SIREN}
-				  AND year = EXTRACT(YEAR FROM CURRENT_DATE)::int
+				  AND year = ${targetYear}
 			)
 		`;
 	} finally {
@@ -373,50 +403,43 @@ export async function deleteCurrentYearCategories() {
 export async function getCurrentDbYear(): Promise<number> {
 	const sql = createConnection();
 	try {
-		const rows = await sql<[{ year: number }]>`
-			SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS year
-		`;
-		return rows[0]?.year ?? 2026;
+		return await effectiveYear(sql);
 	} finally {
 		await sql.end();
 	}
 }
 
-export async function cleanCurrentYearDeclarations() {
+export async function cleanCurrentYearDeclarations(year?: number) {
 	const sql = createConnection();
 	try {
-		const rows = await sql<[{ year: number }]>`
-			SELECT EXTRACT(YEAR FROM CURRENT_DATE)::int AS year
-		`;
-		const year = rows[0]?.year;
-		if (!year) return;
+		const targetYear = await effectiveYear(sql, year);
 		await sql`
 			DELETE FROM app_employee_category
 			WHERE job_category_id IN (
 				SELECT jc.id FROM app_job_category jc
 				INNER JOIN app_declaration d ON d.id = jc.declaration_id
-				WHERE d.siren = ${TEST_SIREN} AND d.year = ${year}
+				WHERE d.siren = ${TEST_SIREN} AND d.year = ${targetYear}
 			)
 		`;
 		await sql`
 			DELETE FROM app_job_category
 			WHERE declaration_id IN (
-				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${targetYear}
 			)
 		`;
 		await sql`
 			DELETE FROM app_cse_opinion
 			WHERE declaration_id IN (
-				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${targetYear}
 			)
 		`;
 		await sql`
 			DELETE FROM app_file
 			WHERE declaration_id IN (
-				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}
+				SELECT id FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${targetYear}
 			)
 		`;
-		await sql`DELETE FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${year}`;
+		await sql`DELETE FROM app_declaration WHERE siren = ${TEST_SIREN} AND year = ${targetYear}`;
 	} finally {
 		await sql.end();
 	}


### PR DESCRIPTION
Closes #4067

## Résumé

Rend la couche fixture E2E cohérente avec l'horloge de campagne pilotable (#4065) et garantit l'**isolation inter-runs** pour la grille #4022 (185 déclarations × 7 années sur un SIREN unique). Ticket 100 % couche fixture E2E (`src/e2e/**`) — aucune migration, aucune surface UI, aucun fichier serveur.

> Périmètre `src/e2e/**` : dérogation explicite de l'utilisateur pour ce ticket (l'epic #4022 produit l'outillage de test lui-même). `e2e-dev` reste la gate indépendante en fin de pipeline.

### Ce qui change (6 fichiers)

- **`helpers/db.ts`** — les helpers year-scoped (`ensureCurrentYearDeclaration`, `setGipWorkforce`, `deleteCurrentYearCategories`, `pushCampaignDeadlinesFarFuture`, `cleanCurrentYearDeclarations`) prennent un `year?` optionnel (défaut = année calendaire DB). Un unique résolveur `effectiveYear()` porte le seul `EXTRACT(YEAR FROM CURRENT_DATE)` du module ; plus aucun EXTRACT non paramétrable.
- **`helpers/db-campaign.ts`** — nouveau `resetCampaignYear(year)` : teardown **transactionnel** d'une coordonnée. Purge 10 tables dans l'ordre des FK (`app_employee_category → job_category → cse_opinion_file → cse_opinion → file → declaration_status_history → declaration_lock → declaration → gip_mds_data → campaign_deadline`), filtrées `(siren, year)`, **relâche le verrou de déclaration explicitement**, puis remet `app_company.has_cse` / `workforce` à plat (non year-scoped).
- **`helpers/campaign-year.ts`** — nouveau `withCampaignYear(coordinate, fn)` : `pinCampaignYear` → `resetCampaignYear(year)` → `pushCampaignDeadlinesFarFuture(year)` → `setGipWorkforce(workforce, year)` → `fn` → (finally) `resetCampaignYear(year)` + filet de sécurité année calendaire. L'API clock de #4065 est intacte.
- **`global-setup.ts`** — ré-affirme la baseline calendaire (GIP ≥ 250 + deadlines) avant la suite.
- **`compliance.e2e.ts` / `declaration.e2e.ts`** — les branches mortes indicateur G sont **épinglées** sur des années stables (6-indicateurs = 2029 ; 7-indicateurs = 2030, triennale ≥ 2030) pour CAS-13-6IND (75), CAS-01/02-6IND (120) et « GIP workforce 70 », plus une preuve de non-résidu sur `/mon-espace`.

### Piège documenté (ne pas « corriger »)

`pushCampaignDeadlinesFarFuture` **ne renseigne jamais `campaign_start_date`** : c'est ce qui garde `getActiveCampaignYear()` neutre (fallback sur `getCurrentYear()`). La seeder ferait pointer toutes les années sur la dernière. Commenté dans le helper.

### Les 7 interférences du point 5 (spec), constatées

1. **`app_declaration` clé `(siren, year)`** → 7 déclarations peuvent coexister sur `/mon-espace` : d'où le teardown complet par coordonnée (pas un simple reset-to-draft). Traité + prouvé.
2. **`resetDeclarationToDraft` sans clause d'année** → agit sur toutes les années ; inoffensif en sériel, documenté. `withCampaignYear` n'en dépend pas (teardown year-scoped dédié).
3. **`app_company.has_cse` / `workforce` partagés** → confirme `workers: 1` comme contrainte structurelle ; remis à plat au teardown.
4. **Verrou de déclaration** (`app_declaration_lock`) → relâché explicitement avant sa déclaration (au-delà du cascade FK, pour que la garantie soit vérifiable).
5. **`app_gip_mds_data` clé `(siren, year)`** → auto-corrigeant, nettoyé quand même (item 9 du purge).
6. **Session ProConnect** `maxAge` 30 j → aucun risque sur un run de quelques heures. Vérifié, rien à faire.
7. **Connexions postgres** (~8/coordonnée, ~1500/run) → fonctionnel ; à mesurer si le run dérape, pas d'optimisation prématurée.

## Test plan

- `pnpm typecheck` ✅ · `pnpm lint:check` ✅ · `pnpm format:check` ✅
- `pnpm test` (vitest unit) ✅ — 3914 tests verts, zéro régression
- `pnpm test:integration` ✅ — nouveau `db-campaign.resetCampaignYear.integration.test.ts` (4 cas) prouve, par comptage de lignes, que `resetCampaignYear(Y)` purge toute la coordonnée Y **et** relâche son verrou, laisse la coordonnée voisine Y2 intacte, et remet `app_company` à plat. Preuve validée par **mutation-probe** (year-scoping cassé → RED).
- Les scénarios Playwright pinned-year sont exécutés par la gate `e2e-dev` en fin de pipeline (l'E2E n'est pas en CI).

## Notes de revue (findings structurels pré-existants, hors scope)

- `compliance.e2e.ts` dépasse 400 lignes (753 ; était 701 **avant** ce ticket, sous la limite dure de 800). Le split naturel (extraire GROUP G / GROUP H dans de nouveaux `*.e2e.ts`) créerait des fichiers hors des 6 du ticket et relève de l'organisation E2E de `e2e-dev` — **différé**.
- **7ᵉ fichier `docs/cahier-de-tests.md`** (hors des 6 du ticket) : indispensable — la gate CI `App · Cahier de tests ↔ E2E` (`check:cahier`) exige qu'un tag `[CAS-…]` d'une spec E2E ait une fiche au catalogue. Les nouveaux tags `[CAS-01-7IND]` (contre-branche 100-149) et `[CAS-13-6IND]` (tranche 50-99, scénarios S1/S2) ont donc reçu leur fiche. Modification documentaire pure, sans impact runtime.
- `DEFAULT_DB_URL` / `createConnection()` dupliqués entre `db.ts` et `db-campaign.ts` (motif pré-existant) : un module `connection.ts` partagé serait un 7ᵉ fichier, hors scope — **différé**.

