### PR TITLE
Représentation équilibrée — modèle de données & règles domaine

### DIFF
--- a/packages/app/drizzle/0046_majestic_rocket_raccoon.sql
+++ b/packages/app/drizzle/0046_majestic_rocket_raccoon.sql
@@ -1,0 +1,41 @@
+CREATE TYPE "public"."representation_declaration_status" AS ENUM('draft', 'submitted');--> statement-breakpoint
+CREATE TYPE "public"."representation_not_computable_executives" AS ENUM('aucun_cadre_dirigeant', 'un_seul_cadre_dirigeant');--> statement-breakpoint
+CREATE TYPE "public"."representation_not_computable_members" AS ENUM('aucune_instance_dirigeante');--> statement-breakpoint
+CREATE TABLE "app_representation_campaign" (
+	"year" integer PRIMARY KEY NOT NULL,
+	"campaign_start_date" date NOT NULL,
+	"campaign_end_date" date NOT NULL,
+	"declaration_deadline" date NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "app_representation_declaration" (
+	"id" varchar(255) PRIMARY KEY NOT NULL,
+	"siren" varchar(9) NOT NULL,
+	"year" integer NOT NULL,
+	"declarant_id" varchar(255),
+	"legacy_declarant" jsonb,
+	"imported_from_v1_at" timestamp with time zone,
+	"reference_period_start" date,
+	"reference_period_end" date,
+	"executive_women_percent" numeric(5, 2),
+	"executive_men_percent" numeric(5, 2),
+	"not_computable_reason_executives" "representation_not_computable_executives",
+	"member_women_percent" numeric(5, 2),
+	"member_men_percent" numeric(5, 2),
+	"not_computable_reason_members" "representation_not_computable_members",
+	"publish_date" date,
+	"publish_url" varchar(500),
+	"publish_modalities" text,
+	"current_step" integer DEFAULT 0,
+	"status" "representation_declaration_status" DEFAULT 'draft' NOT NULL,
+	"submitted_at" timestamp with time zone,
+	"draft" jsonb,
+	"draft_updated_at" timestamp with time zone,
+	"created_at" timestamp with time zone,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "app_representation_declaration" ADD CONSTRAINT "app_representation_declaration_siren_app_company_siren_fk" FOREIGN KEY ("siren") REFERENCES "public"."app_company"("siren") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_representation_declaration" ADD CONSTRAINT "app_representation_declaration_declarant_id_app_user_id_fk" FOREIGN KEY ("declarant_id") REFERENCES "public"."app_user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "representation_declaration_siren_year_unique" ON "app_representation_declaration" USING btree ("siren","year");--> statement-breakpoint
+CREATE INDEX "representation_declaration_declarant_idx" ON "app_representation_declaration" USING btree ("declarant_id");

--- a/packages/app/drizzle/meta/0046_snapshot.json
+++ b/packages/app/drizzle/meta/0046_snapshot.json
@@ -1,3131 +1,3007 @@
 {
-  "id": "196f338f-f2fb-4e5d-8927-10fb71de8ab0",
-  "prevId": "36c80478-b55a-4d93-985c-7fe4329da20e",
-  "version": "7",
-  "dialect": "postgresql",
-  "tables": {
-    "public.app_admin_impersonation_event": {
-      "name": "app_admin_impersonation_event",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "admin_user_id": {
-          "name": "admin_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "started_at": {
-          "name": "started_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "stopped_at": {
-          "name": "stopped_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "admin_impersonation_event_admin_started_idx": {
-          "name": "admin_impersonation_event_admin_started_idx",
-          "columns": [
-            {
-              "expression": "admin_user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "started_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
-          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "admin_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_admin_impersonation_event_siren_app_company_siren_fk": {
-          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
-          "tableFrom": "app_admin_impersonation_event",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_campaign_deadline": {
-      "name": "app_campaign_deadline",
-      "schema": "",
-      "columns": {
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "gip_publication_date": {
-          "name": "gip_publication_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "campaign_start_date": {
-          "name": "campaign_start_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "public_data_release_date": {
-          "name": "public_data_release_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decl1_modification_deadline": {
-          "name": "decl1_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_justification_deadline": {
-          "name": "decl1_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl1_joint_evaluation_deadline": {
-          "name": "decl1_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_modification_deadline": {
-          "name": "decl2_modification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_justification_deadline": {
-          "name": "decl2_justification_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "decl2_joint_evaluation_deadline": {
-          "name": "decl2_joint_evaluation_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_company": {
-      "name": "app_company",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "address": {
-          "name": "address",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "naf_code": {
-          "name": "naf_code",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "naf_label": {
-          "name": "naf_label",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "region": {
-          "name": "region",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "department_code": {
-          "name": "department_code",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "department_label": {
-          "name": "department_label",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce": {
-          "name": "workforce",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "has_cse": {
-          "name": "has_cse",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "statut_diffusion": {
-          "name": "statut_diffusion",
-          "type": "varchar(1)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion_file": {
-      "name": "app_cse_opinion_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_id": {
-          "name": "file_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_file_declaration_idx": {
-          "name": "cse_opinion_file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_cse_opinion_file_file_id_app_file_id_fk": {
-          "name": "app_cse_opinion_file_file_id_app_file_id_fk",
-          "tableFrom": "app_cse_opinion_file",
-          "tableTo": "app_file",
-          "columnsFrom": [
-            "file_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_file_decl_number_type_idx": {
-          "name": "cse_opinion_file_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_cse_opinion": {
-      "name": "app_cse_opinion",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_number": {
-          "name": "declaration_number",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "gap_consulted": {
-          "name": "gap_consulted",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion": {
-          "name": "opinion",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "opinion_date": {
-          "name": "opinion_date",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cse_opinion_declaration_idx": {
-          "name": "cse_opinion_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
-          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_cse_opinion",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "cse_opinion_decl_number_type_idx": {
-          "name": "cse_opinion_decl_number_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "declaration_number",
-            "type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration_lock": {
-      "name": "app_declaration_lock",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "locked_by_user_id": {
-          "name": "locked_by_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "locked_at": {
-          "name": "locked_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "last_heartbeat_at": {
-          "name": "last_heartbeat_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "declaration_lock_declaration_id_unique": {
-          "name": "declaration_lock_declaration_id_unique",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "declaration_lock_expires_at_idx": {
-          "name": "declaration_lock_expires_at_idx",
-          "columns": [
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_lock_declaration_id_app_declaration_id_fk": {
-          "name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_declaration_lock",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "app_declaration_lock_locked_by_user_id_app_user_id_fk": {
-          "name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
-          "tableFrom": "app_declaration_lock",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "locked_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration_status_history": {
-      "name": "app_declaration_status_history",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "event_type": {
-          "name": "event_type",
-          "type": "declaration_event_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "round": {
-          "name": "round",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "actor_user_id": {
-          "name": "actor_user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "decl_status_history_declaration_idx": {
-          "name": "decl_status_history_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": false,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
-          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
-          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
-          "tableFrom": "app_declaration_status_history",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "actor_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_declaration": {
-      "name": "app_declaration",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declarant_id": {
-          "name": "declarant_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "total_women": {
-          "name": "total_women",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "total_men": {
-          "name": "total_men",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "remuneration_score": {
-          "name": "remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_remuneration_score": {
-          "name": "variable_remuneration_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "quartile_score": {
-          "name": "quartile_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "category_score": {
-          "name": "category_score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "first_declaration_path_choice": {
-          "name": "first_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_declaration_path_choice": {
-          "name": "second_declaration_path_choice",
-          "type": "compliance_path",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_women": {
-          "name": "indicator_a_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_annual_men": {
-          "name": "indicator_a_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_women": {
-          "name": "indicator_a_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_a_hourly_men": {
-          "name": "indicator_a_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_women": {
-          "name": "indicator_b_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_annual_men": {
-          "name": "indicator_b_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_women": {
-          "name": "indicator_b_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_b_hourly_men": {
-          "name": "indicator_b_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_women": {
-          "name": "indicator_c_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_annual_men": {
-          "name": "indicator_c_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_women": {
-          "name": "indicator_c_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_c_hourly_men": {
-          "name": "indicator_c_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_women": {
-          "name": "indicator_d_annual_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_annual_men": {
-          "name": "indicator_d_annual_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_women": {
-          "name": "indicator_d_hourly_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_d_hourly_men": {
-          "name": "indicator_d_hourly_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_women": {
-          "name": "indicator_e_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_e_men": {
-          "name": "indicator_e_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold1": {
-          "name": "indicator_f_annual_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold2": {
-          "name": "indicator_f_annual_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_threshold3": {
-          "name": "indicator_f_annual_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women1": {
-          "name": "indicator_f_annual_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women2": {
-          "name": "indicator_f_annual_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women3": {
-          "name": "indicator_f_annual_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_women4": {
-          "name": "indicator_f_annual_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men1": {
-          "name": "indicator_f_annual_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men2": {
-          "name": "indicator_f_annual_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men3": {
-          "name": "indicator_f_annual_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_annual_men4": {
-          "name": "indicator_f_annual_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold1": {
-          "name": "indicator_f_hourly_threshold1",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold2": {
-          "name": "indicator_f_hourly_threshold2",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_threshold3": {
-          "name": "indicator_f_hourly_threshold3",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women1": {
-          "name": "indicator_f_hourly_women1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women2": {
-          "name": "indicator_f_hourly_women2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women3": {
-          "name": "indicator_f_hourly_women3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_women4": {
-          "name": "indicator_f_hourly_women4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men1": {
-          "name": "indicator_f_hourly_men1",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men2": {
-          "name": "indicator_f_hourly_men2",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men3": {
-          "name": "indicator_f_hourly_men3",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "indicator_f_hourly_men4": {
-          "name": "indicator_f_hourly_men4",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "declaration_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'draft'"
-        },
-        "second_declaration_step": {
-          "name": "second_declaration_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_start": {
-          "name": "second_decl_reference_period_start",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "second_decl_reference_period_end": {
-          "name": "second_decl_reference_period_end",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "cse_required": {
-          "name": "cse_required",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "rules_version": {
-          "name": "rules_version",
-          "type": "varchar",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'2027.1'"
-        },
-        "cancelled_at": {
-          "name": "cancelled_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft": {
-          "name": "draft",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft_updated_at": {
-          "name": "draft_updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "declarations_siren_year_active_unique": {
-          "name": "declarations_siren_year_active_unique",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "year",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "cancelled_at IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "declaration_declarant_idx": {
-          "name": "declaration_declarant_idx",
-          "columns": [
-            {
-              "expression": "declarant_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_declaration_siren_app_company_siren_fk": {
-          "name": "app_declaration_siren_app_company_siren_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_declaration_declarant_id_app_user_id_fk": {
-          "name": "app_declaration_declarant_id_app_user_id_fk",
-          "tableFrom": "app_declaration",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "declarant_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_employee_category": {
-      "name": "app_employee_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "job_category_id": {
-          "name": "job_category_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_type": {
-          "name": "declaration_type",
-          "type": "declaration_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "women_count": {
-          "name": "women_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count": {
-          "name": "men_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_women": {
-          "name": "annual_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_base_men": {
-          "name": "annual_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_women": {
-          "name": "annual_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_variable_men": {
-          "name": "annual_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_women": {
-          "name": "hourly_base_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_base_men": {
-          "name": "hourly_base_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_women": {
-          "name": "hourly_variable_women",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_variable_men": {
-          "name": "hourly_variable_men",
-          "type": "numeric",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_employee_category_job_category_id_app_job_category_id_fk": {
-          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
-          "tableFrom": "app_employee_category",
-          "tableTo": "app_job_category",
-          "columnsFrom": [
-            "job_category_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "employee_category_job_type_idx": {
-          "name": "employee_category_job_type_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "job_category_id",
-            "declaration_type"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_export": {
-      "name": "app_export",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "version": {
-          "name": "version",
-          "type": "varchar(10)",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'v1'"
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "s3_key": {
-          "name": "s3_key",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "row_count": {
-          "name": "row_count",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "export_year_version_idx": {
-          "name": "export_year_version_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "year",
-            "version"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_file": {
-      "name": "app_file",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_name": {
-          "name": "file_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "file_path": {
-          "name": "file_path",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "uploaded_at": {
-          "name": "uploaded_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "type": {
-          "name": "type",
-          "type": "file_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "file_declaration_idx": {
-          "name": "file_declaration_idx",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "file_joint_eval_unique": {
-          "name": "file_joint_eval_unique",
-          "columns": [
-            {
-              "expression": "declaration_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "\"type\" = 'joint_evaluation'",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_file_declaration_id_app_declaration_id_fk": {
-          "name": "app_file_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_file",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_gip_mds_data": {
-      "name": "app_gip_mds_data",
-      "schema": "",
-      "columns": {
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "imported_at": {
-          "name": "imported_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_start": {
-          "name": "period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "period_end": {
-          "name": "period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "workforce_ema": {
-          "name": "workforce_ema",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_global": {
-          "name": "men_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_global": {
-          "name": "women_count_annual_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_hourly_global": {
-          "name": "men_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_hourly_global": {
-          "name": "women_count_hourly_global",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "men_count_annual_variable": {
-          "name": "men_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "women_count_annual_variable": {
-          "name": "women_count_annual_variable",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_gap": {
-          "name": "global_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_women": {
-          "name": "global_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_mean_men": {
-          "name": "global_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_gap": {
-          "name": "global_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_women": {
-          "name": "global_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_mean_men": {
-          "name": "global_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_gap": {
-          "name": "variable_annual_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_women": {
-          "name": "variable_annual_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_mean_men": {
-          "name": "variable_annual_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_gap": {
-          "name": "variable_hourly_mean_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_women": {
-          "name": "variable_hourly_mean_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_mean_men": {
-          "name": "variable_hourly_mean_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_gap": {
-          "name": "global_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_women": {
-          "name": "global_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_annual_median_men": {
-          "name": "global_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_gap": {
-          "name": "global_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_women": {
-          "name": "global_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "global_hourly_median_men": {
-          "name": "global_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_gap": {
-          "name": "variable_annual_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_women": {
-          "name": "variable_annual_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_annual_median_men": {
-          "name": "variable_annual_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_gap": {
-          "name": "variable_hourly_median_gap",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_women": {
-          "name": "variable_hourly_median_women",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_hourly_median_men": {
-          "name": "variable_hourly_median_men",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_women": {
-          "name": "variable_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "variable_proportion_men": {
-          "name": "variable_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold1": {
-          "name": "annual_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold2": {
-          "name": "annual_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile_threshold3": {
-          "name": "annual_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_women": {
-          "name": "annual_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_women": {
-          "name": "annual_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_women": {
-          "name": "annual_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_women": {
-          "name": "annual_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_proportion_men": {
-          "name": "annual_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_proportion_men": {
-          "name": "annual_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_proportion_men": {
-          "name": "annual_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_proportion_men": {
-          "name": "annual_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_women_count": {
-          "name": "annual_quartile1_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_women_count": {
-          "name": "annual_quartile2_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_women_count": {
-          "name": "annual_quartile3_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_women_count": {
-          "name": "annual_quartile4_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile1_men_count": {
-          "name": "annual_quartile1_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile2_men_count": {
-          "name": "annual_quartile2_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile3_men_count": {
-          "name": "annual_quartile3_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "annual_quartile4_men_count": {
-          "name": "annual_quartile4_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold1": {
-          "name": "hourly_quartile_threshold1",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold2": {
-          "name": "hourly_quartile_threshold2",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile_threshold3": {
-          "name": "hourly_quartile_threshold3",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_women": {
-          "name": "hourly_quartile1_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_women": {
-          "name": "hourly_quartile2_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_women": {
-          "name": "hourly_quartile3_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_women": {
-          "name": "hourly_quartile4_proportion_women",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_proportion_men": {
-          "name": "hourly_quartile1_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_proportion_men": {
-          "name": "hourly_quartile2_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_proportion_men": {
-          "name": "hourly_quartile3_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_proportion_men": {
-          "name": "hourly_quartile4_proportion_men",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_women_count": {
-          "name": "hourly_quartile1_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_women_count": {
-          "name": "hourly_quartile2_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_women_count": {
-          "name": "hourly_quartile3_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_women_count": {
-          "name": "hourly_quartile4_women_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile1_men_count": {
-          "name": "hourly_quartile1_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile2_men_count": {
-          "name": "hourly_quartile2_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile3_men_count": {
-          "name": "hourly_quartile3_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "hourly_quartile4_men_count": {
-          "name": "hourly_quartile4_men_count",
-          "type": "numeric(9, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_index": {
-          "name": "confidence_index",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_exotic_contracts": {
-          "name": "confidence_exotic_contracts",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_unit_measure": {
-          "name": "confidence_unit_measure",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_suspension_ratio": {
-          "name": "confidence_suspension_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_suspensions": {
-          "name": "confidence_long_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_end_suspensions": {
-          "name": "confidence_no_end_suspensions",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_sick_leave_ratio": {
-          "name": "confidence_sick_leave_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_long_sick_leave": {
-          "name": "confidence_long_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_no_sick_leave": {
-          "name": "confidence_no_sick_leave",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota250": {
-          "name": "confidence_quota250",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_quota0": {
-          "name": "confidence_quota0",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_multi_year": {
-          "name": "confidence_multi_year",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_fp_ratio": {
-          "name": "confidence_fp_ratio",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_remuneration": {
-          "name": "confidence_extreme_remuneration",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "confidence_extreme_rate": {
-          "name": "confidence_extreme_rate",
-          "type": "numeric(9, 4)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "gip_mds_data_siren_idx": {
-          "name": "gip_mds_data_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_gip_mds_data_siren_app_company_siren_fk": {
-          "name": "app_gip_mds_data_siren_app_company_siren_fk",
-          "tableFrom": "app_gip_mds_data",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_gip_mds_data_siren_year_pk": {
-          "name": "app_gip_mds_data_siren_year_pk",
-          "columns": [
-            "siren",
-            "year"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_global_setting": {
-      "name": "app_global_setting",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true,
-          "default": 1
-        },
-        "active_campaign_year": {
-          "name": "active_campaign_year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "declaration_lock_timeout_minutes": {
-          "name": "declaration_lock_timeout_minutes",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true,
-          "default": 30
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_global_setting_updated_by_app_user_id_fk": {
-          "name": "app_global_setting_updated_by_app_user_id_fk",
-          "tableFrom": "app_global_setting",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "updated_by"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_job_category": {
-      "name": "app_job_category",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "declaration_id": {
-          "name": "declaration_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category_index": {
-          "name": "category_index",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "source": {
-          "name": "source",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {
-        "app_job_category_declaration_id_app_declaration_id_fk": {
-          "name": "app_job_category_declaration_id_app_declaration_id_fk",
-          "tableFrom": "app_job_category",
-          "tableTo": "app_declaration",
-          "columnsFrom": [
-            "declaration_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "job_category_declaration_index_idx": {
-          "name": "job_category_declaration_index_idx",
-          "nullsNotDistinct": false,
-          "columns": [
-            "declaration_id",
-            "category_index"
-          ]
-        }
-      },
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_referent": {
-      "name": "app_referent",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "region": {
-          "name": "region",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "county": {
-          "name": "county",
-          "type": "varchar(3)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "referent_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "value": {
-          "name": "value",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "principal": {
-          "name": "principal",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "substitute_name": {
-          "name": "substitute_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "substitute_email": {
-          "name": "substitute_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "referent_region_idx": {
-          "name": "referent_region_idx",
-          "columns": [
-            {
-              "expression": "region",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_representation_campaign": {
-      "name": "app_representation_campaign",
-      "schema": "",
-      "columns": {
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "campaign_start_date": {
-          "name": "campaign_start_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "campaign_end_date": {
-          "name": "campaign_end_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declaration_deadline": {
-          "name": "declaration_deadline",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_representation_declaration": {
-      "name": "app_representation_declaration",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "year": {
-          "name": "year",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "declarant_id": {
-          "name": "declarant_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "legacy_declarant": {
-          "name": "legacy_declarant",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "imported_from_v1_at": {
-          "name": "imported_from_v1_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_period_start": {
-          "name": "reference_period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "reference_period_end": {
-          "name": "reference_period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "executive_women_percent": {
-          "name": "executive_women_percent",
-          "type": "numeric(5, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "executive_men_percent": {
-          "name": "executive_men_percent",
-          "type": "numeric(5, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "not_computable_reason_executives": {
-          "name": "not_computable_reason_executives",
-          "type": "representation_not_computable_executives",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "member_women_percent": {
-          "name": "member_women_percent",
-          "type": "numeric(5, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "member_men_percent": {
-          "name": "member_men_percent",
-          "type": "numeric(5, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "not_computable_reason_members": {
-          "name": "not_computable_reason_members",
-          "type": "representation_not_computable_members",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "publish_date": {
-          "name": "publish_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "publish_url": {
-          "name": "publish_url",
-          "type": "varchar(500)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "publish_modalities": {
-          "name": "publish_modalities",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "current_step": {
-          "name": "current_step",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 0
-        },
-        "status": {
-          "name": "status",
-          "type": "representation_declaration_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'draft'"
-        },
-        "submitted_at": {
-          "name": "submitted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft": {
-          "name": "draft",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "draft_updated_at": {
-          "name": "draft_updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "representation_declaration_siren_year_unique": {
-          "name": "representation_declaration_siren_year_unique",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "year",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "representation_declaration_declarant_idx": {
-          "name": "representation_declaration_declarant_idx",
-          "columns": [
-            {
-              "expression": "declarant_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_representation_declaration_siren_app_company_siren_fk": {
-          "name": "app_representation_declaration_siren_app_company_siren_fk",
-          "tableFrom": "app_representation_declaration",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_representation_declaration_declarant_id_app_user_id_fk": {
-          "name": "app_representation_declaration_declarant_id_app_user_id_fk",
-          "tableFrom": "app_representation_declaration",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "declarant_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user_company": {
-      "name": "app_user_company",
-      "schema": "",
-      "columns": {
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "user_company_user_id_idx": {
-          "name": "user_company_user_id_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "app_user_company_user_id_app_user_id_fk": {
-          "name": "app_user_company_user_id_app_user_id_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_user",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "app_user_company_siren_app_company_siren_fk": {
-          "name": "app_user_company_siren_app_company_siren_fk",
-          "tableFrom": "app_user_company",
-          "tableTo": "app_company",
-          "columnsFrom": [
-            "siren"
-          ],
-          "columnsTo": [
-            "siren"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {
-        "app_user_company_user_id_siren_pk": {
-          "name": "app_user_company_user_id_siren_pk",
-          "columns": [
-            "user_id",
-            "siren"
-          ]
-        }
-      },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.app_user": {
-      "name": "app_user",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "first_name": {
-          "name": "first_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "last_name": {
-          "name": "last_name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email_verified": {
-          "name": "email_verified",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "phone": {
-          "name": "phone",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "is_admin": {
-          "name": "is_admin",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "audit.action_log": {
-      "name": "action_log",
-      "schema": "audit",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "varchar(255)",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_email": {
-          "name": "user_email",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "siren": {
-          "name": "siren",
-          "type": "varchar(9)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "action": {
-          "name": "action",
-          "type": "varchar(100)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "category": {
-          "name": "category",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_type": {
-          "name": "resource_type",
-          "type": "varchar(50)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "resource_id": {
-          "name": "resource_id",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "varchar(20)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "error_message": {
-          "name": "error_message",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "metadata": {
-          "name": "metadata",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "varchar(45)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "duration_ms": {
-          "name": "duration_ms",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "action_log_created_at_idx": {
-          "name": "action_log_created_at_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_user_idx": {
-          "name": "action_log_user_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_siren_idx": {
-          "name": "action_log_siren_idx",
-          "columns": [
-            {
-              "expression": "siren",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_action_idx": {
-          "name": "action_log_action_idx",
-          "columns": [
-            {
-              "expression": "action",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "action_log_category_created_at_idx": {
-          "name": "action_log_category_created_at_idx",
-          "columns": [
-            {
-              "expression": "category",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    }
-  },
-  "enums": {
-    "public.compliance_path": {
-      "name": "compliance_path",
-      "schema": "public",
-      "values": [
-        "justify",
-        "corrective_action",
-        "joint_evaluation"
-      ]
-    },
-    "public.declaration_event_type": {
-      "name": "declaration_event_type",
-      "schema": "public",
-      "values": [
-        "submit",
-        "path_choice",
-        "second_declaration_submit",
-        "joint_evaluation_submit",
-        "cse_opinion_submit",
-        "cancel",
-        "demarche_complete",
-        "step_change"
-      ]
-    },
-    "public.declaration_status": {
-      "name": "declaration_status",
-      "schema": "public",
-      "values": [
-        "draft",
-        "awaiting_compliance_path_choice",
-        "corrective_actions_chosen",
-        "joint_evaluation_chosen",
-        "awaiting_revision_choice",
-        "revised_joint_evaluation_chosen",
-        "awaiting_cse_opinion",
-        "demarche_completed"
-      ]
-    },
-    "public.declaration_type": {
-      "name": "declaration_type",
-      "schema": "public",
-      "values": [
-        "initial",
-        "correction"
-      ]
-    },
-    "public.file_type": {
-      "name": "file_type",
-      "schema": "public",
-      "values": [
-        "cse_opinion",
-        "joint_evaluation"
-      ]
-    },
-    "public.referent_type": {
-      "name": "referent_type",
-      "schema": "public",
-      "values": [
-        "email",
-        "url"
-      ]
-    },
-    "public.representation_declaration_status": {
-      "name": "representation_declaration_status",
-      "schema": "public",
-      "values": [
-        "draft",
-        "submitted"
-      ]
-    },
-    "public.representation_not_computable_executives": {
-      "name": "representation_not_computable_executives",
-      "schema": "public",
-      "values": [
-        "aucun_cadre_dirigeant",
-        "un_seul_cadre_dirigeant"
-      ]
-    },
-    "public.representation_not_computable_members": {
-      "name": "representation_not_computable_members",
-      "schema": "public",
-      "values": [
-        "aucune_instance_dirigeante"
-      ]
-    }
-  },
-  "schemas": {
-    "audit": "audit"
-  },
-  "sequences": {},
-  "roles": {},
-  "policies": {},
-  "views": {},
-  "_meta": {
-    "columns": {},
-    "schemas": {},
-    "tables": {}
-  }
+	"id": "196f338f-f2fb-4e5d-8927-10fb71de8ab0",
+	"prevId": "36c80478-b55a-4d93-985c-7fe4329da20e",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.app_admin_impersonation_event": {
+			"name": "app_admin_impersonation_event",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"admin_user_id": {
+					"name": "admin_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"started_at": {
+					"name": "started_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"stopped_at": {
+					"name": "stopped_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"admin_impersonation_event_admin_started_idx": {
+					"name": "admin_impersonation_event_admin_started_idx",
+					"columns": [
+						{
+							"expression": "admin_user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "started_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+					"name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_user",
+					"columnsFrom": ["admin_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_admin_impersonation_event_siren_app_company_siren_fk": {
+					"name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+					"tableFrom": "app_admin_impersonation_event",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_campaign_deadline": {
+			"name": "app_campaign_deadline",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"gip_publication_date": {
+					"name": "gip_publication_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"public_data_release_date": {
+					"name": "public_data_release_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"decl1_modification_deadline": {
+					"name": "decl1_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_justification_deadline": {
+					"name": "decl1_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl1_joint_evaluation_deadline": {
+					"name": "decl1_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_modification_deadline": {
+					"name": "decl2_modification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_justification_deadline": {
+					"name": "decl2_justification_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"decl2_joint_evaluation_deadline": {
+					"name": "decl2_joint_evaluation_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_company": {
+			"name": "app_company",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"address": {
+					"name": "address",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_code": {
+					"name": "naf_code",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"naf_label": {
+					"name": "naf_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"department_code": {
+					"name": "department_code",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"department_label": {
+					"name": "department_label",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce": {
+					"name": "workforce",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"has_cse": {
+					"name": "has_cse",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"statut_diffusion": {
+					"name": "statut_diffusion",
+					"type": "varchar(1)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion_file": {
+			"name": "app_cse_opinion_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_id": {
+					"name": "file_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_file_declaration_idx": {
+					"name": "cse_opinion_file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_cse_opinion_file_file_id_app_file_id_fk": {
+					"name": "app_cse_opinion_file_file_id_app_file_id_fk",
+					"tableFrom": "app_cse_opinion_file",
+					"tableTo": "app_file",
+					"columnsFrom": ["file_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_file_decl_number_type_idx": {
+					"name": "cse_opinion_file_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_cse_opinion": {
+			"name": "app_cse_opinion",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_number": {
+					"name": "declaration_number",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"gap_consulted": {
+					"name": "gap_consulted",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion": {
+					"name": "opinion",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"opinion_date": {
+					"name": "opinion_date",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"cse_opinion_declaration_idx": {
+					"name": "cse_opinion_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_cse_opinion_declaration_id_app_declaration_id_fk": {
+					"name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_cse_opinion",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"cse_opinion_decl_number_type_idx": {
+					"name": "cse_opinion_decl_number_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "declaration_number", "type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_lock": {
+			"name": "app_declaration_lock",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_by_user_id": {
+					"name": "locked_by_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"locked_at": {
+					"name": "locked_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"last_heartbeat_at": {
+					"name": "last_heartbeat_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"expires_at": {
+					"name": "expires_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"declaration_lock_declaration_id_unique": {
+					"name": "declaration_lock_declaration_id_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_lock_expires_at_idx": {
+					"name": "declaration_lock_expires_at_idx",
+					"columns": [
+						{
+							"expression": "expires_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_lock_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_lock_locked_by_user_id_app_user_id_fk": {
+					"name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_lock",
+					"tableTo": "app_user",
+					"columnsFrom": ["locked_by_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration_status_history": {
+			"name": "app_declaration_status_history",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"event_type": {
+					"name": "event_type",
+					"type": "declaration_event_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"round": {
+					"name": "round",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"actor_user_id": {
+					"name": "actor_user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"decl_status_history_declaration_idx": {
+					"name": "decl_status_history_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": false,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+					"name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"app_declaration_status_history_actor_user_id_app_user_id_fk": {
+					"name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+					"tableFrom": "app_declaration_status_history",
+					"tableTo": "app_user",
+					"columnsFrom": ["actor_user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_declaration": {
+			"name": "app_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"total_women": {
+					"name": "total_women",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_men": {
+					"name": "total_men",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"remuneration_score": {
+					"name": "remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_remuneration_score": {
+					"name": "variable_remuneration_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"quartile_score": {
+					"name": "quartile_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"category_score": {
+					"name": "category_score",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"first_declaration_path_choice": {
+					"name": "first_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_declaration_path_choice": {
+					"name": "second_declaration_path_choice",
+					"type": "compliance_path",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_women": {
+					"name": "indicator_a_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_annual_men": {
+					"name": "indicator_a_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_women": {
+					"name": "indicator_a_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_a_hourly_men": {
+					"name": "indicator_a_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_women": {
+					"name": "indicator_b_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_annual_men": {
+					"name": "indicator_b_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_women": {
+					"name": "indicator_b_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_b_hourly_men": {
+					"name": "indicator_b_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_women": {
+					"name": "indicator_c_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_annual_men": {
+					"name": "indicator_c_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_women": {
+					"name": "indicator_c_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_c_hourly_men": {
+					"name": "indicator_c_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_women": {
+					"name": "indicator_d_annual_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_annual_men": {
+					"name": "indicator_d_annual_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_women": {
+					"name": "indicator_d_hourly_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_d_hourly_men": {
+					"name": "indicator_d_hourly_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_women": {
+					"name": "indicator_e_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_e_men": {
+					"name": "indicator_e_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold1": {
+					"name": "indicator_f_annual_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold2": {
+					"name": "indicator_f_annual_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_threshold3": {
+					"name": "indicator_f_annual_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women1": {
+					"name": "indicator_f_annual_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women2": {
+					"name": "indicator_f_annual_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women3": {
+					"name": "indicator_f_annual_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_women4": {
+					"name": "indicator_f_annual_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men1": {
+					"name": "indicator_f_annual_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men2": {
+					"name": "indicator_f_annual_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men3": {
+					"name": "indicator_f_annual_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_annual_men4": {
+					"name": "indicator_f_annual_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold1": {
+					"name": "indicator_f_hourly_threshold1",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold2": {
+					"name": "indicator_f_hourly_threshold2",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_threshold3": {
+					"name": "indicator_f_hourly_threshold3",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women1": {
+					"name": "indicator_f_hourly_women1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women2": {
+					"name": "indicator_f_hourly_women2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women3": {
+					"name": "indicator_f_hourly_women3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_women4": {
+					"name": "indicator_f_hourly_women4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men1": {
+					"name": "indicator_f_hourly_men1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men2": {
+					"name": "indicator_f_hourly_men2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men3": {
+					"name": "indicator_f_hourly_men3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"indicator_f_hourly_men4": {
+					"name": "indicator_f_hourly_men4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"second_declaration_step": {
+					"name": "second_declaration_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_start": {
+					"name": "second_decl_reference_period_start",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"second_decl_reference_period_end": {
+					"name": "second_decl_reference_period_end",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"cse_required": {
+					"name": "cse_required",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"rules_version": {
+					"name": "rules_version",
+					"type": "varchar",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'2027.1'"
+				},
+				"cancelled_at": {
+					"name": "cancelled_at",
+					"type": "timestamp",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"declarations_siren_year_active_unique": {
+					"name": "declarations_siren_year_active_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "cancelled_at IS NULL",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"declaration_declarant_idx": {
+					"name": "declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_declaration_siren_app_company_siren_fk": {
+					"name": "app_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_employee_category": {
+			"name": "app_employee_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"job_category_id": {
+					"name": "job_category_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_type": {
+					"name": "declaration_type",
+					"type": "declaration_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"women_count": {
+					"name": "women_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count": {
+					"name": "men_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_women": {
+					"name": "annual_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_base_men": {
+					"name": "annual_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_women": {
+					"name": "annual_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_variable_men": {
+					"name": "annual_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_women": {
+					"name": "hourly_base_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_base_men": {
+					"name": "hourly_base_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_women": {
+					"name": "hourly_variable_women",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_variable_men": {
+					"name": "hourly_variable_men",
+					"type": "numeric",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_employee_category_job_category_id_app_job_category_id_fk": {
+					"name": "app_employee_category_job_category_id_app_job_category_id_fk",
+					"tableFrom": "app_employee_category",
+					"tableTo": "app_job_category",
+					"columnsFrom": ["job_category_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"employee_category_job_type_idx": {
+					"name": "employee_category_job_type_idx",
+					"nullsNotDistinct": false,
+					"columns": ["job_category_id", "declaration_type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_export": {
+			"name": "app_export",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"version": {
+					"name": "version",
+					"type": "varchar(10)",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'v1'"
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"s3_key": {
+					"name": "s3_key",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"row_count": {
+					"name": "row_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"export_year_version_idx": {
+					"name": "export_year_version_idx",
+					"nullsNotDistinct": false,
+					"columns": ["year", "version"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_file": {
+			"name": "app_file",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_name": {
+					"name": "file_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"file_path": {
+					"name": "file_path",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"uploaded_at": {
+					"name": "uploaded_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"type": {
+					"name": "type",
+					"type": "file_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"file_declaration_idx": {
+					"name": "file_declaration_idx",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"file_joint_eval_unique": {
+					"name": "file_joint_eval_unique",
+					"columns": [
+						{
+							"expression": "declaration_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"where": "\"type\" = 'joint_evaluation'",
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_file_declaration_id_app_declaration_id_fk": {
+					"name": "app_file_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_file",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_gip_mds_data": {
+			"name": "app_gip_mds_data",
+			"schema": "",
+			"columns": {
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"imported_at": {
+					"name": "imported_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_start": {
+					"name": "period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"period_end": {
+					"name": "period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"workforce_ema": {
+					"name": "workforce_ema",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_global": {
+					"name": "men_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_global": {
+					"name": "women_count_annual_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_hourly_global": {
+					"name": "men_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_hourly_global": {
+					"name": "women_count_hourly_global",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"men_count_annual_variable": {
+					"name": "men_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"women_count_annual_variable": {
+					"name": "women_count_annual_variable",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_gap": {
+					"name": "global_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_women": {
+					"name": "global_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_mean_men": {
+					"name": "global_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_gap": {
+					"name": "global_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_women": {
+					"name": "global_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_mean_men": {
+					"name": "global_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_gap": {
+					"name": "variable_annual_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_women": {
+					"name": "variable_annual_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_mean_men": {
+					"name": "variable_annual_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_gap": {
+					"name": "variable_hourly_mean_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_women": {
+					"name": "variable_hourly_mean_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_mean_men": {
+					"name": "variable_hourly_mean_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_gap": {
+					"name": "global_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_women": {
+					"name": "global_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_annual_median_men": {
+					"name": "global_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_gap": {
+					"name": "global_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_women": {
+					"name": "global_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"global_hourly_median_men": {
+					"name": "global_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_gap": {
+					"name": "variable_annual_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_women": {
+					"name": "variable_annual_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_annual_median_men": {
+					"name": "variable_annual_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_gap": {
+					"name": "variable_hourly_median_gap",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_women": {
+					"name": "variable_hourly_median_women",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_hourly_median_men": {
+					"name": "variable_hourly_median_men",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_women": {
+					"name": "variable_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"variable_proportion_men": {
+					"name": "variable_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold1": {
+					"name": "annual_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold2": {
+					"name": "annual_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile_threshold3": {
+					"name": "annual_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_women": {
+					"name": "annual_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_women": {
+					"name": "annual_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_women": {
+					"name": "annual_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_women": {
+					"name": "annual_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_proportion_men": {
+					"name": "annual_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_proportion_men": {
+					"name": "annual_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_proportion_men": {
+					"name": "annual_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_proportion_men": {
+					"name": "annual_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_women_count": {
+					"name": "annual_quartile1_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_women_count": {
+					"name": "annual_quartile2_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_women_count": {
+					"name": "annual_quartile3_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_women_count": {
+					"name": "annual_quartile4_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile1_men_count": {
+					"name": "annual_quartile1_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile2_men_count": {
+					"name": "annual_quartile2_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile3_men_count": {
+					"name": "annual_quartile3_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"annual_quartile4_men_count": {
+					"name": "annual_quartile4_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold1": {
+					"name": "hourly_quartile_threshold1",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold2": {
+					"name": "hourly_quartile_threshold2",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile_threshold3": {
+					"name": "hourly_quartile_threshold3",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_women": {
+					"name": "hourly_quartile1_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_women": {
+					"name": "hourly_quartile2_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_women": {
+					"name": "hourly_quartile3_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_women": {
+					"name": "hourly_quartile4_proportion_women",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_proportion_men": {
+					"name": "hourly_quartile1_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_proportion_men": {
+					"name": "hourly_quartile2_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_proportion_men": {
+					"name": "hourly_quartile3_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_proportion_men": {
+					"name": "hourly_quartile4_proportion_men",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_women_count": {
+					"name": "hourly_quartile1_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_women_count": {
+					"name": "hourly_quartile2_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_women_count": {
+					"name": "hourly_quartile3_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_women_count": {
+					"name": "hourly_quartile4_women_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile1_men_count": {
+					"name": "hourly_quartile1_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile2_men_count": {
+					"name": "hourly_quartile2_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile3_men_count": {
+					"name": "hourly_quartile3_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"hourly_quartile4_men_count": {
+					"name": "hourly_quartile4_men_count",
+					"type": "numeric(9, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_index": {
+					"name": "confidence_index",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_exotic_contracts": {
+					"name": "confidence_exotic_contracts",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_unit_measure": {
+					"name": "confidence_unit_measure",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_suspension_ratio": {
+					"name": "confidence_suspension_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_suspensions": {
+					"name": "confidence_long_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_end_suspensions": {
+					"name": "confidence_no_end_suspensions",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_sick_leave_ratio": {
+					"name": "confidence_sick_leave_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_long_sick_leave": {
+					"name": "confidence_long_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_no_sick_leave": {
+					"name": "confidence_no_sick_leave",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota250": {
+					"name": "confidence_quota250",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_quota0": {
+					"name": "confidence_quota0",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_multi_year": {
+					"name": "confidence_multi_year",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_fp_ratio": {
+					"name": "confidence_fp_ratio",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_remuneration": {
+					"name": "confidence_extreme_remuneration",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"confidence_extreme_rate": {
+					"name": "confidence_extreme_rate",
+					"type": "numeric(9, 4)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"gip_mds_data_siren_idx": {
+					"name": "gip_mds_data_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_gip_mds_data_siren_app_company_siren_fk": {
+					"name": "app_gip_mds_data_siren_app_company_siren_fk",
+					"tableFrom": "app_gip_mds_data",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_gip_mds_data_siren_year_pk": {
+					"name": "app_gip_mds_data_siren_year_pk",
+					"columns": ["siren", "year"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_global_setting": {
+			"name": "app_global_setting",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true,
+					"default": 1
+				},
+				"active_campaign_year": {
+					"name": "active_campaign_year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"declaration_lock_timeout_minutes": {
+					"name": "declaration_lock_timeout_minutes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 30
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"updated_by": {
+					"name": "updated_by",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_global_setting_updated_by_app_user_id_fk": {
+					"name": "app_global_setting_updated_by_app_user_id_fk",
+					"tableFrom": "app_global_setting",
+					"tableTo": "app_user",
+					"columnsFrom": ["updated_by"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_job_category": {
+			"name": "app_job_category",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"declaration_id": {
+					"name": "declaration_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category_index": {
+					"name": "category_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"source": {
+					"name": "source",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"app_job_category_declaration_id_app_declaration_id_fk": {
+					"name": "app_job_category_declaration_id_app_declaration_id_fk",
+					"tableFrom": "app_job_category",
+					"tableTo": "app_declaration",
+					"columnsFrom": ["declaration_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"job_category_declaration_index_idx": {
+					"name": "job_category_declaration_index_idx",
+					"nullsNotDistinct": false,
+					"columns": ["declaration_id", "category_index"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_referent": {
+			"name": "app_referent",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"county": {
+					"name": "county",
+					"type": "varchar(3)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "referent_type",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"value": {
+					"name": "value",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"principal": {
+					"name": "principal",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				},
+				"substitute_name": {
+					"name": "substitute_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"substitute_email": {
+					"name": "substitute_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"referent_region_idx": {
+					"name": "referent_region_idx",
+					"columns": [
+						{
+							"expression": "region",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_representation_campaign": {
+			"name": "app_representation_campaign",
+			"schema": "",
+			"columns": {
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"campaign_start_date": {
+					"name": "campaign_start_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"campaign_end_date": {
+					"name": "campaign_end_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declaration_deadline": {
+					"name": "declaration_deadline",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_representation_declaration": {
+			"name": "app_representation_declaration",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"year": {
+					"name": "year",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"declarant_id": {
+					"name": "declarant_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"legacy_declarant": {
+					"name": "legacy_declarant",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"imported_from_v1_at": {
+					"name": "imported_from_v1_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_period_start": {
+					"name": "reference_period_start",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"reference_period_end": {
+					"name": "reference_period_end",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"executive_women_percent": {
+					"name": "executive_women_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"executive_men_percent": {
+					"name": "executive_men_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"not_computable_reason_executives": {
+					"name": "not_computable_reason_executives",
+					"type": "representation_not_computable_executives",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_women_percent": {
+					"name": "member_women_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"member_men_percent": {
+					"name": "member_men_percent",
+					"type": "numeric(5, 2)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"not_computable_reason_members": {
+					"name": "not_computable_reason_members",
+					"type": "representation_not_computable_members",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publish_date": {
+					"name": "publish_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publish_url": {
+					"name": "publish_url",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"publish_modalities": {
+					"name": "publish_modalities",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"current_step": {
+					"name": "current_step",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"default": 0
+				},
+				"status": {
+					"name": "status",
+					"type": "representation_declaration_status",
+					"typeSchema": "public",
+					"primaryKey": false,
+					"notNull": true,
+					"default": "'draft'"
+				},
+				"submitted_at": {
+					"name": "submitted_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft": {
+					"name": "draft",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"draft_updated_at": {
+					"name": "draft_updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"representation_declaration_siren_year_unique": {
+					"name": "representation_declaration_siren_year_unique",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "year",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"representation_declaration_declarant_idx": {
+					"name": "representation_declaration_declarant_idx",
+					"columns": [
+						{
+							"expression": "declarant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_representation_declaration_siren_app_company_siren_fk": {
+					"name": "app_representation_declaration_siren_app_company_siren_fk",
+					"tableFrom": "app_representation_declaration",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_representation_declaration_declarant_id_app_user_id_fk": {
+					"name": "app_representation_declaration_declarant_id_app_user_id_fk",
+					"tableFrom": "app_representation_declaration",
+					"tableTo": "app_user",
+					"columnsFrom": ["declarant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user_company": {
+			"name": "app_user_company",
+			"schema": "",
+			"columns": {
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"user_company_user_id_idx": {
+					"name": "user_company_user_id_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"app_user_company_user_id_app_user_id_fk": {
+					"name": "app_user_company_user_id_app_user_id_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"app_user_company_siren_app_company_siren_fk": {
+					"name": "app_user_company_siren_app_company_siren_fk",
+					"tableFrom": "app_user_company",
+					"tableTo": "app_company",
+					"columnsFrom": ["siren"],
+					"columnsTo": ["siren"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"app_user_company_user_id_siren_pk": {
+					"name": "app_user_company_user_id_siren_pk",
+					"columns": ["user_id", "siren"]
+				}
+			},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.app_user": {
+			"name": "app_user",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"first_name": {
+					"name": "first_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"last_name": {
+					"name": "last_name",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"email_verified": {
+					"name": "email_verified",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"phone": {
+					"name": "phone",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"is_admin": {
+					"name": "is_admin",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"audit.action_log": {
+			"name": "action_log",
+			"schema": "audit",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "varchar(255)",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "timestamp with time zone",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_email": {
+					"name": "user_email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"siren": {
+					"name": "siren",
+					"type": "varchar(9)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"action": {
+					"name": "action",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"resource_type": {
+					"name": "resource_type",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"resource_id": {
+					"name": "resource_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"status": {
+					"name": "status",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"error_message": {
+					"name": "error_message",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"metadata": {
+					"name": "metadata",
+					"type": "jsonb",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"ip_address": {
+					"name": "ip_address",
+					"type": "varchar(45)",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"user_agent": {
+					"name": "user_agent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"duration_ms": {
+					"name": "duration_ms",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"action_log_created_at_idx": {
+					"name": "action_log_created_at_idx",
+					"columns": [
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_user_idx": {
+					"name": "action_log_user_idx",
+					"columns": [
+						{
+							"expression": "user_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_siren_idx": {
+					"name": "action_log_siren_idx",
+					"columns": [
+						{
+							"expression": "siren",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_action_idx": {
+					"name": "action_log_action_idx",
+					"columns": [
+						{
+							"expression": "action",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"action_log_category_created_at_idx": {
+					"name": "action_log_category_created_at_idx",
+					"columns": [
+						{
+							"expression": "category",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "created_at",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {
+		"public.compliance_path": {
+			"name": "compliance_path",
+			"schema": "public",
+			"values": ["justify", "corrective_action", "joint_evaluation"]
+		},
+		"public.declaration_event_type": {
+			"name": "declaration_event_type",
+			"schema": "public",
+			"values": [
+				"submit",
+				"path_choice",
+				"second_declaration_submit",
+				"joint_evaluation_submit",
+				"cse_opinion_submit",
+				"cancel",
+				"demarche_complete",
+				"step_change"
+			]
+		},
+		"public.declaration_status": {
+			"name": "declaration_status",
+			"schema": "public",
+			"values": [
+				"draft",
+				"awaiting_compliance_path_choice",
+				"corrective_actions_chosen",
+				"joint_evaluation_chosen",
+				"awaiting_revision_choice",
+				"revised_joint_evaluation_chosen",
+				"awaiting_cse_opinion",
+				"demarche_completed"
+			]
+		},
+		"public.declaration_type": {
+			"name": "declaration_type",
+			"schema": "public",
+			"values": ["initial", "correction"]
+		},
+		"public.file_type": {
+			"name": "file_type",
+			"schema": "public",
+			"values": ["cse_opinion", "joint_evaluation"]
+		},
+		"public.referent_type": {
+			"name": "referent_type",
+			"schema": "public",
+			"values": ["email", "url"]
+		},
+		"public.representation_declaration_status": {
+			"name": "representation_declaration_status",
+			"schema": "public",
+			"values": ["draft", "submitted"]
+		},
+		"public.representation_not_computable_executives": {
+			"name": "representation_not_computable_executives",
+			"schema": "public",
+			"values": ["aucun_cadre_dirigeant", "un_seul_cadre_dirigeant"]
+		},
+		"public.representation_not_computable_members": {
+			"name": "representation_not_computable_members",
+			"schema": "public",
+			"values": ["aucune_instance_dirigeante"]
+		}
+	},
+	"schemas": {
+		"audit": "audit"
+	},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
 }

--- a/packages/app/drizzle/meta/0046_snapshot.json
+++ b/packages/app/drizzle/meta/0046_snapshot.json
@@ -1,0 +1,3131 @@
+{
+  "id": "196f338f-f2fb-4e5d-8927-10fb71de8ab0",
+  "prevId": "36c80478-b55a-4d93-985c-7fe4329da20e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_admin_impersonation_event": {
+      "name": "app_admin_impersonation_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "admin_user_id": {
+          "name": "admin_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_impersonation_event_admin_started_idx": {
+          "name": "admin_impersonation_event_admin_started_idx",
+          "columns": [
+            {
+              "expression": "admin_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_admin_impersonation_event_admin_user_id_app_user_id_fk": {
+          "name": "app_admin_impersonation_event_admin_user_id_app_user_id_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "admin_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_admin_impersonation_event_siren_app_company_siren_fk": {
+          "name": "app_admin_impersonation_event_siren_app_company_siren_fk",
+          "tableFrom": "app_admin_impersonation_event",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_campaign_deadline": {
+      "name": "app_campaign_deadline",
+      "schema": "",
+      "columns": {
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gip_publication_date": {
+          "name": "gip_publication_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaign_start_date": {
+          "name": "campaign_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_data_release_date": {
+          "name": "public_data_release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decl1_modification_deadline": {
+          "name": "decl1_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_justification_deadline": {
+          "name": "decl1_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl1_joint_evaluation_deadline": {
+          "name": "decl1_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_modification_deadline": {
+          "name": "decl2_modification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_justification_deadline": {
+          "name": "decl2_justification_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decl2_joint_evaluation_deadline": {
+          "name": "decl2_joint_evaluation_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_company": {
+      "name": "app_company",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naf_code": {
+          "name": "naf_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "naf_label": {
+          "name": "naf_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_code": {
+          "name": "department_code",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department_label": {
+          "name": "department_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce": {
+          "name": "workforce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_cse": {
+          "name": "has_cse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statut_diffusion": {
+          "name": "statut_diffusion",
+          "type": "varchar(1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion_file": {
+      "name": "app_cse_opinion_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_file_declaration_idx": {
+          "name": "cse_opinion_file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_cse_opinion_file_file_id_app_file_id_fk": {
+          "name": "app_cse_opinion_file_file_id_app_file_id_fk",
+          "tableFrom": "app_cse_opinion_file",
+          "tableTo": "app_file",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_file_decl_number_type_idx": {
+          "name": "cse_opinion_file_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cse_opinion": {
+      "name": "app_cse_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_number": {
+          "name": "declaration_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gap_consulted": {
+          "name": "gap_consulted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion": {
+          "name": "opinion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_date": {
+          "name": "opinion_date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cse_opinion_declaration_idx": {
+          "name": "cse_opinion_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cse_opinion_declaration_id_app_declaration_id_fk": {
+          "name": "app_cse_opinion_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_cse_opinion",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cse_opinion_decl_number_type_idx": {
+          "name": "cse_opinion_decl_number_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "declaration_number",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration_lock": {
+      "name": "app_declaration_lock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by_user_id": {
+          "name": "locked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "declaration_lock_declaration_id_unique": {
+          "name": "declaration_lock_declaration_id_unique",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "declaration_lock_expires_at_idx": {
+          "name": "declaration_lock_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_lock_declaration_id_app_declaration_id_fk": {
+          "name": "app_declaration_lock_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_declaration_lock",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_declaration_lock_locked_by_user_id_app_user_id_fk": {
+          "name": "app_declaration_lock_locked_by_user_id_app_user_id_fk",
+          "tableFrom": "app_declaration_lock",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "locked_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration_status_history": {
+      "name": "app_declaration_status_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "declaration_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "decl_status_history_declaration_idx": {
+          "name": "decl_status_history_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_status_history_declaration_id_app_declaration_id_fk": {
+          "name": "app_declaration_status_history_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_declaration_status_history_actor_user_id_app_user_id_fk": {
+          "name": "app_declaration_status_history_actor_user_id_app_user_id_fk",
+          "tableFrom": "app_declaration_status_history",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_declaration": {
+      "name": "app_declaration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_women": {
+          "name": "total_women",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_men": {
+          "name": "total_men",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "remuneration_score": {
+          "name": "remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_remuneration_score": {
+          "name": "variable_remuneration_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quartile_score": {
+          "name": "quartile_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_score": {
+          "name": "category_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_declaration_path_choice": {
+          "name": "first_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_declaration_path_choice": {
+          "name": "second_declaration_path_choice",
+          "type": "compliance_path",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_women": {
+          "name": "indicator_a_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_annual_men": {
+          "name": "indicator_a_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_women": {
+          "name": "indicator_a_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_a_hourly_men": {
+          "name": "indicator_a_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_women": {
+          "name": "indicator_b_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_annual_men": {
+          "name": "indicator_b_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_women": {
+          "name": "indicator_b_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_b_hourly_men": {
+          "name": "indicator_b_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_women": {
+          "name": "indicator_c_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_annual_men": {
+          "name": "indicator_c_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_women": {
+          "name": "indicator_c_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_c_hourly_men": {
+          "name": "indicator_c_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_women": {
+          "name": "indicator_d_annual_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_annual_men": {
+          "name": "indicator_d_annual_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_women": {
+          "name": "indicator_d_hourly_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_d_hourly_men": {
+          "name": "indicator_d_hourly_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_women": {
+          "name": "indicator_e_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_e_men": {
+          "name": "indicator_e_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold1": {
+          "name": "indicator_f_annual_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold2": {
+          "name": "indicator_f_annual_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_threshold3": {
+          "name": "indicator_f_annual_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women1": {
+          "name": "indicator_f_annual_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women2": {
+          "name": "indicator_f_annual_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women3": {
+          "name": "indicator_f_annual_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_women4": {
+          "name": "indicator_f_annual_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men1": {
+          "name": "indicator_f_annual_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men2": {
+          "name": "indicator_f_annual_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men3": {
+          "name": "indicator_f_annual_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_annual_men4": {
+          "name": "indicator_f_annual_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold1": {
+          "name": "indicator_f_hourly_threshold1",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold2": {
+          "name": "indicator_f_hourly_threshold2",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_threshold3": {
+          "name": "indicator_f_hourly_threshold3",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women1": {
+          "name": "indicator_f_hourly_women1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women2": {
+          "name": "indicator_f_hourly_women2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women3": {
+          "name": "indicator_f_hourly_women3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_women4": {
+          "name": "indicator_f_hourly_women4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men1": {
+          "name": "indicator_f_hourly_men1",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men2": {
+          "name": "indicator_f_hourly_men2",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men3": {
+          "name": "indicator_f_hourly_men3",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indicator_f_hourly_men4": {
+          "name": "indicator_f_hourly_men4",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "declaration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "second_declaration_step": {
+          "name": "second_declaration_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_start": {
+          "name": "second_decl_reference_period_start",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "second_decl_reference_period_end": {
+          "name": "second_decl_reference_period_end",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cse_required": {
+          "name": "cse_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rules_version": {
+          "name": "rules_version",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2027.1'"
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_updated_at": {
+          "name": "draft_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "declarations_siren_year_active_unique": {
+          "name": "declarations_siren_year_active_unique",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "cancelled_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "declaration_declarant_idx": {
+          "name": "declaration_declarant_idx",
+          "columns": [
+            {
+              "expression": "declarant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_declaration_siren_app_company_siren_fk": {
+          "name": "app_declaration_siren_app_company_siren_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_declaration_declarant_id_app_user_id_fk": {
+          "name": "app_declaration_declarant_id_app_user_id_fk",
+          "tableFrom": "app_declaration",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_employee_category": {
+      "name": "app_employee_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "job_category_id": {
+          "name": "job_category_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_type": {
+          "name": "declaration_type",
+          "type": "declaration_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "women_count": {
+          "name": "women_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count": {
+          "name": "men_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_women": {
+          "name": "annual_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_base_men": {
+          "name": "annual_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_women": {
+          "name": "annual_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_variable_men": {
+          "name": "annual_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_women": {
+          "name": "hourly_base_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_base_men": {
+          "name": "hourly_base_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_women": {
+          "name": "hourly_variable_women",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_variable_men": {
+          "name": "hourly_variable_men",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_employee_category_job_category_id_app_job_category_id_fk": {
+          "name": "app_employee_category_job_category_id_app_job_category_id_fk",
+          "tableFrom": "app_employee_category",
+          "tableTo": "app_job_category",
+          "columnsFrom": [
+            "job_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employee_category_job_type_idx": {
+          "name": "employee_category_job_type_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "job_category_id",
+            "declaration_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_export": {
+      "name": "app_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "export_year_version_idx": {
+          "name": "export_year_version_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "year",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_file": {
+      "name": "app_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "file_declaration_idx": {
+          "name": "file_declaration_idx",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_joint_eval_unique": {
+          "name": "file_joint_eval_unique",
+          "columns": [
+            {
+              "expression": "declaration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"type\" = 'joint_evaluation'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_file_declaration_id_app_declaration_id_fk": {
+          "name": "app_file_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_file",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_gip_mds_data": {
+      "name": "app_gip_mds_data",
+      "schema": "",
+      "columns": {
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imported_at": {
+          "name": "imported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workforce_ema": {
+          "name": "workforce_ema",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_global": {
+          "name": "men_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_global": {
+          "name": "women_count_annual_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_hourly_global": {
+          "name": "men_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_hourly_global": {
+          "name": "women_count_hourly_global",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "men_count_annual_variable": {
+          "name": "men_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "women_count_annual_variable": {
+          "name": "women_count_annual_variable",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_gap": {
+          "name": "global_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_women": {
+          "name": "global_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_mean_men": {
+          "name": "global_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_gap": {
+          "name": "global_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_women": {
+          "name": "global_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_mean_men": {
+          "name": "global_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_gap": {
+          "name": "variable_annual_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_women": {
+          "name": "variable_annual_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_mean_men": {
+          "name": "variable_annual_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_gap": {
+          "name": "variable_hourly_mean_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_women": {
+          "name": "variable_hourly_mean_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_mean_men": {
+          "name": "variable_hourly_mean_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_gap": {
+          "name": "global_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_women": {
+          "name": "global_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_annual_median_men": {
+          "name": "global_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_gap": {
+          "name": "global_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_women": {
+          "name": "global_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_hourly_median_men": {
+          "name": "global_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_gap": {
+          "name": "variable_annual_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_women": {
+          "name": "variable_annual_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_annual_median_men": {
+          "name": "variable_annual_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_gap": {
+          "name": "variable_hourly_median_gap",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_women": {
+          "name": "variable_hourly_median_women",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_hourly_median_men": {
+          "name": "variable_hourly_median_men",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_women": {
+          "name": "variable_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variable_proportion_men": {
+          "name": "variable_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold1": {
+          "name": "annual_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold2": {
+          "name": "annual_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile_threshold3": {
+          "name": "annual_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_women": {
+          "name": "annual_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_women": {
+          "name": "annual_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_women": {
+          "name": "annual_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_women": {
+          "name": "annual_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_proportion_men": {
+          "name": "annual_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_proportion_men": {
+          "name": "annual_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_proportion_men": {
+          "name": "annual_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_proportion_men": {
+          "name": "annual_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_women_count": {
+          "name": "annual_quartile1_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_women_count": {
+          "name": "annual_quartile2_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_women_count": {
+          "name": "annual_quartile3_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_women_count": {
+          "name": "annual_quartile4_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile1_men_count": {
+          "name": "annual_quartile1_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile2_men_count": {
+          "name": "annual_quartile2_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile3_men_count": {
+          "name": "annual_quartile3_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annual_quartile4_men_count": {
+          "name": "annual_quartile4_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold1": {
+          "name": "hourly_quartile_threshold1",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold2": {
+          "name": "hourly_quartile_threshold2",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile_threshold3": {
+          "name": "hourly_quartile_threshold3",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_women": {
+          "name": "hourly_quartile1_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_women": {
+          "name": "hourly_quartile2_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_women": {
+          "name": "hourly_quartile3_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_women": {
+          "name": "hourly_quartile4_proportion_women",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_proportion_men": {
+          "name": "hourly_quartile1_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_proportion_men": {
+          "name": "hourly_quartile2_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_proportion_men": {
+          "name": "hourly_quartile3_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_proportion_men": {
+          "name": "hourly_quartile4_proportion_men",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_women_count": {
+          "name": "hourly_quartile1_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_women_count": {
+          "name": "hourly_quartile2_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_women_count": {
+          "name": "hourly_quartile3_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_women_count": {
+          "name": "hourly_quartile4_women_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile1_men_count": {
+          "name": "hourly_quartile1_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile2_men_count": {
+          "name": "hourly_quartile2_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile3_men_count": {
+          "name": "hourly_quartile3_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_quartile4_men_count": {
+          "name": "hourly_quartile4_men_count",
+          "type": "numeric(9, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_index": {
+          "name": "confidence_index",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_exotic_contracts": {
+          "name": "confidence_exotic_contracts",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_unit_measure": {
+          "name": "confidence_unit_measure",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_suspension_ratio": {
+          "name": "confidence_suspension_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_suspensions": {
+          "name": "confidence_long_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_end_suspensions": {
+          "name": "confidence_no_end_suspensions",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_sick_leave_ratio": {
+          "name": "confidence_sick_leave_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_long_sick_leave": {
+          "name": "confidence_long_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_no_sick_leave": {
+          "name": "confidence_no_sick_leave",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota250": {
+          "name": "confidence_quota250",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_quota0": {
+          "name": "confidence_quota0",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_multi_year": {
+          "name": "confidence_multi_year",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_fp_ratio": {
+          "name": "confidence_fp_ratio",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_remuneration": {
+          "name": "confidence_extreme_remuneration",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence_extreme_rate": {
+          "name": "confidence_extreme_rate",
+          "type": "numeric(9, 4)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "gip_mds_data_siren_idx": {
+          "name": "gip_mds_data_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_gip_mds_data_siren_app_company_siren_fk": {
+          "name": "app_gip_mds_data_siren_app_company_siren_fk",
+          "tableFrom": "app_gip_mds_data",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_gip_mds_data_siren_year_pk": {
+          "name": "app_gip_mds_data_siren_year_pk",
+          "columns": [
+            "siren",
+            "year"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_global_setting": {
+      "name": "app_global_setting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "active_campaign_year": {
+          "name": "active_campaign_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declaration_lock_timeout_minutes": {
+          "name": "declaration_lock_timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_global_setting_updated_by_app_user_id_fk": {
+          "name": "app_global_setting_updated_by_app_user_id_fk",
+          "tableFrom": "app_global_setting",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_job_category": {
+      "name": "app_job_category",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "declaration_id": {
+          "name": "declaration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_index": {
+          "name": "category_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_job_category_declaration_id_app_declaration_id_fk": {
+          "name": "app_job_category_declaration_id_app_declaration_id_fk",
+          "tableFrom": "app_job_category",
+          "tableTo": "app_declaration",
+          "columnsFrom": [
+            "declaration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "job_category_declaration_index_idx": {
+          "name": "job_category_declaration_index_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "declaration_id",
+            "category_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_referent": {
+      "name": "app_referent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "county": {
+          "name": "county",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "referent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal": {
+          "name": "principal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "substitute_name": {
+          "name": "substitute_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "substitute_email": {
+          "name": "substitute_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "referent_region_idx": {
+          "name": "referent_region_idx",
+          "columns": [
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_representation_campaign": {
+      "name": "app_representation_campaign",
+      "schema": "",
+      "columns": {
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_start_date": {
+          "name": "campaign_start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_end_date": {
+          "name": "campaign_end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declaration_deadline": {
+          "name": "declaration_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_representation_declaration": {
+      "name": "app_representation_declaration",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "declarant_id": {
+          "name": "declarant_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_declarant": {
+          "name": "legacy_declarant",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported_from_v1_at": {
+          "name": "imported_from_v1_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_period_start": {
+          "name": "reference_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_period_end": {
+          "name": "reference_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executive_women_percent": {
+          "name": "executive_women_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executive_men_percent": {
+          "name": "executive_men_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_computable_reason_executives": {
+          "name": "not_computable_reason_executives",
+          "type": "representation_not_computable_executives",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_women_percent": {
+          "name": "member_women_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_men_percent": {
+          "name": "member_men_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_computable_reason_members": {
+          "name": "not_computable_reason_members",
+          "type": "representation_not_computable_members",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_url": {
+          "name": "publish_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_modalities": {
+          "name": "publish_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "representation_declaration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_updated_at": {
+          "name": "draft_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "representation_declaration_siren_year_unique": {
+          "name": "representation_declaration_siren_year_unique",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "representation_declaration_declarant_idx": {
+          "name": "representation_declaration_declarant_idx",
+          "columns": [
+            {
+              "expression": "declarant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_representation_declaration_siren_app_company_siren_fk": {
+          "name": "app_representation_declaration_siren_app_company_siren_fk",
+          "tableFrom": "app_representation_declaration",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_representation_declaration_declarant_id_app_user_id_fk": {
+          "name": "app_representation_declaration_declarant_id_app_user_id_fk",
+          "tableFrom": "app_representation_declaration",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "declarant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user_company": {
+      "name": "app_user_company",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_company_user_id_idx": {
+          "name": "user_company_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_company_user_id_app_user_id_fk": {
+          "name": "app_user_company_user_id_app_user_id_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "app_user_company_siren_app_company_siren_fk": {
+          "name": "app_user_company_siren_app_company_siren_fk",
+          "tableFrom": "app_user_company",
+          "tableTo": "app_company",
+          "columnsFrom": [
+            "siren"
+          ],
+          "columnsTo": [
+            "siren"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_user_company_user_id_siren_pk": {
+          "name": "app_user_company_user_id_siren_pk",
+          "columns": [
+            "user_id",
+            "siren"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_user": {
+      "name": "app_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "audit.action_log": {
+      "name": "action_log",
+      "schema": "audit",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "siren": {
+          "name": "siren",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "action_log_created_at_idx": {
+          "name": "action_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_user_idx": {
+          "name": "action_log_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_siren_idx": {
+          "name": "action_log_siren_idx",
+          "columns": [
+            {
+              "expression": "siren",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_action_idx": {
+          "name": "action_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_log_category_created_at_idx": {
+          "name": "action_log_category_created_at_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.compliance_path": {
+      "name": "compliance_path",
+      "schema": "public",
+      "values": [
+        "justify",
+        "corrective_action",
+        "joint_evaluation"
+      ]
+    },
+    "public.declaration_event_type": {
+      "name": "declaration_event_type",
+      "schema": "public",
+      "values": [
+        "submit",
+        "path_choice",
+        "second_declaration_submit",
+        "joint_evaluation_submit",
+        "cse_opinion_submit",
+        "cancel",
+        "demarche_complete",
+        "step_change"
+      ]
+    },
+    "public.declaration_status": {
+      "name": "declaration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "awaiting_compliance_path_choice",
+        "corrective_actions_chosen",
+        "joint_evaluation_chosen",
+        "awaiting_revision_choice",
+        "revised_joint_evaluation_chosen",
+        "awaiting_cse_opinion",
+        "demarche_completed"
+      ]
+    },
+    "public.declaration_type": {
+      "name": "declaration_type",
+      "schema": "public",
+      "values": [
+        "initial",
+        "correction"
+      ]
+    },
+    "public.file_type": {
+      "name": "file_type",
+      "schema": "public",
+      "values": [
+        "cse_opinion",
+        "joint_evaluation"
+      ]
+    },
+    "public.referent_type": {
+      "name": "referent_type",
+      "schema": "public",
+      "values": [
+        "email",
+        "url"
+      ]
+    },
+    "public.representation_declaration_status": {
+      "name": "representation_declaration_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted"
+      ]
+    },
+    "public.representation_not_computable_executives": {
+      "name": "representation_not_computable_executives",
+      "schema": "public",
+      "values": [
+        "aucun_cadre_dirigeant",
+        "un_seul_cadre_dirigeant"
+      ]
+    },
+    "public.representation_not_computable_members": {
+      "name": "representation_not_computable_members",
+      "schema": "public",
+      "values": [
+        "aucune_instance_dirigeante"
+      ]
+    }
+  },
+  "schemas": {
+    "audit": "audit"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,328 +1,335 @@
 {
-	"version": "7",
-	"dialect": "postgresql",
-	"entries": [
-		{
-			"idx": 0,
-			"version": "7",
-			"when": 1771922842861,
-			"tag": "0000_fuzzy_romulus",
-			"breakpoints": true
-		},
-		{
-			"idx": 1,
-			"version": "7",
-			"when": 1771928448125,
-			"tag": "0001_worthless_dragon_lord",
-			"breakpoints": true
-		},
-		{
-			"idx": 2,
-			"version": "7",
-			"when": 1772154191182,
-			"tag": "0002_lean_khan",
-			"breakpoints": true
-		},
-		{
-			"idx": 3,
-			"version": "7",
-			"when": 1772215461501,
-			"tag": "0003_absurd_komodo",
-			"breakpoints": true
-		},
-		{
-			"idx": 4,
-			"version": "7",
-			"when": 1772223004236,
-			"tag": "0004_next_jack_murdock",
-			"breakpoints": true
-		},
-		{
-			"idx": 5,
-			"version": "7",
-			"when": 1772611200000,
-			"tag": "0005_standardize_snake_case",
-			"breakpoints": true
-		},
-		{
-			"idx": 6,
-			"version": "7",
-			"when": 1772703893318,
-			"tag": "0006_lovely_korath",
-			"breakpoints": true
-		},
-		{
-			"idx": 7,
-			"version": "7",
-			"when": 1773158962249,
-			"tag": "0007_gigantic_doctor_faustus",
-			"breakpoints": true
-		},
-		{
-			"idx": 8,
-			"version": "7",
-			"when": 1773328599101,
-			"tag": "0008_powerful_omega_flight",
-			"breakpoints": true
-		},
-		{
-			"idx": 9,
-			"version": "7",
-			"when": 1773331852632,
-			"tag": "0009_hot_vector",
-			"breakpoints": true
-		},
-		{
-			"idx": 10,
-			"version": "7",
-			"when": 1773504000000,
-			"tag": "0010_gip_mds_data",
-			"breakpoints": true
-		},
-		{
-			"idx": 11,
-			"version": "7",
-			"when": 1773936000000,
-			"tag": "0011_add_export_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 12,
-			"version": "7",
-			"when": 1774022400000,
-			"tag": "0012_export_date_to_year",
-			"breakpoints": true
-		},
-		{
-			"idx": 13,
-			"version": "7",
-			"when": 1774108800000,
-			"tag": "0013_add_gip_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 14,
-			"version": "7",
-			"when": 1774195200000,
-			"tag": "0014_drop_session_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 15,
-			"version": "7",
-			"when": 1774281600000,
-			"tag": "0015_drop_account_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 16,
-			"version": "7",
-			"when": 1774368000000,
-			"tag": "0016_link_cse_joint_eval_to_declaration",
-			"breakpoints": true
-		},
-		{
-			"idx": 17,
-			"version": "7",
-			"when": 1774874768051,
-			"tag": "0017_flatten-indicator-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 18,
-			"version": "7",
-			"when": 1774945983953,
-			"tag": "0018_rare_next_avengers",
-			"breakpoints": true
-		},
-		{
-			"idx": 19,
-			"version": "7",
-			"when": 1775050635448,
-			"tag": "0019_declaration_siren_fk",
-			"breakpoints": true
-		},
-		{
-			"idx": 20,
-			"version": "7",
-			"when": 1775200000000,
-			"tag": "0020_clean-user-columns",
-			"breakpoints": true
-		},
-		{
-			"idx": 21,
-			"version": "7",
-			"when": 1775400000000,
-			"tag": "0021_add-campaign-deadlines",
-			"breakpoints": true
-		},
-		{
-			"idx": 22,
-			"version": "7",
-			"when": 1775450000000,
-			"tag": "0022_merge_file_tables",
-			"breakpoints": true
-		},
-		{
-			"idx": 23,
-			"version": "7",
-			"when": 1775500000000,
-			"tag": "0023_add_audit_action_log",
-			"breakpoints": true
-		},
-		{
-			"idx": 24,
-			"version": "7",
-			"when": 1775600000000,
-			"tag": "0024_add_admin_impersonation_events",
-			"breakpoints": true
-		},
-		{
-			"idx": 25,
-			"version": "7",
-			"when": 1775700000000,
-			"tag": "0025_add_user_is_admin",
-			"breakpoints": true
-		},
-		{
-			"idx": 26,
-			"version": "7",
-			"when": 1775800000000,
-			"tag": "0026_add_referents_table",
-			"breakpoints": true
-		},
-		{
-			"idx": 27,
-			"version": "7",
-			"when": 1775900000000,
-			"tag": "0027_add_global_settings",
-			"breakpoints": true
-		},
-		{
-			"idx": 28,
-			"version": "7",
-			"when": 1776000000000,
-			"tag": "0028_add_cse_opinion_completed_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 29,
-			"version": "7",
-			"when": 1776100000000,
-			"tag": "0029_add_declaration_submitted_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 30,
-			"version": "7",
-			"when": 1777379362370,
-			"tag": "0030_drop_job_category_detail",
-			"breakpoints": true
-		},
-		{
-			"idx": 31,
-			"version": "7",
-			"when": 1777500000000,
-			"tag": "0031_drop_quartile_threshold4",
-			"breakpoints": true
-		},
-		{
-			"idx": 32,
-			"version": "7",
-			"when": 1778071563871,
-			"tag": "0032_sparkling_monster_badoon",
-			"breakpoints": true
-		},
-		{
-			"idx": 33,
-			"version": "7",
-			"when": 1778489783883,
-			"tag": "0033_add_cancelled_at",
-			"breakpoints": true
-		},
-		{
-			"idx": 34,
-			"version": "7",
-			"when": 1778584824979,
-			"tag": "0034_tranquil_catseye",
-			"breakpoints": true
-		},
-		{
-			"idx": 35,
-			"version": "7",
-			"when": 1778682813792,
-			"tag": "0035_status_history",
-			"breakpoints": true
-		},
-		{
-			"idx": 36,
-			"version": "7",
-			"when": 1779271468703,
-			"tag": "0036_add_step_change_event_type",
-			"breakpoints": true
-		},
-		{
-			"idx": 37,
-			"version": "7",
-			"when": 1779271468704,
-			"tag": "0037_pale_mikhail_rasputin",
-			"breakpoints": true
-		},
-		{
-			"idx": 38,
-			"version": "7",
-			"when": 1780580810342,
-			"tag": "0038_whole_unus",
-			"breakpoints": true
-		},
-		{
-			"idx": 39,
-			"version": "7",
-			"when": 1781107611122,
-			"tag": "0039_cse_opinion_file",
-			"breakpoints": true
-		},
-		{
-			"idx": 40,
-			"version": "7",
-			"when": 1781169333713,
-			"tag": "0040_reconcile_drifted_schema",
-			"breakpoints": true
-		},
-		{
-			"idx": 41,
-			"version": "7",
-			"when": 1782202160639,
-			"tag": "0041_curvy_forgotten_one",
-			"breakpoints": true
-		},
-		{
-			"idx": 42,
-			"version": "7",
-			"when": 1782977960329,
-			"tag": "0042_certain_starbolt",
-			"breakpoints": true
-		},
-		{
-			"idx": 43,
-			"version": "7",
-			"when": 1782981445390,
-			"tag": "0043_vengeful_bucky",
-			"breakpoints": true
-		},
-		{
-			"idx": 44,
-			"version": "7",
-			"when": 1782997206329,
-			"tag": "0044_natural_sentinels",
-			"breakpoints": true
-		},
-		{
-			"idx": 45,
-			"version": "7",
-			"when": 1785769520449,
-			"tag": "0045_bizarre_sphinx",
-			"breakpoints": true
-		}
-	]
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1771922842861,
+      "tag": "0000_fuzzy_romulus",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1771928448125,
+      "tag": "0001_worthless_dragon_lord",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1772154191182,
+      "tag": "0002_lean_khan",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772215461501,
+      "tag": "0003_absurd_komodo",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772223004236,
+      "tag": "0004_next_jack_murdock",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772611200000,
+      "tag": "0005_standardize_snake_case",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1772703893318,
+      "tag": "0006_lovely_korath",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1773158962249,
+      "tag": "0007_gigantic_doctor_faustus",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1773328599101,
+      "tag": "0008_powerful_omega_flight",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1773331852632,
+      "tag": "0009_hot_vector",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1773504000000,
+      "tag": "0010_gip_mds_data",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1773936000000,
+      "tag": "0011_add_export_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1774022400000,
+      "tag": "0012_export_date_to_year",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1774108800000,
+      "tag": "0013_add_gip_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1774195200000,
+      "tag": "0014_drop_session_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1774281600000,
+      "tag": "0015_drop_account_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1774368000000,
+      "tag": "0016_link_cse_joint_eval_to_declaration",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1774874768051,
+      "tag": "0017_flatten-indicator-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1774945983953,
+      "tag": "0018_rare_next_avengers",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1775050635448,
+      "tag": "0019_declaration_siren_fk",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1775200000000,
+      "tag": "0020_clean-user-columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1775400000000,
+      "tag": "0021_add-campaign-deadlines",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1775450000000,
+      "tag": "0022_merge_file_tables",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1775500000000,
+      "tag": "0023_add_audit_action_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1775600000000,
+      "tag": "0024_add_admin_impersonation_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1775700000000,
+      "tag": "0025_add_user_is_admin",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1775800000000,
+      "tag": "0026_add_referents_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1775900000000,
+      "tag": "0027_add_global_settings",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1776000000000,
+      "tag": "0028_add_cse_opinion_completed_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1776100000000,
+      "tag": "0029_add_declaration_submitted_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1777379362370,
+      "tag": "0030_drop_job_category_detail",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1777500000000,
+      "tag": "0031_drop_quartile_threshold4",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1778071563871,
+      "tag": "0032_sparkling_monster_badoon",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778489783883,
+      "tag": "0033_add_cancelled_at",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778584824979,
+      "tag": "0034_tranquil_catseye",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1778682813792,
+      "tag": "0035_status_history",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1779271468703,
+      "tag": "0036_add_step_change_event_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1779271468704,
+      "tag": "0037_pale_mikhail_rasputin",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1780580810342,
+      "tag": "0038_whole_unus",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1781107611122,
+      "tag": "0039_cse_opinion_file",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1781169333713,
+      "tag": "0040_reconcile_drifted_schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1782202160639,
+      "tag": "0041_curvy_forgotten_one",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1782977960329,
+      "tag": "0042_certain_starbolt",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1782981445390,
+      "tag": "0043_vengeful_bucky",
+      "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1782997206329,
+      "tag": "0044_natural_sentinels",
+      "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1785769520449,
+      "tag": "0045_bizarre_sphinx",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1786524807416,
+      "tag": "0046_majestic_rocket_raccoon",
+      "breakpoints": true
+    }
+  ]
 }

--- a/packages/app/drizzle/meta/_journal.json
+++ b/packages/app/drizzle/meta/_journal.json
@@ -1,335 +1,335 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1771922842861,
-      "tag": "0000_fuzzy_romulus",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1771928448125,
-      "tag": "0001_worthless_dragon_lord",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1772154191182,
-      "tag": "0002_lean_khan",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1772215461501,
-      "tag": "0003_absurd_komodo",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1772223004236,
-      "tag": "0004_next_jack_murdock",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1772611200000,
-      "tag": "0005_standardize_snake_case",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1772703893318,
-      "tag": "0006_lovely_korath",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1773158962249,
-      "tag": "0007_gigantic_doctor_faustus",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1773328599101,
-      "tag": "0008_powerful_omega_flight",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1773331852632,
-      "tag": "0009_hot_vector",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1773504000000,
-      "tag": "0010_gip_mds_data",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1773936000000,
-      "tag": "0011_add_export_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1774022400000,
-      "tag": "0012_export_date_to_year",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1774108800000,
-      "tag": "0013_add_gip_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1774195200000,
-      "tag": "0014_drop_session_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1774281600000,
-      "tag": "0015_drop_account_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1774368000000,
-      "tag": "0016_link_cse_joint_eval_to_declaration",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1774874768051,
-      "tag": "0017_flatten-indicator-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 18,
-      "version": "7",
-      "when": 1774945983953,
-      "tag": "0018_rare_next_avengers",
-      "breakpoints": true
-    },
-    {
-      "idx": 19,
-      "version": "7",
-      "when": 1775050635448,
-      "tag": "0019_declaration_siren_fk",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1775200000000,
-      "tag": "0020_clean-user-columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1775400000000,
-      "tag": "0021_add-campaign-deadlines",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1775450000000,
-      "tag": "0022_merge_file_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 23,
-      "version": "7",
-      "when": 1775500000000,
-      "tag": "0023_add_audit_action_log",
-      "breakpoints": true
-    },
-    {
-      "idx": 24,
-      "version": "7",
-      "when": 1775600000000,
-      "tag": "0024_add_admin_impersonation_events",
-      "breakpoints": true
-    },
-    {
-      "idx": 25,
-      "version": "7",
-      "when": 1775700000000,
-      "tag": "0025_add_user_is_admin",
-      "breakpoints": true
-    },
-    {
-      "idx": 26,
-      "version": "7",
-      "when": 1775800000000,
-      "tag": "0026_add_referents_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 27,
-      "version": "7",
-      "when": 1775900000000,
-      "tag": "0027_add_global_settings",
-      "breakpoints": true
-    },
-    {
-      "idx": 28,
-      "version": "7",
-      "when": 1776000000000,
-      "tag": "0028_add_cse_opinion_completed_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 29,
-      "version": "7",
-      "when": 1776100000000,
-      "tag": "0029_add_declaration_submitted_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 30,
-      "version": "7",
-      "when": 1777379362370,
-      "tag": "0030_drop_job_category_detail",
-      "breakpoints": true
-    },
-    {
-      "idx": 31,
-      "version": "7",
-      "when": 1777500000000,
-      "tag": "0031_drop_quartile_threshold4",
-      "breakpoints": true
-    },
-    {
-      "idx": 32,
-      "version": "7",
-      "when": 1778071563871,
-      "tag": "0032_sparkling_monster_badoon",
-      "breakpoints": true
-    },
-    {
-      "idx": 33,
-      "version": "7",
-      "when": 1778489783883,
-      "tag": "0033_add_cancelled_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 34,
-      "version": "7",
-      "when": 1778584824979,
-      "tag": "0034_tranquil_catseye",
-      "breakpoints": true
-    },
-    {
-      "idx": 35,
-      "version": "7",
-      "when": 1778682813792,
-      "tag": "0035_status_history",
-      "breakpoints": true
-    },
-    {
-      "idx": 36,
-      "version": "7",
-      "when": 1779271468703,
-      "tag": "0036_add_step_change_event_type",
-      "breakpoints": true
-    },
-    {
-      "idx": 37,
-      "version": "7",
-      "when": 1779271468704,
-      "tag": "0037_pale_mikhail_rasputin",
-      "breakpoints": true
-    },
-    {
-      "idx": 38,
-      "version": "7",
-      "when": 1780580810342,
-      "tag": "0038_whole_unus",
-      "breakpoints": true
-    },
-    {
-      "idx": 39,
-      "version": "7",
-      "when": 1781107611122,
-      "tag": "0039_cse_opinion_file",
-      "breakpoints": true
-    },
-    {
-      "idx": 40,
-      "version": "7",
-      "when": 1781169333713,
-      "tag": "0040_reconcile_drifted_schema",
-      "breakpoints": true
-    },
-    {
-      "idx": 41,
-      "version": "7",
-      "when": 1782202160639,
-      "tag": "0041_curvy_forgotten_one",
-      "breakpoints": true
-    },
-    {
-      "idx": 42,
-      "version": "7",
-      "when": 1782977960329,
-      "tag": "0042_certain_starbolt",
-      "breakpoints": true
-    },
-    {
-      "idx": 43,
-      "version": "7",
-      "when": 1782981445390,
-      "tag": "0043_vengeful_bucky",
-      "breakpoints": true
-    },
-    {
-      "idx": 44,
-      "version": "7",
-      "when": 1782997206329,
-      "tag": "0044_natural_sentinels",
-      "breakpoints": true
-    },
-    {
-      "idx": 45,
-      "version": "7",
-      "when": 1785769520449,
-      "tag": "0045_bizarre_sphinx",
-      "breakpoints": true
-    },
-    {
-      "idx": 46,
-      "version": "7",
-      "when": 1786524807416,
-      "tag": "0046_majestic_rocket_raccoon",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1771922842861,
+			"tag": "0000_fuzzy_romulus",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1771928448125,
+			"tag": "0001_worthless_dragon_lord",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1772154191182,
+			"tag": "0002_lean_khan",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1772215461501,
+			"tag": "0003_absurd_komodo",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1772223004236,
+			"tag": "0004_next_jack_murdock",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1772611200000,
+			"tag": "0005_standardize_snake_case",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1772703893318,
+			"tag": "0006_lovely_korath",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1773158962249,
+			"tag": "0007_gigantic_doctor_faustus",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1773328599101,
+			"tag": "0008_powerful_omega_flight",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1773331852632,
+			"tag": "0009_hot_vector",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1773504000000,
+			"tag": "0010_gip_mds_data",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1773936000000,
+			"tag": "0011_add_export_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1774022400000,
+			"tag": "0012_export_date_to_year",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1774108800000,
+			"tag": "0013_add_gip_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1774195200000,
+			"tag": "0014_drop_session_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1774281600000,
+			"tag": "0015_drop_account_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1774368000000,
+			"tag": "0016_link_cse_joint_eval_to_declaration",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1774874768051,
+			"tag": "0017_flatten-indicator-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 18,
+			"version": "7",
+			"when": 1774945983953,
+			"tag": "0018_rare_next_avengers",
+			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "7",
+			"when": 1775050635448,
+			"tag": "0019_declaration_siren_fk",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1775200000000,
+			"tag": "0020_clean-user-columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1775400000000,
+			"tag": "0021_add-campaign-deadlines",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1775450000000,
+			"tag": "0022_merge_file_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1775500000000,
+			"tag": "0023_add_audit_action_log",
+			"breakpoints": true
+		},
+		{
+			"idx": 24,
+			"version": "7",
+			"when": 1775600000000,
+			"tag": "0024_add_admin_impersonation_events",
+			"breakpoints": true
+		},
+		{
+			"idx": 25,
+			"version": "7",
+			"when": 1775700000000,
+			"tag": "0025_add_user_is_admin",
+			"breakpoints": true
+		},
+		{
+			"idx": 26,
+			"version": "7",
+			"when": 1775800000000,
+			"tag": "0026_add_referents_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 27,
+			"version": "7",
+			"when": 1775900000000,
+			"tag": "0027_add_global_settings",
+			"breakpoints": true
+		},
+		{
+			"idx": 28,
+			"version": "7",
+			"when": 1776000000000,
+			"tag": "0028_add_cse_opinion_completed_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 29,
+			"version": "7",
+			"when": 1776100000000,
+			"tag": "0029_add_declaration_submitted_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 30,
+			"version": "7",
+			"when": 1777379362370,
+			"tag": "0030_drop_job_category_detail",
+			"breakpoints": true
+		},
+		{
+			"idx": 31,
+			"version": "7",
+			"when": 1777500000000,
+			"tag": "0031_drop_quartile_threshold4",
+			"breakpoints": true
+		},
+		{
+			"idx": 32,
+			"version": "7",
+			"when": 1778071563871,
+			"tag": "0032_sparkling_monster_badoon",
+			"breakpoints": true
+		},
+		{
+			"idx": 33,
+			"version": "7",
+			"when": 1778489783883,
+			"tag": "0033_add_cancelled_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 34,
+			"version": "7",
+			"when": 1778584824979,
+			"tag": "0034_tranquil_catseye",
+			"breakpoints": true
+		},
+		{
+			"idx": 35,
+			"version": "7",
+			"when": 1778682813792,
+			"tag": "0035_status_history",
+			"breakpoints": true
+		},
+		{
+			"idx": 36,
+			"version": "7",
+			"when": 1779271468703,
+			"tag": "0036_add_step_change_event_type",
+			"breakpoints": true
+		},
+		{
+			"idx": 37,
+			"version": "7",
+			"when": 1779271468704,
+			"tag": "0037_pale_mikhail_rasputin",
+			"breakpoints": true
+		},
+		{
+			"idx": 38,
+			"version": "7",
+			"when": 1780580810342,
+			"tag": "0038_whole_unus",
+			"breakpoints": true
+		},
+		{
+			"idx": 39,
+			"version": "7",
+			"when": 1781107611122,
+			"tag": "0039_cse_opinion_file",
+			"breakpoints": true
+		},
+		{
+			"idx": 40,
+			"version": "7",
+			"when": 1781169333713,
+			"tag": "0040_reconcile_drifted_schema",
+			"breakpoints": true
+		},
+		{
+			"idx": 41,
+			"version": "7",
+			"when": 1782202160639,
+			"tag": "0041_curvy_forgotten_one",
+			"breakpoints": true
+		},
+		{
+			"idx": 42,
+			"version": "7",
+			"when": 1782977960329,
+			"tag": "0042_certain_starbolt",
+			"breakpoints": true
+		},
+		{
+			"idx": 43,
+			"version": "7",
+			"when": 1782981445390,
+			"tag": "0043_vengeful_bucky",
+			"breakpoints": true
+		},
+		{
+			"idx": 44,
+			"version": "7",
+			"when": 1782997206329,
+			"tag": "0044_natural_sentinels",
+			"breakpoints": true
+		},
+		{
+			"idx": 45,
+			"version": "7",
+			"when": 1785769520449,
+			"tag": "0045_bizarre_sphinx",
+			"breakpoints": true
+		},
+		{
+			"idx": 46,
+			"version": "7",
+			"when": 1786524807416,
+			"tag": "0046_majestic_rocket_raccoon",
+			"breakpoints": true
+		}
+	]
 }

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -4,6 +4,7 @@ import {
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
+	getDefaultRepresentationCampaign,
 	getPathChoiceDeadline,
 	getReferencePeriod,
 	getReferenceYearFor,
@@ -11,6 +12,7 @@ import {
 	getSecondDeclarationDeadline,
 	getWorkforceYear,
 	isDeadlinePassed,
+	isRepresentationCampaignOpen,
 	shouldRedirectSubmittedToRecap,
 } from "../shared/campaign";
 
@@ -147,6 +149,75 @@ describe("getDefaultCampaignDeadlines", () => {
 		const deadlines = getDefaultCampaignDeadlines(2027);
 		expect(deadlines.gipPublicationDate).toBeNull();
 		expect(deadlines.campaignStartDate).toBeNull();
+	});
+});
+
+describe("getDefaultRepresentationCampaign", () => {
+	it("opens on January 1st and closes on December 31st of the campaign year", () => {
+		const campaign = getDefaultRepresentationCampaign(2027);
+		expect(campaign.campaignStartDate).toEqual(new Date(2027, 0, 1));
+		expect(campaign.campaignEndDate).toEqual(new Date(2027, 11, 31));
+	});
+
+	it("sets the declaration deadline on March 1st of the campaign year", () => {
+		expect(getDefaultRepresentationCampaign(2027).declarationDeadline).toEqual(
+			new Date(2027, 2, 1),
+		);
+	});
+
+	it("follows the requested campaign year", () => {
+		const campaign = getDefaultRepresentationCampaign(2030);
+		expect(campaign.campaignStartDate).toEqual(new Date(2030, 0, 1));
+		expect(campaign.campaignEndDate).toEqual(new Date(2030, 11, 31));
+		expect(campaign.declarationDeadline).toEqual(new Date(2030, 2, 1));
+	});
+});
+
+describe("isRepresentationCampaignOpen", () => {
+	const campaign = getDefaultRepresentationCampaign(2027);
+
+	it("returns false the day before the campaign starts", () => {
+		expect(isRepresentationCampaignOpen(campaign, new Date(2026, 11, 31))).toBe(
+			false,
+		);
+	});
+
+	it("returns true on the first day of the campaign", () => {
+		expect(isRepresentationCampaignOpen(campaign, new Date(2027, 0, 1))).toBe(
+			true,
+		);
+	});
+
+	it("returns true in the middle of the campaign", () => {
+		expect(isRepresentationCampaignOpen(campaign, new Date(2027, 5, 15))).toBe(
+			true,
+		);
+	});
+
+	it("returns true on the campaign end boundary", () => {
+		expect(isRepresentationCampaignOpen(campaign, new Date(2027, 11, 31))).toBe(
+			true,
+		);
+	});
+
+	it("returns false the day after the campaign ends", () => {
+		expect(isRepresentationCampaignOpen(campaign, new Date(2028, 0, 1))).toBe(
+			false,
+		);
+	});
+
+	it("honours the campaign dates over the default ones", () => {
+		const overridden = {
+			campaignStartDate: new Date(2027, 2, 1),
+			campaignEndDate: new Date(2027, 5, 30),
+			declarationDeadline: new Date(2027, 2, 1),
+		};
+		expect(
+			isRepresentationCampaignOpen(overridden, new Date(2027, 0, 15)),
+		).toBe(false);
+		expect(
+			isRepresentationCampaignOpen(overridden, new Date(2027, 3, 15)),
+		).toBe(true);
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/representation.test.ts
+++ b/packages/app/src/modules/domain/__tests__/representation.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	computeRepresentationVerdict,
+	deriveExecutivesNotComputableReason,
+	getRepresentationCampaignYear,
+	getRepresentationTarget,
+	REPRESENTATION_TARGET_INITIAL,
+	REPRESENTATION_TARGET_RAISED,
+	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
+} from "../shared/representation";
+
+describe("regulatory constants", () => {
+	// art. D. 1142-19 — every threshold test below is symbolic, so the literal
+	// values are pinned here to catch a silent drift of the regulation.
+	it("pins the initial target at 30%", () => {
+		expect(REPRESENTATION_TARGET_INITIAL).toBe(30);
+	});
+
+	it("pins the raised target at 40%", () => {
+		expect(REPRESENTATION_TARGET_RAISED).toBe(40);
+	});
+
+	it("pins the raised-target campaign year at 2029", () => {
+		expect(REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR).toBe(2029);
+	});
+});
+
+describe("getRepresentationTarget", () => {
+	it("returns 30 for campaigns before 2029", () => {
+		expect(getRepresentationTarget(2027)).toBe(REPRESENTATION_TARGET_INITIAL);
+		expect(getRepresentationTarget(2028)).toBe(REPRESENTATION_TARGET_INITIAL);
+	});
+
+	it("returns 40 from the 2029 campaign onwards", () => {
+		expect(getRepresentationTarget(2029)).toBe(REPRESENTATION_TARGET_RAISED);
+		expect(getRepresentationTarget(2030)).toBe(REPRESENTATION_TARGET_RAISED);
+	});
+});
+
+describe("computeRepresentationVerdict", () => {
+	it("returns compliant when both percentages reach the 30% target (S13)", () => {
+		expect(computeRepresentationVerdict(35, 65, 2027)).toBe("compliant");
+	});
+
+	it("returns compliant when the lowest percentage equals the target", () => {
+		expect(computeRepresentationVerdict(30, 70, 2027)).toBe("compliant");
+		expect(computeRepresentationVerdict(70, 30, 2027)).toBe("compliant");
+	});
+
+	it("returns non_compliant when the lowest percentage is below the target (S14)", () => {
+		expect(computeRepresentationVerdict(25, 75, 2027)).toBe("non_compliant");
+		expect(computeRepresentationVerdict(75, 25, 2027)).toBe("non_compliant");
+	});
+
+	it("returns non_compliant just below the target boundary", () => {
+		expect(computeRepresentationVerdict(29.99, 70.01, 2027)).toBe(
+			"non_compliant",
+		);
+	});
+
+	it("returns non_compliant for 35/65 once the target is raised in 2029 (S14)", () => {
+		expect(computeRepresentationVerdict(35, 65, 2029)).toBe("non_compliant");
+	});
+
+	it("returns compliant when both percentages reach the raised 40% target", () => {
+		expect(computeRepresentationVerdict(40, 60, 2029)).toBe("compliant");
+		expect(computeRepresentationVerdict(45, 55, 2030)).toBe("compliant");
+	});
+
+	it("returns not_applicable when the women percentage is null (S15)", () => {
+		expect(computeRepresentationVerdict(null, 65, 2027)).toBe("not_applicable");
+	});
+
+	it("returns not_applicable when the men percentage is null (S15)", () => {
+		expect(computeRepresentationVerdict(35, null, 2027)).toBe("not_applicable");
+	});
+
+	it("returns not_applicable when both percentages are null (S15)", () => {
+		expect(computeRepresentationVerdict(null, null, 2027)).toBe(
+			"not_applicable",
+		);
+	});
+
+	it("treats a 0% share as a computed value, not as a missing one", () => {
+		expect(computeRepresentationVerdict(0, 100, 2027)).toBe("non_compliant");
+		expect(computeRepresentationVerdict(100, 0, 2029)).toBe("non_compliant");
+	});
+});
+
+describe("deriveExecutivesNotComputableReason", () => {
+	it("returns aucun_cadre_dirigeant when there is no executive", () => {
+		expect(deriveExecutivesNotComputableReason("none")).toBe(
+			"aucun_cadre_dirigeant",
+		);
+	});
+
+	it("returns un_seul_cadre_dirigeant when there is a single executive", () => {
+		expect(deriveExecutivesNotComputableReason("one")).toBe(
+			"un_seul_cadre_dirigeant",
+		);
+	});
+
+	it("returns null when the indicator is computable", () => {
+		expect(deriveExecutivesNotComputableReason("two_or_more")).toBeNull();
+	});
+});
+
+describe("getRepresentationCampaignYear", () => {
+	it("returns the reference year plus one", () => {
+		expect(getRepresentationCampaignYear(2026)).toBe(2027);
+		expect(getRepresentationCampaignYear(2028)).toBe(2029);
+	});
+});
+
+describe("verdict independence (S16)", () => {
+	// Each indicator carries its own verdict: an aggregated verdict would let a
+	// compliant indicator mask a non-compliant one, so the module surface is
+	// pinned to prove no such helper exists.
+	it("exposes no aggregated verdict helper", async () => {
+		const representation = await import("../shared/representation");
+		expect(Object.keys(representation).sort()).toEqual([
+			"REPRESENTATION_TARGET_INITIAL",
+			"REPRESENTATION_TARGET_RAISED",
+			"REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR",
+			"computeRepresentationVerdict",
+			"deriveExecutivesNotComputableReason",
+			"getRepresentationCampaignYear",
+			"getRepresentationTarget",
+		]);
+	});
+
+	it("computes each indicator verdict from its own percentages only", () => {
+		const executives = computeRepresentationVerdict(35, 65, 2027);
+		const members = computeRepresentationVerdict(25, 75, 2027);
+		expect(executives).toBe("compliant");
+		expect(members).toBe("non_compliant");
+	});
+});

--- a/packages/app/src/modules/domain/__tests__/representation.test.ts
+++ b/packages/app/src/modules/domain/__tests__/representation.test.ts
@@ -11,8 +11,7 @@ import {
 } from "../shared/representation";
 
 describe("regulatory constants", () => {
-	// art. D. 1142-19 — every threshold test below is symbolic, so the literal
-	// values are pinned here to catch a silent drift of the regulation.
+	// art. D. 1142-19 — literals pinned here to catch a silent regulatory drift.
 	it("pins the initial target at 30%", () => {
 		expect(REPRESENTATION_TARGET_INITIAL).toBe(30);
 	});
@@ -114,9 +113,7 @@ describe("getRepresentationCampaignYear", () => {
 });
 
 describe("verdict independence (S16)", () => {
-	// Each indicator carries its own verdict: an aggregated verdict would let a
-	// compliant indicator mask a non-compliant one, so the module surface is
-	// pinned to prove no such helper exists.
+	// An aggregated verdict would let a compliant indicator mask a failing one.
 	it("exposes no aggregated verdict helper", async () => {
 		const representation = await import("../shared/representation");
 		expect(Object.keys(representation).sort()).toEqual([

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -5,6 +5,7 @@ export {
 	getCurrentYear,
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
+	getDefaultRepresentationCampaign,
 	getPathChoiceDeadline,
 	getReferencePeriod,
 	getReferenceYearFor,
@@ -12,6 +13,7 @@ export {
 	getSecondDeclarationDeadline,
 	getWorkforceYear,
 	isDeadlinePassed,
+	isRepresentationCampaignOpen,
 	shouldRedirectSubmittedToRecap,
 } from "./shared/campaign";
 // Campaign clock — test-only override seam behind getCurrentYear (issue #4022)
@@ -221,6 +223,20 @@ export {
 	REGIONS,
 	REGIONS_TO_COUNTIES,
 } from "./shared/regions";
+// Representation equilibrium (art. D. 1142-19)
+export type {
+	ExecutivesCount,
+	RepresentationComplianceVerdict,
+} from "./shared/representation";
+export {
+	computeRepresentationVerdict,
+	deriveExecutivesNotComputableReason,
+	getRepresentationCampaignYear,
+	getRepresentationTarget,
+	REPRESENTATION_TARGET_INITIAL,
+	REPRESENTATION_TARGET_RAISED,
+	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
+} from "./shared/representation";
 // Score brackets for public stats distribution chart
 export type { ScoreBracket, ScoreBracketId } from "./shared/scoreBracket";
 export { getScoreBracket, SCORE_BRACKETS } from "./shared/scoreBracket";
@@ -257,5 +273,6 @@ export type {
 	DeclarationType,
 	GapDirection,
 	GapLevel,
+	RepresentationCampaign,
 } from "./types";
 export { DECLARATION_FSM_STATUSES } from "./types";

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -1,4 +1,4 @@
-import type { CampaignDeadlines } from "../types";
+import type { CampaignDeadlines, RepresentationCampaign } from "../types";
 import { readCampaignYearOverride } from "./campaignClock";
 import { formatLongDate } from "./format";
 
@@ -58,6 +58,26 @@ export function getDefaultCampaignDeadlines(year: number): CampaignDeadlines {
 		decl2JointEvaluationDeadline: new Date(year + 1, 1, 1),
 		pathChoiceDeadline: getPathChoiceDeadline(year),
 	};
+}
+
+export function getDefaultRepresentationCampaign(
+	campaignYear: number,
+): RepresentationCampaign {
+	return {
+		campaignStartDate: new Date(campaignYear, 0, 1),
+		campaignEndDate: new Date(campaignYear, 11, 31),
+		declarationDeadline: new Date(campaignYear, 2, 1),
+	};
+}
+
+export function isRepresentationCampaignOpen(
+	campaign: RepresentationCampaign,
+	now: Date,
+): boolean {
+	return (
+		now.getTime() >= campaign.campaignStartDate.getTime() &&
+		now.getTime() <= campaign.campaignEndDate.getTime()
+	);
 }
 
 /** Returns true if the given deadline is strictly in the past. */

--- a/packages/app/src/modules/domain/shared/representation.ts
+++ b/packages/app/src/modules/domain/shared/representation.ts
@@ -1,0 +1,40 @@
+export const REPRESENTATION_TARGET_INITIAL = 30;
+export const REPRESENTATION_TARGET_RAISED = 40;
+export const REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR = 2029;
+
+export type RepresentationComplianceVerdict =
+	| "compliant"
+	| "non_compliant"
+	| "not_applicable";
+
+export type ExecutivesCount = "none" | "one" | "two_or_more";
+
+export function getRepresentationTarget(campaignYear: number): number {
+	return campaignYear >= REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR
+		? REPRESENTATION_TARGET_RAISED
+		: REPRESENTATION_TARGET_INITIAL;
+}
+
+export function computeRepresentationVerdict(
+	womenPercent: number | null,
+	menPercent: number | null,
+	campaignYear: number,
+): RepresentationComplianceVerdict {
+	if (womenPercent === null || menPercent === null) return "not_applicable";
+	const target = getRepresentationTarget(campaignYear);
+	return Math.min(womenPercent, menPercent) >= target
+		? "compliant"
+		: "non_compliant";
+}
+
+export function deriveExecutivesNotComputableReason(
+	count: ExecutivesCount,
+): "aucun_cadre_dirigeant" | "un_seul_cadre_dirigeant" | null {
+	if (count === "none") return "aucun_cadre_dirigeant";
+	if (count === "one") return "un_seul_cadre_dirigeant";
+	return null;
+}
+
+export function getRepresentationCampaignYear(referenceYear: number): number {
+	return referenceYear + 1;
+}

--- a/packages/app/src/modules/domain/types.ts
+++ b/packages/app/src/modules/domain/types.ts
@@ -50,3 +50,9 @@ export type CampaignDeadlines = {
 	decl2JointEvaluationDeadline: Date;
 	pathChoiceDeadline: Date;
 };
+
+export type RepresentationCampaign = {
+	campaignStartDate: Date;
+	campaignEndDate: Date;
+	declarationDeadline: Date;
+};

--- a/packages/app/src/server/db/__tests__/getRepresentationCampaign.test.ts
+++ b/packages/app/src/server/db/__tests__/getRepresentationCampaign.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDefaultRepresentationCampaign } from "~/modules/domain";
+
+const limitMock = vi.fn();
+const dbMock = {
+	select: vi.fn().mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockReturnValue({ limit: limitMock }),
+		}),
+	}),
+};
+
+vi.mock("..", () => ({
+	db: dbMock,
+}));
+
+async function loadGetRepresentationCampaign() {
+	vi.resetModules();
+	const { getRepresentationCampaign } = await import(
+		"../getRepresentationCampaign"
+	);
+	return getRepresentationCampaign;
+}
+
+describe("getRepresentationCampaign", () => {
+	beforeEach(() => {
+		limitMock.mockReset();
+	});
+
+	it("falls back to the default campaign when no row exists", async () => {
+		limitMock.mockResolvedValueOnce([]);
+		const getRepresentationCampaign = await loadGetRepresentationCampaign();
+
+		const campaign = await getRepresentationCampaign(2027);
+
+		expect(campaign.campaignStartDate).toEqual(new Date(2027, 0, 1));
+		expect(campaign.campaignEndDate).toEqual(new Date(2027, 11, 31));
+		expect(campaign.declarationDeadline).toEqual(new Date(2027, 2, 1));
+	});
+
+	it("matches the domain defaults exactly when no row exists", async () => {
+		limitMock.mockResolvedValueOnce([]);
+		const getRepresentationCampaign = await loadGetRepresentationCampaign();
+
+		expect(await getRepresentationCampaign(2028)).toEqual(
+			getDefaultRepresentationCampaign(2028),
+		);
+	});
+
+	it("gives precedence to the dates configured in database", async () => {
+		limitMock.mockResolvedValueOnce([
+			{
+				year: 2027,
+				campaignStartDate: "2027-02-15",
+				campaignEndDate: "2027-09-30",
+				declarationDeadline: "2027-04-01",
+			},
+		]);
+		const getRepresentationCampaign = await loadGetRepresentationCampaign();
+
+		const campaign = await getRepresentationCampaign(2027);
+
+		expect(campaign.campaignStartDate).toEqual(new Date(2027, 1, 15));
+		expect(campaign.campaignEndDate).toEqual(new Date(2027, 8, 30));
+		expect(campaign.declarationDeadline).toEqual(new Date(2027, 3, 1));
+	});
+
+	it("parses stored dates at local midnight, not UTC", async () => {
+		limitMock.mockResolvedValueOnce([
+			{
+				year: 2027,
+				campaignStartDate: "2027-01-01",
+				campaignEndDate: "2027-12-31",
+				declarationDeadline: "2027-03-01",
+			},
+		]);
+		const getRepresentationCampaign = await loadGetRepresentationCampaign();
+
+		const campaign = await getRepresentationCampaign(2027);
+
+		expect(campaign.campaignStartDate.getHours()).toBe(0);
+		expect(campaign.campaignStartDate.getDate()).toBe(1);
+		expect(campaign.campaignEndDate.getDate()).toBe(31);
+	});
+});

--- a/packages/app/src/server/db/getRepresentationCampaign.ts
+++ b/packages/app/src/server/db/getRepresentationCampaign.ts
@@ -1,0 +1,33 @@
+import { eq } from "drizzle-orm";
+import { cache } from "react";
+
+import type { RepresentationCampaign } from "~/modules/domain";
+import { getDefaultRepresentationCampaign } from "~/modules/domain";
+
+import { db } from ".";
+import { representationCampaigns } from "./schema";
+
+function parseDate(dateStr: string): Date {
+	return new Date(`${dateStr}T00:00:00`);
+}
+
+export const getRepresentationCampaign = cache(
+	async (campaignYear: number): Promise<RepresentationCampaign> => {
+		const rows = await db
+			.select()
+			.from(representationCampaigns)
+			.where(eq(representationCampaigns.year, campaignYear))
+			.limit(1);
+
+		const row = rows[0];
+		if (!row) {
+			return getDefaultRepresentationCampaign(campaignYear);
+		}
+
+		return {
+			campaignStartDate: parseDate(row.campaignStartDate),
+			campaignEndDate: parseDate(row.campaignEndDate),
+			declarationDeadline: parseDate(row.declarationDeadline),
+		};
+	},
+);

--- a/packages/app/src/server/db/schema.ts
+++ b/packages/app/src/server/db/schema.ts
@@ -562,6 +562,7 @@ export const companiesRelations = relations(companies, ({ many }) => ({
 	userCompanies: many(userCompanies),
 	declarations: many(declarations),
 	gipMdsData: many(gipMdsData),
+	representationDeclarations: many(representationDeclarations),
 }));
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -712,6 +713,95 @@ export const campaignDeadlines = createTable("campaign_deadline", (d) => ({
 	decl2JustificationDeadline: d.date().notNull(),
 	decl2JointEvaluationDeadline: d.date().notNull(),
 }));
+
+// ── Representation campaign deadlines (configurable per year) ─────
+
+export const representationCampaigns = createTable(
+	"representation_campaign",
+	(d) => ({
+		year: d.integer().notNull().primaryKey(),
+		campaignStartDate: d.date().notNull(),
+		campaignEndDate: d.date().notNull(),
+		declarationDeadline: d.date().notNull(),
+	}),
+);
+
+// ── Representation declaration (art. D. 1142-19) ───────────────────
+
+export const representationNotComputableExecutivesEnum = pgEnum(
+	"representation_not_computable_executives",
+	["aucun_cadre_dirigeant", "un_seul_cadre_dirigeant"],
+);
+
+export const representationNotComputableMembersEnum = pgEnum(
+	"representation_not_computable_members",
+	["aucune_instance_dirigeante"],
+);
+
+export const representationDeclarationStatusEnum = pgEnum(
+	"representation_declaration_status",
+	["draft", "submitted"],
+);
+
+export const representationDeclarations = createTable(
+	"representation_declaration",
+	(d) => ({
+		id: d
+			.varchar({ length: 255 })
+			.notNull()
+			.primaryKey()
+			.$defaultFn(() => crypto.randomUUID()),
+		siren: d
+			.varchar({ length: 9 })
+			.notNull()
+			.references(() => companies.siren),
+		year: d.integer().notNull(),
+		declarantId: d.varchar({ length: 255 }).references(() => users.id),
+		legacyDeclarant: d.jsonb(),
+		importedFromV1At: d.timestamp("imported_from_v1_at", {
+			withTimezone: true,
+		}),
+		referencePeriodStart: d.date(),
+		referencePeriodEnd: d.date(),
+		executiveWomenPercent: d.numeric({ precision: 5, scale: 2 }),
+		executiveMenPercent: d.numeric({ precision: 5, scale: 2 }),
+		notComputableReasonExecutives: representationNotComputableExecutivesEnum(),
+		memberWomenPercent: d.numeric({ precision: 5, scale: 2 }),
+		memberMenPercent: d.numeric({ precision: 5, scale: 2 }),
+		notComputableReasonMembers: representationNotComputableMembersEnum(),
+		publishDate: d.date(),
+		publishUrl: d.varchar({ length: 500 }),
+		publishModalities: d.text(),
+		currentStep: d.integer().default(0),
+		status: representationDeclarationStatusEnum().notNull().default("draft"),
+		submittedAt: d.timestamp({ withTimezone: true }),
+		draft: d.jsonb(),
+		draftUpdatedAt: d.timestamp({ withTimezone: true }),
+		createdAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+		updatedAt: d.timestamp({ withTimezone: true }).$defaultFn(() => new Date()),
+	}),
+	(t) => [
+		uniqueIndex("representation_declaration_siren_year_unique").on(
+			t.siren,
+			t.year,
+		),
+		index("representation_declaration_declarant_idx").on(t.declarantId),
+	],
+);
+
+export const representationDeclarationsRelations = relations(
+	representationDeclarations,
+	({ one }) => ({
+		declarant: one(users, {
+			fields: [representationDeclarations.declarantId],
+			references: [users.id],
+		}),
+		company: one(companies, {
+			fields: [representationDeclarations.siren],
+			references: [companies.siren],
+		}),
+	}),
+);
 
 // ── Global settings (singleton) ────────────────────────────────────
 


### PR DESCRIPTION
Closes #4151

## Résumé

Socle de données et règles métier pour la représentation équilibrée (art. D. 1142-19) : deux tables Drizzle (`representation_declaration`, `representation_campaign`, découplées de la rémunération) et les fonctions pures de verdict de conformité (seuil 30 % avant la campagne 2029, 40 % à partir de 2029), motifs de non-calculabilité et campagne par défaut. Aucune UI.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (représentation.test.ts, campaign.test.ts, getRepresentationCampaign.test.ts — verts)
- [x] `pnpm lint:check` / `pnpm format:check`
- [x] Migration `0046_majestic_rocket_raccoon.sql` générée et appliquée localement