### PR TITLE
fix: aligner le rendu de l'écran actions correctives sur le Figma (#3577)

### DIFF
--- a/packages/app/src/e2e/second-declaration-info-styling.e2e.ts
+++ b/packages/app/src/e2e/second-declaration-info-styling.e2e.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+
+import {
+	COMPLIANCE_PATH,
+	selectCompliancePath,
+} from "./helpers/compliance-flows";
+import {
+	resetDeclarationToDraft,
+	setCompanyHasCse,
+	setCompanyWorkforce,
+} from "./helpers/db";
+import { completeDeclaration } from "./helpers/declaration-flows";
+
+// SecondDeclarationStep1Info.module.scss re-declares `.fr-callout` inside its own scoped
+// class to outrank DSFR's rule, and FormActions' `fr-mt-0` cancels the 2rem margin its own
+// module sets. SecondDeclarationStep1Info.test.tsx asserts the class names, but jsdom never
+// resolves those cascades, never cancels DSFR's callout artwork, and never evaluates the
+// `respond-from(md)` padding. Only a real browser holds this contract.
+
+const STEP_1_PATH = `${COMPLIANCE_PATH}/etape/1`;
+
+// --background-alt-blue-france → --blue-france-975-75 in DSFR 1.14's light theme.
+const EXPECTED_BACKGROUND = "rgb(245, 245, 254)";
+// 1rem / 1.5rem, from the module's `.fr-callout__text` rule.
+const EXPECTED_TEXT_FONT_SIZE = "16px";
+const EXPECTED_TEXT_LINE_HEIGHT = "24px";
+// 2rem, applied from the md breakpoint (48em) upwards only.
+const EXPECTED_DESKTOP_PADDING = "32px";
+
+const DESKTOP = { width: 1440, height: 900 };
+// Below the md breakpoint the `respond-from(md)` block drops out, so this viewport proves
+// the base override still wins the cascade on its own.
+const MOBILE = { width: 375, height: 800 };
+
+test.describe("second declaration step 1 — DSFR overrides", () => {
+	test.describe.configure({ mode: "serial" });
+
+	test.beforeAll(async () => {
+		await resetDeclarationToDraft();
+		await setCompanyHasCse(true);
+		await setCompanyWorkforce(200);
+	});
+
+	test.afterAll(async () => {
+		await resetDeclarationToDraft();
+	});
+
+	test("the callout and form actions keep their overrides on both viewports", async ({
+		page,
+	}) => {
+		test.slow();
+
+		// Step 1 only renders for a declaration that actually reached the corrective-action
+		// branch, and the funnel clears a path choice seeded without indicator data behind
+		// it — so walk the real parcours instead of forcing the row.
+		await completeDeclaration(page, { hasGap: true });
+		await selectCompliancePath(page, "path-corrective");
+		await page.waitForURL(`**${STEP_1_PATH}`, { timeout: 15_000 });
+
+		const callout = page.locator(".fr-callout");
+		const calloutText = page.locator(".fr-callout__text");
+		const actions = page.getByRole("link", { name: "Précédent" }).locator("..");
+
+		for (const viewport of [DESKTOP, MOBILE]) {
+			await test.step(`viewport ${viewport.width}px`, async () => {
+				await page.setViewportSize(viewport);
+				await expect(callout).toBeVisible();
+
+				const computed = await callout.evaluate((element) => {
+					const { backgroundColor, backgroundImage, marginBottom } =
+						getComputedStyle(element);
+					return { backgroundColor, backgroundImage, marginBottom };
+				});
+				expect(computed).toEqual({
+					backgroundColor: EXPECTED_BACKGROUND,
+					backgroundImage: "none",
+					marginBottom: "0px",
+				});
+
+				const typography = await calloutText.evaluate((element) => {
+					const { fontSize, lineHeight } = getComputedStyle(element);
+					return { fontSize, lineHeight };
+				});
+				expect(typography).toEqual({
+					fontSize: EXPECTED_TEXT_FONT_SIZE,
+					lineHeight: EXPECTED_TEXT_LINE_HEIGHT,
+				});
+
+				await expect(actions).toHaveCSS("margin-top", "0px");
+			});
+		}
+
+		await test.step("2rem callout padding from the md breakpoint up", async () => {
+			await page.setViewportSize(DESKTOP);
+			await expect(callout).toHaveCSS("padding", EXPECTED_DESKTOP_PADDING);
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.module.scss
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.module.scss
@@ -1,0 +1,22 @@
+.introText {
+	color: var(--text-title-grey);
+}
+
+.obligationsCallout {
+	// Qualified with .fr-callout to outrank DSFR's own rule (same specificity, source order would otherwise decide)
+	&:global(.fr-callout) {
+		background-color: var(--background-alt-blue-france);
+		background-image: none;
+		margin-bottom: 0;
+		--title-spacing: 0 0 1rem;
+
+		@include respond-from(md) {
+			padding: 2rem;
+		}
+	}
+
+	:global(.fr-callout__text) {
+		font-size: 1rem;
+		line-height: 1.5rem;
+	}
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep1Info.tsx
@@ -7,6 +7,7 @@ import { FormActions } from "~/modules/declaration-remuneration/shared/FormActio
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { formatLongDate } from "~/modules/domain";
 import { BASE_PATH } from "./constants";
+import styles from "./SecondDeclarationStep1Info.module.scss";
 import { SecondDeclarationStepIndicator } from "./SecondDeclarationStepIndicator";
 
 const EMPTY_DB_VALUES = {} as Record<string, never>;
@@ -48,7 +49,7 @@ export function SecondDeclarationStep1Info({
 
 			<SecondDeclarationStepIndicator currentStep={1} />
 
-			<p className="fr-mb-0">
+			<p className={`fr-mb-0 ${common.fontMedium} ${styles.introText}`}>
 				Vous devez mettre en œuvre des <strong>actions correctives</strong> et
 				effectuer une{" "}
 				<strong>
@@ -65,6 +66,7 @@ export function SecondDeclarationStep1Info({
 			<ObligationsCallout />
 
 			<FormActions
+				className="fr-mt-0"
 				nextHref={`${BASE_PATH}/etape/2`}
 				nextLabel="Suivant"
 				previousHref={BASE_PATH}
@@ -81,10 +83,12 @@ function DeadlineBlock({
 	declarationDate: string;
 }) {
 	return (
-		<div className="fr-pl-3w">
-			<p className="fr-mb-0 fr-text--sm fr-text--mention-grey">Date limite</p>
-			<p className="fr-h5 fr-mb-0">{formatLongDate(deadline)}</p>
-			<p className="fr-mb-0 fr-text--sm fr-text--mention-grey">
+		<div className={`fr-highlight ${common.flexColumnGapHalf}`}>
+			<p className="fr-mb-0">Date limite</p>
+			<p className="fr-mb-0 fr-text--lead fr-text--bold">
+				{formatLongDate(deadline)}
+			</p>
+			<p className="fr-mb-0 fr-text-mention--grey">
 				Déclaration effectuée le {declarationDate}
 			</p>
 		</div>
@@ -93,8 +97,8 @@ function DeadlineBlock({
 
 function ObligationsCallout() {
 	return (
-		<div className="fr-callout">
-			<h3 className="fr-callout__title">
+		<div className={`fr-callout ${styles.obligationsCallout}`}>
+			<h3 className="fr-callout__title fr-h6">
 				Ce que vous devez faire dans un délai de 6 mois
 			</h3>
 			<div className="fr-callout__text">

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep1Info.test.tsx
@@ -2,18 +2,25 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { SecondDeclarationStep1Info } from "../SecondDeclarationStep1Info";
 
-describe("SecondDeclarationStep1Info", () => {
-	const modificationDeadline = new Date("2027-12-01T00:00:00");
+// Scoped SCSS classes resolve to their own key under the vitest scss module mock.
+const SCOPED_CALLOUT_CLASS = "obligationsCallout";
+const SCOPED_FONT_MEDIUM_CLASS = "fontMedium";
 
+function renderStep1() {
+	render(
+		<SecondDeclarationStep1Info
+			declarationDate="01/06/2027"
+			declarationSiren="123456789"
+			declarationYear={2027}
+			modificationDeadline={new Date("2027-12-01T00:00:00")}
+		/>,
+	);
+}
+
+describe("SecondDeclarationStep1Info", () => {
 	it("renders the main title", () => {
-		render(
-			<SecondDeclarationStep1Info
-				declarationDate="01/06/2027"
-				declarationSiren="123456789"
-				declarationYear={2027}
-				modificationDeadline={modificationDeadline}
-			/>,
-		);
+		renderStep1();
+
 		expect(
 			screen.getByText(
 				/Parcours de mise en conformité pour l.indicateur par catégorie de salariés/,
@@ -22,14 +29,8 @@ describe("SecondDeclarationStep1Info", () => {
 	});
 
 	it("renders stepper at step 1 of 3", () => {
-		render(
-			<SecondDeclarationStep1Info
-				declarationDate="01/06/2027"
-				declarationSiren="123456789"
-				declarationYear={2027}
-				modificationDeadline={modificationDeadline}
-			/>,
-		);
+		renderStep1();
+
 		expect(screen.getByText("Étape 1 sur 3")).toBeInTheDocument();
 		expect(
 			screen.getByText("Actions correctives et seconde déclaration"),
@@ -37,40 +38,22 @@ describe("SecondDeclarationStep1Info", () => {
 	});
 
 	it("displays the deadline", () => {
-		render(
-			<SecondDeclarationStep1Info
-				declarationDate="01/06/2027"
-				declarationSiren="123456789"
-				declarationYear={2027}
-				modificationDeadline={modificationDeadline}
-			/>,
-		);
+		renderStep1();
+
 		expect(screen.getByText(/1ᵉʳ décembre 2027/)).toBeInTheDocument();
 	});
 
 	it("displays the declaration date", () => {
-		render(
-			<SecondDeclarationStep1Info
-				declarationDate="01/06/2027"
-				declarationSiren="123456789"
-				declarationYear={2027}
-				modificationDeadline={modificationDeadline}
-			/>,
-		);
+		renderStep1();
+
 		expect(
 			screen.getByText(/Déclaration effectuée le 01\/06\/2027/),
 		).toBeInTheDocument();
 	});
 
 	it("renders the obligations callout", () => {
-		render(
-			<SecondDeclarationStep1Info
-				declarationDate="01/06/2027"
-				declarationSiren="123456789"
-				declarationYear={2027}
-				modificationDeadline={modificationDeadline}
-			/>,
-		);
+		renderStep1();
+
 		expect(
 			screen.getByText("Ce que vous devez faire dans un délai de 6 mois"),
 		).toBeInTheDocument();
@@ -80,14 +63,8 @@ describe("SecondDeclarationStep1Info", () => {
 	});
 
 	it("renders previous link to parcours-conformite and next to step 2", () => {
-		render(
-			<SecondDeclarationStep1Info
-				declarationDate="01/06/2027"
-				declarationSiren="123456789"
-				declarationYear={2027}
-				modificationDeadline={modificationDeadline}
-			/>,
-		);
+		renderStep1();
+
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/parcours-conformite",
@@ -96,5 +73,60 @@ describe("SecondDeclarationStep1Info", () => {
 			"href",
 			"/declaration-remuneration/parcours-conformite/etape/2",
 		);
+	});
+
+	it("renders the deadline block as a DSFR highlight", () => {
+		renderStep1();
+
+		const deadlineBlock = screen.getByText("Date limite").parentElement;
+		expect(deadlineBlock).toHaveClass("fr-highlight");
+		expect(deadlineBlock).not.toHaveClass("fr-pl-3w");
+	});
+
+	it("renders the deadline lines with the expected DSFR typography", () => {
+		renderStep1();
+
+		expect(screen.getByText("Date limite")).not.toHaveClass("fr-text--sm");
+
+		const deadlineDate = screen.getByText(/1ᵉʳ décembre 2027/);
+		expect(deadlineDate).toHaveClass("fr-text--lead", "fr-text--bold");
+		expect(deadlineDate).not.toHaveClass("fr-h5");
+
+		const declarationLine = screen.getByText(/Déclaration effectuée le/);
+		expect(declarationLine).toHaveClass("fr-text-mention--grey");
+		expect(declarationLine).not.toHaveClass("fr-text--sm");
+	});
+
+	it("renders the obligations callout with the scoped styling", () => {
+		renderStep1();
+
+		const title = screen.getByRole("heading", {
+			level: 3,
+			name: "Ce que vous devez faire dans un délai de 6 mois",
+		});
+		expect(title).toHaveClass("fr-callout__title", "fr-h6");
+		expect(title.parentElement).toHaveClass("fr-callout", SCOPED_CALLOUT_CLASS);
+	});
+
+	it("renders the intro paragraph in medium weight while keeping its emphasis", () => {
+		renderStep1();
+
+		expect(screen.getByText(/Vous devez mettre en œuvre des/)).toHaveClass(
+			SCOPED_FONT_MEDIUM_CLASS,
+		);
+		expect(screen.getByText("actions correctives").tagName).toBe("STRONG");
+		expect(
+			screen.getByText(
+				/^seconde déclaration de l.indicateur par catégorie de salariés$/,
+			).tagName,
+		).toBe("STRONG");
+	});
+
+	it("neutralises the top margin of the form actions", () => {
+		renderStep1();
+
+		expect(
+			screen.getByRole("link", { name: /précédent/i }).parentElement,
+		).toHaveClass("fr-mt-0");
 	});
 });


### PR DESCRIPTION
Closes #3577

## Résumé

Aligne le rendu de l'écran « Actions correctives et seconde déclaration » (étape 1) sur le Figma, à partir des mesures DOM vs Figma consignées dans le commentaire `## Analyse du bug` de l'issue.

- **Bloc « Date limite »** : remplace le `<div className="fr-pl-3w">` par le composant DSFR `fr-highlight` — trait bleu et retrait natifs. Retrait de `fr-text--sm` (16px au lieu de 14px), date en `fr-text--lead fr-text--bold` (au lieu de `fr-h5`), sous-ligne « Déclaration effectuée le… » en `fr-text-mention--grey` (classe DSFR correcte — l'ancienne `fr-text--mention-grey` sur cet écran n'existait pas et ne s'appliquait donc pas).
- **Callout « Ce que vous devez faire… »** : titre en `fr-h6` (20px/700 au lieu de 24px), fond `--background-alt-blue-france` (au lieu du gris par défaut) et barre latérale retirée via un module SCSS scopé, taille du texte de liste ramenée à 16px/24px, espace titre → liste porté à 16px.
- **Paragraphe d'intro** : passe en graisse 500 + `--text-title-grey`, en conservant les deux `<strong>` existants (emphase sémantique volontaire, cf. section « écarts assumés » de l'analyse).
- **`FormActions`** : `margin-top` parasite neutralisé localement sur cet écran via la prop `className` déjà exposée par le composant (le fix global fait l'objet d'un ticket dédié).

Chaque valeur (px, couleur, poids) a été vérifiée contre le node Figma `7548:86544` (lecture structurelle via l'API Figma) et contre le CSS DSFR 1.14.4 réellement servi par l'app.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint:check` / `pnpm format:check`
- [x] Suite vitest complète verte (assertions structurelles ajoutées : `fr-highlight`, `fr-h6`, classes de date, `fr-mt-0`)
- [ ] Validation fonctionnelle (scénarios PO) sur le dev server
- [ ] Fidélité visuelle vs Figma (gate `design-validator`)
