### PR TITLE
Représentation équilibrée — export public téléchargeable

### DIFF
--- a/packages/app/src/app/api/public/representations/export/route.ts
+++ b/packages/app/src/app/api/public/representations/export/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import {
+	buildRepresentationExportRows,
+	generateRepresentationXlsx,
+} from "~/modules/export";
+import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
+import { db } from "~/server/db";
+
+export const GET = withAuditedRoute(
+	{
+		action: AUDIT_ACTIONS.PUBLIC_REPRESENTATIONS_EXPORT,
+	},
+	async () => {
+		try {
+			const rows = await buildRepresentationExportRows(db);
+			const xlsxBuffer = await generateRepresentationXlsx(rows);
+
+			return new NextResponse(new Uint8Array(xlsxBuffer), {
+				headers: {
+					"Content-Type":
+						"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+					"Content-Disposition":
+						'attachment; filename="representation_equilibree_export.xlsx"',
+					"Access-Control-Allow-Origin": "*",
+					"Cache-Control": "public, max-age=3600, s-maxage=3600",
+				},
+			});
+		} catch (error) {
+			console.error(
+				"[api/public/representations/export]",
+				error instanceof Error ? error.message : "unknown error",
+			);
+			return NextResponse.json(
+				{ error: "Erreur lors de l'export des représentations équilibrées" },
+				{ status: 500 },
+			);
+		}
+	},
+);

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -114,6 +114,7 @@ export const AUDIT_ACTIONS = {
 	PUBLIC_DECLARATIONS_SEARCH: "public_declarations.search",
 
 	PUBLIC_DECLARATIONS_EXPORT: "public_declarations.export",
+	PUBLIC_REPRESENTATIONS_EXPORT: "public_representations.export",
 
 	// ── Public stats reads ─────────────────────────────────
 	PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE:
@@ -215,6 +216,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.PUBLIC_DECLARATIONS_SEARCH]: "read_sensitive",
 
 	[AUDIT_ACTIONS.PUBLIC_DECLARATIONS_EXPORT]: "export",
+	[AUDIT_ACTIONS.PUBLIC_REPRESENTATIONS_EXPORT]: "export",
 
 	[AUDIT_ACTIONS.PUBLIC_STATS_GET_CURRENT_CAMPAIGN_RATE]: "public_search",
 

--- a/packages/app/src/modules/export/__tests__/generateRepresentationExport.test.ts
+++ b/packages/app/src/modules/export/__tests__/generateRepresentationExport.test.ts
@@ -1,0 +1,358 @@
+import { eq } from "drizzle-orm";
+import ExcelJS from "exceljs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { representationDeclarations } from "~/server/db/schema";
+import {
+	buildRepresentationExportRows,
+	generateRepresentationXlsx,
+	type RepresentationExportRow,
+} from "../generateRepresentationExport";
+
+const EXPECTED_HEADERS = [
+	"Annee_reference",
+	"SIREN",
+	"Raison_sociale",
+	"Region",
+	"Code_departement",
+	"Departement",
+	"Code_NAF",
+	"Libelle_NAF",
+	"Cadres_dirigeants_F",
+	"Cadres_dirigeants_H",
+	"Cadres_dirigeants_motif_non_calculabilite",
+	"Instances_dirigeantes_F",
+	"Instances_dirigeantes_H",
+	"Instances_dirigeantes_motif_non_calculabilite",
+	"Date_publication",
+	"Url_publication",
+	"Modalites_publication",
+];
+
+type DbRow = Record<string, unknown>;
+
+function makeDbRow(overrides: DbRow = {}): DbRow {
+	return {
+		year: 2027,
+		siren: "123456789",
+		name: "Entreprise Diffusible",
+		region: "Île-de-France",
+		departmentCode: "75",
+		departmentLabel: "Paris",
+		nafCode: "62.02A",
+		nafLabel: "Conseil en systèmes informatiques",
+		statutDiffusion: "O",
+		executiveWomenPercent: "40.00",
+		executiveMenPercent: "60.00",
+		notComputableReasonExecutives: null,
+		memberWomenPercent: "45.50",
+		memberMenPercent: "54.50",
+		notComputableReasonMembers: null,
+		publishDate: "2028-03-01",
+		publishUrl: "https://example.fr/representation",
+		publishModalities: null,
+		...overrides,
+	};
+}
+
+function makeExportRow(
+	overrides: Partial<RepresentationExportRow> = {},
+): RepresentationExportRow {
+	return {
+		referenceYear: 2027,
+		siren: "123456789",
+		name: "Entreprise Diffusible",
+		region: "Île-de-France",
+		departmentCode: "75",
+		departmentLabel: "Paris",
+		nafCode: "62.02A",
+		nafLabel: "Conseil en systèmes informatiques",
+		executiveWomenPercent: 40,
+		executiveMenPercent: 60,
+		notComputableReasonExecutives: null,
+		memberWomenPercent: 45.5,
+		memberMenPercent: 54.5,
+		notComputableReasonMembers: null,
+		publishDate: "2028-03-01",
+		publishUrl: "https://example.fr/representation",
+		publishModalities: null,
+		...overrides,
+	};
+}
+
+async function loadSheet(buffer: Buffer) {
+	const workbook = new ExcelJS.Workbook();
+	await workbook.xlsx.load(buffer as never);
+	return workbook;
+}
+
+function readRow(sheet: ExcelJS.Worksheet, rowNumber: number): unknown[] {
+	const row = sheet.getRow(rowNumber);
+	return EXPECTED_HEADERS.map((_, index) => row.getCell(index + 1).value);
+}
+
+describe("buildRepresentationExportRows", () => {
+	const mockOrderBy = vi.fn();
+	const mockWhere = vi.fn(() => ({ orderBy: mockOrderBy }));
+	const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
+	const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
+	const mockSelect = vi.fn((_projection: Record<string, unknown>) => ({
+		from: mockFrom,
+	}));
+	const mockDb = { select: mockSelect };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockOrderBy.mockResolvedValue([]);
+	});
+
+	it("returns an empty array when no submitted declaration exists", async () => {
+		const rows = await buildRepresentationExportRows(mockDb as never);
+
+		expect(rows).toEqual([]);
+	});
+
+	it("restricts the query to submitted declarations", async () => {
+		await buildRepresentationExportRows(mockDb as never);
+
+		expect(mockWhere).toHaveBeenCalledWith(
+			eq(representationDeclarations.status, "submitted"),
+		);
+	});
+
+	it("keeps identity and location for a diffusible company", async () => {
+		mockOrderBy.mockResolvedValue([makeDbRow()]);
+
+		const rows = await buildRepresentationExportRows(mockDb as never);
+
+		expect(rows).toEqual([
+			{
+				referenceYear: 2027,
+				siren: "123456789",
+				name: "Entreprise Diffusible",
+				region: "Île-de-France",
+				departmentCode: "75",
+				departmentLabel: "Paris",
+				nafCode: "62.02A",
+				nafLabel: "Conseil en systèmes informatiques",
+				executiveWomenPercent: 40,
+				executiveMenPercent: 60,
+				notComputableReasonExecutives: null,
+				memberWomenPercent: 45.5,
+				memberMenPercent: 54.5,
+				notComputableReasonMembers: null,
+				publishDate: "2028-03-01",
+				publishUrl: "https://example.fr/representation",
+				publishModalities: null,
+			},
+		]);
+	});
+
+	it("blanks identity and location of a non-diffusible company but keeps its SIREN and indicators", async () => {
+		mockOrderBy.mockResolvedValue([
+			makeDbRow(),
+			makeDbRow({
+				siren: "987654321",
+				name: "Entreprise Non Diffusible",
+				statutDiffusion: "N",
+				executiveWomenPercent: "30.00",
+				executiveMenPercent: "70.00",
+			}),
+		]);
+
+		const rows = await buildRepresentationExportRows(mockDb as never);
+
+		expect(rows[0]).toMatchObject({
+			siren: "123456789",
+			name: "Entreprise Diffusible",
+			region: "Île-de-France",
+		});
+		expect(rows[1]).toMatchObject({
+			siren: "987654321",
+			name: null,
+			region: null,
+			departmentCode: null,
+			departmentLabel: null,
+			nafCode: null,
+			nafLabel: null,
+			executiveWomenPercent: 30,
+			executiveMenPercent: 70,
+			publishUrl: "https://example.fr/representation",
+		});
+	});
+
+	it("never exposes an address, neither for a diffusible nor for a non-diffusible company", async () => {
+		mockOrderBy.mockResolvedValue([
+			makeDbRow(),
+			makeDbRow({ siren: "987654321", statutDiffusion: "N" }),
+		]);
+
+		const rows = await buildRepresentationExportRows(mockDb as never);
+
+		const projection = mockSelect.mock.calls[0]?.[0] ?? {};
+		expect(Object.keys(projection)).not.toContain("address");
+		expect(rows[0]).not.toHaveProperty("address");
+		expect(rows[1]).not.toHaveProperty("address");
+	});
+
+	it("treats an unknown diffusion status as diffusible", async () => {
+		mockOrderBy.mockResolvedValue([makeDbRow({ statutDiffusion: null })]);
+
+		const rows = await buildRepresentationExportRows(mockDb as never);
+
+		expect(rows[0]).toMatchObject({
+			name: "Entreprise Diffusible",
+			region: "Île-de-France",
+		});
+	});
+
+	it("maps a non-computable declaration with null percentages and its reasons", async () => {
+		mockOrderBy.mockResolvedValue([
+			makeDbRow({
+				executiveWomenPercent: null,
+				executiveMenPercent: null,
+				notComputableReasonExecutives: "aucun_cadre_dirigeant",
+				memberWomenPercent: null,
+				memberMenPercent: null,
+				notComputableReasonMembers: "aucune_instance_dirigeante",
+				publishDate: null,
+				publishUrl: null,
+				publishModalities: "Affichage dans les locaux",
+			}),
+		]);
+
+		const rows = await buildRepresentationExportRows(mockDb as never);
+
+		expect(rows[0]).toMatchObject({
+			executiveWomenPercent: null,
+			executiveMenPercent: null,
+			notComputableReasonExecutives: "aucun_cadre_dirigeant",
+			memberWomenPercent: null,
+			memberMenPercent: null,
+			notComputableReasonMembers: "aucune_instance_dirigeante",
+			publishDate: null,
+			publishUrl: null,
+			publishModalities: "Affichage dans les locaux",
+		});
+	});
+
+	it("maps an unparseable percentage to null rather than NaN", async () => {
+		mockOrderBy.mockResolvedValue([
+			makeDbRow({ executiveWomenPercent: "n/a", memberMenPercent: "" }),
+		]);
+
+		const rows = await buildRepresentationExportRows(mockDb as never);
+
+		expect(rows[0]?.executiveWomenPercent).toBeNull();
+		// Postgres never returns "", but Number("") is 0 — pin the coercion down.
+		expect(rows[0]?.memberMenPercent).toBe(0);
+	});
+});
+
+describe("generateRepresentationXlsx", () => {
+	it("generates a single sheet named after the representation export", async () => {
+		const buffer = await generateRepresentationXlsx([makeExportRow()]);
+
+		expect(buffer).toBeInstanceOf(Buffer);
+		const workbook = await loadSheet(buffer);
+
+		expect(workbook.worksheets).toHaveLength(1);
+		expect(workbook.worksheets[0]?.name).toBe("Représentation équilibrée");
+	});
+
+	it("writes the expected column headers in order", async () => {
+		const buffer = await generateRepresentationXlsx([makeExportRow()]);
+		const workbook = await loadSheet(buffer);
+
+		const headers = workbook.worksheets[0]?.getRow(1).values as string[];
+
+		expect(headers.slice(1)).toEqual(EXPECTED_HEADERS);
+	});
+
+	it("writes one data row per declaration with its mapped values", async () => {
+		const buffer = await generateRepresentationXlsx([
+			makeExportRow(),
+			makeExportRow({
+				siren: "987654321",
+				name: null,
+				region: null,
+				departmentCode: null,
+				departmentLabel: null,
+				nafCode: null,
+				nafLabel: null,
+				executiveWomenPercent: 30,
+				executiveMenPercent: 70,
+			}),
+		]);
+		const workbook = await loadSheet(buffer);
+		const sheet = workbook.worksheets[0] as ExcelJS.Worksheet;
+
+		expect(sheet.rowCount).toBe(3);
+		expect(readRow(sheet, 2)).toEqual([
+			2027,
+			"123456789",
+			"Entreprise Diffusible",
+			"Île-de-France",
+			"75",
+			"Paris",
+			"62.02A",
+			"Conseil en systèmes informatiques",
+			40,
+			60,
+			null,
+			45.5,
+			54.5,
+			null,
+			"2028-03-01",
+			"https://example.fr/representation",
+			null,
+		]);
+		expect(readRow(sheet, 3)).toEqual([
+			2027,
+			"987654321",
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			30,
+			70,
+			null,
+			45.5,
+			54.5,
+			null,
+			"2028-03-01",
+			"https://example.fr/representation",
+			null,
+		]);
+	});
+
+	it("writes the non-computable reasons when the percentages are absent", async () => {
+		const buffer = await generateRepresentationXlsx([
+			makeExportRow({
+				executiveWomenPercent: null,
+				executiveMenPercent: null,
+				notComputableReasonExecutives: "aucun_cadre_dirigeant",
+				memberWomenPercent: null,
+				memberMenPercent: null,
+				notComputableReasonMembers: "aucune_instance_dirigeante",
+			}),
+		]);
+		const workbook = await loadSheet(buffer);
+		const row = workbook.worksheets[0]?.getRow(2);
+
+		expect(row?.getCell(9).value).toBeNull();
+		expect(row?.getCell(11).value).toBe("aucun_cadre_dirigeant");
+		expect(row?.getCell(14).value).toBe("aucune_instance_dirigeante");
+	});
+
+	it("generates a header-only sheet when there is nothing to export", async () => {
+		const buffer = await generateRepresentationXlsx([]);
+		const workbook = await loadSheet(buffer);
+
+		expect(workbook.worksheets[0]?.rowCount).toBe(1);
+		expect(
+			(workbook.worksheets[0]?.getRow(1).values as string[]).slice(1),
+		).toEqual(EXPECTED_HEADERS);
+	});
+});

--- a/packages/app/src/modules/export/__tests__/representationExport.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/representationExport.integration.test.ts
@@ -1,0 +1,160 @@
+import ExcelJS from "exceljs";
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+
+// The draft exclusion and the company join are enforced in SQL; a unit test
+// mocks the driver and cannot prove a draft never reaches the export file.
+describe("GET /api/public/representations/export — integration (#4155)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN_DIFFUSIBLE = "123456789";
+	const SIREN_NON_DIFFUSIBLE = "987654321";
+	const SIREN_DRAFT = "111222333";
+	const ALL_SIRENS = [SIREN_DIFFUSIBLE, SIREN_NON_DIFFUSIBLE, SIREN_DRAFT];
+	const YEAR = 2027;
+	const DECL_IDS = [
+		"repr-export-diffusible",
+		"repr-export-non-diffusible",
+		"repr-export-draft",
+	];
+
+	async function cleanup() {
+		await sql`DELETE FROM app_representation_declaration WHERE id IN ${sql(DECL_IDS)}`;
+		await sql`DELETE FROM app_company WHERE siren IN ${sql(ALL_SIRENS)}`;
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+
+		await sql`
+			INSERT INTO app_company (siren, name, address, naf_code, naf_label, region, department_code, department_label, statut_diffusion)
+			VALUES
+				(${SIREN_DIFFUSIBLE},     'Entreprise Diffusible',     '1 rue de la Paix, 75002 Paris', '62.02A', 'Conseil en systemes informatiques', 'Île-de-France', '75', 'Paris',  'O'),
+				(${SIREN_NON_DIFFUSIBLE}, 'Entreprise Non Diffusible', '2 rue Secrete, 69001 Lyon',     '70.10Z', 'Activites des sieges sociaux',      'Auvergne-Rhône-Alpes', '69', 'Rhône', 'N'),
+				(${SIREN_DRAFT},          'Entreprise Brouillon',      '3 rue Brouillon, 44000 Nantes', '46.90Z', 'Commerce de gros non specialise',   'Pays de la Loire', '44', 'Loire-Atlantique', 'O')
+		`;
+		await sql`
+			INSERT INTO app_representation_declaration
+				(id, siren, year, executive_women_percent, executive_men_percent, member_women_percent, member_men_percent, publish_date, publish_url, publish_modalities, status)
+			VALUES
+				('repr-export-diffusible',     ${SIREN_DIFFUSIBLE},     ${YEAR}, 40.00, 60.00, 45.50, 54.50, '2028-03-01', 'https://example.fr/representation', 'Site internet', 'submitted'),
+				('repr-export-non-diffusible', ${SIREN_NON_DIFFUSIBLE}, ${YEAR}, 30.00, 70.00, 25.00, 75.00, '2028-03-02', 'https://example.fr/non-diffusible', 'Site internet', 'submitted'),
+				('repr-export-draft',          ${SIREN_DRAFT},          ${YEAR}, 50.00, 50.00, 50.00, 50.00, NULL,         NULL,                                NULL,            'draft')
+		`;
+	});
+
+	async function fetchExportSheet() {
+		const { GET } = await import(
+			"~/app/api/public/representations/export/route"
+		);
+		const response = await GET(
+			new Request("http://localhost/api/public/representations/export"),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe(
+			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		);
+
+		const workbook = new ExcelJS.Workbook();
+		await workbook.xlsx.load(await response.arrayBuffer());
+		const sheet = workbook.getWorksheet("Représentation équilibrée");
+		if (!sheet) throw new Error("missing representation worksheet");
+		return sheet;
+	}
+
+	function findRowBySiren(sheet: ExcelJS.Worksheet, siren: string) {
+		let found: ExcelJS.Row | undefined;
+		sheet.eachRow((row, rowNumber) => {
+			if (rowNumber > 1 && row.getCell(2).value === siren) found = row;
+		});
+		return found;
+	}
+
+	it("exports a submitted declaration of a diffusible company with its identity and location", async () => {
+		const sheet = await fetchExportSheet();
+		const row = findRowBySiren(sheet, SIREN_DIFFUSIBLE);
+
+		expect(row).toBeDefined();
+		expect(row?.getCell(1).value).toBe(YEAR);
+		expect(row?.getCell(3).value).toBe("Entreprise Diffusible");
+		expect(row?.getCell(4).value).toBe("Île-de-France");
+		expect(row?.getCell(5).value).toBe("75");
+		expect(row?.getCell(6).value).toBe("Paris");
+		expect(row?.getCell(7).value).toBe("62.02A");
+		expect(row?.getCell(9).value).toBe(40);
+		expect(row?.getCell(10).value).toBe(60);
+	});
+
+	it("exports a non-diffusible company with its SIREN and indicators but no identity nor location", async () => {
+		const sheet = await fetchExportSheet();
+		const row = findRowBySiren(sheet, SIREN_NON_DIFFUSIBLE);
+
+		expect(row).toBeDefined();
+		expect(row?.getCell(3).value).toBeNull();
+		expect(row?.getCell(4).value).toBeNull();
+		expect(row?.getCell(5).value).toBeNull();
+		expect(row?.getCell(6).value).toBeNull();
+		expect(row?.getCell(7).value).toBeNull();
+		expect(row?.getCell(8).value).toBeNull();
+		expect(row?.getCell(9).value).toBe(30);
+		expect(row?.getCell(10).value).toBe(70);
+	});
+
+	it("never writes a company address in the file, diffusible or not", async () => {
+		const sheet = await fetchExportSheet();
+
+		const headers = (sheet.getRow(1).values as string[]).filter(Boolean);
+		expect(headers.some((header) => /adresse/i.test(header))).toBe(false);
+
+		const cellValues: unknown[] = [];
+		sheet.eachRow((row) => {
+			row.eachCell((cell) => cellValues.push(cell.value));
+		});
+		expect(cellValues).not.toContain("1 rue de la Paix, 75002 Paris");
+		expect(cellValues).not.toContain("2 rue Secrete, 69001 Lyon");
+	});
+
+	it("excludes a draft declaration from the export", async () => {
+		const sheet = await fetchExportSheet();
+
+		expect(findRowBySiren(sheet, SIREN_DRAFT)).toBeUndefined();
+	});
+
+	it("exports a declaration that becomes submitted after having been a draft", async () => {
+		await sql`UPDATE app_representation_declaration SET status = 'submitted' WHERE id = 'repr-export-draft'`;
+
+		const sheet = await fetchExportSheet();
+
+		expect(findRowBySiren(sheet, SIREN_DRAFT)).toBeDefined();
+	});
+
+	it("writes an audit log entry for the export", async () => {
+		await sql`DELETE FROM audit.action_log WHERE action = 'public_representations.export'`;
+
+		await fetchExportSheet();
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		const logs = await sql`
+			SELECT action, category, status FROM audit.action_log
+			WHERE action = 'public_representations.export'
+		`;
+		expect(logs).toHaveLength(1);
+		expect(logs[0]).toMatchObject({
+			action: "public_representations.export",
+			category: "export",
+			status: "success",
+		});
+	});
+});

--- a/packages/app/src/modules/export/__tests__/representationExport.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/representationExport.integration.test.ts
@@ -3,8 +3,7 @@ import postgres from "postgres";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { env } from "~/env.js";
 
-// The draft exclusion and the company join are enforced in SQL; a unit test
-// mocks the driver and cannot prove a draft never reaches the export file.
+// Draft exclusion and company join are SQL-enforced: a mocked driver cannot prove them.
 describe("GET /api/public/representations/export — integration (#4155)", () => {
 	let sql!: ReturnType<typeof postgres>;
 

--- a/packages/app/src/modules/export/generateRepresentationExport.ts
+++ b/packages/app/src/modules/export/generateRepresentationExport.ts
@@ -1,0 +1,170 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import ExcelJS from "exceljs";
+
+import { isCompanyDiffusible } from "~/modules/public-api";
+import type { DB } from "~/server/db";
+import { companies, representationDeclarations } from "~/server/db/schema";
+
+export type RepresentationExportRow = {
+	referenceYear: number;
+	siren: string;
+	name: string | null;
+	region: string | null;
+	departmentCode: string | null;
+	departmentLabel: string | null;
+	nafCode: string | null;
+	nafLabel: string | null;
+	executiveWomenPercent: number | null;
+	executiveMenPercent: number | null;
+	notComputableReasonExecutives: string | null;
+	memberWomenPercent: number | null;
+	memberMenPercent: number | null;
+	notComputableReasonMembers: string | null;
+	publishDate: string | null;
+	publishUrl: string | null;
+	publishModalities: string | null;
+};
+
+const REPRESENTATION_EXPORT_COLUMNS: Array<{
+	key: keyof RepresentationExportRow;
+	header: string;
+}> = [
+	{ key: "referenceYear", header: "Annee_reference" },
+	{ key: "siren", header: "SIREN" },
+	{ key: "name", header: "Raison_sociale" },
+	{ key: "region", header: "Region" },
+	{ key: "departmentCode", header: "Code_departement" },
+	{ key: "departmentLabel", header: "Departement" },
+	{ key: "nafCode", header: "Code_NAF" },
+	{ key: "nafLabel", header: "Libelle_NAF" },
+	{ key: "executiveWomenPercent", header: "Cadres_dirigeants_F" },
+	{ key: "executiveMenPercent", header: "Cadres_dirigeants_H" },
+	{
+		key: "notComputableReasonExecutives",
+		header: "Cadres_dirigeants_motif_non_calculabilite",
+	},
+	{ key: "memberWomenPercent", header: "Instances_dirigeantes_F" },
+	{ key: "memberMenPercent", header: "Instances_dirigeantes_H" },
+	{
+		key: "notComputableReasonMembers",
+		header: "Instances_dirigeantes_motif_non_calculabilite",
+	},
+	{ key: "publishDate", header: "Date_publication" },
+	{ key: "publishUrl", header: "Url_publication" },
+	{ key: "publishModalities", header: "Modalites_publication" },
+];
+
+function toNumber(value: string | null): number | null {
+	if (value === null) return null;
+	const parsed = Number(value);
+	return Number.isNaN(parsed) ? null : parsed;
+}
+
+async function fetchSubmittedRepresentationDeclarations(db: DB) {
+	return db
+		.select({
+			year: representationDeclarations.year,
+			siren: companies.siren,
+			name: companies.name,
+			region: companies.region,
+			departmentCode: companies.departmentCode,
+			departmentLabel: companies.departmentLabel,
+			nafCode: companies.nafCode,
+			nafLabel: companies.nafLabel,
+			statutDiffusion: companies.statutDiffusion,
+			executiveWomenPercent: representationDeclarations.executiveWomenPercent,
+			executiveMenPercent: representationDeclarations.executiveMenPercent,
+			notComputableReasonExecutives:
+				representationDeclarations.notComputableReasonExecutives,
+			memberWomenPercent: representationDeclarations.memberWomenPercent,
+			memberMenPercent: representationDeclarations.memberMenPercent,
+			notComputableReasonMembers:
+				representationDeclarations.notComputableReasonMembers,
+			publishDate: representationDeclarations.publishDate,
+			publishUrl: representationDeclarations.publishUrl,
+			publishModalities: representationDeclarations.publishModalities,
+		})
+		.from(representationDeclarations)
+		.innerJoin(companies, eq(representationDeclarations.siren, companies.siren))
+		.where(eq(representationDeclarations.status, "submitted"))
+		.orderBy(representationDeclarations.year, companies.siren);
+}
+
+type RepresentationDeclarationRow = Awaited<
+	ReturnType<typeof fetchSubmittedRepresentationDeclarations>
+>[number];
+
+function toExportRow(
+	row: RepresentationDeclarationRow,
+): RepresentationExportRow {
+	const diffusible = isCompanyDiffusible(row.statutDiffusion);
+
+	return {
+		referenceYear: row.year,
+		siren: row.siren,
+		name: diffusible ? row.name : null,
+		region: diffusible ? row.region : null,
+		departmentCode: diffusible ? row.departmentCode : null,
+		departmentLabel: diffusible ? row.departmentLabel : null,
+		nafCode: diffusible ? row.nafCode : null,
+		nafLabel: diffusible ? row.nafLabel : null,
+		executiveWomenPercent: toNumber(row.executiveWomenPercent),
+		executiveMenPercent: toNumber(row.executiveMenPercent),
+		notComputableReasonExecutives: row.notComputableReasonExecutives,
+		memberWomenPercent: toNumber(row.memberWomenPercent),
+		memberMenPercent: toNumber(row.memberMenPercent),
+		notComputableReasonMembers: row.notComputableReasonMembers,
+		publishDate: row.publishDate,
+		publishUrl: row.publishUrl,
+		publishModalities: row.publishModalities,
+	};
+}
+
+/**
+ * Build the flat rows for the public representation export: one row per
+ * submitted (non-draft) representation declaration. Non-diffusible companies
+ * (S28, `isCompanyDiffusible`) keep their SIREN but have identity and
+ * location fields blanked. The address never appears, for anyone — the
+ * `companies` table is not queried for it.
+ */
+export async function buildRepresentationExportRows(
+	db: DB,
+): Promise<RepresentationExportRow[]> {
+	const rows = await fetchSubmittedRepresentationDeclarations(db);
+	return rows.map(toExportRow);
+}
+
+/**
+ * Generate the public representation export XLSX workbook from pre-built
+ * rows (single sheet, one row per submitted declaration).
+ */
+export async function generateRepresentationXlsx(
+	rows: RepresentationExportRow[],
+): Promise<Buffer> {
+	const workbook = new ExcelJS.Workbook();
+	const sheet = workbook.addWorksheet("Représentation équilibrée");
+
+	sheet.columns = REPRESENTATION_EXPORT_COLUMNS.map((col) => ({
+		header: col.header,
+		key: String(col.key),
+		width: 20,
+	}));
+
+	for (const row of rows) {
+		const values: Record<string, unknown> = {};
+		for (const col of REPRESENTATION_EXPORT_COLUMNS) {
+			const val = row[col.key];
+			values[String(col.key)] = val === null || val === undefined ? null : val;
+		}
+		sheet.addRow(values);
+	}
+
+	const headerRow = sheet.getRow(1);
+	headerRow.font = { bold: true };
+	headerRow.alignment = { horizontal: "center" };
+
+	const arrayBuffer = await workbook.xlsx.writeBuffer();
+	return Buffer.from(arrayBuffer);
+}

--- a/packages/app/src/modules/export/generateRepresentationExport.ts
+++ b/packages/app/src/modules/export/generateRepresentationExport.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { eq } from "drizzle-orm";
 import ExcelJS from "exceljs";
 
-import { isCompanyDiffusible } from "~/modules/public-api";
+import { isCompanyDiffusible, toNumber } from "~/modules/public-api";
 import type { DB } from "~/server/db";
 import { companies, representationDeclarations } from "~/server/db/schema";
 
@@ -55,12 +55,6 @@ const REPRESENTATION_EXPORT_COLUMNS: Array<{
 	{ key: "publishUrl", header: "Url_publication" },
 	{ key: "publishModalities", header: "Modalites_publication" },
 ];
-
-function toNumber(value: string | null): number | null {
-	if (value === null) return null;
-	const parsed = Number(value);
-	return Number.isNaN(parsed) ? null : parsed;
-}
 
 async function fetchSubmittedRepresentationDeclarations(db: DB) {
 	return db
@@ -122,13 +116,6 @@ function toExportRow(
 	};
 }
 
-/**
- * Build the flat rows for the public representation export: one row per
- * submitted (non-draft) representation declaration. Non-diffusible companies
- * (S28, `isCompanyDiffusible`) keep their SIREN but have identity and
- * location fields blanked. The address never appears, for anyone — the
- * `companies` table is not queried for it.
- */
 export async function buildRepresentationExportRows(
 	db: DB,
 ): Promise<RepresentationExportRow[]> {
@@ -136,10 +123,6 @@ export async function buildRepresentationExportRows(
 	return rows.map(toExportRow);
 }
 
-/**
- * Generate the public representation export XLSX workbook from pre-built
- * rows (single sheet, one row per submitted declaration).
- */
 export async function generateRepresentationXlsx(
 	rows: RepresentationExportRow[],
 ): Promise<Buffer> {

--- a/packages/app/src/modules/export/index.ts
+++ b/packages/app/src/modules/export/index.ts
@@ -13,6 +13,11 @@ export {
 	fetchJointEvaluationFilesByDeclaration,
 	fetchSubmittedDeclarations,
 } from "./fetchDeclarations";
+export type { RepresentationExportRow } from "./generateRepresentationExport";
+export {
+	buildRepresentationExportRows,
+	generateRepresentationXlsx,
+} from "./generateRepresentationExport";
 export { generateXlsx } from "./generateXlsx";
 export {
 	buildExportKey,

--- a/packages/app/src/modules/public-api/index.ts
+++ b/packages/app/src/modules/public-api/index.ts
@@ -10,6 +10,7 @@ export type {
 export {
 	isCompanyDiffusible,
 	publicDeclarationColumns,
+	toNumber,
 	toPublicDeclaration,
 } from "./projection";
 export type {

--- a/packages/app/src/modules/public-api/projection.ts
+++ b/packages/app/src/modules/public-api/projection.ts
@@ -93,7 +93,7 @@ export function isCompanyDiffusible(statutDiffusion: string | null): boolean {
 	return statutDiffusion !== "N";
 }
 
-function toNumber(value: string | null): number | null {
+export function toNumber(value: string | null): number | null {
 	if (value === null) return null;
 	const parsed = Number(value);
 	return Number.isNaN(parsed) ? null : parsed;


### PR DESCRIPTION
Closes #4155

## Résumé

Ajoute l'équivalent, pour la représentation équilibrée, de l'export public des déclarations de rémunération (`/api/public/declarations/export`) : une nouvelle route publique `GET /api/public/representations/export` qui génère un fichier XLSX listant les déclarations de représentation équilibrée **soumises** (brouillons exclus).

- `packages/app/src/modules/export/generateRepresentationExport.ts` (nouveau) : requête Drizzle (`representationDeclarations` innerJoin `companies`, filtre `status = "submitted"`) + génération du classeur XLSX (une feuille, colonnes : année de référence, SIREN, raison sociale, région, département, code/libellé NAF, pourcentages F/H "cadres dirigeants" + motif de non-calculabilité, pourcentages F/H "membres des instances dirigeantes" + motif de non-calculabilité, informations de publication).
- `packages/app/src/app/api/public/representations/export/route.ts` (nouveau) : route publique sans authentification, sur le pattern de `api/public/declarations/export/route.ts`, wrappée par `withAuditedRoute`.
- `packages/app/src/modules/export/index.ts` : exports du barrel.
- `packages/app/src/modules/audit/shared/actionKeys.ts` : nouvelle clé d'audit `PUBLIC_REPRESENTATIONS_EXPORT` (catégorie `export`), 3 points de câblage conformes à `.claude/rules/audit-logging.md`.
- `packages/app/src/modules/public-api/projection.ts` / `index.ts` : `toNumber` exporté (au lieu d'être dupliqué) pour être réutilisé par le nouveau module — dédup demandée par le structural-auditor.

**Non-diffusion (S28)** : réutilise `isCompanyDiffusible` (aucune duplication de la règle) — pour une entreprise non diffusible, identité (`name`) et localisation (`region`/`departmentCode`/`departmentLabel`/`nafCode`/`nafLabel`) sont mises à `null`, le SIREN reste toujours visible. **L'adresse n'est exportée pour personne**, diffusible ou non — elle n'est même pas sélectionnée dans la requête.

## Test plan

- [x] Tests unitaires (`generateRepresentationExport.test.ts`, 13 tests, 100% de couverture sur `generateRepresentationExport.ts`) : mapping des lignes, scénario S28 (SIREN fictifs `123456789` / `987654321`), absence totale de la colonne adresse, exclusion des brouillons.
- [x] Test d'intégration (`representationExport.integration.test.ts`, Postgres réel) : filtre SQL `status = 'submitted'` + jointure `companies` non prouvables avec un driver mocké.
- [x] Vérification manuelle ad hoc sur le dev server (insertion SQL temporaire de 2 SIREN fictifs diffusible/non-diffusible + 1 brouillon, requête de la route, inspection du xlsx généré, puis rollback des données de test) confirmant le comportement attendu.
- [x] `pnpm typecheck` / `pnpm lint:check` / `pnpm format:check` / `pnpm test` verts.
- [x] Pas de fichier UI touché → pas de vérification Figma applicable.