### PR TITLE
Représentation équilibrée — schemas Zod, router tRPC, brouillon & soumission

### DIFF
--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -85,6 +85,11 @@ export const AUDIT_ACTIONS = {
 	DRAFT_SAVE: "declaration_draft.save",
 	DRAFT_CLEAR: "declaration_draft.clear",
 
+	// ── Representation declaration ─────────────────────────
+	REPRESENTATION_GET: "representation_declaration.get",
+	REPRESENTATION_SAVE_DRAFT: "representation_declaration.save_draft",
+	REPRESENTATION_SUBMIT: "representation_declaration.submit",
+
 	// ── Sensitive reads ────────────────────────────────────
 	DECLARATION_HISTORY_READ: "declaration_history.read",
 	ADMIN_FILE_DOWNLOAD: "admin.file_download",
@@ -193,6 +198,9 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.DRAFT_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.DRAFT_SAVE]: "mutation",
 	[AUDIT_ACTIONS.DRAFT_CLEAR]: "mutation",
+	[AUDIT_ACTIONS.REPRESENTATION_GET]: "read_sensitive",
+	[AUDIT_ACTIONS.REPRESENTATION_SAVE_DRAFT]: "mutation",
+	[AUDIT_ACTIONS.REPRESENTATION_SUBMIT]: "mutation",
 	[AUDIT_ACTIONS.DECLARATION_HISTORY_READ]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_FILE_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.PROFILE_READ]: "read_sensitive",

--- a/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
@@ -1,0 +1,77 @@
+import type { ZodError } from "zod";
+
+export const REPRESENTATION_YEAR = 2025;
+
+export const VALID_REFERENCE_PERIOD = {
+	referencePeriodStart: "2025-01-01",
+	referencePeriodEnd: "2025-12-31",
+};
+
+export const COMPUTABLE_EXECUTIVES = {
+	executivesCount: "two_or_more",
+	executiveWomenPercent: 60,
+	executiveMenPercent: 40,
+} as const;
+
+export const NO_EXECUTIVES = { executivesCount: "none" } as const;
+
+export const SINGLE_EXECUTIVE = { executivesCount: "one" } as const;
+
+export const COMPUTABLE_MEMBERS = {
+	hasManagementBody: true,
+	memberWomenPercent: 55,
+	memberMenPercent: 45,
+} as const;
+
+export const NO_MANAGEMENT_BODY = { hasManagementBody: false } as const;
+
+export const WEBSITE_PUBLICATION = {
+	publishDate: "2026-03-01",
+	hasWebsite: true,
+	publishUrl: "https://exemple.fr/egalite-professionnelle",
+} as const;
+
+export const OFFLINE_PUBLICATION = {
+	publishDate: "2026-03-01",
+	hasWebsite: false,
+	publishModalities: "Affichage dans les locaux et note de service.",
+} as const;
+
+export const FULL_REPRESENTATION_PAYLOAD = {
+	...VALID_REFERENCE_PERIOD,
+	...COMPUTABLE_EXECUTIVES,
+	...COMPUTABLE_MEMBERS,
+	...WEBSITE_PUBLICATION,
+};
+
+export const NOT_COMPUTABLE_PAYLOAD = {
+	...VALID_REFERENCE_PERIOD,
+	...NO_EXECUTIVES,
+	...NO_MANAGEMENT_BODY,
+};
+
+export const VALIDATION_MESSAGES = {
+	sum: "La somme des pourcentages doit être égale à 100 %.",
+	range: "Le pourcentage doit être compris entre 0 et 100.",
+	decimal: "Le pourcentage ne peut comporter plus d'une décimale.",
+	periodYear:
+		"L'année de la date de fin de la période de référence doit correspondre à l'année au titre de laquelle les écarts sont calculés.",
+	periodLength: "La période de référence doit couvrir 12 mois consécutifs.",
+	urlRequired: "L'adresse de la page internet est obligatoire.",
+	urlInvalid: "L'adresse de la page internet est invalide.",
+	modalitiesRequired:
+		"La description des modalités de communication est obligatoire.",
+	publicationNotRequired:
+		"Aucune information de publication n'est requise lorsqu'aucun écart n'est calculable.",
+	publishDateAfterPeriod:
+		"La date de publication doit être postérieure à la fin de la période de référence.",
+} as const;
+
+export function issues(result: { success: boolean; error?: ZodError }) {
+	return (
+		result.error?.issues.map((issue) => ({
+			path: issue.path.join("."),
+			message: issue.message,
+		})) ?? []
+	);
+}

--- a/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
@@ -2,6 +2,10 @@ import type { ZodError } from "zod";
 
 export const REPRESENTATION_YEAR = 2025;
 
+export const MAX_PUBLISH_URL_LENGTH = 500;
+
+export const MAX_PUBLISH_MODALITIES_LENGTH = 5000;
+
 export const VALID_REFERENCE_PERIOD = {
 	referencePeriodStart: "2025-01-01",
 	referencePeriodEnd: "2025-12-31",
@@ -59,8 +63,11 @@ export const VALIDATION_MESSAGES = {
 	periodLength: "La période de référence doit couvrir 12 mois consécutifs.",
 	urlRequired: "L'adresse de la page internet est obligatoire.",
 	urlInvalid: "L'adresse de la page internet est invalide.",
+	urlTooLong: "L'adresse de la page internet est trop longue.",
 	modalitiesRequired:
 		"La description des modalités de communication est obligatoire.",
+	modalitiesTooLong:
+		"La description des modalités de communication est trop longue.",
 	publicationNotRequired:
 		"Aucune information de publication n'est requise lorsqu'aucun écart n'est calculable.",
 	publishDateAfterPeriod:

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.draft.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.draft.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { representationDraftSchema } from "~/modules/declaration-representation";
+
+describe("representationDraftSchema", () => {
+	it("accepts a draft holding only the current step", () => {
+		expect(
+			representationDraftSchema.safeParse({ currentStep: 0 }).success,
+		).toBe(true);
+	});
+
+	it("accepts a partially filled draft", () => {
+		const result = representationDraftSchema.safeParse({
+			currentStep: 3,
+			referencePeriodStart: "2025-01-01",
+			executivesCount: "two_or_more",
+			executiveWomenPercent: 60,
+			hasManagementBody: true,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a draft holding percentages that do not sum to 100", () => {
+		const result = representationDraftSchema.safeParse({
+			currentStep: 2,
+			executiveWomenPercent: 10,
+			executiveMenPercent: 20,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it.each([-1, 6, 2.5])("rejects the current step %s", (currentStep) => {
+		expect(representationDraftSchema.safeParse({ currentStep }).success).toBe(
+			false,
+		);
+	});
+
+	it("rejects a draft without a current step", () => {
+		expect(representationDraftSchema.safeParse({}).success).toBe(false);
+	});
+
+	it("rejects an unknown executives count", () => {
+		const result = representationDraftSchema.safeParse({
+			currentStep: 1,
+			executivesCount: "three",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.executives.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.executives.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { executivesSchema } from "~/modules/declaration-representation";
+import { COMPUTABLE_EXECUTIVES, issues, VALIDATION_MESSAGES } from "./fixtures";
+
+describe("executivesSchema", () => {
+	it.each([
+		"none",
+		"one",
+	])("accepts %s executives without any percentage", (executivesCount) => {
+		const result = executivesSchema.safeParse({ executivesCount });
+
+		expect(result.success).toBe(true);
+	});
+
+	it("drops percentages sent alongside a non-computable count", () => {
+		const result = executivesSchema.safeParse({
+			executivesCount: "none",
+			executiveWomenPercent: 60,
+			executiveMenPercent: 40,
+		});
+
+		expect(result.data).toEqual({ executivesCount: "none" });
+	});
+
+	it("accepts two or more executives with percentages summing to 100", () => {
+		expect(executivesSchema.safeParse(COMPUTABLE_EXECUTIVES).success).toBe(
+			true,
+		);
+	});
+
+	it("accepts one-decimal percentages summing to 100", () => {
+		const result = executivesSchema.safeParse({
+			executivesCount: "two_or_more",
+			executiveWomenPercent: 33.3,
+			executiveMenPercent: 66.7,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects percentages that do not sum to 100 (S6)", () => {
+		const result = executivesSchema.safeParse({
+			...COMPUTABLE_EXECUTIVES,
+			executiveMenPercent: 30,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "executiveMenPercent",
+			message: VALIDATION_MESSAGES.sum,
+		});
+	});
+
+	it("rejects two or more executives without percentages", () => {
+		const result = executivesSchema.safeParse({
+			executivesCount: "two_or_more",
+		});
+
+		expect(issues(result).map((issue) => issue.path)).toEqual([
+			"executiveWomenPercent",
+			"executiveMenPercent",
+		]);
+	});
+
+	it.each([
+		["above 100", 101, VALIDATION_MESSAGES.range],
+		["below 0", -1, VALIDATION_MESSAGES.range],
+		["with two decimals", 33.33, VALIDATION_MESSAGES.decimal],
+	])("rejects a percentage %s", (_label, executiveWomenPercent, message) => {
+		const result = executivesSchema.safeParse({
+			...COMPUTABLE_EXECUTIVES,
+			executiveWomenPercent,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "executiveWomenPercent",
+			message,
+		});
+	});
+
+	it("rejects an unknown executives count", () => {
+		expect(
+			executivesSchema.safeParse({ executivesCount: "three" }).success,
+		).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.members.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.members.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { membersSchema } from "~/modules/declaration-representation";
+import {
+	COMPUTABLE_MEMBERS,
+	issues,
+	NO_MANAGEMENT_BODY,
+	VALIDATION_MESSAGES,
+} from "./fixtures";
+
+describe("membersSchema", () => {
+	it("accepts the absence of a management body without percentages", () => {
+		expect(membersSchema.safeParse(NO_MANAGEMENT_BODY).success).toBe(true);
+	});
+
+	it("drops percentages sent alongside the absence of a management body", () => {
+		const result = membersSchema.safeParse({
+			hasManagementBody: false,
+			memberWomenPercent: 55,
+			memberMenPercent: 45,
+		});
+
+		expect(result.data).toEqual({ hasManagementBody: false });
+	});
+
+	it("accepts a management body with percentages summing to 100", () => {
+		expect(membersSchema.safeParse(COMPUTABLE_MEMBERS).success).toBe(true);
+	});
+
+	it("rejects percentages that do not sum to 100 (S6)", () => {
+		const result = membersSchema.safeParse({
+			...COMPUTABLE_MEMBERS,
+			memberMenPercent: 40,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "memberMenPercent",
+			message: VALIDATION_MESSAGES.sum,
+		});
+	});
+
+	it("rejects a management body without percentages", () => {
+		const result = membersSchema.safeParse({ hasManagementBody: true });
+
+		expect(issues(result).map((issue) => issue.path)).toEqual([
+			"memberWomenPercent",
+			"memberMenPercent",
+		]);
+	});
+
+	it("rejects a percentage outside the 0-100 range", () => {
+		const result = membersSchema.safeParse({
+			...COMPUTABLE_MEMBERS,
+			memberWomenPercent: 120,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "memberWomenPercent",
+			message: VALIDATION_MESSAGES.range,
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.publication.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.publication.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { publicationSchema } from "~/modules/declaration-representation";
 import {
 	issues,
+	MAX_PUBLISH_MODALITIES_LENGTH,
+	MAX_PUBLISH_URL_LENGTH,
 	OFFLINE_PUBLICATION,
 	WEBSITE_PUBLICATION as VALID_PUBLICATION,
 	VALIDATION_MESSAGES,
@@ -55,6 +57,31 @@ describe("publicationSchema", () => {
 		});
 	});
 
+	it("accepts a URL of exactly the maximum length", () => {
+		const prefix = "https://exemple.fr/";
+		const publishUrl =
+			prefix + "a".repeat(MAX_PUBLISH_URL_LENGTH - prefix.length);
+
+		expect(publishUrl).toHaveLength(MAX_PUBLISH_URL_LENGTH);
+		expect(
+			publicationSchema.safeParse({ ...VALID_PUBLICATION, publishUrl }).success,
+		).toBe(true);
+	});
+
+	it("rejects a URL longer than the maximum length", () => {
+		const prefix = "https://exemple.fr/";
+		const result = publicationSchema.safeParse({
+			...VALID_PUBLICATION,
+			publishUrl:
+				prefix + "a".repeat(MAX_PUBLISH_URL_LENGTH - prefix.length + 1),
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishUrl",
+			message: VALIDATION_MESSAGES.urlTooLong,
+		});
+	});
+
 	it("accepts publication modalities when there is no website", () => {
 		expect(publicationSchema.safeParse(OFFLINE_PUBLICATION).success).toBe(true);
 	});
@@ -68,6 +95,27 @@ describe("publicationSchema", () => {
 		expect(issues(result)).toContainEqual({
 			path: "publishModalities",
 			message: VALIDATION_MESSAGES.modalitiesRequired,
+		});
+	});
+
+	it("accepts publication modalities of exactly the maximum length", () => {
+		const result = publicationSchema.safeParse({
+			...OFFLINE_PUBLICATION,
+			publishModalities: "a".repeat(MAX_PUBLISH_MODALITIES_LENGTH),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects publication modalities longer than the maximum length", () => {
+		const result = publicationSchema.safeParse({
+			...OFFLINE_PUBLICATION,
+			publishModalities: "a".repeat(MAX_PUBLISH_MODALITIES_LENGTH + 1),
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishModalities",
+			message: VALIDATION_MESSAGES.modalitiesTooLong,
 		});
 	});
 

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.publication.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.publication.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { publicationSchema } from "~/modules/declaration-representation";
+import {
+	issues,
+	OFFLINE_PUBLICATION,
+	WEBSITE_PUBLICATION as VALID_PUBLICATION,
+	VALIDATION_MESSAGES,
+} from "./fixtures";
+
+describe("publicationSchema", () => {
+	it("accepts a website publication", () => {
+		expect(publicationSchema.safeParse(VALID_PUBLICATION).success).toBe(true);
+	});
+
+	it.each([
+		"https://exemple.fr/egalite",
+		"http://exemple.fr/egalite",
+		"www.exemple.fr/egalite",
+		"exemple.fr",
+	])("accepts the URL %s", (publishUrl) => {
+		const result = publicationSchema.safeParse({
+			...VALID_PUBLICATION,
+			publishUrl,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it.each([
+		"pas une url",
+		"exemple",
+		"https://",
+	])("rejects the URL %s", (publishUrl) => {
+		const result = publicationSchema.safeParse({
+			...VALID_PUBLICATION,
+			publishUrl,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishUrl",
+			message: VALIDATION_MESSAGES.urlInvalid,
+		});
+	});
+
+	it("rejects an empty URL", () => {
+		const result = publicationSchema.safeParse({
+			...VALID_PUBLICATION,
+			publishUrl: "   ",
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishUrl",
+			message: VALIDATION_MESSAGES.urlRequired,
+		});
+	});
+
+	it("accepts publication modalities when there is no website", () => {
+		expect(publicationSchema.safeParse(OFFLINE_PUBLICATION).success).toBe(true);
+	});
+
+	it("rejects empty publication modalities", () => {
+		const result = publicationSchema.safeParse({
+			...OFFLINE_PUBLICATION,
+			publishModalities: "  ",
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishModalities",
+			message: VALIDATION_MESSAGES.modalitiesRequired,
+		});
+	});
+
+	it("rejects a publication date that is not an ISO calendar date", () => {
+		const result = publicationSchema.safeParse({
+			...VALID_PUBLICATION,
+			publishDate: "01/03/2026",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.referencePeriod.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.referencePeriod.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { referencePeriodSchema } from "~/modules/declaration-representation";
+import {
+	issues,
+	VALID_REFERENCE_PERIOD as VALID_PERIOD,
+	VALIDATION_MESSAGES,
+	REPRESENTATION_YEAR as YEAR,
+} from "./fixtures";
+
+describe("referencePeriodSchema", () => {
+	it("accepts a calendar year ending in the declaration year", () => {
+		expect(referencePeriodSchema(YEAR).safeParse(VALID_PERIOD).success).toBe(
+			true,
+		);
+	});
+
+	it("accepts a 12-month period straddling two calendar years", () => {
+		const result = referencePeriodSchema(YEAR).safeParse({
+			referencePeriodStart: "2024-07-01",
+			referencePeriodEnd: "2025-06-30",
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a period starting on a leap day", () => {
+		const result = referencePeriodSchema(YEAR).safeParse({
+			referencePeriodStart: "2024-02-29",
+			referencePeriodEnd: "2025-02-28",
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects an end date whose year differs from the declaration year (S4)", () => {
+		const result = referencePeriodSchema(YEAR).safeParse({
+			referencePeriodStart: "2024-01-01",
+			referencePeriodEnd: "2024-12-31",
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "referencePeriodEnd",
+			message: VALIDATION_MESSAGES.periodYear,
+		});
+	});
+
+	it.each([
+		["shorter than 12 months", "2025-06-01", "2025-12-31"],
+		["longer than 12 months", "2024-12-01", "2025-12-31"],
+		["off by one day", "2025-01-02", "2025-12-31"],
+	])("rejects a period %s", (_label, start, end) => {
+		const result = referencePeriodSchema(YEAR).safeParse({
+			referencePeriodStart: start,
+			referencePeriodEnd: end,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "referencePeriodEnd",
+			message: VALIDATION_MESSAGES.periodLength,
+		});
+	});
+
+	it("rejects a date that is not an ISO calendar date", () => {
+		const result = referencePeriodSchema(YEAR).safeParse({
+			referencePeriodStart: "01/01/2025",
+			referencePeriodEnd: "2025-12-31",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.routerInputs.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.routerInputs.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	getRepresentationDeclarationSchema,
+	saveRepresentationDraftSchema,
+	submitRepresentationDeclarationSchema,
+} from "~/modules/declaration-representation";
+import { REPRESENTATION_YEAR as YEAR } from "./fixtures";
+
+describe("router input schemas", () => {
+	it("drops a client-supplied siren from the get input", () => {
+		const result = getRepresentationDeclarationSchema.safeParse({
+			year: YEAR,
+			siren: "999999999",
+		});
+
+		expect(result.data).toEqual({ year: YEAR });
+	});
+
+	it("drops a client-supplied siren from the saveDraft input", () => {
+		const result = saveRepresentationDraftSchema.safeParse({
+			year: YEAR,
+			siren: "999999999",
+			draft: { currentStep: 1 },
+			currentStep: 1,
+		});
+
+		expect(result.data).toEqual({
+			year: YEAR,
+			draft: { currentStep: 1 },
+			currentStep: 1,
+		});
+	});
+
+	it("drops a client-supplied siren from the submit input", () => {
+		const result = submitRepresentationDeclarationSchema.safeParse({
+			year: YEAR,
+			siren: "999999999",
+			payload: { executivesCount: "none" },
+		});
+
+		expect(result.data).toEqual({
+			year: YEAR,
+			payload: { executivesCount: "none" },
+		});
+	});
+
+	it.each([2025.5, Number.NaN])("rejects the year %s", (year) => {
+		expect(getRepresentationDeclarationSchema.safeParse({ year }).success).toBe(
+			false,
+		);
+	});
+
+	it.each([1999, 2101])("rejects the out-of-range year %s", (year) => {
+		expect(getRepresentationDeclarationSchema.safeParse({ year }).success).toBe(
+			false,
+		);
+	});
+
+	it.each([2000, 2100])("accepts the boundary year %s", (year) => {
+		expect(getRepresentationDeclarationSchema.safeParse({ year }).success).toBe(
+			true,
+		);
+	});
+
+	it.each([
+		[
+			"saveDraft",
+			(year: number) =>
+				saveRepresentationDraftSchema.safeParse({
+					year,
+					draft: { currentStep: 0 },
+					currentStep: 0,
+				}),
+		],
+		[
+			"submit",
+			(year: number) =>
+				submitRepresentationDeclarationSchema.safeParse({ year, payload: {} }),
+		],
+	])("rejects an out-of-range year on the %s input", (_label, parse) => {
+		expect(parse(1999).success).toBe(false);
+		expect(parse(2101).success).toBe(false);
+		expect(parse(YEAR).success).toBe(true);
+	});
+
+	it.each([-1, 6])("rejects the saveDraft current step %s", (currentStep) => {
+		const result = saveRepresentationDraftSchema.safeParse({
+			year: YEAR,
+			draft: { currentStep: 0 },
+			currentStep,
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects a submit payload that is not an object", () => {
+		const result = submitRepresentationDeclarationSchema.safeParse({
+			year: YEAR,
+			payload: "not-an-object",
+		});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.submit.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.submit.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { submitRepresentationSchema } from "~/modules/declaration-representation";
+import {
+	COMPUTABLE_EXECUTIVES,
+	COMPUTABLE_MEMBERS,
+	FULL_REPRESENTATION_PAYLOAD as FULL_PAYLOAD,
+	issues,
+	NO_EXECUTIVES,
+	NO_MANAGEMENT_BODY,
+	VALID_REFERENCE_PERIOD as VALID_PERIOD,
+	WEBSITE_PUBLICATION as VALID_PUBLICATION,
+	VALIDATION_MESSAGES,
+	REPRESENTATION_YEAR as YEAR,
+} from "./fixtures";
+
+describe("submitRepresentationSchema", () => {
+	it("accepts a complete declaration with both gaps computable (S19)", () => {
+		const result = submitRepresentationSchema(YEAR).safeParse(FULL_PAYLOAD);
+
+		expect(result.data).toEqual(FULL_PAYLOAD);
+	});
+
+	it("accepts a declaration without any computable gap and no publication", () => {
+		const result = submitRepresentationSchema(YEAR).safeParse({
+			...VALID_PERIOD,
+			...NO_EXECUTIVES,
+			...NO_MANAGEMENT_BODY,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it.each([
+		["only the executives gap", COMPUTABLE_EXECUTIVES, NO_MANAGEMENT_BODY],
+		["only the members gap", NO_EXECUTIVES, COMPUTABLE_MEMBERS],
+	])("requires publication when %s is computable (S12)", (_l, exec, members) => {
+		const result = submitRepresentationSchema(YEAR).safeParse({
+			...VALID_PERIOD,
+			...exec,
+			...members,
+		});
+
+		expect(issues(result).map((issue) => issue.path)).toContain("publishDate");
+	});
+
+	it.each([
+		["only the executives gap", COMPUTABLE_EXECUTIVES, NO_MANAGEMENT_BODY],
+		["only the members gap", NO_EXECUTIVES, COMPUTABLE_MEMBERS],
+	])("accepts publication when %s is computable (S12)", (_l, exec, members) => {
+		const result = submitRepresentationSchema(YEAR).safeParse({
+			...VALID_PERIOD,
+			...exec,
+			...members,
+			...VALID_PUBLICATION,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it.each([
+		["publishDate", { publishDate: "2026-03-01" }],
+		["hasWebsite", { hasWebsite: false }],
+		["publishUrl", { publishUrl: "https://exemple.fr/egalite" }],
+		["publishModalities", { publishModalities: "Affichage." }],
+	])("rejects %s when no gap is computable (S12)", (_label, publication) => {
+		const result = submitRepresentationSchema(YEAR).safeParse({
+			...VALID_PERIOD,
+			...NO_EXECUTIVES,
+			...NO_MANAGEMENT_BODY,
+			...publication,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishDate",
+			message: VALIDATION_MESSAGES.publicationNotRequired,
+		});
+	});
+
+	it.each([
+		["before the end of the reference period", "2025-12-30"],
+		["on the end of the reference period", "2025-12-31"],
+	])("rejects a publication date %s (S11)", (_label, publishDate) => {
+		const result = submitRepresentationSchema(YEAR).safeParse({
+			...FULL_PAYLOAD,
+			publishDate,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishDate",
+			message: VALIDATION_MESSAGES.publishDateAfterPeriod,
+		});
+	});
+
+	it("accepts a publication date on the day after the reference period", () => {
+		const result = submitRepresentationSchema(YEAR).safeParse({
+			...FULL_PAYLOAD,
+			publishDate: "2026-01-01",
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it("forwards the publication issues when the publication is malformed", () => {
+		const result = submitRepresentationSchema(YEAR).safeParse({
+			...FULL_PAYLOAD,
+			publishUrl: "pas une url",
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "publishUrl",
+			message: VALIDATION_MESSAGES.urlInvalid,
+		});
+	});
+
+	it("reports the reference period issue when the year does not match (S4)", () => {
+		const result = submitRepresentationSchema(2026).safeParse(FULL_PAYLOAD);
+
+		expect(issues(result)).toContainEqual({
+			path: "referencePeriodEnd",
+			message: VALIDATION_MESSAGES.periodYear,
+		});
+	});
+
+	it("rejects an empty payload without throwing", () => {
+		const result = submitRepresentationSchema(YEAR).safeParse({});
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/index.ts
+++ b/packages/app/src/modules/declaration-representation/index.ts
@@ -1,0 +1,21 @@
+export {
+	executivesCountSchema,
+	executivesSchema,
+	getRepresentationDeclarationSchema,
+	membersSchema,
+	publicationSchema,
+	referencePeriodSchema,
+	representationDraftSchema,
+	saveRepresentationDraftSchema,
+	submitRepresentationDeclarationSchema,
+	submitRepresentationSchema,
+} from "./schemas";
+export type {
+	ExecutivesInput,
+	MembersInput,
+	PublicationInput,
+	ReferencePeriodInput,
+	RepresentationDeclarationRow,
+	RepresentationDraft,
+	SubmitRepresentationInput,
+} from "./types";

--- a/packages/app/src/modules/declaration-representation/schemas.ts
+++ b/packages/app/src/modules/declaration-representation/schemas.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+
+const TOLERANT_URL_REGEX =
+	/^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/i;
+
+function parseIsoDate(value: string): Date {
+	return new Date(value);
+}
+
+function isTwelveConsecutiveMonths(start: string, end: string): boolean {
+	const startDate = parseIsoDate(start);
+	const expectedEnd = new Date(startDate);
+	expectedEnd.setUTCFullYear(expectedEnd.getUTCFullYear() + 1);
+	expectedEnd.setUTCDate(expectedEnd.getUTCDate() - 1);
+	return parseIsoDate(end).getTime() === expectedEnd.getTime();
+}
+
+function sumsToOneHundred(a: number, b: number): boolean {
+	return Math.round((a + b) * 10) / 10 === 100;
+}
+
+const percentSchema = z
+	.number()
+	.min(0, "Le pourcentage doit être compris entre 0 et 100.")
+	.max(100, "Le pourcentage doit être compris entre 0 et 100.")
+	.multipleOf(0.1, "Le pourcentage ne peut comporter plus d'une décimale.");
+
+export function referencePeriodSchema(year: number) {
+	return z
+		.object({
+			referencePeriodStart: z.string().date(),
+			referencePeriodEnd: z.string().date(),
+		})
+		.refine(
+			(period) =>
+				parseIsoDate(period.referencePeriodEnd).getUTCFullYear() === year,
+			{
+				message:
+					"L'année de la date de fin de la période de référence doit correspondre à l'année au titre de laquelle les écarts sont calculés.",
+				path: ["referencePeriodEnd"],
+			},
+		)
+		.refine(
+			(period) =>
+				isTwelveConsecutiveMonths(
+					period.referencePeriodStart,
+					period.referencePeriodEnd,
+				),
+			{
+				message: "La période de référence doit couvrir 12 mois consécutifs.",
+				path: ["referencePeriodEnd"],
+			},
+		);
+}
+
+export const executivesCountSchema = z.enum(["none", "one", "two_or_more"]);
+
+export const executivesSchema = z
+	.discriminatedUnion("executivesCount", [
+		z.object({ executivesCount: z.literal("none") }),
+		z.object({ executivesCount: z.literal("one") }),
+		z.object({
+			executivesCount: z.literal("two_or_more"),
+			executiveWomenPercent: percentSchema,
+			executiveMenPercent: percentSchema,
+		}),
+	])
+	.refine(
+		(data) =>
+			data.executivesCount !== "two_or_more" ||
+			sumsToOneHundred(data.executiveWomenPercent, data.executiveMenPercent),
+		{
+			message: "La somme des pourcentages doit être égale à 100 %.",
+			path: ["executiveMenPercent"],
+		},
+	);
+
+export const membersSchema = z
+	.discriminatedUnion("hasManagementBody", [
+		z.object({ hasManagementBody: z.literal(false) }),
+		z.object({
+			hasManagementBody: z.literal(true),
+			memberWomenPercent: percentSchema,
+			memberMenPercent: percentSchema,
+		}),
+	])
+	.refine(
+		(data) =>
+			!data.hasManagementBody ||
+			sumsToOneHundred(data.memberWomenPercent, data.memberMenPercent),
+		{
+			message: "La somme des pourcentages doit être égale à 100 %.",
+			path: ["memberMenPercent"],
+		},
+	);
+
+export const publicationSchema = z
+	.object({ publishDate: z.string().date() })
+	.and(
+		z.discriminatedUnion("hasWebsite", [
+			z.object({
+				hasWebsite: z.literal(true),
+				publishUrl: z
+					.string()
+					.trim()
+					.min(1, "L'adresse de la page internet est obligatoire.")
+					.regex(
+						TOLERANT_URL_REGEX,
+						"L'adresse de la page internet est invalide.",
+					),
+			}),
+			z.object({
+				hasWebsite: z.literal(false),
+				publishModalities: z
+					.string()
+					.trim()
+					.min(
+						1,
+						"La description des modalités de communication est obligatoire.",
+					),
+			}),
+		]),
+	);
+
+const optionalPublicationFieldsSchema = z.object({
+	publishDate: z.string().date().optional(),
+	hasWebsite: z.boolean().optional(),
+	publishUrl: z.string().optional(),
+	publishModalities: z.string().optional(),
+});
+
+export function submitRepresentationSchema(year: number) {
+	return referencePeriodSchema(year)
+		.and(executivesSchema)
+		.and(membersSchema)
+		.and(optionalPublicationFieldsSchema)
+		.superRefine((data, ctx) => {
+			const publicationRequired =
+				data.executivesCount === "two_or_more" ||
+				data.hasManagementBody === true;
+
+			if (!publicationRequired) {
+				if (
+					data.publishDate !== undefined ||
+					data.hasWebsite !== undefined ||
+					data.publishUrl !== undefined ||
+					data.publishModalities !== undefined
+				) {
+					ctx.addIssue({
+						code: "custom",
+						message:
+							"Aucune information de publication n'est requise lorsqu'aucun écart n'est calculable.",
+						path: ["publishDate"],
+					});
+				}
+				return;
+			}
+
+			const result = publicationSchema.safeParse({
+				publishDate: data.publishDate,
+				hasWebsite: data.hasWebsite,
+				publishUrl: data.publishUrl,
+				publishModalities: data.publishModalities,
+			});
+
+			if (!result.success) {
+				for (const issue of result.error.issues) {
+					ctx.addIssue({
+						code: "custom",
+						message: issue.message,
+						path: issue.path,
+					});
+				}
+				return;
+			}
+
+			if (
+				parseIsoDate(result.data.publishDate).getTime() <=
+				parseIsoDate(data.referencePeriodEnd).getTime()
+			) {
+				ctx.addIssue({
+					code: "custom",
+					message:
+						"La date de publication doit être postérieure à la fin de la période de référence.",
+					path: ["publishDate"],
+				});
+			}
+		});
+}
+
+export const representationDraftSchema = z.object({
+	currentStep: z.number().int().min(0).max(5),
+	referencePeriodStart: z.string().optional(),
+	referencePeriodEnd: z.string().optional(),
+	executivesCount: executivesCountSchema.optional(),
+	executiveWomenPercent: z.number().optional(),
+	executiveMenPercent: z.number().optional(),
+	hasManagementBody: z.boolean().optional(),
+	memberWomenPercent: z.number().optional(),
+	memberMenPercent: z.number().optional(),
+	hasWebsite: z.boolean().optional(),
+	publishDate: z.string().optional(),
+	publishUrl: z.string().optional(),
+	publishModalities: z.string().optional(),
+});
+
+const yearSchema = z.number().int().gte(2000).lte(2100);
+
+export const getRepresentationDeclarationSchema = z.object({
+	year: yearSchema,
+});
+
+export const saveRepresentationDraftSchema = z.object({
+	year: yearSchema,
+	draft: representationDraftSchema,
+	currentStep: z.number().int().min(0).max(5),
+});
+
+export const submitRepresentationDeclarationSchema = z.object({
+	year: yearSchema,
+	payload: z.record(z.string(), z.unknown()),
+});

--- a/packages/app/src/modules/declaration-representation/schemas.ts
+++ b/packages/app/src/modules/declaration-representation/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isRepresentationPublicationRequired } from "~/modules/domain";
 
 function isTolerantUrl(value: string): boolean {
 	const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
@@ -110,6 +111,7 @@ export const publicationSchema = z
 					.string()
 					.trim()
 					.min(1, "L'adresse de la page internet est obligatoire.")
+					.max(500, "L'adresse de la page internet est trop longue.")
 					.refine(isTolerantUrl, "L'adresse de la page internet est invalide."),
 			}),
 			z.object({
@@ -120,6 +122,10 @@ export const publicationSchema = z
 					.min(
 						1,
 						"La description des modalités de communication est obligatoire.",
+					)
+					.max(
+						5000,
+						"La description des modalités de communication est trop longue.",
 					),
 			}),
 		]),
@@ -128,8 +134,8 @@ export const publicationSchema = z
 const optionalPublicationFieldsSchema = z.object({
 	publishDate: z.string().date().optional(),
 	hasWebsite: z.boolean().optional(),
-	publishUrl: z.string().optional(),
-	publishModalities: z.string().optional(),
+	publishUrl: z.string().max(500).optional(),
+	publishModalities: z.string().max(5000).optional(),
 });
 
 export function submitRepresentationSchema(year: number) {
@@ -138,9 +144,10 @@ export function submitRepresentationSchema(year: number) {
 		.and(membersSchema)
 		.and(optionalPublicationFieldsSchema)
 		.superRefine((data, ctx) => {
-			const publicationRequired =
-				data.executivesCount === "two_or_more" ||
-				data.hasManagementBody === true;
+			const publicationRequired = isRepresentationPublicationRequired(
+				data.executivesCount,
+				data.hasManagementBody,
+			);
 
 			if (!publicationRequired) {
 				if (
@@ -203,8 +210,8 @@ export const representationDraftSchema = z.object({
 	memberMenPercent: z.number().optional(),
 	hasWebsite: z.boolean().optional(),
 	publishDate: z.string().optional(),
-	publishUrl: z.string().optional(),
-	publishModalities: z.string().optional(),
+	publishUrl: z.string().max(500).optional(),
+	publishModalities: z.string().max(5000).optional(),
 });
 
 const yearSchema = z.number().int().gte(2000).lte(2100);

--- a/packages/app/src/modules/declaration-representation/schemas.ts
+++ b/packages/app/src/modules/declaration-representation/schemas.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
 
-const TOLERANT_URL_REGEX =
-	/^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/i;
+function isTolerantUrl(value: string): boolean {
+	const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+	try {
+		return new URL(candidate).hostname.includes(".");
+	} catch {
+		return false;
+	}
+}
 
 function parseIsoDate(value: string): Date {
 	return new Date(value);
@@ -104,10 +110,7 @@ export const publicationSchema = z
 					.string()
 					.trim()
 					.min(1, "L'adresse de la page internet est obligatoire.")
-					.regex(
-						TOLERANT_URL_REGEX,
-						"L'adresse de la page internet est invalide.",
-					),
+					.refine(isTolerantUrl, "L'adresse de la page internet est invalide."),
 			}),
 			z.object({
 				hasWebsite: z.literal(false),

--- a/packages/app/src/modules/declaration-representation/types.ts
+++ b/packages/app/src/modules/declaration-representation/types.ts
@@ -10,8 +10,10 @@ import type {
 	submitRepresentationSchema,
 } from "./schemas";
 
-export type RepresentationDeclarationRow =
-	typeof representationDeclarations.$inferSelect;
+export type RepresentationDeclarationRow = Omit<
+	typeof representationDeclarations.$inferSelect,
+	"legacyDeclarant" | "importedFromV1At"
+>;
 
 export type ReferencePeriodInput = z.infer<
 	ReturnType<typeof referencePeriodSchema>

--- a/packages/app/src/modules/declaration-representation/types.ts
+++ b/packages/app/src/modules/declaration-representation/types.ts
@@ -1,0 +1,25 @@
+import type { z } from "zod";
+
+import type { representationDeclarations } from "~/server/db/schema";
+import type {
+	executivesSchema,
+	membersSchema,
+	publicationSchema,
+	referencePeriodSchema,
+	representationDraftSchema,
+	submitRepresentationSchema,
+} from "./schemas";
+
+export type RepresentationDeclarationRow =
+	typeof representationDeclarations.$inferSelect;
+
+export type ReferencePeriodInput = z.infer<
+	ReturnType<typeof referencePeriodSchema>
+>;
+export type ExecutivesInput = z.infer<typeof executivesSchema>;
+export type MembersInput = z.infer<typeof membersSchema>;
+export type PublicationInput = z.infer<typeof publicationSchema>;
+export type RepresentationDraft = z.infer<typeof representationDraftSchema>;
+export type SubmitRepresentationInput = z.infer<
+	ReturnType<typeof submitRepresentationSchema>
+>;

--- a/packages/app/src/modules/domain/__tests__/representation.test.ts
+++ b/packages/app/src/modules/domain/__tests__/representation.test.ts
@@ -6,6 +6,7 @@ import {
 	getRepresentationCampaignYear,
 	getRepresentationTarget,
 	isPresumedSubjectToRepresentation,
+	isRepresentationPublicationRequired,
 	REPRESENTATION_SUBJECTION_WINDOW_YEARS,
 	REPRESENTATION_SUBJECTION_WORKFORCE_MIN,
 	REPRESENTATION_TARGET_INITIAL,
@@ -286,6 +287,25 @@ describe("isPresumedSubjectToRepresentation", () => {
 	});
 });
 
+describe("isRepresentationPublicationRequired", () => {
+	it("requires publication when executives are computable, whatever the management body", () => {
+		expect(isRepresentationPublicationRequired("two_or_more", false)).toBe(
+			true,
+		);
+		expect(isRepresentationPublicationRequired("two_or_more", true)).toBe(true);
+	});
+
+	it("requires publication when a management body exists, whatever the executives count", () => {
+		expect(isRepresentationPublicationRequired("none", true)).toBe(true);
+		expect(isRepresentationPublicationRequired("one", true)).toBe(true);
+	});
+
+	it("does not require publication when no indicator is computable", () => {
+		expect(isRepresentationPublicationRequired("none", false)).toBe(false);
+		expect(isRepresentationPublicationRequired("one", false)).toBe(false);
+	});
+});
+
 describe("verdict independence (S16)", () => {
 	// An aggregated verdict would let a compliant indicator mask a failing one.
 	it("exposes no aggregated verdict helper", async () => {
@@ -301,6 +321,7 @@ describe("verdict independence (S16)", () => {
 			"getRepresentationCampaignYear",
 			"getRepresentationTarget",
 			"isPresumedSubjectToRepresentation",
+			"isRepresentationPublicationRequired",
 		]);
 	});
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -235,6 +235,7 @@ export {
 	getRepresentationCampaignYear,
 	getRepresentationTarget,
 	isPresumedSubjectToRepresentation,
+	isRepresentationPublicationRequired,
 	REPRESENTATION_SUBJECTION_WINDOW_YEARS,
 	REPRESENTATION_SUBJECTION_WORKFORCE_MIN,
 	REPRESENTATION_TARGET_INITIAL,

--- a/packages/app/src/modules/domain/shared/representation.ts
+++ b/packages/app/src/modules/domain/shared/representation.ts
@@ -58,3 +58,10 @@ export function isPresumedSubjectToRepresentation(
 		(entry) => entry.workforceEma >= REPRESENTATION_SUBJECTION_WORKFORCE_MIN,
 	);
 }
+
+export function isRepresentationPublicationRequired(
+	executivesCount: ExecutivesCount,
+	hasManagementBody: boolean,
+): boolean {
+	return executivesCount === "two_or_more" || hasManagementBody === true;
+}

--- a/packages/app/src/server/api/root.ts
+++ b/packages/app/src/server/api/root.ts
@@ -14,6 +14,7 @@ import { mailRouter } from "~/server/api/routers/mail";
 import { profileRouter } from "~/server/api/routers/profile";
 import { publicReferentsRouter } from "~/server/api/routers/publicReferents";
 import { publicStatsRouter } from "~/server/api/routers/publicStats";
+import { representationDeclarationRouter } from "~/server/api/routers/representationDeclaration";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -38,6 +39,7 @@ export const appRouter = createTRPCRouter({
 	profile: profileRouter,
 	publicReferents: publicReferentsRouter,
 	publicStats: publicStatsRouter,
+	representationDeclaration: representationDeclarationRouter,
 });
 
 // export type definition of API

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.get.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.get.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { REPRESENTATION_YEAR as YEAR } from "~/modules/declaration-representation/__tests__/fixtures";
+import {
+	buildSession,
+	CAMPAIGN_YEAR,
+	CLOSED_CAMPAIGN,
+	createCaller,
+	createMockDb,
+	installRouterTestEnv,
+	SIREN,
+	whereParams,
+} from "./representationDeclarationHarness";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockGetRepresentationCampaign = vi.fn();
+vi.mock("~/server/db/getRepresentationCampaign", () => ({
+	getRepresentationCampaign: (year: number) =>
+		mockGetRepresentationCampaign(year),
+}));
+
+describe("representationDeclarationRouter.get", () => {
+	installRouterTestEnv(mockGetRepresentationCampaign);
+
+	it("returns the declaration of the company alongside an open campaign", async () => {
+		const row = { id: "repr-1", siren: SIREN, year: YEAR, status: "draft" };
+		const mock = createMockDb([row]);
+
+		const result = await createCaller(mock.db).get({ year: YEAR });
+
+		expect(result).toEqual({ declaration: row, campaignOpen: true });
+	});
+
+	it("returns no declaration when the company has not started one", async () => {
+		const mock = createMockDb([]);
+
+		const result = await createCaller(mock.db).get({ year: YEAR });
+
+		expect(result.declaration).toBeNull();
+	});
+
+	it("flags the campaign as closed outside its window", async () => {
+		mockGetRepresentationCampaign.mockResolvedValue(CLOSED_CAMPAIGN);
+		const mock = createMockDb([]);
+
+		const result = await createCaller(mock.db).get({ year: YEAR });
+
+		expect(result.campaignOpen).toBe(false);
+	});
+
+	it("resolves the campaign of the year following the declared year", async () => {
+		const mock = createMockDb([]);
+
+		await createCaller(mock.db).get({ year: YEAR });
+
+		expect(mockGetRepresentationCampaign).toHaveBeenCalledWith(CAMPAIGN_YEAR);
+	});
+
+	it("scopes the lookup to the SIREN of the session", async () => {
+		const mock = createMockDb([]);
+
+		await createCaller(mock.db).get({ year: YEAR });
+
+		expect(whereParams(mock)).toEqual([SIREN, YEAR]);
+	});
+
+	it("ignores a SIREN supplied by the client", async () => {
+		const mock = createMockDb([]);
+
+		await createCaller(mock.db).get({
+			year: YEAR,
+			siren: "999999999",
+		} as never);
+
+		expect(whereParams(mock)).toEqual([SIREN, YEAR]);
+	});
+
+	it("reads the impersonated SIREN when an admin mimics a company", async () => {
+		const mock = createMockDb([]);
+		const session = buildSession({
+			isAdmin: true,
+			impersonation: { siren: "987654321" },
+		});
+
+		await createCaller(mock.db, session).get({ year: YEAR });
+
+		expect(whereParams(mock)).toEqual(["987654321", YEAR]);
+	});
+
+	it("rejects a session without a usable SIRET", async () => {
+		const mock = createMockDb([]);
+		const caller = createCaller(mock.db, buildSession({ siret: null }));
+
+		await expect(caller.get({ year: YEAR })).rejects.toMatchObject({
+			code: "BAD_REQUEST",
+			message: "SIRET manquant ou invalide dans la session",
+		});
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.integration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.integration.test.ts
@@ -1,0 +1,269 @@
+import postgres from "postgres";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import { env } from "~/env.js";
+import {
+	COMPUTABLE_EXECUTIVES,
+	COMPUTABLE_MEMBERS,
+	FULL_REPRESENTATION_PAYLOAD,
+	NOT_COMPUTABLE_PAYLOAD,
+	OFFLINE_PUBLICATION,
+	VALID_REFERENCE_PERIOD,
+	REPRESENTATION_YEAR as YEAR,
+} from "~/modules/declaration-representation/__tests__/fixtures";
+import { appRouter } from "~/server/api/root";
+import { db } from "~/server/db";
+
+describe("representationDeclarationRouter against a real Postgres", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN = "111222333";
+	const OTHER_SIREN = "444555666";
+	const USER_ID = "representation-integration-user";
+	const USER_EMAIL = "representation-integration@example.fr";
+	const OPEN_CAMPAIGN_YEAR = YEAR + 1;
+	const CLOSED_YEAR = 2030;
+	const CLOSED_CAMPAIGN_YEAR = CLOSED_YEAR + 1;
+	const DRAFT = { currentStep: 2, ...VALID_REFERENCE_PERIOD };
+
+	// Called through the app router so the procedure paths — and therefore the
+	// audit `PROCEDURE_TO_ACTION` keys — are the production ones.
+	function createCaller(siren = SIREN) {
+		return appRouter.createCaller({
+			db,
+			session: {
+				user: {
+					id: USER_ID,
+					email: USER_EMAIL,
+					siret: `${siren}00015`,
+					isAdmin: false,
+					impersonation: null,
+				},
+				expires: "",
+			},
+			headers: new Headers(),
+		} as never).representationDeclaration;
+	}
+
+	async function countDeclarations(siren = SIREN) {
+		const rows = await sql<{ count: string }[]>`
+			SELECT count(*)::text AS count
+			FROM app_representation_declaration
+			WHERE siren = ${siren}
+		`;
+		return Number(rows[0]?.count ?? "0");
+	}
+
+	beforeAll(async () => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+
+		await sql`INSERT INTO app_user (id, email) VALUES (${USER_ID}, ${USER_EMAIL})`;
+		await sql`
+			INSERT INTO app_company (siren, name)
+			VALUES (${SIREN}, 'Société Représentation'), (${OTHER_SIREN}, 'Société Voisine')
+		`;
+		await sql`
+			INSERT INTO app_representation_campaign (year, campaign_start_date, campaign_end_date, declaration_deadline)
+			VALUES
+				(${OPEN_CAMPAIGN_YEAR}, '2000-01-01', '2999-12-31', '2000-03-01'),
+				(${CLOSED_CAMPAIGN_YEAR}, '2000-01-01', '2000-12-31', '2000-03-01')
+		`;
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await sql`DELETE FROM app_representation_declaration WHERE siren IN (${SIREN}, ${OTHER_SIREN})`;
+		await sql`DELETE FROM app_representation_campaign WHERE year IN (${OPEN_CAMPAIGN_YEAR}, ${CLOSED_CAMPAIGN_YEAR})`;
+		await sql`DELETE FROM app_company WHERE siren IN (${SIREN}, ${OTHER_SIREN})`;
+		await sql`DELETE FROM audit.action_log WHERE user_id = ${USER_ID}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await sql`DELETE FROM app_representation_declaration WHERE siren IN (${SIREN}, ${OTHER_SIREN})`;
+		await sql`DELETE FROM audit.action_log WHERE user_id = ${USER_ID}`;
+	});
+
+	it("restores the draft and the current step saved earlier (S21)", async () => {
+		const caller = createCaller();
+
+		await caller.saveDraft({ year: YEAR, draft: DRAFT, currentStep: 2 });
+		const { declaration, campaignOpen } = await caller.get({ year: YEAR });
+
+		expect(campaignOpen).toBe(true);
+		expect(declaration).toMatchObject({
+			siren: SIREN,
+			year: YEAR,
+			status: "draft",
+			currentStep: 2,
+			draft: DRAFT,
+			declarantId: USER_ID,
+		});
+	});
+
+	it("persists a submitted declaration with its derived columns (S19)", async () => {
+		const caller = createCaller();
+
+		await caller.submit({ year: YEAR, payload: FULL_REPRESENTATION_PAYLOAD });
+		const { declaration } = await caller.get({ year: YEAR });
+
+		expect(declaration).toMatchObject({
+			status: "submitted",
+			referencePeriodStart: "2025-01-01",
+			referencePeriodEnd: "2025-12-31",
+			executiveWomenPercent: "60.00",
+			executiveMenPercent: "40.00",
+			notComputableReasonExecutives: null,
+			memberWomenPercent: "55.00",
+			memberMenPercent: "45.00",
+			notComputableReasonMembers: null,
+			publishDate: "2026-03-01",
+			publishUrl: FULL_REPRESENTATION_PAYLOAD.publishUrl,
+			publishModalities: null,
+			draft: null,
+			draftUpdatedAt: null,
+		});
+		expect(declaration?.submittedAt).toBeInstanceOf(Date);
+	});
+
+	it("persists the not-computable motives as valid enum values", async () => {
+		const caller = createCaller();
+
+		await caller.submit({ year: YEAR, payload: NOT_COMPUTABLE_PAYLOAD });
+		const { declaration } = await caller.get({ year: YEAR });
+
+		expect(declaration).toMatchObject({
+			executiveWomenPercent: null,
+			memberWomenPercent: null,
+			notComputableReasonExecutives: "aucun_cadre_dirigeant",
+			notComputableReasonMembers: "aucune_instance_dirigeante",
+			publishDate: null,
+			publishUrl: null,
+			publishModalities: null,
+		});
+	});
+
+	it("replaces the previous submission instead of duplicating it (S22)", async () => {
+		const caller = createCaller();
+
+		await caller.submit({ year: YEAR, payload: FULL_REPRESENTATION_PAYLOAD });
+		await caller.submit({
+			year: YEAR,
+			payload: {
+				...VALID_REFERENCE_PERIOD,
+				...COMPUTABLE_EXECUTIVES,
+				...COMPUTABLE_MEMBERS,
+				...OFFLINE_PUBLICATION,
+			},
+		});
+
+		const { declaration } = await caller.get({ year: YEAR });
+
+		expect(await countDeclarations()).toBe(1);
+		expect(declaration).toMatchObject({
+			status: "submitted",
+			publishUrl: null,
+			publishModalities: OFFLINE_PUBLICATION.publishModalities,
+		});
+	});
+
+	it("keeps the submitted status when a later draft is saved", async () => {
+		const caller = createCaller();
+
+		await caller.submit({ year: YEAR, payload: FULL_REPRESENTATION_PAYLOAD });
+		const submittedAt = (await caller.get({ year: YEAR })).declaration
+			?.submittedAt;
+
+		await caller.saveDraft({ year: YEAR, draft: DRAFT, currentStep: 2 });
+		const { declaration } = await caller.get({ year: YEAR });
+
+		expect(await countDeclarations()).toBe(1);
+		expect(declaration).toMatchObject({
+			status: "submitted",
+			submittedAt,
+			draft: DRAFT,
+			currentStep: 2,
+		});
+	});
+
+	it("never exposes the declaration of another company", async () => {
+		await sql`
+			INSERT INTO app_representation_declaration (id, siren, year, status, publish_url)
+			VALUES ('other-company-row', ${OTHER_SIREN}, ${YEAR}, 'submitted', 'https://voisine.fr')
+		`;
+		const caller = createCaller();
+
+		await caller.saveDraft({ year: YEAR, draft: DRAFT, currentStep: 2 });
+		const { declaration } = await caller.get({ year: YEAR });
+
+		expect(declaration?.siren).toBe(SIREN);
+		expect(declaration?.publishUrl).toBeNull();
+		expect(await countDeclarations(OTHER_SIREN)).toBe(1);
+	});
+
+	it("refuses any write once the campaign is closed (S23)", async () => {
+		const caller = createCaller();
+
+		await expect(
+			caller.saveDraft({ year: CLOSED_YEAR, draft: DRAFT, currentStep: 2 }),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+		await expect(
+			caller.submit({
+				year: CLOSED_YEAR,
+				payload: FULL_REPRESENTATION_PAYLOAD,
+			}),
+		).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+		const { declaration, campaignOpen } = await caller.get({
+			year: CLOSED_YEAR,
+		});
+
+		expect(campaignOpen).toBe(false);
+		expect(declaration).toBeNull();
+		expect(await countDeclarations()).toBe(0);
+	});
+
+	it("records every procedure in the audit log with its retention category", async () => {
+		const caller = createCaller();
+
+		await caller.saveDraft({ year: YEAR, draft: DRAFT, currentStep: 2 });
+		await caller.get({ year: YEAR });
+		await caller.submit({ year: YEAR, payload: FULL_REPRESENTATION_PAYLOAD });
+
+		await vi.waitFor(async () => {
+			const rows = await sql<
+				{ action: string; category: string; siren: string | null }[]
+			>`
+				SELECT DISTINCT action, category, siren FROM audit.action_log
+				WHERE user_id = ${USER_ID}
+				ORDER BY action
+			`;
+			expect([...rows]).toEqual([
+				{
+					action: "representation_declaration.get",
+					category: "read_sensitive",
+					siren: SIREN,
+				},
+				{
+					action: "representation_declaration.save_draft",
+					category: "mutation",
+					siren: SIREN,
+				},
+				{
+					action: "representation_declaration.submit",
+					category: "mutation",
+					siren: SIREN,
+				},
+			]);
+		}, 5_000);
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.integration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.integration.test.ts
@@ -110,6 +110,18 @@ describe("representationDeclarationRouter against a real Postgres", () => {
 		});
 	});
 
+	// The explicit projection is the only guard against leaking the V1 import columns.
+	it("never exposes the V1 import columns to the client", async () => {
+		const caller = createCaller();
+
+		await caller.saveDraft({ year: YEAR, draft: DRAFT, currentStep: 2 });
+		const { declaration } = await caller.get({ year: YEAR });
+
+		expect(declaration).not.toBeNull();
+		expect(declaration).not.toHaveProperty("legacyDeclarant");
+		expect(declaration).not.toHaveProperty("importedFromV1At");
+	});
+
 	it("persists a submitted declaration with its derived columns (S19)", async () => {
 		const caller = createCaller();
 

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.saveDraft.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.saveDraft.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { REPRESENTATION_YEAR as YEAR } from "~/modules/declaration-representation/__tests__/fixtures";
+import {
+	CLOSED_CAMPAIGN,
+	CLOSED_MESSAGE,
+	conflictSet,
+	createCaller,
+	createMockDb,
+	DRAFT,
+	IMPERSONATION_MESSAGE,
+	impersonatingSession,
+	insertedValues,
+	installRouterTestEnv,
+	type MockDb,
+	NOW,
+	SIREN,
+	USER_ID,
+} from "./representationDeclarationHarness";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockGetRepresentationCampaign = vi.fn();
+vi.mock("~/server/db/getRepresentationCampaign", () => ({
+	getRepresentationCampaign: (year: number) =>
+		mockGetRepresentationCampaign(year),
+}));
+
+describe("representationDeclarationRouter.saveDraft", () => {
+	installRouterTestEnv(mockGetRepresentationCampaign);
+
+	async function saveDraft(
+		mock: MockDb,
+		session?: ReturnType<typeof impersonatingSession>,
+	) {
+		return createCaller(mock.db, session).saveDraft({
+			year: YEAR,
+			draft: DRAFT,
+			currentStep: 3,
+		});
+	}
+
+	it("creates the row as a draft owned by the session company", async () => {
+		const mock = createMockDb();
+
+		await saveDraft(mock);
+
+		expect(insertedValues(mock)).toEqual({
+			siren: SIREN,
+			year: YEAR,
+			declarantId: USER_ID,
+			status: "draft",
+			draft: DRAFT,
+			draftUpdatedAt: NOW,
+			currentStep: 3,
+			updatedAt: NOW,
+		});
+	});
+
+	it("targets the (siren, year) unique constraint on conflict", async () => {
+		const mock = createMockDb();
+
+		await saveDraft(mock);
+
+		expect(conflictSet(mock).target).toEqual([
+			expect.objectContaining({ name: "siren" }),
+			expect.objectContaining({ name: "year" }),
+		]);
+	});
+
+	it("never overwrites the status of an existing declaration", async () => {
+		const mock = createMockDb();
+
+		await saveDraft(mock);
+
+		expect(Object.keys(conflictSet(mock).set).sort()).toEqual([
+			"currentStep",
+			"draft",
+			"draftUpdatedAt",
+			"updatedAt",
+		]);
+	});
+
+	it("refuses to save once the campaign is closed (S23)", async () => {
+		mockGetRepresentationCampaign.mockResolvedValue(CLOSED_CAMPAIGN);
+		const mock = createMockDb();
+
+		await expect(saveDraft(mock)).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: CLOSED_MESSAGE,
+		});
+		expect(mock.insert).not.toHaveBeenCalled();
+	});
+
+	it("refuses to save while an admin mimics the company", async () => {
+		const mock = createMockDb();
+
+		await expect(saveDraft(mock, impersonatingSession())).rejects.toMatchObject(
+			{
+				code: "FORBIDDEN",
+				message: IMPERSONATION_MESSAGE,
+			},
+		);
+		expect(mock.insert).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.submit.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.submit.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	COMPUTABLE_EXECUTIVES,
+	COMPUTABLE_MEMBERS,
+	FULL_REPRESENTATION_PAYLOAD as FULL_PAYLOAD,
+	NO_EXECUTIVES,
+	NO_MANAGEMENT_BODY,
+	NOT_COMPUTABLE_PAYLOAD,
+	OFFLINE_PUBLICATION,
+	SINGLE_EXECUTIVE,
+	VALID_REFERENCE_PERIOD,
+	VALIDATION_MESSAGES,
+	REPRESENTATION_YEAR as YEAR,
+} from "~/modules/declaration-representation/__tests__/fixtures";
+import {
+	CLOSED_CAMPAIGN,
+	CLOSED_MESSAGE,
+	conflictSet,
+	createCaller,
+	createMockDb,
+	IMPERSONATION_MESSAGE,
+	impersonatingSession,
+	insertedValues,
+	installRouterTestEnv,
+	type MockDb,
+	NOW,
+	SIREN,
+	USER_ID,
+} from "./representationDeclarationHarness";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockGetRepresentationCampaign = vi.fn();
+vi.mock("~/server/db/getRepresentationCampaign", () => ({
+	getRepresentationCampaign: (year: number) =>
+		mockGetRepresentationCampaign(year),
+}));
+
+describe("representationDeclarationRouter.submit", () => {
+	installRouterTestEnv(mockGetRepresentationCampaign);
+
+	async function submit(
+		mock: MockDb,
+		payload: Record<string, unknown>,
+		session?: ReturnType<typeof impersonatingSession>,
+	) {
+		return createCaller(mock.db, session).submit({ year: YEAR, payload });
+	}
+
+	it("stores a complete declaration as submitted (S19)", async () => {
+		const mock = createMockDb();
+
+		await submit(mock, FULL_PAYLOAD);
+
+		expect(insertedValues(mock)).toEqual({
+			siren: SIREN,
+			year: YEAR,
+			declarantId: USER_ID,
+			referencePeriodStart: "2025-01-01",
+			referencePeriodEnd: "2025-12-31",
+			executiveWomenPercent: "60",
+			executiveMenPercent: "40",
+			notComputableReasonExecutives: null,
+			memberWomenPercent: "55",
+			memberMenPercent: "45",
+			notComputableReasonMembers: null,
+			publishDate: "2026-03-01",
+			publishUrl: "https://exemple.fr/egalite-professionnelle",
+			publishModalities: null,
+			status: "submitted",
+			submittedAt: NOW,
+			updatedAt: NOW,
+			draft: null,
+			draftUpdatedAt: null,
+		});
+	});
+
+	it.each([
+		["no executive", NO_EXECUTIVES, "aucun_cadre_dirigeant"],
+		["a single executive", SINGLE_EXECUTIVE, "un_seul_cadre_dirigeant"],
+	])("derives the executives motive when there is %s", async (_label, executives, reason) => {
+		const mock = createMockDb();
+
+		await submit(mock, {
+			...VALID_REFERENCE_PERIOD,
+			...executives,
+			...COMPUTABLE_MEMBERS,
+			...OFFLINE_PUBLICATION,
+		});
+
+		expect(insertedValues(mock)).toMatchObject({
+			executiveWomenPercent: null,
+			executiveMenPercent: null,
+			notComputableReasonExecutives: reason,
+		});
+	});
+
+	it("derives the members motive when there is no management body", async () => {
+		const mock = createMockDb();
+
+		await submit(mock, {
+			...VALID_REFERENCE_PERIOD,
+			...COMPUTABLE_EXECUTIVES,
+			...NO_MANAGEMENT_BODY,
+			...OFFLINE_PUBLICATION,
+		});
+
+		expect(insertedValues(mock)).toMatchObject({
+			memberWomenPercent: null,
+			memberMenPercent: null,
+			notComputableReasonMembers: "aucune_instance_dirigeante",
+		});
+	});
+
+	it("stores the publication modalities when there is no website", async () => {
+		const mock = createMockDb();
+
+		await submit(mock, {
+			...VALID_REFERENCE_PERIOD,
+			...COMPUTABLE_EXECUTIVES,
+			...COMPUTABLE_MEMBERS,
+			...OFFLINE_PUBLICATION,
+		});
+
+		expect(insertedValues(mock)).toMatchObject({
+			publishDate: "2026-03-01",
+			publishUrl: null,
+			publishModalities: OFFLINE_PUBLICATION.publishModalities,
+		});
+	});
+
+	it("leaves the publication columns empty when no gap is computable", async () => {
+		const mock = createMockDb();
+
+		await submit(mock, NOT_COMPUTABLE_PAYLOAD);
+
+		expect(insertedValues(mock)).toMatchObject({
+			notComputableReasonExecutives: "aucun_cadre_dirigeant",
+			notComputableReasonMembers: "aucune_instance_dirigeante",
+			publishDate: null,
+			publishUrl: null,
+			publishModalities: null,
+		});
+	});
+
+	it("replaces the previous submission on conflict (S22)", async () => {
+		const mock = createMockDb();
+
+		await submit(mock, FULL_PAYLOAD);
+		const { target, set } = conflictSet(mock);
+
+		expect(target).toEqual([
+			expect.objectContaining({ name: "siren" }),
+			expect.objectContaining({ name: "year" }),
+		]);
+		expect(set).toMatchObject({
+			status: "submitted",
+			submittedAt: NOW,
+			draft: null,
+			draftUpdatedAt: null,
+		});
+	});
+
+	it("never overwrites the SIREN or the declarant on conflict", async () => {
+		const mock = createMockDb();
+
+		await submit(mock, FULL_PAYLOAD);
+
+		expect(conflictSet(mock).set).not.toHaveProperty("siren");
+		expect(conflictSet(mock).set).not.toHaveProperty("declarantId");
+	});
+
+	it.each([
+		[
+			"percentages that do not sum to 100 (S6)",
+			{ ...FULL_PAYLOAD, executiveMenPercent: 30 },
+			VALIDATION_MESSAGES.sum,
+		],
+		[
+			"a publication date within the reference period (S11)",
+			{ ...FULL_PAYLOAD, publishDate: "2025-12-31" },
+			VALIDATION_MESSAGES.publishDateAfterPeriod,
+		],
+		[
+			"publication data while no gap is computable (S12)",
+			{ ...NOT_COMPUTABLE_PAYLOAD, publishDate: "2026-03-01" },
+			VALIDATION_MESSAGES.publicationNotRequired,
+		],
+		[
+			"a reference period ending on another year (S4)",
+			{
+				...FULL_PAYLOAD,
+				referencePeriodStart: "2024-01-01",
+				referencePeriodEnd: "2024-12-31",
+			},
+			VALIDATION_MESSAGES.periodYear,
+		],
+	])("rejects %s", async (_label, payload, message) => {
+		const mock = createMockDb();
+
+		await expect(submit(mock, payload)).rejects.toMatchObject({
+			code: "BAD_REQUEST",
+			message,
+		});
+		expect(mock.insert).not.toHaveBeenCalled();
+	});
+
+	it("refuses to submit once the campaign is closed (S23)", async () => {
+		mockGetRepresentationCampaign.mockResolvedValue(CLOSED_CAMPAIGN);
+		const mock = createMockDb();
+
+		await expect(submit(mock, FULL_PAYLOAD)).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: CLOSED_MESSAGE,
+		});
+		expect(mock.insert).not.toHaveBeenCalled();
+	});
+
+	it("refuses to submit while an admin mimics the company", async () => {
+		const mock = createMockDb();
+
+		await expect(
+			submit(mock, FULL_PAYLOAD, impersonatingSession()),
+		).rejects.toMatchObject({
+			code: "FORBIDDEN",
+			message: IMPERSONATION_MESSAGE,
+		});
+		expect(mock.insert).not.toHaveBeenCalled();
+	});
+});

--- a/packages/app/src/server/api/routers/__tests__/representationDeclarationHarness.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclarationHarness.ts
@@ -1,0 +1,109 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { afterEach, beforeEach, type Mock, vi } from "vitest";
+
+import {
+	VALID_REFERENCE_PERIOD,
+	REPRESENTATION_YEAR as YEAR,
+} from "~/modules/declaration-representation/__tests__/fixtures";
+import { representationDeclarationRouter } from "~/server/api/routers/representationDeclaration";
+
+export const SIREN = "123456789";
+export const SIRET = `${SIREN}00015`;
+export const USER_ID = "user-1";
+export const NOW = new Date("2026-06-15T09:30:00.000Z");
+export const CAMPAIGN_YEAR = YEAR + 1;
+export const CLOSED_MESSAGE =
+	"La campagne de représentation équilibrée est close : la déclaration ne peut plus être modifiée.";
+export const IMPERSONATION_MESSAGE =
+	"Mode mimoquage actif : cette action est en lecture seule et ne peut pas être effectuée.";
+
+export const OPEN_CAMPAIGN = {
+	campaignStartDate: new Date("2026-01-01T00:00:00.000Z"),
+	campaignEndDate: new Date("2026-12-31T00:00:00.000Z"),
+	declarationDeadline: new Date("2026-03-01T00:00:00.000Z"),
+};
+
+export const CLOSED_CAMPAIGN = {
+	campaignStartDate: new Date("2027-01-01T00:00:00.000Z"),
+	campaignEndDate: new Date("2027-12-31T00:00:00.000Z"),
+	declarationDeadline: new Date("2027-03-01T00:00:00.000Z"),
+};
+
+export const DRAFT = { currentStep: 3, ...VALID_REFERENCE_PERIOD };
+
+export function createMockDb(rows: unknown[] = []) {
+	const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+	const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+	const insert = vi.fn().mockReturnValue({ values });
+	const limit = vi.fn().mockResolvedValue(rows);
+	const where = vi.fn().mockReturnValue({ limit });
+	const from = vi.fn().mockReturnValue({ where });
+	const select = vi.fn().mockReturnValue({ from });
+
+	return {
+		db: { select, insert } as unknown,
+		insert,
+		values,
+		onConflictDoUpdate,
+		where,
+	};
+}
+
+export type MockDb = ReturnType<typeof createMockDb>;
+
+export function buildSession(overrides: Record<string, unknown> = {}) {
+	return {
+		user: {
+			id: USER_ID,
+			email: "declarant@exemple.fr",
+			siret: SIRET,
+			isAdmin: false,
+			impersonation: null,
+			...overrides,
+		},
+		expires: "",
+	};
+}
+
+export function impersonatingSession(siren = SIREN) {
+	return buildSession({ isAdmin: true, impersonation: { siren } });
+}
+
+export function createCaller(db: unknown, session = buildSession()) {
+	return representationDeclarationRouter.createCaller({
+		db,
+		session,
+		headers: new Headers(),
+	} as never);
+}
+
+export function insertedValues(mock: MockDb) {
+	return mock.values.mock.calls[0]?.[0] as Record<string, unknown>;
+}
+
+export function conflictSet(mock: MockDb) {
+	return mock.onConflictDoUpdate.mock.calls[0]?.[0] as {
+		target: unknown[];
+		set: Record<string, unknown>;
+	};
+}
+
+export function whereParams(mock: MockDb) {
+	const clause = mock.where.mock.calls[0]?.[0];
+	return new PgDialect().sqlToQuery(clause as never).params;
+}
+
+export function installRouterTestEnv(campaignMock: Mock) {
+	beforeEach(() => {
+		// Only `Date` is faked: the tRPC timing middleware awaits a real setTimeout.
+		vi.useFakeTimers({ toFake: ["Date"] });
+		vi.setSystemTime(NOW);
+		campaignMock.mockReset();
+		campaignMock.mockResolvedValue(OPEN_CAMPAIGN);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+}

--- a/packages/app/src/server/api/routers/representationDeclaration.ts
+++ b/packages/app/src/server/api/routers/representationDeclaration.ts
@@ -11,6 +11,7 @@ import {
 	deriveExecutivesNotComputableReason,
 	getRepresentationCampaignYear,
 	isRepresentationCampaignOpen,
+	isRepresentationPublicationRequired,
 } from "~/modules/domain";
 import {
 	companyProcedure,
@@ -43,7 +44,33 @@ export const representationDeclarationRouter = createTRPCRouter({
 			const { year } = input;
 
 			const rows = await ctx.db
-				.select()
+				.select({
+					id: representationDeclarations.id,
+					siren: representationDeclarations.siren,
+					year: representationDeclarations.year,
+					declarantId: representationDeclarations.declarantId,
+					referencePeriodStart: representationDeclarations.referencePeriodStart,
+					referencePeriodEnd: representationDeclarations.referencePeriodEnd,
+					executiveWomenPercent:
+						representationDeclarations.executiveWomenPercent,
+					executiveMenPercent: representationDeclarations.executiveMenPercent,
+					notComputableReasonExecutives:
+						representationDeclarations.notComputableReasonExecutives,
+					memberWomenPercent: representationDeclarations.memberWomenPercent,
+					memberMenPercent: representationDeclarations.memberMenPercent,
+					notComputableReasonMembers:
+						representationDeclarations.notComputableReasonMembers,
+					publishDate: representationDeclarations.publishDate,
+					publishUrl: representationDeclarations.publishUrl,
+					publishModalities: representationDeclarations.publishModalities,
+					currentStep: representationDeclarations.currentStep,
+					status: representationDeclarations.status,
+					submittedAt: representationDeclarations.submittedAt,
+					draft: representationDeclarations.draft,
+					draftUpdatedAt: representationDeclarations.draftUpdatedAt,
+					createdAt: representationDeclarations.createdAt,
+					updatedAt: representationDeclarations.updatedAt,
+				})
 				.from(representationDeclarations)
 				.where(
 					and(
@@ -117,9 +144,10 @@ export const representationDeclarationRouter = createTRPCRouter({
 			}
 			const payload = parsed.data;
 
-			const publicationRequired =
-				payload.executivesCount === "two_or_more" ||
-				payload.hasManagementBody === true;
+			const publicationRequired = isRepresentationPublicationRequired(
+				payload.executivesCount,
+				payload.hasManagementBody,
+			);
 
 			const now = new Date();
 			const columns = {

--- a/packages/app/src/server/api/routers/representationDeclaration.ts
+++ b/packages/app/src/server/api/routers/representationDeclaration.ts
@@ -1,0 +1,182 @@
+import { TRPCError } from "@trpc/server";
+import { and, eq } from "drizzle-orm";
+
+import {
+	getRepresentationDeclarationSchema,
+	saveRepresentationDraftSchema,
+	submitRepresentationDeclarationSchema,
+	submitRepresentationSchema,
+} from "~/modules/declaration-representation";
+import {
+	deriveExecutivesNotComputableReason,
+	getRepresentationCampaignYear,
+	isRepresentationCampaignOpen,
+} from "~/modules/domain";
+import {
+	companyProcedure,
+	companyWriteProcedure,
+	createTRPCRouter,
+} from "~/server/api/trpc";
+import { getRepresentationCampaign } from "~/server/db/getRepresentationCampaign";
+import { representationDeclarations } from "~/server/db/schema";
+
+const CAMPAIGN_CLOSED_MESSAGE =
+	"La campagne de représentation équilibrée est close : la déclaration ne peut plus être modifiée.";
+
+async function assertRepresentationCampaignOpen(year: number): Promise<void> {
+	const campaign = await getRepresentationCampaign(
+		getRepresentationCampaignYear(year),
+	);
+	if (!isRepresentationCampaignOpen(campaign, new Date())) {
+		throw new TRPCError({
+			code: "FORBIDDEN",
+			message: CAMPAIGN_CLOSED_MESSAGE,
+		});
+	}
+}
+
+export const representationDeclarationRouter = createTRPCRouter({
+	get: companyProcedure
+		.input(getRepresentationDeclarationSchema)
+		.query(async ({ ctx, input }) => {
+			const { siren } = ctx;
+			const { year } = input;
+
+			const rows = await ctx.db
+				.select()
+				.from(representationDeclarations)
+				.where(
+					and(
+						eq(representationDeclarations.siren, siren),
+						eq(representationDeclarations.year, year),
+					),
+				)
+				.limit(1);
+
+			const campaign = await getRepresentationCampaign(
+				getRepresentationCampaignYear(year),
+			);
+
+			return {
+				declaration: rows[0] ?? null,
+				campaignOpen: isRepresentationCampaignOpen(campaign, new Date()),
+			};
+		}),
+
+	saveDraft: companyWriteProcedure
+		.input(saveRepresentationDraftSchema)
+		.mutation(async ({ ctx, input }) => {
+			const { siren } = ctx;
+			const { year, draft, currentStep } = input;
+
+			await assertRepresentationCampaignOpen(year);
+
+			const now = new Date();
+			const columns = {
+				draft,
+				draftUpdatedAt: now,
+				currentStep,
+				updatedAt: now,
+			};
+
+			await ctx.db
+				.insert(representationDeclarations)
+				.values({
+					siren,
+					year,
+					declarantId: ctx.session.user.id,
+					status: "draft",
+					...columns,
+				})
+				.onConflictDoUpdate({
+					target: [
+						representationDeclarations.siren,
+						representationDeclarations.year,
+					],
+					set: columns,
+				});
+
+			return { success: true as const };
+		}),
+
+	submit: companyWriteProcedure
+		.input(submitRepresentationDeclarationSchema)
+		.mutation(async ({ ctx, input }) => {
+			const { siren } = ctx;
+			const { year } = input;
+
+			await assertRepresentationCampaignOpen(year);
+
+			const parsed = submitRepresentationSchema(year).safeParse(input.payload);
+			if (!parsed.success) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: parsed.error.issues[0]?.message ?? "Déclaration invalide.",
+					cause: parsed.error,
+				});
+			}
+			const payload = parsed.data;
+
+			const publicationRequired =
+				payload.executivesCount === "two_or_more" ||
+				payload.hasManagementBody === true;
+
+			const now = new Date();
+			const columns = {
+				referencePeriodStart: payload.referencePeriodStart,
+				referencePeriodEnd: payload.referencePeriodEnd,
+				executiveWomenPercent:
+					payload.executivesCount === "two_or_more"
+						? String(payload.executiveWomenPercent)
+						: null,
+				executiveMenPercent:
+					payload.executivesCount === "two_or_more"
+						? String(payload.executiveMenPercent)
+						: null,
+				notComputableReasonExecutives: deriveExecutivesNotComputableReason(
+					payload.executivesCount,
+				),
+				memberWomenPercent: payload.hasManagementBody
+					? String(payload.memberWomenPercent)
+					: null,
+				memberMenPercent: payload.hasManagementBody
+					? String(payload.memberMenPercent)
+					: null,
+				notComputableReasonMembers: payload.hasManagementBody
+					? null
+					: ("aucune_instance_dirigeante" as const),
+				publishDate: publicationRequired ? (payload.publishDate ?? null) : null,
+				publishUrl:
+					publicationRequired && payload.hasWebsite === true
+						? (payload.publishUrl ?? null)
+						: null,
+				publishModalities:
+					publicationRequired && payload.hasWebsite === false
+						? (payload.publishModalities ?? null)
+						: null,
+				status: "submitted" as const,
+				submittedAt: now,
+				updatedAt: now,
+				draft: null,
+				draftUpdatedAt: null,
+			};
+
+			await ctx.db
+				.insert(representationDeclarations)
+				.values({
+					siren,
+					year,
+					declarantId: ctx.session.user.id,
+					...columns,
+				})
+				.onConflictDoUpdate({
+					target: [
+						representationDeclarations.siren,
+						representationDeclarations.year,
+					],
+					set: columns,
+				});
+
+			return { success: true as const };
+		}),
+});

--- a/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
+++ b/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
@@ -197,6 +197,51 @@ describe("auditMiddleware", () => {
 		});
 	});
 
+	// The allowlist keeps declaration content (percentages, free text) out of audit.action_log.
+	it.each([
+		"representationDeclaration.get",
+		"representationDeclaration.saveDraft",
+		"representationDeclaration.submit",
+	])("keeps only the allowlisted keys in metadata for %s", async (path) => {
+		const next = vi.fn(async () => undefined);
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path,
+			getRawInput: buildGetRawInput({
+				year: 2025,
+				executiveWomenPercent: 60,
+				publishModalities: "Affichage dans les locaux et note de service.",
+			}),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]?.metadata).toEqual({ year: 2025 });
+	});
+
+	it("returns null metadata when an allowlisted path carries none of its allowed keys", async () => {
+		const next = vi.fn(async () => undefined);
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "representationDeclaration.submit",
+			getRawInput: buildGetRawInput({ executiveWomenPercent: 60 }),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]?.metadata).toBeNull();
+	});
+
+	it("wraps a non-object input into a value field instead of applying the allowlist", async () => {
+		const next = vi.fn(async () => undefined);
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "representationDeclaration.get",
+			getRawInput: buildGetRawInput(2025),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]?.metadata).toEqual({ value: 2025 });
+	});
+
 	it("returns null metadata when input is empty", async () => {
 		const next = vi.fn(async () => undefined);
 		await auditMiddleware({

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -105,6 +105,12 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"declarationDraft.save": AUDIT_ACTIONS.DRAFT_SAVE,
 	"declarationDraft.clear": AUDIT_ACTIONS.DRAFT_CLEAR,
 
+	// ── representation declaration ─────────────────────────
+	"representationDeclaration.get": AUDIT_ACTIONS.REPRESENTATION_GET,
+	"representationDeclaration.saveDraft":
+		AUDIT_ACTIONS.REPRESENTATION_SAVE_DRAFT,
+	"representationDeclaration.submit": AUDIT_ACTIONS.REPRESENTATION_SUBMIT,
+
 	// ── mail ──────────────────────────────────────────────
 	"mail.resendReceipt": AUDIT_ACTIONS.MAIL_RECEIPT_RESEND,
 };

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -115,6 +115,18 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 	"mail.resendReceipt": AUDIT_ACTIONS.MAIL_RECEIPT_RESEND,
 };
 
+/**
+ * Per-path metadata allowlist. When a path is listed here, only these input
+ * keys are kept in `audit.action_log.metadata` — everything else on the raw
+ * input (percentages, free-text fields, etc.) is dropped before sanitization.
+ * Paths not listed keep the default behavior (full sanitized input).
+ */
+const METADATA_ALLOWED_KEYS: Partial<Record<string, readonly string[]>> = {
+	"representationDeclaration.get": ["year"],
+	"representationDeclaration.saveDraft": ["year"],
+	"representationDeclaration.submit": ["year"],
+};
+
 type SessionLike = {
 	user?: {
 		id?: string | null;
@@ -170,7 +182,7 @@ export async function auditMiddleware<TResult>({
 	} catch {
 		rawInput = undefined;
 	}
-	const metadata = sanitizeMetadata(rawInput);
+	const metadata = sanitizeMetadata(rawInput, path);
 
 	try {
 		const result = await next();
@@ -215,13 +227,29 @@ export async function auditMiddleware<TResult>({
  * storage. Recursively walks objects and arrays to drop `undefined` fields
  * and strip obviously-technical sensitive keys at every depth.
  *
+ * When `path` has an entry in {@link METADATA_ALLOWED_KEYS}, only those top-level
+ * input keys are kept before sanitization.
+ *
  * Wraps non-object scalars into `{ value }` so the column can stay typed as
  * `Record<string, unknown>`.
  */
-function sanitizeMetadata(rawInput: unknown): AuditMetadata | null {
+function sanitizeMetadata(
+	rawInput: unknown,
+	path: string,
+): AuditMetadata | null {
 	if (rawInput === undefined || rawInput === null) return null;
 
-	const sanitized = sanitizeValue(rawInput);
+	const allowedKeys = METADATA_ALLOWED_KEYS[path];
+	const scopedInput =
+		allowedKeys && typeof rawInput === "object" && !Array.isArray(rawInput)
+			? Object.fromEntries(
+					allowedKeys
+						.filter((key) => key in (rawInput as Record<string, unknown>))
+						.map((key) => [key, (rawInput as Record<string, unknown>)[key]]),
+				)
+			: rawInput;
+
+	const sanitized = sanitizeValue(scopedInput);
 	if (sanitized === undefined) return null;
 
 	if (


### PR DESCRIPTION
Closes #4152

## Résumé

Couche serveur du parcours de représentation équilibrée (art. D. 1142-19), sans UI (le funnel viendra dans des tickets suivants de l'epic #3702) :

- `modules/declaration-representation/schemas.ts` — schemas Zod par étape : `referencePeriodSchema(year)` (refine année de fin + 12 mois consécutifs), `executivesSchema` / `membersSchema` (unions discriminées, refine somme = 100 %), `publicationSchema` (union discriminée `hasWebsite`, URL tolérante sans schéma `http(s)://`), `submitRepresentationSchema(year)` (composition + règles transverses S11/S12), `representationDraftSchema`.
- `server/api/routers/representationDeclaration.ts` — router tRPC `get` / `saveDraft` / `submit`, SIREN exclusivement dérivé de la session (`companyProcedure`/`companyWriteProcedure`, aucun input siren), gate de campagne ouverte/close, upsert atomique `onConflictDoUpdate` sur la contrainte unique `(siren, year)`.
- Câblage audit complet (3 points par procédure : `AUDIT_ACTIONS`, catégories, `PROCEDURE_TO_ACTION`).

## Test plan

- [x] Tests unitaires (schemas + router) écrits par `tu-dev` : refines S4/S6/S11/S12 avec les messages FR exacts, upsert/gate de campagne, ownership (SIREN session uniquement), dérivation des motifs de non-calculabilité.
- [x] Test d'intégration DB-layer (upsert composite-target, préservation conditionnelle de `status`, round-trip des enums/numeric).
- [x] `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` verts.
- [ ] CI GitHub Actions
- [ ] SonarCloud Quality Gate

Aucun fichier UI touché — pas de screenshot applicable pour cette PR.