### PR TITLE
fix(declaration-remuneration): aligner l'indicateur « enregistré » sur la première ligne du titre

### DIFF
--- a/packages/app/src/e2e/declaration-header-alignment.e2e.ts
+++ b/packages/app/src/e2e/declaration-header-alignment.e2e.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "@playwright/test";
+import {
+	pushCampaignDeadlinesFarFuture,
+	resetDeclarationToDraft,
+	setDeclarationComplianceState,
+	setWorkforceCounts,
+} from "./helpers/db";
+
+// #3579. Every declaration header pairs a growing <h1> with a fixed-height
+// companion — the "Enregistré" indicator, or the recap's download button. The
+// row used to centre that companion on the *whole* title box
+// (`fr-grid-row--middle`, and `align-items: center` on `.flexBetween`), so the
+// moment the title wrapped it slid down to the middle of two lines instead of
+// staying on the first one. Both were flipped to a top alignment.
+//
+// jsdom cannot hold this contract: the component tests see the class string,
+// never the line boxes it has to align, and the SCSS module is mocked away
+// there. Only a real browser lays the title out and decides where it wraps.
+
+// The width the ticket's capture was taken at. Every screen below wraps its
+// title here — funnel step 1 included even once the dev-only "[DEV] Remplir"
+// button is discounted, so the contract survives a build that drops it.
+const VIEWPORT = { width: 1006, height: 900 };
+
+// The fix leaves the companion 2px above the first line's centre (4px below on
+// the recap, whose taller button carries its own metrics). Centring it on a
+// two-line title instead drops it 16px. 8px sits clear of both states.
+const MAX_CENTER_OFFSET = 8;
+
+type Screen = {
+	name: string;
+	path: string;
+	companion: string;
+	setup: () => Promise<void>;
+};
+
+const SCREENS: Screen[] = [
+	{
+		name: "funnel step 1",
+		path: "/declaration-remuneration/etape/1",
+		companion: "p[role='status']",
+		// The indicator only renders once the step holds data.
+		setup: async () => {
+			await resetDeclarationToDraft();
+			await setWorkforceCounts(75, 80);
+		},
+	},
+	{
+		name: "funnel step 6 review",
+		path: "/declaration-remuneration/etape/6",
+		companion: "p[role='status']",
+		setup: async () => {
+			await resetDeclarationToDraft();
+			await setDeclarationComplianceState({ status: "draft", currentStep: 6 });
+		},
+	},
+	{
+		name: "récapitulatif",
+		path: "/declaration-remuneration/recapitulatif",
+		companion: "a[download]",
+		setup: async () => {
+			await setDeclarationComplianceState({
+				status: "awaiting_compliance_path_choice",
+				currentStep: 6,
+			});
+		},
+	},
+	{
+		// The `.flexBetween` half of the fix: no `fr-grid-row` screen exercises the
+		// SCSS rule. This header is also the one whose title is long enough to wrap
+		// at every desktop width, so it holds the contract whatever the breakpoint.
+		name: "second declaration step 1",
+		path: "/declaration-remuneration/parcours-conformite/etape/1",
+		companion: "p[role='status']",
+		setup: async () => {
+			await setDeclarationComplianceState({
+				status: "corrective_actions_chosen",
+				firstDeclarationPathChoice: "corrective_action",
+				currentStep: 6,
+			});
+		},
+	},
+];
+
+test.describe("declaration header alignment", () => {
+	// Serial: every screen below reconfigures the one declaration record the
+	// suite shares, so these cannot interleave with one another.
+	test.describe.configure({ mode: "serial" });
+	test.use({ viewport: VIEWPORT });
+
+	// Re-asserted rather than inherited from globalSetup: the deadline specs run
+	// earlier in the alphabet and leave the campaign closed, which bounces the
+	// funnel out before any header renders.
+	test.beforeAll(async () => {
+		await pushCampaignDeadlinesFarFuture();
+	});
+
+	for (const screen of SCREENS) {
+		test(`${screen.name} — the companion stays on the title's first line`, async ({
+			page,
+		}) => {
+			await screen.setup();
+			await page.goto(screen.path);
+
+			const heading = page.getByRole("main").getByRole("heading", { level: 1 });
+			await expect(heading).toBeVisible();
+
+			const measurement = await heading.evaluate((h1, companionSelector) => {
+				// Scoped to the header itself: an unrelated `p[role="status"]` sits
+				// further down some of these pages and a document-wide lookup wins it.
+				const column = h1.parentElement;
+				if (!column) throw new Error("Heading has no parent");
+				const row = column.classList.contains("fr-col")
+					? column.parentElement
+					: column;
+				const companion = row?.querySelector(companionSelector);
+				if (!companion) {
+					throw new Error(`No ${companionSelector} in the header row`);
+				}
+
+				// Line boxes, not the heading's bounding box: that one spans every
+				// line, so its centre reads the same before and after the fix.
+				const range = document.createRange();
+				range.selectNodeContents(h1);
+				const lines: { bottom: number; top: number }[] = [];
+				for (const rect of Array.from(range.getClientRects())) {
+					if (rect.width === 0 || rect.height === 0) continue;
+					const line = lines.find((l) => Math.abs(l.top - rect.top) < 4);
+					if (line) line.bottom = Math.max(line.bottom, rect.bottom);
+					else lines.push({ bottom: rect.bottom, top: rect.top });
+				}
+				lines.sort((a, b) => a.top - b.top);
+				const firstLine = lines[0];
+				if (!firstLine) throw new Error("Heading has no line box");
+
+				const box = companion.getBoundingClientRect();
+				return {
+					lineCount: lines.length,
+					offset: Math.round(
+						(box.top + box.bottom) / 2 - (firstLine.top + firstLine.bottom) / 2,
+					),
+				};
+			}, screen.companion);
+
+			// Asserted first: a shorter title would fit on one line and make the
+			// offset below pass without proving anything about the alignment.
+			expect(measurement.lineCount).toBeGreaterThan(1);
+			expect(Math.abs(measurement.offset)).toBeLessThanOrEqual(
+				MAX_CENTER_OFFSET,
+			);
+		});
+	}
+});

--- a/packages/app/src/e2e/helpers/db.ts
+++ b/packages/app/src/e2e/helpers/db.ts
@@ -223,6 +223,24 @@ export async function setCompanyWorkforce(workforce: number | null) {
 	}
 }
 
+/**
+ * Persist a step-1 workforce on the shared declaration. The funnel reads these
+ * columns to decide whether a step already holds data, so this reaches the
+ * "saved" rendering without replaying the form and waiting on its autosave.
+ */
+export async function setWorkforceCounts(women: number, men: number) {
+	const sql = createConnection();
+	try {
+		await sql`
+			UPDATE app_declaration
+			SET total_women = ${women}, total_men = ${men}
+			WHERE siren = ${TEST_SIREN}
+		`;
+	} finally {
+		await sql.end();
+	}
+}
+
 export async function setDeclarationComplianceState(state: {
 	status?: string;
 	currentStep?: number;

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/RecapitulatifPage.tsx
@@ -121,7 +121,7 @@ export function RecapitulatifPage({
 
 	return (
 		<div className={common.flexColumnGap2}>
-			<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+			<div className="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
 				<div className="fr-col">
 					<TitleTag className="fr-h4 fr-mb-0">
 						{isCorrection

--- a/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/StepTitleRow.tsx
@@ -21,7 +21,7 @@ export function StepTitleRow({
 	devFillDisabled = false,
 }: StepTitleRowProps) {
 	return (
-		<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+		<div className="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
 			<div className="fr-col">{title}</div>
 			<div className="fr-col-auto">
 				<DevFillButton disabled={devFillDisabled} onFill={onDevFill} />

--- a/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/shared/common.module.scss
@@ -48,7 +48,7 @@
 .flexBetween {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 }
 
 .flexBaseline {

--- a/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step6Review.tsx
@@ -135,7 +135,7 @@ export function Step6Review({
 			    from some assistive technologies (#3803). */}
 			<fieldset className={common.readOnlyFieldset}>
 				<legend className="fr-sr-only">Récapitulatif de la déclaration</legend>
-				<div className="fr-grid-row fr-grid-row--middle fr-grid-row--gutters">
+				<div className="fr-grid-row fr-grid-row--top fr-grid-row--gutters">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">
 							Déclaration des indicateurs de rémunération {declarationYear}


### PR DESCRIPTION
Closes #3579

## Résumé

Sur les écrans de la déclaration de rémunération, quand le titre `<h1>` passe sur plusieurs lignes, l'icône/texte « enregistré » (ou le bouton « Télécharger » sur le récapitulatif) était centré verticalement sur toute la hauteur du titre au lieu de rester aligné sur sa première ligne.

Fix minimal (variante A retenue en analyse, 4 lignes / 4 fichiers) :

- `StepTitleRow.tsx`, `Step6Review.tsx`, `RecapitulatifPage.tsx` : `fr-grid-row--middle` → `fr-grid-row--top`
- `common.module.scss` (`.flexBetween`, utilisé par la 2nde déclaration et le parcours de conformité) : `align-items: center` → `flex-start`

Voir l'analyse détaillée (mesures DOM sur 24 largeurs × 9 écrans) : [## Analyse du bug (révisé 2026-08-11)](https://github.com/SocialGouv/egapro/issues/3579#issuecomment-5251203170).

## Mesures de non-régression

À 1006 px, titre sur plusieurs lignes (mesure `Range.getClientRects()` vs `getBoundingClientRect()`, Δcentre = centre de `p[role="status"]` − centre de la première ligne du `<h1>`) :

| Écran | Δcentre avant | Δcentre après | Seuil |
|---|---|---|---|
| Étape 1 | +15,5 px | **−2 px** | \|Δ\| ≤ 5 px |
| Étape 6 | +15,5 px | **−2 px** | \|Δ\| ≤ 5 px |

![Étape 1 après fix](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-3579/step1-after-fix.png)
![Étape 6 après fix](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-3579/step6-after-fix.png)

Le récapitulatif (`RecapitulatifPage`, cas le plus grave d'après l'analyse : +16 à +32 px) suit exactement le même correctif d'une ligne ; sa vérification indépendante (mesure DOM + overlay) est faite par le gate `design-validator`.

## Test plan

- [x] `pnpm typecheck` / lint / format / tests unitaires (4459 tests, 0 régression — voir délégation `tu-dev`)
- [x] Vérification manuelle (Playwright, dev server) : étape 1 et étape 6, Δcentre mesuré −2 px sur les deux
- [ ] `design-validator` (gate indépendante, step 9a-bis) sur les 6 écrans du périmètre
- [ ] E2E (`e2e-dev`, propriété exclusive, après `validated`)

Aucun test unitaire pertinent : changement CSS/SCSS pur, non observable en jsdom (SCSS mockée). Le test de non-régression réel est un E2E à mesure DOM.
