### PR TITLE
Représentation équilibrée — règles d'affichage de la ligne dans Mon espace

### DIFF
--- a/packages/app/src/modules/domain/__tests__/representation.test.ts
+++ b/packages/app/src/modules/domain/__tests__/representation.test.ts
@@ -5,6 +5,9 @@ import {
 	deriveExecutivesNotComputableReason,
 	getRepresentationCampaignYear,
 	getRepresentationTarget,
+	isPresumedSubjectToRepresentation,
+	REPRESENTATION_SUBJECTION_WINDOW_YEARS,
+	REPRESENTATION_SUBJECTION_WORKFORCE_MIN,
 	REPRESENTATION_TARGET_INITIAL,
 	REPRESENTATION_TARGET_RAISED,
 	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
@@ -22,6 +25,15 @@ describe("regulatory constants", () => {
 
 	it("pins the raised-target campaign year at 2029", () => {
 		expect(REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR).toBe(2029);
+	});
+
+	// art. L. 1142-11 — "at least 1 000 employees".
+	it("pins the subjection workforce threshold at 1 000", () => {
+		expect(REPRESENTATION_SUBJECTION_WORKFORCE_MIN).toBe(1000);
+	});
+
+	it("pins the subjection window at 3 years", () => {
+		expect(REPRESENTATION_SUBJECTION_WINDOW_YEARS).toBe(3);
 	});
 });
 
@@ -112,11 +124,175 @@ describe("getRepresentationCampaignYear", () => {
 	});
 });
 
+describe("isPresumedSubjectToRepresentation", () => {
+	it("presumes subjection from a single known year above the threshold (S33)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[{ year: 2026, workforceEma: 1200 }],
+				2026,
+			),
+		).toBe(true);
+	});
+
+	it("presumes subjection when both known years are above the threshold (S34)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[
+					{ year: 2026, workforceEma: 1200 },
+					{ year: 2025, workforceEma: 1050 },
+				],
+				2026,
+			),
+		).toBe(true);
+	});
+
+	it("presumes subjection when the three known years are above the threshold (S35)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[
+					{ year: 2026, workforceEma: 1200 },
+					{ year: 2025, workforceEma: 1050 },
+					{ year: 2024, workforceEma: 1400 },
+				],
+				2026,
+			),
+		).toBe(true);
+	});
+
+	it("ignores years older than the three-year sliding window (S35)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[
+					{ year: 2026, workforceEma: 1200 },
+					{ year: 2025, workforceEma: 1050 },
+					{ year: 2024, workforceEma: 1400 },
+					{ year: 2023, workforceEma: 800 },
+				],
+				2026,
+			),
+		).toBe(true);
+	});
+
+	it("drops the presumption when a single year of the window is below the threshold (S36)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[
+					{ year: 2026, workforceEma: 1200 },
+					{ year: 2025, workforceEma: 940 },
+					{ year: 2024, workforceEma: 1400 },
+				],
+				2026,
+			),
+		).toBe(false);
+	});
+
+	it("treats the threshold as inclusive at exactly 1 000 (S37)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[
+					{ year: 2026, workforceEma: 1000 },
+					{ year: 2025, workforceEma: 1000 },
+					{ year: 2024, workforceEma: 1000 },
+				],
+				2026,
+			),
+		).toBe(true);
+	});
+
+	it("compares the exact workforce value, without rounding up (S37)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[{ year: 2026, workforceEma: 999.99 }],
+				2026,
+			),
+		).toBe(false);
+	});
+
+	it("presumes subjection when no workforce is known (S38)", () => {
+		expect(isPresumedSubjectToRepresentation([], 2026)).toBe(true);
+	});
+
+	// Divergence from `getObligationWorkforce`, which reads a missing GIP record as
+	// a 0 headcount: here an unknown workforce is neutral, never a below-threshold one.
+	it("does not read an unknown workforce as a zero headcount (S38)", () => {
+		expect(isPresumedSubjectToRepresentation([], 2026)).toBe(true);
+		expect(
+			isPresumedSubjectToRepresentation(
+				[{ year: 2026, workforceEma: 0 }],
+				2026,
+			),
+		).toBe(false);
+	});
+
+	it("ignores years more recent than the reference year (S39)", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[
+					{ year: 2027, workforceEma: 500 },
+					{ year: 2026, workforceEma: 1200 },
+				],
+				2026,
+			),
+		).toBe(true);
+	});
+
+	it("stays visible on the available years while the latest vintage is missing (S39)", () => {
+		const knownYears = [
+			{ year: 2025, workforceEma: 1200 },
+			{ year: 2024, workforceEma: 1050 },
+		];
+
+		expect(isPresumedSubjectToRepresentation(knownYears, 2026)).toBe(true);
+	});
+
+	it("re-evaluates on its own once the missing vintage is published (S39)", () => {
+		const knownYears = [
+			{ year: 2025, workforceEma: 1200 },
+			{ year: 2024, workforceEma: 1050 },
+		];
+		const afterPublication = [{ year: 2026, workforceEma: 940 }, ...knownYears];
+
+		expect(isPresumedSubjectToRepresentation(afterPublication, 2026)).toBe(
+			false,
+		);
+	});
+
+	it("orders the window by year regardless of the input order", () => {
+		expect(
+			isPresumedSubjectToRepresentation(
+				[
+					{ year: 2023, workforceEma: 800 },
+					{ year: 2025, workforceEma: 1050 },
+					{ year: 2024, workforceEma: 1400 },
+					{ year: 2026, workforceEma: 1200 },
+				],
+				2026,
+			),
+		).toBe(true);
+	});
+
+	it("does not mutate the caller's workforce list", () => {
+		const workforces = [
+			{ year: 2024, workforceEma: 1400 },
+			{ year: 2026, workforceEma: 1200 },
+		];
+
+		isPresumedSubjectToRepresentation(workforces, 2026);
+
+		expect(workforces).toEqual([
+			{ year: 2024, workforceEma: 1400 },
+			{ year: 2026, workforceEma: 1200 },
+		]);
+	});
+});
+
 describe("verdict independence (S16)", () => {
 	// An aggregated verdict would let a compliant indicator mask a failing one.
 	it("exposes no aggregated verdict helper", async () => {
 		const representation = await import("../shared/representation");
 		expect(Object.keys(representation).sort()).toEqual([
+			"REPRESENTATION_SUBJECTION_WINDOW_YEARS",
+			"REPRESENTATION_SUBJECTION_WORKFORCE_MIN",
 			"REPRESENTATION_TARGET_INITIAL",
 			"REPRESENTATION_TARGET_RAISED",
 			"REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR",
@@ -124,6 +300,7 @@ describe("verdict independence (S16)", () => {
 			"deriveExecutivesNotComputableReason",
 			"getRepresentationCampaignYear",
 			"getRepresentationTarget",
+			"isPresumedSubjectToRepresentation",
 		]);
 	});
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -227,12 +227,16 @@ export {
 export type {
 	ExecutivesCount,
 	RepresentationComplianceVerdict,
+	WorkforceHistoryEntry,
 } from "./shared/representation";
 export {
 	computeRepresentationVerdict,
 	deriveExecutivesNotComputableReason,
 	getRepresentationCampaignYear,
 	getRepresentationTarget,
+	isPresumedSubjectToRepresentation,
+	REPRESENTATION_SUBJECTION_WINDOW_YEARS,
+	REPRESENTATION_SUBJECTION_WORKFORCE_MIN,
 	REPRESENTATION_TARGET_INITIAL,
 	REPRESENTATION_TARGET_RAISED,
 	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,

--- a/packages/app/src/modules/domain/shared/representation.ts
+++ b/packages/app/src/modules/domain/shared/representation.ts
@@ -1,6 +1,8 @@
 export const REPRESENTATION_TARGET_INITIAL = 30;
 export const REPRESENTATION_TARGET_RAISED = 40;
 export const REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR = 2029;
+export const REPRESENTATION_SUBJECTION_WORKFORCE_MIN = 1000;
+export const REPRESENTATION_SUBJECTION_WINDOW_YEARS = 3;
 
 export type RepresentationComplianceVerdict =
 	| "compliant"
@@ -8,6 +10,8 @@ export type RepresentationComplianceVerdict =
 	| "not_applicable";
 
 export type ExecutivesCount = "none" | "one" | "two_or_more";
+
+export type WorkforceHistoryEntry = { year: number; workforceEma: number };
 
 export function getRepresentationTarget(campaignYear: number): number {
 	return campaignYear >= REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR
@@ -37,4 +41,20 @@ export function deriveExecutivesNotComputableReason(
 
 export function getRepresentationCampaignYear(referenceYear: number): number {
 	return referenceYear + 1;
+}
+
+export function isPresumedSubjectToRepresentation(
+	workforcesByYear: WorkforceHistoryEntry[],
+	referenceYear: number,
+): boolean {
+	const window = workforcesByYear
+		.filter((entry) => entry.year <= referenceYear)
+		.sort((a, b) => b.year - a.year)
+		.slice(0, REPRESENTATION_SUBJECTION_WINDOW_YEARS);
+
+	if (window.length === 0) return true;
+
+	return window.every(
+		(entry) => entry.workforceEma >= REPRESENTATION_SUBJECTION_WORKFORCE_MIN,
+	);
 }

--- a/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/buildDeclarationList.test.ts
@@ -207,6 +207,136 @@ describe("buildDeclarationList", () => {
 		});
 	});
 
+	it("emits the representation row when visibility is explicitly granted", () => {
+		const result = buildDeclarationList(SIREN, [], 2026, new Set(), true);
+
+		expect(result.map((r) => r.type)).toEqual([
+			"remuneration",
+			"representation",
+		]);
+	});
+
+	it("omits the current year representation row when visibility is denied", () => {
+		const result = buildDeclarationList(SIREN, [], 2026, new Set(), false);
+
+		expect(result).toEqual([
+			{
+				type: "remuneration",
+				siren: SIREN,
+				year: 2026,
+				status: "to_complete",
+				currentStep: 0,
+				updatedAt: null,
+				...PLACEHOLDER_ROW,
+			},
+		]);
+	});
+
+	it("keeps the remuneration prefill flag when representation is hidden", () => {
+		const result = buildDeclarationList(
+			SIREN,
+			[],
+			2026,
+			new Set([2026]),
+			false,
+		);
+
+		expect(result).toHaveLength(1);
+		expect(result[0]).toMatchObject({
+			type: "remuneration",
+			hasPrefillData: true,
+		});
+	});
+
+	it("keeps an existing representation draft visible when visibility is denied", () => {
+		const updatedAt = new Date("2026-03-02");
+		const result = buildDeclarationList(
+			SIREN,
+			[
+				{
+					type: "representation",
+					year: 2026,
+					status: "in_progress",
+					fsmStatus: "draft",
+					currentStep: 2,
+					updatedAt,
+					...EMPTY_DECLARATION,
+				},
+			],
+			2026,
+			new Set(),
+			false,
+		);
+
+		expect(result).toHaveLength(2);
+		expect(result[1]).toEqual({
+			type: "representation",
+			siren: SIREN,
+			year: 2026,
+			status: "in_progress",
+			fsmStatus: "draft",
+			currentStep: 2,
+			updatedAt,
+			...EMPTY_DECLARATION,
+		});
+	});
+
+	it("keeps a submitted representation declaration visible when visibility is denied", () => {
+		const result = buildDeclarationList(
+			SIREN,
+			[
+				{
+					type: "representation",
+					year: 2026,
+					status: "done",
+					fsmStatus: "demarche_completed",
+					currentStep: 6,
+					updatedAt: null,
+					...EMPTY_DECLARATION,
+				},
+			],
+			2026,
+			new Set(),
+			false,
+		);
+
+		expect(result).toHaveLength(2);
+		expect(result[1]).toMatchObject({
+			type: "representation",
+			year: 2026,
+			status: "done",
+			fsmStatus: "demarche_completed",
+		});
+	});
+
+	it("keeps previous year representation declarations visible when visibility is denied", () => {
+		const result = buildDeclarationList(
+			SIREN,
+			[
+				{
+					type: "representation",
+					year: 2025,
+					status: "done",
+					fsmStatus: "demarche_completed",
+					currentStep: 6,
+					updatedAt: null,
+					...EMPTY_DECLARATION,
+				},
+			],
+			2026,
+			new Set(),
+			false,
+		);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toMatchObject({ type: "remuneration", year: 2026 });
+		expect(result[1]).toMatchObject({
+			type: "representation",
+			year: 2025,
+			status: "done",
+		});
+	});
+
 	it("propagates cseRequired from DB records", () => {
 		const result = buildDeclarationList(
 			SIREN,

--- a/packages/app/src/modules/my-space/buildDeclarationList.ts
+++ b/packages/app/src/modules/my-space/buildDeclarationList.ts
@@ -30,6 +30,7 @@ export function buildDeclarationList(
 	dbDeclarations: DbDeclaration[],
 	currentYear: number,
 	yearsWithPrefill: Set<number> = new Set(),
+	representationVisible = true,
 ): DeclarationItem[] {
 	const rows: DeclarationItem[] = [];
 
@@ -54,7 +55,7 @@ export function buildDeclarationList(
 				hasJointEvaluationFile: existing.hasJointEvaluationFile,
 				hasPrefillData: existing.hasPrefillData,
 			});
-		} else {
+		} else if (type !== "representation" || representationVisible) {
 			rows.push({
 				type,
 				siren,

--- a/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const { getRepresentationWorkforceHistoryMock } = vi.hoisted(() => ({
+	getRepresentationWorkforceHistoryMock: vi.fn(),
+}));
+
 vi.mock("~/server/services/suit");
 vi.mock("~/server/auth", () => ({ auth: vi.fn() }));
 vi.mock("~/server/db", () => ({ db: {} }));
+vi.mock("~/server/db/getRepresentationWorkforceHistory", () => ({
+	getRepresentationWorkforceHistory: getRepresentationWorkforceHistoryMock,
+}));
 
 function makeCompanyRow() {
 	return {
@@ -58,9 +65,35 @@ function makeSelectMock(declRows: unknown[]) {
 	});
 }
 
+async function makeCaller(declRows: unknown[]) {
+	const mockDb = { select: makeSelectMock(declRows) } as unknown;
+	const { companyRouter } = await import("../company");
+	return companyRouter.createCaller({
+		db: mockDb,
+		session: { user: { id: "user-1" }, expires: "" },
+		headers: new Headers(),
+	} as never);
+}
+
+function makeDeclRow(year: number) {
+	return {
+		siren: "339787277",
+		year,
+		status: "submitted",
+		currentStep: 6,
+		updatedAt: new Date(),
+		firstDeclarationPathChoice: null,
+		secondDeclarationPathChoice: null,
+		secondDeclarationSubmittedAt: null,
+		demarcheCompletedAt: null,
+		cseOpinionCompletedAt: null,
+	};
+}
+
 describe("companyRouter.getWithDeclarations", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		getRepresentationWorkforceHistoryMock.mockResolvedValue([]);
 	});
 
 	afterEach(() => {
@@ -68,29 +101,7 @@ describe("companyRouter.getWithDeclarations", () => {
 	});
 
 	it("returns company with declaration list", async () => {
-		const declRows = [
-			{
-				siren: "339787277",
-				year: 2026,
-				status: "submitted",
-				currentStep: 6,
-				updatedAt: new Date(),
-				firstDeclarationPathChoice: null,
-				secondDeclarationPathChoice: null,
-				secondDeclarationSubmittedAt: null,
-				demarcheCompletedAt: null,
-				cseOpinionCompletedAt: null,
-			},
-		];
-
-		const mockDb = { select: makeSelectMock(declRows) } as unknown;
-
-		const { companyRouter } = await import("../company");
-		const caller = companyRouter.createCaller({
-			db: mockDb,
-			session: { user: { id: "user-1" }, expires: "" },
-			headers: new Headers(),
-		} as never);
+		const caller = await makeCaller([makeDeclRow(2026)]);
 
 		const result = await caller.getWithDeclarations({ siren: "339787277" });
 
@@ -99,29 +110,7 @@ describe("companyRouter.getWithDeclarations", () => {
 	});
 
 	it("excludes cancelled declarations from the timeline", async () => {
-		const activeDeclRows = [
-			{
-				siren: "339787277",
-				year: 2026,
-				status: "submitted",
-				currentStep: 6,
-				updatedAt: new Date(),
-				firstDeclarationPathChoice: null,
-				secondDeclarationPathChoice: null,
-				secondDeclarationSubmittedAt: null,
-				demarcheCompletedAt: null,
-				cseOpinionCompletedAt: null,
-			},
-		];
-
-		const mockDb = { select: makeSelectMock(activeDeclRows) } as unknown;
-
-		const { companyRouter } = await import("../company");
-		const caller = companyRouter.createCaller({
-			db: mockDb,
-			session: { user: { id: "user-1" }, expires: "" },
-			headers: new Headers(),
-		} as never);
+		const caller = await makeCaller([makeDeclRow(2026)]);
 
 		const result = await caller.getWithDeclarations({ siren: "339787277" });
 
@@ -129,5 +118,49 @@ describe("companyRouter.getWithDeclarations", () => {
 			(d) => d.type === "remuneration",
 		);
 		expect(remunerationDecls).toHaveLength(1);
+	});
+
+	it("offers the representation démarche when the whole window reaches the threshold", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue([
+			{ year: 2026, workforceEma: 1200 },
+			{ year: 2025, workforceEma: 1050 },
+			{ year: 2024, workforceEma: 1400 },
+		]);
+		const caller = await makeCaller([]);
+
+		const result = await caller.getWithDeclarations({ siren: "339787277" });
+
+		expect(result.declarations.some((d) => d.type === "representation")).toBe(
+			true,
+		);
+	});
+
+	it("hides the representation démarche when a year of the window is below the threshold", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue([
+			{ year: 2026, workforceEma: 1200 },
+			{ year: 2025, workforceEma: 940 },
+			{ year: 2024, workforceEma: 1400 },
+		]);
+		const caller = await makeCaller([]);
+
+		const result = await caller.getWithDeclarations({ siren: "339787277" });
+
+		expect(result.declarations.some((d) => d.type === "representation")).toBe(
+			false,
+		);
+		expect(result.declarations.some((d) => d.type === "remuneration")).toBe(
+			true,
+		);
+	});
+
+	it("offers the representation démarche when no workforce is known", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue([]);
+		const caller = await makeCaller([]);
+
+		const result = await caller.getWithDeclarations({ siren: "339787277" });
+
+		expect(result.declarations.some((d) => d.type === "representation")).toBe(
+			true,
+		);
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
@@ -1,4 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCurrentYear } from "~/modules/domain";
+import {
+	companies,
+	declarationStatusHistory,
+	declarations,
+	files,
+	gipMdsData,
+	representationDeclarations,
+} from "~/server/db/schema";
 
 const { getRepresentationWorkforceHistoryMock } = vi.hoisted(() => ({
 	getRepresentationWorkforceHistoryMock: vi.fn(),
@@ -11,9 +20,11 @@ vi.mock("~/server/db/getRepresentationWorkforceHistory", () => ({
 	getRepresentationWorkforceHistory: getRepresentationWorkforceHistoryMock,
 }));
 
+const SIREN = "339787277";
+
 function makeCompanyRow() {
 	return {
-		siren: "339787277",
+		siren: SIREN,
 		name: "Test Company",
 		address: "1 rue de Paris",
 		nafCode: "6202A",
@@ -22,62 +33,76 @@ function makeCompanyRow() {
 	};
 }
 
-function makeSelectMock(declRows: unknown[]) {
-	let selectCallCount = 0;
-	return vi.fn().mockImplementation(() => {
-		selectCallCount++;
-		if (selectCallCount === 1) {
-			return {
-				from: vi.fn().mockReturnValue({
-					leftJoin: vi.fn().mockReturnValue({
-						innerJoin: vi.fn().mockReturnValue({
-							where: vi.fn().mockReturnValue({
-								limit: vi.fn().mockResolvedValue([makeCompanyRow()]),
-							}),
-						}),
-					}),
-				}),
+type QueryLog = { table: unknown; where: unknown };
+
+/** Mirrors Drizzle's builder: awaitable at any point of the chain, and keyed on
+ * the table passed to `from()` rather than on a call order the router owns. */
+type QueryBuilder = Promise<unknown[]> & {
+	leftJoin: () => QueryBuilder;
+	innerJoin: () => QueryBuilder;
+	where: (condition: unknown) => QueryBuilder;
+	orderBy: () => QueryBuilder;
+	limit: () => QueryBuilder;
+};
+
+function makeSelectMock(
+	rowsByTable: Map<unknown, unknown[]>,
+	queries: QueryLog[],
+) {
+	return vi.fn(() => ({
+		from: (table: unknown) => {
+			const log: QueryLog = { table, where: null };
+			queries.push(log);
+			const builder = Promise.resolve(
+				rowsByTable.get(table) ?? [],
+			) as QueryBuilder;
+			builder.leftJoin = () => builder;
+			builder.innerJoin = () => builder;
+			builder.where = (condition: unknown) => {
+				log.where = condition;
+				return builder;
 			};
-		}
-		if (selectCallCount === 2) {
-			return {
-				from: vi.fn().mockReturnValue({
-					where: vi.fn().mockReturnValue({
-						orderBy: vi.fn().mockResolvedValue(declRows),
-					}),
-				}),
-			};
-		}
-		if (selectCallCount === 4) {
-			return {
-				from: vi.fn().mockReturnValue({
-					where: vi.fn().mockResolvedValue([]),
-				}),
-			};
-		}
-		return {
-			from: vi.fn().mockReturnValue({
-				innerJoin: vi.fn().mockReturnValue({
-					where: vi.fn().mockResolvedValue([]),
-				}),
-			}),
-		};
-	});
+			builder.orderBy = () => builder;
+			builder.limit = () => builder;
+			return builder;
+		},
+	}));
 }
 
-async function makeCaller(declRows: unknown[]) {
-	const mockDb = { select: makeSelectMock(declRows) } as unknown;
+async function makeCaller({
+	declRows = [],
+	eventRows = [],
+	representationDeclarationRows = [],
+}: {
+	declRows?: unknown[];
+	eventRows?: unknown[];
+	representationDeclarationRows?: unknown[];
+} = {}) {
+	const queries: QueryLog[] = [];
+	const rowsByTable = new Map<unknown, unknown[]>([
+		[companies, [makeCompanyRow()]],
+		[declarations, declRows],
+		[files, []],
+		[gipMdsData, []],
+		[declarationStatusHistory, eventRows],
+		[representationDeclarations, representationDeclarationRows],
+	]);
+	const mockDb = { select: makeSelectMock(rowsByTable, queries) } as unknown;
 	const { companyRouter } = await import("../company");
-	return companyRouter.createCaller({
+	const caller = companyRouter.createCaller({
 		db: mockDb,
 		session: { user: { id: "user-1" }, expires: "" },
 		headers: new Headers(),
 	} as never);
+	return { caller, queries };
 }
+
+const DECLARATION_ID = "declaration-1";
 
 function makeDeclRow(year: number) {
 	return {
-		siren: "339787277",
+		id: DECLARATION_ID,
+		siren: SIREN,
 		year,
 		status: "submitted",
 		currentStep: 6,
@@ -90,6 +115,54 @@ function makeDeclRow(year: number) {
 	};
 }
 
+function makeRepresentationDeclarationRow(year: number) {
+	return { year };
+}
+
+/** Flattens a Drizzle `and(eq(col, value), …)` condition into a
+ * column-object → parameter-value map, so a test can assert exactly which
+ * columns a query filters on without matching generated SQL text. */
+function collectEqualityFilters(condition: unknown): Map<unknown, unknown> {
+	const filters = new Map<unknown, unknown>();
+	let pendingColumn: unknown = null;
+
+	const walk = (node: unknown): void => {
+		if (node === null || typeof node !== "object") return;
+		if ("queryChunks" in node && Array.isArray(node.queryChunks)) {
+			for (const chunk of node.queryChunks) walk(chunk);
+			return;
+		}
+		if ("name" in node && typeof node.name === "string") {
+			pendingColumn = node;
+			return;
+		}
+		const column = pendingColumn;
+		if ("encoder" in node && "value" in node && column !== null) {
+			filters.set(column, node.value);
+			pendingColumn = null;
+		}
+	};
+
+	walk(condition);
+	return filters;
+}
+
+function findQuery(queries: QueryLog[], table: unknown) {
+	return queries.find((q) => q.table === table);
+}
+
+const workforceBelowThreshold = [
+	{ year: getCurrentYear(), workforceEma: 1200 },
+	{ year: getCurrentYear() - 1, workforceEma: 940 },
+	{ year: getCurrentYear() - 2, workforceEma: 1400 },
+];
+
+const workforceAboveThreshold = [
+	{ year: getCurrentYear(), workforceEma: 1200 },
+	{ year: getCurrentYear() - 1, workforceEma: 1050 },
+	{ year: getCurrentYear() - 2, workforceEma: 1400 },
+];
+
 describe("companyRouter.getWithDeclarations", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
@@ -101,18 +174,22 @@ describe("companyRouter.getWithDeclarations", () => {
 	});
 
 	it("returns company with declaration list", async () => {
-		const caller = await makeCaller([makeDeclRow(2026)]);
+		const { caller } = await makeCaller({
+			declRows: [makeDeclRow(getCurrentYear())],
+		});
 
-		const result = await caller.getWithDeclarations({ siren: "339787277" });
+		const result = await caller.getWithDeclarations({ siren: SIREN });
 
-		expect(result.company.siren).toBe("339787277");
+		expect(result.company.siren).toBe(SIREN);
 		expect(result.declarations).toBeDefined();
 	});
 
 	it("excludes cancelled declarations from the timeline", async () => {
-		const caller = await makeCaller([makeDeclRow(2026)]);
+		const { caller } = await makeCaller({
+			declRows: [makeDeclRow(getCurrentYear())],
+		});
 
-		const result = await caller.getWithDeclarations({ siren: "339787277" });
+		const result = await caller.getWithDeclarations({ siren: SIREN });
 
 		const remunerationDecls = result.declarations.filter(
 			(d) => d.type === "remuneration",
@@ -120,15 +197,35 @@ describe("companyRouter.getWithDeclarations", () => {
 		expect(remunerationDecls).toHaveLength(1);
 	});
 
-	it("offers the representation démarche when the whole window reaches the threshold", async () => {
-		getRepresentationWorkforceHistoryMock.mockResolvedValue([
-			{ year: 2026, workforceEma: 1200 },
-			{ year: 2025, workforceEma: 1050 },
-			{ year: 2024, workforceEma: 1400 },
-		]);
-		const caller = await makeCaller([]);
+	it("flags the second declaration and the CSE opinion from the status history", async () => {
+		const { caller } = await makeCaller({
+			declRows: [makeDeclRow(getCurrentYear())],
+			eventRows: [
+				{
+					declarationId: DECLARATION_ID,
+					eventType: "second_declaration_submit",
+				},
+				{ declarationId: DECLARATION_ID, eventType: "cse_opinion_submit" },
+			],
+		});
 
-		const result = await caller.getWithDeclarations({ siren: "339787277" });
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "remuneration"),
+		).toMatchObject({
+			hasSubmittedSecondDeclaration: true,
+			hasSubmittedCseOpinion: true,
+		});
+	});
+
+	it("offers the representation démarche when the whole window reaches the threshold", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceAboveThreshold,
+		);
+		const { caller } = await makeCaller();
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
 
 		expect(result.declarations.some((d) => d.type === "representation")).toBe(
 			true,
@@ -136,14 +233,12 @@ describe("companyRouter.getWithDeclarations", () => {
 	});
 
 	it("hides the representation démarche when a year of the window is below the threshold", async () => {
-		getRepresentationWorkforceHistoryMock.mockResolvedValue([
-			{ year: 2026, workforceEma: 1200 },
-			{ year: 2025, workforceEma: 940 },
-			{ year: 2024, workforceEma: 1400 },
-		]);
-		const caller = await makeCaller([]);
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller();
 
-		const result = await caller.getWithDeclarations({ siren: "339787277" });
+		const result = await caller.getWithDeclarations({ siren: SIREN });
 
 		expect(result.declarations.some((d) => d.type === "representation")).toBe(
 			false,
@@ -155,12 +250,101 @@ describe("companyRouter.getWithDeclarations", () => {
 
 	it("offers the representation démarche when no workforce is known", async () => {
 		getRepresentationWorkforceHistoryMock.mockResolvedValue([]);
-		const caller = await makeCaller([]);
+		const { caller } = await makeCaller();
 
-		const result = await caller.getWithDeclarations({ siren: "339787277" });
+		const result = await caller.getWithDeclarations({ siren: SIREN });
 
 		expect(result.declarations.some((d) => d.type === "representation")).toBe(
 			true,
 		);
+	});
+
+	it("keeps an existing representation declaration visible even when the workforce filter would hide it", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow(getCurrentYear()),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(result.declarations.some((d) => d.type === "representation")).toBe(
+			true,
+		);
+	});
+
+	it("keeps the representation démarche hidden when the workforce filter excludes it and no declaration exists", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({ representationDeclarationRows: [] });
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(result.declarations.some((d) => d.type === "representation")).toBe(
+			false,
+		);
+	});
+
+	it("lists the representation démarche once when both the workforce filter and an existing declaration make it visible", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceAboveThreshold,
+		);
+		const { caller } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow(getCurrentYear()),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.filter((d) => d.type === "representation"),
+		).toHaveLength(1);
+	});
+
+	it("scopes the existing-declaration lookup to the company and the current year", async () => {
+		const { caller, queries } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow(getCurrentYear()),
+			],
+		});
+
+		await caller.getWithDeclarations({ siren: SIREN });
+
+		const query = findQuery(queries, representationDeclarations);
+		const filters = collectEqualityFilters(query?.where);
+		expect(filters.get(representationDeclarations.siren)).toBe(SIREN);
+		expect(filters.get(representationDeclarations.year)).toBe(getCurrentYear());
+		// Exactly two filters: no status predicate, so a draft counts as much as a
+		// submitted declaration — the line must never disappear once started.
+		expect(filters.size).toBe(2);
+	});
+
+	it("shows the existing representation declaration with the generic stub state", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow(getCurrentYear()),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		// Visibility only: mapping the representation state machine onto the row is
+		// owned by the "panneau latéral & activation" ticket, not this one.
+		expect(
+			result.declarations.find((d) => d.type === "representation"),
+		).toMatchObject({
+			year: getCurrentYear(),
+			status: "to_complete",
+			fsmStatus: null,
+			currentStep: 0,
+		});
 	});
 });

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -6,6 +6,7 @@ import {
 	getCurrentYear,
 	getObligationWorkforce,
 	isCseRequired,
+	isPresumedSubjectToRepresentation,
 	parseGipWorkforce,
 } from "~/modules/domain";
 import { buildDeclarationList } from "~/modules/my-space/buildDeclarationList";
@@ -19,6 +20,7 @@ import {
 	isImpersonatingSiren,
 } from "~/server/auth/companyAccess";
 import type { DB } from "~/server/db";
+import { getRepresentationWorkforceHistory } from "~/server/db/getRepresentationWorkforceHistory";
 import {
 	companies,
 	declarationStatusHistory,
@@ -187,62 +189,68 @@ export const companyRouter = createTRPCRouter({
 		.input(sirenInputSchema)
 		.query(async ({ ctx, input }) => {
 			const company = await findUserCompany(ctx.db, ctx.session, input.siren);
+			const year = getCurrentYear();
 
-			const [declarationRows, jointEvalRows, prefillRows, eventRows] =
-				await Promise.all([
-					ctx.db
-						.select({
-							id: declarations.id,
-							siren: declarations.siren,
-							year: declarations.year,
-							status: declarations.status,
-							currentStep: declarations.currentStep,
-							updatedAt: declarations.updatedAt,
-							firstDeclarationPathChoice:
-								declarations.firstDeclarationPathChoice,
-							secondDeclarationPathChoice:
-								declarations.secondDeclarationPathChoice,
-							cseRequired: declarations.cseRequired,
-						})
-						.from(declarations)
-						.where(
-							and(
-								eq(declarations.siren, input.siren),
-								isNull(declarations.cancelledAt),
-							),
-						)
-						.orderBy(desc(declarations.year)),
-					ctx.db
-						.select({ year: declarations.year })
-						.from(files)
-						.innerJoin(declarations, eq(files.declarationId, declarations.id))
-						.where(
-							and(
-								eq(declarations.siren, input.siren),
-								eq(files.type, "joint_evaluation"),
-							),
+			const [
+				declarationRows,
+				jointEvalRows,
+				prefillRows,
+				eventRows,
+				representationWorkforceHistory,
+			] = await Promise.all([
+				ctx.db
+					.select({
+						id: declarations.id,
+						siren: declarations.siren,
+						year: declarations.year,
+						status: declarations.status,
+						currentStep: declarations.currentStep,
+						updatedAt: declarations.updatedAt,
+						firstDeclarationPathChoice: declarations.firstDeclarationPathChoice,
+						secondDeclarationPathChoice:
+							declarations.secondDeclarationPathChoice,
+						cseRequired: declarations.cseRequired,
+					})
+					.from(declarations)
+					.where(
+						and(
+							eq(declarations.siren, input.siren),
+							isNull(declarations.cancelledAt),
 						),
-					ctx.db
-						.select({ year: gipMdsData.year })
-						.from(gipMdsData)
-						.where(eq(gipMdsData.siren, input.siren)),
-					ctx.db
-						.select({
-							declarationId: declarationStatusHistory.declarationId,
-							eventType: declarationStatusHistory.eventType,
-						})
-						.from(declarationStatusHistory)
-						.innerJoin(
-							declarations,
-							eq(declarationStatusHistory.declarationId, declarations.id),
-						)
-						.where(
-							and(
-								eq(declarations.siren, input.siren),
-								isNull(declarations.cancelledAt),
-							),
+					)
+					.orderBy(desc(declarations.year)),
+				ctx.db
+					.select({ year: declarations.year })
+					.from(files)
+					.innerJoin(declarations, eq(files.declarationId, declarations.id))
+					.where(
+						and(
+							eq(declarations.siren, input.siren),
+							eq(files.type, "joint_evaluation"),
 						),
-				]);
+					),
+				ctx.db
+					.select({ year: gipMdsData.year })
+					.from(gipMdsData)
+					.where(eq(gipMdsData.siren, input.siren)),
+				ctx.db
+					.select({
+						declarationId: declarationStatusHistory.declarationId,
+						eventType: declarationStatusHistory.eventType,
+					})
+					.from(declarationStatusHistory)
+					.innerJoin(
+						declarations,
+						eq(declarationStatusHistory.declarationId, declarations.id),
+					)
+					.where(
+						and(
+							eq(declarations.siren, input.siren),
+							isNull(declarations.cancelledAt),
+						),
+					),
+				getRepresentationWorkforceHistory(input.siren, year),
+			]);
 
 			const yearsWithJointEval = new Set(jointEvalRows.map((r) => r.year));
 			const yearsWithPrefill = new Set(prefillRows.map((r) => r.year));
@@ -257,7 +265,10 @@ export const companyRouter = createTRPCRouter({
 					.map((r) => r.declarationId),
 			);
 
-			const year = getCurrentYear();
+			const representationVisible = isPresumedSubjectToRepresentation(
+				representationWorkforceHistory,
+				year,
+			);
 			const mappedDeclarations = declarationRows.map((d) => ({
 				type: "remuneration" as const,
 				year: d.year,
@@ -282,6 +293,7 @@ export const companyRouter = createTRPCRouter({
 				mappedDeclarations,
 				year,
 				yearsWithPrefill,
+				representationVisible,
 			);
 
 			return { company, declarations: declarationItems };

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -27,6 +27,7 @@ import {
 	declarations,
 	files,
 	gipMdsData,
+	representationDeclarations,
 	userCompanies,
 } from "~/server/db/schema";
 import { syncCseRequirement } from "~/server/services/cseRequirementSync";
@@ -197,6 +198,7 @@ export const companyRouter = createTRPCRouter({
 				prefillRows,
 				eventRows,
 				representationWorkforceHistory,
+				currentYearRepresentationDeclarationRows,
 			] = await Promise.all([
 				ctx.db
 					.select({
@@ -250,6 +252,16 @@ export const companyRouter = createTRPCRouter({
 						),
 					),
 				getRepresentationWorkforceHistory(input.siren, year),
+				ctx.db
+					.select({ year: representationDeclarations.year })
+					.from(representationDeclarations)
+					.where(
+						and(
+							eq(representationDeclarations.siren, input.siren),
+							eq(representationDeclarations.year, year),
+						),
+					)
+					.limit(1),
 			]);
 
 			const yearsWithJointEval = new Set(jointEvalRows.map((r) => r.year));
@@ -265,10 +277,11 @@ export const companyRouter = createTRPCRouter({
 					.map((r) => r.declarationId),
 			);
 
-			const representationVisible = isPresumedSubjectToRepresentation(
-				representationWorkforceHistory,
-				year,
-			);
+			const hasCurrentYearRepresentationDeclaration =
+				currentYearRepresentationDeclarationRows.length > 0;
+			const representationVisible =
+				hasCurrentYearRepresentationDeclaration ||
+				isPresumedSubjectToRepresentation(representationWorkforceHistory, year);
 			const mappedDeclarations = declarationRows.map((d) => ({
 				type: "remuneration" as const,
 				year: d.year,

--- a/packages/app/src/server/db/__tests__/getRepresentationWorkforceHistory.test.ts
+++ b/packages/app/src/server/db/__tests__/getRepresentationWorkforceHistory.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { REPRESENTATION_SUBJECTION_WINDOW_YEARS } from "~/modules/domain";
+
+const limitMock = vi.fn();
+const orderByMock = vi.fn().mockReturnValue({ limit: limitMock });
+const dbMock = {
+	select: vi.fn().mockReturnValue({
+		from: vi.fn().mockReturnValue({
+			where: vi.fn().mockReturnValue({ orderBy: orderByMock }),
+		}),
+	}),
+};
+
+vi.mock("..", () => ({
+	db: dbMock,
+}));
+
+async function loadGetRepresentationWorkforceHistory() {
+	vi.resetModules();
+	const { getRepresentationWorkforceHistory } = await import(
+		"../getRepresentationWorkforceHistory"
+	);
+	return getRepresentationWorkforceHistory;
+}
+
+describe("getRepresentationWorkforceHistory", () => {
+	beforeEach(() => {
+		limitMock.mockReset();
+		orderByMock.mockClear();
+	});
+
+	it("returns an empty history when the company has no known workforce", async () => {
+		limitMock.mockResolvedValueOnce([]);
+		const getRepresentationWorkforceHistory =
+			await loadGetRepresentationWorkforceHistory();
+
+		expect(await getRepresentationWorkforceHistory("339787277", 2026)).toEqual(
+			[],
+		);
+	});
+
+	// `workforce_ema` is a numeric column: the driver hands it back as a string.
+	it("parses the numeric workforce column into numbers", async () => {
+		limitMock.mockResolvedValueOnce([
+			{ year: 2026, workforceEma: "1200.00" },
+			{ year: 2025, workforceEma: "1050.50" },
+		]);
+		const getRepresentationWorkforceHistory =
+			await loadGetRepresentationWorkforceHistory();
+
+		expect(await getRepresentationWorkforceHistory("339787277", 2026)).toEqual([
+			{ year: 2026, workforceEma: 1200 },
+			{ year: 2025, workforceEma: 1050.5 },
+		]);
+	});
+
+	it("drops years whose workforce value is unusable", async () => {
+		limitMock.mockResolvedValueOnce([
+			{ year: 2026, workforceEma: "1200.00" },
+			{ year: 2025, workforceEma: null },
+			{ year: 2024, workforceEma: "not-a-number" },
+		]);
+		const getRepresentationWorkforceHistory =
+			await loadGetRepresentationWorkforceHistory();
+
+		expect(await getRepresentationWorkforceHistory("339787277", 2026)).toEqual([
+			{ year: 2026, workforceEma: 1200 },
+		]);
+	});
+
+	it("reads at most the subjection window worth of years", async () => {
+		limitMock.mockResolvedValueOnce([]);
+		const getRepresentationWorkforceHistory =
+			await loadGetRepresentationWorkforceHistory();
+
+		await getRepresentationWorkforceHistory("339787277", 2026);
+
+		expect(limitMock).toHaveBeenCalledWith(
+			REPRESENTATION_SUBJECTION_WINDOW_YEARS,
+		);
+	});
+});

--- a/packages/app/src/server/db/getRepresentationWorkforceHistory.ts
+++ b/packages/app/src/server/db/getRepresentationWorkforceHistory.ts
@@ -1,0 +1,40 @@
+import { and, desc, eq, isNotNull, lte } from "drizzle-orm";
+import { cache } from "react";
+
+import type { WorkforceHistoryEntry } from "~/modules/domain";
+import {
+	parseGipWorkforce,
+	REPRESENTATION_SUBJECTION_WINDOW_YEARS,
+} from "~/modules/domain";
+
+import { db } from ".";
+import { gipMdsData } from "./schema";
+
+export const getRepresentationWorkforceHistory = cache(
+	async (
+		siren: string,
+		referenceYear: number,
+	): Promise<WorkforceHistoryEntry[]> => {
+		const rows = await db
+			.select({ year: gipMdsData.year, workforceEma: gipMdsData.workforceEma })
+			.from(gipMdsData)
+			.where(
+				and(
+					eq(gipMdsData.siren, siren),
+					lte(gipMdsData.year, referenceYear),
+					isNotNull(gipMdsData.workforceEma),
+				),
+			)
+			.orderBy(desc(gipMdsData.year))
+			.limit(REPRESENTATION_SUBJECTION_WINDOW_YEARS);
+
+		return rows
+			.map((row) => ({
+				year: row.year,
+				workforceEma: parseGipWorkforce(row.workforceEma),
+			}))
+			.filter(
+				(entry): entry is WorkforceHistoryEntry => entry.workforceEma !== null,
+			);
+	},
+);


### PR DESCRIPTION
Closes #3898

## Résumé

Ajoute une présomption de **visibilité** de la ligne « Représentation » dans Mon espace, basée sur l'historique d'effectifs GIP (`gip_mds_data.workforce_ema`) — fenêtre glissante des `min(3, disponibles)` années les plus récentes `<= année de référence`, seuil `>= 1 000` (art. L. 1142-11).

**Ce ticket implémente un filtre d'affichage, jamais un contrôle bloquant** : l'écran « L'entreprise est-elle concernée ? » reste l'unique source de vérité pour l'assujettissement déclaré. Une déclaration existante (brouillon ou transmise) reste toujours visible, quel que soit le pré-filtre.

## Changements

- `modules/domain/shared/representation.ts` — `isPresumedSubjectToRepresentation()` (fonction pure) + `REPRESENTATION_SUBJECTION_WORKFORCE_MIN` (1000) + `REPRESENTATION_SUBJECTION_WINDOW_YEARS` (3)
- `server/db/getRepresentationWorkforceHistory.ts` (nouveau) — query `gip_mds_data` (pattern `getCampaignDeadlines.ts`, wrap `cache()`)
- `modules/my-space/buildDeclarationList.ts` — nouveau paramètre `representationVisible` (défaut `true`) ; la ligne courante sans déclaration existante n'est émise que si `true`
- `server/api/routers/company.ts` — câblage dans `getWithDeclarations` (requête parallèle + calcul du booléen + passage à `buildDeclarationList`)

Aucune table, aucune migration : l'historique est déjà porté par `gip_mds_data`.

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (couverture 100% sur `representation.ts` et `buildDeclarationList.ts`)
- [x] `pnpm lint:check` / `pnpm format:check` verts
- [x] Scénarios S33–S39 + fenêtre glissante (4 années, la plus ancienne hors fenêtre) + déclaration existante toujours visible — couverts par les tests ajoutés
- [x] `validator` / `structural-auditor` / `security-auditor` PASS (pas de `.tsx` modifié → `rgaa-auditor` skip)

Pas de référence Figma pour ce ticket (filtre d'affichage uniquement, l'UI de la ligne/panneau est couverte par #4162).