### PR TITLE
fix(declaration-remuneration): #4085 — acquérir le verrou d'édition sur tout le parcours de mise en conformité

### DIFF
--- a/packages/app/src/app/declaration-remuneration/(with-banner)/layout.tsx
+++ b/packages/app/src/app/declaration-remuneration/(with-banner)/layout.tsx
@@ -3,10 +3,10 @@ import {
 	DeclarationLayout,
 	MissingSiret,
 } from "~/modules/declaration-remuneration";
+import { isDeclarationWritingClosed } from "~/modules/domain";
 import { auth } from "~/server/auth";
 import { getEffectiveSiren } from "~/server/auth/companyAccess";
-import { db } from "~/server/db";
-import { getLockReadState } from "~/server/services/declarationLockService";
+import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
 import { api } from "~/trpc/server";
 
 /**
@@ -36,18 +36,19 @@ export default async function WithBannerLayout({
 	]);
 
 	const declaration = declarationData.declaration;
-	const { isReadOnly, lockHolder } = await getLockReadState(
-		db,
-		declaration.id,
-		session.user.id,
+
+	const deadlines = await getCampaignDeadlines(declaration.year);
+	const lockAcquisitionSuspended = isDeclarationWritingClosed(
+		declaration.status,
+		deadlines.decl1ModificationDeadline,
 	);
 
 	return (
 		<DeclarationLayout
 			company={company}
+			declarationId={declaration.id}
 			declarationYear={declaration.year}
-			isReadOnly={isReadOnly}
-			lockHolder={lockHolder}
+			lockAcquisitionSuspended={lockAcquisitionSuspended}
 		>
 			{children}
 		</DeclarationLayout>

--- a/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-remuneration/DeclarationLayout.tsx
@@ -1,6 +1,5 @@
 import { CompanyBanner } from "./shared/CompanyBanner";
-import { DeclarationLockAlert } from "./shared/lock/DeclarationLockAlert";
-import type { LockHolder } from "./shared/lock/LockContext";
+import { DeclarationLockAlertGate } from "./shared/lock/DeclarationLockAlertGate";
 import { LockProvider } from "./shared/lock/LockContext";
 
 type CompanyData = {
@@ -14,18 +13,18 @@ type CompanyData = {
 
 type DeclarationLayoutProps = {
 	company: CompanyData;
+	declarationId: string;
 	declarationYear: number;
 	children: React.ReactNode;
-	isReadOnly?: boolean;
-	lockHolder?: LockHolder | null;
+	lockAcquisitionSuspended?: boolean;
 };
 
 export function DeclarationLayout({
 	company,
+	declarationId,
 	declarationYear,
 	children,
-	isReadOnly = false,
-	lockHolder = null,
+	lockAcquisitionSuspended = false,
 }: DeclarationLayoutProps) {
 	return (
 		<main id="content" tabIndex={-1}>
@@ -34,12 +33,13 @@ export function DeclarationLayout({
 				currentPageLabel={`Démarche des indicateurs de rémunération ${declarationYear}`}
 			/>
 			<div className="fr-container fr-py-7w">
-				<LockProvider holder={lockHolder} isReadOnly={isReadOnly}>
+				<LockProvider
+					declarationId={declarationId}
+					modificationClosed={lockAcquisitionSuspended}
+				>
 					<div className="fr-grid-row fr-grid-row--center">
 						<div className="fr-col-12 fr-col-lg-8">
-							{isReadOnly && lockHolder && (
-								<DeclarationLockAlert holder={lockHolder} />
-							)}
+							<DeclarationLockAlertGate />
 							{children}
 						</div>
 					</div>

--- a/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-remuneration/StepPageClient.tsx
@@ -15,7 +15,7 @@ import {
 } from "./shared/funnelConfig";
 import type { GipPrefillData } from "./shared/gipMdsMapping";
 import { DeclarationModificationClosedAlert } from "./shared/lock/DeclarationModificationClosedAlert";
-import { LockProvider } from "./shared/lock/LockContext";
+import { LockProvider, useLockContext } from "./shared/lock/LockContext";
 import { Step1Workforce } from "./steps/Step1Workforce";
 import { Step2PayGap } from "./steps/Step2PayGap";
 import { Step3VariablePay } from "./steps/Step3VariablePay";
@@ -84,6 +84,19 @@ export function StepPageClient({
 		[declaration.year, sizeRange],
 	);
 	useFunnelTracking(DECLARATION_FUNNEL, { step, dimensions });
+
+	// The lock is already acquired by the ancestor provider — a second dynamic
+	// one here would re-acquire it and race the heartbeat. This only folds the
+	// funnel-specific `modificationClosed` cutoff into the inherited state.
+	const {
+		holder: lockHolder,
+		isLoading: isLockLoading,
+		isReadOnly: isLockReadOnly,
+		reason: lockReason,
+	} = useLockContext();
+	const isReadOnly = isLockReadOnly || modificationClosed;
+	const reason = modificationClosed ? "modification_closed" : lockReason;
+	const holder = modificationClosed ? null : lockHolder;
 
 	function renderStep() {
 		switch (step) {
@@ -167,8 +180,10 @@ export function StepPageClient({
 
 	return (
 		<LockProvider
-			declarationId={declaration.id}
-			modificationClosed={modificationClosed}
+			holder={holder}
+			isLoading={isLockLoading}
+			isReadOnly={isReadOnly}
+			reason={reason}
 		>
 			{modificationClosed && modificationDeadline ? (
 				<DeclarationModificationClosedAlert deadline={modificationDeadline} />

--- a/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
@@ -1,8 +1,23 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { useSession } from "next-auth/react";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
+
+const acquireMutateAsync = vi.fn();
+const heartbeatMutateAsync = vi.fn();
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		declarationLock: {
+			acquireLock: { useMutation: () => ({ mutateAsync: acquireMutateAsync }) },
+			heartbeat: { useMutation: () => ({ mutateAsync: heartbeatMutateAsync }) },
+		},
+	},
+}));
 
 import { DeclarationLayout } from "../DeclarationLayout";
 import { useLockContext } from "../shared/lock/LockContext";
+
+const useSessionMock = useSession as unknown as Mock;
 
 const company = {
 	name: "Alpha Solutions",
@@ -26,30 +41,45 @@ function LockProbe() {
 	);
 }
 
-describe("DeclarationLayout", () => {
-	it("renders the children inside the banner layout", () => {
-		render(
-			<DeclarationLayout company={company} declarationYear={2024}>
-				<p>Step content</p>
-			</DeclarationLayout>,
-		);
+function declarationLayout(lockAcquisitionSuspended = false) {
+	return (
+		<DeclarationLayout
+			company={company}
+			declarationId="decl-1"
+			declarationYear={2024}
+			lockAcquisitionSuspended={lockAcquisitionSuspended}
+		>
+			<p>Step content</p>
+			<LockProbe />
+		</DeclarationLayout>
+	);
+}
 
-		expect(screen.getByText("Step content")).toBeInTheDocument();
+beforeEach(() => {
+	acquireMutateAsync.mockReset();
+	heartbeatMutateAsync.mockReset();
+	acquireMutateAsync.mockResolvedValue({ acquired: true, holder: null });
+	useSessionMock.mockReturnValue({
+		data: { user: { id: "user-1", impersonation: null } },
+		status: "authenticated",
+	});
+});
+
+describe("DeclarationLayout", () => {
+	it("renders the children inside the banner layout", async () => {
+		render(declarationLayout());
+
+		expect(await screen.findByText("Step content")).toBeInTheDocument();
 	});
 
-	it("shows the lock alert when read-only and a holder is provided", () => {
-		render(
-			<DeclarationLayout
-				company={company}
-				declarationYear={2024}
-				isReadOnly
-				lockHolder={lockHolder}
-			>
-				<p>Step content</p>
-			</DeclarationLayout>,
-		);
+	it("shows the lock alert when the declaration is held by another user", async () => {
+		acquireMutateAsync.mockResolvedValue({
+			acquired: false,
+			holder: lockHolder,
+		});
+		render(declarationLayout());
 
-		expect(screen.getByRole("alert")).toHaveTextContent(
+		expect(await screen.findByRole("alert")).toHaveTextContent(
 			"Déclaration en cours de modification",
 		);
 		expect(
@@ -57,45 +87,73 @@ describe("DeclarationLayout", () => {
 		).toBeInTheDocument();
 	});
 
-	it("does not show the lock alert by default", () => {
-		render(
-			<DeclarationLayout company={company} declarationYear={2024}>
-				<p>Step content</p>
-			</DeclarationLayout>,
-		);
+	it("does not show the lock alert once the lock is acquired", async () => {
+		render(declarationLayout());
 
+		expect(await screen.findByTestId("lock-probe")).toHaveTextContent(
+			"false:none",
+		);
 		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
-	it("does not show the lock alert when read-only but no holder is resolved", () => {
-		render(
-			<DeclarationLayout
-				company={company}
-				declarationYear={2024}
-				isReadOnly
-				lockHolder={null}
-			>
-				<p>Step content</p>
-			</DeclarationLayout>,
-		);
+	it("does not show the lock alert when read-only but no holder is resolved", async () => {
+		acquireMutateAsync.mockResolvedValue({ acquired: false, holder: null });
+		render(declarationLayout());
 
+		expect(await screen.findByTestId("lock-probe")).toHaveTextContent(
+			"true:none",
+		);
 		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 
-	it("provides the lock state to descendant consumers", () => {
-		render(
-			<DeclarationLayout
-				company={company}
-				declarationYear={2024}
-				isReadOnly
-				lockHolder={lockHolder}
-			>
-				<LockProbe />
-			</DeclarationLayout>,
-		);
+	it("provides the lock state to descendant consumers", async () => {
+		acquireMutateAsync.mockResolvedValue({
+			acquired: false,
+			holder: lockHolder,
+		});
+		render(declarationLayout());
 
-		expect(screen.getByTestId("lock-probe")).toHaveTextContent(
+		expect(await screen.findByTestId("lock-probe")).toHaveTextContent(
 			"true:camille.martin@example.fr",
 		);
+	});
+});
+
+// The lock is shared by every page of the `(with-banner)` group, so it may only
+// be skipped once *nothing* under it is writable. The compliance-path pages keep
+// writing for months after `decl1ModificationDeadline` elapses.
+describe("DeclarationLayout — collaborative lock acquisition", () => {
+	it.each([
+		{
+			acquires: true,
+			lockAcquisitionSuspended: false,
+			scenario: "a writable surface remains under the route group",
+		},
+		{
+			acquires: false,
+			lockAcquisitionSuspended: true,
+			scenario: "démarche completed and the modification deadline elapsed",
+		},
+	])("$scenario → acquires: $acquires", async ({
+		acquires,
+		lockAcquisitionSuspended,
+	}) => {
+		render(declarationLayout(lockAcquisitionSuspended));
+		await screen.findByTestId("lock-probe");
+
+		if (acquires) {
+			expect(acquireMutateAsync).toHaveBeenCalledWith({
+				declarationId: "decl-1",
+			});
+		} else {
+			expect(acquireMutateAsync).not.toHaveBeenCalled();
+		}
+	});
+
+	it("keeps the démarche read-only without a holder when the lock is skipped", () => {
+		render(declarationLayout(true));
+
+		expect(screen.getByTestId("lock-probe")).toHaveTextContent("true:none");
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/__tests__/StepPageClient.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/StepPageClient.test.tsx
@@ -102,20 +102,7 @@ describe("StepPageClient — modification closed banner (#3716)", () => {
 		expect(screen.getByTestId("step-1")).toBeInTheDocument();
 	});
 
-	it("does not acquire the collaborative lock when modification is closed", () => {
-		render(
-			<StepPageClient
-				{...baseProps}
-				modificationClosed
-				modificationDeadline={DEADLINE}
-			/>,
-		);
-
-		expect(acquireMutateAsync).not.toHaveBeenCalled();
-	});
-
 	it("does not render the banner when modification is open (the regression: step stays editable)", () => {
-		acquireMutateAsync.mockResolvedValue({ acquired: true, holder: null });
 		render(<StepPageClient {...baseProps} modificationClosed={false} />);
 
 		expect(

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlertGate.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/DeclarationLockAlertGate.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { DeclarationLockAlert } from "./DeclarationLockAlert";
+import { useLockContext } from "./LockContext";
+
+export function DeclarationLockAlertGate() {
+	const { holder, isReadOnly } = useLockContext();
+	if (!isReadOnly || !holder) return null;
+	return <DeclarationLockAlert holder={holder} />;
+}

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/LockContext.tsx
@@ -31,6 +31,7 @@ type StaticLockProviderProps = {
 	isReadOnly?: boolean;
 	reason?: ReadOnlyReason | null;
 	holder?: LockHolder | null;
+	isLoading?: boolean;
 };
 
 type DynamicLockProviderProps = {
@@ -46,6 +47,7 @@ function StaticLockProvider({
 	isReadOnly = false,
 	reason,
 	holder = null,
+	isLoading,
 }: StaticLockProviderProps) {
 	// Impersonation is read-only too, but the layouts feed this provider from
 	// `getLockReadState` (lock only, no impersonation). Fold it in here so the
@@ -62,6 +64,7 @@ function StaticLockProvider({
 				isReadOnly: isReadOnly || isImpersonating,
 				reason: resolvedReason,
 				holder: isImpersonating ? null : holder,
+				isLoading,
 			}}
 		>
 			{children}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -19,6 +19,7 @@ import { api } from "~/trpc/react";
 import common from "../shared/common.module.scss";
 import { getPostComplianceDestination } from "../shared/complianceNavigation";
 import { FormActions } from "../shared/FormActions";
+import { FormErrors } from "../shared/FormErrors";
 import { SavedIndicator } from "../shared/SavedIndicator";
 import styles from "./CompliancePathChoice.module.scss";
 import {
@@ -254,6 +255,8 @@ export function CompliancePathChoice({
 						)}
 					/>
 				</div>
+
+				<FormErrors mutationError={mutation.error?.message} />
 
 				<FormActions
 					isSubmitting={mutation.isPending}

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -23,9 +23,10 @@ const CORRECTIVE_ACTION_TITLE =
 const mockMutate = vi.fn();
 const mockPush = vi.fn();
 
-const { mockSetField, draftRef } = vi.hoisted(() => ({
+const { mockSetField, draftRef, mutationErrorRef } = vi.hoisted(() => ({
 	mockSetField: vi.fn(),
 	draftRef: { current: {} as Record<string, unknown> },
+	mutationErrorRef: { current: null as { message: string } | null },
 }));
 
 vi.mock(
@@ -60,7 +61,7 @@ vi.mock("~/trpc/react", () => ({
 						opts.onSuccess?.(undefined, args);
 					},
 					isPending: false,
-					error: null,
+					error: mutationErrorRef.current,
 				}),
 			},
 		},
@@ -93,6 +94,30 @@ beforeEach(() => {
 	mockPush.mockClear();
 	mockSetField.mockClear();
 	draftRef.current = {};
+	mutationErrorRef.current = null;
+});
+
+// The save mutation had no error surface at all, so a server rejection (a
+// CONFLICT 409 from the lock) left the button inert with zero feedback.
+describe("CompliancePathChoice — mutation error surface", () => {
+	it("renders the rejection as an error alert", () => {
+		mutationErrorRef.current = {
+			message: "Déclaration verrouillée par un autre utilisateur.",
+		};
+		const { container } = render(compliancePathChoice());
+
+		const alert = screen.getByRole("alert");
+		expect(alert).toHaveTextContent(
+			"Déclaration verrouillée par un autre utilisateur.",
+		);
+		expect(container.querySelector(".fr-alert--error")).toBeInTheDocument();
+	});
+
+	it("renders no error alert while the mutation has not failed", () => {
+		const { container } = render(compliancePathChoice());
+
+		expect(container.querySelector(".fr-alert--error")).not.toBeInTheDocument();
+	});
 });
 
 describe("CompliancePathChoice", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -8,6 +8,7 @@ import { useReadOnlyGuard } from "~/modules/auth";
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
 import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
+import { FormErrors } from "~/modules/declaration-remuneration/shared/FormErrors";
 import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import { formatLongDate } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
@@ -194,6 +195,10 @@ export function JointEvaluationForm({
 							</p>
 						</div>
 					</div>
+
+					<FormErrors
+						mutationError={submitJointEvaluationMutation.error?.message}
+					/>
 
 					<div className={`fr-mt-4w ${common.flexBetween}`}>
 						<Link

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -5,6 +5,7 @@ import { useCallback, useRef } from "react";
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
 import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
+import { FormErrors } from "~/modules/declaration-remuneration/shared/FormErrors";
 import { NextStepsBox } from "~/modules/declaration-remuneration/shared/NextStepsBox";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { SubmitDeclarationModal } from "~/modules/declaration-remuneration/shared/SubmitDeclarationModal";
@@ -153,6 +154,8 @@ export function SecondDeclarationStep3Review({
 				isSecondDeclaration
 				siren={siren}
 			/>
+
+			<FormErrors mutationError={mutation.error?.message} />
 
 			<FormActions
 				nextLabel="Soumettre"

--- a/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationStatus.test.ts
@@ -6,6 +6,7 @@ import {
 	isCancelled,
 	isComplianceProcessCompleted,
 	isDeclarationSubmitted,
+	isDeclarationWritingClosed,
 	isDraft,
 	isInComplianceProcess,
 	isSecondDeclarationDeadlineApplicable,
@@ -35,6 +36,32 @@ describe("isComplianceProcessCompleted", () => {
 		expect(isComplianceProcessCompleted("awaiting_cse_opinion")).toBe(false);
 		expect(isComplianceProcessCompleted("draft")).toBe(false);
 		expect(isComplianceProcessCompleted(null)).toBe(false);
+	});
+});
+
+describe("isDeclarationWritingClosed", () => {
+	const past = new Date("2020-01-01T00:00:00Z");
+	const future = new Date("2999-01-01T00:00:00Z");
+
+	it("closes writing only when the démarche is completed and the deadline elapsed", () => {
+		expect(isDeclarationWritingClosed("demarche_completed", past)).toBe(true);
+	});
+
+	it("keeps writing open while the modification deadline has not elapsed", () => {
+		expect(isDeclarationWritingClosed("demarche_completed", future)).toBe(
+			false,
+		);
+	});
+
+	it("keeps writing open while the démarche is still running", () => {
+		expect(
+			isDeclarationWritingClosed("awaiting_compliance_path_choice", past),
+		).toBe(false);
+		expect(isDeclarationWritingClosed("awaiting_cse_opinion", past)).toBe(
+			false,
+		);
+		expect(isDeclarationWritingClosed("draft", past)).toBe(false);
+		expect(isDeclarationWritingClosed(null, past)).toBe(false);
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -85,6 +85,7 @@ export {
 	isCancelled,
 	isComplianceProcessCompleted,
 	isDeclarationSubmitted,
+	isDeclarationWritingClosed,
 	isDraft,
 	isInComplianceProcess,
 	isSecondDeclarationDeadlineApplicable,

--- a/packages/app/src/modules/domain/shared/declarationStatus.ts
+++ b/packages/app/src/modules/domain/shared/declarationStatus.ts
@@ -1,4 +1,5 @@
 import type { DeclarationFsmStatus, DeclarationStatus } from "../types";
+import { isDeadlinePassed } from "./campaign";
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
@@ -12,6 +13,20 @@ export function isDraft(status: string | null): boolean {
 
 export function isComplianceProcessCompleted(status: string | null): boolean {
 	return status === "demarche_completed";
+}
+
+// Neither condition alone closes writing: `demarche_completed` is reached as
+// early as March for a no-gap declaration, and `decl1ModificationDeadline`
+// routinely elapses months before the compliance-path pages stop needing to
+// write. Distinct from the step-level cutoff, which uses `isDeclarationSubmitted`.
+export function isDeclarationWritingClosed(
+	status: string | null,
+	decl1ModificationDeadline: Date,
+): boolean {
+	return (
+		isComplianceProcessCompleted(status) &&
+		isDeadlinePassed(decl1ModificationDeadline)
+	);
 }
 
 export function getCurrentCompliancePath(declaration: {


### PR DESCRIPTION
Closes #4085

## Contexte

Sur la page « Parcours de mise en conformité », le bouton « Suivant » ne faisait rien, quel que soit le choix sélectionné. Reproduit localement : `declaration.saveCompliancePath` répondait `CONFLICT (409) — Déclaration verrouillée par un autre utilisateur`, et ce pour les trois parcours — le rejet a lieu dans le middleware, avant même que le choix ne soit lu.

**Cause** : `saveCompliancePath` est un `declarationLockedWriteProcedure`, qui exige un verrou d'édition détenu par l'appelant. Or ce verrou n'était acquis que par le `LockProvider` **dynamique** monté dans `StepPageClient` — donc uniquement sur les pages `/etape/[step]` du tunnel A–F. Toutes les pages du groupe `(with-banner)`, dont `/parcours-conformite`, passaient par un `LockProvider` **statique** qui se contente de lire l'état de verrouillage sans jamais l'acquérir.

Le choix de parcours ne fonctionnait donc que par effet de bord : quand l'utilisateur enchaînait étape 6 → soumission → parcours sans rechargement, le verrou posé par le tunnel était encore valide (TTL 30 min). Dès qu'il ne l'était plus — arrivée depuis « Mon espace », reprise après reconnexion, 30 minutes écoulées, navigation dure — la page devenait un cul-de-sac.

**Défaut aggravant** : la mutation n'avait aucun `onError` ni zone d'erreur. Le 409 était entièrement avalé — bouton inerte, zéro feedback.

## Changement

- Le `LockProvider` **dynamique** (acquisition + heartbeat) est hissé au layout `(with-banner)`, de sorte que **toutes** les surfaces d'écriture de la démarche détiennent le verrou, et plus seulement les pages d'étape.
- `StepPageClient` ne monte plus de provider dynamique — un second provoquerait une double acquisition et une course sur le heartbeat. Il conserve un provider **statique** qui replie le `modificationClosed` propre au tunnel dans l'état hérité, ce qui préserve `DeclarationModificationClosedAlert` et le `useLockContext()` de chaque étape.
- Nouveau `DeclarationLockAlertGate`, composant client qui lit l'état du contexte pour décider d'afficher `DeclarationLockAlert` (le layout étant serveur, il ne peut plus le décider lui-même).
- `FormErrors` branché sur `mutation.error?.message` dans `CompliancePathChoice`, `JointEvaluationForm` et `SecondDeclarationStep3Review` — aucun rejet serveur ne peut plus se traduire par un bouton silencieusement inerte. `SecondDeclarationStep2Form` remontait déjà l'erreur via `submitError`, laissé tel quel.
- Nouveau prédicat domaine `isDeclarationWritingClosed(status, decl1ModificationDeadline)` : l'acquisition n'est suspendue que si la démarche est conclue **et** que la fenêtre de modification de la première déclaration est close. Aucune des deux conditions ne suffit seule — `demarche_completed` est atteint dès mars pour une déclaration sans écart, et `decl1ModificationDeadline` expire des mois avant que les pages de parcours cessent d'écrire.

## Test plan

- `DeclarationLayout.test.tsx` — couverture de l'acquisition du verrou (acquis quand une surface reste inscriptible, ignoré quand l'écriture est close), et de l'alerte de verrouillage
- `CompliancePathChoice.test.tsx` — un rejet serveur rend bien une alerte `fr-alert--error`
- `declarationStatus.test.ts` — 3 cas sur le nouveau prédicat domaine
- Suppression d'une assertion devenue vacante dans `StepPageClient.test.tsx` : elle vérifiait la non-acquisition du verrou, mais depuis que l'acquisition a migré vers le layout, elle passait inconditionnellement — fausse couverture sur le chemin même que ce ticket modifie
- Suite unitaire complète verte (4169 tests) après rebase sur `alpha` incluant #4093
- Typecheck, lint et format verts

## Note pour la revue

⚠️ **Conflit attendu avec la PR de #3952** (#4117), qui modifie aussi `(with-banner)/layout.tsx` pour y ajouter la garde du prérequis téléphone/CSE. La seconde des deux à être mergée devra être rebasée.
