### PR TITLE
fix(layout): #3454 — poser la flèche des tuiles et cartes sur la dernière ligne du texte

### DIFF
--- a/packages/app/src/modules/layout/dsfrFixes.scss
+++ b/packages/app/src/modules/layout/dsfrFixes.scss
@@ -73,6 +73,70 @@
 	}
 }
 
+// DSFR anchors the arrow of an enlarged-link tile or card to the bottom of the
+// CARD, and `.fr-grid-row .fr-tile` stretches every tile of a row to the
+// tallest one. So the arrow drifts away from the text it belongs to, by however
+// much that sibling is taller: measured at 0px on the FAQ tile of the home
+// banner but 24px on its two neighbours, and up to 49px on the cards of Mon
+// espace (issue 3454).
+//
+// The Figma puts the arrow on the LAST LINE of the text, flush right. Anchoring
+// it to the text block instead of the card reproduces that at any height, and
+// keeps the row's equal heights untouched.
+//
+// The overlay that extends the click zone is the `::before` of the same link,
+// and it stays anchored to the card: the elements made `relative` here are the
+// text blocks, which are not ancestors of that link.
+$dsfr-icons: "/dsfr/icons";
+
+.fr-tile.fr-enlarge-link:not(.fr-tile--no-icon)
+	.fr-tile__title
+	a:not([target="_blank"])::after,
+.fr-card.fr-enlarge-link:not(.fr-card--no-icon)
+	.fr-card__title
+	a:not([target="_blank"])::after {
+	content: none;
+}
+
+.fr-tile.fr-enlarge-link:not(.fr-tile--no-icon) .fr-tile__detail,
+.fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__desc,
+.fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__end {
+	position: relative;
+}
+
+.fr-tile.fr-enlarge-link:not(.fr-tile--no-icon) .fr-tile__detail::after,
+.fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__desc::after,
+.fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__end::after {
+	content: "";
+	position: absolute;
+	right: 0;
+	bottom: 0;
+	width: 1rem;
+	// One line tall, so the icon centres on the last line rather than sitting
+	// on its baseline.
+	height: 1.5rem;
+	background-color: currentcolor;
+	color: var(--text-action-high-blue-france);
+	mask-image: url("#{$dsfr-icons}/arrows/arrow-right-line.svg");
+	mask-size: 1rem 1rem;
+	mask-position: center;
+	mask-repeat: no-repeat;
+}
+
+// Download variants keep their own glyph.
+.fr-card--download.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__desc::after,
+.fr-card--download.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__end::after,
+.fr-tile--download.fr-enlarge-link:not(.fr-tile--no-icon)
+	.fr-tile__detail::after {
+	mask-image: url("#{$dsfr-icons}/system/download-line.svg");
+}
+
+// When a card carries both blocks the icon belongs to the last one, not to both.
+.fr-card.fr-enlarge-link:not(.fr-card--no-icon)
+	.fr-card__desc:has(~ .fr-card__end)::after {
+	content: none;
+}
+
 // DSFR 1.14 sets white-space: nowrap on all table cells, which is inherited by
 // .fr-error-text rendered inside a <td>. The message overflows onto adjacent
 // columns. Target only the message to preserve nowrap on numeric data cells.

--- a/packages/app/src/modules/layout/dsfrFixes.scss
+++ b/packages/app/src/modules/layout/dsfrFixes.scss
@@ -87,8 +87,6 @@
 // The overlay that extends the click zone is the `::before` of the same link,
 // and it stays anchored to the card: the elements made `relative` here are the
 // text blocks, which are not ancestors of that link.
-$dsfr-icons: "/dsfr/icons";
-
 .fr-tile.fr-enlarge-link:not(.fr-tile--no-icon)
 	.fr-tile__title
 	a:not([target="_blank"])::after,
@@ -98,12 +96,16 @@ $dsfr-icons: "/dsfr/icons";
 	content: none;
 }
 
+// Both text blocks of each component are candidates, since a tile or a card may
+// carry either or both; the icon is then removed from all but the last one.
+.fr-tile.fr-enlarge-link:not(.fr-tile--no-icon) .fr-tile__desc,
 .fr-tile.fr-enlarge-link:not(.fr-tile--no-icon) .fr-tile__detail,
 .fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__desc,
 .fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__end {
 	position: relative;
 }
 
+.fr-tile.fr-enlarge-link:not(.fr-tile--no-icon) .fr-tile__desc::after,
 .fr-tile.fr-enlarge-link:not(.fr-tile--no-icon) .fr-tile__detail::after,
 .fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__desc::after,
 .fr-card.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__end::after {
@@ -115,9 +117,11 @@ $dsfr-icons: "/dsfr/icons";
 	// One line tall, so the icon centres on the last line rather than sitting
 	// on its baseline.
 	height: 1.5rem;
-	background-color: currentcolor;
+	// Set on the pseudo-element itself, so `currentcolor` below resolves to the
+	// action blue and not to the muted colour the text block inherits.
 	color: var(--text-action-high-blue-france);
-	mask-image: url("#{$dsfr-icons}/arrows/arrow-right-line.svg");
+	background-color: currentcolor;
+	mask-image: url("/dsfr/icons/arrows/arrow-right-line.svg");
 	mask-size: 1rem 1rem;
 	mask-position: center;
 	mask-repeat: no-repeat;
@@ -126,12 +130,17 @@ $dsfr-icons: "/dsfr/icons";
 // Download variants keep their own glyph.
 .fr-card--download.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__desc::after,
 .fr-card--download.fr-enlarge-link:not(.fr-card--no-icon) .fr-card__end::after,
+.fr-tile--download.fr-enlarge-link:not(.fr-tile--no-icon) .fr-tile__desc::after,
 .fr-tile--download.fr-enlarge-link:not(.fr-tile--no-icon)
 	.fr-tile__detail::after {
-	mask-image: url("#{$dsfr-icons}/system/download-line.svg");
+	mask-image: url("/dsfr/icons/system/download-line.svg");
 }
 
-// When a card carries both blocks the icon belongs to the last one, not to both.
+// A block followed by another text block is not the last one: only the last
+// carries the icon. `:has()` outranks the rule above on `content`, and the
+// download variants never redeclare `content`, so one icon is drawn either way.
+.fr-tile.fr-enlarge-link:not(.fr-tile--no-icon)
+	.fr-tile__desc:has(~ .fr-tile__detail)::after,
 .fr-card.fr-enlarge-link:not(.fr-card--no-icon)
 	.fr-card__desc:has(~ .fr-card__end)::after {
 	content: none;


### PR DESCRIPTION
Closes #3454

## Ce qui décroche la flèche

DSFR ancre la flèche d'une tuile ou d'une carte à lien étendu **au bas de la carte**, et `.fr-grid-row .fr-tile { height: 100% }` étire toutes les tuiles d'une rangée à la hauteur de la plus haute. La flèche s'éloigne donc de son propre texte d'autant que sa voisine est plus grande.

Mesuré au DOM sur le bandeau d'accueil — c'est la tuile FAQ, dont le titre passe sur deux lignes, qui impose la hauteur :

| Tuile | Écart texte → flèche |
|---|---|
| Questions fréquentes (FAQ) | 0 px |
| Centre d'aide | 24 px |
| Nous contacter | 24 px |
| Cartes de Mon espace / Aide | jusqu'à 49 px |

## Ce que dit le Figma

Sur le node du bandeau (`9298-91170`, page d'accueil de la maquette), la flèche est posée **sur la dernière ligne du texte**, alignée à droite — et les trois tuiles gardent des hauteurs égales, bordures bleues alignées.

C'est aussi la lecture littérale de l'énoncé d'origine : « mettre les flèches en face du texte et pas en dessous ».

## La correction

Ancrer la flèche au **bloc de texte** au lieu de la carte. Le placement devient indépendant de la hauteur de la carte, donc l'égalisation des hauteurs reste intacte.

Une seule règle, dans `dsfrFixes.scss` — déjà importé une fois au niveau racine et déjà dédié aux correctifs de rendu DSFR transverses. Aucun composant n'est touché, les cinq surfaces sont couvertes mécaniquement : les 3 tuiles du bandeau, les cartes de la page Aide, les cartes entreprise de Mon espace, et les deux jeux de cartes de téléchargement. Ces dernières gardent leur propre glyphe, et l'icône se pose sur le dernier bloc quand la carte porte à la fois une description et un pied.

> **La zone de clic étendue est préservée.** C'est le point délicat : `::before` (l'overlay de clic) et `::after` (la flèche) sont portés par le **même** lien. Passer `.fr-tile__content` en `relative` aurait réduit la zone de clic à ce seul bloc. Les éléments passés en `relative` ici sont les blocs de **texte**, qui ne sont pas des ancêtres du lien — l'overlay reste donc ancré à la carte.

## Vérification

Pas de serveur de dev disponible (la stack exige Docker), et JSDOM ne mesure pas un pseudo-élément. J'ai donc monté un banc statique servant le **vrai CSS DSFR** et le SCSS de cette PR compilé, puis mesuré au DOM via Playwright, en 1280 px et en 390 px, sur les cinq surfaces :

- exactement **une** icône par carte partout — ni doublon, ni disparition ;
- **zone de clic = boîte de la carte** sur chaque carte et chaque viewport ;
- rendu comparé au node Figma : flèche sur la dernière ligne, à ~31 px du bord droit contre ~32 px mesurés.

Captures desktop et mobile en commentaire.
