### PR TITLE
fix(home): #4062 — le CTA « Déclarer mes indicateurs » atterrit sur Mon espace

### DIFF
--- a/packages/app/src/modules/home/HomeHero.tsx
+++ b/packages/app/src/modules/home/HomeHero.tsx
@@ -39,7 +39,7 @@ export function HomeHero() {
 						</p>
 						<Link
 							className={`fr-btn fr-icon-file-text-line fr-btn--icon-left ${styles.cta}`}
-							href="/declaration-remuneration"
+							href="/mon-espace"
 						>
 							Déclarer mes indicateurs
 						</Link>

--- a/packages/app/src/modules/home/__tests__/HomeHero.test.tsx
+++ b/packages/app/src/modules/home/__tests__/HomeHero.test.tsx
@@ -20,13 +20,14 @@ describe("HomeHero", () => {
 		).toBeInTheDocument();
 	});
 
+	// /mon-espace enforces the missing-information gate; /declaration-remuneration skips it via callbackUrl
 	it("renders the declaration CTA link", () => {
 		render(<HomeHero />);
 		const link = screen.getByRole("link", {
 			name: /déclarer mes indicateurs/i,
 		});
 		expect(link).toBeInTheDocument();
-		expect(link).toHaveAttribute("href", "/declaration-remuneration");
+		expect(link).toHaveAttribute("href", "/mon-espace");
 	});
 
 	it("renders the info about companies with 50+ employees", () => {


### PR DESCRIPTION
Closes #4062

## Contexte

Depuis la page d'accueil, le bouton « Déclarer mes indicateurs » envoyait l'utilisateur dans le tunnel de déclaration au lieu de « Mon espace ». Après connexion ProConnect, il atterrissait donc sur « Étape 1 sur 6 — Effectifs physiques pris en compte pour le calcul des indicateurs ».

Chaîne mesurée : `/declaration-remuneration` → `307 /login?callbackUrl=%2Fdeclaration-remuneration` → retour ProConnect → `/declaration-remuneration/etape/1`.

Le middleware capture volontairement la cible dans `callbackUrl` (nécessaire aux deep-links), donc le repli `?? "/mon-espace"` de `ProConnectButton` n'était jamais atteint. Rien ne dysfonctionnait côté login : c'est la cible du lien qui était fausse. Le CTA pointait sur le tunnel depuis #2825 et n'a jamais visé Mon espace.

## Changement

`HomeHero.tsx` — le `href` du CTA passe de `/declaration-remuneration` à `/mon-espace`. Le middleware protège déjà cette route : un visiteur anonyme passe par `/login` puis atterrit sur Mon espace, un utilisateur connecté y va directement.

## Hors périmètre

Le prérequis « téléphone + CSE » n'est aujourd'hui appliqué que côté client, sur Mon espace — toute entrée directe dans le tunnel le contourne encore. C'est le second volet du même défaut, traité séparément dans #3952 (garde serveur dans `(with-banner)/layout.tsx`). Les deux périmètres ne partagent aucun fichier.

## Test plan

- `HomeHero.test.tsx` : assertion mise à jour sur le nouveau `href`, revert-verify RED→GREEN
- Suite unitaire complète verte (4151 tests) après rebase sur `alpha`
- Vérifié sur dev server : `href` conforme, redirection `/login?callbackUrl=%2Fmon-espace` confirmée, hero inchangé
- Typecheck, lint et format verts
