### PR TITLE
fix: corrige la marge du fil d'Ariane DSFR (haute et basse)

### DIFF
--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -12,7 +12,7 @@ import {
 import { ProfileModal } from "~/modules/profile";
 import { TRPCReactProvider } from "~/trpc/react";
 
-// Loaded after the DSFR stylesheet links below so these overrides win.
+// Overrides must win on specificity — this bundle loads before dsfr.min.css.
 import "~/modules/layout/dsfrFixes.scss";
 
 export const metadata: Metadata = {

--- a/packages/app/src/e2e/breadcrumb-spacing.e2e.ts
+++ b/packages/app/src/e2e/breadcrumb-spacing.e2e.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+
+// DSFR 1.14 ships `.fr-breadcrumb { margin: 1rem 0 2rem }` plus a `min-width: 48em`
+// override raising the bottom margin to 2.5rem. dsfrFixes.scss neutralises both with a
+// doubled-class selector, and the two banners that used to carry their own override now
+// rely on it alone. Only a real browser resolves that cascade and those media queries,
+// so this contract cannot be held by a jsdom unit test.
+
+const EXPECTED_MARGIN_TOP = "0px";
+const EXPECTED_MARGIN_BOTTOM = "32px";
+
+const DESKTOP = { width: 1440, height: 900 };
+
+// Both viewports earn their place: the stray 1rem top margin is unconditional, while the
+// 2.5rem bottom margin only applies from 48em up. Desktop alone would leave the top-margin
+// fix unguarded below the breakpoint.
+const VIEWPORTS = [
+	{ name: "desktop", ...DESKTOP },
+	{ name: "mobile", width: 375, height: 800 },
+];
+
+// `/mon-espace` is not redundant with the public pages: its CompanyInfoBanner is one of the
+// two components whose local `:global(.fr-breadcrumb)` override this fix deleted, so it is
+// the surface that regresses first if the shared rule stops applying.
+const SCREENS = [
+	{ name: "legal notice", path: "/mentions-legales" },
+	{ name: "FAQ", path: "/faq" },
+	{ name: "my space", path: "/mon-espace" },
+];
+
+test.describe("breadcrumb spacing", () => {
+	for (const viewport of VIEWPORTS) {
+		test.describe(`${viewport.name} (${viewport.width}px)`, () => {
+			test.use({
+				viewport: { width: viewport.width, height: viewport.height },
+			});
+
+			for (const screen of SCREENS) {
+				test(`${screen.name} — the breadcrumb keeps no top margin and 32px below`, async ({
+					page,
+				}) => {
+					await page.goto(screen.path);
+
+					const breadcrumb = page.locator(".fr-breadcrumb").first();
+					await expect(breadcrumb).toBeVisible();
+
+					const margins = await breadcrumb.evaluate((element) => {
+						const { marginTop, marginBottom } = getComputedStyle(element);
+						return { marginTop, marginBottom };
+					});
+
+					expect(margins).toEqual({
+						marginTop: EXPECTED_MARGIN_TOP,
+						marginBottom: EXPECTED_MARGIN_BOTTOM,
+					});
+				});
+			}
+		});
+	}
+
+	test.describe("rendered spacing", () => {
+		// Pinned to desktop: this is where DSFR's 2.5rem override applies, so an unpinned
+		// viewport would silently stop exercising the branch the fix actually neutralises.
+		test.use({ viewport: DESKTOP });
+
+		// Measured on /faq specifically. On /mentions-legales, /plan-du-site and /referents the
+		// next element is an `h1.fr-mt-4w`, which carries 32px of its own top margin — a gap
+		// assertion there would pass with or without the fix. The FAQ's "Retour" link has no top
+		// margin, so the gap comes from the breadcrumb alone; asserting that premise keeps the
+		// check from silently going tautological if the page gains a spaced neighbour.
+		test("the bottom margin renders as 32px of real spacing", async ({
+			page,
+		}) => {
+			await page.goto("/faq");
+
+			const breadcrumb = page.locator(".fr-breadcrumb").first();
+			await expect(breadcrumb).toBeVisible();
+
+			const spacing = await breadcrumb.evaluate((element) => {
+				const next = element.nextElementSibling;
+				if (!next) throw new Error("No element follows the breadcrumb");
+				return {
+					nextMarginTop: getComputedStyle(next).marginTop,
+					gap: Math.round(
+						next.getBoundingClientRect().top -
+							element.getBoundingClientRect().bottom,
+					),
+				};
+			});
+
+			expect(spacing).toEqual({ nextMarginTop: "0px", gap: 32 });
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/CompanyBanner.module.scss
@@ -1,10 +1,5 @@
 .banner {
 	background: var(--background-alt-blue-france);
-
-	:global(.fr-breadcrumb) {
-		margin-top: 0;
-		margin-bottom: 2rem;
-	}
 }
 
 .companyRow {

--- a/packages/app/src/modules/layout/dsfrFixes.scss
+++ b/packages/app/src/modules/layout/dsfrFixes.scss
@@ -79,3 +79,9 @@
 .fr-table__content .fr-error-text {
 	white-space: normal;
 }
+
+// Doubled selector beats DSFR 1.14's own margin rules regardless of load order.
+.fr-breadcrumb.fr-breadcrumb {
+	margin-top: 0;
+	margin-bottom: 2rem;
+}

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
@@ -1,10 +1,5 @@
 .banner {
 	background-color: var(--background-alt-blue-france);
-
-	:global(.fr-breadcrumb) {
-		margin-top: 0;
-		margin-bottom: 2rem;
-	}
 }
 
 .infoRow {


### PR DESCRIPTION
Closes #3534

## Résumé

DSFR 1.14 déclare `.fr-breadcrumb { margin: 1rem 0 2rem; }`, puis sous `@media (min-width: 48em)` une surcharge `margin-bottom: 2.5rem` — soit 16px en haut et 40px en bas au lieu des 32px bas / 0px haut voulus par le design (composant partagé `Company Overview`).

13 des 15 écrans porteurs d'un fil d'Ariane étaient concernés (seuls les bandeaux `CompanyBanner` et `CompanyInfoBanner` compensaient localement, en dupliquant la même règle).

## Fix

- `dsfrFixes.scss` : une règle globale unique, sélecteur de classe doublé (`.fr-breadcrumb.fr-breadcrumb`, spécificité 0-2-0) pour l'emporter sur DSFR **indépendamment de l'ordre de chargement des feuilles de style** (vérifié : le bundle app se charge avant `dsfr.min.css`, contrairement à ce qu'affirmait l'ancien commentaire dans `layout.tsx`, corrigé au passage).
- Suppression des deux surcharges locales devenues redondantes (`CompanyBanner.module.scss`, `CompanyInfoBanner.module.scss`).
- `CseOpinionLayout.module.scss` n'a reçu aucune édition : ce bandeau, seul des trois à n'avoir aucune surcharge, s'aligne automatiquement sur ses jumeaux grâce à la règle globale.

## Mesures DOM (avant → après)

| Écran | marge haute | marge basse |
|---|---|---|
| `/mentions-legales` | 16px → **0px** ✅ | 40px → **32px** ✅ |
| `/faq` | 16px → **0px** ✅ | 40px → **32px** ✅ |

Testé en 1440px via Playwright MCP sur le dev server local (`getComputedStyle` + `getBoundingClientRect`).

## Test plan

- [x] Typecheck / lint / format / suite vitest existante (4453 tests) — verts, aucune régression
- [x] Mesure DOM directe sur `/mentions-legales` et `/faq` (1440px) — valeurs cibles atteintes
- [ ] Test E2E de reproduction (`src/e2e/`) — hors périmètre de cette PR, à la charge de `e2e-dev` en fin de pipeline
- [ ] Validation visuelle indépendante (`design-validator`) — pas de référence Figma exploitable pour ce ticket (node renuméroté), valeurs cibles mesurées et documentées dans l'analyse du bug

## Hors périmètre

L'écran "Historique des actions" compose un bandeau distinct qui ne relève pas d'une marge de fil d'Ariane — non traité ici (cf. analyse du bug). L'harmonisation des paddings de conteneur (24px bandeaux vs 48px pages légales) est un sujet de restylage distinct.