### PR TITLE
fix(orchestration): remonte les erreurs des scripts de board

### DIFF
--- a/.github/workflows/ticket-end-date.yaml
+++ b/.github/workflows/ticket-end-date.yaml
@@ -6,16 +6,9 @@ name: 🗓️ Ticket end date
 # the final epic PR (`epic/<N>`) and human non-ticket branches are skipped.
 #
 # Auth: GitHub App token minted by SocialGouv/token-bureau (OIDC), same pattern
-# as release.yml / promote-test-env.yaml.
-#
-# PREREQUISITE — the token-bureau token must carry `organization_projects: write`.
-#   Writing an org Project V2 needs the projects scope; the default GITHUB_TOKEN
-#   cannot, and the token-bureau whitelist (infra-apps) must allow it. As of now
-#   the deployed default whitelist is contents/metadata/issues/pull_requests/
-#   deployments — add `organization_projects: write` (default or an egapro
-#   override) in SocialGouv/infra-apps token-bureau values, and ensure the
-#   backing App has "Organization projects: Read and write", or the board write
-#   step 403s.
+# as release.yml / promote-test-env.yaml. Writing an org Project V2 board needs
+# `organization_projects: write`, which the default GITHUB_TOKEN cannot carry;
+# it comes from the egapro override in SocialGouv/infra-apps token-bureau values.
 
 on:
   pull_request:
@@ -23,6 +16,7 @@ on:
 
 permissions:
   id-token: write # required for token-bureau OIDC
+  contents: read # checkout
 
 jobs:
   stamp-end-date:
@@ -38,6 +32,9 @@ jobs:
         with:
           token-bureau-url: https://token-bureau.fabrique.social.gouv.fr
           audience: socialgouv
+          # Only what the stamping step needs: read the issue node id, write the
+          # board field. Checkout uses the job's own GITHUB_TOKEN.
+          permissions: '{"issues": "read", "organization_projects": "write"}'
 
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/scripts/orchestration/set_ticket_date.sh
+++ b/scripts/orchestration/set_ticket_date.sh
@@ -80,7 +80,10 @@ query($owner:String!, $repo:String!, $n:Int!) {
   repository(owner:$owner, name:$repo) {
     issue(number:$n) { id }
   }
-}' -f owner=SocialGouv -f repo=egapro -F n="$TICKET" --jq '.data.repository.issue.id')
+}' -f owner=SocialGouv -f repo=egapro -F n="$TICKET" --jq '.data.repository.issue.id') || {
+    echo "ERROR: [1/4] could not resolve issue #$TICKET (needs \`issues: read\`)" >&2
+    exit 1
+}
 
 if [ -z "$NODE_ID" ] || [ "$NODE_ID" = "null" ]; then
     echo "ERROR: issue #$TICKET not found in SocialGouv/egapro" >&2
@@ -98,8 +101,12 @@ query($owner:String!, $repo:String!, $n:Int!) {
     }
   }
 }' -f owner=SocialGouv -f repo=egapro -F n="$TICKET" \
-  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" \
-  | head -1 || true)
+  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id") || {
+    echo "ERROR: [2/4] could not list project items of issue #$TICKET" >&2
+    exit 1
+}
+# Piping straight into `head` would hide a failed query behind an empty result.
+ITEM_ID=$(printf '%s\n' "$ITEM_ID" | head -1)
 
 if [ -z "$ITEM_ID" ]; then
     ITEM_ID=$(gh api graphql -f query='
@@ -107,7 +114,10 @@ mutation($project:ID!, $content:ID!) {
   addProjectV2ItemById(input: { projectId: $project, contentId: $content }) {
     item { id }
   }
-}' -f project="$PROJECT_ID" -f content="$NODE_ID" --jq '.data.addProjectV2ItemById.item.id')
+}' -f project="$PROJECT_ID" -f content="$NODE_ID" --jq '.data.addProjectV2ItemById.item.id') || {
+        echo "ERROR: [2/4] could not add issue #$TICKET to the board (needs \`organization_projects: write\`)" >&2
+        exit 1
+    }
 fi
 
 if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
@@ -117,7 +127,8 @@ fi
 
 # 3. Idempotency guard — skip if the field already holds a value.
 # Read by field ID (same key the write uses) so an EGAPRO_*_FIELD_ID env
-# override stays consistent between the guard and the mutation.
+# override stays consistent between the guard and the mutation. A failed read
+# aborts: swallowing it would read as "field is empty" and trigger a write.
 if [ "$IF_EMPTY" = "1" ]; then
     CURRENT=$(gh api graphql -f query='
 query($item:ID!) {
@@ -135,8 +146,10 @@ query($item:ID!) {
     }
   }
 }' -f item="$ITEM_ID" \
-      --jq "[.data.node.fieldValues.nodes[] | select(.field.id == \"$FIELD_ID\") | .date] | .[0] // \"\"" \
-      2>/dev/null || echo "")
+      --jq "[.data.node.fieldValues.nodes[] | select(.field.id == \"$FIELD_ID\") | .date] | .[0] // \"\"") || {
+        echo "ERROR: [3/4] could not read $FIELD_NAME on item $ITEM_ID (needs \`organization_projects: read\`)" >&2
+        exit 1
+    }
     if [ -n "$CURRENT" ] && [ "$CURRENT" != "null" ]; then
         echo "ticket #$TICKET → $FIELD_NAME already set ($CURRENT), skipping" >&2
         exit 0
@@ -157,6 +170,9 @@ mutation($project:ID!, $item:ID!, $field:ID!, $date:Date!) {
   -f item="$ITEM_ID" \
   -f field="$FIELD_ID" \
   -f date="$DATE" \
-  --jq '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null
+  --jq '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null || {
+    echo "ERROR: [4/4] could not write $FIELD_NAME on item $ITEM_ID (needs \`organization_projects: write\`)" >&2
+    exit 1
+}
 
 echo "ticket #$TICKET → $FIELD_NAME = $DATE"

--- a/scripts/orchestration/set_ticket_status.sh
+++ b/scripts/orchestration/set_ticket_status.sh
@@ -101,8 +101,9 @@ query($owner:String!, $repo:String!, $n:Int!) {
     }
   }
 }' -f owner=SocialGouv -f repo=egapro -F n="$TICKET" \
-  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id" \
-  | head -1 || true)
+  --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+# Piping straight into `head` would hide a failed query behind an empty result.
+ITEM_ID=$(printf '%s\n' "$ITEM_ID" | head -1)
 
 if [ -z "$ITEM_ID" ]; then
     # Not on the project yet — add it


### PR DESCRIPTION
Suite à l'incident sur `ticket-end-date` (token-bureau ne portait pas `organization_projects` — corrigé côté serveur en [v0.0.10](https://github.com/SocialGouv/token-bureau/commit/7553831), la pipeline est verte).

Ce qui a rendu l'incident opaque, et que cette PR corrige.

### Les erreurs GraphQL étaient avalées

Dans `set_ticket_date.sh`, deux appels masquaient leur échec :

- la résolution de l'item du board finissait par `| head -1 || true`
- la lecture du garde `--if-empty` par `2>/dev/null || echo ""`

Conséquence : une lecture refusée devenait « le champ est vide », et le script enchaînait sur une écriture. Le job ne laissait qu'une seule ligne `gh: Resource not accessible by integration`, sans dire quelle étape avait échoué — les trois appels précédents étaient invisibles.

Au passage, c'est aussi un risque de perte de donnée hors incident de permission : un échec de lecture transitoire fait sauter le garde `--if-empty`, qui est justement censé préserver la première valeur écrite.

Chaque appel nomme maintenant l'étape et la permission attendue. Vérifié avec un token volontairement sous-privilégié :

```
avant : gh: Resource not accessible by integration
        exit=1

après : gh: Resource not accessible by integration
        ERROR: [2/4] could not add issue #4067 to the board (needs `organization_projects: write`)
        exit=1
```

Même traitement sur le `|| true` équivalent dans `set_ticket_status.sh`, qui partage ce bout de résolution.

### Périmètre du token

Le step token-bureau ne passait pas d'input `permissions` et récupérait donc tout le jeu par défaut : `contents:write`, `deployments:write`, `issues:write`, `pull_requests:write`. Le job ne fait que lire une issue et écrire un champ de board :

```yaml
permissions: '{"issues": "read", "organization_projects": "write"}'
```

`contents: read` est ajouté au bloc `permissions` du workflow pour le checkout, qui utilise le `GITHUB_TOKEN` du job et non ce token. Chemin nominal rejoué avec ce jeu restreint : `ticket #4067 → End date already set (2026-08-03), skipping`, exit 0.

Enfin, le bloc `PREREQUISITE` en tête du workflow est réduit : il décrivait une configuration à mettre en place, qui est en place et vérifiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)