### PR TITLE
Envoi à SUIT des données de la représentation équilibrée

### DIFF
--- a/.kontinuous/templates/apisix-suit.configmap.yaml
+++ b/.kontinuous/templates/apisix-suit.configmap.yaml
@@ -121,11 +121,19 @@ data:
             rejected_code: 429
           prometheus: {}
     # Routes:
-    #   - 3 SUIT API endpoints (Bearer-auth via `suit-api`)
+    #   - 4 SUIT API endpoints (Bearer-auth via `suit-api`)
     #   - 2 docs endpoints + 1 static asset prefix (public via `suit-docs`)
     routes:
       - id: suit-export-declarations
         uri: /api/v1/export/declarations
+        methods: [GET]
+        plugin_config_id: suit-api
+        upstream:
+          type: roundrobin
+          nodes:
+            "app:80": 1
+      - id: suit-export-representations
+        uri: /api/v1/export/representations
         methods: [GET]
         plugin_config_id: suit-api
         upstream:

--- a/packages/app/src/app/api/v1/export/representations/route.ts
+++ b/packages/app/src/app/api/v1/export/representations/route.ts
@@ -1,8 +1,8 @@
 import { AUDIT_ACTIONS } from "~/modules/audit";
 import {
 	assembleRepresentation,
-	exportDeclarationsQuerySchema,
 	fetchSubmittedRepresentations,
+	parseExportDateWindow,
 } from "~/modules/export";
 import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
 import { assertGatewaySource } from "~/server/services/gatewaySource";
@@ -50,27 +50,11 @@ async function apiExportRepresentationsHandler(
 	const gatewayError = assertGatewaySource(request);
 	if (gatewayError) return gatewayError;
 
+	const dateWindow = parseExportDateWindow(request);
+	if (dateWindow instanceof Response) return dateWindow;
+
 	try {
-		const url = new URL(request.url);
-		const parsed = exportDeclarationsQuerySchema.safeParse({
-			date_begin: url.searchParams.get("date_begin") ?? undefined,
-			date_end: url.searchParams.get("date_end") ?? undefined,
-		});
-
-		if (!parsed.success) {
-			return Response.json(
-				{
-					error:
-						"Paramètres invalides. 'date_begin' est requis, format YYYY-MM-DD.",
-					details: parsed.error.issues,
-				},
-				{ status: 400 },
-			);
-		}
-
-		const { date_begin } = parsed.data;
-		const dateEnd = parsed.data.date_end ?? getNextDate(date_begin);
-
+		const { date_begin, dateEnd } = dateWindow;
 		const rows = await fetchSubmittedRepresentations(date_begin, dateEnd);
 		const data = rows.map(assembleRepresentation);
 
@@ -96,10 +80,4 @@ async function apiExportRepresentationsHandler(
 			{ status: 500 },
 		);
 	}
-}
-
-function getNextDate(date: string): string {
-	const d = new Date(`${date}T00:00:00Z`);
-	d.setUTCDate(d.getUTCDate() + 1);
-	return d.toISOString().slice(0, 10);
 }

--- a/packages/app/src/app/api/v1/export/representations/route.ts
+++ b/packages/app/src/app/api/v1/export/representations/route.ts
@@ -1,0 +1,105 @@
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import {
+	assembleRepresentation,
+	exportDeclarationsQuerySchema,
+	fetchSubmittedRepresentations,
+} from "~/modules/export";
+import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
+import { assertGatewaySource } from "~/server/services/gatewaySource";
+
+/**
+ * GET /api/v1/export/representations?date_begin=YYYY-MM-DD&date_end=YYYY-MM-DD
+ *
+ * Secured REST API returning submitted balanced-representation declarations
+ * (art. D. 1142-19) as JSON, in the same envelope format as
+ * `/api/v1/export/declarations` — served on a dedicated route, the
+ * remuneration declarations endpoint is left untouched.
+ *
+ * Authentication is handled at the edge by the APISIX gateway
+ * (`key-auth` + `limit-req` plugins, see
+ * `.kontinuous/templates/apisix-suit.configmap.yaml`). The handler only
+ * enforces that the request actually transited through APISIX via the
+ * `X-Gateway-Forwarded` header (see `assertGatewaySource`).
+ *
+ * - date_begin (required): start date (inclusive), filters on submission date (submittedAt, UTC)
+ * - date_end (optional): end date (exclusive). If omitted, returns only date_begin day.
+ *
+ * SUIT is a controlling authority, so identity/location fields are returned
+ * in full even for non-diffusible companies (S30) — the public-facing
+ * non-diffusion rule only applies to public channels.
+ */
+export const GET = withAuditedRoute(
+	{
+		action: AUDIT_ACTIONS.EXPORT_API_REPRESENTATIONS,
+		resolveContext: (request) => {
+			const url = new URL(request.url);
+			return {
+				metadata: {
+					date_begin: url.searchParams.get("date_begin") ?? null,
+					date_end: url.searchParams.get("date_end") ?? null,
+				},
+			};
+		},
+	},
+	apiExportRepresentationsHandler,
+);
+
+async function apiExportRepresentationsHandler(
+	request: Request,
+): Promise<Response> {
+	const gatewayError = assertGatewaySource(request);
+	if (gatewayError) return gatewayError;
+
+	try {
+		const url = new URL(request.url);
+		const parsed = exportDeclarationsQuerySchema.safeParse({
+			date_begin: url.searchParams.get("date_begin") ?? undefined,
+			date_end: url.searchParams.get("date_end") ?? undefined,
+		});
+
+		if (!parsed.success) {
+			return Response.json(
+				{
+					error:
+						"Paramètres invalides. 'date_begin' est requis, format YYYY-MM-DD.",
+					details: parsed.error.issues,
+				},
+				{ status: 400 },
+			);
+		}
+
+		const { date_begin } = parsed.data;
+		const dateEnd = parsed.data.date_end ?? getNextDate(date_begin);
+
+		const rows = await fetchSubmittedRepresentations(date_begin, dateEnd);
+		const data = rows.map(assembleRepresentation);
+
+		return Response.json({
+			Date_debut: date_begin,
+			Date_fin: dateEnd,
+			Nombre: data.length,
+			Representations: data,
+		});
+	} catch (error) {
+		// Only log the message: AWS SDK / pg errors sometimes attach the request
+		// payload (presigned URLs, DB credentials) in `.cause`, which would leak
+		// to the log shipper if we printed the raw object.
+		console.error(
+			"[api/v1/export/representations]",
+			error instanceof Error ? error.message : "unknown error",
+		);
+		return Response.json(
+			{
+				error:
+					"Erreur lors de la récupération des données de représentation équilibrée",
+			},
+			{ status: 500 },
+		);
+	}
+}
+
+function getNextDate(date: string): string {
+	const d = new Date(`${date}T00:00:00Z`);
+	d.setUTCDate(d.getUTCDate() + 1);
+	return d.toISOString().slice(0, 10);
+}

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -99,6 +99,7 @@ export const AUDIT_ACTIONS = {
 	EXPORT_GENERATE: "export.generate",
 	EXPORT_API_DECLARATIONS: "export.api_declarations",
 	EXPORT_API_FILES: "export.api_files",
+	EXPORT_API_REPRESENTATIONS: "export.api_representations",
 
 	// ── Mail ───────────────────────────────────────────────
 	MAIL_RECEIPT_SEND: "mail.receipt_send",
@@ -204,6 +205,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.EXPORT_GENERATE]: "export",
 	[AUDIT_ACTIONS.EXPORT_API_DECLARATIONS]: "export",
 	[AUDIT_ACTIONS.EXPORT_API_FILES]: "export",
+	[AUDIT_ACTIONS.EXPORT_API_REPRESENTATIONS]: "export",
 
 	[AUDIT_ACTIONS.MAIL_RECEIPT_SEND]: "mutation",
 	[AUDIT_ACTIONS.MAIL_RECEIPT_RESEND]: "mutation",

--- a/packages/app/src/modules/export/__tests__/fetchRepresentations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchRepresentations.test.ts
@@ -1,0 +1,312 @@
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeRepresentationRow as makeRow } from "./helpers/representationRowFixture";
+
+const mockWhere = vi.fn();
+const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
+const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
+const mockSelect = vi.fn<(fields: Record<string, unknown>) => unknown>(() => ({
+	from: mockFrom,
+}));
+
+vi.mock("~/server/db", () => ({
+	db: { select: (fields: Record<string, unknown>) => mockSelect(fields) },
+}));
+
+const SUIT_REPRESENTATION_KEYS = [
+	"id",
+	"SIREN",
+	"Raison_sociale",
+	"Adresse",
+	"Code_NAF",
+	"Région",
+	"Département",
+	"Année_référence",
+	"Période_référence_début",
+	"Période_référence_fin",
+	"Pourcentage_femmes_cadres",
+	"Pourcentage_hommes_cadres",
+	"Motif_non_calculabilité_cadres",
+	"Pourcentage_femmes_membres",
+	"Pourcentage_hommes_membres",
+	"Motif_non_calculabilité_membres",
+	"Date_publication",
+	"URL_publication",
+	"Modalités_communication",
+	"Date_déclaration",
+];
+
+function compile(condition: SQL | undefined): {
+	sql: string;
+	params: unknown[];
+} {
+	if (!condition) {
+		throw new Error("no condition to compile");
+	}
+	const dialect = new PgDialect({ casing: "snake_case" });
+	const built = dialect.sqlToQuery(condition);
+	return { sql: built.sql, params: built.params };
+}
+
+function toIsoString(param: unknown): unknown {
+	return param instanceof Date ? param.toISOString() : param;
+}
+
+describe("assembleRepresentation", () => {
+	it("should map a row to the SUIT payload with the agreed French keys, in order", async () => {
+		const { assembleRepresentation } = await import("../fetchRepresentations");
+
+		const payload = assembleRepresentation(makeRow());
+
+		expect(Object.keys(payload)).toEqual(SUIT_REPRESENTATION_KEYS);
+		expect(payload).toEqual({
+			id: "repr-1",
+			SIREN: "123456789",
+			Raison_sociale: "Entreprise Test",
+			Adresse: "1 rue de la Paix, 75002 Paris",
+			Code_NAF: "62.02A",
+			Région: "Île-de-France",
+			Département: "Paris",
+			Année_référence: 2027,
+			Période_référence_début: "2027-01-01",
+			Période_référence_fin: "2027-12-31",
+			Pourcentage_femmes_cadres: 40,
+			Pourcentage_hommes_cadres: 60,
+			Motif_non_calculabilité_cadres: null,
+			Pourcentage_femmes_membres: 45.5,
+			Pourcentage_hommes_membres: 54.5,
+			Motif_non_calculabilité_membres: null,
+			Date_publication: "2028-03-01",
+			URL_publication: "https://example.fr/representation",
+			Modalités_communication: "Site internet",
+			Date_déclaration: "2027-03-15T10:00:00.000Z",
+		});
+	});
+
+	it("should convert the numeric percentage strings to numbers", async () => {
+		const { assembleRepresentation } = await import("../fetchRepresentations");
+
+		const payload = assembleRepresentation(
+			makeRow({
+				executiveWomenPercent: "33.33",
+				executiveMenPercent: "66.67",
+				memberWomenPercent: "0.00",
+				memberMenPercent: "100.00",
+			}),
+		);
+
+		expect(payload.Pourcentage_femmes_cadres).toBe(33.33);
+		expect(payload.Pourcentage_hommes_cadres).toBe(66.67);
+		expect(payload.Pourcentage_femmes_membres).toBe(0);
+		expect(payload.Pourcentage_hommes_membres).toBe(100);
+	});
+
+	it("should return null percentages when the declaration is not computable", async () => {
+		const { assembleRepresentation } = await import("../fetchRepresentations");
+
+		const payload = assembleRepresentation(
+			makeRow({
+				executiveWomenPercent: null,
+				executiveMenPercent: null,
+				notComputableReasonExecutives: "aucun_cadre_dirigeant",
+				memberWomenPercent: null,
+				memberMenPercent: null,
+				notComputableReasonMembers: "aucune_instance_dirigeante",
+			}),
+		);
+
+		expect(payload.Pourcentage_femmes_cadres).toBeNull();
+		expect(payload.Pourcentage_hommes_cadres).toBeNull();
+		expect(payload.Motif_non_calculabilité_cadres).toBe(
+			"aucun_cadre_dirigeant",
+		);
+		expect(payload.Pourcentage_femmes_membres).toBeNull();
+		expect(payload.Pourcentage_hommes_membres).toBeNull();
+		expect(payload.Motif_non_calculabilité_membres).toBe(
+			"aucune_instance_dirigeante",
+		);
+	});
+
+	it("should serialise the submission date as an ISO string and null when absent", async () => {
+		const { assembleRepresentation } = await import("../fetchRepresentations");
+
+		expect(
+			assembleRepresentation(
+				makeRow({ submittedAt: new Date("2027-12-31T23:59:59Z") }),
+			).Date_déclaration,
+		).toBe("2027-12-31T23:59:59.000Z");
+		expect(
+			assembleRepresentation(makeRow({ submittedAt: null })).Date_déclaration,
+		).toBeNull();
+	});
+
+	it("should keep the optional publication and reference-period fields nullable", async () => {
+		const { assembleRepresentation } = await import("../fetchRepresentations");
+
+		const payload = assembleRepresentation(
+			makeRow({
+				referencePeriodStart: null,
+				referencePeriodEnd: null,
+				publishDate: null,
+				publishUrl: null,
+				publishModalities: null,
+			}),
+		);
+
+		expect(payload.Période_référence_début).toBeNull();
+		expect(payload.Période_référence_fin).toBeNull();
+		expect(payload.Date_publication).toBeNull();
+		expect(payload.URL_publication).toBeNull();
+		expect(payload.Modalités_communication).toBeNull();
+	});
+
+	it("should keep identity and location complete for a non-diffusible company (S30)", async () => {
+		const { assembleRepresentation } = await import("../fetchRepresentations");
+
+		const payload = assembleRepresentation(
+			makeRow({
+				siren: "123456789",
+				companyName: "Entreprise Non Diffusible",
+				address: "2 rue Secrète, 69001 Lyon",
+				nafCode: "70.10Z",
+				region: "Auvergne-Rhône-Alpes",
+				departmentLabel: "Rhône",
+			}),
+		);
+
+		expect(payload.Raison_sociale).toBe("Entreprise Non Diffusible");
+		expect(payload.Adresse).toBe("2 rue Secrète, 69001 Lyon");
+		expect(payload.Code_NAF).toBe("70.10Z");
+		expect(payload.Région).toBe("Auvergne-Rhône-Alpes");
+		expect(payload.Département).toBe("Rhône");
+	});
+
+	it("should pass through the nullable company columns without inventing a placeholder", async () => {
+		const { assembleRepresentation } = await import("../fetchRepresentations");
+
+		const payload = assembleRepresentation(
+			makeRow({
+				address: null,
+				nafCode: null,
+				region: null,
+				departmentLabel: null,
+			}),
+		);
+
+		expect(payload.Raison_sociale).toBe("Entreprise Test");
+		expect(payload.Adresse).toBeNull();
+		expect(payload.Code_NAF).toBeNull();
+		expect(payload.Région).toBeNull();
+		expect(payload.Département).toBeNull();
+	});
+});
+
+describe("fetchSubmittedRepresentations", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockResolvedValue([]);
+	});
+
+	it("should return the rows produced by the driver", async () => {
+		const rows = [makeRow()];
+		mockWhere.mockResolvedValue(rows);
+
+		const { fetchSubmittedRepresentations } = await import(
+			"../fetchRepresentations"
+		);
+		await expect(
+			fetchSubmittedRepresentations("2027-03-15", "2027-03-16"),
+		).resolves.toEqual(rows);
+	});
+
+	it("should inner-join companies on the declaration siren", async () => {
+		const { fetchSubmittedRepresentations } = await import(
+			"../fetchRepresentations"
+		);
+		await fetchSubmittedRepresentations("2027-03-15", "2027-03-16");
+
+		expect(mockInnerJoin).toHaveBeenCalledTimes(1);
+		const joinCall = mockInnerJoin.mock.calls[0] as unknown as
+			| [unknown, SQL]
+			| undefined;
+		const { sql } = compile(joinCall?.[1]);
+
+		expect(sql).toContain(
+			'"app_representation_declaration"."siren" = "app_company"."siren"',
+		);
+	});
+
+	it("should select the identity and location columns SUIT needs", async () => {
+		const { fetchSubmittedRepresentations } = await import(
+			"../fetchRepresentations"
+		);
+		await fetchSubmittedRepresentations("2027-03-15", "2027-03-16");
+
+		const fields = mockSelect.mock.calls[0]?.[0];
+		expect(fields).toBeDefined();
+		for (const column of [
+			"companyName",
+			"address",
+			"nafCode",
+			"region",
+			"departmentLabel",
+		]) {
+			expect(fields).toHaveProperty(column);
+		}
+	});
+
+	it("should not select statutDiffusion, which SUIT must never be filtered on (S30)", async () => {
+		const { fetchSubmittedRepresentations } = await import(
+			"../fetchRepresentations"
+		);
+		await fetchSubmittedRepresentations("2027-03-15", "2027-03-16");
+
+		expect(mockSelect.mock.calls[0]?.[0]).not.toHaveProperty("statutDiffusion");
+	});
+
+	it("should keep only submitted declarations", async () => {
+		const { fetchSubmittedRepresentations } = await import(
+			"../fetchRepresentations"
+		);
+		await fetchSubmittedRepresentations("2027-03-15", "2027-03-16");
+
+		const { sql, params } = compile(mockWhere.mock.calls[0]?.[0] as SQL);
+
+		expect(sql).toContain('"status" =');
+		expect(params).toContain("submitted");
+	});
+
+	it("should bound submittedAt on an inclusive begin and an exclusive end, in UTC", async () => {
+		const { fetchSubmittedRepresentations } = await import(
+			"../fetchRepresentations"
+		);
+		await fetchSubmittedRepresentations("2027-03-15", "2027-03-20");
+
+		const { sql, params } = compile(mockWhere.mock.calls[0]?.[0] as SQL);
+
+		expect(sql).toContain('"submitted_at" >=');
+		expect(sql).toContain('"submitted_at" <');
+		// Bound as timestamp params mapped by the column, never inlined as text.
+		expect(params.map(toIsoString)).toEqual([
+			"submitted",
+			"2027-03-15T00:00:00.000Z",
+			"2027-03-20T00:00:00.000Z",
+		]);
+	});
+
+	it("should shift both bounds when the window moves", async () => {
+		const { fetchSubmittedRepresentations } = await import(
+			"../fetchRepresentations"
+		);
+		await fetchSubmittedRepresentations("2026-12-31", "2027-01-01");
+
+		const { params } = compile(mockWhere.mock.calls[0]?.[0] as SQL);
+
+		expect(params.map(toIsoString).slice(1)).toEqual([
+			"2026-12-31T00:00:00.000Z",
+			"2027-01-01T00:00:00.000Z",
+		]);
+	});
+});

--- a/packages/app/src/modules/export/__tests__/helpers/representationRowFixture.ts
+++ b/packages/app/src/modules/export/__tests__/helpers/representationRowFixture.ts
@@ -1,0 +1,29 @@
+import type { RepresentationRow } from "~/modules/export";
+
+export function makeRepresentationRow(
+	overrides: Partial<RepresentationRow> = {},
+): RepresentationRow {
+	return {
+		id: "repr-1",
+		siren: "123456789",
+		year: 2027,
+		referencePeriodStart: "2027-01-01",
+		referencePeriodEnd: "2027-12-31",
+		executiveWomenPercent: "40.00",
+		executiveMenPercent: "60.00",
+		notComputableReasonExecutives: null,
+		memberWomenPercent: "45.50",
+		memberMenPercent: "54.50",
+		notComputableReasonMembers: null,
+		publishDate: "2028-03-01",
+		publishUrl: "https://example.fr/representation",
+		publishModalities: "Site internet",
+		submittedAt: new Date("2027-03-15T10:00:00Z"),
+		companyName: "Entreprise Test",
+		address: "1 rue de la Paix, 75002 Paris",
+		nafCode: "62.02A",
+		region: "Île-de-France",
+		departmentLabel: "Paris",
+		...overrides,
+	};
+}

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
+import {
+	representationNotComputableExecutivesEnum,
+	representationNotComputableMembersEnum,
+} from "~/server/db/schema";
 import { openApiSpec } from "../openapi";
 
 describe("openApiSpec", () => {
@@ -61,6 +65,89 @@ describe("openApiSpec", () => {
 		expect(details.type).toBe("array");
 		expect(details.items).toBeDefined();
 		expect(details.items.type).toBe("object");
+	});
+
+	describe("representations endpoint", () => {
+		const path = openApiSpec.paths["/api/v1/export/representations"];
+
+		it("should define the representations endpoint", () => {
+			expect(path).toBeDefined();
+			expect(path.get).toBeDefined();
+			expect(path.get.operationId).toBe("getRepresentations");
+		});
+
+		it("should require date_begin and make date_end optional", () => {
+			const params = path.get.parameters;
+			expect(params.find((p) => p.name === "date_begin")?.required).toBe(true);
+			expect(params.find((p) => p.name === "date_end")?.required).toBe(false);
+		});
+
+		it("should define the same response codes as the declarations endpoint", () => {
+			expect(Object.keys(path.get.responses).sort()).toEqual(
+				Object.keys(
+					openApiSpec.paths["/api/v1/export/declarations"].get.responses,
+				).sort(),
+			);
+		});
+
+		it("should document the envelope with a Representations array", () => {
+			const schema =
+				path.get.responses["200"].content["application/json"].schema;
+			expect(Object.keys(schema.properties)).toEqual([
+				"Date_debut",
+				"Date_fin",
+				"Nombre",
+				"Representations",
+			]);
+			expect(schema.properties.Representations.type).toBe("array");
+		});
+
+		it("should document every field the handler emits", () => {
+			const representationSchema =
+				path.get.responses["200"].content["application/json"].schema.properties
+					.Representations.items;
+			expect(Object.keys(representationSchema.properties)).toEqual([
+				"id",
+				"SIREN",
+				"Raison_sociale",
+				"Adresse",
+				"Code_NAF",
+				"Région",
+				"Département",
+				"Année_référence",
+				"Période_référence_début",
+				"Période_référence_fin",
+				"Pourcentage_femmes_cadres",
+				"Pourcentage_hommes_cadres",
+				"Motif_non_calculabilité_cadres",
+				"Pourcentage_femmes_membres",
+				"Pourcentage_hommes_membres",
+				"Motif_non_calculabilité_membres",
+				"Date_publication",
+				"URL_publication",
+				"Modalités_communication",
+				"Date_déclaration",
+			]);
+		});
+
+		it("should mirror the DB enums on the non-computable reasons", () => {
+			const properties =
+				path.get.responses["200"].content["application/json"].schema.properties
+					.Representations.items.properties;
+			const executivesEnum =
+				properties.Motif_non_calculabilité_cadres.oneOf.find(
+					(v) => v.type === "string",
+				);
+			const membersEnum = properties.Motif_non_calculabilité_membres.oneOf.find(
+				(v) => v.type === "string",
+			);
+			expect(
+				executivesEnum && "enum" in executivesEnum && executivesEnum.enum,
+			).toEqual([...representationNotComputableExecutivesEnum.enumValues]);
+			expect(membersEnum && "enum" in membersEnum && membersEnum.enum).toEqual([
+				...representationNotComputableMembersEnum.enumValues,
+			]);
+		});
 	});
 
 	describe("Statut field (declaration FSM status)", () => {

--- a/packages/app/src/modules/export/__tests__/representationsApi.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/representationsApi.integration.test.ts
@@ -1,0 +1,308 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+
+// The date window, the `submitted` filter and the company join are SQL-enforced:
+// a mocked driver cannot prove them (see rules/audit-logging.md).
+describe("GET /api/v1/export/representations — integration (#4127)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN_WINDOW_START = "900000001";
+	const SIREN_NON_DIFFUSIBLE = "900000002";
+	const SIREN_WINDOW_END = "900000003";
+	const SIREN_DRAFT = "900000004";
+	const SIREN_BEFORE_WINDOW = "900000005";
+	const ALL_SIRENS = [
+		SIREN_WINDOW_START,
+		SIREN_NON_DIFFUSIBLE,
+		SIREN_WINDOW_END,
+		SIREN_DRAFT,
+		SIREN_BEFORE_WINDOW,
+	];
+	const YEAR = 2029;
+	const DECL_IDS = [
+		"suit-repr-window-start",
+		"suit-repr-non-diffusible",
+		"suit-repr-window-end",
+		"suit-repr-draft",
+		"suit-repr-before-window",
+	];
+
+	const DATE_BEGIN = "2030-03-15";
+	const DATE_END = "2030-03-20";
+
+	async function cleanup() {
+		await sql`DELETE FROM app_representation_declaration WHERE id IN ${sql(DECL_IDS)}`;
+		await sql`DELETE FROM app_company WHERE siren IN ${sql(ALL_SIRENS)}`;
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+
+		await sql`
+			INSERT INTO app_company (siren, name, address, naf_code, naf_label, region, department_code, department_label, statut_diffusion)
+			VALUES
+				(${SIREN_WINDOW_START},   'Entreprise Borne Debut',    '1 rue de la Paix, 75002 Paris', '62.02A', 'Conseil en systemes informatiques', 'Île-de-France',        '75', 'Paris',            'O'),
+				(${SIREN_NON_DIFFUSIBLE}, 'Entreprise Non Diffusible', '2 rue Secrete, 69001 Lyon',     '70.10Z', 'Activites des sieges sociaux',      'Auvergne-Rhône-Alpes', '69', 'Rhône',            'N'),
+				(${SIREN_WINDOW_END},     'Entreprise Borne Fin',      '3 rue Brouillon, 44000 Nantes', '46.90Z', 'Commerce de gros non specialise',   'Pays de la Loire',     '44', 'Loire-Atlantique', 'O'),
+				(${SIREN_DRAFT},          'Entreprise Brouillon',      '4 rue Brouillon, 33000 Bordeaux','43.99C','Travaux de maconnerie generale',    'Nouvelle-Aquitaine',   '33', 'Gironde',          'O'),
+				(${SIREN_BEFORE_WINDOW},  'Entreprise Hors Fenetre',   '5 rue Ancienne, 59000 Lille',   '10.71C', 'Boulangerie et boulangerie-patisserie', 'Hauts-de-France',  '59', 'Nord',             'O')
+		`;
+		await sql`
+			INSERT INTO app_representation_declaration
+				(id, siren, year, reference_period_start, reference_period_end,
+				 executive_women_percent, executive_men_percent, not_computable_reason_executives,
+				 member_women_percent, member_men_percent, not_computable_reason_members,
+				 publish_date, publish_url, publish_modalities, status, submitted_at)
+			VALUES
+				('suit-repr-window-start',   ${SIREN_WINDOW_START},   ${YEAR}, '2029-01-01', '2029-12-31', 40.00, 60.00, NULL, 45.50, 54.50, NULL, '2030-03-01', 'https://example.fr/borne-debut', 'Site internet', 'submitted', '2030-03-15T00:00:00Z'),
+				('suit-repr-non-diffusible', ${SIREN_NON_DIFFUSIBLE}, ${YEAR}, '2029-01-01', '2029-12-31', 30.00, 70.00, NULL, 25.00, 75.00, NULL, '2030-03-02', 'https://example.fr/non-diffusible', 'Affichage', 'submitted', '2030-03-17T09:30:00Z'),
+				('suit-repr-window-end',     ${SIREN_WINDOW_END},     ${YEAR}, NULL,         NULL,         NULL,  NULL,  'aucun_cadre_dirigeant', NULL, NULL, 'aucune_instance_dirigeante', NULL, NULL, NULL, 'submitted', '2030-03-20T00:00:00Z'),
+				('suit-repr-draft',          ${SIREN_DRAFT},          ${YEAR}, NULL,         NULL,         50.00, 50.00, NULL, 50.00, 50.00, NULL, NULL, NULL, NULL, 'draft',     '2030-03-17T09:30:00Z'),
+				('suit-repr-before-window',  ${SIREN_BEFORE_WINDOW},  ${YEAR}, NULL,         NULL,         10.00, 90.00, NULL, 20.00, 80.00, NULL, NULL, NULL, NULL, 'submitted', '2030-03-14T23:59:59Z')
+		`;
+	});
+
+	function gatewayRequest(params: Record<string, string>): Request {
+		return new Request(
+			`http://localhost/api/v1/export/representations?${new URLSearchParams(params)}`,
+			{ headers: { "x-gateway-forwarded": "test-value" } },
+		);
+	}
+
+	async function fetchWindow(params: Record<string, string>) {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(gatewayRequest(params));
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		return body as {
+			Date_debut: string;
+			Date_fin: string;
+			Nombre: number;
+			Representations: Array<Record<string, unknown>>;
+		};
+	}
+
+	function seededOnly(representations: Array<Record<string, unknown>>) {
+		return representations.filter((r) =>
+			ALL_SIRENS.includes(r.SIREN as string),
+		);
+	}
+
+	function bySiren(
+		representations: Array<Record<string, unknown>>,
+		siren: string,
+	) {
+		return representations.find((r) => r.SIREN === siren);
+	}
+
+	it("includes a declaration submitted exactly on date_begin and excludes one submitted exactly on date_end (S29)", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: DATE_END,
+		});
+
+		const sirens = seededOnly(body.Representations).map((r) => r.SIREN);
+		expect(sirens).toContain(SIREN_WINDOW_START);
+		expect(sirens).not.toContain(SIREN_WINDOW_END);
+	});
+
+	it("includes the declaration submitted on date_end once the window is widened", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: "2030-03-21",
+		});
+
+		expect(seededOnly(body.Representations).map((r) => r.SIREN)).toContain(
+			SIREN_WINDOW_END,
+		);
+	});
+
+	it("excludes a declaration submitted the second before date_begin (S29)", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: DATE_END,
+		});
+
+		expect(seededOnly(body.Representations).map((r) => r.SIREN)).not.toContain(
+			SIREN_BEFORE_WINDOW,
+		);
+	});
+
+	it("returns only the date_begin day when date_end is omitted (S29)", async () => {
+		const body = await fetchWindow({ date_begin: DATE_BEGIN });
+
+		expect(body.Date_debut).toBe(DATE_BEGIN);
+		expect(body.Date_fin).toBe("2030-03-16");
+		expect(seededOnly(body.Representations).map((r) => r.SIREN)).toEqual([
+			SIREN_WINDOW_START,
+		]);
+	});
+
+	it("excludes a draft declaration even when its submission date falls inside the window", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: DATE_END,
+		});
+
+		expect(seededOnly(body.Representations).map((r) => r.SIREN)).not.toContain(
+			SIREN_DRAFT,
+		);
+	});
+
+	it("includes a declaration that becomes submitted after having been a draft", async () => {
+		await sql`UPDATE app_representation_declaration SET status = 'submitted' WHERE id = 'suit-repr-draft'`;
+
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: DATE_END,
+		});
+
+		expect(seededOnly(body.Representations).map((r) => r.SIREN)).toContain(
+			SIREN_DRAFT,
+		);
+	});
+
+	it("returns the envelope with a Nombre matching the Representations length (S29)", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: DATE_END,
+		});
+
+		expect(Object.keys(body)).toEqual([
+			"Date_debut",
+			"Date_fin",
+			"Nombre",
+			"Representations",
+		]);
+		expect(body.Date_debut).toBe(DATE_BEGIN);
+		expect(body.Date_fin).toBe(DATE_END);
+		expect(body.Nombre).toBe(body.Representations.length);
+	});
+
+	it("joins the company identity and location onto the declaration", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: DATE_END,
+		});
+
+		expect(bySiren(body.Representations, SIREN_WINDOW_START)).toMatchObject({
+			id: "suit-repr-window-start",
+			SIREN: SIREN_WINDOW_START,
+			Raison_sociale: "Entreprise Borne Debut",
+			Adresse: "1 rue de la Paix, 75002 Paris",
+			Code_NAF: "62.02A",
+			Région: "Île-de-France",
+			Département: "Paris",
+			Année_référence: YEAR,
+			Période_référence_début: "2029-01-01",
+			Période_référence_fin: "2029-12-31",
+			Pourcentage_femmes_cadres: 40,
+			Pourcentage_hommes_cadres: 60,
+			Pourcentage_femmes_membres: 45.5,
+			Pourcentage_hommes_membres: 54.5,
+			Date_publication: "2030-03-01",
+			URL_publication: "https://example.fr/borne-debut",
+			Modalités_communication: "Site internet",
+			Date_déclaration: "2030-03-15T00:00:00.000Z",
+		});
+	});
+
+	it("returns full identity and location for a non-diffusible company (S30)", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: DATE_END,
+		});
+
+		expect(bySiren(body.Representations, SIREN_NON_DIFFUSIBLE)).toMatchObject({
+			SIREN: SIREN_NON_DIFFUSIBLE,
+			Raison_sociale: "Entreprise Non Diffusible",
+			Adresse: "2 rue Secrete, 69001 Lyon",
+			Code_NAF: "70.10Z",
+			Région: "Auvergne-Rhône-Alpes",
+			Département: "Rhône",
+		});
+	});
+
+	it("returns the non-computable reasons verbatim from the DB enums", async () => {
+		const body = await fetchWindow({
+			date_begin: DATE_BEGIN,
+			date_end: "2030-03-21",
+		});
+
+		expect(bySiren(body.Representations, SIREN_WINDOW_END)).toMatchObject({
+			Pourcentage_femmes_cadres: null,
+			Pourcentage_hommes_cadres: null,
+			Motif_non_calculabilité_cadres: "aucun_cadre_dirigeant",
+			Pourcentage_femmes_membres: null,
+			Pourcentage_hommes_membres: null,
+			Motif_non_calculabilité_membres: "aucune_instance_dirigeante",
+		});
+	});
+
+	it("returns the raw rows unfiltered by diffusibility from the DB layer (S30)", async () => {
+		const { fetchSubmittedRepresentations } = await import(
+			"~/modules/export/fetchRepresentations"
+		);
+
+		const rows = await fetchSubmittedRepresentations(DATE_BEGIN, DATE_END);
+		const row = rows.find((r) => r.siren === SIREN_NON_DIFFUSIBLE);
+
+		expect(row).toMatchObject({
+			companyName: "Entreprise Non Diffusible",
+			address: "2 rue Secrete, 69001 Lyon",
+			nafCode: "70.10Z",
+			region: "Auvergne-Rhône-Alpes",
+			departmentLabel: "Rhône",
+		});
+		expect(row).not.toHaveProperty("statutDiffusion");
+	});
+
+	it("traces the call in the audit log under the export category (S29)", async () => {
+		await sql`DELETE FROM audit.action_log WHERE action = 'export.api_representations'`;
+
+		await fetchWindow({ date_begin: DATE_BEGIN, date_end: DATE_END });
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		const logs = await sql`
+			SELECT action, category, status, metadata FROM audit.action_log
+			WHERE action = 'export.api_representations'
+		`;
+		expect(logs).toHaveLength(1);
+		expect(logs[0]).toMatchObject({
+			action: "export.api_representations",
+			category: "export",
+			status: "success",
+			metadata: { date_begin: DATE_BEGIN, date_end: DATE_END },
+		});
+	});
+
+	it("traces a rejected call as a failure without touching the database", async () => {
+		await sql`DELETE FROM audit.action_log WHERE action = 'export.api_representations'`;
+
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			new Request("http://localhost/api/v1/export/representations"),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 200));
+
+		expect(response.status).toBe(403);
+		const logs = await sql`
+			SELECT status FROM audit.action_log
+			WHERE action = 'export.api_representations'
+		`;
+		expect(logs).toHaveLength(1);
+		expect(logs[0]).toMatchObject({ status: "failure" });
+	});
+});

--- a/packages/app/src/modules/export/__tests__/representationsApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/representationsApi.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeRepresentationRow as makeRow } from "./helpers/representationRowFixture";
+
+const mockFetchRepresentations = vi.fn().mockResolvedValue([]);
+
+vi.mock("~/server/db", () => ({ db: {} }));
+
+vi.mock("~/modules/export/fetchRepresentations", async (importOriginal) => ({
+	...(await importOriginal<
+		typeof import("~/modules/export/fetchRepresentations")
+	>()),
+	fetchSubmittedRepresentations: (...args: unknown[]) =>
+		mockFetchRepresentations(...args),
+}));
+
+/**
+ * APISIX-forwarded requests carry `X-Gateway-Forwarded` (injected by the
+ * gateway's `proxy-rewrite` plugin). Bearer + rate-limit are enforced by
+ * APISIX upstream, so tests only need to simulate the header presence that
+ * the middleware has already validated — same pattern as `exportApi.test.ts`.
+ */
+function gatewayForwardedRequest(url: string): Request {
+	return new Request(url, {
+		headers: { "x-gateway-forwarded": "test-gateway-secret" },
+	});
+}
+
+describe("GET /api/v1/export/representations", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockFetchRepresentations.mockResolvedValue([]);
+	});
+
+	it("should return 403 when X-Gateway-Forwarded header is missing", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			new Request("http://localhost/api/v1/export/representations"),
+		);
+
+		expect(response.status).toBe(403);
+		expect(mockFetchRepresentations).not.toHaveBeenCalled();
+	});
+
+	it("should return 403 when the gateway header is present but empty", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			new Request(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15",
+				{ headers: { "x-gateway-forwarded": "" } },
+			),
+		);
+
+		expect(response.status).toBe(403);
+	});
+
+	it("should return 400 when date_begin param is missing", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest("http://localhost/api/v1/export/representations"),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.error).toContain("date_begin");
+		expect(body.details).toBeDefined();
+	});
+
+	it("should return 400 when date_begin format is invalid", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-3-5",
+			),
+		);
+
+		expect(response.status).toBe(400);
+	});
+
+	it("should return 400 when date_end format is invalid", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15&date_end=bad",
+			),
+		);
+
+		expect(response.status).toBe(400);
+		const body = await response.json();
+		expect(body.details).toBeDefined();
+	});
+
+	it("should return the same error shape as the declarations endpoint on a missing date_begin", async () => {
+		const [{ GET }, declarations] = await Promise.all([
+			import("~/app/api/v1/export/representations/route"),
+			import("~/app/api/v1/export/declarations/route"),
+		]);
+
+		const [representationsBody, declarationsBody] = await Promise.all([
+			GET(
+				gatewayForwardedRequest(
+					"http://localhost/api/v1/export/representations",
+				),
+			).then((r) => r.json()),
+			declarations
+				.GET(
+					gatewayForwardedRequest(
+						"http://localhost/api/v1/export/declarations",
+					),
+				)
+				.then((r) => r.json()),
+		]);
+
+		expect(Object.keys(representationsBody)).toEqual(
+			Object.keys(declarationsBody),
+		);
+		expect(representationsBody.error).toBe(declarationsBody.error);
+	});
+
+	it("should return an empty envelope when no declaration matches", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15",
+			),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(Object.keys(body)).toEqual([
+			"Date_debut",
+			"Date_fin",
+			"Nombre",
+			"Representations",
+		]);
+		expect(body.Nombre).toBe(0);
+		expect(body.Representations).toEqual([]);
+		expect(body.Date_debut).toBe("2027-03-15");
+		expect(body.Date_fin).toBe("2027-03-16");
+	});
+
+	it("should default date_end to the day after date_begin (S29)", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15",
+			),
+		);
+
+		expect(mockFetchRepresentations).toHaveBeenCalledWith(
+			"2027-03-15",
+			"2027-03-16",
+		);
+	});
+
+	it("should roll the default date_end over a month boundary", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-02-28",
+			),
+		);
+
+		expect((await response.json()).Date_fin).toBe("2027-03-01");
+		expect(mockFetchRepresentations).toHaveBeenCalledWith(
+			"2027-02-28",
+			"2027-03-01",
+		);
+	});
+
+	it("should use date_end when provided (S29)", async () => {
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15&date_end=2027-03-20",
+			),
+		);
+
+		expect(response.status).toBe(200);
+		expect((await response.json()).Date_fin).toBe("2027-03-20");
+		expect(mockFetchRepresentations).toHaveBeenCalledWith(
+			"2027-03-15",
+			"2027-03-20",
+		);
+	});
+
+	it("should return the assembled representations and their count (S29)", async () => {
+		mockFetchRepresentations.mockResolvedValue([
+			makeRow(),
+			makeRow({ id: "repr-2", siren: "987654321" }),
+		]);
+
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15",
+			),
+		);
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.Nombre).toBe(2);
+		expect(body.Representations).toHaveLength(2);
+		expect(body.Representations[0]).toMatchObject({
+			id: "repr-1",
+			SIREN: "123456789",
+			Année_référence: 2027,
+			Pourcentage_femmes_cadres: 40,
+			Pourcentage_hommes_cadres: 60,
+			Pourcentage_femmes_membres: 45.5,
+			Pourcentage_hommes_membres: 54.5,
+			Date_déclaration: "2027-03-15T10:00:00.000Z",
+		});
+		expect(body.Representations[1].SIREN).toBe("987654321");
+	});
+
+	it("should return full identity and location for a non-diffusible company (S30)", async () => {
+		mockFetchRepresentations.mockResolvedValue([
+			makeRow({
+				siren: "123456789",
+				companyName: "Entreprise Non Diffusible",
+				address: "2 rue Secrète, 69001 Lyon",
+				nafCode: "70.10Z",
+				region: "Auvergne-Rhône-Alpes",
+				departmentLabel: "Rhône",
+			}),
+		]);
+
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15",
+			),
+		);
+
+		expect(response.status).toBe(200);
+		const representation = (await response.json()).Representations[0];
+		expect(representation.Raison_sociale).toBe("Entreprise Non Diffusible");
+		expect(representation.Adresse).toBe("2 rue Secrète, 69001 Lyon");
+		expect(representation.Code_NAF).toBe("70.10Z");
+		expect(representation.Région).toBe("Auvergne-Rhône-Alpes");
+		expect(representation.Département).toBe("Rhône");
+	});
+
+	it("should not expose a Declarations key, the remuneration envelope being untouched", async () => {
+		mockFetchRepresentations.mockResolvedValue([makeRow()]);
+
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15",
+			),
+		);
+
+		expect(await response.json()).not.toHaveProperty("Declarations");
+	});
+
+	it("should return 500 when the fetch throws", async () => {
+		mockFetchRepresentations.mockRejectedValue(
+			new Error("DB connection failed"),
+		);
+
+		const { GET } = await import("~/app/api/v1/export/representations/route");
+		const response = await GET(
+			gatewayForwardedRequest(
+				"http://localhost/api/v1/export/representations?date_begin=2027-03-15",
+			),
+		);
+
+		expect(response.status).toBe(500);
+		const body = await response.json();
+		expect(body.error).toBe(
+			"Erreur lors de la récupération des données de représentation équilibrée",
+		);
+		expect(JSON.stringify(body)).not.toContain("DB connection failed");
+	});
+});

--- a/packages/app/src/modules/export/fetchRepresentations.ts
+++ b/packages/app/src/modules/export/fetchRepresentations.ts
@@ -5,6 +5,40 @@ import { and, eq, gte, lt } from "drizzle-orm";
 import { toNumber } from "~/modules/public-api";
 import { db } from "~/server/db";
 import { companies, representationDeclarations } from "~/server/db/schema";
+import { exportDeclarationsQuerySchema } from "./schemas";
+
+function getNextDate(date: string): string {
+	const d = new Date(`${date}T00:00:00Z`);
+	d.setUTCDate(d.getUTCDate() + 1);
+	return d.toISOString().slice(0, 10);
+}
+
+export function parseExportDateWindow(
+	request: Request,
+): { date_begin: string; dateEnd: string } | Response {
+	const url = new URL(request.url);
+	const parsed = exportDeclarationsQuerySchema.safeParse({
+		date_begin: url.searchParams.get("date_begin") ?? undefined,
+		date_end: url.searchParams.get("date_end") ?? undefined,
+	});
+
+	if (!parsed.success) {
+		return Response.json(
+			{
+				error:
+					"Paramètres invalides. 'date_begin' est requis, format YYYY-MM-DD.",
+				details: parsed.error.issues,
+			},
+			{ status: 400 },
+		);
+	}
+
+	const { date_begin } = parsed.data;
+	return {
+		date_begin,
+		dateEnd: parsed.data.date_end ?? getNextDate(date_begin),
+	};
+}
 
 async function fetchSubmittedRepresentationsRows(
 	dateBegin: string,

--- a/packages/app/src/modules/export/fetchRepresentations.ts
+++ b/packages/app/src/modules/export/fetchRepresentations.ts
@@ -1,0 +1,94 @@
+import "server-only";
+
+import { and, eq, gte, lt } from "drizzle-orm";
+
+import { toNumber } from "~/modules/public-api";
+import { db } from "~/server/db";
+import { companies, representationDeclarations } from "~/server/db/schema";
+
+async function fetchSubmittedRepresentationsRows(
+	dateBegin: string,
+	dateEnd: string,
+) {
+	return db
+		.select({
+			id: representationDeclarations.id,
+			siren: representationDeclarations.siren,
+			year: representationDeclarations.year,
+			referencePeriodStart: representationDeclarations.referencePeriodStart,
+			referencePeriodEnd: representationDeclarations.referencePeriodEnd,
+			executiveWomenPercent: representationDeclarations.executiveWomenPercent,
+			executiveMenPercent: representationDeclarations.executiveMenPercent,
+			notComputableReasonExecutives:
+				representationDeclarations.notComputableReasonExecutives,
+			memberWomenPercent: representationDeclarations.memberWomenPercent,
+			memberMenPercent: representationDeclarations.memberMenPercent,
+			notComputableReasonMembers:
+				representationDeclarations.notComputableReasonMembers,
+			publishDate: representationDeclarations.publishDate,
+			publishUrl: representationDeclarations.publishUrl,
+			publishModalities: representationDeclarations.publishModalities,
+			submittedAt: representationDeclarations.submittedAt,
+			companyName: companies.name,
+			address: companies.address,
+			nafCode: companies.nafCode,
+			region: companies.region,
+			departmentLabel: companies.departmentLabel,
+		})
+		.from(representationDeclarations)
+		.innerJoin(companies, eq(representationDeclarations.siren, companies.siren))
+		.where(
+			and(
+				eq(representationDeclarations.status, "submitted"),
+				gte(
+					representationDeclarations.submittedAt,
+					new Date(`${dateBegin}T00:00:00Z`),
+				),
+				lt(
+					representationDeclarations.submittedAt,
+					new Date(`${dateEnd}T00:00:00Z`),
+				),
+			),
+		);
+}
+
+export type RepresentationRow = Awaited<
+	ReturnType<typeof fetchSubmittedRepresentationsRows>
+>[number];
+
+/**
+ * SUIT is a controlling authority — unlike the public representation export
+ * (`generateRepresentationExport.ts`), identity and location fields are
+ * always returned in full, including for non-diffusible companies (S30).
+ */
+export function assembleRepresentation(row: RepresentationRow) {
+	return {
+		id: row.id,
+		SIREN: row.siren,
+		Raison_sociale: row.companyName,
+		Adresse: row.address,
+		Code_NAF: row.nafCode,
+		Région: row.region,
+		Département: row.departmentLabel,
+		Année_référence: row.year,
+		Période_référence_début: row.referencePeriodStart,
+		Période_référence_fin: row.referencePeriodEnd,
+		Pourcentage_femmes_cadres: toNumber(row.executiveWomenPercent),
+		Pourcentage_hommes_cadres: toNumber(row.executiveMenPercent),
+		Motif_non_calculabilité_cadres: row.notComputableReasonExecutives,
+		Pourcentage_femmes_membres: toNumber(row.memberWomenPercent),
+		Pourcentage_hommes_membres: toNumber(row.memberMenPercent),
+		Motif_non_calculabilité_membres: row.notComputableReasonMembers,
+		Date_publication: row.publishDate,
+		URL_publication: row.publishUrl,
+		Modalités_communication: row.publishModalities,
+		Date_déclaration: row.submittedAt?.toISOString() ?? null,
+	};
+}
+
+export async function fetchSubmittedRepresentations(
+	dateBegin: string,
+	dateEnd: string,
+): Promise<RepresentationRow[]> {
+	return fetchSubmittedRepresentationsRows(dateBegin, dateEnd);
+}

--- a/packages/app/src/modules/export/index.ts
+++ b/packages/app/src/modules/export/index.ts
@@ -13,6 +13,11 @@ export {
 	fetchJointEvaluationFilesByDeclaration,
 	fetchSubmittedDeclarations,
 } from "./fetchDeclarations";
+export type { RepresentationRow } from "./fetchRepresentations";
+export {
+	assembleRepresentation,
+	fetchSubmittedRepresentations,
+} from "./fetchRepresentations";
 export type { RepresentationExportRow } from "./generateRepresentationExport";
 export {
 	buildRepresentationExportRows,

--- a/packages/app/src/modules/export/index.ts
+++ b/packages/app/src/modules/export/index.ts
@@ -17,6 +17,7 @@ export type { RepresentationRow } from "./fetchRepresentations";
 export {
 	assembleRepresentation,
 	fetchSubmittedRepresentations,
+	parseExportDateWindow,
 } from "./fetchRepresentations";
 export type { RepresentationExportRow } from "./generateRepresentationExport";
 export {

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -494,6 +494,97 @@ const declarationSchema = {
 	},
 } as const;
 
+const representationSchema = {
+	type: "object",
+	description:
+		"Déclaration de représentation équilibrée F/H (art. D. 1142-19) — écarts parmi les cadres dirigeants et les membres des instances dirigeantes.",
+	properties: {
+		id: {
+			type: "string",
+			format: "uuid",
+			description: "Identifiant interne de la déclaration (UUID)",
+			example: "11111111-2222-4333-8444-555555555555",
+		},
+		SIREN: {
+			type: "string",
+			description: "SIREN de l'entreprise (9 chiffres)",
+			example: "319159877",
+		},
+		Raison_sociale: {
+			type: ["string", "null"],
+			example: "THALES LAS FRANCE SAS",
+		},
+		Adresse: {
+			type: ["string", "null"],
+			example: "2 AVENUE GAY-LUSSAC, 78990 ELANCOURT",
+		},
+		Code_NAF: {
+			type: ["string", "null"],
+			description: "Code NAF/APE",
+			example: "26.51A",
+		},
+		Région: { type: ["string", "null"], example: "Île-de-France" },
+		Département: { type: ["string", "null"], example: "Yvelines" },
+		Année_référence: {
+			type: "integer",
+			description:
+				"Année de référence des écarts déclarés (N−1 de l'année de campagne).",
+			example: 2026,
+		},
+		Période_référence_début: { type: ["string", "null"], format: "date" },
+		Période_référence_fin: { type: ["string", "null"], format: "date" },
+		Pourcentage_femmes_cadres: {
+			type: ["number", "null"],
+			description:
+				"Part de femmes parmi les cadres dirigeants, entre 0 et 100.",
+		},
+		Pourcentage_hommes_cadres: {
+			type: ["number", "null"],
+			description: "Part d'hommes parmi les cadres dirigeants, entre 0 et 100.",
+		},
+		Motif_non_calculabilité_cadres: {
+			description:
+				"Motif de non-calculabilité de l'écart cadres dirigeants. `null` si calculable.",
+			oneOf: [
+				{
+					type: "string",
+					enum: ["aucun_cadre_dirigeant", "un_seul_cadre_dirigeant"],
+				},
+				{ type: "null" },
+			],
+		},
+		Pourcentage_femmes_membres: {
+			type: ["number", "null"],
+			description:
+				"Part de femmes parmi les membres des instances dirigeantes, entre 0 et 100.",
+		},
+		Pourcentage_hommes_membres: {
+			type: ["number", "null"],
+			description:
+				"Part d'hommes parmi les membres des instances dirigeantes, entre 0 et 100.",
+		},
+		Motif_non_calculabilité_membres: {
+			description:
+				"Motif de non-calculabilité de l'écart instances dirigeantes. `null` si calculable.",
+			oneOf: [
+				{ type: "string", enum: ["aucune_instance_dirigeante"] },
+				{ type: "null" },
+			],
+		},
+		Date_publication: { type: ["string", "null"], format: "date" },
+		URL_publication: { type: ["string", "null"] },
+		Modalités_communication: {
+			type: ["string", "null"],
+			description: "Modalités de communication des résultats aux salariés.",
+		},
+		Date_déclaration: {
+			type: ["string", "null"],
+			format: "date-time",
+			description: "Date de soumission de la déclaration.",
+		},
+	},
+} as const;
+
 const fileMetadataSchema = {
 	type: "object",
 	properties: {
@@ -676,6 +767,122 @@ export const openApiSpec = {
 											type: "string",
 											example:
 												"Erreur lors de la récupération des déclarations",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"/api/v1/export/representations": {
+			get: {
+				operationId: "getRepresentations",
+				summary: "Lister les déclarations de représentation équilibrée",
+				description:
+					"Retourne les déclarations de représentation équilibrée F/H (art. D. 1142-19) soumises dont la date de soumission (`Date_déclaration`) est comprise dans l'intervalle [`date_begin`, `date_end`[. Identité et localisation complètes, y compris pour les entreprises non diffusibles (SUIT est un destinataire de contrôle authentifié).",
+				parameters: [
+					{
+						name: "date_begin",
+						in: "query",
+						required: true,
+						description: "Date de début (inclusive). Format YYYY-MM-DD.",
+						example: "2026-03-01",
+						schema: { type: "string", format: "date" },
+					},
+					{
+						name: "date_end",
+						in: "query",
+						required: false,
+						description:
+							"Date de fin (exclusive). Format YYYY-MM-DD. Si omis, retourne uniquement le jour de `date_begin` (équivalent à `date_begin + 1 jour`).",
+						example: "2026-03-24",
+						schema: { type: "string", format: "date" },
+					},
+				],
+				responses: {
+					"200": {
+						description:
+							"Liste des déclarations de représentation équilibrée correspondant à la plage de dates",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										Date_debut: {
+											type: "string",
+											format: "date",
+											example: "2026-03-01",
+										},
+										Date_fin: {
+											type: "string",
+											format: "date",
+											example: "2026-03-24",
+										},
+										Nombre: {
+											type: "integer",
+											description: "Nombre de déclarations retournées",
+											example: 5,
+										},
+										Representations: {
+											type: "array",
+											items: representationSchema,
+										},
+									},
+								},
+							},
+						},
+					},
+					"401": {
+						description:
+							"Clé API manquante ou invalide (renvoyé par la passerelle)",
+						content: { "application/json": { schema: errorSchema } },
+					},
+					"429": {
+						description:
+							"Quota dépassé (rate limit appliqué par la passerelle)",
+						content: { "application/json": { schema: errorSchema } },
+					},
+					"400": {
+						description: "Paramètres invalides",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										error: {
+											type: "string",
+											example:
+												"Paramètres invalides. 'date_begin' est requis, format YYYY-MM-DD.",
+										},
+										details: {
+											type: "array",
+											description: "Zod validation issues",
+											items: {
+												type: "object",
+												properties: {
+													path: { type: "array", items: { type: "string" } },
+													message: { type: "string" },
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"500": {
+						description: "Erreur serveur",
+						content: {
+							"application/json": {
+								schema: {
+									type: "object",
+									properties: {
+										error: {
+											type: "string",
+											example:
+												"Erreur lors de la récupération des données de représentation équilibrée",
 										},
 									},
 								},

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -853,48 +853,11 @@ export const openApiSpec = {
 					},
 					"400": {
 						description: "Paramètres invalides",
-						content: {
-							"application/json": {
-								schema: {
-									type: "object",
-									properties: {
-										error: {
-											type: "string",
-											example:
-												"Paramètres invalides. 'date_begin' est requis, format YYYY-MM-DD.",
-										},
-										details: {
-											type: "array",
-											description: "Zod validation issues",
-											items: {
-												type: "object",
-												properties: {
-													path: { type: "array", items: { type: "string" } },
-													message: { type: "string" },
-												},
-											},
-										},
-									},
-								},
-							},
-						},
+						content: { "application/json": { schema: errorSchema } },
 					},
 					"500": {
 						description: "Erreur serveur",
-						content: {
-							"application/json": {
-								schema: {
-									type: "object",
-									properties: {
-										error: {
-											type: "string",
-											example:
-												"Erreur lors de la récupération des données de représentation équilibrée",
-										},
-									},
-								},
-							},
-						},
+						content: { "application/json": { schema: errorSchema } },
 					},
 				},
 			},

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -1,6 +1,10 @@
 // OpenAPI 3.1 specification for the declarations export API.
 
 import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
+import {
+	representationNotComputableExecutivesEnum,
+	representationNotComputableMembersEnum,
+} from "~/server/db/schema";
 
 const declarantSchema = {
 	type: "object",
@@ -548,7 +552,7 @@ const representationSchema = {
 			oneOf: [
 				{
 					type: "string",
-					enum: ["aucun_cadre_dirigeant", "un_seul_cadre_dirigeant"],
+					enum: [...representationNotComputableExecutivesEnum.enumValues],
 				},
 				{ type: "null" },
 			],
@@ -567,7 +571,10 @@ const representationSchema = {
 			description:
 				"Motif de non-calculabilité de l'écart instances dirigeantes. `null` si calculable.",
 			oneOf: [
-				{ type: "string", enum: ["aucune_instance_dirigeante"] },
+				{
+					type: "string",
+					enum: [...representationNotComputableMembersEnum.enumValues],
+				},
 				{ type: "null" },
 			],
 		},


### PR DESCRIPTION
Closes #4127

## Résumé

Ajoute un endpoint SUIT dédié `GET /api/v1/export/representations`, servi sur une route distincte de `/api/v1/export/declarations` (laissé strictement inchangé) — même enveloppe, même sémantique de fenêtre de dates, mêmes formats d'erreur.

- `packages/app/src/modules/export/fetchRepresentations.ts` — query `representationDeclarations` jointe à `companies`, filtrée sur `status = "submitted"` et une fenêtre UTC sur `submittedAt` ; fonction pure `assembleRepresentation` produisant l'enveloppe SUIT (champs FR conformes au corps du ticket)
- `packages/app/src/app/api/v1/export/representations/route.ts` — même garde `assertGatewaySource`, même schéma Zod réutilisé (`exportDeclarationsQuerySchema`), mêmes formats d'erreur 400/500
- `packages/app/src/modules/export/openapi.ts` — documentation v1 du nouvel endpoint, enums de non-calculabilité dérivés du schéma Drizzle (single source of truth)
- `packages/app/src/modules/audit/shared/actionKeys.ts` — `AUDIT_ACTIONS.EXPORT_API_REPRESENTATIONS` (catégorie `export`)
- `.kontinuous/templates/apisix-suit.configmap.yaml` — nouvelle route `suit-export-representations`, même bundle de plugins que `suit-export-declarations` (key-auth, limit-req, header `X-Gateway-Forwarded`)

Données complètes y compris pour les entreprises non diffusibles (S30) — SUIT est un destinataire de contrôle authentifié, la non-diffusion ne s'applique qu'aux canaux publics.

## Test plan

- [x] Tests unitaires (`assembleRepresentation`, route handler) et d'intégration (fenêtre de dates, S30, traçage audit) — voir `packages/app/src/modules/export/__tests__/`
- [x] Typecheck / lint / format verts
- [x] `pnpm test` vert (4426/4426)
- [ ] CI GitHub Actions
- [ ] Revue SonarCloud