### PR TITLE
feat(#4072): workflow nocturne de recette grille + mise à jour du cahier de tests

### DIFF
--- a/.github/workflows/e2e-grille.yaml
+++ b/.github/workflows/e2e-grille.yaml
@@ -1,0 +1,214 @@
+# Nightly acceptance run: rolls the 185-coordinate grid from docs/cahier-de-tests.md.
+#
+# Sharding note — if duration becomes a bottleneck the lever is --shard=i/N in a
+# job matrix (each runner on its own :3000 + docker stack), with the blob reporter
+# and `merge-reports` to reassemble a single HTML/JSON output. Explicit decision
+# not to implement this as long as the run fits within the nightly window.
+
+name: 🧪 Recette grille (nightly)
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      annee:
+        description: "Année de campagne"
+        required: false
+        default: "toutes"
+        type: choice
+        options:
+          - toutes
+          - "2027"
+          - "2028"
+          - "2029"
+          - "2030"
+          - "2031"
+          - "2032"
+          - "2033"
+      tranche:
+        description: "Tranche d'effectif"
+        required: false
+        default: "toutes"
+        type: choice
+        options:
+          - toutes
+          - "49"
+          - "99"
+          - "149"
+          - "249"
+          - "250P"
+
+concurrency:
+  group: e2e-grille
+  cancel-in-progress: false
+
+jobs:
+  grille:
+    name: "Recette grille"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 130
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5438/egapro
+      AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+      NEXTAUTH_URL: http://localhost:3000/api/auth
+      EGAPRO_PROCONNECT_CLIENT_ID: ${{ secrets.EGAPRO_PROCONNECT_CLIENT_ID }}
+      EGAPRO_PROCONNECT_CLIENT_SECRET: ${{ secrets.EGAPRO_PROCONNECT_CLIENT_SECRET }}
+      EGAPRO_PROCONNECT_ISSUER: ${{ secrets.EGAPRO_PROCONNECT_ISSUER }}
+      EGAPRO_WEEZ_API_URL: ${{ secrets.EGAPRO_WEEZ_API_URL }}
+      EGAPRO_SUIT_API_URL: ${{ secrets.EGAPRO_SUIT_API_URL }}
+      EGAPRO_GATEWAY_SHARED_SECRET: dev-gateway-shared-secret-minimum-32-chars
+      EGAPRO_E2E_CLOCK: "true"
+      S3_ENDPOINT: http://localhost:9000
+      S3_REGION: us-east-1
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
+      S3_BUCKET_NAME: egapro-dev-app
+      CLAMAV_HOST: localhost
+      CLAMAV_PORT: 3310
+      ADMIN_EMAILS: test@fia1.fr
+      NOTIFICATIONS_DATABASE_URL: postgresql://postgres:postgres@localhost:5439/egapro_notifications
+      MAIL_ENABLED: "true"
+      SMTP_HOST: localhost
+      SMTP_PORT: "1025"
+      SMTP_SECURE: "false"
+      MAIL_FROM: no-reply@egapro.local
+      MAILDEV_URL: http://localhost:1080
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+      - name: Restore CI build cache
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ./*
+          key: "${{ github.sha }}"
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+      - name: Install Chromium manually (bypass Playwright extractor)
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          CHROMIUM_VERSION=1217
+          CFT_BUILD=147.0.7727.15
+
+          install_browser() {
+            local zip_name="$1" dest_subdir="$2" extracted_dir="$3" final_dir="$4"
+            local dest="$HOME/.cache/ms-playwright/${dest_subdir}"
+            mkdir -p "$dest"
+            echo "::group::Download ${zip_name}"
+            time curl --fail --location --silent --show-error \
+              --max-time 120 \
+              -o "/tmp/${zip_name}" \
+              "https://cdn.playwright.dev/builds/cft/${CFT_BUILD}/linux64/${zip_name}"
+            ls -lh "/tmp/${zip_name}"
+            echo "::endgroup::"
+            echo "::group::Extract ${zip_name} with system unzip"
+            time unzip -q "/tmp/${zip_name}" -d "$dest"
+            if [ "$extracted_dir" != "$final_dir" ]; then
+              mv "$dest/$extracted_dir" "$dest/$final_dir"
+            fi
+            touch "$dest/INSTALLATION_COMPLETE"
+            rm "/tmp/${zip_name}"
+            ls -la "$dest" | head -5
+            echo "::endgroup::"
+          }
+
+          install_browser \
+            "chrome-linux64.zip" \
+            "chromium-${CHROMIUM_VERSION}" \
+            "chrome-linux64" \
+            "chrome-linux"
+
+          install_browser \
+            "chrome-headless-shell-linux64.zip" \
+            "chromium_headless_shell-${CHROMIUM_VERSION}" \
+            "chrome-headless-shell-linux64" \
+            "chrome-headless-shell-linux64"
+      - name: Install Playwright system dependencies
+        run: pnpm --filter app exec playwright install-deps chromium
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+      - name: Start services
+        run: docker compose up -d
+      - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm build
+      - name: Apply database schema
+        run: pnpm db:push
+      - name: Run recette grille
+        id: run-grille
+        continue-on-error: true
+        env:
+          ANNEE: ${{ github.event.inputs.annee || 'toutes' }}
+          TRANCHE: ${{ github.event.inputs.tranche || 'toutes' }}
+        run: |
+          set -euo pipefail
+
+          # Compute human-readable scope for the report
+          if [ "$ANNEE" = "toutes" ] && [ "$TRANCHE" = "toutes" ]; then
+            SCOPE="tous les cas (185 coordonnées)"
+          elif [ "$ANNEE" != "toutes" ] && [ "$TRANCHE" = "toutes" ]; then
+            SCOPE="année $ANNEE"
+          elif [ "$ANNEE" = "toutes" ] && [ "$TRANCHE" != "toutes" ]; then
+            SCOPE="tranche $TRANCHE"
+          else
+            SCOPE="année $ANNEE, tranche $TRANCHE"
+          fi
+          echo "RECETTE_SCOPE=$SCOPE" >> "$GITHUB_ENV"
+
+          # Build grep filter and run
+          if [ "$ANNEE" != "toutes" ] && [ "$TRANCHE" != "toutes" ]; then
+            pnpm --filter app test:e2e:grille -- --grep "\\[$ANNEE-$TRANCHE-"
+          elif [ "$ANNEE" != "toutes" ]; then
+            pnpm --filter app test:e2e:grille -- --grep "\\[$ANNEE-"
+          elif [ "$TRANCHE" != "toutes" ]; then
+            pnpm --filter app test:e2e:grille -- --grep "-$TRANCHE-CAS"
+          else
+            pnpm --filter app test:e2e:grille
+          fi
+      - name: Générer le rapport de recette
+        if: always()
+        run: |
+          pnpm --filter app report:grille \
+            --scope "${RECETTE_SCOPE:-tous les cas}" \
+            --commit "${{ github.sha }}" \
+            --report-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Stop services
+        if: always()
+        run: docker compose down
+      - name: Upload rapport de recette
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: grille-recette
+          path: packages/app/playwright-report/grille-recette.md
+          retention-days: 30
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-grille-report
+          path: packages/app/playwright-report/
+          retention-days: 14
+      - name: Upload Playwright traces
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-grille-traces
+          path: packages/app/test-results/
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Fail if coordinates failed
+        if: steps.run-grille.outcome == 'failure'
+        run: exit 1

--- a/docs/cahier-de-tests.md
+++ b/docs/cahier-de-tests.md
@@ -18,6 +18,7 @@ Audience : équipe métier / PO (référence d'acceptance et suivi des tests) et
 4. [Scénarios complémentaires hors Excel](#4-scénarios-complémentaires-hors-excel)
 5. [Limites de l'automatisation](#5-limites-de-lautomatisation)
 6. [Arbitrages métier (divergences résolues)](#6-arbitrages-métier-divergences-résolues)
+7. [Lancer la recette](#7-lancer-la-recette)
 
 ---
 
@@ -32,10 +33,11 @@ Les cellules de l'Excel se **regroupent** : un même cas se répète dans plusie
 1. **Côté tests** : le titre du `test.describe(...)` qui couvre un parcours porte le tag entre crochets, ex. `test.describe("[CAS-02] Path 1: no gap + hasCse → ...")`. Un même describe peut porter plusieurs tags. C'est ce tag que ciblent les commandes `--grep` du cahier.
 2. **Côté cahier** : la ligne « Test E2E » de chaque fiche décrit ce que le test déroule réellement — y compris, honnêtement, ce qu'il ne déroule pas encore. Cette profondeur se juge en revue de PR ; l'outillage, lui, ne vérifie que l'existence.
 
-Le script [`packages/app/scripts/check-cahier.mjs`](../packages/app/scripts/check-cahier.mjs) (`pnpm --filter app check:cahier`, exécuté en CI) vérifie que :
+Le script [`packages/app/scripts/check-cahier.ts`](../packages/app/scripts/check-cahier.ts) (`pnpm --filter app check:cahier`, exécuté en CI) vérifie trois niveaux :
 
 - toute fiche `CAS-xx` du §2 (et toute ligne `ANX-xx` du §4) est taguée dans au moins une spec `packages/app/src/e2e/*.e2e.ts` — **une fiche sans test fait échouer la CI** : un trou de couverture est visible en rouge, jamais caché ;
-- tout tag présent dans une spec correspond à une fiche ou une ligne du cahier.
+- tout tag présent dans une spec correspond à une fiche ou une ligne du cahier ;
+- **bijection au niveau coordonnée** : toute coordonnée `AAAA-EFFMAX-CASnn` du §3 est produite par `buildGrid()` et réciproquement — un §3 ou une règle de cadence désynchronisés font échouer la CI.
 
 **Règles de mise à jour** : nouveau parcours métier (évolution de l'Excel) → créer la fiche et la référencer dans les feuilles concernées ; la CI reste rouge jusqu'à l'arrivée du test qui la couvre. Test supprimé ou renommé → répercuter ici. La CI échoue si les deux dérivent.
 
@@ -345,11 +347,12 @@ L'année et la tranche fixent déjà la variante « 6 ou 7 indicateurs », donc 
 
 **Lecture d'une ligne de cellule** : `coordonnée : rappel`. Le texte après les deux-points est un **résumé** du cas (conditions · issue), pas une seconde information : `2027-149-CAS01 : sans CSE → fin de démarche directe` se lit « la coordonnée 2027-149-CAS01, qui correspond au parcours *sans CSE, fin de démarche directe* ». Cliquez la coordonnée pour la fiche complète (§2).
 
-La coordonnée est **au-dessus des tests** : elle pointe vers la **fiche du parcours-type** (§2 — `CAS-01` … `CAS-12`, `CAS-01-6IND`, `CAS-02-6IND`) où vit le test E2E. Comme le contenu d'un cas ne dépend ni de l'année ni de la tranche, un même test couvre toutes les coordonnées qui pointent vers sa fiche — d'où ~14 tests pour toute la grille. Pour lancer **un** cas précis, ouvrez sa fiche : la commande `--grep` y est. Pour lancer **une configuration entière** :
+La coordonnée est **au-dessus des tests** : elle pointe vers la **fiche du parcours-type** (§2 — `CAS-01` … `CAS-12`, `CAS-01-6IND`, `CAS-02-6IND`) où vit le test E2E. Comme le contenu d'un cas ne dépend ni de l'année ni de la tranche, un même test couvre toutes les coordonnées qui pointent vers sa fiche — d'où ~14 tests pour toute la grille. Pour lancer **un** cas précis, ouvrez sa fiche : la commande `--grep` y est. Pour lancer **une configuration entière** par coordonnée (via `test:e2e:grille`, voir §7) :
 
-- **Année « 7 indicateurs » (les 12 cas)** : `pnpm --filter app test:e2e --grep "\[CAS-(0[1-9]|1[0-2])\]"`
-- **Année « 6 premiers indicateurs » (cas 1-2)** : `pnpm --filter app test:e2e --grep "\[CAS-0[12]-6IND\]"`
-- **Tranches < 100** : `pnpm --filter app test:e2e --grep "\[CAS-1[34](-6IND)?\]"`
+- **Une année entière** : `pnpm --filter app test:e2e:grille -- --grep "\[2030-"`
+- **Une tranche entière** : `pnpm --filter app test:e2e:grille -- --grep "-149-CAS"`
+- **Une cellule précise (année × tranche)** : `pnpm --filter app test:e2e:grille -- --grep "\[2030-149-"`
+- **Toute la grille** : `pnpm --filter app test:e2e:grille`
 
 ### Feuille « <50 et 50-99 »
 
@@ -451,11 +454,11 @@ Le socle déclaratif (étapes 1–6, brouillon, historique, panneau de démarche
 
 ## 5. Limites de l'automatisation
 
-Ce que les tests E2E ne peuvent pas rejouer tel quel, et comment c'est compensé :
+Ce que les tests E2E ne peuvent pas rejouer tel quel :
 
-1. **La dimension année de campagne** — les specs E2E tournent sur l'année de campagne courante, pas sur 2027 → 2033. Le *contenu* de chaque cellule de l'Excel (les parcours) est déroulé par les tests du §2 ; le *cadencement* (quelle année déclenche 6 ou 7 indicateurs pour quelle tranche) est verrouillé par les tests unitaires du domaine (`indicatorG.test.ts`, `companyObligation.test.ts`), qui couvrent chaque tranche × année de la matrice.
-2. **La tranche d'effectif** — les parcours de conformité (cas 1 à 12) tournent en 250 et + (effectif GIP 250) ; les variantes 6 indicateurs (`CAS-01-6IND`, `CAS-02-6IND`) tournent avec un effectif GIP de 120, représentatif de la tranche 100-149 ; les nouveaux parcours < 100 tournent avec un effectif GIP de 30 (représentatif < 50) pour `CAS-13`/`CAS-14` et de 75 (représentatif 50-99) pour `CAS-13-6IND`.
-3. **Avis CSE défavorables** — tous les tests déposent des avis « favorable » ; les variantes « défavorable » (sans impact de routage attendu, mais affichées au récapitulatif) ne sont pas déroulées.
+1. **Le jugement humain** — l'ergonomie, la formulation des textes, la lisibilité du PDF généré et la cohérence visuelle d'ensemble ne sont pas mesurables par des assertions automatisées.
+2. **Les autres navigateurs et le mobile** — la grille tourne uniquement sur Chromium (bureau). Compatibilité Firefox/Safari et rendu mobile restent hors périmètre automatisé.
+3. **Les années hors 2027 → 2033** — le seam d'horloge (`withCampaignYear`) permet d'épingler les années 2027 à 2033 ; les années antérieures (données historiques) et les années futures au-delà de 2033 ne sont pas couvertes.
 
 ---
 
@@ -466,3 +469,27 @@ Les 3 divergences relevées en transcrivant le fichier Excel ont été arbitrée
 1. **Moins de 50 salariés (volontariat)** — déclarent **les 7 indicateurs chaque année**, indicateur G compris. La déclaration reste volontaire ; c'est son *contenu* qui change. *Statut : répercutée dans le code par #4043 (`isIndicatorGRequired` renvoie `true` sous 50 salariés, toutes années).*
 2. **50 à 99 salariés** — sont assujetties **chaque année** dès 2027 : les **6 premiers indicateurs** en 2027, 2028, 2029, 2031 et 2032, et les **7 indicateurs** en **2030 et 2033**. *Statut : répercutée dans le code par #4043 (`isObligatedForYear` assujettit les 50-99 chaque année dès `V2_FIRST_CAMPAIGN_YEAR`).*
 3. **Sous 100 salariés en année « 7 indicateurs »** — les tranches < 100 (50-99 comprises en 2030/2033, et les < 50 volontaires) ne sont **pas** concernées par les obligations déclenchées par un écart ≥ 5 % : pas de parcours de conformité, pas de seconde déclaration, pas de rapport d'évaluation conjointe, pas d'avis CSE. Le seuil de ces obligations reste **100 salariés**. *Statut : le code était déjà conforme — le seuil 100 vit dans `isComplianceProcessRequired`/`isCseOpinionRequired` (domaine) et `phase2Required`/`cseRequired` (moteur de règles) ; la divergence décrivait un état antérieur du code (« sans condition de tranche ») qui n'existe plus. Verrouillée par des tests, sans changement de comportement.*
+
+---
+
+## 7. Lancer la recette
+
+### Depuis l'onglet Actions (déclenchement manuel)
+
+1. Accédez à **Actions → Recette grille (nightly)** dans le dépôt GitHub.
+2. Cliquez **Run workflow**.
+3. Choisissez l'**Année de campagne** (`toutes` pour les 185 coordonnées, ou une année précise de 2027 à 2033) et la **Tranche d'effectif** (`toutes`, `49`, `99`, `149`, `249`, `250P`).
+4. Le rapport de recette apparaît dans le **résumé du run** et est téléchargeable en artefact (`grille-recette`).
+
+Le workflow tourne aussi automatiquement chaque nuit à 2h UTC. Un échec nocturne fait échouer le job et notifie les watchers du dépôt — aucune pull request n'est bloquée.
+
+### En local
+
+```bash
+pnpm --filter app test:e2e:grille                        # les 185 coordonnées
+pnpm --filter app test:e2e:grille -- --grep "\[2030-"    # une année
+pnpm --filter app test:e2e:grille -- --grep "\-149-CAS"  # une tranche
+pnpm --filter app report:grille                          # le rapport de recette
+```
+
+Le dev server doit tourner sur le port 3000 avec `EGAPRO_E2E_CLOCK=true` (actif dans `.github/workflows/e2e-grille.yaml` ; à passer manuellement en local).


### PR DESCRIPTION
Closes #4072

## Résumé

- **`.github/workflows/e2e-grille.yaml`** (nouveau) — workflow nightly (2h UTC) + déclenchement manuel avec ciblage `annee` × `tranche`. Déroulé : `test:e2e:grille` avec `continue-on-error: true` → `report:grille` (écrit dans `$GITHUB_STEP_SUMMARY`) → `docker compose down` → upload artefacts → `exit 1` si des coordonnées ont échoué. `EGAPRO_E2E_CLOCK: "true"` présent ici et nulle part ailleurs. `timeout-minutes: 130` (double de l'extrapolation haute de #4070). `cancel-in-progress: false` explicite.
- **`docs/cahier-de-tests.md`** — §1 : `check:cahier` mentionne la bijection coordonnée ; §3 : ciblage par coordonnée (`test:e2e:grille -- --grep`) en lieu et place des grep `[CAS-xx]` ; §5 : trois anciennes limites supprimées, reformulation de ce qui reste hors d'atteinte ; §7 nouveau : lancement manuel (Actions) et local.

## Plan de test

- [ ] `pnpm --filter app check:cahier` vert (22 scénarios, 17 fiches, 185 coordonnées)
- [ ] `EGAPRO_E2E_CLOCK` absent de `e2e.yaml`, `.kontinuous/env/preprod`, `.kontinuous/env/prod`
- [ ] `e2e.yaml` inchangé (`timeout-minutes: 20`)
- [ ] Déclenchement manuel `annee=2030 tranche=149` → seules les 12 coordonnées de cette cellule dans le rapport
- [ ] Rapport produit même si des coordonnées échouent ; job échoue ensuite
- [ ] Aucune protection de branche ne référence `e2e-grille.yaml`