### PR TITLE
fix(declaration-remuneration): #3952 — bloquer l'accès au tunnel sans téléphone ni CSE renseignés

### DIFF
--- a/packages/app/src/app/declaration-remuneration/(with-banner)/layout.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/layout.tsx
@@ -3,9 +3,17 @@ import {
 	DeclarationLayout,
 	MissingSiret,
 } from "~/modules/declaration-remuneration";
-import { isDeclarationWritingClosed } from "~/modules/domain";
+import {
+	getObligationWorkforce,
+	hasRequiredDeclarationInfo,
+	isCseRequired,
+	isDeclarationWritingClosed,
+} from "~/modules/domain";
 import { auth } from "~/server/auth";
-import { getEffectiveSiren } from "~/server/auth/companyAccess";
+import {
+	getEffectiveSiren,
+	isImpersonating,
+} from "~/server/auth/companyAccess";
 import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { api } from "~/trpc/server";
 
@@ -30,11 +38,28 @@ export default async function WithBannerLayout({
 	const siren = getEffectiveSiren(session);
 	if (!siren) return <MissingSiret />;
 
-	const [company, declarationData] = await Promise.all([
+	const [company, profile] = await Promise.all([
 		api.company.get({ siren }),
-		api.declaration.getOrCreate(),
+		api.profile.get().catch(() => null),
 	]);
 
+	const cseApplicable = isCseRequired(
+		getObligationWorkforce(company.gipWorkforce),
+	);
+	if (
+		!isImpersonating(session) &&
+		!hasRequiredDeclarationInfo(
+			profile?.phone ?? null,
+			company.hasCse,
+			cseApplicable,
+		)
+	) {
+		redirect("/mon-espace");
+	}
+
+	// Kept after the guard: `getOrCreate` inserts a draft declaration, and a
+	// visitor bounced back to Mon espace must not leave one behind.
+	const declarationData = await api.declaration.getOrCreate();
 	const declaration = declarationData.declaration;
 
 	const deadlines = await getCampaignDeadlines(declaration.year);

--- a/packages/app/src/e2e/auth.setup.ts
+++ b/packages/app/src/e2e/auth.setup.ts
@@ -1,5 +1,10 @@
 import { test as setup } from "@playwright/test";
-import { resetGipWorkforce } from "./helpers/db";
+import { TEST_USER_PHONE } from "./constants";
+import {
+	resetGipWorkforce,
+	setCompanyHasCse,
+	setUserPhone,
+} from "./helpers/db";
 import { AUTH_FILE, loginWithProConnect } from "./helpers/login";
 
 setup("authenticate via ProConnect", async ({ page }) => {
@@ -7,7 +12,16 @@ setup("authenticate via ProConnect", async ({ page }) => {
 	await loginWithProConnect(page);
 	await page.context().storageState({ path: AUTH_FILE });
 
-	// Seeded here rather than in global-setup: app_gip_mds_data references app_company,
-	// and the company row only exists once the first ProConnect login has run.
+	// Seeded here rather than in global-setup: app_gip_mds_data and app_user_company
+	// reference app_company, and the company row only exists once the first ProConnect
+	// login has run.
 	await resetGipWorkforce();
+
+	// Declaration prerequisites (#3952): the funnel layout bounces to /mon-espace until
+	// the phone and — above the CSE threshold, which the >= 250 baseline always crosses —
+	// the CSE answer are known. A ProConnect sign-up carries neither, so without this
+	// baseline every spec entering the funnel would silently depend on which earlier
+	// spec file happened to fill them in.
+	await setUserPhone(TEST_USER_PHONE);
+	await setCompanyHasCse(true);
 });

--- a/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
+++ b/packages/app/src/e2e/campaign-deadlines-gating.e2e.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { getCurrentYear } from "~/modules/domain";
+import { TEST_USER_PHONE } from "./constants";
 import {
 	resetDeclarationToDraft,
 	setCompanyHasCse,
@@ -56,7 +57,7 @@ test.describe("Campaign deadlines gating", () => {
 	// Phone + CSE flags must be set before login so the JWT picks them up and
 	// the missing-info-modal does not intercept clicks on /mon-espace.
 	async function seedUserProfile() {
-		await setUserPhone("0122334455");
+		await setUserPhone(TEST_USER_PHONE);
 		await setCompanyHasCse(true);
 	}
 

--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -425,6 +425,12 @@ test.describe("[ANX-05] Path 13: 50-99 tranche — indicator G gated by the pinn
 // be told to deposit a CSE opinion: the recap "Prochaines étapes" box and the
 // compliance-choice options drop every CSE-opinion mention, while the gap actions
 // and the "Mettre à jour l'existence d'un CSE" escape hatch stay.
+//
+// Only the `false` branch is reachable end to end. Since #3952 the funnel layout
+// intercepts a >= 100 company whose CSE answer is still null and sends it back to
+// /mon-espace to answer, so no journey reaches the recap in that state — that bounce
+// is asserted in missing-info-modal.e2e.ts, and the recap's own null-like-false
+// rendering by Step6Review.test.tsx ("CSE consultation section gating (issue #3945)").
 
 const CSE_OPINION_RECAP_TEXT = /avis du CSE devront être transmis/;
 const CSE_JUSTIFY_PARENTHESIS = /avis à transmettre sur le portail/;
@@ -486,29 +492,6 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=false → no CSE opinion 
 		await expect(
 			page.getByText(/Transmettre l.avis ou les avis du CSE/),
 		).toHaveCount(0);
-	});
-});
-
-test.describe("[#3945] gap + workforce >= 100 + hasCse=null → no CSE opinion mention", () => {
-	test.beforeAll(async () => {
-		await resetDeclarationToDraft();
-		await setCompanyHasCse(null);
-		await setCompanyWorkforce(200);
-	});
-
-	test("step 6 recap treats an unset CSE flag like an absent CSE", async ({
-		page,
-	}) => {
-		test.slow();
-		await reachStep6ComplianceRecap(page);
-
-		await expect(
-			page.getByRole("heading", { name: "Informer et consulter le CSE" }),
-		).toHaveCount(0);
-		await expect(page.getByText(CSE_OPINION_RECAP_TEXT)).toHaveCount(0);
-		await expect(
-			page.getByRole("button", { name: UPDATE_CSE_BUTTON }),
-		).toBeVisible();
 	});
 });
 

--- a/packages/app/src/e2e/constants.ts
+++ b/packages/app/src/e2e/constants.ts
@@ -6,3 +6,7 @@ export const TEST_SIREN = "130025265";
 // GIP-MDS annual average workforce of the test company. Every size-based rule reads this value,
 // so the suite baseline is a >= 250 company: 6-step funnel (indicator G required) + CSE field.
 export const TEST_GIP_WORKFORCE = 250;
+
+// Phone number of the test user. A ProConnect sign-up never carries one, and since #3952 the
+// funnel layout bounces to /mon-espace until it is known, so the suite seeds it as a baseline.
+export const TEST_USER_PHONE = "0122334455";

--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { getCurrentYear } from "~/modules/domain";
+import { TEST_USER_PHONE } from "./constants";
 import {
 	deleteCseOpinions,
 	deleteJointEvaluationFiles,
@@ -33,7 +34,7 @@ test.describe("Declaration process panel", () => {
 		await deleteJointEvaluationFiles();
 		await deleteCseOpinions();
 		await setCompanyHasCse(true);
-		await setUserPhone("0122334455");
+		await setUserPhone(TEST_USER_PHONE);
 	});
 
 	test.describe("DB state → variant: closed (compliance completed + CSE deposited)", () => {
@@ -73,7 +74,7 @@ test.describe("Declaration process panel", () => {
 		test.beforeAll(async () => {
 			await resetDeclarationToDraft();
 			await setCompanyHasCse(null);
-			await setUserPhone("0122334455");
+			await setUserPhone(TEST_USER_PHONE);
 		});
 
 		test.afterAll(async () => {
@@ -141,7 +142,7 @@ test.describe("Declaration process panel", () => {
 				await ensureCurrentYearDeclaration();
 				await setGipWorkforce(79);
 				await setCompanyHasCse(false);
-				await setUserPhone("0122334455");
+				await setUserPhone(TEST_USER_PHONE);
 				await resetDeclarationToDraft();
 			});
 
@@ -168,7 +169,7 @@ test.describe("Declaration process panel", () => {
 				await ensureCurrentYearDeclaration();
 				await setGipWorkforce(79);
 				await setCompanyHasCse(false);
-				await setUserPhone("0122334455");
+				await setUserPhone(TEST_USER_PHONE);
 				await setDeclarationComplianceState({
 					status: "demarche_completed",
 					demarcheCompletedAt: new Date(),
@@ -231,7 +232,7 @@ test.describe("Declaration process panel", () => {
 				await ensureCurrentYearDeclaration();
 				await resetGipWorkforce();
 				await setCompanyHasCse(false);
-				await setUserPhone("0122334455");
+				await setUserPhone(TEST_USER_PHONE);
 				await resetDeclarationToDraft();
 			});
 
@@ -254,7 +255,7 @@ test.describe("Declaration process panel", () => {
 				await ensureCurrentYearDeclaration();
 				await resetGipWorkforce();
 				await setCompanyHasCse(false);
-				await setUserPhone("0122334455");
+				await setUserPhone(TEST_USER_PHONE);
 				await setDeclarationComplianceState({
 					status: "demarche_completed",
 					demarcheCompletedAt: new Date(),

--- a/packages/app/src/e2e/helpers/campaign-year.ts
+++ b/packages/app/src/e2e/helpers/campaign-year.ts
@@ -3,6 +3,7 @@ import {
 	getCurrentDbYear,
 	pushCampaignDeadlinesFarFuture,
 	resetGipWorkforce,
+	setCompanyHasCse,
 	setGipWorkforce,
 } from "./db";
 import { resetCampaignYear as resetCampaignYearData } from "./db-campaign";
@@ -83,16 +84,23 @@ export type CampaignCoordinate = {
  * Run `fn` under a fully isolated campaign-year coordinate (#4067).
  *
  * Pins the clock on both surfaces, wipes any residue of the target year, seeds
- * its deadlines (never a `campaign_start_date` — see pushCampaignDeadlinesFarFuture)
- * and its GIP workforce, then runs the body. The teardown always runs (even when
- * `fn` throws) and double-resets: the coordinate's own year, plus the calendar
- * year as a safety net for any residue a default-year helper wrote inside `fn`
- * (`setCompanyHasCse`, an unpinned `setGipWorkforce`, …). The calendar year is
- * then restored to the baseline the unpinned suite depends on (far-future
+ * its deadlines (never a `campaign_start_date` — see pushCampaignDeadlinesFarFuture),
+ * its GIP workforce and its CSE answer, then runs the body. The teardown always
+ * runs (even when `fn` throws) and double-resets: the coordinate's own year, plus
+ * the calendar year as a safety net for any residue a default-year helper wrote
+ * inside `fn` (`setCompanyHasCse`, an unpinned `setGipWorkforce`, …). The calendar
+ * year is then restored to the baseline the unpinned suite depends on (far-future
  * deadlines + the >= 250 GIP workforce), so a pinned spec never leaves the shared
  * company GIP-less for the next spec file. It leaves no declaration, file, CSE
  * opinion, lock or `has_cse` flag of the coordinate behind — the invariant the
  * grid relies on to chain 185 coordinates without cross-contamination.
+ *
+ * `has_cse` gets its own re-seed on both ends because `resetCampaignYearData`
+ * flattens it (it is not year-scoped) while, since #3952, the funnel layout
+ * bounces to /mon-espace whenever the CSE answer is missing above the threshold:
+ * without it a coordinate could no longer enter the funnel it pins, and would
+ * leave the next spec file unable to enter it either. Coordinates that assert on
+ * a specific answer still override it inside `fn`, as the grid fiches do.
  */
 export async function withCampaignYear(
 	coordinate: CampaignCoordinate,
@@ -103,6 +111,7 @@ export async function withCampaignYear(
 	await resetCampaignYearData(year);
 	await pushCampaignDeadlinesFarFuture(year);
 	await setGipWorkforce(workforce, year);
+	await setCompanyHasCse(true);
 	try {
 		await fn();
 	} finally {
@@ -118,5 +127,6 @@ export async function withCampaignYear(
 			await pushCampaignDeadlinesFarFuture();
 			await resetGipWorkforce();
 		}
+		await setCompanyHasCse(true);
 	}
 }

--- a/packages/app/src/e2e/missing-info-modal.e2e.ts
+++ b/packages/app/src/e2e/missing-info-modal.e2e.ts
@@ -1,6 +1,13 @@
 import { expect, test } from "@playwright/test";
 
-import { setCompanyHasCse, setUserPhone } from "./helpers/db";
+import { TEST_USER_PHONE } from "./constants";
+import {
+	resetDeclarationToDraft,
+	resetGipWorkforce,
+	setCompanyHasCse,
+	setDeclarationComplianceState,
+	setUserPhone,
+} from "./helpers/db";
 import { clickAndExpectDialogOpen, waitForDsfrModal } from "./helpers/dsfr";
 import { loginWithProConnect } from "./helpers/login";
 
@@ -12,7 +19,7 @@ test.describe("Missing info modal", () => {
 
 	test.describe("CSE only (phone already set)", () => {
 		test.beforeAll(async () => {
-			await setUserPhone("0122334455");
+			await setUserPhone(TEST_USER_PHONE);
 			await setCompanyHasCse(null);
 		});
 
@@ -57,7 +64,7 @@ test.describe("Missing info modal", () => {
 		});
 
 		test.afterAll(async () => {
-			await setUserPhone("0122334455");
+			await setUserPhone(TEST_USER_PHONE);
 		});
 
 		test("opens modal and submits phone number", async ({ page }) => {
@@ -94,7 +101,7 @@ test.describe("Missing info modal", () => {
 		});
 
 		test.afterAll(async () => {
-			await setUserPhone("0122334455");
+			await setUserPhone(TEST_USER_PHONE);
 		});
 
 		test("shows validation error when phone is empty", async ({ page }) => {
@@ -130,7 +137,7 @@ test.describe("Missing info modal", () => {
 		});
 
 		test.afterAll(async () => {
-			await setUserPhone("0122334455");
+			await setUserPhone(TEST_USER_PHONE);
 			await setCompanyHasCse(true);
 		});
 
@@ -184,7 +191,7 @@ test.describe("Missing info modal", () => {
 
 	test.describe("Validation error on empty CSE", () => {
 		test.beforeAll(async () => {
-			await setUserPhone("0122334455");
+			await setUserPhone(TEST_USER_PHONE);
 			await setCompanyHasCse(null);
 		});
 
@@ -225,6 +232,76 @@ test.describe("Missing info modal", () => {
 				}),
 			).toBeVisible();
 			expect(page.url()).toContain("/mon-espace");
+		});
+	});
+
+	// Regression guard for #3952: the phone + CSE prerequisites were only enforced by
+	// the "Rémunération" link of Mon espace, so every other way in — the home CTA, a
+	// bookmark, a deep link, a callbackUrl coming back from ProConnect — walked
+	// straight into the funnel and skipped the modal above entirely. The guard now
+	// sits on the funnel layout, so it holds whatever the entry point.
+	test.describe("Entering the funnel outside Mon espace (#3952)", () => {
+		test.beforeAll(async () => {
+			await resetGipWorkforce();
+			// Not a draft: the read-only recap asserted below only renders for a
+			// declaration that reached the compliance stage.
+			await setDeclarationComplianceState({
+				currentStep: 6,
+				status: "awaiting_compliance_path_choice",
+			});
+			await setUserPhone(null);
+			await setCompanyHasCse(null);
+		});
+
+		test.afterAll(async () => {
+			await setUserPhone(TEST_USER_PHONE);
+			await setCompanyHasCse(true);
+			await resetDeclarationToDraft();
+		});
+
+		test("a direct URL lands on Mon espace until both prerequisites are answered", async ({
+			page,
+		}) => {
+			await page.context().clearCookies();
+			await loginWithProConnect(page);
+
+			await test.step("neither answered — the funnel entry point bounces", async () => {
+				await page.goto("/declaration-remuneration");
+				await page.waitForURL("**/mon-espace");
+				// Bounced, but not into a dead end: the modal that collects both is right there.
+				await waitForDsfrModal(page, MISSING_INFO_MODAL_ID);
+			});
+
+			await test.step("a deep link into a later step bounces too", async () => {
+				await page.goto("/declaration-remuneration/etape/4");
+				await page.waitForURL("**/mon-espace");
+			});
+
+			// The guard sits on the (with-banner) group, not on the funnel root, so the
+			// read-only recap stays readable — a colleague who never filled the funnel in
+			// must still be able to consult what the company declared.
+			await test.step("the read-only recap stays outside the guard", async () => {
+				await page.goto("/declaration-remuneration/recapitulatif");
+				await expect(
+					page.getByRole("heading", {
+						level: 1,
+						name: /Déclaration des indicateurs de rémunération/,
+					}),
+				).toBeVisible();
+			});
+
+			await test.step("the phone alone is not enough above the CSE threshold", async () => {
+				await setUserPhone(TEST_USER_PHONE);
+				await page.goto("/declaration-remuneration");
+				await page.waitForURL("**/mon-espace");
+			});
+
+			await test.step("both answered — the same deep link now opens the funnel", async () => {
+				await setCompanyHasCse(true);
+				await page.goto("/declaration-remuneration/etape/4");
+				await page.waitForURL("**/declaration-remuneration/etape/4");
+				await expect(page.getByText("Étape 4 sur 6")).toBeVisible();
+			});
 		});
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/__tests__/WithBannerLayout.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/WithBannerLayout.test.tsx
@@ -1,0 +1,226 @@
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedirect, mockAuth, mockGetEffectiveSiren } = vi.hoisted(() => ({
+	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
+		throw new Error("NEXT_REDIRECT");
+	}),
+	mockAuth: vi.fn(),
+	mockGetEffectiveSiren: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+	redirect: mockRedirect,
+}));
+
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+
+vi.mock("~/server/auth/companyAccess", async (importOriginal) => ({
+	...(await importOriginal<typeof import("~/server/auth/companyAccess")>()),
+	getEffectiveSiren: mockGetEffectiveSiren,
+}));
+
+vi.mock("~/server/db/getCampaignDeadlines", async () => {
+	const { getDefaultCampaignDeadlines } =
+		await vi.importActual<typeof import("~/modules/domain")>(
+			"~/modules/domain",
+		);
+	return {
+		getCampaignDeadlines: vi.fn((year: number) =>
+			Promise.resolve(getDefaultCampaignDeadlines(year)),
+		),
+	};
+});
+
+vi.mock("~/trpc/server", () => ({
+	api: {
+		company: { get: vi.fn() },
+		declaration: { getOrCreate: vi.fn() },
+		profile: { get: vi.fn() },
+	},
+}));
+
+// The barrel pulls client components this redirect-only suite never renders.
+vi.mock("~/modules/declaration-remuneration", () => ({
+	DeclarationLayout: ({ children }: { children: React.ReactNode }) => children,
+	MissingSiret: () => "missing-siret",
+}));
+
+import WithBannerLayout from "~/app/declaration-remuneration/(with-banner)/layout";
+import { COMPANY_SIZE_ANNUAL_MIN } from "~/modules/domain";
+import { api } from "~/trpc/server";
+
+const SIREN = "123456789";
+const PHONE = "0612345678";
+const MY_SPACE_PATH = "/mon-espace";
+const DEFAULT_USER = { id: "u1", siret: `${SIREN}00015` };
+
+function mockLayout({
+	gipWorkforce = COMPANY_SIZE_ANNUAL_MIN,
+	hasCse = true as boolean | null,
+	phone = PHONE as string | null,
+	profileFails = false,
+	user = DEFAULT_USER as Record<string, unknown>,
+}: {
+	gipWorkforce?: number | null;
+	hasCse?: boolean | null;
+	phone?: string | null;
+	profileFails?: boolean;
+	user?: Record<string, unknown>;
+} = {}) {
+	mockAuth.mockResolvedValue({ user });
+	mockGetEffectiveSiren.mockReturnValue(SIREN);
+	vi.mocked(api.company.get).mockResolvedValue({
+		name: "Société Démo",
+		siren: SIREN,
+		nafCode: null,
+		nafLabel: null,
+		gipWorkforce,
+		hasCse,
+	} as never);
+	vi.mocked(api.declaration.getOrCreate).mockResolvedValue({
+		declaration: { id: "d1", year: 2026, siren: SIREN, status: "draft" },
+	} as never);
+	if (profileFails) {
+		vi.mocked(api.profile.get).mockRejectedValue(new Error("NOT_FOUND"));
+	} else {
+		vi.mocked(api.profile.get).mockResolvedValue({ phone } as never);
+	}
+}
+
+function renderLayout() {
+	return WithBannerLayout({ children: "child" as unknown as React.ReactNode });
+}
+
+describe("WithBannerLayout", () => {
+	beforeEach(() => {
+		mockRedirect.mockClear();
+		mockAuth.mockReset();
+		mockGetEffectiveSiren.mockReset();
+		vi.mocked(api.declaration.getOrCreate).mockClear();
+	});
+
+	it("redirects unauthenticated users to /login", async () => {
+		mockAuth.mockResolvedValue(null);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/login");
+	});
+
+	it("renders the missing-SIRET screen when no company is in scope", async () => {
+		mockAuth.mockResolvedValue({ user: { id: "u1" } });
+		mockGetEffectiveSiren.mockReturnValue(null);
+
+		await expect(renderLayout()).resolves.toBeDefined();
+		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+
+	// `false` is a complete CSE answer, not a missing one — truthiness would bounce it.
+	it.each([
+		true,
+		false,
+	])("serves the funnel when the phone and the CSE answer are both known (hasCse: %s)", async (hasCse) => {
+		mockLayout({ gipWorkforce: COMPANY_SIZE_ANNUAL_MIN, hasCse });
+
+		await expect(renderLayout()).resolves.toBeDefined();
+		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+
+	// The reported bug: entering the funnel outside Mon espace skipped the prerequisites.
+	it.each([
+		null,
+		"",
+	])("sends a user with no phone number back to Mon espace (phone: %s)", async (phone) => {
+		mockLayout({ phone });
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(MY_SPACE_PATH);
+	});
+
+	// `getOrCreate` inserts a draft declaration — bouncing must not leave one behind.
+	it("creates no draft declaration when it bounces the visitor", async () => {
+		mockLayout({ phone: null });
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(api.declaration.getOrCreate).not.toHaveBeenCalled();
+	});
+
+	it("sends a user back to Mon espace when the CSE applies and its answer is missing", async () => {
+		mockLayout({ gipWorkforce: COMPANY_SIZE_ANNUAL_MIN, hasCse: null });
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(MY_SPACE_PATH);
+	});
+
+	// `has_cse` is only collectable above the threshold — requiring it below bounces forever.
+	it.each([
+		COMPANY_SIZE_ANNUAL_MIN - 1,
+		null,
+	])("serves the funnel under the CSE threshold with no CSE answer (workforce: %s)", async (gipWorkforce) => {
+		mockLayout({ gipWorkforce, hasCse: null });
+
+		await expect(renderLayout()).resolves.toBeDefined();
+		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+
+	it("sends a user back to Mon espace when the profile row cannot be read", async () => {
+		mockLayout({ profileFails: true });
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(MY_SPACE_PATH);
+	});
+
+	it("lets an admin impersonating a company through despite the missing info", async () => {
+		mockLayout({
+			hasCse: null,
+			phone: null,
+			user: {
+				...DEFAULT_USER,
+				isAdmin: true,
+				impersonation: { siren: SIREN },
+			},
+		});
+
+		await expect(renderLayout()).resolves.toBeDefined();
+		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+
+	// The exception is scoped to an active impersonation, not to the admin flag.
+	it("still guards an admin who is not impersonating", async () => {
+		mockLayout({
+			phone: null,
+			user: { ...DEFAULT_USER, isAdmin: true },
+		});
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(MY_SPACE_PATH);
+	});
+
+	// Mirrors `assertNotImpersonating`: a stray `impersonation` without `isAdmin` unlocks nothing.
+	it("still guards a non-admin session carrying a stray impersonation", async () => {
+		mockLayout({
+			phone: null,
+			user: { ...DEFAULT_USER, impersonation: { siren: SIREN } },
+		});
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(MY_SPACE_PATH);
+	});
+
+	// Redirecting inside the guarded route group loops forever — the #4061 regression.
+	it("never redirects back into the funnel it guards", async () => {
+		mockLayout({ phone: null });
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		for (const [target] of mockRedirect.mock.calls) {
+			expect(target).not.toContain("/declaration-remuneration");
+		}
+	});
+});

--- a/packages/app/src/server/auth/companyAccess.ts
+++ b/packages/app/src/server/auth/companyAccess.ts
@@ -47,6 +47,21 @@ export function isImpersonatingSiren(
 }
 
 /**
+ * Is the current session an admin actively impersonating a company
+ * ("mimoquage") ?
+ *
+ * Read-only surfaces use it to relax user-data prerequisites an admin cannot
+ * fill in (phone number, CSE answer); write surfaces go through
+ * `assertNotImpersonating` instead.
+ *
+ * Gating on `isAdmin` blocks a crafted session carrying a stray
+ * `impersonation` field.
+ */
+export function isImpersonating(session: Session | null): boolean {
+	return Boolean(session?.user?.isAdmin && session.user.impersonation);
+}
+
+/**
  * Read-only guard for admin impersonation ("mimoquage").
  *
  * When an admin is impersonating a company, every write path (tRPC mutations,
@@ -58,11 +73,7 @@ export function isImpersonatingSiren(
  * Handlers can catch it and translate to HTTP 403.
  */
 export function assertNotImpersonating(session: Session | null): void {
-	// Only admins can mint an impersonation in the JWT (see auth/config.ts).
-	// Gating on `isAdmin` here too keeps this helper consistent with
-	// `isImpersonatingSiren` and prevents a crafted session with a stray
-	// `impersonation` field from blocking a legitimate non-admin user.
-	if (session?.user?.isAdmin && session.user.impersonation) {
+	if (isImpersonating(session)) {
 		throw new TRPCError({
 			code: "FORBIDDEN",
 			message:


### PR DESCRIPTION
Closes #3952

## Contexte

Le prérequis « numéro de téléphone + CSE » n'était vérifié **que côté client**, sur « Mon espace » : `hasRequiredDeclarationInfo()` n'avait qu'un seul appelant, `DeclarationLink.tsx`, qui se contentait de choisir quel modal ouvrir au clic. Les layouts du tunnel ne vérifiaient que la session et le SIREN.

Conséquence : toute entrée dans `/declaration-remuneration` ne passant pas par le lien de « Mon espace » contournait intégralement la demande — et `declaration.getOrCreate()` créait un brouillon au passage. Les étapes 2 à 6 répondaient `200` en accès direct.

Les deux hypothèses avancées sur le ticket ont été testées et **infirmées** : ce n'était ni un SIRET déjà utilisé (le téléphone est porté par l'utilisateur, pas par l'entreprise) ni un cache de parcours (il n'existe aucun état de parcours persisté côté client, ni aucune reprise de parcours — l'écran observé était l'étape 1).

## Changement

- `(with-banner)/layout.tsx` — garde serveur : `redirect("/mon-espace")` quand `hasRequiredDeclarationInfo(profile.phone, company.hasCse, cseApplicable)` est faux, avec `cseApplicable = isCseRequired(getObligationWorkforce(company.gipWorkforce))`, comme dans `CompanyDeclarationsPage`.
- La garde s'exécute **avant** `declaration.getOrCreate()` : cet appel insère un brouillon, et un visiteur renvoyé vers « Mon espace » ne doit pas en laisser un derrière lui — c'est l'effet de bord décrit dans le contexte. `getOrCreate()` sort donc du `Promise.all` et n'est atteint qu'une fois les prérequis vérifiés.
- Exception mimoquage : la garde ne s'applique pas à un admin en impersonation, cohérent avec `DeclarationLink` et `MissingInfoModal`.
- `companyAccess.ts` — extraction de `isImpersonating()`, désormais réutilisé par `assertNotImpersonating()` (la condition était dupliquée).

La garde est posée sur le groupe `(with-banner)` et non sur le layout racine : `/declaration-remuneration/recapitulatif` est hors de ce groupe et reste donc accessible en consultation.

## Périmètre

Ce ticket porte le volet « garde serveur ». Le volet « lien » — la cible du CTA de la page d'accueil — est traité par #4062 (PR #4116). Aucun fichier commun entre les deux.

Le conflit annoncé avec la PR de #4085 (qui modifiait aussi `(with-banner)/layout.tsx` pour le `LockProvider`) a eu lieu : #4085 ayant été mergée en premier, cette branche a été rebasée sur `alpha` et le conflit résolu (la garde cohabite avec `getCampaignDeadlines` / `isDeclarationWritingClosed`).

## Test plan

- `WithBannerLayout.test.tsx` — 15 cas couvrant la garde : téléphone manquant, CSE manquant, CSE non applicable, mimoquage, absence de brouillon créé lors d'un renvoi, cas nominal
- Suite unitaire complète verte (4285 tests) après rebase sur `alpha`
- Typecheck, build, lint et format verts