### PR TITLE
fix(declaration-pdf): #4126 — supprimer les césures dans les en-têtes de tableaux

### DIFF
--- a/packages/app/src/modules/declarationPdf/__tests__/helpers/pdfTextStream.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/helpers/pdfTextStream.ts
@@ -1,0 +1,76 @@
+import { inflateSync } from "node:zlib";
+
+// A rendered PDF stores its drawing instructions in deflated content streams.
+// Inflating the one that positions text gives back the `Tm` matrices and the
+// `TJ` operands, which is the only way to assert on what the layout engine
+// actually produced rather than on what we asked it to produce.
+
+const GLYPH_ID_LENGTH = 4;
+
+export type PositionedRun = {
+	glyphIds: string[];
+	x: number;
+	y: number;
+};
+
+export function extractTextStream(pdf: Buffer): string {
+	const inflateFailures: string[] = [];
+	let cursor = 0;
+
+	while (cursor < pdf.length) {
+		const streamStart = pdf.indexOf("stream", cursor);
+		if (streamStart === -1) break;
+
+		let contentStart = streamStart + "stream".length;
+		if (pdf[contentStart] === 0x0d) contentStart += 1;
+		if (pdf[contentStart] === 0x0a) contentStart += 1;
+
+		const contentEnd = pdf.indexOf("endstream", contentStart);
+		cursor = contentEnd + "endstream".length;
+
+		try {
+			const content = inflateSync(
+				pdf.subarray(contentStart, contentEnd),
+			).toString("latin1");
+			if (content.includes("Tf") && content.includes("TJ")) return content;
+		} catch (error) {
+			inflateFailures.push(`${streamStart}: ${String(error)}`);
+		}
+	}
+
+	throw new Error(
+		`No text content stream found in the rendered PDF (${inflateFailures.length} stream(s) could not be inflated: ${inflateFailures.join(" | ")})`,
+	);
+}
+
+function splitGlyphIds(textShowingOperands: string): string[] {
+	const ids: string[] = [];
+
+	for (const [, hex] of textShowingOperands.matchAll(/<([0-9a-f]+)>/g)) {
+		if (!hex) continue;
+		for (let i = 0; i < hex.length; i += GLYPH_ID_LENGTH) {
+			ids.push(hex.slice(i, i + GLYPH_ID_LENGTH));
+		}
+	}
+
+	return ids;
+}
+
+export function extractPositionedRuns(stream: string): PositionedRun[] {
+	const runs: PositionedRun[] = [];
+	let position: { x: number; y: number } | null = null;
+
+	for (const line of stream.split("\n")) {
+		const textMatrix = /^1 0 0 1 (-?[\d.]+) (-?[\d.]+) Tm$/.exec(line);
+		if (textMatrix?.[1] && textMatrix[2]) {
+			position = { x: Number(textMatrix[1]), y: Number(textMatrix[2]) };
+			continue;
+		}
+
+		if (line.startsWith("[<") && position) {
+			runs.push({ glyphIds: splitGlyphIds(line), ...position });
+		}
+	}
+
+	return runs;
+}

--- a/packages/app/src/modules/declarationPdf/__tests__/helpers/pdfTextStream.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/helpers/pdfTextStream.ts
@@ -26,6 +26,10 @@ export function extractTextStream(pdf: Buffer): string {
 		if (pdf[contentStart] === 0x0a) contentStart += 1;
 
 		const contentEnd = pdf.indexOf("endstream", contentStart);
+		// Without this guard a truncated buffer yields -1, subarray() slices the
+		// whole file, and the cursor rewinds to 8 — an infinite loop.
+		if (contentEnd === -1) break;
+
 		cursor = contentEnd + "endstream".length;
 
 		try {

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfAccentRendering.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfAccentRendering.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment node
 
 import { createRequire } from "node:module";
-import { inflateSync } from "node:zlib";
 
 import {
 	Document,
@@ -14,10 +13,14 @@ import {
 import { describe, expect, it } from "vitest";
 
 import { PDF_FONT_FAMILY } from "../pdfFonts";
+import {
+	extractPositionedRuns,
+	extractTextStream,
+	type PositionedRun,
+} from "./helpers/pdfTextStream";
 
 const FONT_SIZE = 100;
 const FRENCH_DIACRITICS = "éèêëàâùûîïôöçÉÈÊÀÇ";
-const GLYPH_ID_LENGTH = 4;
 
 const marianneRegular = createRequire(import.meta.url).resolve(
 	"@gouvfr/dsfr/dist/fonts/Marianne-Regular.woff",
@@ -33,74 +36,6 @@ const styles = StyleSheet.create({
 	sample: { fontSize: FONT_SIZE },
 	superscript: { verticalAlign: "super" },
 });
-
-type PositionedRun = {
-	glyphIds: string[];
-	x: number;
-	y: number;
-};
-
-function extractTextStream(pdf: Buffer): string {
-	const inflateFailures: string[] = [];
-	let cursor = 0;
-
-	while (cursor < pdf.length) {
-		const streamStart = pdf.indexOf("stream", cursor);
-		if (streamStart === -1) break;
-
-		let contentStart = streamStart + "stream".length;
-		if (pdf[contentStart] === 0x0d) contentStart += 1;
-		if (pdf[contentStart] === 0x0a) contentStart += 1;
-
-		const contentEnd = pdf.indexOf("endstream", contentStart);
-		cursor = contentEnd + "endstream".length;
-
-		try {
-			const content = inflateSync(
-				pdf.subarray(contentStart, contentEnd),
-			).toString("latin1");
-			if (content.includes("Tf") && content.includes("TJ")) return content;
-		} catch (error) {
-			inflateFailures.push(`${streamStart}: ${String(error)}`);
-		}
-	}
-
-	throw new Error(
-		`No text content stream found in the rendered PDF (${inflateFailures.length} stream(s) could not be inflated: ${inflateFailures.join(" | ")})`,
-	);
-}
-
-function splitGlyphIds(textShowingOperands: string): string[] {
-	const ids: string[] = [];
-
-	for (const [, hex] of textShowingOperands.matchAll(/<([0-9a-f]+)>/g)) {
-		if (!hex) continue;
-		for (let i = 0; i < hex.length; i += GLYPH_ID_LENGTH) {
-			ids.push(hex.slice(i, i + GLYPH_ID_LENGTH));
-		}
-	}
-
-	return ids;
-}
-
-function extractPositionedRuns(stream: string): PositionedRun[] {
-	const runs: PositionedRun[] = [];
-	let position: { x: number; y: number } | null = null;
-
-	for (const line of stream.split("\n")) {
-		const textMatrix = /^1 0 0 1 (-?[\d.]+) (-?[\d.]+) Tm$/.exec(line);
-		if (textMatrix?.[1] && textMatrix[2]) {
-			position = { x: Number(textMatrix[1]), y: Number(textMatrix[2]) };
-			continue;
-		}
-
-		if (line.startsWith("[<") && position) {
-			runs.push({ glyphIds: splitGlyphIds(line), ...position });
-		}
-	}
-
-	return runs;
-}
 
 async function renderPositionedRuns(
 	content: React.ReactNode,

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfFontsRegistration.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfFontsRegistration.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+
+// ensurePdfFontsRegistered() is idempotent by design and @react-pdf's Font is a
+// module singleton, so each case reloads both from a fresh module graph.
+// This also keeps the registration — which points Marianne at public/dsfr/fonts,
+// generated at dev/build time — away from the rendering tests.
+async function loadFresh() {
+	vi.resetModules();
+
+	const [{ Font }, pdfFonts] = await Promise.all([
+		import("@react-pdf/renderer"),
+		import("../pdfFonts"),
+	]);
+
+	return { Font, ...pdfFonts };
+}
+
+describe("ensurePdfFontsRegistered", () => {
+	it("registers the Marianne family", async () => {
+		const { Font, ensurePdfFontsRegistered, PDF_FONT_FAMILY } =
+			await loadFresh();
+
+		ensurePdfFontsRegistered();
+
+		expect(Font.getRegisteredFontFamilies()).toContain(PDF_FONT_FAMILY);
+	});
+
+	it("disables the bundled en-US hyphenation engine", async () => {
+		const { Font, ensurePdfFontsRegistered, splitOnSoftHyphen } =
+			await loadFresh();
+
+		// Stands in for "production never called registerHyphenationCallback".
+		// If the call is ever dropped, this sentinel survives — and left to its
+		// bundled en-US patterns react-pdf cuts French copy mid-syllable
+		// ("Pourcentage" → "Pourcent-age", issue 4126).
+		const sentinel = (word: string) => [word];
+		Font.registerHyphenationCallback(sentinel);
+
+		ensurePdfFontsRegistered();
+
+		expect(Font.getHyphenationCallback()).toBe(splitOnSoftHyphen);
+	});
+});

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfHyphenation.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfHyphenation.test.tsx
@@ -146,6 +146,8 @@ describe("PDF hyphenation", () => {
 		// 40pt cannot hold "Pourcentage" at any padding. Left to its bundled
 		// en-US patterns, react-pdf cuts it into "Pourcent-" + "age" — the 12th
 		// glyph being the inserted hyphen (issue 4126).
+		// The count is exact rather than an upper bound because the word carries
+		// no ligature pair; pick another word here and that stops holding.
 		const runs = await renderHeaderCell("Pourcentage", 40);
 		const glyphIds = runs.flatMap((run) => run.glyphIds);
 

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfHyphenation.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfHyphenation.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+import { createRequire } from "node:module";
+
+import { Document, Font, Page, renderToBuffer } from "@react-pdf/renderer";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { PDF_FONT_FAMILY, splitOnSoftHyphen } from "../pdfFonts";
+import { styles } from "../recapPdfStyles";
+import { Cell, Row, Table } from "../sections/tableParts";
+import { PAY_TABLE, QUARTILE_TABLE } from "../sections/tableWidths";
+import {
+	extractPositionedRuns,
+	extractTextStream,
+} from "./helpers/pdfTextStream";
+
+// Fonts are resolved from node_modules rather than through
+// ensurePdfFontsRegistered(), which reads public/dsfr/fonts — generated at
+// dev/build time and git-ignored. The hyphenation callback, however, IS the
+// production one: registering a local stand-in would let this file pass while
+// the real PDF still hyphenates.
+const resolve = createRequire(import.meta.url).resolve;
+
+Font.register({
+	family: PDF_FONT_FAMILY,
+	fonts: [
+		{
+			src: resolve("@gouvfr/dsfr/dist/fonts/Marianne-Regular.woff"),
+			fontWeight: 400,
+		},
+		{
+			src: resolve("@gouvfr/dsfr/dist/fonts/Marianne-Bold.woff"),
+			fontWeight: 700,
+		},
+	],
+});
+Font.registerHyphenationCallback(splitOnSoftHyphen);
+
+const REGULAR = 400;
+const BOLD = 700;
+const LONG_LABEL = "Montants des tranches de rémunération horaire brute";
+
+function styleNumber(value: string | number | undefined, name: string): number {
+	if (typeof value !== "number") {
+		throw new Error(`Expected ${name} to be a number, got ${String(value)}`);
+	}
+	return value;
+}
+
+const CELL_PADDING = styleNumber(
+	styles.cell.paddingHorizontal,
+	"cell.paddingHorizontal",
+);
+const CELL_BORDER = styleNumber(
+	styles.cell.borderRightWidth,
+	"cell.borderRightWidth",
+);
+const HEADER_FONT_SIZE = styleNumber(
+	styles.cellTextBold.fontSize,
+	"cellTextBold.fontSize",
+);
+const HINT_FONT_SIZE = styleNumber(
+	styles.headerHint.fontSize,
+	"headerHint.fontSize",
+);
+
+/** Room a cell actually leaves its text, once padding and grid line are paid. */
+function contentWidth(columnWidth: number): number {
+	return columnWidth - 2 * CELL_PADDING - CELL_BORDER;
+}
+
+async function measure(
+	text: string,
+	fontSize: number,
+	fontWeight: number,
+): Promise<number> {
+	const source = Font.getFont({
+		fontFamily: PDF_FONT_FAMILY,
+		fontStyle: "normal",
+		fontWeight,
+	});
+	await source.load();
+
+	if (!source.data) throw new Error(`Font ${PDF_FONT_FAMILY} failed to load`);
+
+	const { advanceWidth } = source.data.layout(text);
+
+	return (advanceWidth / source.data.unitsPerEm) * fontSize;
+}
+
+async function renderHeaderCell(text: string, width: number) {
+	const pdf = await renderToBuffer(
+		<Document>
+			<Page size="A4">
+				<Table>
+					<Row>
+						<Cell header text={text} width={width} />
+					</Row>
+				</Table>
+			</Page>
+		</Document>,
+	);
+
+	return extractPositionedRuns(extractTextStream(pdf));
+}
+
+// Every fragment below is laid out on a line of its own — either because the
+// label carries an explicit line break (QuartileSection) or because it is the
+// whole cell. None may overflow, otherwise the engine has to break it.
+const SINGLE_LINE_HEADERS = [
+	{ text: "Pourcentage", column: QUARTILE_TABLE.num },
+	{ text: "de femmes", column: QUARTILE_TABLE.num },
+	{ text: "d'hommes", column: QUARTILE_TABLE.num },
+	{ text: "Nombre", column: QUARTILE_TABLE.num },
+	{ text: "Nombre de femmes", column: PAY_TABLE.value },
+];
+
+describe("PDF table headers", () => {
+	beforeAll(async () => {
+		await Font.load({ fontFamily: PDF_FONT_FAMILY, fontWeight: BOLD });
+		await Font.load({ fontFamily: PDF_FONT_FAMILY, fontWeight: REGULAR });
+	});
+
+	it.each(SINGLE_LINE_HEADERS)('fits "$text" inside its column', async ({
+		text,
+		column,
+	}) => {
+		const width = await measure(text, HEADER_FONT_SIZE, BOLD);
+
+		expect(width).toBeLessThanOrEqual(contentWidth(column));
+	});
+
+	it("fits the regulatory threshold hint inside the gap column", async () => {
+		const width = await measure(
+			"Seuil réglementaire : 5%",
+			HINT_FONT_SIZE,
+			REGULAR,
+		);
+
+		expect(width).toBeLessThanOrEqual(contentWidth(PAY_TABLE.gap));
+	});
+});
+
+describe("PDF hyphenation", () => {
+	it("keeps a French word whole even when its column is too narrow", async () => {
+		// 40pt cannot hold "Pourcentage" at any padding. Left to its bundled
+		// en-US patterns, react-pdf cuts it into "Pourcent-" + "age" — the 12th
+		// glyph being the inserted hyphen (issue 4126).
+		const runs = await renderHeaderCell("Pourcentage", 40);
+		const glyphIds = runs.flatMap((run) => run.glyphIds);
+
+		expect(glyphIds).toHaveLength("Pourcentage".length);
+		expect(runs).toHaveLength(1);
+	});
+
+	it("wraps a long label on a word boundary", async () => {
+		const runs = await renderHeaderCell(LONG_LABEL, QUARTILE_TABLE.tranche * 2);
+		const glyphIds = runs.flatMap((run) => run.glyphIds);
+
+		// No hyphen is inserted, so the drawn glyphs never outnumber the label's
+		// own characters — a break would add one.
+		expect(runs.length).toBeGreaterThan(1);
+		expect(glyphIds.length).toBeLessThanOrEqual(LONG_LABEL.length);
+	});
+});
+
+describe("splitOnSoftHyphen", () => {
+	it("keeps a word whole when it carries no soft hyphen", () => {
+		expect(splitOnSoftHyphen("rémunération")).toEqual(["rémunération"]);
+	});
+
+	it("breaks only where the author placed a soft hyphen", () => {
+		expect(splitOnSoftHyphen("rémuné­ration")).toEqual(["rémuné", "ration"]);
+	});
+});

--- a/packages/app/src/modules/declarationPdf/pdfFonts.ts
+++ b/packages/app/src/modules/declarationPdf/pdfFonts.ts
@@ -3,6 +3,18 @@ import { Font } from "@react-pdf/renderer";
 
 export const PDF_FONT_FAMILY = "Marianne";
 
+const SOFT_HYPHEN = "­";
+
+// Left to itself, @react-pdf/renderer hyphenates with its bundled `hyphen`
+// engine, which only ships en-US patterns. Applied to French copy they cut
+// words mid-syllable: "rémunération" renders as "ré-munéra-tion" and
+// "Pourcentage" as "Pour-cent-age" in the table headers (issue 4126).
+// Splitting on the soft hyphen instead keeps every word whole, while leaving
+// authors an explicit opt-in break point.
+export function splitOnSoftHyphen(word: string): string[] {
+	return word.split(SOFT_HYPHEN);
+}
+
 let arePdfFontsRegistered = false;
 
 export function ensurePdfFontsRegistered() {
@@ -24,6 +36,8 @@ export function ensurePdfFontsRegistered() {
 			},
 		],
 	});
+
+	Font.registerHyphenationCallback(splitOnSoftHyphen);
 
 	arePdfFontsRegistered = true;
 }

--- a/packages/app/src/modules/declarationPdf/recapPdfStyles.ts
+++ b/packages/app/src/modules/declarationPdf/recapPdfStyles.ts
@@ -180,7 +180,11 @@ export const styles = StyleSheet.create({
 		flexDirection: "row",
 	},
 	cell: {
-		paddingHorizontal: 8,
+		// Figma specifies 8, but the narrowest quartile column is 69.75pt wide:
+		// at 8 the padding eats 23% of it and "Pourcentage" (54.2pt) no longer
+		// fits on one line. 6 buys the 1.5pt it needs — and the same margin for
+		// the "Seuil réglementaire : 5%" hint, which overflowed by 0.29pt.
+		paddingHorizontal: 6,
 		paddingVertical: 4,
 		minHeight: 24,
 		borderRightWidth: 1,


### PR DESCRIPTION
Closes #4126

## Le problème n'est pas la marge

Le ticket attribue les coupures (« Montants des tranches de ré-munération », « Pourcent-age de femmes ») à des marges internes trop faibles. La mesure dit autre chose : **aucun `hyphenationCallback` n'était enregistré**, donc `@react-pdf/renderer` retombait sur son moteur de césure intégré — qui n'embarque que les motifs **en-US** et les appliquait au français.

Reproduit au caractère près avec le moteur réellement installé :

| Mot | Rendu avant |
|---|---|
| `rémunération` | `ré-munéra-tion` |
| `Pourcentage` | `Pour-cent-age` |
| `Bénéficiaires` | `Béné-fi-ci-aires` |

## Et la marge devait baisser, pas monter

`cell.paddingHorizontal` valait déjà 8 pt, soit 16 pt consommés sur une colonne de quartile large de 69,75 pt (23 %). L'augmenter aurait aggravé les coupures.

Mesures avec les métriques de la fonte Marianne, à 9 pt :

| Libellé | Largeur | Place utile à 8 pt | à 6 pt |
|---|---|---|---|
| `Pourcentage` | 54,23 pt | 52,75 pt ❌ | 56,75 pt ✅ |
| `Seuil réglementaire : 5%` | 103,29 pt | 103,00 pt ❌ | 107,00 pt ✅ |

Le second cas est un **débordement latent qui n'avait pas été signalé**, présent dans six tableaux.

Les largeurs de colonnes saturant exactement les 525 pt de zone de contenu, élargir une colonne aurait imposé d'en rétrécir une autre : c'est donc la marge qui bouge, de 8 à 6 pt — **en écart assumé avec le Figma**, qui spécifie 8.

## Uniformité

Les neuf tableaux du récapitulatif partagent tous les primitives `Table` / `Row` / `Cell`, qui composent un unique style `cell`. L'exigence « uniforme sur l'ensemble des tableaux » est donc satisfaite par construction, sans duplication à traquer.

## Tests

Les tests rendent un vrai PDF plutôt que de mocker le moteur :

- chaque libellé qui doit tenir sur une ligne est mesuré avec les métriques de fonte de react-pdf et comparé à la place réellement laissée par sa colonne (largeur − marges − filet) ;
- les glyphes dessinés sont comptés pour vérifier qu'aucun trait d'union n'est inséré, même quand la colonne est trop étroite ;
- un test vérifie que la production enregistre bien le callback.

Chacun a été vérifié en échec avant correction.