### PR TITLE
feat(layout)!: #4055 — version dans la liste de liens du footer, bascule de la série en 4.0

### DIFF
--- a/.github/workflows/review-auto.yaml
+++ b/.github/workflows/review-auto.yaml
@@ -5,6 +5,12 @@ on:
       - "**"
       - "!dependabot/**"
       - "!master"
+      # Persistent test envs (rgaa-persist, perf-persist) are deployed only by
+      # promote-test-env.yaml, which builds from a release tag — that is what
+      # makes their footer link to the release changelog. A push here would
+      # rebuild them with APP_VERSION=<branch> and break that. Same exclusion
+      # convention as deactivate.yaml.
+      - "!**-persist"
 
 concurrency:
   cancel-in-progress: true

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -86,6 +86,14 @@ module.exports = {
     ["@semantic-release/commit-analyzer", conventionalPreset],
     ["@semantic-release/release-notes-generator", conventionalPreset],
     ...(COMMIT_PLUGIN_BRANCHES.includes(branch) ? commitPlugins : []),
-    "@semantic-release/github",
+    [
+      "@semantic-release/github",
+      {
+        // The default only carries the channel (`released on @alpha`), which
+        // never says which prerelease an issue shipped in. Labels are lodash
+        // templates rendered with the semantic-release context.
+        releasedLabels: ["released <%= nextRelease.gitTag %>"],
+      },
+    ],
   ],
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "egapro",
-	"version": "3.13.2",
+	"version": "4.0.0-alpha.0",
 	"private": true,
 	"workspaces": [
 		"packages/*"

--- a/packages/app/src/modules/layout/Footer/AppVersion.tsx
+++ b/packages/app/src/modules/layout/Footer/AppVersion.tsx
@@ -10,16 +10,8 @@ import { NewTabNotice } from "../shared/NewTabNotice";
 const REPOSITORY_URL = "https://github.com/SocialGouv/egapro";
 
 /**
- * Footer release indicator (issue #4020): lets a reviewer know which version
- * of the code a review app is running.
- *
- * - In production: the git tag → links to the release.
- * - On a review app: the branch name → links to the PR when its number is
- *   resolved at build time, otherwise to a branch-scoped PR search.
- * - In local dev / CI without the build var: renders nothing.
- *
- * The version comes from `NEXT_PUBLIC_APP_VERSION` (inlined at build time);
- * the PR number from `NEXT_PUBLIC_PR_NUMBER` (review builds only).
+ * Owns its `<li>` so that an absent version leaves no empty list item — which
+ * would still paint the DSFR separator bar.
  */
 export function AppVersion() {
 	const version = env.NEXT_PUBLIC_APP_VERSION;
@@ -29,18 +21,20 @@ export function AppVersion() {
 	const href = buildHref(version, prNumber);
 
 	return (
-		<p className="fr-footer__bottom-copy">
-			{"Version "}
+		<li className="fr-footer__bottom-item">
 			<a
+				className="fr-footer__bottom-link"
 				href={href}
 				rel="noopener noreferrer"
 				target="_blank"
-				title={`Code source pour la version ${version} - nouvelle fenêtre`}
 			>
-				{version}
+				Version {version}
+				{/* The destination belongs to the accessible name: `title` does not
+				    count as link context under WCAG 2.4.4. */}
+				<span className="fr-sr-only"> : code source sur GitHub</span>
 				<NewTabNotice />
 			</a>
-		</p>
+		</li>
 	);
 }
 

--- a/packages/app/src/modules/layout/Footer/FooterBottom.tsx
+++ b/packages/app/src/modules/layout/Footer/FooterBottom.tsx
@@ -46,6 +46,7 @@ export function FooterBottom() {
 						Paramètres d'affichage
 					</button>
 				</li>
+				<AppVersion />
 			</ul>
 			<div className="fr-footer__bottom-copy">
 				<p>
@@ -59,7 +60,6 @@ export function FooterBottom() {
 						<NewTabNotice />
 					</a>
 				</p>
-				<AppVersion />
 			</div>
 		</div>
 	);

--- a/packages/app/src/modules/layout/Footer/__tests__/AppVersion.test.tsx
+++ b/packages/app/src/modules/layout/Footer/__tests__/AppVersion.test.tsx
@@ -26,6 +26,37 @@ describe("AppVersion", () => {
 		expect(container).toBeEmptyDOMElement();
 	});
 
+	it("renders as a list item so it can sit in the footer bottom link list", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "v4.0.0-alpha.1",
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		render(
+			<ul>
+				<Comp />
+			</ul>,
+		);
+		expect(screen.getByRole("listitem")).toContainElement(
+			screen.getByRole("link"),
+		);
+	});
+
+	it("names the destination in the accessible name, not only in a title", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "v4.0.0-alpha.1",
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		render(
+			<ul>
+				<Comp />
+			</ul>,
+		);
+		const link = screen.getByRole("link", {
+			name: /^Version v4\.0\.0-alpha\.1.*code source sur GitHub/,
+		});
+		expect(link).not.toHaveAttribute("title");
+	});
+
 	it("links to the release page for a git tag (production)", async () => {
 		const Comp = await withEnv({
 			NEXT_PUBLIC_APP_VERSION: "v3.14.0-alpha.11",

--- a/packages/app/src/modules/layout/Footer/__tests__/FooterBottom.test.tsx
+++ b/packages/app/src/modules/layout/Footer/__tests__/FooterBottom.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `src/test/setup.ts` does not mock `~/env`, so each test defines its own.
+async function withEnv(env: Record<string, string | undefined>) {
+	vi.resetModules();
+	vi.doMock("~/env", () => ({ env }));
+	const mod = await import("../FooterBottom");
+	return mod.FooterBottom;
+}
+
+function bottomListLabels() {
+	return Array.from(
+		screen.getByRole("list").children,
+		(item) => item.textContent ?? "",
+	);
+}
+
+afterEach(() => {
+	vi.doUnmock("~/env");
+	vi.resetModules();
+	cleanup();
+});
+
+describe("FooterBottom", () => {
+	it("shows the version right after the display settings, at the end of the list", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "v4.0.0-alpha.1",
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		render(<Comp />);
+
+		const labels = bottomListLabels();
+		const settingsIndex = labels.findIndex((label) =>
+			label.includes("Paramètres"),
+		);
+		const versionIndex = labels.findIndex((label) =>
+			label.includes("Version v4.0.0-alpha.1"),
+		);
+
+		expect(settingsIndex).toBeGreaterThanOrEqual(0);
+		expect(versionIndex).toBe(settingsIndex + 1);
+		expect(versionIndex).toBe(labels.length - 1);
+	});
+
+	it("keeps the version out of the licence block", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: "v4.0.0-alpha.1",
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		const { container } = render(<Comp />);
+
+		const copy = container.querySelector(".fr-footer__bottom-copy");
+		expect(copy).not.toBeNull();
+		expect(copy?.textContent).not.toContain("Version");
+	});
+
+	it("renders the list without a version item in local dev", async () => {
+		const Comp = await withEnv({
+			NEXT_PUBLIC_APP_VERSION: undefined,
+			NEXT_PUBLIC_PR_NUMBER: undefined,
+		});
+		render(<Comp />);
+
+		const labels = bottomListLabels();
+		expect(labels.some((label) => label.includes("Version"))).toBe(false);
+		expect(labels.at(-1)).toContain("Paramètres");
+	});
+});


### PR DESCRIPTION
Closes #4055

Le socle de l'issue existait déjà (#4020, PR #4047). Cette PR traite les retours postés en commentaires de #4055.

## 1. La version passe dans la liste de liens du pied de page

`AppVersion` rendait un `<p>` isolé sous la mention de licence. Il rend maintenant un `<li class="fr-footer__bottom-item">`, inséré en fin de `<ul class="fr-footer__bottom-list">`, **juste après « Paramètres d'affichage »** — même typographie et même séparateur DSFR que ses voisins, sans une ligne de CSS ajoutée.

Le lien est **conservé dans tous les environnements**, y compris en production.

| environnement | version affichée | destination |
|---|---|---|
| production (tag `v*`) | `v4.0.0-alpha.1` | page de release = changelog |
| envs de test persistants (rgaa / perf) | tag promu | page de release = changelog |
| préprod (`beta`) | `beta` | arbre de la branche |
| review app | nom de branche | la PR |
| dev local | — | le composant ne rend rien |

## 2. Accessibilité du lien

L'attribut `title` portait seul la destination (« code source sur GitHub »), or WCAG 2.4.4 ne le compte pas comme contexte de lien. La destination passe donc dans le nom accessible via un complément `fr-sr-only`, et le `title` est supprimé.

- libellé visible : `Version v4.0.0-alpha.1`
- nom accessible : `Version v4.0.0-alpha.1 : code source sur GitHub (ouvre une nouvelle fenêtre)`

WCAG 2.5.3 (Label in Name) tient : le libellé visible reste préfixe du nom accessible.

## 3. Les environnements de test persistants ne peuvent plus être écrasés

`rgaa-persist` / `perf-persist` ne doivent être déployés que par « 🎯 Promote test env », qui construit l'image depuis un tag `v*` — c'est ce qui fait pointer leur pied de page vers la release. Or `review-auto.yaml` se déclenchait sur `branches: ["**", …]` : un push sur la branche homonyme rebuildait l'image avec `APP_VERSION=rgaa-persist` et le lien retombait sur `/tree/rgaa-persist`.

Le filtre exclut désormais `**-persist`, même convention que `deactivate.yaml`.

> **Suite à faire après le merge** : supprimer les branches `origin/rgaa-persist` et `origin/perf-persist`, vestiges de l'ancienne promotion par force-push. Sans risque — `deactivate.yaml` ignore explicitement les suppressions de branches `**-persist`, donc les namespaces ne seront pas détruits.

## 4. Bascule de la série 3.14 → 4.0

Le canal alpha stagnait en `3.14.0-alpha.N` alors que `master`, dormante, est à `3.18.4`.

**Le titre de cette PR porte volontairement le `!` conventionnel.** C'est lui qui déclenche la bascule : `lib/get-next-version.js` de semantic-release ne se contente pas d'incrémenter le suffixe sur un canal prerelease, il prend le `highest()` entre la continuité de série et le bump appliqué au plus haut tag de la branche.

```js
version = highest(
  semver.inc(lastRelease.version, "prerelease"),                       // 3.14.0-alpha.13
  `${semver.inc(getLatestVersion(...), type)}-${branch.prerelease}.1`, // 4.0.0-alpha.1 si type=major
);
```

Vérifié en exécutant le code installé :

| type de bump | version calculée |
|---|---|
| patch | `3.14.0-alpha.13` |
| minor | `3.14.0-alpha.13` |
| **major** | **`4.0.0-alpha.1`** |

Deux points à ne pas perdre de vue :

- Le dépôt est réglé en `squash_merge_commit_title: PR_TITLE` / `squash_merge_commit_message: BLANK`, donc le squash produit un commit **sans corps** : un footer `BREAKING CHANGE:` serait perdu. **Le `!` du titre est le seul levier.** Merci de ne pas le retirer en mergeant.
- Un tag d'amorce `v4.0.0-alpha.0` aurait aussi marché, mais `production.yaml` se déclenche sur `push: tags: v*` sans filtre de prerelease : le pousser aurait **déployé en production**. La voie du commit n'a aucun effet de bord.

`package.json` passe de `3.13.2` à `4.0.0-alpha.0` pour que le dépôt cesse de raconter deux histoires (`@semantic-release/npm` ne tourne pas sur `alpha`, ce champ n'est jamais bumpé et n'est importé nulle part dans le code).

## 5. Le label de release porte le numéro exact

`@semantic-release/github` était déclaré sans options : le label posé sur les issues livrées valait `released on @alpha`, sans dire dans quelle prerelease. Il devient `released v4.0.0-alpha.1`.

Contrepartie assumée : un label distinct par release.

## Vérifications

- `pnpm typecheck` / `pnpm lint:check` / `pnpm format:check` verts
- `pnpm test` : 4458 tests verts, dont 10 sur le pied de page (`AppVersion` + `FooterBottom` nouveau, couvrant l'ordre dans la liste et le nom accessible)
- rendu contrôlé hors serveur sur le composant réel : en 1280px la version est bien sur la même ligne que « Paramètres d'affichage » (même `y`), en 12px et dans le gris de mention DSFR, en thème clair comme sombre ; le complément `fr-sr-only` mesure 1×1px
- audit RGAA (ultra11y + adjudication) : PASS
- audit structurel : aucune erreur

## Reste à vérifier après release

- après la prochaine « 🔖 Prerelease (alpha) », que la production affiche bien la version (retour n°3 de l'issue)
- après une promotion sur l'env RGAA, que le pied de page pointe vers `/releases/tag/…`
- que le label posé sur les issues livrées porte le numéro exact
