### PR TITLE
Représentation équilibrée — script de reprise des déclarations V1

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -43,6 +43,7 @@
 		"test:lighthouse": "lhci collect --url=${LIGHTHOUSE_URL:-http://localhost:3000} && lhci upload && lhci assert",
 		"typecheck": "tsc --noEmit",
 		"generate:fetch-companies": "tsx scripts/fetch-companies.ts",
+		"import:v1-representation": "tsx scripts/import-v1-representation.mjs",
 		"generate:mock-gip": "tsx scripts/generate-mock-gip-data.ts",
 		"mock:refresh": "tsx scripts/fetch-companies.ts --per-bucket=40 && tsx scripts/generate-mock-gip-data.ts",
 		"suit:encode-cert": "node scripts/encode-suit-cert.mjs",

--- a/packages/app/scripts/import-v1-representation-mapping.mjs
+++ b/packages/app/scripts/import-v1-representation-mapping.mjs
@@ -1,0 +1,180 @@
+import { COUNTIES, REGIONS } from "~/modules/domain";
+
+/**
+ * @typedef {Object} V1Company
+ * @property {string} siren
+ * @property {string} raison_sociale
+ * @property {string} [adresse]
+ * @property {string} [code_naf]
+ * @property {string} [région]
+ * @property {string} [département]
+ */
+
+/**
+ * @typedef {Object} V1Indicator
+ * @property {number} [pourcentage_femmes_cadres]
+ * @property {number} [pourcentage_hommes_cadres]
+ * @property {string} [motif_non_calculabilité_cadres]
+ * @property {number} [pourcentage_femmes_membres]
+ * @property {number} [pourcentage_hommes_membres]
+ * @property {string} [motif_non_calculabilité_membres]
+ */
+
+/**
+ * @typedef {Object} V1Publication
+ * @property {string} date
+ * @property {string} [url]
+ * @property {string} [modalités]
+ */
+
+/**
+ * @typedef {Object} V1Data
+ * @property {{ email: string, nom: string, prénom: string, téléphone: string }} déclarant
+ * @property {{ année_indicateurs: number, fin_période_référence: string, publication?: V1Publication }} déclaration
+ * @property {V1Company} entreprise
+ * @property {{ représentation_équilibrée: V1Indicator }} indicateurs
+ */
+
+/**
+ * @typedef {Object} V1Row
+ * @property {string} siren
+ * @property {number} year
+ * @property {Date} declared_at
+ * @property {Date} modified_at
+ * @property {V1Data} data
+ */
+
+/**
+ * @typedef {Object} MappedCompany
+ * @property {string} siren
+ * @property {string} name
+ * @property {string | null} address
+ * @property {string | null} nafCode
+ * @property {string | null} region
+ * @property {string | null} departmentCode
+ * @property {string | null} departmentLabel
+ */
+
+/**
+ * @typedef {Object} MappedDeclaration
+ * @property {string} siren
+ * @property {number} year
+ * @property {{ email: string, lastname: string, firstname: string, phone: string }} legacyDeclarant
+ * @property {string} referencePeriodStart
+ * @property {string} referencePeriodEnd
+ * @property {number | null} executiveWomenPercent
+ * @property {number | null} executiveMenPercent
+ * @property {string | null} notComputableReasonExecutives
+ * @property {number | null} memberWomenPercent
+ * @property {number | null} memberMenPercent
+ * @property {string | null} notComputableReasonMembers
+ * @property {string | null} publishDate
+ * @property {string | null} publishUrl
+ * @property {string | null} publishModalities
+ * @property {Date} submittedAt
+ * @property {Date} createdAt
+ * @property {Date} updatedAt
+ */
+
+/**
+ * @typedef {Object} ImportError
+ * @property {string} siren
+ * @property {number} year
+ * @property {string} cause
+ */
+
+/**
+ * @typedef {Object} ImportCounters
+ * @property {number} total
+ * @property {number} imported
+ * @property {number} updated
+ * @property {number} skippedUpToDate
+ * @property {number} skippedNative
+ * @property {ImportError[]} errors
+ */
+
+const NON_DIFFUSIBLE_NAF = "[NON-DIFFUSIBLE]";
+
+/** @type {Record<string, string>} */
+const REGION_LABELS = REGIONS;
+/** @type {Record<string, string>} */
+const DEPARTMENT_LABELS = COUNTIES;
+
+/**
+ * @param {string} referencePeriodEnd
+ * @returns {string}
+ */
+export function computeReferencePeriodStart(referencePeriodEnd) {
+	const start = new Date(`${referencePeriodEnd}T00:00:00.000Z`);
+	start.setUTCFullYear(start.getUTCFullYear() - 1);
+	start.setUTCDate(start.getUTCDate() + 1);
+	return start.toISOString().slice(0, 10);
+}
+
+/**
+ * @param {V1Company} entreprise
+ * @returns {MappedCompany}
+ */
+export function mapCompanyFromV1(entreprise) {
+	const regionCode = entreprise.région ?? null;
+	const departmentCode = entreprise.département ?? null;
+	return {
+		siren: entreprise.siren,
+		name: entreprise.raison_sociale,
+		address: entreprise.adresse ?? null,
+		nafCode:
+			entreprise.code_naf && entreprise.code_naf !== NON_DIFFUSIBLE_NAF
+				? entreprise.code_naf
+				: null,
+		region: regionCode ? (REGION_LABELS[regionCode] ?? null) : null,
+		departmentCode,
+		departmentLabel: departmentCode
+			? (DEPARTMENT_LABELS[departmentCode] ?? null)
+			: null,
+	};
+}
+
+/**
+ * @param {V1Row} row
+ * @returns {MappedDeclaration}
+ */
+export function mapDeclarationFromV1(row) {
+	const indicator = row.data.indicateurs.représentation_équilibrée;
+	const publication = row.data.déclaration.publication;
+	const referencePeriodEnd = row.data.déclaration.fin_période_référence;
+
+	return {
+		siren: row.siren,
+		year: row.year,
+		legacyDeclarant: {
+			email: row.data.déclarant.email,
+			lastname: row.data.déclarant.nom,
+			firstname: row.data.déclarant.prénom,
+			phone: row.data.déclarant.téléphone,
+		},
+		referencePeriodStart: computeReferencePeriodStart(referencePeriodEnd),
+		referencePeriodEnd,
+		executiveWomenPercent: indicator.motif_non_calculabilité_cadres
+			? null
+			: (indicator.pourcentage_femmes_cadres ?? null),
+		executiveMenPercent: indicator.motif_non_calculabilité_cadres
+			? null
+			: (indicator.pourcentage_hommes_cadres ?? null),
+		notComputableReasonExecutives:
+			indicator.motif_non_calculabilité_cadres ?? null,
+		memberWomenPercent: indicator.motif_non_calculabilité_membres
+			? null
+			: (indicator.pourcentage_femmes_membres ?? null),
+		memberMenPercent: indicator.motif_non_calculabilité_membres
+			? null
+			: (indicator.pourcentage_hommes_membres ?? null),
+		notComputableReasonMembers:
+			indicator.motif_non_calculabilité_membres ?? null,
+		publishDate: publication?.date ?? null,
+		publishUrl: publication?.url ?? null,
+		publishModalities: publication?.modalités ?? null,
+		submittedAt: row.declared_at,
+		createdAt: row.declared_at,
+		updatedAt: row.modified_at,
+	};
+}

--- a/packages/app/scripts/import-v1-representation.mjs
+++ b/packages/app/scripts/import-v1-representation.mjs
@@ -3,7 +3,102 @@ import { fileURLToPath } from "node:url";
 
 import postgres from "postgres";
 
-import { COUNTIES, REGIONS } from "../src/modules/domain/index.ts";
+import { COUNTIES, REGIONS } from "~/modules/domain";
+
+/** @typedef {import("postgres").Sql} Sql */
+
+/**
+ * @typedef {Object} V1Company
+ * @property {string} siren
+ * @property {string} raison_sociale
+ * @property {string} [adresse]
+ * @property {string} [code_naf]
+ * @property {string} [région]
+ * @property {string} [département]
+ */
+
+/**
+ * @typedef {Object} V1Indicator
+ * @property {number} [pourcentage_femmes_cadres]
+ * @property {number} [pourcentage_hommes_cadres]
+ * @property {string} [motif_non_calculabilité_cadres]
+ * @property {number} [pourcentage_femmes_membres]
+ * @property {number} [pourcentage_hommes_membres]
+ * @property {string} [motif_non_calculabilité_membres]
+ */
+
+/**
+ * @typedef {Object} V1Publication
+ * @property {string} date
+ * @property {string} [url]
+ * @property {string} [modalités]
+ */
+
+/**
+ * @typedef {Object} V1Data
+ * @property {{ email: string, nom: string, prénom: string, téléphone: string }} déclarant
+ * @property {{ année_indicateurs: number, fin_période_référence: string, publication?: V1Publication }} déclaration
+ * @property {V1Company} entreprise
+ * @property {{ représentation_équilibrée: V1Indicator }} indicateurs
+ */
+
+/**
+ * @typedef {Object} V1Row
+ * @property {string} siren
+ * @property {number} year
+ * @property {Date} declared_at
+ * @property {Date} modified_at
+ * @property {V1Data} data
+ */
+
+/**
+ * @typedef {Object} MappedCompany
+ * @property {string} siren
+ * @property {string} name
+ * @property {string | null} address
+ * @property {string | null} nafCode
+ * @property {string | null} region
+ * @property {string | null} departmentCode
+ * @property {string | null} departmentLabel
+ */
+
+/**
+ * @typedef {Object} MappedDeclaration
+ * @property {string} siren
+ * @property {number} year
+ * @property {{ email: string, lastname: string, firstname: string, phone: string }} legacyDeclarant
+ * @property {string} referencePeriodStart
+ * @property {string} referencePeriodEnd
+ * @property {number | null} executiveWomenPercent
+ * @property {number | null} executiveMenPercent
+ * @property {string | null} notComputableReasonExecutives
+ * @property {number | null} memberWomenPercent
+ * @property {number | null} memberMenPercent
+ * @property {string | null} notComputableReasonMembers
+ * @property {string | null} publishDate
+ * @property {string | null} publishUrl
+ * @property {string | null} publishModalities
+ * @property {Date} submittedAt
+ * @property {Date} createdAt
+ * @property {Date} updatedAt
+ */
+
+/**
+ * @typedef {Object} ImportError
+ * @property {string} siren
+ * @property {number} year
+ * @property {string} cause
+ */
+
+/**
+ * @typedef {Object} ImportCounters
+ * @property {number} total
+ * @property {number} imported
+ * @property {number} updated
+ * @property {number} skippedUpToDate
+ * @property {number} skippedNative
+ * @property {ImportError[]} errors
+ */
 
 const USAGE =
 	"Usage: import-v1-representation --from YYYY-MM-DD [--to YYYY-MM-DD] [--dry-run]";
@@ -12,7 +107,18 @@ const NON_DIFFUSIBLE_NAF = "[NON-DIFFUSIBLE]";
 const IMPORTED_DECLARATION_STEP = 5;
 const IMPORTED_DECLARATION_STATUS = "submitted";
 
+/** @type {Record<string, string>} */
+const REGION_LABELS = REGIONS;
+/** @type {Record<string, string>} */
+const DEPARTMENT_LABELS = COUNTIES;
+
+/**
+ * @param {string[]} argv
+ * @param {{ now?: Date }} [options]
+ * @returns {{ from: Date, to: Date, dryRun: boolean }}
+ */
 export function parseCliArgs(argv, { now = new Date() } = {}) {
+	/** @type {{ dryRun: boolean, from?: string, to?: string }} */
 	const flags = { dryRun: false };
 	for (let i = 0; i < argv.length; i++) {
 		const token = argv[i];
@@ -21,7 +127,8 @@ export function parseCliArgs(argv, { now = new Date() } = {}) {
 			continue;
 		}
 		if (token === "--from" || token === "--to") {
-			flags[token.slice(2)] = argv[i + 1];
+			const key = token === "--from" ? "from" : "to";
+			flags[key] = argv[i + 1];
 			i++;
 		}
 	}
@@ -40,6 +147,11 @@ export function parseCliArgs(argv, { now = new Date() } = {}) {
 	return { from, to, dryRun: flags.dryRun };
 }
 
+/**
+ * @param {string} value
+ * @param {string} label
+ * @returns {Date}
+ */
 function parseDateBoundary(value, label) {
 	if (!DATE_PATTERN.test(value)) {
 		throw new Error(`Invalid ${label} date "${value}": expected YYYY-MM-DD`);
@@ -51,6 +163,10 @@ function parseDateBoundary(value, label) {
 	return date;
 }
 
+/**
+ * @param {string} referencePeriodEnd
+ * @returns {string}
+ */
 export function computeReferencePeriodStart(referencePeriodEnd) {
 	const start = new Date(`${referencePeriodEnd}T00:00:00.000Z`);
 	start.setUTCFullYear(start.getUTCFullYear() - 1);
@@ -58,6 +174,10 @@ export function computeReferencePeriodStart(referencePeriodEnd) {
 	return start.toISOString().slice(0, 10);
 }
 
+/**
+ * @param {V1Company} entreprise
+ * @returns {MappedCompany}
+ */
 export function mapCompanyFromV1(entreprise) {
 	const regionCode = entreprise.région ?? null;
 	const departmentCode = entreprise.département ?? null;
@@ -69,12 +189,18 @@ export function mapCompanyFromV1(entreprise) {
 			entreprise.code_naf && entreprise.code_naf !== NON_DIFFUSIBLE_NAF
 				? entreprise.code_naf
 				: null,
-		region: regionCode ? (REGIONS[regionCode] ?? null) : null,
+		region: regionCode ? (REGION_LABELS[regionCode] ?? null) : null,
 		departmentCode,
-		departmentLabel: departmentCode ? (COUNTIES[departmentCode] ?? null) : null,
+		departmentLabel: departmentCode
+			? (DEPARTMENT_LABELS[departmentCode] ?? null)
+			: null,
 	};
 }
 
+/**
+ * @param {V1Row} row
+ * @returns {MappedDeclaration}
+ */
 export function mapDeclarationFromV1(row) {
 	const indicator = row.data.indicateurs.représentation_équilibrée;
 	const publication = row.data.déclaration.publication;
@@ -116,6 +242,10 @@ export function mapDeclarationFromV1(row) {
 	};
 }
 
+/**
+ * @param {Sql} tx
+ * @param {MappedCompany} company
+ */
 async function ensureCompany(tx, company) {
 	await tx`
 		INSERT INTO app_company (
@@ -128,6 +258,10 @@ async function ensureCompany(tx, company) {
 	`;
 }
 
+/**
+ * @param {Sql} tx
+ * @param {MappedDeclaration} declaration
+ */
 async function insertDeclaration(tx, declaration) {
 	await tx`
 		INSERT INTO app_representation_declaration (
@@ -152,6 +286,10 @@ async function insertDeclaration(tx, declaration) {
 	`;
 }
 
+/**
+ * @param {Sql} tx
+ * @param {MappedDeclaration} declaration
+ */
 async function updateDeclaration(tx, declaration) {
 	await tx`
 		UPDATE app_representation_declaration
@@ -173,6 +311,13 @@ async function updateDeclaration(tx, declaration) {
 	`;
 }
 
+/**
+ * @param {Object} args
+ * @param {Sql} args.sql
+ * @param {V1Row} args.row
+ * @param {boolean} args.dryRun
+ * @param {ImportCounters} args.counters
+ */
 async function importRow({ sql, row, dryRun, counters }) {
 	const company = mapCompanyFromV1(row.data.entreprise);
 	const declaration = mapDeclarationFromV1(row);
@@ -203,9 +348,7 @@ async function importRow({ sql, row, dryRun, counters }) {
 	}
 
 	await sql.begin(async (txRaw) => {
-		const tx = /** @type {import("postgres").Sql} */ (
-			/** @type {unknown} */ (txRaw)
-		);
+		const tx = /** @type {Sql} */ (/** @type {unknown} */ (txRaw));
 		await ensureCompany(tx, company);
 		if (existing) {
 			await updateDeclaration(tx, declaration);
@@ -221,6 +364,15 @@ async function importRow({ sql, row, dryRun, counters }) {
 	}
 }
 
+/**
+ * @param {Object} args
+ * @param {Sql} args.legacySql
+ * @param {Sql} args.sql
+ * @param {Date} args.from
+ * @param {Date} args.to
+ * @param {boolean} [args.dryRun]
+ * @returns {Promise<ImportCounters>}
+ */
 export async function runImportV1Representation({
 	legacySql,
 	sql,
@@ -234,6 +386,7 @@ export async function runImportV1Representation({
 		WHERE declared_at >= ${from} AND declared_at < ${to}
 	`;
 
+	/** @type {ImportCounters} */
 	const counters = {
 		total: legacyRows.length,
 		imported: 0,
@@ -245,7 +398,12 @@ export async function runImportV1Representation({
 
 	for (const row of legacyRows) {
 		try {
-			await importRow({ sql, row, dryRun, counters });
+			await importRow({
+				sql,
+				row: /** @type {V1Row} */ (/** @type {unknown} */ (row)),
+				dryRun,
+				counters,
+			});
 		} catch (error) {
 			counters.errors.push({
 				siren: row.siren,
@@ -258,6 +416,11 @@ export async function runImportV1Representation({
 	return counters;
 }
 
+/**
+ * @param {ImportCounters} counters
+ * @param {boolean} dryRun
+ * @returns {string}
+ */
 export function formatReport(counters, dryRun) {
 	const lines = [
 		`${dryRun ? "[dry-run] " : ""}import-v1-representation report`,
@@ -313,7 +476,9 @@ const isMain = (() => {
 
 if (isMain) {
 	let exitCode = 0;
+	/** @type {Sql | undefined} */
 	let sql;
+	/** @type {Sql | undefined} */
 	let legacySql;
 	try {
 		const { from, to, dryRun } = parseCliArgs(process.argv.slice(2));

--- a/packages/app/scripts/import-v1-representation.mjs
+++ b/packages/app/scripts/import-v1-representation.mjs
@@ -3,85 +3,16 @@ import { fileURLToPath } from "node:url";
 
 import postgres from "postgres";
 
-import { COUNTIES, REGIONS } from "~/modules/domain";
+import {
+	computeReferencePeriodStart,
+	mapCompanyFromV1,
+	mapDeclarationFromV1,
+} from "./import-v1-representation-mapping.mjs";
 
 /** @typedef {import("postgres").Sql} Sql */
-
-/**
- * @typedef {Object} V1Company
- * @property {string} siren
- * @property {string} raison_sociale
- * @property {string} [adresse]
- * @property {string} [code_naf]
- * @property {string} [région]
- * @property {string} [département]
- */
-
-/**
- * @typedef {Object} V1Indicator
- * @property {number} [pourcentage_femmes_cadres]
- * @property {number} [pourcentage_hommes_cadres]
- * @property {string} [motif_non_calculabilité_cadres]
- * @property {number} [pourcentage_femmes_membres]
- * @property {number} [pourcentage_hommes_membres]
- * @property {string} [motif_non_calculabilité_membres]
- */
-
-/**
- * @typedef {Object} V1Publication
- * @property {string} date
- * @property {string} [url]
- * @property {string} [modalités]
- */
-
-/**
- * @typedef {Object} V1Data
- * @property {{ email: string, nom: string, prénom: string, téléphone: string }} déclarant
- * @property {{ année_indicateurs: number, fin_période_référence: string, publication?: V1Publication }} déclaration
- * @property {V1Company} entreprise
- * @property {{ représentation_équilibrée: V1Indicator }} indicateurs
- */
-
-/**
- * @typedef {Object} V1Row
- * @property {string} siren
- * @property {number} year
- * @property {Date} declared_at
- * @property {Date} modified_at
- * @property {V1Data} data
- */
-
-/**
- * @typedef {Object} MappedCompany
- * @property {string} siren
- * @property {string} name
- * @property {string | null} address
- * @property {string | null} nafCode
- * @property {string | null} region
- * @property {string | null} departmentCode
- * @property {string | null} departmentLabel
- */
-
-/**
- * @typedef {Object} MappedDeclaration
- * @property {string} siren
- * @property {number} year
- * @property {{ email: string, lastname: string, firstname: string, phone: string }} legacyDeclarant
- * @property {string} referencePeriodStart
- * @property {string} referencePeriodEnd
- * @property {number | null} executiveWomenPercent
- * @property {number | null} executiveMenPercent
- * @property {string | null} notComputableReasonExecutives
- * @property {number | null} memberWomenPercent
- * @property {number | null} memberMenPercent
- * @property {string | null} notComputableReasonMembers
- * @property {string | null} publishDate
- * @property {string | null} publishUrl
- * @property {string | null} publishModalities
- * @property {Date} submittedAt
- * @property {Date} createdAt
- * @property {Date} updatedAt
- */
+/** @typedef {import("./import-v1-representation-mapping.mjs").V1Row} V1Row */
+/** @typedef {import("./import-v1-representation-mapping.mjs").MappedCompany} MappedCompany */
+/** @typedef {import("./import-v1-representation-mapping.mjs").MappedDeclaration} MappedDeclaration */
 
 /**
  * @typedef {Object} ImportError
@@ -100,17 +31,13 @@ import { COUNTIES, REGIONS } from "~/modules/domain";
  * @property {ImportError[]} errors
  */
 
+export { computeReferencePeriodStart, mapCompanyFromV1, mapDeclarationFromV1 };
+
 const USAGE =
 	"Usage: import-v1-representation --from YYYY-MM-DD [--to YYYY-MM-DD] [--dry-run]";
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-const NON_DIFFUSIBLE_NAF = "[NON-DIFFUSIBLE]";
 const IMPORTED_DECLARATION_STEP = 5;
 const IMPORTED_DECLARATION_STATUS = "submitted";
-
-/** @type {Record<string, string>} */
-const REGION_LABELS = REGIONS;
-/** @type {Record<string, string>} */
-const DEPARTMENT_LABELS = COUNTIES;
 
 /**
  * @param {string[]} argv
@@ -161,85 +88,6 @@ function parseDateBoundary(value, label) {
 		throw new Error(`Invalid ${label} date "${value}"`);
 	}
 	return date;
-}
-
-/**
- * @param {string} referencePeriodEnd
- * @returns {string}
- */
-export function computeReferencePeriodStart(referencePeriodEnd) {
-	const start = new Date(`${referencePeriodEnd}T00:00:00.000Z`);
-	start.setUTCFullYear(start.getUTCFullYear() - 1);
-	start.setUTCDate(start.getUTCDate() + 1);
-	return start.toISOString().slice(0, 10);
-}
-
-/**
- * @param {V1Company} entreprise
- * @returns {MappedCompany}
- */
-export function mapCompanyFromV1(entreprise) {
-	const regionCode = entreprise.région ?? null;
-	const departmentCode = entreprise.département ?? null;
-	return {
-		siren: entreprise.siren,
-		name: entreprise.raison_sociale,
-		address: entreprise.adresse ?? null,
-		nafCode:
-			entreprise.code_naf && entreprise.code_naf !== NON_DIFFUSIBLE_NAF
-				? entreprise.code_naf
-				: null,
-		region: regionCode ? (REGION_LABELS[regionCode] ?? null) : null,
-		departmentCode,
-		departmentLabel: departmentCode
-			? (DEPARTMENT_LABELS[departmentCode] ?? null)
-			: null,
-	};
-}
-
-/**
- * @param {V1Row} row
- * @returns {MappedDeclaration}
- */
-export function mapDeclarationFromV1(row) {
-	const indicator = row.data.indicateurs.représentation_équilibrée;
-	const publication = row.data.déclaration.publication;
-	const referencePeriodEnd = row.data.déclaration.fin_période_référence;
-
-	return {
-		siren: row.siren,
-		year: row.year,
-		legacyDeclarant: {
-			email: row.data.déclarant.email,
-			lastname: row.data.déclarant.nom,
-			firstname: row.data.déclarant.prénom,
-			phone: row.data.déclarant.téléphone,
-		},
-		referencePeriodStart: computeReferencePeriodStart(referencePeriodEnd),
-		referencePeriodEnd,
-		executiveWomenPercent: indicator.motif_non_calculabilité_cadres
-			? null
-			: (indicator.pourcentage_femmes_cadres ?? null),
-		executiveMenPercent: indicator.motif_non_calculabilité_cadres
-			? null
-			: (indicator.pourcentage_hommes_cadres ?? null),
-		notComputableReasonExecutives:
-			indicator.motif_non_calculabilité_cadres ?? null,
-		memberWomenPercent: indicator.motif_non_calculabilité_membres
-			? null
-			: (indicator.pourcentage_femmes_membres ?? null),
-		memberMenPercent: indicator.motif_non_calculabilité_membres
-			? null
-			: (indicator.pourcentage_hommes_membres ?? null),
-		notComputableReasonMembers:
-			indicator.motif_non_calculabilité_membres ?? null,
-		publishDate: publication?.date ?? null,
-		publishUrl: publication?.url ?? null,
-		publishModalities: publication?.modalités ?? null,
-		submittedAt: row.declared_at,
-		createdAt: row.declared_at,
-		updatedAt: row.modified_at,
-	};
 }
 
 /**

--- a/packages/app/scripts/import-v1-representation.mjs
+++ b/packages/app/scripts/import-v1-representation.mjs
@@ -1,0 +1,351 @@
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import postgres from "postgres";
+
+import { COUNTIES, REGIONS } from "../src/modules/domain/index.ts";
+
+const USAGE =
+	"Usage: import-v1-representation --from YYYY-MM-DD [--to YYYY-MM-DD] [--dry-run]";
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const NON_DIFFUSIBLE_NAF = "[NON-DIFFUSIBLE]";
+const IMPORTED_DECLARATION_STEP = 5;
+const IMPORTED_DECLARATION_STATUS = "submitted";
+
+export function parseCliArgs(argv, { now = new Date() } = {}) {
+	const flags = { dryRun: false };
+	for (let i = 0; i < argv.length; i++) {
+		const token = argv[i];
+		if (token === "--dry-run") {
+			flags.dryRun = true;
+			continue;
+		}
+		if (token === "--from" || token === "--to") {
+			flags[token.slice(2)] = argv[i + 1];
+			i++;
+		}
+	}
+
+	if (!flags.from) {
+		throw new Error(`--from is required. ${USAGE}`);
+	}
+	const from = parseDateBoundary(flags.from, "--from");
+	const to = flags.to ? parseDateBoundary(flags.to, "--to") : now;
+	if (!(to > from)) {
+		throw new Error(
+			`--to (${flags.to ?? "now"}) must be after --from (${flags.from})`,
+		);
+	}
+
+	return { from, to, dryRun: flags.dryRun };
+}
+
+function parseDateBoundary(value, label) {
+	if (!DATE_PATTERN.test(value)) {
+		throw new Error(`Invalid ${label} date "${value}": expected YYYY-MM-DD`);
+	}
+	const date = new Date(`${value}T00:00:00.000Z`);
+	if (Number.isNaN(date.getTime())) {
+		throw new Error(`Invalid ${label} date "${value}"`);
+	}
+	return date;
+}
+
+export function computeReferencePeriodStart(referencePeriodEnd) {
+	const start = new Date(`${referencePeriodEnd}T00:00:00.000Z`);
+	start.setUTCFullYear(start.getUTCFullYear() - 1);
+	start.setUTCDate(start.getUTCDate() + 1);
+	return start.toISOString().slice(0, 10);
+}
+
+export function mapCompanyFromV1(entreprise) {
+	const regionCode = entreprise.région ?? null;
+	const departmentCode = entreprise.département ?? null;
+	return {
+		siren: entreprise.siren,
+		name: entreprise.raison_sociale,
+		address: entreprise.adresse ?? null,
+		nafCode:
+			entreprise.code_naf && entreprise.code_naf !== NON_DIFFUSIBLE_NAF
+				? entreprise.code_naf
+				: null,
+		region: regionCode ? (REGIONS[regionCode] ?? null) : null,
+		departmentCode,
+		departmentLabel: departmentCode ? (COUNTIES[departmentCode] ?? null) : null,
+	};
+}
+
+export function mapDeclarationFromV1(row) {
+	const indicator = row.data.indicateurs.représentation_équilibrée;
+	const publication = row.data.déclaration.publication;
+	const referencePeriodEnd = row.data.déclaration.fin_période_référence;
+
+	return {
+		siren: row.siren,
+		year: row.year,
+		legacyDeclarant: {
+			email: row.data.déclarant.email,
+			lastname: row.data.déclarant.nom,
+			firstname: row.data.déclarant.prénom,
+			phone: row.data.déclarant.téléphone,
+		},
+		referencePeriodStart: computeReferencePeriodStart(referencePeriodEnd),
+		referencePeriodEnd,
+		executiveWomenPercent: indicator.motif_non_calculabilité_cadres
+			? null
+			: (indicator.pourcentage_femmes_cadres ?? null),
+		executiveMenPercent: indicator.motif_non_calculabilité_cadres
+			? null
+			: (indicator.pourcentage_hommes_cadres ?? null),
+		notComputableReasonExecutives:
+			indicator.motif_non_calculabilité_cadres ?? null,
+		memberWomenPercent: indicator.motif_non_calculabilité_membres
+			? null
+			: (indicator.pourcentage_femmes_membres ?? null),
+		memberMenPercent: indicator.motif_non_calculabilité_membres
+			? null
+			: (indicator.pourcentage_hommes_membres ?? null),
+		notComputableReasonMembers:
+			indicator.motif_non_calculabilité_membres ?? null,
+		publishDate: publication?.date ?? null,
+		publishUrl: publication?.url ?? null,
+		publishModalities: publication?.modalités ?? null,
+		submittedAt: row.declared_at,
+		createdAt: row.declared_at,
+		updatedAt: row.modified_at,
+	};
+}
+
+async function ensureCompany(tx, company) {
+	await tx`
+		INSERT INTO app_company (
+			siren, name, address, naf_code, region, department_code, department_label, created_at, updated_at
+		) VALUES (
+			${company.siren}, ${company.name}, ${company.address}, ${company.nafCode},
+			${company.region}, ${company.departmentCode}, ${company.departmentLabel}, NOW(), NOW()
+		)
+		ON CONFLICT (siren) DO NOTHING
+	`;
+}
+
+async function insertDeclaration(tx, declaration) {
+	await tx`
+		INSERT INTO app_representation_declaration (
+			id, siren, year, legacy_declarant, imported_from_v1_at,
+			reference_period_start, reference_period_end,
+			executive_women_percent, executive_men_percent, not_computable_reason_executives,
+			member_women_percent, member_men_percent, not_computable_reason_members,
+			publish_date, publish_url, publish_modalities,
+			current_step, status, submitted_at, created_at, updated_at
+		) VALUES (
+			${crypto.randomUUID()}, ${declaration.siren}, ${declaration.year},
+			${tx.json(declaration.legacyDeclarant)}, NOW(),
+			${declaration.referencePeriodStart}, ${declaration.referencePeriodEnd},
+			${declaration.executiveWomenPercent}, ${declaration.executiveMenPercent},
+			${declaration.notComputableReasonExecutives},
+			${declaration.memberWomenPercent}, ${declaration.memberMenPercent},
+			${declaration.notComputableReasonMembers},
+			${declaration.publishDate}, ${declaration.publishUrl}, ${declaration.publishModalities},
+			${IMPORTED_DECLARATION_STEP}, ${IMPORTED_DECLARATION_STATUS},
+			${declaration.submittedAt}, ${declaration.createdAt}, ${declaration.updatedAt}
+		)
+	`;
+}
+
+async function updateDeclaration(tx, declaration) {
+	await tx`
+		UPDATE app_representation_declaration
+		SET legacy_declarant = ${tx.json(declaration.legacyDeclarant)},
+			reference_period_start = ${declaration.referencePeriodStart},
+			reference_period_end = ${declaration.referencePeriodEnd},
+			executive_women_percent = ${declaration.executiveWomenPercent},
+			executive_men_percent = ${declaration.executiveMenPercent},
+			not_computable_reason_executives = ${declaration.notComputableReasonExecutives},
+			member_women_percent = ${declaration.memberWomenPercent},
+			member_men_percent = ${declaration.memberMenPercent},
+			not_computable_reason_members = ${declaration.notComputableReasonMembers},
+			publish_date = ${declaration.publishDate},
+			publish_url = ${declaration.publishUrl},
+			publish_modalities = ${declaration.publishModalities},
+			submitted_at = ${declaration.submittedAt},
+			updated_at = ${declaration.updatedAt}
+		WHERE siren = ${declaration.siren} AND year = ${declaration.year}
+	`;
+}
+
+async function importRow({ sql, row, dryRun, counters }) {
+	const company = mapCompanyFromV1(row.data.entreprise);
+	const declaration = mapDeclarationFromV1(row);
+
+	const [existing] = await sql`
+		SELECT imported_from_v1_at, updated_at
+		FROM app_representation_declaration
+		WHERE siren = ${row.siren} AND year = ${row.year}
+	`;
+
+	if (existing && existing.imported_from_v1_at === null) {
+		counters.skippedNative++;
+		return;
+	}
+
+	if (existing && !(row.modified_at > existing.updated_at)) {
+		counters.skippedUpToDate++;
+		return;
+	}
+
+	if (dryRun) {
+		if (existing) {
+			counters.updated++;
+		} else {
+			counters.imported++;
+		}
+		return;
+	}
+
+	await sql.begin(async (txRaw) => {
+		const tx = /** @type {import("postgres").Sql} */ (
+			/** @type {unknown} */ (txRaw)
+		);
+		await ensureCompany(tx, company);
+		if (existing) {
+			await updateDeclaration(tx, declaration);
+		} else {
+			await insertDeclaration(tx, declaration);
+		}
+	});
+
+	if (existing) {
+		counters.updated++;
+	} else {
+		counters.imported++;
+	}
+}
+
+export async function runImportV1Representation({
+	legacySql,
+	sql,
+	from,
+	to,
+	dryRun = false,
+}) {
+	const legacyRows = await legacySql`
+		SELECT siren, year, declared_at, modified_at, data
+		FROM representation_equilibree
+		WHERE declared_at >= ${from} AND declared_at < ${to}
+	`;
+
+	const counters = {
+		total: legacyRows.length,
+		imported: 0,
+		updated: 0,
+		skippedUpToDate: 0,
+		skippedNative: 0,
+		errors: [],
+	};
+
+	for (const row of legacyRows) {
+		try {
+			await importRow({ sql, row, dryRun, counters });
+		} catch (error) {
+			counters.errors.push({
+				siren: row.siren,
+				year: row.year,
+				cause: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	return counters;
+}
+
+export function formatReport(counters, dryRun) {
+	const lines = [
+		`${dryRun ? "[dry-run] " : ""}import-v1-representation report`,
+		`  total read:            ${counters.total}`,
+		`  imported:              ${counters.imported}`,
+		`  updated:               ${counters.updated}`,
+		`  skipped (up to date):  ${counters.skippedUpToDate}`,
+		`  skipped (native V2):   ${counters.skippedNative}`,
+		`  errors:                ${counters.errors.length}`,
+	];
+	for (const error of counters.errors) {
+		lines.push(
+			`    siren=${error.siren} year=${error.year} cause=${error.cause}`,
+		);
+	}
+	return lines.join("\n");
+}
+
+function getDatabaseUrl() {
+	if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+
+	const {
+		POSTGRES_USER,
+		POSTGRES_PASSWORD,
+		POSTGRES_HOST,
+		POSTGRES_PORT,
+		POSTGRES_DB,
+		POSTGRES_SSLMODE,
+	} = process.env;
+
+	if (POSTGRES_HOST && POSTGRES_DB) {
+		const user = encodeURIComponent(POSTGRES_USER ?? "postgres");
+		const password = POSTGRES_PASSWORD
+			? `:${encodeURIComponent(POSTGRES_PASSWORD)}`
+			: "";
+		const port = POSTGRES_PORT ?? "5432";
+		const sslmode = POSTGRES_SSLMODE ? `?sslmode=${POSTGRES_SSLMODE}` : "";
+		return `postgresql://${user}${password}@${POSTGRES_HOST}:${port}/${POSTGRES_DB}${sslmode}`;
+	}
+
+	throw new Error("DATABASE_URL or POSTGRES_HOST+POSTGRES_DB must be set");
+}
+
+const isMain = (() => {
+	const entry = process.argv[1];
+	if (!entry) return false;
+	try {
+		return fileURLToPath(import.meta.url) === realpathSync(entry);
+	} catch {
+		return false;
+	}
+})();
+
+if (isMain) {
+	let exitCode = 0;
+	let sql;
+	let legacySql;
+	try {
+		const { from, to, dryRun } = parseCliArgs(process.argv.slice(2));
+
+		if (!process.env.LEGACY_DATABASE_URL) {
+			throw new Error("LEGACY_DATABASE_URL must be set");
+		}
+
+		legacySql = postgres(process.env.LEGACY_DATABASE_URL, { max: 1 });
+		sql = postgres(getDatabaseUrl(), { max: 1 });
+
+		const counters = await runImportV1Representation({
+			legacySql,
+			sql,
+			from,
+			to,
+			dryRun,
+		});
+
+		console.log(formatReport(counters, dryRun));
+		if (counters.errors.length > 0) {
+			exitCode = 1;
+		}
+	} catch (error) {
+		console.error(
+			"[import-v1-representation] Failed:",
+			error instanceof Error ? error.message : error,
+		);
+		exitCode = 1;
+	} finally {
+		await sql?.end();
+		await legacySql?.end();
+	}
+	process.exit(exitCode);
+}

--- a/packages/app/src/__tests__/scripts/importV1Representation.test.ts
+++ b/packages/app/src/__tests__/scripts/importV1Representation.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it } from "vitest";
+import {
+	computeReferencePeriodStart,
+	formatReport,
+	mapCompanyFromV1,
+	mapDeclarationFromV1,
+	parseCliArgs,
+} from "#scripts/import-v1-representation.mjs";
+import {
+	v1Company,
+	v1Data,
+	v1Indicator,
+	v1Row,
+} from "~/test/v1RepresentationFixtures";
+
+const NOW = new Date("2024-03-15T10:00:00.000Z");
+
+describe("parseCliArgs", () => {
+	it("rejects a missing --from", () => {
+		expect(() => parseCliArgs([], { now: NOW })).toThrow("--from is required");
+	});
+
+	it("rejects a --from flag left without a value", () => {
+		expect(() => parseCliArgs(["--dry-run"], { now: NOW })).toThrow(
+			"--from is required",
+		);
+	});
+
+	it("defaults --to to the injected clock and --dry-run to false", () => {
+		const { from, to, dryRun } = parseCliArgs(["--from", "2023-01-01"], {
+			now: NOW,
+		});
+
+		expect(from.toISOString()).toBe("2023-01-01T00:00:00.000Z");
+		expect(to).toBe(NOW);
+		expect(dryRun).toBe(false);
+	});
+
+	it("defaults the clock to the current date when none is injected", () => {
+		const before = Date.now();
+
+		const { to } = parseCliArgs(["--from", "2023-01-01"]);
+
+		expect(to.getTime()).toBeGreaterThanOrEqual(before);
+	});
+
+	it("parses an explicit range and the dry-run flag in any order", () => {
+		const { from, to, dryRun } = parseCliArgs(
+			["--dry-run", "--to", "2024-01-01", "--from", "2023-01-01"],
+			{ now: NOW },
+		);
+
+		expect(from.toISOString()).toBe("2023-01-01T00:00:00.000Z");
+		expect(to.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+		expect(dryRun).toBe(true);
+	});
+
+	it("ignores unknown tokens", () => {
+		const { from, dryRun } = parseCliArgs(
+			["--verbose", "--from", "2023-01-01"],
+			{ now: NOW },
+		);
+
+		expect(from.toISOString()).toBe("2023-01-01T00:00:00.000Z");
+		expect(dryRun).toBe(false);
+	});
+
+	it.each([
+		["--from", ["--from", "01/01/2023"]],
+		["--to", ["--from", "2023-01-01", "--to", "2023/12/31"]],
+	])("rejects a malformed %s date", (label, argv) => {
+		expect(() => parseCliArgs(argv, { now: NOW })).toThrow(
+			`Invalid ${label} date`,
+		);
+	});
+
+	it("rejects a well-formed but non-existent date", () => {
+		expect(() => parseCliArgs(["--from", "2023-13-01"], { now: NOW })).toThrow(
+			'Invalid --from date "2023-13-01"',
+		);
+	});
+
+	it.each([
+		["equal to", "2023-01-01"],
+		["before", "2022-12-31"],
+	])("rejects a --to %s --from", (_label, to) => {
+		expect(() =>
+			parseCliArgs(["--from", "2023-01-01", "--to", to], { now: NOW }),
+		).toThrow(`--to (${to}) must be after --from (2023-01-01)`);
+	});
+
+	it("rejects a --from in the future of the default clock", () => {
+		expect(() => parseCliArgs(["--from", "2999-01-01"], { now: NOW })).toThrow(
+			"--to (now) must be after --from (2999-01-01)",
+		);
+	});
+});
+
+describe("computeReferencePeriodStart", () => {
+	it.each([
+		["a calendar year", "2023-12-31", "2023-01-01"],
+		["a mid-year fiscal period", "2024-06-30", "2023-07-01"],
+		["a first-of-month end", "2023-03-01", "2022-03-02"],
+		["a leap year", "2024-12-31", "2024-01-01"],
+		["a period spanning a 29th of February", "2024-02-28", "2023-03-01"],
+	])("derives the start of %s", (_label, end, expected) => {
+		expect(computeReferencePeriodStart(end)).toBe(expected);
+	});
+});
+
+describe("mapCompanyFromV1", () => {
+	it("maps a fully documented V1 company", () => {
+		expect(mapCompanyFromV1(v1Company())).toEqual({
+			siren: "123456789",
+			name: "Société Démo",
+			address: "1 rue de la Paix",
+			nafCode: "62.01Z",
+			region: "Île-de-France",
+			departmentCode: "75",
+			departmentLabel: "Paris",
+		});
+	});
+
+	it("resolves Corsican codes", () => {
+		const company = mapCompanyFromV1(
+			v1Company({ région: "94", département: "2A" }),
+		);
+
+		expect(company.region).toBe("Corse");
+		expect(company.departmentLabel).toBe("Corse-du-Sud");
+	});
+
+	it.each([
+		["the non-diffusible sentinel", "[NON-DIFFUSIBLE]"],
+		["an absent code", undefined],
+	])("nulls the NAF code for %s", (_label, codeNaf) => {
+		expect(
+			mapCompanyFromV1(v1Company({ code_naf: codeNaf })).nafCode,
+		).toBeNull();
+	});
+
+	it("nulls every optional field absent from V1", () => {
+		expect(
+			mapCompanyFromV1({
+				siren: "123456789",
+				raison_sociale: "Société Démo",
+			}),
+		).toEqual({
+			siren: "123456789",
+			name: "Société Démo",
+			address: null,
+			nafCode: null,
+			region: null,
+			departmentCode: null,
+			departmentLabel: null,
+		});
+	});
+
+	it("keeps an unknown department code but nulls the labels it cannot resolve", () => {
+		expect(
+			mapCompanyFromV1(v1Company({ région: "99", département: "999" })),
+		).toMatchObject({
+			region: null,
+			departmentCode: "999",
+			departmentLabel: null,
+		});
+	});
+});
+
+describe("mapDeclarationFromV1", () => {
+	it("maps a computable declaration published by URL", () => {
+		expect(mapDeclarationFromV1(v1Row())).toEqual({
+			siren: "123456789",
+			year: 2023,
+			legacyDeclarant: {
+				email: "declarant@example.fr",
+				lastname: "Martin",
+				firstname: "Camille",
+				phone: "0102030405",
+			},
+			referencePeriodStart: "2023-01-01",
+			referencePeriodEnd: "2023-12-31",
+			executiveWomenPercent: 45,
+			executiveMenPercent: 55,
+			notComputableReasonExecutives: null,
+			memberWomenPercent: 40,
+			memberMenPercent: 60,
+			notComputableReasonMembers: null,
+			publishDate: "2024-02-01",
+			publishUrl: "https://example.fr/representation",
+			publishModalities: null,
+			submittedAt: new Date("2024-02-10T09:30:00.000Z"),
+			createdAt: new Date("2024-02-10T09:30:00.000Z"),
+			updatedAt: new Date("2024-02-11T14:45:00.000Z"),
+		});
+	});
+
+	it("takes the year from the V1 row column", () => {
+		expect(mapDeclarationFromV1(v1Row({ year: 2022 })).year).toBe(2022);
+	});
+
+	it.each([
+		"aucun_cadre_dirigeant",
+		"un_seul_cadre_dirigeant",
+	])("drops the executive percentages when the reason is %s", (reason) => {
+		const row = v1Row({
+			data: v1Data({
+				indicateurs: {
+					représentation_équilibrée: v1Indicator({
+						motif_non_calculabilité_cadres: reason,
+					}),
+				},
+			}),
+		});
+
+		expect(mapDeclarationFromV1(row)).toMatchObject({
+			executiveWomenPercent: null,
+			executiveMenPercent: null,
+			notComputableReasonExecutives: reason,
+			memberWomenPercent: 40,
+			memberMenPercent: 60,
+			notComputableReasonMembers: null,
+		});
+	});
+
+	it("drops the member percentages when the governing body is missing", () => {
+		const row = v1Row({
+			data: v1Data({
+				indicateurs: {
+					représentation_équilibrée: v1Indicator({
+						motif_non_calculabilité_membres: "aucune_instance_dirigeante",
+					}),
+				},
+			}),
+		});
+
+		expect(mapDeclarationFromV1(row)).toMatchObject({
+			executiveWomenPercent: 45,
+			executiveMenPercent: 55,
+			notComputableReasonExecutives: null,
+			memberWomenPercent: null,
+			memberMenPercent: null,
+			notComputableReasonMembers: "aucune_instance_dirigeante",
+		});
+	});
+
+	it("keeps a zero percentage instead of nulling it", () => {
+		const row = v1Row({
+			data: v1Data({
+				indicateurs: {
+					représentation_équilibrée: v1Indicator({
+						pourcentage_femmes_cadres: 0,
+						pourcentage_hommes_cadres: 100,
+					}),
+				},
+			}),
+		});
+
+		expect(mapDeclarationFromV1(row)).toMatchObject({
+			executiveWomenPercent: 0,
+			executiveMenPercent: 100,
+		});
+	});
+
+	it("nulls percentages absent from a computable V1 indicator", () => {
+		const row = v1Row({
+			data: v1Data({ indicateurs: { représentation_équilibrée: {} } }),
+		});
+
+		expect(mapDeclarationFromV1(row)).toMatchObject({
+			executiveWomenPercent: null,
+			executiveMenPercent: null,
+			memberWomenPercent: null,
+			memberMenPercent: null,
+		});
+	});
+
+	it("maps a publication described by modalities", () => {
+		const row = v1Row({
+			data: v1Data({
+				déclaration: {
+					année_indicateurs: 2023,
+					fin_période_référence: "2023-12-31",
+					publication: {
+						date: "2024-02-01",
+						modalités: "Affichage dans les locaux",
+					},
+				},
+			}),
+		});
+
+		expect(mapDeclarationFromV1(row)).toMatchObject({
+			publishDate: "2024-02-01",
+			publishUrl: null,
+			publishModalities: "Affichage dans les locaux",
+		});
+	});
+
+	it("nulls every publication field when V1 carries no publication", () => {
+		const row = v1Row({
+			data: v1Data({
+				déclaration: {
+					année_indicateurs: 2023,
+					fin_période_référence: "2023-12-31",
+				},
+			}),
+		});
+
+		expect(mapDeclarationFromV1(row)).toMatchObject({
+			publishDate: null,
+			publishUrl: null,
+			publishModalities: null,
+		});
+	});
+
+	it("derives the reference period start from the V1 period end", () => {
+		const row = v1Row({
+			data: v1Data({
+				déclaration: {
+					année_indicateurs: 2023,
+					fin_période_référence: "2024-06-30",
+				},
+			}),
+		});
+
+		expect(mapDeclarationFromV1(row)).toMatchObject({
+			referencePeriodStart: "2023-07-01",
+			referencePeriodEnd: "2024-06-30",
+		});
+	});
+});
+
+describe("formatReport", () => {
+	const counters = {
+		total: 10,
+		imported: 4,
+		updated: 3,
+		skippedUpToDate: 2,
+		skippedNative: 1,
+		errors: [],
+	};
+
+	it("reports every counter without a dry-run prefix", () => {
+		const report = formatReport(counters, false);
+
+		expect(report.split("\n")[0]).toBe("import-v1-representation report");
+		expect(report).toMatch(/ {2}total read: +10$/m);
+		expect(report).toMatch(/ {2}imported: +4$/m);
+		expect(report).toMatch(/ {2}updated: +3$/m);
+		expect(report).toMatch(/ {2}skipped \(up to date\): +2$/m);
+		expect(report).toMatch(/ {2}skipped \(native V2\): +1$/m);
+		expect(report).toMatch(/ {2}errors: +0$/m);
+	});
+
+	it("flags a dry run in the report header", () => {
+		expect(formatReport(counters, true).split("\n")[0]).toBe(
+			"[dry-run] import-v1-representation report",
+		);
+	});
+
+	it("lists one identified line per error and no declarant identity", () => {
+		const report = formatReport(
+			{
+				...counters,
+				errors: [
+					{ siren: "123456789", year: 2023, cause: "malformed jsonb" },
+					{ siren: "987654321", year: 2022, cause: "missing raison_sociale" },
+				],
+			},
+			false,
+		);
+
+		expect(report).toMatch(/ {2}errors: +2$/m);
+		expect(report).toContain(
+			"    siren=123456789 year=2023 cause=malformed jsonb",
+		);
+		expect(report).toContain(
+			"    siren=987654321 year=2022 cause=missing raison_sociale",
+		);
+		expect(report).not.toContain("declarant@example.fr");
+	});
+});

--- a/packages/app/src/server/db/__tests__/importV1RepresentationScript.integration.test.ts
+++ b/packages/app/src/server/db/__tests__/importV1RepresentationScript.integration.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Integration test for `scripts/import-v1-representation.mjs` — runs against
+ * the real Postgres container booted by `src/test/integration-setup.ts`.
+ *
+ * Why this exists as an integration test (issue #4156):
+ *  The import bypasses the drizzle schema entirely: raw upsert SQL, a jsonb
+ *  `legacy_declarant`, two pgEnum columns, `numeric(5,2)` percentages, a
+ *  `date` reference period, an `ON CONFLICT DO NOTHING` company insert and a
+ *  `sql.begin()` transaction. Only a real database proves the FK to
+ *  `app_company`, the enum values are accepted, and the three upsert branches
+ *  (insert / update / skip) key correctly off the `(siren, year)` unique
+ *  index. A mocked driver would hide all of it.
+ *
+ * The V1 `representation_equilibree` table is not part of this repo's drizzle
+ * schema (it lives in the legacy V1 database), so the suite creates and drops
+ * a throwaway copy of it and points the script's `legacySql` client at the
+ * same container.
+ */
+
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { runImportV1Representation } from "#scripts/import-v1-representation.mjs";
+import { env } from "~/env.js";
+import {
+	V1_DECLARANT,
+	type V1RepresentationCompany,
+	type V1RepresentationRow,
+	v1Company,
+	v1Data,
+	v1Indicator,
+	v1Row,
+} from "~/test/v1RepresentationFixtures";
+
+const SIREN_A = "800000001";
+const SIREN_B = "800000002";
+const SIREN_C = "800000003";
+const SIREN_D = "800000004";
+const ALL_SIRENS = [SIREN_A, SIREN_B, SIREN_C, SIREN_D];
+
+const WIDE_FROM = new Date("2020-01-01T00:00:00.000Z");
+const WIDE_TO = new Date("2030-01-01T00:00:00.000Z");
+const DECLARED_AT = new Date("2023-06-15T09:30:00.000Z");
+const MODIFIED_AT = new Date("2023-06-16T14:45:00.000Z");
+
+type DeclarationRow = {
+	created_at: Date;
+	current_step: number;
+	declarant_id: string | null;
+	executive_men_percent: string | null;
+	executive_women_percent: string | null;
+	imported_from_v1_at: Date | null;
+	legacy_declarant: Record<string, string> | null;
+	member_men_percent: string | null;
+	member_women_percent: string | null;
+	not_computable_reason_executives: string | null;
+	not_computable_reason_members: string | null;
+	publish_date: string | null;
+	publish_modalities: string | null;
+	publish_url: string | null;
+	reference_period_end: string | null;
+	reference_period_start: string | null;
+	siren: string;
+	status: string;
+	submitted_at: Date | null;
+	updated_at: Date | null;
+	year: number;
+};
+
+type CompanyRow = {
+	address: string | null;
+	department_code: string | null;
+	department_label: string | null;
+	naf_code: string | null;
+	name: string;
+	region: string | null;
+	siren: string;
+};
+
+describe("import-v1-representation.mjs (integration)", () => {
+	let sql!: ReturnType<typeof postgres>;
+	let legacySql!: ReturnType<typeof postgres>;
+
+	beforeAll(async () => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+		legacySql = postgres(env.DATABASE_URL, { max: 1 });
+		await legacySql`
+			CREATE TABLE IF NOT EXISTS representation_equilibree (
+				siren varchar(9) NOT NULL,
+				year integer NOT NULL,
+				declared_at timestamptz NOT NULL,
+				modified_at timestamptz NOT NULL,
+				ft text,
+				data jsonb NOT NULL,
+				PRIMARY KEY (siren, year)
+			)
+		`;
+	});
+
+	afterAll(async () => {
+		await cleanup();
+		await legacySql`DROP TABLE IF EXISTS representation_equilibree`;
+		await sql.end();
+		await legacySql.end();
+	});
+
+	beforeEach(cleanup);
+
+	async function cleanup() {
+		await legacySql`TRUNCATE representation_equilibree`;
+		await sql`DELETE FROM app_representation_declaration WHERE siren IN ${sql(ALL_SIRENS)}`;
+		await sql`DELETE FROM app_company WHERE siren IN ${sql(ALL_SIRENS)}`;
+	}
+
+	async function seedLegacy(overrides: Partial<V1RepresentationRow> = {}) {
+		const base = v1Row({
+			siren: SIREN_A,
+			declared_at: DECLARED_AT,
+			modified_at: MODIFIED_AT,
+			...overrides,
+		});
+		// V1 always carries the same siren in the column and in the jsonb payload.
+		const row = {
+			...base,
+			data: {
+				...base.data,
+				...(base.data.entreprise
+					? { entreprise: { ...base.data.entreprise, siren: base.siren } }
+					: {}),
+			},
+		};
+		await legacySql`
+			INSERT INTO representation_equilibree (siren, year, declared_at, modified_at, ft, data)
+			VALUES (
+				${row.siren}, ${row.year}, ${row.declared_at}, ${row.modified_at},
+				${row.data.entreprise?.raison_sociale ?? null},
+				${legacySql.json(row.data)}
+			)
+		`;
+		return row;
+	}
+
+	function runImport(
+		overrides: { dryRun?: boolean; from?: Date; to?: Date } = {},
+	) {
+		return runImportV1Representation({
+			legacySql,
+			sql,
+			from: WIDE_FROM,
+			to: WIDE_TO,
+			dryRun: false,
+			...overrides,
+		});
+	}
+
+	async function readDeclaration(siren: string, year = 2023) {
+		const [row] = await sql<DeclarationRow[]>`
+			SELECT
+				siren, year, declarant_id, legacy_declarant, imported_from_v1_at,
+				reference_period_start::text AS reference_period_start,
+				reference_period_end::text AS reference_period_end,
+				executive_women_percent::text AS executive_women_percent,
+				executive_men_percent::text AS executive_men_percent,
+				not_computable_reason_executives,
+				member_women_percent::text AS member_women_percent,
+				member_men_percent::text AS member_men_percent,
+				not_computable_reason_members,
+				publish_date::text AS publish_date,
+				publish_url, publish_modalities,
+				current_step, status, submitted_at, created_at, updated_at
+			FROM app_representation_declaration
+			WHERE siren = ${siren} AND year = ${year}
+		`;
+		return row;
+	}
+
+	async function readCompany(siren: string) {
+		const [row] = await sql<CompanyRow[]>`
+			SELECT siren, name, address, naf_code, region, department_code, department_label
+			FROM app_company WHERE siren = ${siren}
+		`;
+		return row;
+	}
+
+	async function readSirens() {
+		const rows = await sql<{ siren: string }[]>`
+			SELECT siren FROM app_representation_declaration
+			WHERE siren IN ${sql(ALL_SIRENS)} ORDER BY siren
+		`;
+		return rows.map((row) => row.siren);
+	}
+
+	async function seedNativeDeclaration(siren: string) {
+		await sql`INSERT INTO app_company (siren, name) VALUES (${siren}, 'Nom Natif V2')`;
+		await sql`
+			INSERT INTO app_representation_declaration (
+				id, siren, year, executive_women_percent, current_step, status
+			) VALUES (
+				${crypto.randomUUID()}, ${siren}, 2023, 10, 2, 'draft'
+			)
+		`;
+	}
+
+	it("imports only the declarations whose declared_at falls in the range (S31)", async () => {
+		await seedLegacy({
+			siren: SIREN_A,
+			declared_at: new Date("2022-12-31T23:59:59.000Z"),
+		});
+		await seedLegacy({
+			siren: SIREN_B,
+			declared_at: new Date("2023-01-01T00:00:00.000Z"),
+		});
+		await seedLegacy({
+			siren: SIREN_C,
+			declared_at: new Date("2023-06-15T12:00:00.000Z"),
+		});
+		await seedLegacy({
+			siren: SIREN_D,
+			declared_at: new Date("2023-12-31T00:00:00.000Z"),
+		});
+
+		const counters = await runImport({
+			from: new Date("2023-01-01T00:00:00.000Z"),
+			to: new Date("2023-12-31T00:00:00.000Z"),
+		});
+
+		expect(counters).toEqual({
+			total: 2,
+			imported: 2,
+			updated: 0,
+			skippedUpToDate: 0,
+			skippedNative: 0,
+			errors: [],
+		});
+		expect(await readSirens()).toEqual([SIREN_B, SIREN_C]);
+	});
+
+	it("persists every mapped column of a computable declaration", async () => {
+		await seedLegacy({ siren: SIREN_A });
+
+		await runImport();
+
+		expect(await readDeclaration(SIREN_A)).toMatchObject({
+			siren: SIREN_A,
+			year: 2023,
+			declarant_id: null,
+			legacy_declarant: {
+				email: V1_DECLARANT.email,
+				lastname: V1_DECLARANT.nom,
+				firstname: V1_DECLARANT.prénom,
+				phone: V1_DECLARANT.téléphone,
+			},
+			reference_period_start: "2023-01-01",
+			reference_period_end: "2023-12-31",
+			executive_women_percent: "45.00",
+			executive_men_percent: "55.00",
+			not_computable_reason_executives: null,
+			member_women_percent: "40.00",
+			member_men_percent: "60.00",
+			not_computable_reason_members: null,
+			publish_date: "2024-02-01",
+			publish_url: "https://example.fr/representation",
+			publish_modalities: null,
+			current_step: 5,
+			status: "submitted",
+			submitted_at: DECLARED_AT,
+			created_at: DECLARED_AT,
+			updated_at: MODIFIED_AT,
+		});
+		expect(
+			(await readDeclaration(SIREN_A))?.imported_from_v1_at,
+		).toBeInstanceOf(Date);
+	});
+
+	it("creates the missing company from the V1 payload", async () => {
+		await seedLegacy({ siren: SIREN_A });
+
+		await runImport();
+
+		expect(await readCompany(SIREN_A)).toEqual({
+			siren: SIREN_A,
+			name: "Société Démo",
+			address: "1 rue de la Paix",
+			naf_code: "62.01Z",
+			region: "Île-de-France",
+			department_code: "75",
+			department_label: "Paris",
+		});
+	});
+
+	it("never overwrites an existing company", async () => {
+		await sql`
+			INSERT INTO app_company (siren, name, naf_code)
+			VALUES (${SIREN_A}, 'Nom Historique', '01.11Z')
+		`;
+		await seedLegacy({ siren: SIREN_A });
+
+		const counters = await runImport();
+
+		expect(counters.imported).toBe(1);
+		expect(await readCompany(SIREN_A)).toMatchObject({
+			name: "Nom Historique",
+			naf_code: "01.11Z",
+			region: null,
+			department_code: null,
+		});
+	});
+
+	it("persists the not-computable reasons as enum values", async () => {
+		await seedLegacy({
+			siren: SIREN_A,
+			data: v1Data({
+				entreprise: v1Company({ siren: SIREN_A }),
+				indicateurs: {
+					représentation_équilibrée: v1Indicator({
+						motif_non_calculabilité_cadres: "un_seul_cadre_dirigeant",
+						motif_non_calculabilité_membres: "aucune_instance_dirigeante",
+					}),
+				},
+			}),
+		});
+
+		await runImport();
+
+		expect(await readDeclaration(SIREN_A)).toMatchObject({
+			executive_women_percent: null,
+			executive_men_percent: null,
+			not_computable_reason_executives: "un_seul_cadre_dirigeant",
+			member_women_percent: null,
+			member_men_percent: null,
+			not_computable_reason_members: "aucune_instance_dirigeante",
+		});
+	});
+
+	it("replays the same range without duplicating anything (S32)", async () => {
+		await seedLegacy({ siren: SIREN_A });
+		await runImport();
+		const firstPass = await readDeclaration(SIREN_A);
+
+		const counters = await runImport();
+
+		expect(counters).toMatchObject({
+			total: 1,
+			imported: 0,
+			updated: 0,
+			skippedUpToDate: 1,
+		});
+		expect(await readSirens()).toEqual([SIREN_A]);
+		expect(await readDeclaration(SIREN_A)).toStrictEqual(firstPass);
+	});
+
+	it("skips an already up-to-date declaration on an overlapping range", async () => {
+		await seedLegacy({ siren: SIREN_A });
+		await runImport({
+			from: new Date("2023-01-01T00:00:00.000Z"),
+			to: new Date("2023-07-01T00:00:00.000Z"),
+		});
+
+		const counters = await runImport({
+			from: new Date("2023-06-01T00:00:00.000Z"),
+			to: new Date("2024-01-01T00:00:00.000Z"),
+		});
+
+		expect(counters).toMatchObject({
+			total: 1,
+			imported: 0,
+			skippedUpToDate: 1,
+		});
+		expect(await readSirens()).toEqual([SIREN_A]);
+	});
+
+	it("updates an imported declaration modified more recently in V1", async () => {
+		await seedLegacy({ siren: SIREN_A });
+		await runImport();
+		const before = await readDeclaration(SIREN_A);
+		const reModifiedAt = new Date("2024-03-01T08:00:00.000Z");
+		await legacySql`
+			UPDATE representation_equilibree
+			SET modified_at = ${reModifiedAt},
+				data = ${legacySql.json(
+					v1Data({
+						entreprise: v1Company({ siren: SIREN_A }),
+						indicateurs: {
+							représentation_équilibrée: v1Indicator({
+								pourcentage_femmes_cadres: 50,
+								pourcentage_hommes_cadres: 50,
+							}),
+						},
+					}),
+				)}
+			WHERE siren = ${SIREN_A}
+		`;
+
+		const counters = await runImport();
+
+		expect(counters).toMatchObject({
+			total: 1,
+			imported: 0,
+			updated: 1,
+			skippedUpToDate: 0,
+		});
+		expect(await readDeclaration(SIREN_A)).toMatchObject({
+			executive_women_percent: "50.00",
+			executive_men_percent: "50.00",
+			updated_at: reModifiedAt,
+			created_at: before?.created_at,
+		});
+		expect(await readSirens()).toEqual([SIREN_A]);
+	});
+
+	it("never touches a native V2 declaration", async () => {
+		await seedNativeDeclaration(SIREN_A);
+		const before = await readDeclaration(SIREN_A);
+		await seedLegacy({ siren: SIREN_A });
+
+		const counters = await runImport();
+
+		expect(counters).toMatchObject({
+			total: 1,
+			imported: 0,
+			updated: 0,
+			skippedNative: 1,
+		});
+		expect(await readDeclaration(SIREN_A)).toStrictEqual(before);
+		expect(await readCompany(SIREN_A)).toMatchObject({ name: "Nom Natif V2" });
+	});
+
+	it("writes nothing in dry-run while still counting the import", async () => {
+		await seedLegacy({ siren: SIREN_A });
+
+		const counters = await runImport({ dryRun: true });
+
+		expect(counters).toMatchObject({ total: 1, imported: 1, updated: 0 });
+		expect(await readSirens()).toEqual([]);
+		expect(await readCompany(SIREN_A)).toBeUndefined();
+	});
+
+	it("writes nothing in dry-run over an outdated imported declaration", async () => {
+		await seedLegacy({ siren: SIREN_A });
+		await runImport();
+		const before = await readDeclaration(SIREN_A);
+		await legacySql`
+			UPDATE representation_equilibree
+			SET modified_at = ${new Date("2024-03-01T08:00:00.000Z")}
+			WHERE siren = ${SIREN_A}
+		`;
+
+		const counters = await runImport({ dryRun: true });
+
+		expect(counters).toMatchObject({ total: 1, imported: 0, updated: 1 });
+		expect(await readDeclaration(SIREN_A)).toStrictEqual(before);
+	});
+
+	it("isolates a malformed row and reports it without any declarant identity", async () => {
+		await seedLegacy({
+			siren: SIREN_A,
+			data: v1Data({
+				entreprise: undefined as unknown as V1RepresentationCompany,
+			}),
+		});
+		await seedLegacy({ siren: SIREN_B });
+
+		const counters = await runImport();
+
+		expect(counters).toMatchObject({ total: 2, imported: 1 });
+		expect(counters.errors).toHaveLength(1);
+		expect(Object.keys(counters.errors[0] ?? {})).toEqual([
+			"siren",
+			"year",
+			"cause",
+		]);
+		expect(counters.errors[0]).toMatchObject({ siren: SIREN_A, year: 2023 });
+		expect(JSON.stringify(counters.errors)).not.toContain(V1_DECLARANT.email);
+		expect(await readSirens()).toEqual([SIREN_B]);
+	});
+});

--- a/packages/app/src/test/v1RepresentationFixtures.ts
+++ b/packages/app/src/test/v1RepresentationFixtures.ts
@@ -1,0 +1,121 @@
+/**
+ * Fixtures for legacy V1 `representation_equilibree` rows, shared by the unit
+ * and the integration suites of `scripts/import-v1-representation.mjs`.
+ *
+ * Key names and shapes mirror `RepresentationEquilibreeDataRaw` from the V1
+ * codebase (`origin/master`), accents included — that jsonb is the contract
+ * the import script reads.
+ */
+
+export type V1RepresentationCompany = {
+	siren: string;
+	raison_sociale: string;
+	adresse?: string;
+	code_naf?: string;
+	code_postal?: string;
+	commune?: string;
+	département?: string;
+	région?: string;
+};
+
+export type V1RepresentationIndicator = {
+	motif_non_calculabilité_cadres?: string;
+	motif_non_calculabilité_membres?: string;
+	pourcentage_femmes_cadres?: number;
+	pourcentage_femmes_membres?: number;
+	pourcentage_hommes_cadres?: number;
+	pourcentage_hommes_membres?: number;
+};
+
+export type V1RepresentationData = {
+	déclarant: {
+		email: string;
+		nom: string;
+		prénom: string;
+		téléphone: string;
+	};
+	déclaration: {
+		année_indicateurs: number;
+		date?: string;
+		fin_période_référence: string;
+		publication?: { date: string; modalités?: string; url?: string };
+	};
+	entreprise: V1RepresentationCompany;
+	indicateurs: { représentation_équilibrée: V1RepresentationIndicator };
+};
+
+export type V1RepresentationRow = {
+	data: V1RepresentationData;
+	declared_at: Date;
+	modified_at: Date;
+	siren: string;
+	year: number;
+};
+
+export const V1_DECLARANT = {
+	email: "declarant@example.fr",
+	nom: "Martin",
+	prénom: "Camille",
+	téléphone: "0102030405",
+};
+
+export function v1Company(
+	overrides: Partial<V1RepresentationCompany> = {},
+): V1RepresentationCompany {
+	return {
+		siren: "123456789",
+		raison_sociale: "Société Démo",
+		adresse: "1 rue de la Paix",
+		code_naf: "62.01Z",
+		code_postal: "75002",
+		commune: "Paris",
+		département: "75",
+		région: "11",
+		...overrides,
+	};
+}
+
+export function v1Indicator(
+	overrides: Partial<V1RepresentationIndicator> = {},
+): V1RepresentationIndicator {
+	return {
+		pourcentage_femmes_cadres: 45,
+		pourcentage_hommes_cadres: 55,
+		pourcentage_femmes_membres: 40,
+		pourcentage_hommes_membres: 60,
+		...overrides,
+	};
+}
+
+export function v1Data(
+	overrides: Partial<V1RepresentationData> = {},
+): V1RepresentationData {
+	return {
+		déclarant: { ...V1_DECLARANT },
+		déclaration: {
+			année_indicateurs: 2023,
+			date: "2024-02-10",
+			fin_période_référence: "2023-12-31",
+			publication: {
+				date: "2024-02-01",
+				url: "https://example.fr/representation",
+			},
+		},
+		entreprise: v1Company(),
+		indicateurs: { représentation_équilibrée: v1Indicator() },
+		...overrides,
+	};
+}
+
+export function v1Row(
+	overrides: Partial<V1RepresentationRow> = {},
+): V1RepresentationRow {
+	return {
+		siren: "123456789",
+		year: 2023,
+		declared_at: new Date("2024-02-10T09:30:00.000Z"),
+		modified_at: new Date("2024-02-11T14:45:00.000Z"),
+		data: v1Data(),
+		...overrides,
+	};
+}


### PR DESCRIPTION
Closes #4156

## Résumé

Script d'exploitation `packages/app/scripts/import-v1-representation.mjs` (+ module de mapping `import-v1-representation-mapping.mjs`) qui reprend les déclarations de représentation équilibrée V1 vers V2, sur une plage de dates (`--from`/`--to`, from inclusif / to exclusif), rejouable sans duplication, avec `--dry-run` et compte rendu d'exécution (exit code non-zéro si erreurs).

- Connexions : V1 via `LEGACY_DATABASE_URL` (échec explicite si absente), V2 via `DATABASE_URL` (mécanique des scripts existants).
- Mapping complet du jsonb V1 (`data.déclarant/déclaration/entreprise/indicateurs`) vers `app_representation_declaration`, vérifié contre `representationEquilibreeMap.ts` de `master`.
- Company minimale créée si absente (région/département résolus via les tables domaine `REGIONS`/`COUNTIES`), jamais écrasée si existante.
- Idempotence par `(siren, year)` : insert / update (si `modified_at` V1 plus récent) / ignoré (déjà à jour ou déclaration V2 native `imported_from_v1_at IS NULL`, jamais touchée).
- Aucun email/PII loggé — le compte rendu d'erreur ne contient que `siren`/`year`/`cause`.
- npm script : `pnpm import:v1-representation -- --from ... [--to ...] [--dry-run]` (exécuté via `tsx`, le script important le module domaine `~/modules/domain` pour la résolution région/département).

## Tests

- `tu-dev` : 36 tests unitaires (`src/__tests__/scripts/importV1Representation.test.ts`) + 12 tests d'intégration DB réelle (`src/server/db/__tests__/importV1RepresentationScript.integration.test.ts`) couvrant S31 (plage de dates), S32 (rejeu sans duplication, plage chevauchante), les 3 branches d'upsert, la protection des déclarations natives, `--dry-run`, et l'isolation des erreurs sans PII.
- `pnpm typecheck` / `pnpm test` (390 fichiers / 4379 tests) / `pnpm test:integration` (suite ciblée) / `pnpm lint:check` / `pnpm format:check` : tous verts.

## Validators internes

- `validator` (typecheck+test+lint+format) : PASS
- `structural-auditor` : 2 ERROR file-size (>400 lignes) corrigés par extraction du module de mapping ; WARN restants documentés ci-dessous (non bloquants)
- `security-auditor` : aucun finding CRITICAL/HIGH/MEDIUM ; 4 LOW de durcissement, non bloquants (détail ci-dessous)
- `rgaa-auditor` : N/A, aucun `.tsx` modifié
- `design-validator` : N/A, script d'exploitation sans écran (cf. ticket : « C'est un script, pas un parcours produit »)

### Suivi non-bloquant identifié par les auditeurs (à traiter dans un ticket dédié si souhaité)

- `getDatabaseUrl()` et l'IIFE `isMain` dupliquent (4ᵉ/3ᵉ copie) le pattern déjà présent dans `migrate.mjs`/`declaration-cleanup.mjs`/`audit-cleanup.mjs` — candidat à extraction partagée.
- `computeReferencePeriodStart` implémente une règle métier (période de référence = 1 an se terminant à `fin_période_référence`) en dehors de `~/modules/domain` — candidat à migration vers `campaign.ts` aux côtés de `getReferencePeriod()`.
- Sécurité (LOW) : cohérence `siren` (colonne V1 vs `data.entreprise.siren`) non assertée explicitement (fail-safe via la FK aujourd'hui) ; lookup existant hors transaction (fenêtre TOCTOU théorique, mitigée par l'index unique + `max:1`) ; pas de schéma Zod sur le jsonb V1 (échoue proprement par ligne aujourd'hui) ; pas de test verrouillant explicitement « jamais d'email dans le rapport ».

## Test plan

- [x] Plage de dates respectée (from inclusif, to exclusif)
- [x] Mapping complet V1 → V2 vérifié contre le mapper V1 de `master`
- [x] Company minimale créée si absente, jamais écrasée si existante
- [x] Idempotence : 3 branches d'upsert, déclaration V2 native jamais modifiée
- [x] Compte rendu + code de sortie non-zéro sur erreur
- [x] `--dry-run` sans aucune écriture
- [x] Aucune valeur de connexion en dur ni loggée ; aucun email loggé
- [x] Tests verts, typecheck vert, lint vert