### PR TITLE
Module de grille dérivée + extraction des 17 scénarios de parcours (#4066)

### DIFF
--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "@playwright/test";
+import { buildGrid, pickCoordinate } from "./grille/coordinates";
+import { FICHE_SCENARIOS } from "./grille/scenarios";
 import { withCampaignYear } from "./helpers/campaign-year";
 import {
 	COMPLIANCE_PATH,
@@ -6,7 +8,6 @@ import {
 	fillCseStep1,
 	selectCompliancePath,
 	submitCseStep2,
-	uploadJointEvalPdf,
 } from "./helpers/compliance-flows";
 import {
 	resetDeclarationToDraft,
@@ -17,412 +18,217 @@ import {
 } from "./helpers/db";
 import {
 	completeDeclaration,
-	reachRecapWithoutGap,
 	reachStep6ComplianceRecap,
-	reachStep6Recap,
-	submitFromStep6Recap,
 } from "./helpers/declaration-flows";
-import {
-	indicatorGRequiredForGip,
-	indicatorGRequiredForGipInYear,
-	recapStepperLabel,
-} from "./helpers/indicator-g";
 
 test.describe.configure({ mode: "serial" });
 
-const CONFIRMATION_PATH = `${COMPLIANCE_PATH}/confirmation`;
+// The 185 coordinates are derived from the domain (grille/coordinates.ts); every
+// fiche's parcours-type lives in FICHE_SCENARIOS (grille/scenarios.ts). Each
+// describe below keeps its literal [CAS-xx] tag (read by check-cahier), keeps its
+// configuration, and delegates to the scenario with a representative coordinate of
+// the fiche. Behaviour is unchanged — only extracted.
+const GRID = buildGrid();
+
+// >= 100 tier, a 7-indicator year: exercises the full compliance funnel (step 5)
+// like the current suite baseline. The company workforce (200) drives the CSE and
+// compliance obligations; the baseline GIP workforce (>= 250) drives the funnel.
+function complianceCoordinate(fiche: string) {
+	return pickCoordinate(GRID, { fiche, effmax: "249", year: 2027 });
+}
 
 // === GROUP A: No gap — auto-redirects ===
 
 test.describe("[CAS-02] Path 1: no gap + hasCse → /avis-cse → full CSE flow", () => {
+	const coordinate = complianceCoordinate("CAS-02");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(true);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("complete declaration without gap, then CSE opinion flow", async ({
-		page,
-	}) => {
-		test.slow(); // Full declaration (6 steps) + CSE step 1 + CSE step 2
-		await completeDeclaration(page, { hasGap: false });
-
-		// No gap + hasCse → auto-redirect to /avis-cse
-		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-		await fillCseStep1(page);
-		await submitCseStep2(page);
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+	test("no-gap declaration, then full CSE opinion flow", async ({ page }) => {
+		test.slow();
+		await FICHE_SCENARIOS["CAS-02"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-01] Path 2: no gap + no hasCse → /confirmation", () => {
+	const coordinate = complianceCoordinate("CAS-01");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(false);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("complete declaration without gap, redirects to confirmation", async ({
+	test("no-gap declaration completes and /avis-cse stays unreachable", async ({
 		page,
 	}) => {
-		await completeDeclaration(page, { hasGap: false });
-
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
-	});
-
-	test("reaching /avis-cse directly redirects away when there is no CSE", async ({
-		page,
-	}) => {
-		// Every field of that funnel is required, so a company without a CSE
-		// cannot fill it in — the screen must stay out of reach even by URL.
-		await page.goto("/avis-cse/etape/1");
-
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		await FICHE_SCENARIOS["CAS-01"]({ page, coordinate });
 	});
 });
 
 // === GROUP B: Gap — compliance choice form ===
 
 test.describe("[CAS-04] Path 3: gap + hasCse → compliance choice → justify", () => {
+	const coordinate = complianceCoordinate("CAS-04");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(true);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("complete declaration with gap, shows 3 compliance options", async ({
+	test("gap declaration → 3 options → justify → CSE opinion with two columns", async ({
 		page,
 	}) => {
-		await completeDeclaration(page, { hasGap: true });
-
-		// Gap + hasCse → compliance choice page
-		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText("Actions correctives et seconde déclaration", {
-				exact: true,
-			}),
-		).toBeVisible();
-		await expect(
-			page.getByText(
-				"Mettre en place une évaluation conjointe des rémunérations",
-				{
-					exact: true,
-				},
-			),
-		).toBeVisible();
-		await expect(
-			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
-				exact: true,
-			}),
-		).toBeVisible();
-	});
-
-	test("justify → CSE opinion with accuracy + gap justification columns", async ({
-		page,
-	}) => {
-		test.slow(); // CSE step 1 (gap consulted) + step 2 matrix with 2 columns
-		await selectCompliancePath(page, "path-justify");
-		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
-
-		// CSE consulted on gap justification → step 2 requires the
-		// "Justification" column on top of "Exactitude" (Excel: cas 4).
-		await fillCseStep1(page, { firstDeclGapConsulted: true });
-		await submitCseStep2(page, {
-			columns: [
-				{ declarationNumber: 1, type: "accuracy" },
-				{ declarationNumber: 1, type: "gap" },
-			],
-		});
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-04"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-06] Path 4: gap + hasCse → joint evaluation → /avis-cse", () => {
+	const coordinate = complianceCoordinate("CAS-06");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(true);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("complete declaration with gap, joint evaluation → CSE opinion deposited", async ({
+	test("gap declaration → joint evaluation → CSE opinion deposited", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance choice + joint eval upload + CSE flow
-		await completeDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-joint");
-		await uploadJointEvalPdf(page);
-		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-
-		// Complete the CSE opinion after the joint evaluation (Excel: cas 6 —
-		// accuracy opinion, gap justification opinion being optional here).
-		await fillCseStep1(page);
-		await submitCseStep2(page);
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-06"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-05] Path 5: gap + no hasCse → joint evaluation → /confirmation", () => {
+	const coordinate = complianceCoordinate("CAS-05");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(false);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("shows all 3 options including justify (hasCse=false)", async ({
+	test("gap declaration → joint evaluation → /confirmation", async ({
 		page,
 	}) => {
-		await completeDeclaration(page, { hasGap: true });
-		await expect(
-			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
-				exact: true,
-			}),
-		).toBeVisible();
-	});
-
-	test("joint evaluation → upload PDF → /confirmation", async ({ page }) => {
-		await selectCompliancePath(page, "path-joint");
-		await uploadJointEvalPdf(page);
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		test.slow();
+		await FICHE_SCENARIOS["CAS-05"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-03] Path 5.b: gap + no hasCse → justify → /confirmation", () => {
+	const coordinate = complianceCoordinate("CAS-03");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(false);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
 	test("justify without CSE completes the démarche directly", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance choice
-		await completeDeclaration(page, { hasGap: true });
-
-		// No CSE → the justify path has no opinion to deposit: the FSM goes
-		// straight to demarche_completed (Excel: cas 3).
-		await selectCompliancePath(page, "path-justify");
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-03"]({ page, coordinate });
 	});
 });
 
 // === GROUP C: Corrective action — second declaration (no remaining gap) ===
 
 test.describe("[CAS-08] Path 6: gap + corrective action (no gap after) + hasCse → /avis-cse", () => {
+	const coordinate = complianceCoordinate("CAS-08");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(true);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("declaration → corrective action → correct without gap → CSE opinion on both declarations", async ({
+	test("corrective action → no gap → CSE opinion on both declarations", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance + second declaration + CSE flow
-		await completeDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-corrective");
-		await completeSecondDeclaration(page, { hasGap: false });
-		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-
-		// Two declarations submitted → the CSE step asks for both opinions and
-		// the step 2 matrix carries one "Exactitude" column per declaration
-		// (Excel: cas 8).
-		await fillCseStep1(page, { hasSecondDeclaration: true });
-		await submitCseStep2(page, {
-			hasSecondDeclaration: true,
-			columns: [
-				{ declarationNumber: 1, type: "accuracy" },
-				{ declarationNumber: 2, type: "accuracy" },
-			],
-		});
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-08"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-07] Path 7: gap + corrective action (no gap after) + no hasCse → /confirmation", () => {
+	const coordinate = complianceCoordinate("CAS-07");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(false);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("declaration → corrective action → correct without gap → /confirmation", async ({
-		page,
-	}) => {
-		test.slow(); // Full declaration + compliance + second declaration
-		await completeDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-corrective");
-		await completeSecondDeclaration(page, { hasGap: false });
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+	test("corrective action → no gap → /confirmation", async ({ page }) => {
+		test.slow();
+		await FICHE_SCENARIOS["CAS-07"]({ page, coordinate });
 	});
 });
 
 // === GROUP D: Corrective action with remaining gap → second round ===
 
 test.describe("[CAS-10] Path 8: gap + corrective action (gap persists) → second round choices", () => {
+	const coordinate = complianceCoordinate("CAS-10");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(true);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("declaration → corrective action → correct WITH gap → back to compliance choice", async ({
+	test("second round → justify → CSE opinion on both declarations with justification", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance + second declaration
-		await completeDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-corrective");
-		await completeSecondDeclaration(page, { hasGap: true });
-		// Gap still exists → redirect back to compliance choice
-		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
-	});
-
-	test("second round shows only justify and joint evaluation (no corrective action)", async ({
-		page,
-	}) => {
-		await page.goto(COMPLIANCE_PATH);
-		await expect(
-			page.getByText("Justifier les écarts de rémunération ≥ 5 %", {
-				exact: true,
-			}),
-		).toBeVisible();
-		await expect(
-			page.getByText(
-				"Mettre en place une évaluation conjointe des rémunérations",
-				{
-					exact: true,
-				},
-			),
-		).toBeVisible();
-		await expect(
-			page.getByText("Actions correctives et seconde déclaration", {
-				exact: true,
-			}),
-		).not.toBeVisible();
-	});
-
-	test("second round: justify → CSE opinion on both declarations with gap justification", async ({
-		page,
-	}) => {
-		test.slow(); // CSE step 1 (2 declarations) + step 2 matrix with 3 columns
-		await selectCompliancePath(page, "path-justify");
-		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
-
-		// Both declarations keep a gap ≥ 5%; the CSE was consulted on justifying
-		// the second one → step 2 requires accuracy ×2 + the second declaration's
-		// "Justification" column (Excel: cas 10).
-		await fillCseStep1(page, {
-			hasSecondDeclaration: true,
-			secondDeclGapConsulted: true,
-		});
-		await submitCseStep2(page, {
-			hasSecondDeclaration: true,
-			columns: [
-				{ declarationNumber: 1, type: "accuracy" },
-				{ declarationNumber: 2, type: "accuracy" },
-				{ declarationNumber: 2, type: "gap" },
-			],
-		});
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-10"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-09] Path 9: second round + justify + no hasCse → /confirmation", () => {
+	const coordinate = complianceCoordinate("CAS-09");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(false);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
 	test("full flow → second round → justify → /confirmation", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance + second decl + second round
-		await completeDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-corrective");
-		await completeSecondDeclaration(page, { hasGap: true });
-		// Gap persists → back to compliance choice for the second round
-		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
-
-		// No CSE → justify has no opinion to deposit: straight to completion
-		// (Excel: cas 9).
-		await selectCompliancePath(page, "path-justify");
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-09"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-12] Path 10: second round + joint evaluation + hasCse → /avis-cse", () => {
+	const coordinate = complianceCoordinate("CAS-12");
 	test.beforeAll(async () => {
-		// Fresh run: declaration → corrective action with gap → second round
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(true);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
-	test("full flow → second round → joint evaluation → CSE opinion on both declarations", async ({
+	test("full flow → second round → joint evaluation → CSE opinion on both", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance + second decl + second round + CSE flow
-		await completeDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-corrective");
-		await completeSecondDeclaration(page, { hasGap: true });
-		// Now in second round
-		await selectCompliancePath(page, "path-joint");
-		await uploadJointEvalPdf(page);
-		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-
-		// Joint evaluation deposited → close the démarche with the CSE opinion
-		// covering both declarations (Excel: cas 12).
-		await fillCseStep1(page, { hasSecondDeclaration: true });
-		await submitCseStep2(page, {
-			hasSecondDeclaration: true,
-			columns: [
-				{ declarationNumber: 1, type: "accuracy" },
-				{ declarationNumber: 2, type: "accuracy" },
-			],
-		});
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-12"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-11] Path 11: second round + joint evaluation + no hasCse → /confirmation", () => {
+	const coordinate = complianceCoordinate("CAS-11");
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setCompanyHasCse(false);
-		await setCompanyWorkforce(200);
+		await setCompanyHasCse(coordinate.hasCse);
+		await setCompanyWorkforce(coordinate.workforce);
 	});
 
 	test("full flow → second round → joint evaluation → /confirmation", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + compliance + second decl + second round
-		await completeDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-corrective");
-		await completeSecondDeclaration(page, { hasGap: true });
-		await selectCompliancePath(page, "path-joint");
-		await uploadJointEvalPdf(page);
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		test.slow();
+		await FICHE_SCENARIOS["CAS-11"]({ page, coordinate });
 	});
 });
 
@@ -499,7 +305,7 @@ test.describe("[ANX-02] Path 12: compliance already completed → redirect", () 
 	test("complete full flow, then verify compliance path redirects away", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + CSE step 1 + CSE step 2 + redirect check
+		test.slow();
 		// Complete declaration without gap → auto-redirect to CSE → complete CSE
 		await completeDeclaration(page, { hasGap: false });
 		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
@@ -517,73 +323,39 @@ test.describe("[ANX-02] Path 12: compliance already completed → redirect", () 
 });
 
 // === GROUP G: indicator G gated by the campaign year (#4022 / #4067) ===
-// Whether the funnel carries the categories step (step 5 / indicator G) is
-// decided by isIndicatorGRequired(workforce, year): below 250 it only applies on
-// the triennial cadence (base 2027), and — from 2030 — down to every mandatory
-// 50+ company. Every spec here PINS its campaign year through withCampaignYear so
-// both branches stay exercised instead of silently flipping when the calendar
-// reaches 2030; the fixture also tears the coordinate down, leaving no residue.
-// The expectation still comes from the domain (#4043) — just read on the pinned
-// year rather than on the calendar one.
-
-// 2029: < 2030 and off the triennial cadence → indicator G not required for < 250.
-const SIX_INDICATOR_YEAR = 2029;
-// 2030: triennial ((2030-2027) % 3 === 0) and >= 2030 → indicator G required for 50+.
-const SEVEN_INDICATOR_YEAR = 2030;
-
-const GIP_120_SIX_IND = indicatorGRequiredForGipInYear(120, SIX_INDICATOR_YEAR);
+// Whether the funnel carries the categories step (step 5 / indicator G) is decided
+// by isIndicatorGRequired(workforce, year): below 250 it only applies on the
+// triennial cadence (base 2027), and — from 2030 — down to every mandatory 50+
+// company. Each 6-indicator fiche pins its campaign year through the coordinate it
+// receives (year 2029, workforce 120), so both branches stay exercised.
 
 test.describe("[CAS-01-6IND] Path 14: 6 indicators (no G) + no hasCse → direct completion", () => {
+	const coordinate = pickCoordinate(GRID, {
+		fiche: "CAS-01-6IND",
+		effmax: "149",
+		year: 2029,
+	});
+
 	test("submits the tier's funnel and completes the démarche directly", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + submission
-		await withCampaignYear(
-			{ page, year: SIX_INDICATOR_YEAR, workforce: 120 },
-			async () => {
-				await setCompanyHasCse(false);
-				await reachRecapWithoutGap(page, {
-					indicatorGRequired: GIP_120_SIX_IND,
-				});
-				await expect(
-					page.getByText(recapStepperLabel(GIP_120_SIX_IND), { exact: true }),
-				).toBeVisible();
-
-				// Submit — no gap and no CSE → demarche completed directly
-				await submitFromStep6Recap(page);
-				await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-				await expect(
-					page.getByText(/Votre parcours .* est (désormais )?terminé/),
-				).toBeVisible();
-			},
-		);
+		test.slow();
+		await FICHE_SCENARIOS["CAS-01-6IND"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse", () => {
+	const coordinate = pickCoordinate(GRID, {
+		fiche: "CAS-02-6IND",
+		effmax: "149",
+		year: 2029,
+	});
+
 	test("submits the tier's funnel then deposits the CSE accuracy opinion", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + submission + CSE flow
-		await withCampaignYear(
-			{ page, year: SIX_INDICATOR_YEAR, workforce: 120 },
-			async () => {
-				await setCompanyHasCse(true);
-				await reachRecapWithoutGap(page, {
-					indicatorGRequired: GIP_120_SIX_IND,
-				});
-
-				// Submit — no gap but a CSE → straight to the CSE opinion
-				await submitFromStep6Recap(page);
-				await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
-
-				await fillCseStep1(page);
-				await submitCseStep2(page);
-				await expect(
-					page.getByText(/Votre parcours .* est (désormais )?terminé/),
-				).toBeVisible();
-			},
-		);
+		test.slow();
+		await FICHE_SCENARIOS["CAS-02-6IND"]({ page, coordinate });
 	});
 });
 
@@ -591,6 +363,8 @@ test.describe("[CAS-02-6IND] Path 15: 6 indicators (no G) + hasCse → /avis-cse
 // in a triennial year from 2030 — the assertion that would have silently broken
 // without #4067. Kept lightweight (funnel shape only): the full compliance flows
 // for a 7-indicator company are already covered by the >= 250 baseline cases.
+const SEVEN_INDICATOR_YEAR = 2030;
+
 test.describe("[ANX-04] Path 14bis: 100-149 company regains indicator G in a triennial year >= 2030", () => {
 	test("the funnel carries the indicator-G step (6 steps)", async ({
 		page,
@@ -607,8 +381,10 @@ test.describe("[ANX-04] Path 14bis: 100-149 company regains indicator G in a tri
 	});
 });
 
-// ANX-05 — the 50-99 tranche (scenarios S1/S2 of #4067): indicator G is
-// absent below 2030 and returns only in a triennial year from 2030.
+// ANX-05 — the 50-99 tranche (scenarios S1/S2 of #4067): indicator G is absent
+// below 2030 and returns only in a triennial year from 2030.
+const SIX_INDICATOR_YEAR = 2029;
+
 test.describe("[ANX-05] Path 13: 50-99 tranche — indicator G gated by the pinned year", () => {
 	test.describe.configure({ mode: "serial" });
 
@@ -645,10 +421,10 @@ test.describe("[ANX-05] Path 13: 50-99 tranche — indicator G gated by the pinn
 });
 
 // === GROUP H: [#3945] CSE opinion mentions gated by the declared CSE existence ===
-// A company >= 100 that declared it has no CSE (hasCse false or null) must no
-// longer be told to deposit a CSE opinion: the recap "Prochaines étapes" box and
-// the compliance-choice options drop every CSE-opinion mention, while the gap
-// actions and the "Mettre à jour l'existence d'un CSE" escape hatch stay.
+// A company >= 100 that declared it has no CSE (hasCse false or null) must no longer
+// be told to deposit a CSE opinion: the recap "Prochaines étapes" box and the
+// compliance-choice options drop every CSE-opinion mention, while the gap actions
+// and the "Mettre à jour l'existence d'un CSE" escape hatch stay.
 
 const CSE_OPINION_RECAP_TEXT = /avis du CSE devront être transmis/;
 const CSE_JUSTIFY_PARENTHESIS = /avis à transmettre sur le portail/;
@@ -664,7 +440,7 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=false → no CSE opinion 
 	test("step 6 recap hides the CSE opinion but keeps the gap actions and the update-CSE button", async ({
 		page,
 	}) => {
-		test.slow(); // Full 5-step declaration up to the recap
+		test.slow();
 		await reachStep6ComplianceRecap(page);
 
 		await expect(
@@ -695,7 +471,7 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=false → no CSE opinion 
 	test("compliance choice page drops the CSE opinion bullets", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + submission
+		test.slow();
 		await completeDeclaration(page, { hasGap: true });
 		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
 
@@ -723,7 +499,7 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=null → no CSE opinion m
 	test("step 6 recap treats an unset CSE flag like an absent CSE", async ({
 		page,
 	}) => {
-		test.slow(); // Full 5-step declaration up to the recap
+		test.slow();
 		await reachStep6ComplianceRecap(page);
 
 		await expect(
@@ -744,7 +520,7 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=true → CSE opinion stil
 	});
 
 	test("step 6 recap shows the CSE opinion mention", async ({ page }) => {
-		test.slow(); // Full 5-step declaration up to the recap
+		test.slow();
 		await reachStep6ComplianceRecap(page);
 
 		await expect(
@@ -757,7 +533,7 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=true → CSE opinion stil
 	test("compliance choice page keeps the CSE opinion bullet", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + submission
+		test.slow();
 		await completeDeclaration(page, { hasGap: true });
 		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
 
@@ -770,19 +546,21 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=true → CSE opinion stil
 // === GROUP I: tranches < 100 — the gap ≥ 5 % obligations stop at 100 salariés ===
 // Arbitrage 2026-07 (#4043, cahier de tests §6): the voluntary tier (< 50) declares
 // all 7 indicators every year, the 50-99 tier declares the 6 first ones outside its
-// own indicator G years, and neither owes anything when a gap ≥ 5 % shows up — the
-// compliance process, the second declaration, the joint evaluation and the CSE
-// opinion all stay gated at 100 salariés (Excel sheet "<50 et 50-99").
-// `hasCse` starts unset, as the question is never asked below 100 — but the CSE
-// probe of [CAS-14] declares one on purpose: `isCseOpinionRequired` is an AND of
-// the effectif and the CSE, so leaving `hasCse` unset would keep that probe green
-// even with no threshold at all, and [CAS-01] already covers the absent CSE. Each
+// own indicator G years, and neither owes anything when a gap ≥ 5 % shows up. The
+// [CAS-14] probe declares a CSE on purpose: isCseOpinionRequired is an AND of the
+// effectif and the CSE, so it fails if the 100-salarié gate ever disappears. Each
 // describe restores the file's exit state (GIP >= 250 + hasCse true) after it.
 
 test.describe("[CAS-13] 7 indicators + GIP 30 (< 50) + no gap → direct completion", () => {
+	const coordinate = pickCoordinate(GRID, {
+		fiche: "CAS-13",
+		effmax: "49",
+		year: 2027,
+	});
+
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setGipWorkforce(30);
+		await setGipWorkforce(coordinate.workforce);
 		await setCompanyHasCse(null);
 	});
 
@@ -794,33 +572,21 @@ test.describe("[CAS-13] 7 indicators + GIP 30 (< 50) + no gap → direct complet
 	test("declares the 7 indicators and completes the démarche directly", async ({
 		page,
 	}) => {
-		test.slow(); // 6-step declaration + submission
-		await reachStep6Recap(page, { hasGap: false });
-
-		// Step 5 was presented: 6-step funnel + indicator G block on the recap.
-		// `exact` scopes to the stepper — the Next.js route announcer repeats the
-		// label followed by the step title.
-		await expect(
-			page.getByText("Étape 6 sur 6", { exact: true }),
-		).toBeVisible();
-		await expect(
-			page.getByRole("heading", {
-				name: "Indicateurs par catégorie de salariés",
-			}),
-		).toBeVisible();
-
-		await submitFromStep6Recap(page);
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-13"]({ page, coordinate });
 	});
 });
 
 test.describe("[CAS-14] 7 indicators + GIP 30 (< 50) + gap ≥ 5 % → no obligation triggered", () => {
+	const coordinate = pickCoordinate(GRID, {
+		fiche: "CAS-14",
+		effmax: "49",
+		year: 2027,
+	});
+
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setGipWorkforce(30);
+		await setGipWorkforce(coordinate.workforce);
 		await setCompanyHasCse(null);
 	});
 
@@ -829,61 +595,11 @@ test.describe("[CAS-14] 7 indicators + GIP 30 (< 50) + gap ≥ 5 % → no obliga
 		await setCompanyHasCse(true);
 	});
 
-	test("the recap proposes no compliance action despite the gap", async ({
-		page,
-	}) => {
-		test.slow(); // 6-step declaration up to the recap
-		await reachStep6ComplianceRecap(page);
-
-		// Same gap inputs that render the "Prochaines étapes" box at 200 salariés
-		// (GROUP H): below 100 nothing is due, so the box is absent altogether.
-		await expect(
-			page.getByRole("heading", { name: "Prochaines étapes" }),
-		).toHaveCount(0);
-		await expect(
-			page.getByText("Écarts détectés", { exact: true }),
-		).toHaveCount(0);
-		await expect(
-			page.getByRole("heading", { name: "Actions à engager" }),
-		).toHaveCount(0);
-	});
-
 	test("submits into a direct completion, with every compliance surface out of reach", async ({
 		page,
 	}) => {
-		await page.goto("/declaration-remuneration/etape/6");
-		await submitFromStep6Recap(page);
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
-
-		// The compliance path choice, which carries the second declaration and the
-		// joint evaluation, is unreachable even by URL: below 100 salariés a gap
-		// ≥ 5 % opens none of them.
-		await page.goto(COMPLIANCE_PATH);
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-
-		// Declaring a CSE leaves the effectif as the only unmet term of
-		// `isCseOpinionRequired`, so this probe fails if the 100-salarié gate goes
-		// away — which an unset `hasCse` would have hidden.
-		await setCompanyHasCse(true);
-		const cseFunnelResponse = await page.goto("/avis-cse/etape/1");
-
-		// Read off the settled navigation instead of polling for the URL: a gate
-		// bouncing this company back into /avis-cse loops, and must surface as a
-		// redirect error or as the funnel pathname, never as a silent timeout.
-		expect(cseFunnelResponse?.ok()).toBe(true);
-		expect(new URL(page.url()).pathname).toBe(CONFIRMATION_PATH);
-		await expect(
-			page.getByRole("heading", {
-				name: "Transmettre l'avis ou les avis du CSE",
-			}),
-		).toHaveCount(0);
-		await expect(page.locator("#first-decl-accuracy-favorable")).toHaveCount(0);
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-14"]({ page, coordinate });
 	});
 });
 
@@ -893,11 +609,15 @@ test.describe("[CAS-14] 7 indicators + GIP 30 (< 50) + gap ≥ 5 % → no obliga
 // domain — what is under test either way is the outcome: below 100 salariés a gap-free
 // declaration completes the démarche directly, with no compliance obligation.
 test.describe("[CAS-13-6IND] GIP 75 (50-99) → direct completion", () => {
-	const indicatorGRequired = indicatorGRequiredForGip(75);
+	const coordinate = pickCoordinate(GRID, {
+		fiche: "CAS-13-6IND",
+		effmax: "99",
+		year: 2027,
+	});
 
 	test.beforeAll(async () => {
 		await resetDeclarationToDraft();
-		await setGipWorkforce(75);
+		await setGipWorkforce(coordinate.workforce);
 		await setCompanyHasCse(null);
 	});
 
@@ -909,30 +629,7 @@ test.describe("[CAS-13-6IND] GIP 75 (50-99) → direct completion", () => {
 	test("submits the tier's funnel and completes the démarche directly", async ({
 		page,
 	}) => {
-		test.slow(); // Full declaration + submission
-		await page.goto("/declaration-remuneration/etape/5");
-		if (indicatorGRequired) {
-			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/5$/);
-			await expect(
-				page.getByRole("heading", {
-					name: /Écart de rémunération par catégories de salariés/,
-				}),
-			).toBeVisible();
-		} else {
-			// Off those years step 5 is out of reach even by URL — unlike the < 50
-			// tier, which always carries it.
-			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/6$/);
-		}
-
-		await reachRecapWithoutGap(page, { indicatorGRequired });
-		await expect(
-			page.getByText(recapStepperLabel(indicatorGRequired), { exact: true }),
-		).toBeVisible();
-
-		await submitFromStep6Recap(page);
-		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
-		await expect(
-			page.getByText(/Votre parcours .* est (désormais )?terminé/),
-		).toBeVisible();
+		test.slow();
+		await FICHE_SCENARIOS["CAS-13-6IND"]({ page, coordinate });
 	});
 });

--- a/packages/app/src/e2e/grille/__tests__/coordinates.test.ts
+++ b/packages/app/src/e2e/grille/__tests__/coordinates.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import { isCseRequired, isIndicatorGRequired } from "~/modules/domain";
+import {
+	buildGrid,
+	CAMPAIGN_YEARS,
+	type Coordinate,
+	pickCoordinate,
+	TRANCHES,
+} from "../coordinates";
+
+const grid = buildGrid();
+
+const ID_PATTERN = /^\d{4}-(49|99|149|249|250P)-CAS\d{2}$/;
+
+// The case number ranges the grid must project, re-stated from the démarche
+// taxonomy: the 12 seven-indicator compliance fiches, the 2 six-indicator ones,
+// and the sub-100 tiers with no compliance package (CAS-13 / CAS-14).
+function expectedCaseNumbers(
+	requiresCompliance: boolean,
+	sevenIndicators: boolean,
+): number[] {
+	if (!requiresCompliance) {
+		return sevenIndicators ? [13, 14] : [13];
+	}
+	return sevenIndicators ? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] : [1, 2];
+}
+
+function expectedFiche(caseNumber: number, sevenIndicators: boolean): string {
+	return `CAS-${String(caseNumber).padStart(2, "0")}${
+		sevenIndicators ? "" : "-6IND"
+	}`;
+}
+
+function countByEffmax(coordinates: Coordinate[]): Record<string, number> {
+	return coordinates.reduce<Record<string, number>>((acc, coordinate) => {
+		acc[coordinate.effmax] = (acc[coordinate.effmax] ?? 0) + 1;
+		return acc;
+	}, {});
+}
+
+describe("buildGrid — cardinality", () => {
+	it("derives exactly 185 coordinates", () => {
+		expect(grid).toHaveLength(185);
+	});
+
+	it("splits 14 / 9 / 34 / 44 / 84 across the five tranches", () => {
+		expect(countByEffmax(grid)).toEqual({
+			"49": 14,
+			"99": 9,
+			"149": 34,
+			"249": 44,
+			"250P": 84,
+		});
+	});
+
+	it("covers the seven campaign years with no year hardcoded outside CAMPAIGN_YEARS", () => {
+		const years = new Set(grid.map((coordinate) => coordinate.year));
+		expect([...years].sort()).toEqual([...CAMPAIGN_YEARS].sort());
+	});
+
+	it("spans the 17 distinct fiches of the démarche taxonomy", () => {
+		const fiches = new Set(grid.map((coordinate) => coordinate.fiche));
+		expect([...fiches].sort()).toEqual(
+			[
+				"CAS-01",
+				"CAS-01-6IND",
+				"CAS-02",
+				"CAS-02-6IND",
+				"CAS-03",
+				"CAS-04",
+				"CAS-05",
+				"CAS-06",
+				"CAS-07",
+				"CAS-08",
+				"CAS-09",
+				"CAS-10",
+				"CAS-11",
+				"CAS-12",
+				"CAS-13",
+				"CAS-13-6IND",
+				"CAS-14",
+			].sort(),
+		);
+	});
+});
+
+// S5 — "the grid follows the code, it is not a copy of the test book": every
+// coordinate is re-derived from the domain here, so if isIndicatorGRequired or
+// isCseRequired changed, the assertions would follow the grid without an edit.
+describe("buildGrid — S5 domain coherence", () => {
+	it("recomputes each field from the domain for every coordinate", () => {
+		for (const coordinate of grid) {
+			const requiresCompliance = isCseRequired(coordinate.workforce);
+			const sevenIndicators = isIndicatorGRequired(
+				coordinate.workforce,
+				coordinate.year,
+			);
+
+			expect(coordinate.indicatorGRequired).toBe(sevenIndicators);
+			expect(
+				expectedCaseNumbers(requiresCompliance, sevenIndicators),
+			).toContain(coordinate.caseNumber);
+			expect(coordinate.fiche).toBe(
+				expectedFiche(coordinate.caseNumber, sevenIndicators),
+			);
+
+			const expectedHasCse = requiresCompliance
+				? coordinate.caseNumber % 2 === 0
+				: coordinate.caseNumber === 14
+					? true
+					: null;
+			expect(coordinate.hasCse).toBe(expectedHasCse);
+		}
+	});
+
+	it("emits every domain-required case number for each (year, tranche) pair", () => {
+		for (const year of CAMPAIGN_YEARS) {
+			for (const tranche of TRANCHES) {
+				const cell = grid.filter(
+					(coordinate) =>
+						coordinate.year === year && coordinate.effmax === tranche.effmax,
+				);
+				const expected = expectedCaseNumbers(
+					isCseRequired(tranche.workforce),
+					isIndicatorGRequired(tranche.workforce, year),
+				);
+				expect(cell.map((coordinate) => coordinate.caseNumber)).toEqual(
+					expected,
+				);
+				expect(
+					cell.every(
+						(coordinate) => coordinate.workforce === tranche.workforce,
+					),
+				).toBe(true);
+			}
+		}
+	});
+
+	it("never marks a sub-100 tranche as CSE-required in a compliance fiche", () => {
+		for (const coordinate of grid) {
+			if (!isCseRequired(coordinate.workforce)) {
+				expect(coordinate.caseNumber).toBeGreaterThanOrEqual(13);
+			}
+		}
+	});
+});
+
+describe("buildGrid — coordinate shape", () => {
+	it("formats every id as AAAA-EFFMAX-CASNN consistent with its fields", () => {
+		for (const coordinate of grid) {
+			expect(coordinate.id).toMatch(ID_PATTERN);
+			expect(coordinate.id).toBe(
+				`${coordinate.year}-${coordinate.effmax}-CAS${String(
+					coordinate.caseNumber,
+				).padStart(2, "0")}`,
+			);
+		}
+	});
+
+	it("carries a non-empty rappel for every fiche", () => {
+		for (const coordinate of grid) {
+			expect(coordinate.rappel.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("keeps ids unique across the grid", () => {
+		const ids = grid.map((coordinate) => coordinate.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});
+
+describe("pickCoordinate", () => {
+	it("returns the first coordinate matching a fiche", () => {
+		const picked = pickCoordinate(grid, { fiche: "CAS-14" });
+		expect(picked.fiche).toBe("CAS-14");
+		expect(picked.caseNumber).toBe(14);
+	});
+
+	it("narrows by effmax and year when provided", () => {
+		const picked = pickCoordinate(grid, {
+			fiche: "CAS-12",
+			effmax: "250P",
+			year: 2027,
+		});
+		expect(picked).toMatchObject({
+			fiche: "CAS-12",
+			effmax: "250P",
+			year: 2027,
+			caseNumber: 12,
+		});
+	});
+
+	it("throws when no coordinate matches the criteria", () => {
+		// CAS-12 is a compliance fiche (>= 100 salariés); effmax 49 is the sub-50
+		// tranche — the pairing is impossible in the derived grid.
+		expect(() =>
+			pickCoordinate(grid, { fiche: "CAS-12", effmax: "49" }),
+		).toThrow(/No coordinate matches/);
+	});
+});

--- a/packages/app/src/e2e/grille/coordinates.ts
+++ b/packages/app/src/e2e/grille/coordinates.ts
@@ -1,0 +1,128 @@
+import { isCseRequired, isIndicatorGRequired } from "~/modules/domain";
+
+export const CAMPAIGN_YEARS = [
+	2027, 2028, 2029, 2030, 2031, 2032, 2033,
+] as const;
+
+export const TRANCHES = [
+	{ effmax: "49", workforce: 30, label: "Moins de 50 salariés" },
+	{ effmax: "99", workforce: 75, label: "50 à 99 salariés" },
+	{ effmax: "149", workforce: 120, label: "100 à 149 salariés" },
+	{ effmax: "249", workforce: 200, label: "150 à 249 salariés" },
+	{ effmax: "250P", workforce: 250, label: "250 salariés et plus" },
+] as const;
+
+export type Tranche = (typeof TRANCHES)[number];
+
+export type Coordinate = {
+	id: string;
+	year: number;
+	effmax: string;
+	workforce: number;
+	caseNumber: number;
+	fiche: string;
+	indicatorGRequired: boolean;
+	hasCse: boolean | null;
+	rappel: string;
+};
+
+const RAPPELS: Record<string, string> = {
+	"CAS-01": "sans CSE · aucun écart → fin de démarche",
+	"CAS-02": "avec CSE · aucun écart → avis CSE « exactitude »",
+	"CAS-03": "sans CSE · écart ≥ 5 % → justification des écarts",
+	"CAS-04": "avec CSE · écart ≥ 5 % → justification + avis CSE",
+	"CAS-05": "sans CSE · écart ≥ 5 % → évaluation conjointe",
+	"CAS-06": "avec CSE · écart ≥ 5 % → évaluation conjointe + avis CSE",
+	"CAS-07": "sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. sans écart",
+	"CAS-08":
+		"avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. sans écart + avis CSE",
+	"CAS-09":
+		"sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → justification",
+	"CAS-10":
+		"avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → justification + avis CSE",
+	"CAS-11":
+		"sans CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → évaluation conjointe",
+	"CAS-12":
+		"avec CSE · écart ≥ 5 % → actions correctives, 2ᵉ décl. avec écart → évaluation conjointe + avis CSE",
+	"CAS-01-6IND": "sans CSE → fin de démarche directe",
+	"CAS-02-6IND": "avec CSE → avis CSE « exactitude »",
+	"CAS-13": "aucun écart → fin de démarche directe",
+	"CAS-14": "écart ≥ 5 % → fin de démarche directe (aucune obligation)",
+	"CAS-13-6IND": "6 premiers indicateurs → fin de démarche directe",
+};
+
+function padCase(caseNumber: number): string {
+	return String(caseNumber).padStart(2, "0");
+}
+
+function caseNumbersFor(
+	requiresCompliance: boolean,
+	sevenIndicators: boolean,
+): number[] {
+	if (!requiresCompliance) {
+		return sevenIndicators ? [13, 14] : [13];
+	}
+	return sevenIndicators ? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] : [1, 2];
+}
+
+function ficheFor(caseNumber: number, sevenIndicators: boolean): string {
+	return `CAS-${padCase(caseNumber)}${sevenIndicators ? "" : "-6IND"}`;
+}
+
+function hasCseFor(
+	caseNumber: number,
+	requiresCompliance: boolean,
+): boolean | null {
+	if (requiresCompliance) {
+		return caseNumber % 2 === 0;
+	}
+	return caseNumber === 14 ? true : null;
+}
+
+export function buildGrid(): Coordinate[] {
+	const grid: Coordinate[] = [];
+	for (const year of CAMPAIGN_YEARS) {
+		for (const tranche of TRANCHES) {
+			const { effmax, workforce } = tranche;
+			const sevenIndicators = isIndicatorGRequired(workforce, year);
+			const requiresCompliance = isCseRequired(workforce);
+			for (const caseNumber of caseNumbersFor(
+				requiresCompliance,
+				sevenIndicators,
+			)) {
+				const fiche = ficheFor(caseNumber, sevenIndicators);
+				grid.push({
+					id: `${year}-${effmax}-CAS${padCase(caseNumber)}`,
+					year,
+					effmax,
+					workforce,
+					caseNumber,
+					fiche,
+					indicatorGRequired: sevenIndicators,
+					hasCse: hasCseFor(caseNumber, requiresCompliance),
+					rappel: RAPPELS[fiche] ?? "",
+				});
+			}
+		}
+	}
+	return grid;
+}
+
+export function pickCoordinate(
+	grid: Coordinate[],
+	criteria: { fiche: string; effmax?: string; year?: number },
+): Coordinate {
+	const match = grid.find(
+		(coordinate) =>
+			coordinate.fiche === criteria.fiche &&
+			(criteria.effmax === undefined ||
+				coordinate.effmax === criteria.effmax) &&
+			(criteria.year === undefined || coordinate.year === criteria.year),
+	);
+	if (!match) {
+		throw new Error(
+			`No coordinate matches ${JSON.stringify(criteria)} in the derived grid`,
+		);
+	}
+	return match;
+}

--- a/packages/app/src/e2e/grille/scenarios.ts
+++ b/packages/app/src/e2e/grille/scenarios.ts
@@ -273,7 +273,6 @@ export const FICHE_SCENARIOS = {
 
 	"CAS-13": async ({ page }) => {
 		await reachStep6Recap(page, { hasGap: false });
-		// Step 5 was presented: 6-step funnel + indicator G block on the recap.
 		await expect(
 			page.getByText("Étape 6 sur 6", { exact: true }),
 		).toBeVisible();

--- a/packages/app/src/e2e/grille/scenarios.ts
+++ b/packages/app/src/e2e/grille/scenarios.ts
@@ -1,0 +1,359 @@
+import { expect, type Page, test } from "@playwright/test";
+import { withCampaignYear } from "../helpers/campaign-year";
+import {
+	COMPLIANCE_PATH,
+	completeSecondDeclaration,
+	fillCseStep1,
+	selectCompliancePath,
+	submitCseStep2,
+	uploadJointEvalPdf,
+} from "../helpers/compliance-flows";
+import { setCompanyHasCse } from "../helpers/db";
+import {
+	completeDeclaration,
+	reachRecapWithoutGap,
+	reachStep6ComplianceRecap,
+	reachStep6Recap,
+	submitFromStep6Recap,
+} from "../helpers/declaration-flows";
+import {
+	indicatorGRequiredForGip,
+	recapStepperLabel,
+} from "../helpers/indicator-g";
+import type { Coordinate } from "./coordinates";
+
+export type ScenarioContext = { page: Page; coordinate: Coordinate };
+
+const CONFIRMATION_PATH = `${COMPLIANCE_PATH}/confirmation`;
+const DEMARCHE_COMPLETED = /Votre parcours .* est (désormais )?terminé/;
+
+async function finDeDemarche(
+	page: Page,
+	options: { url?: string; completed?: boolean } = {},
+): Promise<void> {
+	await test.step("fin de démarche", async () => {
+		if (options.url) {
+			await page.waitForURL(options.url, { timeout: 10_000 });
+		}
+		if (options.completed) {
+			await expect(page.getByText(DEMARCHE_COMPLETED)).toBeVisible();
+		}
+	});
+}
+
+async function expectComplianceOptions(
+	page: Page,
+	options: { corrective: boolean; joint: boolean; justify: boolean },
+): Promise<void> {
+	await test.step("choix du parcours de conformité", async () => {
+		const corrective = page.getByText(
+			"Actions correctives et seconde déclaration",
+			{ exact: true },
+		);
+		const joint = page.getByText(
+			"Mettre en place une évaluation conjointe des rémunérations",
+			{ exact: true },
+		);
+		const justify = page.getByText(
+			"Justifier les écarts de rémunération ≥ 5 %",
+			{
+				exact: true,
+			},
+		);
+		await (options.corrective
+			? expect(corrective).toBeVisible()
+			: expect(corrective).not.toBeVisible());
+		if (options.joint) await expect(joint).toBeVisible();
+		if (options.justify) await expect(justify).toBeVisible();
+	});
+}
+
+export const FICHE_SCENARIOS = {
+	"CAS-01": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: false });
+		await finDeDemarche(page, {
+			url: `**${CONFIRMATION_PATH}`,
+			completed: true,
+		});
+		// Every field of the /avis-cse funnel is required, so a company without a
+		// CSE cannot fill it in — the screen must stay out of reach even by URL.
+		await test.step("fin de démarche", async () => {
+			await page.goto("/avis-cse/etape/1");
+			await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+		});
+	},
+
+	"CAS-02": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: false });
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+		await fillCseStep1(page);
+		await submitCseStep2(page);
+		await finDeDemarche(page, { completed: true });
+	},
+
+	"CAS-03": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-justify");
+		await finDeDemarche(page, {
+			url: `**${CONFIRMATION_PATH}`,
+			completed: true,
+		});
+	},
+
+	"CAS-04": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+		await expectComplianceOptions(page, {
+			corrective: true,
+			joint: true,
+			justify: true,
+		});
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+		await fillCseStep1(page, { firstDeclGapConsulted: true });
+		await submitCseStep2(page, {
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 1, type: "gap" },
+			],
+		});
+		await finDeDemarche(page, { completed: true });
+	},
+
+	"CAS-05": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await expectComplianceOptions(page, {
+			corrective: true,
+			joint: true,
+			justify: true,
+		});
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await finDeDemarche(page, { url: `**${CONFIRMATION_PATH}` });
+	},
+
+	"CAS-06": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+		await fillCseStep1(page);
+		await submitCseStep2(page);
+		await finDeDemarche(page, { completed: true });
+	},
+
+	"CAS-07": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await completeSecondDeclaration(page, { hasGap: false });
+		await finDeDemarche(page, { url: `**${CONFIRMATION_PATH}` });
+	},
+
+	"CAS-08": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await completeSecondDeclaration(page, { hasGap: false });
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+		await fillCseStep1(page, { hasSecondDeclaration: true });
+		await submitCseStep2(page, {
+			hasSecondDeclaration: true,
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 2, type: "accuracy" },
+			],
+		});
+		await finDeDemarche(page, { completed: true });
+	},
+
+	"CAS-09": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await completeSecondDeclaration(page, { hasGap: true });
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+		await selectCompliancePath(page, "path-justify");
+		await finDeDemarche(page, {
+			url: `**${CONFIRMATION_PATH}`,
+			completed: true,
+		});
+	},
+
+	"CAS-10": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await completeSecondDeclaration(page, { hasGap: true });
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+		await page.goto(COMPLIANCE_PATH);
+		await expectComplianceOptions(page, {
+			corrective: false,
+			joint: true,
+			justify: true,
+		});
+		await selectCompliancePath(page, "path-justify");
+		await page.waitForURL("**/avis-cse/etape/1", { timeout: 10_000 });
+		await fillCseStep1(page, {
+			hasSecondDeclaration: true,
+			secondDeclGapConsulted: true,
+		});
+		await submitCseStep2(page, {
+			hasSecondDeclaration: true,
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 2, type: "accuracy" },
+				{ declarationNumber: 2, type: "gap" },
+			],
+		});
+		await finDeDemarche(page, { completed: true });
+	},
+
+	"CAS-11": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await completeSecondDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await finDeDemarche(page, { url: `**${CONFIRMATION_PATH}` });
+	},
+
+	"CAS-12": async ({ page }) => {
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await completeSecondDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-joint");
+		await uploadJointEvalPdf(page);
+		await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+		await fillCseStep1(page, { hasSecondDeclaration: true });
+		await submitCseStep2(page, {
+			hasSecondDeclaration: true,
+			columns: [
+				{ declarationNumber: 1, type: "accuracy" },
+				{ declarationNumber: 2, type: "accuracy" },
+			],
+		});
+		await finDeDemarche(page, { completed: true });
+	},
+
+	"CAS-01-6IND": async ({ page, coordinate }) => {
+		await withCampaignYear(
+			{ page, year: coordinate.year, workforce: coordinate.workforce },
+			async () => {
+				await setCompanyHasCse(false);
+				await reachRecapWithoutGap(page, {
+					indicatorGRequired: coordinate.indicatorGRequired,
+				});
+				await expect(
+					page.getByText(recapStepperLabel(coordinate.indicatorGRequired), {
+						exact: true,
+					}),
+				).toBeVisible();
+				await submitFromStep6Recap(page);
+				await finDeDemarche(page, {
+					url: `**${CONFIRMATION_PATH}`,
+					completed: true,
+				});
+			},
+		);
+	},
+
+	"CAS-02-6IND": async ({ page, coordinate }) => {
+		await withCampaignYear(
+			{ page, year: coordinate.year, workforce: coordinate.workforce },
+			async () => {
+				await setCompanyHasCse(true);
+				await reachRecapWithoutGap(page, {
+					indicatorGRequired: coordinate.indicatorGRequired,
+				});
+				await submitFromStep6Recap(page);
+				await page.waitForURL("**/avis-cse/**", { timeout: 10_000 });
+				await fillCseStep1(page);
+				await submitCseStep2(page);
+				await finDeDemarche(page, { completed: true });
+			},
+		);
+	},
+
+	"CAS-13": async ({ page }) => {
+		await reachStep6Recap(page, { hasGap: false });
+		// Step 5 was presented: 6-step funnel + indicator G block on the recap.
+		await expect(
+			page.getByText("Étape 6 sur 6", { exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", {
+				name: "Indicateurs par catégorie de salariés",
+			}),
+		).toBeVisible();
+		await submitFromStep6Recap(page);
+		await finDeDemarche(page, {
+			url: `**${CONFIRMATION_PATH}`,
+			completed: true,
+		});
+	},
+
+	"CAS-14": async ({ page }) => {
+		await reachStep6ComplianceRecap(page);
+		// Same gap inputs that render "Prochaines étapes" at 200 salariés: below
+		// 100 nothing is due, so the box is absent altogether.
+		await expect(
+			page.getByRole("heading", { name: "Prochaines étapes" }),
+		).toHaveCount(0);
+		await expect(
+			page.getByText("Écarts détectés", { exact: true }),
+		).toHaveCount(0);
+		await expect(
+			page.getByRole("heading", { name: "Actions à engager" }),
+		).toHaveCount(0);
+
+		await page.goto("/declaration-remuneration/etape/6");
+		await submitFromStep6Recap(page);
+		await finDeDemarche(page, {
+			url: `**${CONFIRMATION_PATH}`,
+			completed: true,
+		});
+
+		// The compliance path choice is unreachable even by URL: below 100 salariés
+		// a gap ≥ 5 % opens none of the compliance surfaces.
+		await page.goto(COMPLIANCE_PATH);
+		await page.waitForURL(`**${CONFIRMATION_PATH}`, { timeout: 10_000 });
+
+		// Declaring a CSE leaves the effectif as the only unmet term of
+		// isCseOpinionRequired, so this probe fails if the 100-salarié gate goes away.
+		await setCompanyHasCse(true);
+		const cseFunnelResponse = await page.goto("/avis-cse/etape/1");
+		expect(cseFunnelResponse?.ok()).toBe(true);
+		expect(new URL(page.url()).pathname).toBe(CONFIRMATION_PATH);
+		await expect(
+			page.getByRole("heading", {
+				name: "Transmettre l'avis ou les avis du CSE",
+			}),
+		).toHaveCount(0);
+		await expect(page.locator("#first-decl-accuracy-favorable")).toHaveCount(0);
+		await expect(page.getByText(DEMARCHE_COMPLETED)).toBeVisible();
+	},
+
+	"CAS-13-6IND": async ({ page, coordinate }) => {
+		const indicatorGRequired = indicatorGRequiredForGip(coordinate.workforce);
+		await page.goto("/declaration-remuneration/etape/5");
+		if (indicatorGRequired) {
+			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/5$/);
+			await expect(
+				page.getByRole("heading", {
+					name: /Écart de rémunération par catégories de salariés/,
+				}),
+			).toBeVisible();
+		} else {
+			// Off those years step 5 is out of reach even by URL — unlike the < 50
+			// tier, which always carries it.
+			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/6$/);
+		}
+
+		await reachRecapWithoutGap(page, { indicatorGRequired });
+		await expect(
+			page.getByText(recapStepperLabel(indicatorGRequired), { exact: true }),
+		).toBeVisible();
+		await submitFromStep6Recap(page);
+		await finDeDemarche(page, {
+			url: `**${CONFIRMATION_PATH}`,
+			completed: true,
+		});
+	},
+} satisfies Record<string, (ctx: ScenarioContext) => Promise<void>>;

--- a/packages/app/src/e2e/grille/scenarios.ts
+++ b/packages/app/src/e2e/grille/scenarios.ts
@@ -16,10 +16,7 @@ import {
 	reachStep6Recap,
 	submitFromStep6Recap,
 } from "../helpers/declaration-flows";
-import {
-	indicatorGRequiredForGip,
-	recapStepperLabel,
-} from "../helpers/indicator-g";
+import { recapStepperLabel } from "../helpers/indicator-g";
 import type { Coordinate } from "./coordinates";
 
 export type ScenarioContext = { page: Page; coordinate: Coordinate };
@@ -330,7 +327,7 @@ export const FICHE_SCENARIOS = {
 	},
 
 	"CAS-13-6IND": async ({ page, coordinate }) => {
-		const indicatorGRequired = indicatorGRequiredForGip(coordinate.workforce);
+		const indicatorGRequired = coordinate.indicatorGRequired;
 		await page.goto("/declaration-remuneration/etape/5");
 		if (indicatorGRequired) {
 			await expect(page).toHaveURL(/\/declaration-remuneration\/etape\/5$/);

--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { expect, type Page } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import { fillCategoryPayAmounts } from "./declaration-flows";
 
@@ -36,28 +36,30 @@ export async function fillCseStep1(page: Page, options: CseStep1Options = {}) {
 		firstDeclGapConsulted = false,
 		secondDeclGapConsulted = false,
 	} = options;
-	await page.waitForURL("**/avis-cse/etape/1");
-	// DSFR hides native radio inputs — click on the associated label instead
-	await page.locator('label[for="first-decl-accuracy-favorable"]').click();
-	await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
-	await fillGapConsultation(
-		page,
-		"first-decl-gap",
-		firstDeclGapConsulted,
-		"2025-03-15",
-	);
-	if (hasSecondDeclaration) {
-		await page.locator('label[for="second-decl-accuracy-favorable"]').click();
-		await page.locator("#second-decl-accuracy-date").fill("2025-06-15");
+	await test.step("avis CSE — étape 1 : avis rendus", async () => {
+		await page.waitForURL("**/avis-cse/etape/1");
+		// DSFR hides native radio inputs — click on the associated label instead
+		await page.locator('label[for="first-decl-accuracy-favorable"]').click();
+		await page.locator("#first-decl-accuracy-date").fill("2025-03-15");
 		await fillGapConsultation(
 			page,
-			"second-decl-gap",
-			secondDeclGapConsulted,
-			"2025-06-15",
+			"first-decl-gap",
+			firstDeclGapConsulted,
+			"2025-03-15",
 		);
-	}
-	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL("**/avis-cse/etape/2");
+		if (hasSecondDeclaration) {
+			await page.locator('label[for="second-decl-accuracy-favorable"]').click();
+			await page.locator("#second-decl-accuracy-date").fill("2025-06-15");
+			await fillGapConsultation(
+				page,
+				"second-decl-gap",
+				secondDeclGapConsulted,
+				"2025-06-15",
+			);
+		}
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.waitForURL("**/avis-cse/etape/2");
+	});
 }
 
 // A matrix column to associate to the uploaded file, expressed the way the UI
@@ -101,61 +103,69 @@ export async function submitCseStep2(
 	} = options;
 	const fileName = path.basename(DUMMY_PDF);
 
-	await page.waitForURL("**/avis-cse/etape/2");
+	await test.step("avis CSE — étape 2 : dépôt des fichiers", async () => {
+		await page.waitForURL("**/avis-cse/etape/2");
 
-	// Phase A — selecting the file auto-uploads it (no intermediate "Importer"
-	// step), after which the page re-renders with the matrix.
-	await page.locator("#cse-file-upload").setInputFiles(DUMMY_PDF);
-	await expect(
-		page.getByRole("table", { name: /Associez chaque fichier déposé/ }),
-	).toBeVisible({ timeout: 30_000 });
+		// Phase A — selecting the file auto-uploads it (no intermediate "Importer"
+		// step), after which the page re-renders with the matrix.
+		await page.locator("#cse-file-upload").setInputFiles(DUMMY_PDF);
+		await expect(
+			page.getByRole("table", { name: /Associez chaque fichier déposé/ }),
+		).toBeVisible({ timeout: 30_000 });
 
-	// Phase B — tick the required columns, waiting for each association to persist
-	// before submitting. The client submit gate is optimistic, so finalize could
-	// otherwise race the setFileContentTypes mutation.
-	for (const column of columns) {
-		const persisted = page.waitForResponse(
-			(response) =>
-				response.url().includes("setFileContentTypes") && response.ok(),
-		);
+		// Phase B — tick the required columns, waiting for each association to
+		// persist before submitting. The client submit gate is optimistic, so
+		// finalize could otherwise race the setFileContentTypes mutation.
+		for (const column of columns) {
+			const persisted = page.waitForResponse(
+				(response) =>
+					response.url().includes("setFileContentTypes") && response.ok(),
+			);
+			await page
+				.getByRole("checkbox", {
+					name: cseCheckboxName(column, fileName, hasSecondDeclaration),
+				})
+				.check();
+			await persisted;
+		}
+
+		// Phase C — submit, certify, validate, then wait for the confirmation page.
+		const submit = page.getByRole("button", { name: "Soumettre" });
+		await expect(submit).toBeEnabled();
+		await submit.click();
 		await page
-			.getByRole("checkbox", {
-				name: cseCheckboxName(column, fileName, hasSecondDeclaration),
-			})
-			.check();
-		await persisted;
-	}
-
-	// Phase C — submit, certify, validate, then wait for the confirmation page.
-	const submit = page.getByRole("button", { name: "Soumettre" });
-	await expect(submit).toBeEnabled();
-	await submit.click();
-	await page
-		.getByText(/Je certifie que les avis transmis sont conformes/)
-		.click();
-	await page.getByRole("button", { name: "Valider" }).click();
-	await page.waitForURL("**/avis-cse/confirmation", { timeout: 30_000 });
+			.getByText(/Je certifie que les avis transmis sont conformes/)
+			.click();
+		await page.getByRole("button", { name: "Valider" }).click();
+		await page.waitForURL("**/avis-cse/confirmation", { timeout: 30_000 });
+	});
 }
 
 export async function uploadJointEvalPdf(page: Page) {
-	await page.waitForURL("**/evaluation-conjointe");
-	await page.locator("#joint-evaluation-file-upload").setInputFiles(DUMMY_PDF);
-	await page.getByRole("button", { name: "Transmettre" }).click();
-	await page
-		.getByText(/Je certifie que le rapport transmis est conforme/)
-		.click();
-	await page.getByRole("button", { name: "Valider" }).click();
+	await test.step("dépôt du rapport d'évaluation conjointe", async () => {
+		await page.waitForURL("**/evaluation-conjointe");
+		await page
+			.locator("#joint-evaluation-file-upload")
+			.setInputFiles(DUMMY_PDF);
+		await page.getByRole("button", { name: "Transmettre" }).click();
+		await page
+			.getByText(/Je certifie que le rapport transmis est conforme/)
+			.click();
+		await page.getByRole("button", { name: "Valider" }).click();
+	});
 }
 
 export async function selectCompliancePath(
 	page: Page,
 	pathId: "path-corrective" | "path-joint" | "path-justify",
 ) {
-	await page.goto(COMPLIANCE_PATH);
-	await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
-	// DSFR hides native radio inputs — click on the associated label instead
-	await page.locator(`label[for="${pathId}"]`).click();
-	await page.getByRole("button", { name: "Suivant" }).click();
+	await test.step("choix du parcours de conformité", async () => {
+		await page.goto(COMPLIANCE_PATH);
+		await page.waitForURL(`**${COMPLIANCE_PATH}`, { timeout: 10_000 });
+		// DSFR hides native radio inputs — click on the associated label instead
+		await page.locator(`label[for="${pathId}"]`).click();
+		await page.getByRole("button", { name: "Suivant" }).click();
+	});
 }
 
 /**
@@ -167,27 +177,29 @@ export async function completeSecondDeclaration(
 	page: Page,
 	options: { hasGap: boolean },
 ) {
-	// Step 1: Info page — just click through
-	await page.waitForURL(`**${COMPLIANCE_PATH}/etape/1`, { timeout: 10_000 });
-	await page.getByRole("link", { name: "Suivant" }).click();
-	await page.waitForURL(`**${COMPLIANCE_PATH}/etape/2`);
+	await test.step("seconde déclaration", async () => {
+		// Step 1: Info page — just click through
+		await page.waitForURL(`**${COMPLIANCE_PATH}/etape/1`, { timeout: 10_000 });
+		await page.getByRole("link", { name: "Suivant" }).click();
+		await page.waitForURL(`**${COMPLIANCE_PATH}/etape/2`);
 
-	// Step 2: Edit correction employee category data
-	// women=1000, men=1100 → 9% gap | women=1000, men=1020 → 2% gap
-	const menSalary = options.hasGap ? "1100" : "1020";
-	await fillCategoryPayAmounts(page, { men: menSalary, women: "1000" });
+		// Step 2: Edit correction employee category data
+		// women=1000, men=1100 → 9% gap | women=1000, men=1020 → 2% gap
+		const menSalary = options.hasGap ? "1100" : "1020";
+		await fillCategoryPayAmounts(page, { men: menSalary, women: "1000" });
 
-	// Fill required reference period dates
-	await page.locator("#period-start-date").fill("2026-01-01");
-	await page.locator("#period-end-date").fill("2026-12-31");
+		// Fill required reference period dates
+		await page.locator("#period-start-date").fill("2026-01-01");
+		await page.locator("#period-end-date").fill("2026-12-31");
 
-	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL(`**${COMPLIANCE_PATH}/etape/3`);
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.waitForURL(`**${COMPLIANCE_PATH}/etape/3`);
 
-	// Step 3: Review and submit (opens confirmation modal)
-	await page.getByRole("button", { name: "Soumettre" }).click();
-	await page
-		.getByText(/Je certifie que les données saisies sont exactes/)
-		.click();
-	await page.getByRole("button", { name: "Valider" }).click();
+		// Step 3: Review and submit (opens confirmation modal)
+		await page.getByRole("button", { name: "Soumettre" }).click();
+		await page
+			.getByText(/Je certifie que les données saisies sont exactes/)
+			.click();
+		await page.getByRole("button", { name: "Valider" }).click();
+	});
 }

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -154,7 +154,6 @@ export async function submitStepsThroughQuartiles(
 	});
 
 	await test.step("étape 3 — composantes variables", async () => {
-		// Same table + beneficiary counts
 		await fillPayGapTable(page);
 		await page.getByRole("textbox", { name: "Bénéficiaires femmes" }).fill("5");
 		await page.getByRole("textbox", { name: "Bénéficiaires hommes" }).fill("5");
@@ -163,7 +162,6 @@ export async function submitStepsThroughQuartiles(
 	});
 
 	await test.step("étape 4 — répartition par quartile", async () => {
-		// Fill 8 quartiles (4 annual + 4 hourly)
 		await fillStep4Quartiles(page);
 		await page.getByRole("button", { name: "Suivant" }).click();
 	});

--- a/packages/app/src/e2e/helpers/declaration-flows.ts
+++ b/packages/app/src/e2e/helpers/declaration-flows.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { type Page, test } from "@playwright/test";
 
 /**
  * Fill all pay gap textboxes on steps 2 and 3. Every row is equal (no gap) by
@@ -133,33 +133,40 @@ export async function submitStepsThroughQuartiles(
 	page: Page,
 	options: { annualMeanGap?: boolean } = {},
 ) {
-	// Navigate to create/resume declaration → redirects to step 1
-	await page.goto("/declaration-remuneration");
-	await page.waitForURL("**/declaration-remuneration/etape/1");
-
-	// Step 1: Fill workforce (10 women + 15 men = 25 total)
-	await page.getByRole("textbox", { name: "Nombre de femmes" }).fill("10");
-	await page.getByRole("textbox", { name: "Nombre d'hommes" }).fill("15");
-	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL("**/declaration-remuneration/etape/2");
-
-	// Step 2: Pay gap — mean annual row optionally carries the indicator A gap
-	await fillPayGapTable(page, {
-		annualMeanMen: options.annualMeanGap ? "1100" : "1000",
+	await test.step("étape 1 — effectifs", async () => {
+		// Navigate to create/resume declaration → redirects to step 1
+		await page.goto("/declaration-remuneration");
+		await page.waitForURL("**/declaration-remuneration/etape/1");
+		// 10 women + 15 men = 25 total
+		await page.getByRole("textbox", { name: "Nombre de femmes" }).fill("10");
+		await page.getByRole("textbox", { name: "Nombre d'hommes" }).fill("15");
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.waitForURL("**/declaration-remuneration/etape/2");
 	});
-	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL("**/declaration-remuneration/etape/3");
 
-	// Step 3: Variable pay — same table + beneficiary counts
-	await fillPayGapTable(page);
-	await page.getByRole("textbox", { name: "Bénéficiaires femmes" }).fill("5");
-	await page.getByRole("textbox", { name: "Bénéficiaires hommes" }).fill("5");
-	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL("**/declaration-remuneration/etape/4");
+	await test.step("étape 2 — écarts de rémunération", async () => {
+		// Mean annual row optionally carries the indicator A gap
+		await fillPayGapTable(page, {
+			annualMeanMen: options.annualMeanGap ? "1100" : "1000",
+		});
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.waitForURL("**/declaration-remuneration/etape/3");
+	});
 
-	// Step 4: Quartile distribution — fill 8 quartiles (4 annual + 4 hourly)
-	await fillStep4Quartiles(page);
-	await page.getByRole("button", { name: "Suivant" }).click();
+	await test.step("étape 3 — composantes variables", async () => {
+		// Same table + beneficiary counts
+		await fillPayGapTable(page);
+		await page.getByRole("textbox", { name: "Bénéficiaires femmes" }).fill("5");
+		await page.getByRole("textbox", { name: "Bénéficiaires hommes" }).fill("5");
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.waitForURL("**/declaration-remuneration/etape/4");
+	});
+
+	await test.step("étape 4 — répartition par quartile", async () => {
+		// Fill 8 quartiles (4 annual + 4 hourly)
+		await fillStep4Quartiles(page);
+		await page.getByRole("button", { name: "Suivant" }).click();
+	});
 }
 
 /**
@@ -198,9 +205,11 @@ export async function submitIndicatorGStep(
 	page: Page,
 	options: { hasGap: boolean },
 ) {
-	await fillStep5Categories(page, options);
-	await page.getByRole("button", { name: "Suivant" }).click();
-	await page.waitForURL("**/declaration-remuneration/etape/6");
+	await test.step("étape 5 — écarts par catégorie", async () => {
+		await fillStep5Categories(page, options);
+		await page.getByRole("button", { name: "Suivant" }).click();
+		await page.waitForURL("**/declaration-remuneration/etape/6");
+	});
 }
 
 /**
@@ -252,10 +261,12 @@ export async function reachStep6ComplianceRecap(page: Page) {
  * post-submission routing depends on the workforce, the gap and the CSE.
  */
 export async function submitFromStep6Recap(page: Page) {
-	await page.getByRole("button", { name: "Suivant" }).click();
-	// Click the label, as the DSFR checkbox label intercepts pointer events.
-	await page.getByText(/Je certifie/).click();
-	await page.getByRole("button", { name: "Valider" }).click();
+	await test.step("étape 6 — récapitulatif et transmission", async () => {
+		await page.getByRole("button", { name: "Suivant" }).click();
+		// Click the label, as the DSFR checkbox label intercepts pointer events.
+		await page.getByText(/Je certifie/).click();
+		await page.getByRole("button", { name: "Valider" }).click();
+	});
 }
 
 /**

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -39,7 +39,10 @@ export default defineConfig({
 		exclude: [
 			"src/**/*.integration.test.ts",
 			"src/**/*.e2e.{ts,tsx}",
-			"src/e2e/**",
+			// Playwright specs live under src/e2e; the pure grille derivation
+			// (src/e2e/grille) is isomorphic and carries vitest unit tests, so only
+			// the specs are excluded here, not the whole directory.
+			"src/e2e/**/*.e2e.{ts,tsx}",
 			"node_modules",
 			".next",
 		],


### PR DESCRIPTION
Closes #4066

## Résumé

Ticket d'**infrastructure de test** (epic #4022) : produit les deux briques que tout le reste de l'epic (#4068–#4072) consomme, **sans changer aucun comportement de test**.

1. **`src/e2e/grille/coordinates.ts`** — dérivation **pure** (zéro Playwright, zéro DB) : `buildGrid()` calcule les **185 coordonnées** `AAAA-EFFMAX-CASNN` à partir du domaine (`isIndicatorGRequired`, `isCseRequired` de `~/modules/domain`). Aucun littéral d'année, aucune table année → cas en dur : la grille suit le code (scénario PO **S5**).
2. **`src/e2e/grille/scenarios.ts`** — les **17 parcours-types** (`FICHE_SCENARIOS`), extraits des `describe` de `compliance.e2e.ts` et paramétrés par la coordonnée (`indicatorGRequired` / `hasCse` / `workforce`). Chaque phase est enveloppée dans un `test.step()` au **libellé métier français** (aligné §2 du cahier), via les helpers de flow.
3. **`compliance.e2e.ts`** devient un **appelant mince** : chaque `describe` garde son tag littéral `[CAS-xx]` (lu par `check:cahier`), sa configuration, et délègue à `FICHE_SCENARIOS`. La sonde discriminante de **CAS-14** (CSE déclaré post-soumission → `/avis-cse` inatteignable) est conservée **intacte**. Passé de 938 → 635 lignes.
4. **`helpers/declaration-flows.ts` + `helpers/compliance-flows.ts`** — les phases du funnel et du parcours de conformité sont enveloppées dans les `test.step()` métier partagés.

## Dérivation (vérifiée par test unitaire)

`buildGrid()` → **185** coordonnées, réparties **14 / 9 / 34 / 44 / 84** par feuille (`49` / `99` / `149` / `249` / `250P`), **17 fiches distinctes**. Ces nombres **sortent de la dérivation**, pas d'une recopie du cahier : le test (`__tests__/coordinates.test.ts`, 13 cas, écrit par `tu-dev`) **re-dérive** chaque coordonnée depuis le domaine et compare cellule par cellule (7 années × 5 tranches) — si le domaine changeait, la grille et le test suivraient sans édition (S5).

## 7ᵉ fichier justifié — `vitest.config.ts`

Le test unitaire de la dérivation vit sous `src/e2e/grille/__tests__/` (chemin imposé par le ticket), mais l'`exclude` vitest ignorait tout `src/e2e/**`. L'exclusion a été **réduite aux seuls specs Playwright** (`*.e2e.{ts,tsx}`) pour que le module isomorphe `coordinates.ts` (pur, importe uniquement le domaine) soit couvert par `pnpm test`, sans exposer les specs Playwright au runner vitest. Vérifié : la suite vitest complète reste verte, aucun spec `*.e2e.ts` n'est collecté.

## Test plan

- `pnpm --filter app typecheck` ✅
- `pnpm --filter app test` ✅ — **4061** tests (4048 + 13 nouveaux)
- `pnpm --filter app lint:check` / `format:check` ✅
- `pnpm --filter app check:cahier` ✅ — 22 scénarios, bijection cahier ↔ tags préservée
- Gates : validator PASS · structural-auditor MINOR (3 commentaires paraphrase retirés) · rgaa N/A (aucun `.tsx`) · security N/A (aucun fichier serveur)

> La suite **E2E Playwright** n'est pas rejouée en CI (elle exige un dev server) ; l'extraction préserve le périmètre et l'ordre des `describe`, et la gate E2E de fin d'epic (`e2e-dev`) reste l'autorité.
