### PR TITLE
fix: aligner le libellé du CTA "Commencer" avec Figma dans le panneau latéral

### DIFF
--- a/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/DeclarationProcessPanel.tsx
@@ -107,7 +107,11 @@ export function DeclarationProcessPanel({
 					<div>
 						<HelpSection />
 						<div className={styles.footer}>
-							<a className="fr-btn" href={ctaHref}>
+							<a
+								aria-describedby={PANEL_TITLE_ID}
+								className="fr-btn"
+								href={ctaHref}
+							>
 								{lockedByOther
 									? "Consulter en lecture seule"
 									: getCtaLabel(variant)}
@@ -122,7 +126,7 @@ export function DeclarationProcessPanel({
 
 function getCtaLabel(variant: PanelVariant): string {
 	if (variant === "closed") return "Voir la déclaration";
-	if (variant === "start") return "Commencer la déclaration";
+	if (variant === "start") return "Commencer";
 	return "Continuer";
 }
 

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -131,6 +131,18 @@ describe("DeclarationProcessPanel", () => {
 			expect(cta).toHaveTextContent(/^Commencer$/);
 		});
 
+		it("describes the CTA link by the panel title", () => {
+			const { dialog } = renderPanel("start");
+			const cta = dialog.querySelector("a.fr-btn");
+			const describedBy = cta?.getAttribute("aria-describedby");
+			expect(describedBy).toBeTruthy();
+			const description = dialog.querySelector(`#${describedBy}`);
+			expect(description?.tagName).toBe("H2");
+			expect(description).toHaveTextContent(
+				/Démarche des indicateurs de rémunération/,
+			);
+		});
+
 		it("renders help section buttons", () => {
 			const { dialog } = renderPanel("start");
 			const buttons = dialog.querySelectorAll("button.fr-link");
@@ -290,14 +302,6 @@ describe("DeclarationProcessPanel", () => {
 					"Cette démarche est terminée. Les avis du CSE restent modifiables jusqu'à l'échéance.",
 				),
 			).toBeInTheDocument();
-		});
-
-		it("renders the closed message without the CSE mention when no CSE opinion is required", () => {
-			const { panel } = renderPanel("closed", { cseOpinionRequired: false });
-			expect(
-				panel.getByText("Cette démarche est terminée."),
-			).toBeInTheDocument();
-			expect(panel.queryByText(/avis du CSE restent modifiables/)).toBeNull();
 		});
 
 		it('renders "Voir la déclaration" CTA', () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationProcessPanel.test.tsx
@@ -128,7 +128,7 @@ describe("DeclarationProcessPanel", () => {
 				"href",
 				"/declaration-remuneration?siren=532847196",
 			);
-			expect(cta).toHaveTextContent("Commencer la déclaration");
+			expect(cta).toHaveTextContent(/^Commencer$/);
 		});
 
 		it("renders help section buttons", () => {
@@ -292,6 +292,14 @@ describe("DeclarationProcessPanel", () => {
 			).toBeInTheDocument();
 		});
 
+		it("renders the closed message without the CSE mention when no CSE opinion is required", () => {
+			const { panel } = renderPanel("closed", { cseOpinionRequired: false });
+			expect(
+				panel.getByText("Cette démarche est terminée."),
+			).toBeInTheDocument();
+			expect(panel.queryByText(/avis du CSE restent modifiables/)).toBeNull();
+		});
+
 		it('renders "Voir la déclaration" CTA', () => {
 			const { dialog } = renderPanel("closed");
 			const footerCta = dialog.querySelector(".footer a.fr-btn");
@@ -357,7 +365,7 @@ describe("DeclarationProcessPanel", () => {
 			const ctaLinks = dialog.querySelectorAll("a.fr-btn");
 			const cta = ctaLinks[ctaLinks.length - 1];
 			expect(cta).toHaveTextContent("Consulter en lecture seule");
-			expect(cta).not.toHaveTextContent("Commencer la déclaration");
+			expect(cta).not.toHaveTextContent("Commencer");
 		});
 
 		it("keeps the CTA href pointing to the declaration for read-only access", () => {
@@ -395,7 +403,7 @@ describe("DeclarationProcessPanel", () => {
 			const { dialog } = renderPanel("start", { lockedByOther: false });
 			const ctaLinks = dialog.querySelectorAll("a.fr-btn");
 			const cta = ctaLinks[ctaLinks.length - 1];
-			expect(cta).toHaveTextContent("Commencer la déclaration");
+			expect(cta).toHaveTextContent(/^Commencer$/);
 			expect(cta).not.toHaveTextContent("Consulter en lecture seule");
 		});
 	});


### PR DESCRIPTION
Closes #3520

## Résumé

Le CTA de la variante "start" du panneau latéral de suivi de déclaration affichait « Commencer la déclaration », alors que le node Figma de référence (`8470:95512`, composant `Thème clair / Primaire / MD`) spécifie le verbatim « Commencer ».

- `DeclarationProcessPanel.tsx` : `getCtaLabel("start")` retourne désormais `"Commencer"`.
- Ajout de `aria-describedby={PANEL_TITLE_ID}` sur le CTA pour garder un intitulé de lien non ambigu hors contexte (RGAA 6.1 / WCAG 2.4.4), sur les 3 variantes du libellé.

## Durcissement des tests

`toHaveTextContent` matche par sous-chaîne — un réalignement naïf sur `"Commencer"` aurait aussi laissé passer l'ancien libellé `"Commencer la déclaration"` (qui contient `"Commencer"`), rendant le test non discriminant :

- Les deux assertions positives (variante `start`, cas verrouillé/non verrouillé) passent en correspondance exacte (`/^Commencer$/`).
- L'assertion négative du cas « verrou détenu par un tiers » (`not.toHaveTextContent`) est requalifiée de `"Commencer la déclaration"` à `"Commencer"` — sinon elle devenait tautologique après le renommage (elle passerait même si la substitution verrou cassait).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (suite complète, 4298/4298 côté `app`)
- [x] `pnpm lint:check` / `pnpm format:check`
- [x] Audit RGAA (ultra11y) — critère 6.1 / WCAG 2.4.4 confirmé conforme après l'ajout de `aria-describedby`
- [ ] Validation fonctionnelle + fidélité visuelle Figma (gates automatisées)

## Périmètre exclu (voir analyse du bug)

- Aucun test E2E — `src/e2e/` ne référence pas ce libellé, hors périmètre de ce ticket.
- `packages/notifications/.../cycleOpeningInfo.tsx` (surface e-mail) — non concerné.
- `docs/parcours-utilisateurs.md` — déjà aligné sur « Commencer ».