### PR TITLE
Passer le bouton « Retour à mon espace » en bouton secondaire

### DIFF
--- a/packages/app/src/e2e/recapitulatif.e2e.ts
+++ b/packages/app/src/e2e/recapitulatif.e2e.ts
@@ -25,6 +25,26 @@ test.describe("Recapitulatif page", () => {
 		await expect(page.getByRole("link", { name: "Télécharger" })).toBeVisible();
 	});
 
+	test("closes on a secondary 'Mon espace' action that returns to Mon espace", async ({
+		page,
+	}) => {
+		await page.goto("/declaration-remuneration/recapitulatif");
+
+		// Scoped to <main>: the breadcrumb above it links to "Mon espace" too.
+		const bottomAction = page
+			.getByRole("main")
+			.getByRole("link", { name: "Mon espace", exact: true });
+
+		await expect(bottomAction).toHaveClass(/fr-btn--secondary/);
+		await expect(bottomAction).not.toHaveClass(/fr-btn--primary/);
+		await expect(
+			page.getByRole("link", { name: "Retour à Mon Espace" }),
+		).toHaveCount(0);
+
+		await bottomAction.click();
+		await page.waitForURL("**/mon-espace");
+	});
+
 	test("returns 404 for non-submitted declaration with correction type", async ({
 		page,
 	}) => {

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.module.scss
@@ -96,6 +96,6 @@
 	color: var(--text-mention-grey);
 }
 
-.primaryAction {
+.bottomAction {
 	align-self: flex-end;
 }

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -199,10 +199,10 @@ export function RecapitulatifPage({
 			</section>
 
 			<Link
-				className={`fr-btn ${isCorrection ? "fr-btn--secondary" : "fr-btn--primary"} ${styles.primaryAction}`}
+				className={`fr-btn fr-btn--secondary ${styles.bottomAction}`}
 				href="/mon-espace"
 			>
-				{isCorrection ? "Mon espace" : "Retour à Mon Espace"}
+				Mon espace
 			</Link>
 		</div>
 	);

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.correction.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.correction.test.tsx
@@ -93,15 +93,4 @@ describe("RecapitulatifPage — second declaration (isCorrection)", () => {
 			screen.getByText("Catégorie d'emplois n°1 : Ouvriers / Employés"),
 		).toBeInTheDocument();
 	});
-
-	it("renders a secondary 'Mon espace' bottom action instead of the primary one", () => {
-		render(<RecapitulatifPage {...defaultProps()} isCorrection />);
-		const action = screen.getByRole("link", { name: "Mon espace" });
-		expect(action).toHaveAttribute("href", "/mon-espace");
-		expect(action.className).toContain("fr-btn--secondary");
-		expect(action.className).not.toContain("fr-btn--primary");
-		expect(
-			screen.queryByRole("link", { name: "Retour à Mon Espace" }),
-		).not.toBeInTheDocument();
-	});
 });

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/RecapitulatifPage.test.tsx
@@ -61,7 +61,7 @@ describe("RecapitulatifPage", () => {
 		expect(
 			screen.queryByRole("navigation", { name: /vous êtes ici/i }),
 		).not.toBeInTheDocument();
-		// The bottom action is the full "Retour à Mon Espace" button — there is
+		// The bottom action is the full "Mon espace" button — there is
 		// no standalone top "Retour" breadcrumb link.
 		expect(
 			screen.queryByRole("link", { name: "Retour" }),
@@ -375,14 +375,22 @@ describe("RecapitulatifPage", () => {
 		expect(screen.getByText("Accord d'entreprise")).toBeInTheDocument();
 	});
 
-	it("renders primary 'Retour à Mon Espace' button linking to mon-espace", () => {
-		render(<RecapitulatifPage {...defaultProps()} />);
-		const returnLink = screen.getByRole("link", {
-			name: "Retour à Mon Espace",
-		});
+	// The Figma reference shows a single secondary "Mon espace" instance, so the
+	// bottom action must not vary with isCorrection.
+	it.each([
+		false,
+		true,
+	])("renders the same secondary 'Mon espace' bottom action (isCorrection: %s)", (isCorrection) => {
+		render(
+			<RecapitulatifPage {...defaultProps()} isCorrection={isCorrection} />,
+		);
+		const returnLink = screen.getByRole("link", { name: "Mon espace" });
 		expect(returnLink).toHaveAttribute("href", "/mon-espace");
-		expect(returnLink.className).toContain("fr-btn--primary");
-		expect(returnLink.className).not.toContain("fr-btn--secondary");
+		expect(returnLink.className).toContain("fr-btn--secondary");
+		expect(returnLink.className).not.toContain("fr-btn--primary");
+		expect(
+			screen.queryByRole("link", { name: "Retour à Mon Espace" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("does not render its own ResourceBanner (PublicChrome handles it)", () => {


### PR DESCRIPTION
Closes #3518

## Résumé

Sur la page de récapitulatif de déclaration, l'action de bas de page était branchée sur un ternaire `isCorrection` qui ne reflétait plus le Figma : seule la branche « seconde déclaration » avait été alignée lors d'un ticket précédent (#3650), laissant la branche « déclaration initiale » avec une classe `fr-btn--primary` (qui n'existe pas dans le DSFR — inopérante) et un libellé différent.

Le Figma ne fait aucune distinction entre les deux frames sur ce bouton : c'est toujours la même instance secondaire, bordée, libellée « Mon espace ».

## Changements

- `RecapitulatifPage.tsx` : collapse du ternaire — le lien est désormais inconditionnellement `fr-btn fr-btn--secondary`, libellé « Mon espace »
- `RecapitulatifPage.module.scss` : renommage de la classe `.primaryAction` → `.bottomAction` (devenue trompeuse)
- Tests mis à jour en conséquence (`RecapitulatifPage.test.tsx`, `RecapitulatifPage.correction.test.tsx`)

## Effet de bord accepté

`RecapitulatifPage` est aussi monté par `AdminDeclarationDetailPage` (détail déclaration côté admin) — le changement s'y applique donc aussi. Un bouton primaire « Retour à Mon Espace » sur un écran d'admin était de toute façon incohérent ; pas de prop d'échappement ajoutée.

## Test plan

- [x] Suite vitest complète verte (typecheck + test + lint + format)
- [x] Audit structurel : PASS
- [x] Audit RGAA : PASS (deux liens « Mon espace » sur la même page ciblent la même destination — conforme RGAA 6.1/test 10.3)
- [ ] Validation fonctionnelle et visuelle (en cours)