### PR TITLE
fix(cse-opinion): #3459 — typographie, largeur des tuiles et titres du dépôt d'avis

### DIFF
--- a/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
@@ -8,6 +8,9 @@
 // utility — only light (300), regular (400), bold (700) and heavy (900).
 .introText {
 	font-weight: 500;
+	// Figma: "$text-title-grey". DSFR ships the token as a custom property but
+	// no utility class for it — `fr-text-title--grey` does not exist.
+	color: var(--text-title-grey);
 }
 
 .readOnlyFieldset {

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
@@ -4,6 +4,12 @@
 	gap: 1.5rem;
 }
 
+// Figma: "MD - Texte standard - Medium" (500). DSFR ships no 500 weight
+// utility — only light (300), regular (400), bold (700) and heavy (900).
+.introText {
+	font-weight: 500;
+}
+
 .readOnlyFieldset {
 	border: none;
 	margin: 0;

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -239,18 +239,21 @@ export function Step1Opinions({
 
 				<CseStepIndicator currentStep={1} />
 
-				<p className="fr-text--md fr-mb-2w">
+				<p className={`fr-text--md fr-mb-2w ${styles.introText}`}>
 					Indiquez si le CSE a été consulté et précisez les avis émis avant de
 					soumettre votre déclaration aux services du ministère chargé du
 					Travail.
 				</p>
 				<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
 
-				{isJointEvaluation ? (
-					<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
-				) : (
-					<h2 className="fr-h6 fr-mb-3w">Première déclaration</h2>
-				)}
+				{/* A single declaration has nothing to be told apart from, so the
+				    per-declaration headings only earn their place in pairs. */}
+				{hasSecondDeclaration &&
+					(isJointEvaluation ? (
+						<h3 className="fr-h6 fr-mb-3w">Première déclaration</h3>
+					) : (
+						<h2 className="fr-h6 fr-mb-3w">Première déclaration</h2>
+					))}
 
 				<div className={styles.cardStack}>
 					<AccuracyOpinionCard

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -203,7 +203,7 @@ describe("Step1Opinions", () => {
 		expect(screen.getByText("Deuxième déclaration")).toBeInTheDocument();
 	});
 
-	it("hides second declaration section when hasSecondDeclaration is false", () => {
+	it("drops both declaration headings when there is only one declaration", () => {
 		render(
 			<Step1Opinions
 				cseDeadline={cseDeadline}
@@ -213,8 +213,17 @@ describe("Step1Opinions", () => {
 			/>,
 		);
 
-		expect(screen.getByText("Première déclaration")).toBeInTheDocument();
+		// A lone declaration has nothing to be told apart from, so numbering it
+		// only adds noise (issue 3459).
+		expect(screen.queryByText("Première déclaration")).not.toBeInTheDocument();
 		expect(screen.queryByText("Deuxième déclaration")).not.toBeInTheDocument();
+
+		// The section itself stays: only its heading goes.
+		expect(
+			screen.getByText(
+				"Exactitude des données et des méthodes de calcul de la déclaration de l'ensemble des indicateurs",
+			),
+		).toBeInTheDocument();
 	});
 
 	it("renders the submission banner for joint_evaluation path", () => {

--- a/packages/app/src/modules/cseOpinion/components/OpinionCard.module.scss
+++ b/packages/app/src/modules/cseOpinion/components/OpinionCard.module.scss
@@ -7,7 +7,9 @@
 	// ends up visibly narrower than "Défavorable". The Figma gives the options
 	// of a group equal widths filling the row, which also makes the whole tile
 	// the pointer target rather than just the words.
-	:global(.fr-fieldset__element--inline) {
+	// Scoped to the group's own options: a descendant selector would also stretch
+	// the options of any fieldset a future card variant happens to nest.
+	:global(.fr-fieldset > .fr-fieldset__element--inline) {
 		flex: 1 1 0;
 	}
 }

--- a/packages/app/src/modules/cseOpinion/components/OpinionCard.module.scss
+++ b/packages/app/src/modules/cseOpinion/components/OpinionCard.module.scss
@@ -12,4 +12,11 @@
 	:global(.fr-fieldset > .fr-fieldset__element--inline) {
 		flex: 1 1 0;
 	}
+
+	// Figma spaces the two options by 24px. DSFR's own element padding only
+	// yields 16, and it also aligns the outer tiles with the card edge — so the
+	// missing 8 are added as a column gap rather than by widening that padding.
+	:global(.fr-fieldset) {
+		column-gap: 0.5rem;
+	}
 }

--- a/packages/app/src/modules/cseOpinion/components/OpinionCard.module.scss
+++ b/packages/app/src/modules/cseOpinion/components/OpinionCard.module.scss
@@ -2,4 +2,12 @@
 	border: 1px solid var(--border-default-grey);
 	border-radius: 4px;
 	padding: 1rem;
+
+	// DSFR sizes an inline fieldset element to its own label, so "Favorable"
+	// ends up visibly narrower than "Défavorable". The Figma gives the options
+	// of a group equal widths filling the row, which also makes the whole tile
+	// the pointer target rather than just the words.
+	:global(.fr-fieldset__element--inline) {
+		flex: 1 1 0;
+	}
 }


### PR DESCRIPTION
Closes #3459

Les trois points étaient bien ouverts — confirmé par la capture jointe à #3914, qui est un rendu réel de cet écran.

## Police en medium

`fr-text--md` ne pose que la **taille** ; le poids restait à 400. DSFR n'expose aucun utilitaire 500 — seulement light (300), regular (400), bold (700) et heavy (900). La valeur du Figma passe donc par le module SCSS de l'écran, comme le fait déjà `CompliancePathOption` pour le même besoin.

Mesuré après correction : `font-weight: 500`.

## Tuiles radio pleine largeur

DSFR dimensionne un `fr-fieldset__element--inline` sur son propre libellé (`flex: 0 0 auto`), d'où « Favorable » visiblement plus étroit que « Défavorable ». Aucun override local n'existait.

Les éléments passent en `flex: 1 1 0` : largeurs égales remplissant la rangée, ce qui fait aussi de la tuile entière la cible du pointeur et non des seuls mots. Les **trois** groupes de l'écran (Favorable/Défavorable et les deux Oui/Non) sont couverts d'un coup, les deux cartes partageant le même module SCSS.

Mesuré : 386 / 386 px en 1280, et largeurs égales aussi en 390.

## Titres conditionnels

Le bloc « Deuxième déclaration » était **déjà** conditionné à `hasSecondDeclaration`. Seul « Première déclaration » restait affiché en toutes circonstances — à numéroter une déclaration unique qui n'a rien à distinguer.

La donnée existait déjà côté props (`hasSecondDeclaration`, dérivée du helper domaine `hasSubmittedSecondDeclaration`), il n'y avait rien à remonter. Le même parti pris est déjà appliqué ailleurs dans le module, sur le récapitulatif des avis.

Hiérarchie de titres vérifiée : les titres retirés étaient les seuls de leur niveau, les titres de cartes sont des paragraphes, aucun niveau n'est sauté.

## Vérification

Suite complète verte (4303 tests), typecheck, lint et format OK. Aucun test E2E n'assertait sur ces titres.

Le rendu a été mesuré au DOM sur un banc servant le vrai CSS DSFR et les modules SCSS de cette PR compilés — pas de serveur de dev disponible en local (la stack exige Docker). Capture en commentaire.
