### PR TITLE
fix: message d'erreur non visible dans les tableaux des indicateurs (#3971)

### DIFF
--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -233,6 +233,48 @@ test.describe("Declaration workflow", () => {
 		).toBeVisible();
 	});
 
+	test("step 1 - empty submission errors wrap inside their cell, not onto the next column (#3971)", async ({
+		page,
+	}) => {
+		await goToStep(page, 1);
+
+		// Clear any GIP-prefilled counts so the "empty → required error" path fires.
+		await page.getByRole("textbox", { name: "Nombre de femmes" }).fill("");
+		await page.getByRole("textbox", { name: "Nombre d'hommes" }).fill("");
+
+		await page.getByRole("button", { name: "Suivant" }).click();
+
+		await expect(
+			page.getByText("Veuillez renseigner le nombre de femmes."),
+		).toBeVisible();
+
+		// DSFR 1.14 sets white-space: nowrap on table cells; inherited by
+		// .fr-error-text it painted the message onto the neighbouring column. A
+		// visible message is not enough — the bug kept it visible, just overflowing.
+		// Assert the rendered text extent stays within its owning <td>.
+		const measure = await page.evaluate(() => {
+			const paragraph = document.getElementById("women-error");
+			const cell = paragraph?.closest("td");
+			if (!paragraph || !cell) return null;
+			const range = document.createRange();
+			range.selectNodeContents(paragraph);
+			const textRight = Math.max(
+				...Array.from(range.getClientRects()).map((rect) => rect.right),
+			);
+			return {
+				textRight,
+				cellRight: cell.getBoundingClientRect().right,
+				scrollWidth: paragraph.scrollWidth,
+				clientWidth: paragraph.clientWidth,
+			};
+		});
+
+		if (!measure) throw new Error("step 1 women error paragraph not found");
+		// nowrap would force one line wider than the cell → scrollWidth > clientWidth.
+		expect(measure.scrollWidth).toBeLessThanOrEqual(measure.clientWidth + 1);
+		expect(measure.textRight).toBeLessThanOrEqual(measure.cellRight + 1);
+	});
+
 	test("previous button navigates back", async ({ page }) => {
 		await page.goto("/declaration-remuneration/etape/2");
 

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -303,7 +303,11 @@ export function Step1Workforce({
 																	}
 																	aria-invalid={womenError ? true : undefined}
 																	aria-label="Nombre de femmes"
-																	className={`fr-input ${common.numericInput}${womenError ? " fr-input--error" : ""}`}
+																	className={
+																		womenError
+																			? `fr-input fr-input--error ${common.numericInput}`
+																			: `fr-input ${common.numericInput}`
+																	}
 																	disabled={isImpersonating}
 																	inputMode="numeric"
 																	onChange={handleWomenChange}
@@ -333,7 +337,11 @@ export function Step1Workforce({
 																	}
 																	aria-invalid={menError ? true : undefined}
 																	aria-label="Nombre d'hommes"
-																	className={`fr-input ${common.numericInput}${menError ? " fr-input--error" : ""}`}
+																	className={
+																		menError
+																			? `fr-input fr-input--error ${common.numericInput}`
+																			: `fr-input ${common.numericInput}`
+																	}
 																	disabled={isImpersonating}
 																	inputMode="numeric"
 																	onChange={handleMenChange}

--- a/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step1Workforce.tsx
@@ -303,7 +303,7 @@ export function Step1Workforce({
 																	}
 																	aria-invalid={womenError ? true : undefined}
 																	aria-label="Nombre de femmes"
-																	className={`fr-input ${common.numericInput}${womenError ? "fr-input--error" : ""}`}
+																	className={`fr-input ${common.numericInput}${womenError ? " fr-input--error" : ""}`}
 																	disabled={isImpersonating}
 																	inputMode="numeric"
 																	onChange={handleWomenChange}
@@ -333,7 +333,7 @@ export function Step1Workforce({
 																	}
 																	aria-invalid={menError ? true : undefined}
 																	aria-label="Nombre d'hommes"
-																	className={`fr-input ${common.numericInput}${menError ? "fr-input--error" : ""}`}
+																	className={`fr-input ${common.numericInput}${menError ? " fr-input--error" : ""}`}
 																	disabled={isImpersonating}
 																	inputMode="numeric"
 																	onChange={handleMenChange}

--- a/packages/app/src/modules/layout/dsfrFixes.scss
+++ b/packages/app/src/modules/layout/dsfrFixes.scss
@@ -72,3 +72,10 @@
 		box-shadow: none;
 	}
 }
+
+// DSFR 1.14 sets white-space: nowrap on all table cells, which is inherited by
+// .fr-error-text rendered inside a <td>. The message overflows onto adjacent
+// columns. Target only the message to preserve nowrap on numeric data cells.
+.fr-table__content .fr-error-text {
+	white-space: normal;
+}


### PR DESCRIPTION
Closes #3971

## Résumé

**Root cause** : DSFR 1.14 impose `white-space: nowrap` sur toutes les cellules de tableau (`th`/`td`). Comme `white-space` est une propriété héritée, le `<p class="fr-error-text">` rendu à l'intérieur d'un `<td>` héritait de cette valeur et ne pouvait plus revenir à la ligne — le message débordait sur la colonne voisine.

**Fixes** :
1. `dsfrFixes.scss` — Ajout d'une règle globale ciblant uniquement les messages d'erreur dans les tableaux (pas les cellules) : `.fr-table__content .fr-error-text { white-space: normal; }`. Préserve le `nowrap` sur les données chiffrées.
2. `Step1Workforce.tsx` — Fix de 2 `className` : l'interpolation manquait un espace avant `fr-input--error`, fusionnant deux noms de classe en un seul identifiant invalide. Remplacé par un ternaire explicite.

## Plan de test

- [ ] Étape 1 de la déclaration — soumettre un formulaire vide → les messages d'erreur "Femmes" et "Hommes" restent dans leur colonne
- [ ] Étape 4 (quartiles) — aucune régression (déjà conforme, déjà `white-space: normal` dans son SCSS local)
- [ ] Saisir une valeur invalide → l'input montre bien le soulignement rouge (`fr-input--error`)