### PR TITLE
Représentation équilibrée — campagne surchargeable en back-office

### DIFF
--- a/packages/app/src/modules/admin/settings/AdminSettingsPage.tsx
+++ b/packages/app/src/modules/admin/settings/AdminSettingsPage.tsx
@@ -3,6 +3,7 @@ import { api, HydrateClient } from "~/trpc/server";
 
 import { CampaignDeadlinesForm } from "./CampaignDeadlinesForm";
 import { LockTimeoutForm } from "./LockTimeoutForm";
+import { RepresentationCampaignForm } from "./RepresentationCampaignForm";
 
 export async function AdminSettingsPage() {
 	const overview = await api.adminSettings.getOverview();
@@ -25,6 +26,16 @@ export async function AdminSettingsPage() {
 					configuredYears={overview.configuredYears}
 					initialYear={initialYear}
 				/>
+			</section>
+
+			<section
+				aria-labelledby="representation-campaign-heading"
+				className="fr-mt-4w"
+			>
+				<h2 className="fr-h3" id="representation-campaign-heading">
+					Campagne représentation équilibrée
+				</h2>
+				<RepresentationCampaignForm initialYear={getCurrentYear()} />
 			</section>
 
 			<section aria-labelledby="lock-timeout-heading" className="fr-mt-4w">

--- a/packages/app/src/modules/admin/settings/RepresentationCampaignForm.tsx
+++ b/packages/app/src/modules/admin/settings/RepresentationCampaignForm.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { FIRST_DECLARATION_YEAR, getCurrentYear } from "~/modules/domain";
+import { useZodForm } from "~/modules/shared/useZodForm";
+import { api } from "~/trpc/react";
+
+import {
+	type RepresentationCampaignFormInput,
+	representationCampaignFormSchema,
+} from "./schemas";
+
+type Props = {
+	initialYear: number;
+};
+
+type DateFieldKey = Exclude<keyof RepresentationCampaignFormInput, "year">;
+
+const DATE_FIELDS: readonly DateFieldKey[] = [
+	"campaignStartDate",
+	"campaignEndDate",
+	"declarationDeadline",
+];
+
+const FIELD_LABELS: Record<DateFieldKey, string> = {
+	campaignStartDate: "Date de démarrage de la campagne",
+	campaignEndDate: "Date de clôture de la campagne",
+	declarationDeadline: "Date limite de déclaration",
+};
+
+export function RepresentationCampaignForm({ initialYear }: Props) {
+	const [selectedYear, setSelectedYear] = useState<number>(initialYear);
+	const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+	const [serverError, setServerError] = useState<string | null>(null);
+
+	const utils = api.useUtils();
+	const campaignQuery =
+		api.adminSettings.getRepresentationCampaignByYear.useQuery(
+			{ year: selectedYear },
+			{ staleTime: 0 },
+		);
+
+	const form = useZodForm(representationCampaignFormSchema, {
+		defaultValues: buildDefaults(selectedYear),
+	});
+
+	useEffect(() => {
+		if (!campaignQuery.data) return;
+		form.reset({
+			year: selectedYear,
+			campaignStartDate: campaignQuery.data.campaignStartDate,
+			campaignEndDate: campaignQuery.data.campaignEndDate,
+			declarationDeadline: campaignQuery.data.declarationDeadline,
+		});
+	}, [campaignQuery.data, form, selectedYear]);
+
+	const mutation = api.adminSettings.upsertRepresentationCampaign.useMutation({
+		onSuccess: async () => {
+			setStatus("success");
+			setServerError(null);
+			await utils.adminSettings.getRepresentationCampaignByYear.invalidate({
+				year: selectedYear,
+			});
+		},
+		onError: (err) => {
+			setStatus("error");
+			setServerError(err.message);
+		},
+	});
+
+	const onSubmit = form.handleSubmit((values) => {
+		setStatus("idle");
+		mutation.mutate(values);
+	});
+
+	const yearOptions = buildYearOptions();
+	const isDefault = campaignQuery.data?.isDefault ?? false;
+
+	return (
+		<>
+			<div className="fr-select-group fr-mb-3w">
+				<label
+					className="fr-label"
+					htmlFor="representation-campaign-year-selector"
+				>
+					Sélectionnez l'année de campagne à modifier
+					<span className="fr-hint-text">
+						Choisissez une année dans la liste. Les champs ci-dessous
+						correspondent à l'année sélectionnée.
+					</span>
+				</label>
+				<select
+					className="fr-select"
+					id="representation-campaign-year-selector"
+					onChange={(e) => setSelectedYear(Number(e.target.value))}
+					value={selectedYear}
+				>
+					{yearOptions.map((year) => (
+						<option key={year} value={year}>
+							{year}
+						</option>
+					))}
+				</select>
+			</div>
+
+			<form autoComplete="off" noValidate onSubmit={onSubmit}>
+				<input
+					type="hidden"
+					{...form.register("year", { valueAsNumber: true })}
+				/>
+
+				<div className="fr-p-3w fr-background-alt--grey">
+					<p className="fr-text--sm fr-text-mention--grey fr-mb-2w">
+						Paramètres applicables à la campagne <strong>{selectedYear}</strong>
+						.
+					</p>
+
+					{isDefault && (
+						<p className="fr-badge fr-badge--info fr-mb-2w">
+							Valeurs par défaut — aucune surcharge enregistrée pour cette année
+						</p>
+					)}
+
+					<fieldset className="fr-fieldset">
+						<legend className="fr-fieldset__legend">
+							Campagne représentation équilibrée
+						</legend>
+						<div className="fr-fieldset__content fr-grid-row fr-grid-row--gutters">
+							{DATE_FIELDS.map((key) => (
+								<div className="fr-col-12 fr-col-md-4" key={key}>
+									<DateField
+										error={form.formState.errors[key]?.message}
+										fieldKey={key}
+										register={form.register(key)}
+									/>
+								</div>
+							))}
+						</div>
+					</fieldset>
+				</div>
+
+				{status === "success" && (
+					<div
+						aria-live="polite"
+						className="fr-alert fr-alert--success fr-alert--sm fr-mt-2w"
+					>
+						<p>
+							Campagne représentation équilibrée enregistrée pour {selectedYear}
+							.
+						</p>
+					</div>
+				)}
+				{status === "error" && serverError && (
+					<div className="fr-alert fr-alert--error fr-mt-2w" role="alert">
+						<p>{serverError}</p>
+					</div>
+				)}
+
+				<ul className="fr-btns-group fr-btns-group--inline-sm fr-mt-2w">
+					<li>
+						<button
+							className="fr-btn"
+							disabled={mutation.isPending || campaignQuery.isLoading}
+							type="submit"
+						>
+							{mutation.isPending ? "Enregistrement…" : "Enregistrer"}
+						</button>
+					</li>
+				</ul>
+			</form>
+		</>
+	);
+}
+
+type DateFieldProps = {
+	fieldKey: DateFieldKey;
+	register: ReturnType<
+		ReturnType<typeof useZodForm<RepresentationCampaignFormInput>>["register"]
+	>;
+	error: string | undefined;
+};
+
+function DateField({ fieldKey, register, error }: DateFieldProps) {
+	const id = `representation-settings-${fieldKey}`;
+	return (
+		<div
+			className={
+				error ? "fr-input-group fr-input-group--error" : "fr-input-group"
+			}
+		>
+			<label className="fr-label" htmlFor={id}>
+				{FIELD_LABELS[fieldKey]}
+			</label>
+			<input
+				aria-describedby={error ? `${id}-error` : undefined}
+				aria-invalid={Boolean(error)}
+				className="fr-input"
+				id={id}
+				required
+				type="date"
+				{...register}
+			/>
+			{error && (
+				<p className="fr-error-text" id={`${id}-error`}>
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}
+
+function buildDefaults(year: number): RepresentationCampaignFormInput {
+	return {
+		year,
+		campaignStartDate: "",
+		campaignEndDate: "",
+		declarationDeadline: "",
+	};
+}
+
+function buildYearOptions(): number[] {
+	const max = getCurrentYear() + 10;
+	const years: number[] = [];
+	for (let y = FIRST_DECLARATION_YEAR; y <= max; y++) {
+		years.push(y);
+	}
+	return years;
+}

--- a/packages/app/src/modules/admin/settings/RepresentationCampaignForm.tsx
+++ b/packages/app/src/modules/admin/settings/RepresentationCampaignForm.tsx
@@ -142,6 +142,7 @@ export function RepresentationCampaignForm({ initialYear }: Props) {
 
 				{status === "success" && (
 					<div
+						aria-atomic="true"
 						aria-live="polite"
 						className="fr-alert fr-alert--success fr-alert--sm fr-mt-2w"
 					>

--- a/packages/app/src/modules/admin/settings/__tests__/AdminSettingsPage.test.tsx
+++ b/packages/app/src/modules/admin/settings/__tests__/AdminSettingsPage.test.tsx
@@ -37,6 +37,14 @@ vi.mock("../LockTimeoutForm", () => ({
 		}),
 }));
 
+vi.mock("../RepresentationCampaignForm", () => ({
+	RepresentationCampaignForm: (props: { initialYear: number }) =>
+		React.createElement("div", {
+			"data-testid": "representation-campaign-form",
+			"data-initial-year": props.initialYear,
+		}),
+}));
+
 import { AdminSettingsPage } from "../AdminSettingsPage";
 
 describe("AdminSettingsPage", () => {
@@ -73,6 +81,28 @@ describe("AdminSettingsPage", () => {
 		expect(deadlines.getAttribute("data-initial-year")).toBe(
 			String(new Date().getFullYear()),
 		);
+	});
+
+	it("seeds the representation campaign form with the current year, independently of the configured deadline years", async () => {
+		getOverviewMock.mockResolvedValue({ configuredYears: [2019, 2020] });
+		getLockTimeoutMock.mockResolvedValue({ timeoutMinutes: 30 });
+		render(await AdminSettingsPage());
+		expect(
+			screen.getByRole("heading", {
+				level: 2,
+				name: /campagne représentation équilibrée/i,
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen
+				.getByTestId("campaign-deadlines-form")
+				.getAttribute("data-initial-year"),
+		).toBe("2020");
+		expect(
+			screen
+				.getByTestId("representation-campaign-form")
+				.getAttribute("data-initial-year"),
+		).toBe(String(new Date().getFullYear()));
 	});
 
 	it("renders the lock timeout section seeded with the stored timeout", async () => {

--- a/packages/app/src/modules/admin/settings/__tests__/RepresentationCampaignForm.test.tsx
+++ b/packages/app/src/modules/admin/settings/__tests__/RepresentationCampaignForm.test.tsx
@@ -1,0 +1,280 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type CampaignData = {
+	year: number;
+	isDefault: boolean;
+	campaignStartDate: string;
+	campaignEndDate: string;
+	declarationDeadline: string;
+};
+
+const { upsertMutate, upsertState, queryState, invalidateCampaign } =
+	vi.hoisted(() => ({
+		upsertMutate: vi.fn(),
+		upsertState: { isPending: false } as {
+			isPending: boolean;
+			onSuccess?: () => Promise<void> | void;
+			onError?: (err: { message: string }) => void;
+		},
+		queryState: { dataByYear: {}, isLoading: false } as {
+			dataByYear: Record<number, unknown>;
+			isLoading: boolean;
+		},
+		invalidateCampaign: vi.fn().mockResolvedValue(undefined),
+	}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		adminSettings: {
+			getRepresentationCampaignByYear: {
+				useQuery: (input: { year: number }) => ({
+					data: queryState.dataByYear[input.year],
+					isLoading: queryState.isLoading,
+				}),
+				invalidate: invalidateCampaign,
+			},
+			upsertRepresentationCampaign: {
+				useMutation: (opts: {
+					onSuccess?: () => Promise<void> | void;
+					onError?: (err: { message: string }) => void;
+				}) => {
+					upsertState.onSuccess = opts.onSuccess;
+					upsertState.onError = opts.onError;
+					return { mutate: upsertMutate, isPending: upsertState.isPending };
+				},
+			},
+		},
+		useUtils: () => ({
+			adminSettings: {
+				getRepresentationCampaignByYear: { invalidate: invalidateCampaign },
+			},
+		}),
+	},
+}));
+
+import { RepresentationCampaignForm } from "../RepresentationCampaignForm";
+
+const storedCampaign: CampaignData = {
+	year: 2026,
+	isDefault: false,
+	campaignStartDate: "2026-02-01",
+	campaignEndDate: "2026-11-30",
+	declarationDeadline: "2026-04-15",
+};
+
+const defaultCampaign: CampaignData = {
+	year: 2027,
+	isDefault: true,
+	campaignStartDate: "2027-01-01",
+	campaignEndDate: "2027-12-31",
+	declarationDeadline: "2027-03-01",
+};
+
+const startInput = () =>
+	document.getElementById(
+		"representation-settings-campaignStartDate",
+	) as HTMLInputElement;
+const endInput = () =>
+	document.getElementById(
+		"representation-settings-campaignEndDate",
+	) as HTMLInputElement;
+const deadlineInput = () =>
+	document.getElementById(
+		"representation-settings-declarationDeadline",
+	) as HTMLInputElement;
+
+describe("RepresentationCampaignForm", () => {
+	beforeEach(() => {
+		upsertMutate.mockReset();
+		invalidateCampaign.mockClear();
+		upsertState.isPending = false;
+		queryState.isLoading = false;
+		queryState.dataByYear = {
+			2026: storedCampaign,
+			2027: defaultCampaign,
+		};
+	});
+
+	it("populates the three date fields from the query", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => {
+			expect(startInput()).toHaveValue("2026-02-01");
+		});
+		expect(endInput()).toHaveValue("2026-11-30");
+		expect(deadlineInput()).toHaveValue("2026-04-15");
+	});
+
+	it("lists every year from FIRST_DECLARATION_YEAR up to ten years ahead", () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		const select = screen.getByLabelText(
+			/sélectionnez l'année de campagne à modifier/i,
+		);
+		const values = Array.from(select.querySelectorAll("option")).map(
+			(o) => o.value,
+		);
+		expect(values).toEqual(expect.arrayContaining(["2019", "2026", "2027"]));
+	});
+
+	it("reloads the fields for the newly selected year", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		await userEvent.selectOptions(
+			screen.getByLabelText(/sélectionnez l'année de campagne à modifier/i),
+			"2027",
+		);
+
+		await waitFor(() => expect(startInput()).toHaveValue("2027-01-01"));
+		expect(endInput()).toHaveValue("2027-12-31");
+		expect(deadlineInput()).toHaveValue("2027-03-01");
+	});
+
+	it("shows the default-values badge only when no override is stored", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+		expect(screen.queryByText(/valeurs par défaut/i)).not.toBeInTheDocument();
+
+		await userEvent.selectOptions(
+			screen.getByLabelText(/sélectionnez l'année de campagne à modifier/i),
+			"2027",
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText(/valeurs par défaut/i)).toBeInTheDocument();
+		});
+	});
+
+	it("submits the loaded values on save", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+
+		await waitFor(() => expect(upsertMutate).toHaveBeenCalled());
+		expect(upsertMutate.mock.calls[0]?.[0]).toMatchObject({
+			year: 2026,
+			campaignStartDate: "2026-02-01",
+			campaignEndDate: "2026-11-30",
+			declarationDeadline: "2026-04-15",
+		});
+	});
+
+	it("submits the edited values rather than the loaded ones", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		fireEvent.change(startInput(), { target: { value: "2026-03-10" } });
+		fireEvent.change(deadlineInput(), { target: { value: "2026-05-20" } });
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+
+		await waitFor(() => expect(upsertMutate).toHaveBeenCalled());
+		expect(upsertMutate.mock.calls[0]?.[0]).toMatchObject({
+			campaignStartDate: "2026-03-10",
+			declarationDeadline: "2026-05-20",
+		});
+	});
+
+	it("submits under the newly selected year, not the initial one", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		await userEvent.selectOptions(
+			screen.getByLabelText(/sélectionnez l'année de campagne à modifier/i),
+			"2027",
+		);
+		await waitFor(() => expect(startInput()).toHaveValue("2027-01-01"));
+		fireEvent.change(endInput(), { target: { value: "2027-11-30" } });
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+
+		await waitFor(() => expect(upsertMutate).toHaveBeenCalled());
+		expect(upsertMutate.mock.calls[0]?.[0]).toEqual({
+			year: 2027,
+			campaignStartDate: "2027-01-01",
+			campaignEndDate: "2027-11-30",
+			declarationDeadline: "2027-03-01",
+		});
+	});
+
+	it("blocks submission when the start date is not before the end date", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		fireEvent.change(endInput(), { target: { value: "2026-01-15" } });
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					/la date de démarrage de la campagne doit être antérieure à la date de clôture/i,
+				),
+			).toBeInTheDocument();
+		});
+		expect(upsertMutate).not.toHaveBeenCalled();
+		expect(endInput()).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("blocks submission when the start and end dates are equal", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		fireEvent.change(endInput(), { target: { value: "2026-02-01" } });
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(/antérieure à la date de clôture/i),
+			).toBeInTheDocument();
+		});
+		expect(upsertMutate).not.toHaveBeenCalled();
+	});
+
+	it("shows a success alert and invalidates the query on success", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+		await waitFor(() => expect(upsertMutate).toHaveBeenCalled());
+		await upsertState.onSuccess?.();
+
+		await waitFor(() => {
+			expect(
+				screen.getByText(
+					/campagne représentation équilibrée enregistrée pour 2026/i,
+				),
+			).toBeInTheDocument();
+		});
+		expect(invalidateCampaign).toHaveBeenCalledWith({ year: 2026 });
+	});
+
+	it("surfaces the server error when the mutation fails", async () => {
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		await waitFor(() => expect(startInput()).toHaveValue("2026-02-01"));
+
+		await userEvent.click(screen.getByRole("button", { name: /enregistrer/i }));
+		await waitFor(() => expect(upsertMutate).toHaveBeenCalled());
+		upsertState.onError?.({ message: "Année déjà verrouillée" });
+
+		await waitFor(() => {
+			expect(screen.getByRole("alert")).toHaveTextContent(
+				"Année déjà verrouillée",
+			);
+		});
+	});
+
+	it("disables the submit button while the query is loading", () => {
+		queryState.isLoading = true;
+		queryState.dataByYear = {};
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		expect(screen.getByRole("button", { name: /enregistrer/i })).toBeDisabled();
+	});
+
+	it("disables the submit button and shows progress while saving", async () => {
+		upsertState.isPending = true;
+		render(<RepresentationCampaignForm initialYear={2026} />);
+		expect(
+			screen.getByRole("button", { name: /enregistrement…/i }),
+		).toBeDisabled();
+	});
+});

--- a/packages/app/src/modules/admin/settings/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/admin/settings/__tests__/schemas.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { campaignDeadlinesFormSchema } from "../schemas";
+import {
+	campaignDeadlinesFormSchema,
+	getRepresentationCampaignByYearSchema,
+	representationCampaignFormSchema,
+} from "../schemas";
 
 const validDates = {
 	decl1ModificationDeadline: "2026-06-01",
@@ -92,5 +96,106 @@ describe("campaignDeadlinesFormSchema", () => {
 			decl2ModificationDeadline: "2026-05-01",
 		});
 		expect(result.success).toBe(false);
+	});
+});
+
+const validRepresentationCampaign = {
+	year: 2026,
+	campaignStartDate: "2026-02-01",
+	campaignEndDate: "2026-11-30",
+	declarationDeadline: "2026-04-15",
+};
+
+describe("representationCampaignFormSchema", () => {
+	it("accepts a valid payload", () => {
+		const result = representationCampaignFormSchema.safeParse(
+			validRepresentationCampaign,
+		);
+		expect(result.success).toBe(true);
+	});
+
+	it.each([
+		"campaignStartDate",
+		"campaignEndDate",
+		"declarationDeadline",
+	] as const)("requires %s", (field) => {
+		const result = representationCampaignFormSchema.safeParse({
+			...validRepresentationCampaign,
+			[field]: "",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it.each([
+		"campaignStartDate",
+		"campaignEndDate",
+		"declarationDeadline",
+	] as const)("rejects a non ISO %s", (field) => {
+		const result = representationCampaignFormSchema.safeParse({
+			...validRepresentationCampaign,
+			[field]: "01/02/2026",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects an end date before the start date, flagged on campaignEndDate", () => {
+		const result = representationCampaignFormSchema.safeParse({
+			...validRepresentationCampaign,
+			campaignEndDate: "2026-01-15",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issue = result.error.issues[0];
+			expect(issue?.path).toEqual(["campaignEndDate"]);
+			expect(issue?.message).toBe(
+				"La date de démarrage de la campagne doit être antérieure à la date de clôture.",
+			);
+		}
+	});
+
+	it("rejects an end date equal to the start date", () => {
+		const result = representationCampaignFormSchema.safeParse({
+			...validRepresentationCampaign,
+			campaignEndDate: validRepresentationCampaign.campaignStartDate,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts a declaration deadline outside the campaign window", () => {
+		const result = representationCampaignFormSchema.safeParse({
+			...validRepresentationCampaign,
+			declarationDeadline: "2027-01-31",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects years below FIRST_DECLARATION_YEAR", () => {
+		const result = representationCampaignFormSchema.safeParse({
+			...validRepresentationCampaign,
+			year: 1999,
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects years above 2100", () => {
+		const result = representationCampaignFormSchema.safeParse({
+			...validRepresentationCampaign,
+			year: 2101,
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("getRepresentationCampaignByYearSchema", () => {
+	it("accepts a supported year", () => {
+		expect(
+			getRepresentationCampaignByYearSchema.safeParse({ year: 2026 }).success,
+		).toBe(true);
+	});
+
+	it("rejects a non-integer year", () => {
+		expect(
+			getRepresentationCampaignByYearSchema.safeParse({ year: 2026.5 }).success,
+		).toBe(false);
 	});
 });

--- a/packages/app/src/modules/admin/settings/index.ts
+++ b/packages/app/src/modules/admin/settings/index.ts
@@ -5,4 +5,8 @@ export {
 	campaignDeadlinesFormSchema,
 	campaignYearSchema,
 	getCampaignDeadlinesByYearSchema,
+	getRepresentationCampaignByYearSchema,
+	type RepresentationCampaignFormInput,
+	type RepresentationCampaignFormValues,
+	representationCampaignFormSchema,
 } from "./schemas";

--- a/packages/app/src/modules/admin/settings/schemas.ts
+++ b/packages/app/src/modules/admin/settings/schemas.ts
@@ -53,13 +53,13 @@ export type CampaignDeadlinesFormValues = z.output<
 	typeof campaignDeadlinesFormSchema
 >;
 
-export const getCampaignDeadlinesByYearSchema = z.object({
+const campaignYearParamSchema = z.object({
 	year: campaignYearSchema,
 });
 
-export const getRepresentationCampaignByYearSchema = z.object({
-	year: campaignYearSchema,
-});
+export const getCampaignDeadlinesByYearSchema = campaignYearParamSchema;
+
+export const getRepresentationCampaignByYearSchema = campaignYearParamSchema;
 
 export const representationCampaignFormSchema = z
 	.object({

--- a/packages/app/src/modules/admin/settings/schemas.ts
+++ b/packages/app/src/modules/admin/settings/schemas.ts
@@ -57,6 +57,30 @@ export const getCampaignDeadlinesByYearSchema = z.object({
 	year: campaignYearSchema,
 });
 
+export const getRepresentationCampaignByYearSchema = z.object({
+	year: campaignYearSchema,
+});
+
+export const representationCampaignFormSchema = z
+	.object({
+		year: campaignYearSchema,
+		campaignStartDate: isoDateString,
+		campaignEndDate: isoDateString,
+		declarationDeadline: isoDateString,
+	})
+	.refine((data) => data.campaignStartDate < data.campaignEndDate, {
+		message:
+			"La date de démarrage de la campagne doit être antérieure à la date de clôture.",
+		path: ["campaignEndDate"],
+	});
+
+export type RepresentationCampaignFormInput = z.input<
+	typeof representationCampaignFormSchema
+>;
+export type RepresentationCampaignFormValues = z.output<
+	typeof representationCampaignFormSchema
+>;
+
 export const updateLockTimeoutSchema = z.object({
 	timeoutMinutes: z.number().int().min(1).max(1440),
 });

--- a/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
+++ b/packages/app/src/modules/audit/__tests__/actionKeys.test.ts
@@ -28,6 +28,28 @@ describe("AUDIT_ACTIONS", () => {
 		).toBe("mutation");
 	});
 
+	it("maps the representation campaign upsert to a mutation", () => {
+		expect(AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_REPRESENTATION_CAMPAIGN).toBe(
+			"admin_settings.upsert_representation_campaign",
+		);
+		expect(
+			AUDIT_ACTION_CATEGORIES[
+				AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_REPRESENTATION_CAMPAIGN
+			],
+		).toBe("mutation");
+	});
+
+	it("maps the representation campaign read to a sensitive read", () => {
+		expect(AUDIT_ACTIONS.ADMIN_SETTINGS_GET_REPRESENTATION_CAMPAIGN).toBe(
+			"admin_settings.get_representation_campaign",
+		);
+		expect(
+			AUDIT_ACTION_CATEGORIES[
+				AUDIT_ACTIONS.ADMIN_SETTINGS_GET_REPRESENTATION_CAMPAIGN
+			],
+		).toBe("read_sensitive");
+	});
+
 	it("maps the declaration lock state read to a sensitive read (holder PII)", () => {
 		expect(AUDIT_ACTIONS.DECLARATION_LOCK_STATE_READ).toBe(
 			"declaration.lock_state_read",

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -63,6 +63,10 @@ export const AUDIT_ACTIONS = {
 	// ── Admin settings mutations ──────────────────────────
 	ADMIN_SETTINGS_UPSERT_DEADLINES: "admin_settings.upsert_deadlines",
 	ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT: "admin_settings.update_lock_timeout",
+	ADMIN_SETTINGS_GET_REPRESENTATION_CAMPAIGN:
+		"admin_settings.get_representation_campaign",
+	ADMIN_SETTINGS_UPSERT_REPRESENTATION_CAMPAIGN:
+		"admin_settings.upsert_representation_campaign",
 
 	// ── Admin stats reads ─────────────────────────────────
 	ADMIN_STATS_CAMPAIGN_PROGRESSION: "admin_stats.campaign_progression",
@@ -179,6 +183,8 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.ADMIN_DECLARATION_CANCEL]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT]: "mutation",
+	[AUDIT_ACTIONS.ADMIN_SETTINGS_GET_REPRESENTATION_CAMPAIGN]: "read_sensitive",
+	[AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_REPRESENTATION_CAMPAIGN]: "mutation",
 	[AUDIT_ACTIONS.ADMIN_STATS_CAMPAIGN_PROGRESSION]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_CAMPAIGN_STATS]: "read_sensitive",
 	[AUDIT_ACTIONS.ADMIN_STATS_GET_STEP_DURATIONS]: "read_sensitive",

--- a/packages/app/src/server/api/routers/__tests__/adminSettings.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminSettings.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { DEFAULT_LOCK_TIMEOUT_MINUTES } from "~/modules/domain";
+import { campaignDeadlines, representationCampaigns } from "~/server/db/schema";
+
 vi.mock("~/server/auth", () => ({
 	auth: vi.fn(),
 }));
@@ -19,6 +22,13 @@ const validInput = {
 	decl2ModificationDeadline: "2026-12-01",
 	decl2JustificationDeadline: "2026-12-01",
 	decl2JointEvaluationDeadline: "2027-02-01",
+};
+
+const validRepresentationInput = {
+	year: 2026,
+	campaignStartDate: "2026-02-01",
+	campaignEndDate: "2026-11-30",
+	declarationDeadline: "2026-04-15",
 };
 
 function buildDb(overrides: Partial<Record<string, unknown>> = {}) {
@@ -47,16 +57,28 @@ const adminSession = {
 	expires: "",
 };
 
+const nonAdminSession = {
+	user: { id: "u", email: "u@x", isAdmin: false },
+	expires: "",
+};
+
+async function buildCaller(
+	db: ReturnType<typeof buildDb>,
+	session: typeof adminSession | typeof nonAdminSession = adminSession,
+) {
+	const { adminSettingsRouter } = await import("../adminSettings");
+	return adminSettingsRouter.createCaller({
+		db,
+		session,
+		headers: new Headers(),
+	} as never);
+}
+
 describe("adminSettingsRouter — access control", () => {
 	beforeEach(() => vi.resetAllMocks());
 
 	it("rejects non-admin callers on getOverview", async () => {
-		const { adminSettingsRouter } = await import("../adminSettings");
-		const caller = adminSettingsRouter.createCaller({
-			db: buildDb(),
-			session: { user: { id: "u", email: "u@x", isAdmin: false }, expires: "" },
-			headers: new Headers(),
-		} as never);
+		const caller = await buildCaller(buildDb(), nonAdminSession);
 		await expect(caller.getOverview()).rejects.toThrow(/administrateurs/i);
 	});
 });
@@ -73,12 +95,7 @@ describe("adminSettingsRouter — getOverview", () => {
 					.mockResolvedValue([{ year: 2025 }, { year: 2026 }, { year: 2027 }]),
 			}),
 		});
-		const { adminSettingsRouter } = await import("../adminSettings");
-		const caller = adminSettingsRouter.createCaller({
-			db,
-			session: adminSession,
-			headers: new Headers(),
-		} as never);
+		const caller = await buildCaller(db);
 		const result = await caller.getOverview();
 		expect(result.configuredYears).toEqual([2025, 2026, 2027]);
 	});
@@ -88,12 +105,7 @@ describe("adminSettingsRouter — getOverview", () => {
 		db.select.mockReturnValueOnce({
 			from: vi.fn().mockReturnValue({ orderBy: vi.fn().mockResolvedValue([]) }),
 		});
-		const { adminSettingsRouter } = await import("../adminSettings");
-		const caller = adminSettingsRouter.createCaller({
-			db,
-			session: adminSession,
-			headers: new Headers(),
-		} as never);
+		const caller = await buildCaller(db);
 		const result = await caller.getOverview();
 		expect(result.configuredYears).toEqual([]);
 	});
@@ -124,12 +136,7 @@ describe("adminSettingsRouter — getDeadlinesByYear", () => {
 				}),
 			}),
 		});
-		const { adminSettingsRouter } = await import("../adminSettings");
-		const caller = adminSettingsRouter.createCaller({
-			db,
-			session: adminSession,
-			headers: new Headers(),
-		} as never);
+		const caller = await buildCaller(db);
 		const result = await caller.getDeadlinesByYear({ year: 2026 });
 		expect(result.exists).toBe(true);
 		expect(result.gipPublicationDate).toBe("2026-03-01");
@@ -146,12 +153,7 @@ describe("adminSettingsRouter — getDeadlinesByYear", () => {
 					.mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
 			}),
 		});
-		const { adminSettingsRouter } = await import("../adminSettings");
-		const caller = adminSettingsRouter.createCaller({
-			db,
-			session: adminSession,
-			headers: new Headers(),
-		} as never);
+		const caller = await buildCaller(db);
 		const result = await caller.getDeadlinesByYear({ year: 2027 });
 		expect(result.exists).toBe(false);
 		expect(result.gipPublicationDate).toBeNull();
@@ -166,12 +168,7 @@ describe("adminSettingsRouter — upsertCampaignDeadlines", () => {
 
 	it("calls insert().onConflictDoUpdate with the validated values", async () => {
 		const db = buildDb();
-		const { adminSettingsRouter } = await import("../adminSettings");
-		const caller = adminSettingsRouter.createCaller({
-			db,
-			session: adminSession,
-			headers: new Headers(),
-		} as never);
+		const caller = await buildCaller(db);
 		const result = await caller.upsertCampaignDeadlines(validInput);
 		expect(result).toEqual({ success: true });
 		expect(db.insert).toHaveBeenCalled();
@@ -186,18 +183,201 @@ describe("adminSettingsRouter — upsertCampaignDeadlines", () => {
 	});
 
 	it("rejects when decl2 is not strictly after decl1", async () => {
-		const db = buildDb();
-		const { adminSettingsRouter } = await import("../adminSettings");
-		const caller = adminSettingsRouter.createCaller({
-			db,
-			session: adminSession,
-			headers: new Headers(),
-		} as never);
+		const caller = await buildCaller(buildDb());
 		await expect(
 			caller.upsertCampaignDeadlines({
 				...validInput,
 				decl2ModificationDeadline: "2026-05-01",
 			}),
 		).rejects.toThrow();
+	});
+});
+
+describe("adminSettingsRouter — lock timeout", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("returns the stored timeout", async () => {
+		const db = buildDb();
+		db.__chainQuery.limit.mockResolvedValue([
+			{ declarationLockTimeoutMinutes: 45 },
+		]);
+		const caller = await buildCaller(db);
+
+		expect(await caller.getLockTimeout()).toEqual({ timeoutMinutes: 45 });
+	});
+
+	it("falls back to the default timeout when nothing is stored", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		expect(await caller.getLockTimeout()).toEqual({
+			timeoutMinutes: DEFAULT_LOCK_TIMEOUT_MINUTES,
+		});
+	});
+
+	it("writes the new timeout and stamps the acting admin", async () => {
+		const where = vi.fn().mockResolvedValue(undefined);
+		const set = vi.fn().mockReturnValue({ where });
+		const db = buildDb({ update: vi.fn().mockReturnValue({ set }) });
+		const caller = await buildCaller(db);
+
+		const result = await caller.updateLockTimeout({ timeoutMinutes: 60 });
+
+		expect(result).toEqual({ success: true });
+		expect(set).toHaveBeenCalledWith(
+			expect.objectContaining({
+				declarationLockTimeoutMinutes: 60,
+				updatedBy: "admin-1",
+			}),
+		);
+	});
+
+	it.each([
+		0, 1441, 12.5,
+	])("rejects an out-of-range timeout (%s)", async (v) => {
+		const update = vi.fn();
+		const caller = await buildCaller(buildDb({ update }));
+
+		await expect(
+			caller.updateLockTimeout({ timeoutMinutes: v }),
+		).rejects.toThrow();
+		expect(update).not.toHaveBeenCalled();
+	});
+});
+
+describe("adminSettingsRouter — getRepresentationCampaignByYear", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("returns the stored override when a row exists", async () => {
+		const db = buildDb();
+		db.__chainQuery.limit.mockResolvedValue([
+			{
+				year: 2026,
+				campaignStartDate: "2026-02-01",
+				campaignEndDate: "2026-11-30",
+				declarationDeadline: "2026-04-15",
+			},
+		]);
+		const caller = await buildCaller(db);
+
+		const result = await caller.getRepresentationCampaignByYear({ year: 2026 });
+
+		expect(result).toEqual({
+			year: 2026,
+			isDefault: false,
+			campaignStartDate: "2026-02-01",
+			campaignEndDate: "2026-11-30",
+			declarationDeadline: "2026-04-15",
+		});
+	});
+
+	it("falls back to the domain defaults when no row exists", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		const result = await caller.getRepresentationCampaignByYear({ year: 2027 });
+
+		expect(result).toEqual({
+			year: 2027,
+			isDefault: true,
+			campaignStartDate: "2027-01-01",
+			campaignEndDate: "2027-12-31",
+			declarationDeadline: "2027-03-01",
+		});
+	});
+
+	it("reads the representation_campaign table, never campaign_deadline", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		await caller.getRepresentationCampaignByYear({ year: 2026 });
+
+		expect(db.__chainQuery.from).toHaveBeenCalledWith(representationCampaigns);
+		expect(db.__chainQuery.from).not.toHaveBeenCalledWith(campaignDeadlines);
+	});
+
+	it("rejects years below FIRST_DECLARATION_YEAR", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+		await expect(
+			caller.getRepresentationCampaignByYear({ year: 1999 }),
+		).rejects.toThrow();
+	});
+
+	it("rejects non-admin callers", async () => {
+		const caller = await buildCaller(buildDb(), nonAdminSession);
+		await expect(
+			caller.getRepresentationCampaignByYear({ year: 2026 }),
+		).rejects.toThrow(/administrateurs/i);
+	});
+});
+
+describe("adminSettingsRouter — upsertRepresentationCampaign", () => {
+	beforeEach(() => vi.resetAllMocks());
+
+	it("inserts the validated values into representation_campaign", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		const result = await caller.upsertRepresentationCampaign(
+			validRepresentationInput,
+		);
+
+		expect(result).toEqual({ success: true });
+		expect(db.insert).toHaveBeenCalledWith(representationCampaigns);
+		expect(db.__insert.values).toHaveBeenCalledWith(validRepresentationInput);
+	});
+
+	it("updates the existing row on conflict instead of duplicating the year", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		await caller.upsertRepresentationCampaign(validRepresentationInput);
+
+		expect(db.__onConflict).toHaveBeenCalledWith({
+			target: representationCampaigns.year,
+			set: validRepresentationInput,
+		});
+	});
+
+	it("never writes to campaign_deadline", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		await caller.upsertRepresentationCampaign(validRepresentationInput);
+
+		expect(db.insert).not.toHaveBeenCalledWith(campaignDeadlines);
+	});
+
+	it("rejects when the start date is not strictly before the end date", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		await expect(
+			caller.upsertRepresentationCampaign({
+				...validRepresentationInput,
+				campaignEndDate: "2026-01-15",
+			}),
+		).rejects.toThrow();
+		expect(db.insert).not.toHaveBeenCalled();
+	});
+
+	it("rejects a malformed date", async () => {
+		const db = buildDb();
+		const caller = await buildCaller(db);
+
+		await expect(
+			caller.upsertRepresentationCampaign({
+				...validRepresentationInput,
+				declarationDeadline: "15/04/2026",
+			}),
+		).rejects.toThrow();
+	});
+
+	it("rejects non-admin callers", async () => {
+		const caller = await buildCaller(buildDb(), nonAdminSession);
+		await expect(
+			caller.upsertRepresentationCampaign(validRepresentationInput),
+		).rejects.toThrow(/administrateurs/i);
 	});
 });

--- a/packages/app/src/server/api/routers/adminSettings.ts
+++ b/packages/app/src/server/api/routers/adminSettings.ts
@@ -3,14 +3,21 @@ import { eq } from "drizzle-orm";
 import {
 	campaignDeadlinesFormSchema,
 	getCampaignDeadlinesByYearSchema,
+	getRepresentationCampaignByYearSchema,
+	representationCampaignFormSchema,
 	updateLockTimeoutSchema,
 } from "~/modules/admin/settings/schemas";
 import {
 	DEFAULT_LOCK_TIMEOUT_MINUTES,
 	getDefaultCampaignDeadlines,
+	getDefaultRepresentationCampaign,
 } from "~/modules/domain";
 import { adminProcedure, createTRPCRouter } from "~/server/api/trpc";
-import { campaignDeadlines, globalSettings } from "~/server/db/schema";
+import {
+	campaignDeadlines,
+	globalSettings,
+	representationCampaigns,
+} from "~/server/db/schema";
 
 /**
  * Admin / settings router — edits platform-wide global variables.
@@ -153,6 +160,56 @@ export const adminSettingsRouter = createTRPCRouter({
 				target: campaignDeadlines.year,
 				set: values,
 			});
+
+			return { success: true as const };
+		}),
+
+	getRepresentationCampaignByYear: adminProcedure
+		.input(getRepresentationCampaignByYearSchema)
+		.query(async ({ ctx, input }) => {
+			const [row] = await ctx.db
+				.select()
+				.from(representationCampaigns)
+				.where(eq(representationCampaigns.year, input.year))
+				.limit(1);
+
+			if (row) {
+				return {
+					year: row.year,
+					isDefault: false as const,
+					campaignStartDate: row.campaignStartDate,
+					campaignEndDate: row.campaignEndDate,
+					declarationDeadline: row.declarationDeadline,
+				};
+			}
+
+			const defaults = getDefaultRepresentationCampaign(input.year);
+			return {
+				year: input.year,
+				isDefault: true as const,
+				campaignStartDate: toIsoDate(defaults.campaignStartDate),
+				campaignEndDate: toIsoDate(defaults.campaignEndDate),
+				declarationDeadline: toIsoDate(defaults.declarationDeadline),
+			};
+		}),
+
+	upsertRepresentationCampaign: adminProcedure
+		.input(representationCampaignFormSchema)
+		.mutation(async ({ ctx, input }) => {
+			const values = {
+				year: input.year,
+				campaignStartDate: input.campaignStartDate,
+				campaignEndDate: input.campaignEndDate,
+				declarationDeadline: input.declarationDeadline,
+			};
+
+			await ctx.db
+				.insert(representationCampaigns)
+				.values(values)
+				.onConflictDoUpdate({
+					target: representationCampaigns.year,
+					set: values,
+				});
 
 			return { success: true as const };
 		}),

--- a/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
+++ b/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
@@ -85,6 +85,43 @@ describe("auditMiddleware", () => {
 		});
 	});
 
+	it("logs the representation campaign upsert mutation", async () => {
+		const next = vi.fn(async () => ({ success: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "adminSettings.upsertRepresentationCampaign",
+			getRawInput: buildGetRawInput({
+				year: 2026,
+				campaignStartDate: "2026-02-01",
+				campaignEndDate: "2026-11-30",
+				declarationDeadline: "2026-04-15",
+			}),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "admin_settings.upsert_representation_campaign",
+			status: "success",
+			metadata: { year: 2026, campaignStartDate: "2026-02-01" },
+		});
+	});
+
+	it("logs the representation campaign read as an opt-in sensitive query", async () => {
+		const next = vi.fn(async () => ({ year: 2026, isDefault: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "adminSettings.getRepresentationCampaignByYear",
+			getRawInput: buildGetRawInput({ year: 2026 }),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "admin_settings.get_representation_campaign",
+			status: "success",
+			metadata: { year: 2026 },
+		});
+	});
+
 	it("logs a failed mutation with the error message and re-throws", async () => {
 		const error = new TRPCError({
 			code: "BAD_REQUEST",

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -75,6 +75,10 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 		AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_DEADLINES,
 	"adminSettings.updateLockTimeout":
 		AUDIT_ACTIONS.ADMIN_SETTINGS_UPDATE_LOCK_TIMEOUT,
+	"adminSettings.getRepresentationCampaignByYear":
+		AUDIT_ACTIONS.ADMIN_SETTINGS_GET_REPRESENTATION_CAMPAIGN,
+	"adminSettings.upsertRepresentationCampaign":
+		AUDIT_ACTIONS.ADMIN_SETTINGS_UPSERT_REPRESENTATION_CAMPAIGN,
 
 	// ── admin stats sensitive reads ──────────────────────
 	"adminStats.getCampaignProgression":


### PR DESCRIPTION
Closes #4153

## Résumé

Ajoute la surcharge en back-office de la campagne de représentation équilibrée (dates de démarrage, clôture, échéance de déclaration), par année de campagne, totalement indépendante de la campagne rémunération (`campaign_deadline`).

- Nouveau composant `RepresentationCampaignForm` dans `AdminSettingsPage` : sélecteur d'année + 3 champs date, valeurs par défaut du domaine affichées et signalées (`isDefault`) tant qu'aucune ligne n'existe pour l'année.
- Nouvelles procédures tRPC `adminSettings.getRepresentationCampaignByYear` (query) et `adminSettings.upsertRepresentationCampaign` (mutation), toutes deux `adminProcedure`, sur la table `representation_campaign` (upsert Drizzle `onConflictDoUpdate`).
- Validation Zod `campaignStartDate < campaignEndDate` avec message FR.
- Audit câblé sur les deux procédures (`ADMIN_SETTINGS_GET_REPRESENTATION_CAMPAIGN` en `read_sensitive`, `ADMIN_SETTINGS_UPSERT_REPRESENTATION_CAMPAIGN` en `mutation`).
- Aucune lecture/écriture de `campaign_deadline` — la campagne rémunération reste inchangée.
- Le lecteur déclarant `getRepresentationCampaign` (issu de #4151) lit déjà la même table en live : la surcharge devient effective côté déclarant sans code supplémentaire.

## Test plan

- [x] Tests unitaires (formulaire, schemas, router, audit) écrits/complétés par `tu-dev` — suite verte, coverage 100% sur les fichiers de logique du ticket
- [x] Typecheck vert
- [x] Lint / format verts
- [x] `validator`, `structural-auditor`, `rgaa-auditor`, `security-auditor` : PASS / SECURE
- [ ] `functional-validator` (scénarios PO)
- [ ] CI GitHub Actions
- [ ] SonarCloud Quality Gate

## Screenshots

À suivre (dev server).