### PR TITLE
Représentation équilibrée — squelette du funnel & composants partagés

### DIFF
--- a/packages/app/src/app/declaration-representation/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-representation/etape/[step]/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from "next/navigation";
 
 import {
 	getStepDefinition,
-	isValidStep,
+	parseStepParam,
 	representationDraftSchema,
 	StepPageClient,
 	stepHref,
@@ -20,11 +20,12 @@ export async function generateMetadata({
 	params,
 }: StepPageProps): Promise<Metadata> {
 	const { step: stepParam } = await params;
-	const definition = getStepDefinition(Number.parseInt(stepParam, 10));
+	const step = parseStepParam(stepParam);
+	const definition = step === undefined ? undefined : getStepDefinition(step);
 
 	return {
 		title: definition
-			? `Étape ${stepParam} sur ${TOTAL_REPRESENTATION_STEPS} — ${definition.title}`
+			? `Étape ${step} sur ${TOTAL_REPRESENTATION_STEPS} — ${definition.title}`
 			: "Démarche des indicateurs de représentation équilibrée",
 	};
 }
@@ -33,9 +34,9 @@ export default async function RepresentationStepPage({
 	params,
 }: StepPageProps) {
 	const { step: stepParam } = await params;
-	const step = Number.parseInt(stepParam, 10);
+	const step = parseStepParam(stepParam);
 
-	if (!isValidStep(step)) {
+	if (step === undefined) {
 		notFound();
 	}
 

--- a/packages/app/src/app/declaration-representation/etape/[step]/page.tsx
+++ b/packages/app/src/app/declaration-representation/etape/[step]/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { notFound, redirect } from "next/navigation";
+
+import {
+	getStepDefinition,
+	isValidStep,
+	representationDraftSchema,
+	StepPageClient,
+	stepHref,
+	TOTAL_REPRESENTATION_STEPS,
+} from "~/modules/declaration-representation";
+import { getCurrentYear, getReferenceYearFor } from "~/modules/domain";
+import { api } from "~/trpc/server";
+
+type StepPageProps = {
+	params: Promise<{ step: string }>;
+};
+
+export async function generateMetadata({
+	params,
+}: StepPageProps): Promise<Metadata> {
+	const { step: stepParam } = await params;
+	const definition = getStepDefinition(Number.parseInt(stepParam, 10));
+
+	return {
+		title: definition
+			? `Étape ${stepParam} sur ${TOTAL_REPRESENTATION_STEPS} — ${definition.title}`
+			: "Démarche des indicateurs de représentation équilibrée",
+	};
+}
+
+export default async function RepresentationStepPage({
+	params,
+}: StepPageProps) {
+	const { step: stepParam } = await params;
+	const step = Number.parseInt(stepParam, 10);
+
+	if (!isValidStep(step)) {
+		notFound();
+	}
+
+	const campaignYear = getCurrentYear();
+	const year = getReferenceYearFor(campaignYear);
+
+	const { declaration, campaignOpen } = await api.representationDeclaration.get(
+		{ year },
+	);
+
+	if (!campaignOpen) {
+		if (step !== TOTAL_REPRESENTATION_STEPS) {
+			redirect(stepHref(TOTAL_REPRESENTATION_STEPS));
+		}
+	} else {
+		const reachableStep = Math.max(declaration?.currentStep ?? 0, 1);
+		if (step > reachableStep) {
+			redirect(stepHref(reachableStep));
+		}
+	}
+
+	const parsedDraft = representationDraftSchema.safeParse(declaration?.draft);
+
+	return (
+		<StepPageClient
+			campaignOpen={campaignOpen}
+			campaignYear={campaignYear}
+			initialDraft={
+				parsedDraft.success ? parsedDraft.data : { currentStep: step }
+			}
+			step={step}
+			year={year}
+		/>
+	);
+}

--- a/packages/app/src/app/declaration-representation/layout.tsx
+++ b/packages/app/src/app/declaration-representation/layout.tsx
@@ -1,0 +1,32 @@
+import { redirect } from "next/navigation";
+
+import { MissingSiret } from "~/modules/declaration-remuneration";
+import { DeclarationLayout } from "~/modules/declaration-representation";
+import { getCurrentYear } from "~/modules/domain";
+import { auth } from "~/server/auth";
+import { getEffectiveSiren } from "~/server/auth/companyAccess";
+import { api } from "~/trpc/server";
+
+export default async function RepresentationFunnelLayout({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const session = await auth();
+	if (!session?.user) {
+		redirect("/login");
+	}
+
+	const siren = getEffectiveSiren(session);
+	if (!siren) {
+		return <MissingSiret />;
+	}
+
+	const company = await api.company.get({ siren });
+
+	return (
+		<DeclarationLayout campaignYear={getCurrentYear()} company={company}>
+			{children}
+		</DeclarationLayout>
+	);
+}

--- a/packages/app/src/app/declaration-representation/page.tsx
+++ b/packages/app/src/app/declaration-representation/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import {
+	stepHref,
+	TOTAL_REPRESENTATION_STEPS,
+} from "~/modules/declaration-representation";
+import { getCurrentYear, getReferenceYearFor } from "~/modules/domain";
+import { api } from "~/trpc/server";
+
+export const metadata: Metadata = {
+	title: "Démarche des indicateurs de représentation équilibrée",
+};
+
+export default async function RepresentationHomePage() {
+	const campaignYear = getCurrentYear();
+	const year = getReferenceYearFor(campaignYear);
+
+	const { declaration, campaignOpen } = await api.representationDeclaration.get(
+		{ year },
+	);
+
+	if (!campaignOpen) {
+		redirect(stepHref(TOTAL_REPRESENTATION_STEPS));
+	}
+
+	const currentStep = declaration?.currentStep ?? 0;
+	if (currentStep >= 1) {
+		redirect(stepHref(currentStep));
+	}
+
+	return (
+		<>
+			<h1 className="fr-h4">
+				Démarche des indicateurs de représentation {campaignYear}
+			</h1>
+			<p>
+				Cette démarche concerne les entreprises d'au moins 1 000 salariés. Elle
+				porte sur la représentation équilibrée des femmes et des hommes parmi
+				les cadres dirigeants et les membres des instances dirigeantes au titre
+				de l'année {year}.
+			</p>
+			<div className="fr-callout">
+				<p className="fr-callout__text">
+					L'écran d'assujettissement est en construction et sera disponible
+					prochainement.
+				</p>
+			</div>
+			<div className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-6w">
+				<Link
+					className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+					href={stepHref(1)}
+				>
+					Commencer la démarche
+				</Link>
+			</div>
+		</>
+	);
+}

--- a/packages/app/src/app/test-panel/representation/page.tsx
+++ b/packages/app/src/app/test-panel/representation/page.tsx
@@ -1,0 +1,17 @@
+import dynamic from "next/dynamic";
+import { notFound } from "next/navigation";
+
+import { env } from "~/env.js";
+
+const RepresentationPlayground = dynamic(() =>
+	import("~/modules/declaration-representation").then(
+		(m) => m.RepresentationPlayground,
+	),
+);
+
+export default function RepresentationTestPanelPage() {
+	if (env.NODE_ENV === "production") {
+		notFound();
+	}
+	return <RepresentationPlayground />;
+}

--- a/packages/app/src/modules/declaration-remuneration/index.ts
+++ b/packages/app/src/modules/declaration-remuneration/index.ts
@@ -14,6 +14,7 @@ export {
 	updateStep3Schema,
 	updateStep4Schema,
 } from "./schemas";
+export { CompanyBanner } from "./shared/CompanyBanner";
 export { computeIndicatorPercentages } from "./shared/computeIndicatorPercentages";
 export { DevFillButton } from "./shared/DevFillButton";
 export type {

--- a/packages/app/src/modules/declaration-representation/DeclarationLayout.tsx
+++ b/packages/app/src/modules/declaration-representation/DeclarationLayout.tsx
@@ -1,0 +1,32 @@
+import { CompanyBanner } from "~/modules/declaration-remuneration";
+
+type DeclarationLayoutProps = {
+	company: {
+		name: string;
+		siren: string;
+		gipWorkforce: number | null;
+		hasCse: boolean | null;
+	};
+	campaignYear: number;
+	children: React.ReactNode;
+};
+
+export function DeclarationLayout({
+	company,
+	campaignYear,
+	children,
+}: DeclarationLayoutProps) {
+	return (
+		<main id="content" tabIndex={-1}>
+			<CompanyBanner
+				company={company}
+				currentPageLabel={`Démarche des indicateurs de représentation ${campaignYear}`}
+			/>
+			<div className="fr-container fr-py-7w">
+				<div className="fr-grid-row fr-grid-row--center">
+					<div className="fr-col-12 fr-col-lg-8">{children}</div>
+				</div>
+			</div>
+		</main>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/RepresentationPlayground.tsx
+++ b/packages/app/src/modules/declaration-representation/RepresentationPlayground.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+
+import type { RepresentationComplianceVerdict } from "~/modules/domain";
+import { ComplianceBadge } from "./shared/ComplianceBadge";
+import type { PercentagePairValues } from "./shared/PercentagePairFields";
+import { PercentagePairFields } from "./shared/PercentagePairFields";
+
+const VERDICTS: RepresentationComplianceVerdict[] = [
+	"compliant",
+	"non_compliant",
+	"not_applicable",
+];
+
+export function RepresentationPlayground() {
+	const [values, setValues] = useState<PercentagePairValues>({
+		womenPercent: "",
+		menPercent: "",
+	});
+
+	return (
+		<main className="fr-container fr-py-6w" id="content" tabIndex={-1}>
+			<h1 className="fr-h3">Représentation équilibrée — Playground</h1>
+			<p className="fr-text--sm fr-text-mention--grey">
+				Page réservée au développement : rendu isolé des composants partagés du
+				funnel de représentation équilibrée.
+			</p>
+
+			<h2 className="fr-h5 fr-mt-4w">ComplianceBadge</h2>
+			<ul className="fr-badges-group" id="compliance-badges">
+				{VERDICTS.map((verdict) => (
+					<li id={`compliance-badge-${verdict}`} key={verdict}>
+						<ComplianceBadge verdict={verdict} />
+					</li>
+				))}
+			</ul>
+
+			<h2 className="fr-h5 fr-mt-4w">PercentagePairFields</h2>
+			<div id="percentage-pair-fields">
+				<PercentagePairFields
+					legend="Indiquez le pourcentage de représentation des femmes et des hommes parmi les cadres dirigeants."
+					onChange={setValues}
+					values={values}
+				/>
+			</div>
+			<p className="fr-text--sm" id="percentage-pair-values">
+				Femmes : {values.womenPercent || "—"} · Hommes :{" "}
+				{values.menPercent || "—"}
+			</p>
+		</main>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-representation/StepPageClient.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Stepper } from "./Stepper";
+import { RepresentationDraftProvider } from "./shared/draft/DraftContext";
+import { useRepresentationDraft } from "./shared/draft/useRepresentationDraft";
+import {
+	getNextStepHref,
+	getPreviousStepHref,
+	getStepDefinition,
+} from "./steps";
+import type { RepresentationDraft } from "./types";
+
+type StepPageClientProps = {
+	step: number;
+	year: number;
+	campaignYear: number;
+	initialDraft: RepresentationDraft;
+	campaignOpen: boolean;
+};
+
+export function StepPageClient({
+	step,
+	year,
+	campaignYear,
+	initialDraft,
+	campaignOpen,
+}: StepPageClientProps) {
+	const router = useRouter();
+	const [navigationError, setNavigationError] = useState<string | null>(null);
+	const [isAdvancing, setIsAdvancing] = useState(false);
+
+	const { draft, setDraftValues, saveProgress, isSaving, isPendingSave } =
+		useRepresentationDraft({
+			year,
+			step,
+			initialDraft,
+			enabled: campaignOpen,
+		});
+
+	const definition = getStepDefinition(step);
+	const previousHref = getPreviousStepHref(step);
+	const nextHref = getNextStepHref(step);
+
+	if (definition === undefined) return null;
+
+	const StepComponent = definition.Component;
+
+	async function handleNext() {
+		if (nextHref === undefined) return;
+		setNavigationError(null);
+		setIsAdvancing(true);
+		try {
+			await saveProgress(step + 1);
+			router.push(nextHref);
+		} catch {
+			setNavigationError(
+				"L'enregistrement de votre progression a échoué. Veuillez réessayer.",
+			);
+		} finally {
+			setIsAdvancing(false);
+		}
+	}
+
+	return (
+		<RepresentationDraftProvider
+			value={{
+				year,
+				step,
+				draft,
+				setDraftValues,
+				isSaving,
+				isPendingSave,
+				isReadOnly: !campaignOpen,
+			}}
+		>
+			<h1 className="fr-h4">
+				Démarche des indicateurs de représentation {campaignYear}
+			</h1>
+
+			{campaignOpen ? null : (
+				<div className="fr-alert fr-alert--info fr-mb-4w">
+					<h2 className="fr-alert__title">
+						La campagne de représentation équilibrée est close
+					</h2>
+					<p>
+						Votre déclaration est consultable en lecture seule : elle ne peut
+						plus être modifiée.
+					</p>
+				</div>
+			)}
+
+			<Stepper currentStep={step} />
+
+			<StepComponent />
+
+			{navigationError ? (
+				<div
+					className="fr-alert fr-alert--error fr-alert--sm fr-mt-4w"
+					role="alert"
+				>
+					<p>{navigationError}</p>
+				</div>
+			) : null}
+
+			<div className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-6w">
+				<Link
+					className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
+					href={previousHref}
+				>
+					Précédent
+				</Link>
+				{nextHref !== undefined && campaignOpen ? (
+					<button
+						className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+						disabled={isAdvancing}
+						onClick={handleNext}
+						type="button"
+					>
+						{isAdvancing ? "Enregistrement…" : "Suivant"}
+					</button>
+				) : null}
+			</div>
+		</RepresentationDraftProvider>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/Stepper.tsx
+++ b/packages/app/src/modules/declaration-representation/Stepper.tsx
@@ -1,0 +1,30 @@
+import { REPRESENTATION_STEPS } from "./steps";
+import { TOTAL_REPRESENTATION_STEPS } from "./types";
+
+export function Stepper({ currentStep }: { currentStep: number }) {
+	const title = REPRESENTATION_STEPS[currentStep - 1]?.title;
+	const nextTitle = REPRESENTATION_STEPS[currentStep]?.title;
+
+	if (title === undefined) return null;
+
+	return (
+		<div className="fr-stepper">
+			<h2 className="fr-stepper__title">
+				{title}
+				<span className="fr-stepper__state">
+					Étape {currentStep} sur {TOTAL_REPRESENTATION_STEPS}
+				</span>
+			</h2>
+			<div
+				className="fr-stepper__steps"
+				data-fr-current-step={currentStep}
+				data-fr-steps={TOTAL_REPRESENTATION_STEPS}
+			/>
+			{nextTitle ? (
+				<p className="fr-stepper__details">
+					<span className="fr-text--bold">Étape suivante :</span> {nextTitle}
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/__tests__/DeclarationLayout.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/DeclarationLayout.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DeclarationLayout } from "../DeclarationLayout";
+
+const COMPANY = {
+	name: "Société Démo",
+	siren: "123456789",
+	gipWorkforce: 1200,
+	hasCse: true,
+};
+
+describe("DeclarationLayout", () => {
+	it("wraps the funnel content in the shared company chrome", () => {
+		render(
+			<DeclarationLayout campaignYear={2026} company={COMPANY}>
+				<p>Contenu de l'étape</p>
+			</DeclarationLayout>,
+		);
+
+		expect(screen.getByText("123 456 789")).toBeInTheDocument();
+		expect(screen.getByText("Contenu de l'étape")).toBeInTheDocument();
+		expect(screen.getByRole("main")).toHaveAttribute("id", "content");
+	});
+
+	it("names the funnel as the current breadcrumb page", () => {
+		render(
+			<DeclarationLayout campaignYear={2026} company={COMPANY}>
+				<p>Contenu de l'étape</p>
+			</DeclarationLayout>,
+		);
+
+		expect(
+			screen.getByText("Démarche des indicateurs de représentation 2026"),
+		).toHaveAttribute("aria-current", "page");
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationFunnelLayout.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationFunnelLayout.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedirect, mockAuth, mockGetEffectiveSiren } = vi.hoisted(() => ({
+	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
+		throw new Error("NEXT_REDIRECT");
+	}),
+	mockAuth: vi.fn(),
+	mockGetEffectiveSiren: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+	redirect: mockRedirect,
+}));
+
+vi.mock("~/server/auth", () => ({ auth: mockAuth }));
+
+vi.mock("~/server/auth/companyAccess", () => ({
+	getEffectiveSiren: mockGetEffectiveSiren,
+}));
+
+vi.mock("~/trpc/server", () => ({ api: { company: { get: vi.fn() } } }));
+
+import RepresentationFunnelLayout from "~/app/declaration-representation/layout";
+import { api } from "~/trpc/server";
+
+const SIREN = "123456789";
+
+function renderLayout() {
+	return RepresentationFunnelLayout({ children: <p>Contenu de l'étape</p> });
+}
+
+beforeEach(() => {
+	mockRedirect.mockClear();
+	mockAuth.mockReset();
+	mockGetEffectiveSiren.mockReset();
+	vi.mocked(api.company.get).mockResolvedValue({
+		name: "Société Démo",
+		siren: SIREN,
+		gipWorkforce: 1200,
+		hasCse: true,
+	} as never);
+});
+
+describe("RepresentationFunnelLayout", () => {
+	it("redirects unauthenticated users to the login page", async () => {
+		mockAuth.mockResolvedValue(null);
+
+		await expect(renderLayout()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith("/login");
+		expect(api.company.get).not.toHaveBeenCalled();
+	});
+
+	it("explains the missing SIRET instead of serving the funnel", async () => {
+		mockAuth.mockResolvedValue({ user: { id: "u1" } });
+		mockGetEffectiveSiren.mockReturnValue(null);
+
+		render(await renderLayout());
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("heading", { level: 1, name: "SIRET manquant" }),
+		).toBeInTheDocument();
+	});
+
+	it("serves the funnel with the company of the session", async () => {
+		mockAuth.mockResolvedValue({ user: { id: "u1", siret: `${SIREN}00015` } });
+		mockGetEffectiveSiren.mockReturnValue(SIREN);
+
+		render(await renderLayout());
+
+		expect(api.company.get).toHaveBeenCalledWith({ siren: SIREN });
+		expect(screen.getByText("123 456 789")).toBeInTheDocument();
+		expect(screen.getByText("Contenu de l'étape")).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -37,10 +37,10 @@ vi.mock("~/modules/declaration-representation", async (importOriginal) => ({
 	),
 }));
 
-import RepresentationHomePage from "~/app/declaration-representation/page";
 import RepresentationStepPage, {
 	generateMetadata,
 } from "~/app/declaration-representation/etape/[step]/page";
+import RepresentationHomePage from "~/app/declaration-representation/page";
 import type { RepresentationDraft } from "~/modules/declaration-representation";
 import { getCurrentYear, getReferenceYearFor } from "~/modules/domain";
 import { api } from "~/trpc/server";

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRedirect, mockNotFound } = vi.hoisted(() => ({
+	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
+		throw new Error("NEXT_REDIRECT");
+	}),
+	mockNotFound: vi.fn<() => never>().mockImplementation(() => {
+		throw new Error("NEXT_NOT_FOUND");
+	}),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+	notFound: mockNotFound,
+	redirect: mockRedirect,
+}));
+
+vi.mock("~/trpc/server", () => ({
+	api: { representationDeclaration: { get: vi.fn() } },
+}));
+
+// The step page only decides which step to serve; the client funnel is
+// exercised by StepPageClient.test.tsx.
+vi.mock("~/modules/declaration-representation", async (importOriginal) => ({
+	...(await importOriginal<
+		typeof import("~/modules/declaration-representation")
+	>()),
+	StepPageClient: (props: Record<string, unknown>) => (
+		<span data-testid="step-page">{JSON.stringify(props)}</span>
+	),
+}));
+
+import RepresentationHomePage from "~/app/declaration-representation/page";
+import RepresentationStepPage, {
+	generateMetadata,
+} from "~/app/declaration-representation/etape/[step]/page";
+import type { RepresentationDraft } from "~/modules/declaration-representation";
+import { getCurrentYear, getReferenceYearFor } from "~/modules/domain";
+import { api } from "~/trpc/server";
+
+const CAMPAIGN_YEAR = getCurrentYear();
+const YEAR = getReferenceYearFor(CAMPAIGN_YEAR);
+const STEP_5_HREF = "/declaration-representation/etape/5";
+
+const getDeclaration = vi.mocked(api.representationDeclaration.get);
+
+function mockFunnelState({
+	campaignOpen = true,
+	currentStep,
+	draft,
+}: {
+	campaignOpen?: boolean;
+	currentStep?: number;
+	draft?: unknown;
+} = {}) {
+	getDeclaration.mockResolvedValue({
+		campaignOpen,
+		declaration:
+			currentStep === undefined ? null : { currentStep, draft: draft ?? null },
+	} as never);
+}
+
+function stepPageProps() {
+	const payload = screen.getByTestId("step-page").textContent ?? "{}";
+	return JSON.parse(payload) as {
+		step: number;
+		year: number;
+		campaignYear: number;
+		campaignOpen: boolean;
+		initialDraft: RepresentationDraft;
+	};
+}
+
+async function renderStepPage(step: string) {
+	return render(
+		await RepresentationStepPage({ params: Promise.resolve({ step }) }),
+	);
+}
+
+beforeEach(() => {
+	mockRedirect.mockClear();
+	mockNotFound.mockClear();
+	getDeclaration.mockReset();
+});
+
+describe("RepresentationHomePage", () => {
+	it("reads the declaration of the reference year", async () => {
+		mockFunnelState();
+
+		render(await RepresentationHomePage());
+
+		expect(getDeclaration).toHaveBeenCalledWith({ year: YEAR });
+	});
+
+	it("serves the entry screen when no draft has been started", async () => {
+		mockFunnelState();
+
+		render(await RepresentationHomePage());
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole("link", { name: "Commencer la démarche" }),
+		).toHaveAttribute("href", "/declaration-representation/etape/1");
+	});
+
+	it("keeps serving the entry screen when the draft has not reached a step yet", async () => {
+		mockFunnelState({ currentStep: 0 });
+
+		render(await RepresentationHomePage());
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+	});
+
+	it("resumes an existing draft at its current step (S21)", async () => {
+		mockFunnelState({ currentStep: 3 });
+
+		await expect(RepresentationHomePage()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(
+			"/declaration-representation/etape/3",
+		);
+	});
+
+	it("sends the user to the recap when the campaign is closed (S23)", async () => {
+		mockFunnelState({ campaignOpen: false, currentStep: 2 });
+
+		await expect(RepresentationHomePage()).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(STEP_5_HREF);
+	});
+});
+
+describe("RepresentationStepPage — step guard", () => {
+	it.each(["0", "6", "-1", "abc"])("404s on the step %s", async (step) => {
+		mockFunnelState({ currentStep: 5 });
+
+		await expect(renderStepPage(step)).rejects.toThrow("NEXT_NOT_FOUND");
+		expect(getDeclaration).not.toHaveBeenCalled();
+	});
+});
+
+describe("RepresentationStepPage — resume guard (S21)", () => {
+	it("redirects a step ahead of the draft progress back to the current step", async () => {
+		mockFunnelState({ currentStep: 2 });
+
+		await expect(renderStepPage("4")).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(
+			"/declaration-representation/etape/2",
+		);
+	});
+
+	it("opens the first step when the draft has no progress yet", async () => {
+		mockFunnelState({ currentStep: 0 });
+
+		await renderStepPage("1");
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(stepPageProps().step).toBe(1);
+	});
+
+	it("opens the first step when no draft exists at all", async () => {
+		mockFunnelState();
+
+		await renderStepPage("1");
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(stepPageProps().step).toBe(1);
+	});
+
+	it("redirects to the first step when a later step is requested without a draft", async () => {
+		mockFunnelState();
+
+		await expect(renderStepPage("2")).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(
+			"/declaration-representation/etape/1",
+		);
+	});
+
+	it("lets the user go back to an already completed step", async () => {
+		mockFunnelState({ currentStep: 4 });
+
+		await renderStepPage("2");
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(stepPageProps().step).toBe(2);
+	});
+});
+
+describe("RepresentationStepPage — closed campaign (S23)", () => {
+	it("redirects every step of the funnel to the recap", async () => {
+		mockFunnelState({ campaignOpen: false, currentStep: 4 });
+
+		await expect(renderStepPage("3")).rejects.toThrow("NEXT_REDIRECT");
+		expect(mockRedirect).toHaveBeenCalledWith(STEP_5_HREF);
+	});
+
+	it("serves the recap read-only without applying the resume guard", async () => {
+		mockFunnelState({ campaignOpen: false, currentStep: 1 });
+
+		await renderStepPage("5");
+
+		expect(mockRedirect).not.toHaveBeenCalled();
+		expect(stepPageProps()).toMatchObject({ step: 5, campaignOpen: false });
+	});
+});
+
+describe("RepresentationStepPage — draft hydration", () => {
+	it("hands the stored draft to the client funnel", async () => {
+		const draft = { currentStep: 3, executiveWomenPercent: 60 };
+		mockFunnelState({ currentStep: 3, draft });
+
+		await renderStepPage("3");
+
+		expect(stepPageProps()).toMatchObject({
+			campaignOpen: true,
+			campaignYear: CAMPAIGN_YEAR,
+			initialDraft: draft,
+			year: YEAR,
+		});
+	});
+
+	it("falls back to the requested step when the stored draft is unusable", async () => {
+		mockFunnelState({ currentStep: 3, draft: { currentStep: 99 } });
+
+		await renderStepPage("3");
+
+		expect(stepPageProps().initialDraft).toEqual({ currentStep: 3 });
+	});
+
+	it("falls back to the requested step when no draft is stored", async () => {
+		mockFunnelState({ currentStep: 2 });
+
+		await renderStepPage("2");
+
+		expect(stepPageProps().initialDraft).toEqual({ currentStep: 2 });
+	});
+});
+
+describe("generateMetadata", () => {
+	it("titles the page with the step position and name", async () => {
+		await expect(
+			generateMetadata({ params: Promise.resolve({ step: "2" }) }),
+		).resolves.toEqual({
+			title: "Étape 2 sur 5 — Écarts de représentation - Cadres dirigeants",
+		});
+	});
+
+	it("falls back to the funnel title on an unknown step", async () => {
+		await expect(
+			generateMetadata({ params: Promise.resolve({ step: "9" }) }),
+		).resolves.toEqual({
+			title: "Démarche des indicateurs de représentation équilibrée",
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -26,8 +26,7 @@ vi.mock("~/trpc/server", () => ({
 	api: { representationDeclaration: { get: vi.fn() } },
 }));
 
-// The step page only decides which step to serve; the client funnel is
-// exercised by StepPageClient.test.tsx.
+// The client funnel itself is exercised by StepPageClient.test.tsx.
 vi.mock("~/modules/declaration-representation", async (importOriginal) => ({
 	...(await importOriginal<
 		typeof import("~/modules/declaration-representation")
@@ -136,11 +135,28 @@ describe("RepresentationHomePage", () => {
 });
 
 describe("RepresentationStepPage — step guard", () => {
-	it.each(["0", "6", "-1", "abc"])("404s on the step %s", async (step) => {
+	it.each([
+		"0",
+		"6",
+		"-1",
+		"+1",
+		"1.5",
+		"1abc",
+		"abc",
+	])("404s on the step %s", async (step) => {
 		mockFunnelState({ currentStep: 5 });
 
 		await expect(renderStepPage(step)).rejects.toThrow("NEXT_NOT_FOUND");
 		expect(getDeclaration).not.toHaveBeenCalled();
+	});
+
+	it("normalises a zero-padded step number", async () => {
+		mockFunnelState({ currentStep: 1 });
+
+		await renderStepPage("01");
+
+		expect(mockNotFound).not.toHaveBeenCalled();
+		expect(stepPageProps().step).toBe(1);
 	});
 });
 
@@ -250,9 +266,23 @@ describe("generateMetadata", () => {
 		});
 	});
 
-	it("falls back to the funnel title on an unknown step", async () => {
+	it("normalises a zero-padded step number in the title", async () => {
 		await expect(
-			generateMetadata({ params: Promise.resolve({ step: "9" }) }),
+			generateMetadata({ params: Promise.resolve({ step: "01" }) }),
+		).resolves.toEqual({
+			title: "Étape 1 sur 5 — Période de référence",
+		});
+	});
+
+	it.each([
+		"9",
+		"0",
+		"1.5",
+		"+1",
+		"abc",
+	])("falls back to the funnel title on the step %s", async (step) => {
+		await expect(
+			generateMetadata({ params: Promise.resolve({ step }) }),
 		).resolves.toEqual({
 			title: "Démarche des indicateurs de représentation équilibrée",
 		});

--- a/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.test.tsx
@@ -1,0 +1,183 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { push, mutate, mutateAsync } = vi.hoisted(() => ({
+	push: vi.fn(),
+	mutate: vi.fn(),
+	mutateAsync: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push,
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		representationDeclaration: {
+			saveDraft: {
+				useMutation: () => ({ mutate, mutateAsync, isPending: false }),
+			},
+		},
+	},
+}));
+
+import { StepPageClient } from "../StepPageClient";
+
+const CAMPAIGN_YEAR = 2026;
+const YEAR = 2025;
+const CLOSED_BANNER = "La campagne de représentation équilibrée est close";
+
+function renderStep({ step = 2, campaignOpen = true, currentStep = 2 } = {}) {
+	return render(
+		<StepPageClient
+			campaignOpen={campaignOpen}
+			campaignYear={CAMPAIGN_YEAR}
+			initialDraft={{ currentStep }}
+			step={step}
+			year={YEAR}
+		/>,
+	);
+}
+
+beforeEach(() => {
+	push.mockReset();
+	mutate.mockReset();
+	mutateAsync.mockReset().mockResolvedValue(undefined);
+});
+
+describe("StepPageClient — rendering", () => {
+	it("renders the funnel heading, the stepper and the step content", () => {
+		renderStep();
+
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: `Démarche des indicateurs de représentation ${CAMPAIGN_YEAR}`,
+			}),
+		).toBeInTheDocument();
+		expect(screen.getByText("Étape 2 sur 5")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"Cette étape est en construction et sera disponible prochainement.",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("renders nothing for a step outside the funnel", () => {
+		const { container } = renderStep({ step: 6 });
+
+		expect(container).toBeEmptyDOMElement();
+	});
+});
+
+describe("StepPageClient — navigation", () => {
+	it("links back to the previous step", () => {
+		renderStep({ step: 3, currentStep: 3 });
+
+		expect(screen.getByRole("link", { name: "Précédent" })).toHaveAttribute(
+			"href",
+			"/declaration-representation/etape/2",
+		);
+	});
+
+	it("links back to the funnel root from the first step", () => {
+		renderStep({ step: 1, currentStep: 1 });
+
+		expect(screen.getByRole("link", { name: "Précédent" })).toHaveAttribute(
+			"href",
+			"/declaration-representation",
+		);
+	});
+
+	it("saves the progress before routing to the next step", async () => {
+		renderStep({ step: 2 });
+
+		await userEvent.click(screen.getByRole("button", { name: "Suivant" }));
+
+		expect(mutateAsync).toHaveBeenCalledWith({
+			year: YEAR,
+			currentStep: 3,
+			draft: { currentStep: 3 },
+		});
+		expect(push).toHaveBeenCalledWith("/declaration-representation/etape/3");
+	});
+
+	it("disables the button while the progress is being saved", async () => {
+		let resolveSave: () => void = () => undefined;
+		mutateAsync.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveSave = resolve;
+				}),
+		);
+		renderStep({ step: 2 });
+
+		await userEvent.click(screen.getByRole("button", { name: "Suivant" }));
+
+		const button = screen.getByRole("button", { name: "Enregistrement…" });
+		expect(button).toBeDisabled();
+		expect(push).not.toHaveBeenCalled();
+
+		await act(async () => {
+			resolveSave();
+		});
+
+		expect(push).toHaveBeenCalledWith("/declaration-representation/etape/3");
+	});
+
+	it("keeps the user on the step and explains the failure when the save fails", async () => {
+		mutateAsync.mockRejectedValueOnce(new Error("network"));
+		renderStep({ step: 2 });
+
+		await userEvent.click(screen.getByRole("button", { name: "Suivant" }));
+
+		expect(screen.getByRole("alert")).toHaveTextContent(
+			"L'enregistrement de votre progression a échoué. Veuillez réessayer.",
+		);
+		expect(push).not.toHaveBeenCalled();
+		expect(screen.getByRole("button", { name: "Suivant" })).toBeEnabled();
+	});
+
+	it("offers no next step on the last step", () => {
+		renderStep({ step: 5, currentStep: 5 });
+
+		expect(
+			screen.queryByRole("button", { name: "Suivant" }),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Précédent" })).toBeInTheDocument();
+	});
+});
+
+describe("StepPageClient — closed campaign (S23)", () => {
+	it("shows the read-only banner", () => {
+		renderStep({ campaignOpen: false, step: 5, currentStep: 5 });
+
+		expect(screen.getByText(CLOSED_BANNER)).toBeInTheDocument();
+		expect(
+			screen.getByText(/Votre déclaration est consultable en lecture seule/),
+		).toBeInTheDocument();
+	});
+
+	it("hides the next-step button so no mutation can be triggered", () => {
+		renderStep({ campaignOpen: false, step: 2 });
+
+		expect(
+			screen.queryByRole("button", { name: "Suivant" }),
+		).not.toBeInTheDocument();
+		expect(mutate).not.toHaveBeenCalled();
+		expect(mutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("does not show the banner while the campaign is open", () => {
+		renderStep();
+
+		expect(screen.queryByText(CLOSED_BANNER)).not.toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/Stepper.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/Stepper.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Stepper } from "../Stepper";
+import { TOTAL_REPRESENTATION_STEPS } from "../types";
+
+describe("Stepper", () => {
+	it("announces the current step, its title and the next one", () => {
+		render(<Stepper currentStep={2} />);
+
+		const heading = screen.getByRole("heading", { level: 2 });
+		expect(heading).toHaveTextContent(
+			"Écarts de représentation - Cadres dirigeants",
+		);
+		expect(screen.getByText("Étape 2 sur 5")).toBeInTheDocument();
+		expect(
+			screen.getByText("Étape suivante :").parentElement,
+		).toHaveTextContent(
+			"Étape suivante : Écarts de représentation - Instances dirigeantes",
+		);
+	});
+
+	it("exposes the DSFR progress attributes", () => {
+		const { container } = render(<Stepper currentStep={3} />);
+
+		const steps = container.querySelector(".fr-stepper__steps");
+		expect(steps).toHaveAttribute("data-fr-current-step", "3");
+		expect(steps).toHaveAttribute(
+			"data-fr-steps",
+			String(TOTAL_REPRESENTATION_STEPS),
+		);
+	});
+
+	it("drops the next-step mention on the last step", () => {
+		render(<Stepper currentStep={TOTAL_REPRESENTATION_STEPS} />);
+
+		expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+			"Récapitulatif",
+		);
+		expect(screen.getByText("Étape 5 sur 5")).toBeInTheDocument();
+		expect(screen.queryByText("Étape suivante :")).not.toBeInTheDocument();
+	});
+
+	it.each([
+		0,
+		TOTAL_REPRESENTATION_STEPS + 1,
+	])("renders nothing for the out-of-range step %i", (step) => {
+		const { container } = render(<Stepper currentStep={step} />);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	getNextStepHref,
+	getPreviousStepHref,
+	getStepDefinition,
+	isValidStep,
+	REPRESENTATION_FUNNEL_ROOT,
+	REPRESENTATION_STEPS,
+	stepHref,
+} from "../steps";
+import { StepPlaceholder } from "../steps/StepPlaceholder";
+import {
+	REPRESENTATION_STEP_SLUGS,
+	TOTAL_REPRESENTATION_STEPS,
+} from "../types";
+
+describe("REPRESENTATION_STEPS", () => {
+	it("declares the five funnel steps in order", () => {
+		expect(REPRESENTATION_STEPS).toHaveLength(TOTAL_REPRESENTATION_STEPS);
+		expect(REPRESENTATION_STEPS.map((step) => step.slug)).toEqual([
+			...REPRESENTATION_STEP_SLUGS,
+		]);
+		expect(REPRESENTATION_STEPS.map((step) => step.title)).toEqual([
+			"Période de référence",
+			"Écarts de représentation - Cadres dirigeants",
+			"Écarts de représentation - Instances dirigeantes",
+			"Informations de publication",
+			"Récapitulatif",
+		]);
+	});
+
+	it("renders every step with the placeholder until the step tickets land", () => {
+		for (const step of REPRESENTATION_STEPS) {
+			expect(step.Component).toBe(StepPlaceholder);
+		}
+	});
+});
+
+describe("isValidStep", () => {
+	it.each([1, 2, 3, 4, 5])("accepts step %i", (step) => {
+		expect(isValidStep(step)).toBe(true);
+	});
+
+	it.each([0, -1, 6, 1.5, Number.NaN])("rejects %s", (step) => {
+		expect(isValidStep(step)).toBe(false);
+	});
+});
+
+describe("getStepDefinition", () => {
+	it("returns the definition matching the 1-based step number", () => {
+		expect(getStepDefinition(1)?.slug).toBe("periode-de-reference");
+		expect(getStepDefinition(5)?.slug).toBe("recapitulatif");
+	});
+
+	it("returns undefined outside the funnel range", () => {
+		expect(getStepDefinition(0)).toBeUndefined();
+		expect(getStepDefinition(6)).toBeUndefined();
+		expect(getStepDefinition(Number.NaN)).toBeUndefined();
+	});
+});
+
+describe("navigation hrefs", () => {
+	it("builds the step href from the funnel root", () => {
+		expect(stepHref(3)).toBe(`${REPRESENTATION_FUNNEL_ROOT}/etape/3`);
+	});
+
+	it("goes back to the previous step", () => {
+		expect(getPreviousStepHref(3)).toBe(
+			`${REPRESENTATION_FUNNEL_ROOT}/etape/2`,
+		);
+	});
+
+	it("goes back to the funnel root from the first step", () => {
+		expect(getPreviousStepHref(1)).toBe(REPRESENTATION_FUNNEL_ROOT);
+	});
+
+	it("goes forward to the next step", () => {
+		expect(getNextStepHref(1)).toBe(`${REPRESENTATION_FUNNEL_ROOT}/etape/2`);
+		expect(getNextStepHref(4)).toBe(`${REPRESENTATION_FUNNEL_ROOT}/etape/5`);
+	});
+
+	it("has no next step on the last step", () => {
+		expect(getNextStepHref(TOTAL_REPRESENTATION_STEPS)).toBeUndefined();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
@@ -5,6 +5,7 @@ import {
 	getPreviousStepHref,
 	getStepDefinition,
 	isValidStep,
+	parseStepParam,
 	REPRESENTATION_FUNNEL_ROOT,
 	REPRESENTATION_STEPS,
 	stepHref,
@@ -44,6 +45,33 @@ describe("isValidStep", () => {
 
 	it.each([0, -1, 6, 1.5, Number.NaN])("rejects %s", (step) => {
 		expect(isValidStep(step)).toBe(false);
+	});
+});
+
+describe("parseStepParam", () => {
+	it.each([
+		["1", 1],
+		["5", 5],
+		["01", 1],
+	])("parses the route param %s into step %i", (raw, expected) => {
+		expect(parseStepParam(raw)).toBe(expected);
+	});
+
+	it.each([
+		"0",
+		"6",
+		"-1",
+		"+1",
+		"1.5",
+		"1,5",
+		"1abc",
+		"1e0",
+		"0x2",
+		" 1",
+		"",
+		"abc",
+	])("rejects the route param %s", (raw) => {
+		expect(parseStepParam(raw)).toBeUndefined();
 	});
 });
 

--- a/packages/app/src/modules/declaration-representation/index.ts
+++ b/packages/app/src/modules/declaration-representation/index.ts
@@ -33,6 +33,7 @@ export {
 	getPreviousStepHref,
 	getStepDefinition,
 	isValidStep,
+	parseStepParam,
 	REPRESENTATION_FUNNEL_ROOT,
 	REPRESENTATION_STEPS,
 	stepHref,

--- a/packages/app/src/modules/declaration-representation/index.ts
+++ b/packages/app/src/modules/declaration-representation/index.ts
@@ -1,3 +1,7 @@
+export { DeclarationLayout } from "./DeclarationLayout";
+export { RepresentationPlayground } from "./RepresentationPlayground";
+export { StepPageClient } from "./StepPageClient";
+export { Stepper } from "./Stepper";
 export {
 	executivesCountSchema,
 	executivesSchema,
@@ -10,6 +14,29 @@ export {
 	submitRepresentationDeclarationSchema,
 	submitRepresentationSchema,
 } from "./schemas";
+export { ComplianceBadge } from "./shared/ComplianceBadge";
+export type { RepresentationDraftContextValue } from "./shared/draft/DraftContext";
+export {
+	RepresentationDraftProvider,
+	useRepresentationDraftContext,
+} from "./shared/draft/DraftContext";
+export { useRepresentationDraft } from "./shared/draft/useRepresentationDraft";
+export type { PercentagePairValues } from "./shared/PercentagePairFields";
+export {
+	complementPercentage,
+	isPercentageInput,
+	PercentagePairFields,
+} from "./shared/PercentagePairFields";
+export type { StepDefinition } from "./steps";
+export {
+	getNextStepHref,
+	getPreviousStepHref,
+	getStepDefinition,
+	isValidStep,
+	REPRESENTATION_FUNNEL_ROOT,
+	REPRESENTATION_STEPS,
+	stepHref,
+} from "./steps";
 export type {
 	ExecutivesInput,
 	MembersInput,
@@ -17,5 +44,10 @@ export type {
 	ReferencePeriodInput,
 	RepresentationDeclarationRow,
 	RepresentationDraft,
+	RepresentationStepSlug,
 	SubmitRepresentationInput,
+} from "./types";
+export {
+	REPRESENTATION_STEP_SLUGS,
+	TOTAL_REPRESENTATION_STEPS,
 } from "./types";

--- a/packages/app/src/modules/declaration-representation/shared/ComplianceBadge.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/ComplianceBadge.tsx
@@ -1,0 +1,28 @@
+import type { RepresentationComplianceVerdict } from "~/modules/domain";
+
+const BADGE_BY_VERDICT: Record<
+	RepresentationComplianceVerdict,
+	{ className: string; label: string }
+> = {
+	compliant: {
+		className: "fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon",
+		label: "Conforme",
+	},
+	non_compliant: {
+		className: "fr-badge fr-badge--sm fr-badge--warning fr-badge--no-icon",
+		label: "Non conforme",
+	},
+	not_applicable: {
+		className: "fr-badge fr-badge--sm fr-badge--no-icon",
+		label: "Non applicable",
+	},
+};
+
+export function ComplianceBadge({
+	verdict,
+}: {
+	verdict: RepresentationComplianceVerdict;
+}) {
+	const { className, label } = BADGE_BY_VERDICT[verdict];
+	return <p className={className}>{label}</p>;
+}

--- a/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
@@ -29,7 +29,10 @@ export function complementPercentage(raw: string): string | undefined {
 }
 
 export function isPercentageInput(raw: string): boolean {
-	return PERCENTAGE_INPUT_PATTERN.test(raw);
+	if (!PERCENTAGE_INPUT_PATTERN.test(raw)) return false;
+	if (raw === "") return true;
+	const value = Number(raw.replace(",", "."));
+	return Number.isFinite(value) && value <= 100;
 }
 
 export function PercentagePairFields({

--- a/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
@@ -112,7 +112,6 @@ export function PercentagePairFields({
 							</label>
 							<input
 								aria-describedby={describedBy || undefined}
-								aria-disabled={readOnly || undefined}
 								aria-invalid={error ? true : undefined}
 								className="fr-input"
 								id={womenId}
@@ -132,7 +131,6 @@ export function PercentagePairFields({
 							</label>
 							<input
 								aria-describedby={describedBy || undefined}
-								aria-disabled={readOnly || undefined}
 								aria-invalid={error ? true : undefined}
 								className="fr-input"
 								id={menId}

--- a/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useId, useState } from "react";
+
+const PERCENTAGE_INPUT_PATTERN = /^\d{0,3}([.,]\d?)?$/;
+
+export type PercentagePairValues = {
+	womenPercent: string;
+	menPercent: string;
+};
+
+type PercentagePairFieldsProps = {
+	legend: string;
+	values: PercentagePairValues;
+	onChange: (values: PercentagePairValues) => void;
+	hint?: string;
+	womenLabel?: string;
+	menLabel?: string;
+	error?: string;
+	disabled?: boolean;
+};
+
+export function complementPercentage(raw: string): string | undefined {
+	const normalized = raw.replace(",", ".");
+	if (normalized === "" || normalized.endsWith(".")) return undefined;
+	const value = Number(normalized);
+	if (!Number.isFinite(value) || value < 0 || value > 100) return undefined;
+	return String(Math.round((100 - value) * 10) / 10);
+}
+
+export function isPercentageInput(raw: string): boolean {
+	return PERCENTAGE_INPUT_PATTERN.test(raw);
+}
+
+export function PercentagePairFields({
+	legend,
+	values,
+	onChange,
+	hint = "La saisie d'un pourcentage calcule automatiquement l'autre.",
+	womenLabel = "Femmes",
+	menLabel = "Hommes",
+	error,
+	disabled = false,
+}: PercentagePairFieldsProps) {
+	const baseId = useId();
+	const womenId = `${baseId}-women`;
+	const menId = `${baseId}-men`;
+	const hintId = `${baseId}-hint`;
+	const errorId = `${baseId}-error`;
+	const [editedFields, setEditedFields] = useState({
+		women: false,
+		men: false,
+	});
+
+	function handleWomenChange(raw: string) {
+		if (!isPercentageInput(raw)) return;
+		setEditedFields((previous) => ({ ...previous, women: true }));
+		const complement = editedFields.men ? undefined : complementPercentage(raw);
+		onChange({
+			womenPercent: raw,
+			menPercent: complement ?? values.menPercent,
+		});
+	}
+
+	function handleMenChange(raw: string) {
+		if (!isPercentageInput(raw)) return;
+		setEditedFields((previous) => ({ ...previous, men: true }));
+		const complement = editedFields.women
+			? undefined
+			: complementPercentage(raw);
+		onChange({
+			womenPercent: complement ?? values.womenPercent,
+			menPercent: raw,
+		});
+	}
+
+	const describedBy = [hint ? hintId : null, error ? errorId : null]
+		.filter(Boolean)
+		.join(" ");
+
+	return (
+		<fieldset
+			className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`}
+			disabled={disabled}
+		>
+			<legend className="fr-fieldset__legend fr-text--regular">
+				{legend}
+				{hint ? (
+					<span className="fr-hint-text" id={hintId}>
+						{hint}
+					</span>
+				) : null}
+			</legend>
+			<div className="fr-fieldset__content">
+				<div className="fr-grid-row fr-grid-row--gutters">
+					<div className="fr-col-12 fr-col-sm-4">
+						<div className="fr-input-group">
+							<label className="fr-label" htmlFor={womenId}>
+								{womenLabel}
+								<span className="fr-hint-text">En pourcentage</span>
+							</label>
+							<input
+								aria-describedby={describedBy || undefined}
+								aria-invalid={error ? true : undefined}
+								className="fr-input"
+								id={womenId}
+								inputMode="decimal"
+								onChange={(event) => handleWomenChange(event.target.value)}
+								type="text"
+								value={values.womenPercent}
+							/>
+						</div>
+					</div>
+					<div className="fr-col-12 fr-col-sm-4">
+						<div className="fr-input-group">
+							<label className="fr-label" htmlFor={menId}>
+								{menLabel}
+								<span className="fr-hint-text">En pourcentage</span>
+							</label>
+							<input
+								aria-describedby={describedBy || undefined}
+								aria-invalid={error ? true : undefined}
+								className="fr-input"
+								id={menId}
+								inputMode="decimal"
+								onChange={(event) => handleMenChange(event.target.value)}
+								type="text"
+								value={values.menPercent}
+							/>
+						</div>
+					</div>
+				</div>
+			</div>
+			{error ? (
+				<div aria-live="polite" className="fr-messages-group" id={errorId}>
+					<p className="fr-message fr-message--error">{error}</p>
+				</div>
+			) : null}
+		</fieldset>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/PercentagePairFields.tsx
@@ -17,7 +17,7 @@ type PercentagePairFieldsProps = {
 	womenLabel?: string;
 	menLabel?: string;
 	error?: string;
-	disabled?: boolean;
+	readOnly?: boolean;
 };
 
 export function complementPercentage(raw: string): string | undefined {
@@ -43,7 +43,7 @@ export function PercentagePairFields({
 	womenLabel = "Femmes",
 	menLabel = "Hommes",
 	error,
-	disabled = false,
+	readOnly = false,
 }: PercentagePairFieldsProps) {
 	const baseId = useId();
 	const womenId = `${baseId}-women`;
@@ -54,11 +54,17 @@ export function PercentagePairFields({
 		women: false,
 		men: false,
 	});
+	const [announcement, setAnnouncement] = useState("");
 
 	function handleWomenChange(raw: string) {
 		if (!isPercentageInput(raw)) return;
 		setEditedFields((previous) => ({ ...previous, women: true }));
 		const complement = editedFields.men ? undefined : complementPercentage(raw);
+		setAnnouncement(
+			complement === undefined
+				? ""
+				: `${menLabel} : ${complement} % renseigné automatiquement.`,
+		);
 		onChange({
 			womenPercent: raw,
 			menPercent: complement ?? values.menPercent,
@@ -71,6 +77,11 @@ export function PercentagePairFields({
 		const complement = editedFields.women
 			? undefined
 			: complementPercentage(raw);
+		setAnnouncement(
+			complement === undefined
+				? ""
+				: `${womenLabel} : ${complement} % renseigné automatiquement.`,
+		);
 		onChange({
 			womenPercent: complement ?? values.womenPercent,
 			menPercent: raw,
@@ -82,10 +93,7 @@ export function PercentagePairFields({
 		.join(" ");
 
 	return (
-		<fieldset
-			className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`}
-			disabled={disabled}
-		>
+		<fieldset className={`fr-fieldset ${error ? "fr-fieldset--error" : ""}`}>
 			<legend className="fr-fieldset__legend fr-text--regular">
 				{legend}
 				{hint ? (
@@ -104,11 +112,13 @@ export function PercentagePairFields({
 							</label>
 							<input
 								aria-describedby={describedBy || undefined}
+								aria-disabled={readOnly || undefined}
 								aria-invalid={error ? true : undefined}
 								className="fr-input"
 								id={womenId}
 								inputMode="decimal"
 								onChange={(event) => handleWomenChange(event.target.value)}
+								readOnly={readOnly}
 								type="text"
 								value={values.womenPercent}
 							/>
@@ -122,11 +132,13 @@ export function PercentagePairFields({
 							</label>
 							<input
 								aria-describedby={describedBy || undefined}
+								aria-disabled={readOnly || undefined}
 								aria-invalid={error ? true : undefined}
 								className="fr-input"
 								id={menId}
 								inputMode="decimal"
 								onChange={(event) => handleMenChange(event.target.value)}
+								readOnly={readOnly}
 								type="text"
 								value={values.menPercent}
 							/>
@@ -134,11 +146,17 @@ export function PercentagePairFields({
 					</div>
 				</div>
 			</div>
-			{error ? (
-				<div aria-live="polite" className="fr-messages-group" id={errorId}>
-					<p className="fr-message fr-message--error">{error}</p>
-				</div>
-			) : null}
+			<div
+				aria-atomic="true"
+				aria-live="polite"
+				className="fr-messages-group"
+				id={errorId}
+			>
+				{error ? <p className="fr-message fr-message--error">{error}</p> : null}
+			</div>
+			<p aria-atomic="true" aria-live="polite" className="fr-sr-only">
+				{announcement}
+			</p>
 		</fieldset>
 	);
 }

--- a/packages/app/src/modules/declaration-representation/shared/__tests__/ComplianceBadge.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/__tests__/ComplianceBadge.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { RepresentationComplianceVerdict } from "~/modules/domain";
+import { ComplianceBadge } from "../ComplianceBadge";
+
+const CASES: Array<[RepresentationComplianceVerdict, string, string]> = [
+	["compliant", "Conforme", "fr-badge--info"],
+	["non_compliant", "Non conforme", "fr-badge--warning"],
+	["not_applicable", "Non applicable", ""],
+];
+
+describe("ComplianceBadge", () => {
+	it.each(
+		CASES,
+	)("renders the %s verdict as « %s »", (verdict, label, modifier) => {
+		render(<ComplianceBadge verdict={verdict} />);
+
+		const badge = screen.getByText(label);
+		expect(badge).toHaveClass("fr-badge", "fr-badge--sm");
+		if (modifier) expect(badge).toHaveClass(modifier);
+	});
+
+	it("keeps the not_applicable badge neutral", () => {
+		render(<ComplianceBadge verdict="not_applicable" />);
+
+		const badge = screen.getByText("Non applicable");
+		expect(badge).not.toHaveClass("fr-badge--info");
+		expect(badge).not.toHaveClass("fr-badge--warning");
+	});
+});

--- a/packages/app/src/modules/declaration-representation/shared/__tests__/PercentagePairFields.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/__tests__/PercentagePairFields.test.tsx
@@ -14,7 +14,7 @@ const LEGEND = "Écarts de représentation parmi les cadres dirigeants";
 
 type HarnessProps = {
 	error?: string;
-	disabled?: boolean;
+	readOnly?: boolean;
 	hint?: string;
 	womenLabel?: string;
 	menLabel?: string;
@@ -40,6 +40,13 @@ function fields() {
 	return {
 		women: screen.getByLabelText(/Femmes/) as HTMLInputElement,
 		men: screen.getByLabelText(/Hommes/) as HTMLInputElement,
+	};
+}
+
+function liveRegions() {
+	return {
+		messages: document.querySelector(".fr-messages-group") as HTMLElement,
+		announcement: document.querySelector(".fr-sr-only") as HTMLElement,
 	};
 }
 
@@ -122,14 +129,30 @@ describe("PercentagePairFields — input filtering", () => {
 		expect(men).toHaveValue("0");
 	});
 
-	it("leaves the other field untouched while the entry is out of the 0–100 range", async () => {
+	it("stops the entry at the last value within the 0–100 range", async () => {
 		render(<Harness />);
 		const { women, men } = fields();
 
 		await userEvent.type(women, "150");
 
-		expect(women).toHaveValue("150");
+		expect(women).toHaveValue("15");
 		expect(men).toHaveValue("85");
+	});
+
+	it("accepts 100 but refuses any entry above the ceiling", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "100");
+		expect(men).toHaveValue("0");
+
+		await userEvent.clear(women);
+		await userEvent.type(women, "101");
+		expect(women).toHaveValue("10");
+
+		await userEvent.clear(women);
+		await userEvent.type(women, "100.5");
+		expect(women).toHaveValue("100.");
 	});
 
 	it("refuses an invalid entry in the men field too", async () => {
@@ -198,6 +221,7 @@ describe("PercentagePairFields — accessibility and states", () => {
 		expect(women).not.toHaveAttribute("aria-describedby");
 		expect(men).not.toHaveAttribute("aria-describedby");
 		expect(women).not.toHaveAttribute("aria-invalid");
+		expect(women).not.toHaveAttribute("aria-disabled");
 	});
 
 	it("wires the error message to both inputs", () => {
@@ -216,12 +240,74 @@ describe("PercentagePairFields — accessibility and states", () => {
 		);
 	});
 
-	it("disables both inputs through the fieldset when read-only", () => {
-		render(<Harness disabled />);
+	it("marks both inputs read-only instead of disabling the fieldset", async () => {
+		render(<Harness readOnly />);
 		const { women, men } = fields();
 
-		expect(women).toBeDisabled();
-		expect(men).toBeDisabled();
+		expect(women).toHaveAttribute("readonly");
+		expect(men).toHaveAttribute("readonly");
+		expect(women).toHaveAttribute("aria-disabled", "true");
+		expect(men).toHaveAttribute("aria-disabled", "true");
+		expect(women).not.toBeDisabled();
+		expect(men).not.toBeDisabled();
+
+		await userEvent.type(women, "35");
+
+		expect(women).toHaveValue("");
+	});
+});
+
+describe("PercentagePairFields — live regions", () => {
+	it("mounts both live regions empty so they stay observed", () => {
+		render(<Harness />);
+		const { messages, announcement } = liveRegions();
+
+		expect(messages).toHaveAttribute("aria-live", "polite");
+		expect(messages).toHaveAttribute("aria-atomic", "true");
+		expect(messages.textContent).toBe("");
+		expect(announcement).toHaveAttribute("aria-live", "polite");
+		expect(announcement.textContent).toBe("");
+	});
+
+	it("hosts the error message inside the already mounted region", () => {
+		render(
+			<Harness error="La somme des pourcentages doit être égale à 100 %." />,
+		);
+
+		expect(liveRegions().messages).toHaveTextContent(
+			"La somme des pourcentages doit être égale à 100 %.",
+		);
+	});
+
+	it("announces the automatically filled counterpart", async () => {
+		render(<Harness />);
+		const { women } = fields();
+
+		await userEvent.type(women, "35");
+
+		expect(liveRegions().announcement).toHaveTextContent(
+			"Hommes : 65 % renseigné automatiquement.",
+		);
+	});
+
+	it("names the counterpart with its custom label", async () => {
+		render(<Harness menLabel="Hommes cadres" womenLabel="Femmes cadres" />);
+
+		await userEvent.type(screen.getByLabelText(/Hommes cadres/), "40");
+
+		expect(liveRegions().announcement).toHaveTextContent(
+			"Femmes cadres : 60 % renseigné automatiquement.",
+		);
+	});
+
+	it("empties the announcement when no counterpart is computed", async () => {
+		render(<Harness />);
+		const { women } = fields();
+
+		await userEvent.type(women, "35");
+		await userEvent.type(women, ".");
+
+		expect(liveRegions().announcement.textContent).toBe("");
 	});
 });
 
@@ -261,7 +347,16 @@ describe("isPercentageInput", () => {
 		expect(isPercentageInput(raw)).toBe(true);
 	});
 
-	it.each(["35.55", "1000", "-5", "abc", "3 5"])("rejects %s", (raw) => {
+	it.each([
+		"35.55",
+		"1000",
+		"101",
+		"100.5",
+		".",
+		"-5",
+		"abc",
+		"3 5",
+	])("rejects %s", (raw) => {
 		expect(isPercentageInput(raw)).toBe(false);
 	});
 });

--- a/packages/app/src/modules/declaration-representation/shared/__tests__/PercentagePairFields.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/__tests__/PercentagePairFields.test.tsx
@@ -1,0 +1,267 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { PercentagePairValues } from "../PercentagePairFields";
+import {
+	complementPercentage,
+	isPercentageInput,
+	PercentagePairFields,
+} from "../PercentagePairFields";
+
+const LEGEND = "Écarts de représentation parmi les cadres dirigeants";
+
+type HarnessProps = {
+	error?: string;
+	disabled?: boolean;
+	hint?: string;
+	womenLabel?: string;
+	menLabel?: string;
+};
+
+function Harness(props: HarnessProps = {}) {
+	const [values, setValues] = useState<PercentagePairValues>({
+		womenPercent: "",
+		menPercent: "",
+	});
+
+	return (
+		<PercentagePairFields
+			{...props}
+			legend={LEGEND}
+			onChange={setValues}
+			values={values}
+		/>
+	);
+}
+
+function fields() {
+	return {
+		women: screen.getByLabelText(/Femmes/) as HTMLInputElement,
+		men: screen.getByLabelText(/Hommes/) as HTMLInputElement,
+	};
+}
+
+describe("PercentagePairFields — auto-complement (S5)", () => {
+	it("fills the men field with 100 − x when the women percentage is typed", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "35");
+
+		expect(women).toHaveValue("35");
+		expect(men).toHaveValue("65");
+	});
+
+	it("fills the women field when the men percentage is typed first", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(men, "40");
+
+		expect(men).toHaveValue("40");
+		expect(women).toHaveValue("60");
+	});
+
+	it("complements a one-decimal percentage typed with a comma", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "35,5");
+
+		expect(women).toHaveValue("35,5");
+		expect(men).toHaveValue("64.5");
+	});
+});
+
+describe("PercentagePairFields — manual override (S6)", () => {
+	it("keeps the auto-filled field editable and stops recomputing the other one", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "35");
+		await userEvent.clear(men);
+		await userEvent.type(men, "70");
+
+		expect(men).toHaveValue("70");
+		expect(women).toHaveValue("35");
+	});
+
+	it("no longer complements the men field once it has been edited by hand", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(men, "70");
+		await userEvent.clear(women);
+		await userEvent.type(women, "10");
+
+		expect(women).toHaveValue("10");
+		expect(men).toHaveValue("70");
+	});
+});
+
+describe("PercentagePairFields — input filtering", () => {
+	it("refuses a second decimal digit", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "12.34");
+
+		expect(women).toHaveValue("12.3");
+		expect(men).toHaveValue("87.7");
+	});
+
+	it("refuses a fourth integer digit", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "1000");
+
+		expect(women).toHaveValue("100");
+		expect(men).toHaveValue("0");
+	});
+
+	it("leaves the other field untouched while the entry is out of the 0–100 range", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "150");
+
+		expect(women).toHaveValue("150");
+		expect(men).toHaveValue("85");
+	});
+
+	it("refuses an invalid entry in the men field too", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(men, "40");
+		await userEvent.type(men, "abc");
+
+		expect(men).toHaveValue("40");
+		expect(women).toHaveValue("60");
+	});
+
+	it("leaves the other field untouched on an incomplete or empty entry", async () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		await userEvent.type(women, "20");
+		await userEvent.type(women, ".");
+		expect(men).toHaveValue("80");
+
+		await userEvent.clear(women);
+		expect(women).toHaveValue("");
+		expect(men).toHaveValue("80");
+	});
+});
+
+describe("PercentagePairFields — accessibility and states", () => {
+	it("associates each label with its input and exposes the hint", () => {
+		render(<Harness />);
+		const { women, men } = fields();
+
+		expect(women.id).not.toBe("");
+		expect(men.id).not.toBe("");
+		expect(women.id).not.toBe(men.id);
+		expect(screen.getByText(LEGEND).tagName).toBe("LEGEND");
+
+		const hint = screen.getByText(
+			"La saisie d'un pourcentage calcule automatiquement l'autre.",
+		);
+		expect(women).toHaveAttribute("aria-describedby", hint.id);
+		expect(men).toHaveAttribute("aria-describedby", hint.id);
+	});
+
+	it("supports custom labels and hint", () => {
+		render(
+			<Harness
+				hint="Le total doit atteindre 100 %."
+				menLabel="Hommes cadres"
+				womenLabel="Femmes cadres"
+			/>,
+		);
+
+		const hint = screen.getByText("Le total doit atteindre 100 %.");
+		expect(screen.getByLabelText(/Femmes cadres/)).toHaveAttribute(
+			"aria-describedby",
+			hint.id,
+		);
+		expect(screen.getByLabelText(/Hommes cadres/)).toBeInTheDocument();
+	});
+
+	it("describes nothing when there is neither hint nor error", () => {
+		render(<Harness hint="" />);
+		const { women, men } = fields();
+
+		expect(women).not.toHaveAttribute("aria-describedby");
+		expect(men).not.toHaveAttribute("aria-describedby");
+		expect(women).not.toHaveAttribute("aria-invalid");
+	});
+
+	it("wires the error message to both inputs", () => {
+		render(
+			<Harness error="La somme des pourcentages doit être égale à 100 %." />,
+		);
+		const { women, men } = fields();
+
+		const message = screen.getByText(
+			"La somme des pourcentages doit être égale à 100 %.",
+		);
+		expect(women).toHaveAttribute("aria-invalid", "true");
+		expect(men).toHaveAttribute("aria-invalid", "true");
+		expect(women.getAttribute("aria-describedby")).toContain(
+			message.parentElement?.id,
+		);
+	});
+
+	it("disables both inputs through the fieldset when read-only", () => {
+		render(<Harness disabled />);
+		const { women, men } = fields();
+
+		expect(women).toBeDisabled();
+		expect(men).toBeDisabled();
+	});
+});
+
+describe("complementPercentage", () => {
+	it.each([
+		["35", "65"],
+		["35,5", "64.5"],
+		["33.3", "66.7"],
+		["0", "100"],
+		["100", "0"],
+	])("complements %s to %s", (raw, expected) => {
+		expect(complementPercentage(raw)).toBe(expected);
+	});
+
+	it.each([
+		"",
+		"35.",
+		"35,",
+		"150",
+		"-5",
+		"abc",
+	])("returns undefined for %s", (raw) => {
+		expect(complementPercentage(raw)).toBeUndefined();
+	});
+});
+
+describe("isPercentageInput", () => {
+	it.each([
+		"",
+		"3",
+		"35",
+		"100",
+		"35.",
+		"35,5",
+		"35.5",
+	])("accepts %s", (raw) => {
+		expect(isPercentageInput(raw)).toBe(true);
+	});
+
+	it.each(["35.55", "1000", "-5", "abc", "3 5"])("rejects %s", (raw) => {
+		expect(isPercentageInput(raw)).toBe(false);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/shared/__tests__/PercentagePairFields.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/__tests__/PercentagePairFields.test.tsx
@@ -246,8 +246,8 @@ describe("PercentagePairFields — accessibility and states", () => {
 
 		expect(women).toHaveAttribute("readonly");
 		expect(men).toHaveAttribute("readonly");
-		expect(women).toHaveAttribute("aria-disabled", "true");
-		expect(men).toHaveAttribute("aria-disabled", "true");
+		expect(women).not.toHaveAttribute("aria-disabled");
+		expect(men).not.toHaveAttribute("aria-disabled");
 		expect(women).not.toBeDisabled();
 		expect(men).not.toBeDisabled();
 

--- a/packages/app/src/modules/declaration-representation/shared/draft/DraftContext.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/draft/DraftContext.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+import type { RepresentationDraft } from "../../types";
+
+export type RepresentationDraftContextValue = {
+	year: number;
+	step: number;
+	draft: RepresentationDraft;
+	setDraftValues: (values: Partial<RepresentationDraft>) => void;
+	isSaving: boolean;
+	isPendingSave: boolean;
+	isReadOnly: boolean;
+};
+
+const RepresentationDraftContext =
+	createContext<RepresentationDraftContextValue | null>(null);
+
+export function RepresentationDraftProvider({
+	value,
+	children,
+}: {
+	value: RepresentationDraftContextValue;
+	children: React.ReactNode;
+}) {
+	return (
+		<RepresentationDraftContext.Provider value={value}>
+			{children}
+		</RepresentationDraftContext.Provider>
+	);
+}
+
+export function useRepresentationDraftContext(): RepresentationDraftContextValue {
+	const context = useContext(RepresentationDraftContext);
+	if (context === null) {
+		throw new Error(
+			"useRepresentationDraftContext doit être utilisé dans un RepresentationDraftProvider.",
+		);
+	}
+	return context;
+}

--- a/packages/app/src/modules/declaration-representation/shared/draft/DraftContext.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/draft/DraftContext.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext } from "react";
 
-import type { RepresentationDraft } from "../../types";
+import type { RepresentationDraft } from "~/modules/declaration-representation/types";
 
 export type RepresentationDraftContextValue = {
 	year: number;

--- a/packages/app/src/modules/declaration-representation/shared/draft/__tests__/DraftContext.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/draft/__tests__/DraftContext.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { RepresentationDraftContextValue } from "../DraftContext";
+import {
+	RepresentationDraftProvider,
+	useRepresentationDraftContext,
+} from "../DraftContext";
+
+const value: RepresentationDraftContextValue = {
+	year: 2025,
+	step: 2,
+	draft: { currentStep: 2, executiveWomenPercent: 60 },
+	setDraftValues: vi.fn(),
+	isSaving: false,
+	isPendingSave: true,
+	isReadOnly: true,
+};
+
+function Consumer() {
+	const context = useRepresentationDraftContext();
+	return (
+		<span data-testid="probe">
+			{`${context.year}|${context.step}|${context.draft.executiveWomenPercent}|${context.isPendingSave}|${context.isReadOnly}`}
+		</span>
+	);
+}
+
+describe("RepresentationDraftProvider", () => {
+	it("exposes the draft state to the step components", () => {
+		render(
+			<RepresentationDraftProvider value={value}>
+				<Consumer />
+			</RepresentationDraftProvider>,
+		);
+
+		expect(screen.getByTestId("probe")).toHaveTextContent(
+			"2025|2|60|true|true",
+		);
+	});
+
+	it("fails loudly when a step is rendered outside the provider", () => {
+		const consoleError = vi
+			.spyOn(console, "error")
+			.mockImplementation(() => undefined);
+
+		expect(() => render(<Consumer />)).toThrow(
+			"useRepresentationDraftContext doit être utilisé dans un RepresentationDraftProvider.",
+		);
+
+		consoleError.mockRestore();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/shared/draft/__tests__/useRepresentationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/draft/__tests__/useRepresentationDraft.test.tsx
@@ -21,7 +21,7 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
-import type { RepresentationDraft } from "../../../types";
+import type { RepresentationDraft } from "~/modules/declaration-representation/types";
 import { useRepresentationDraft } from "../useRepresentationDraft";
 
 const YEAR = 2025;

--- a/packages/app/src/modules/declaration-representation/shared/draft/__tests__/useRepresentationDraft.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/draft/__tests__/useRepresentationDraft.test.tsx
@@ -1,0 +1,206 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mutate, mutateAsync, mutationState } = vi.hoisted(() => ({
+	mutate: vi.fn(),
+	mutateAsync: vi.fn(),
+	mutationState: { isPending: false },
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		representationDeclaration: {
+			saveDraft: {
+				useMutation: () => ({
+					mutate,
+					mutateAsync,
+					isPending: mutationState.isPending,
+				}),
+			},
+		},
+	},
+}));
+
+import type { RepresentationDraft } from "../../../types";
+import { useRepresentationDraft } from "../useRepresentationDraft";
+
+const YEAR = 2025;
+const DEBOUNCE_MS = 600;
+const VISUAL_DELAY_MS = 400;
+
+function renderDraft({
+	step = 2,
+	initialDraft = { currentStep: 2 } as RepresentationDraft,
+	enabled = true,
+} = {}) {
+	return renderHook(() =>
+		useRepresentationDraft({ year: YEAR, step, initialDraft, enabled }),
+	);
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	mutate.mockReset();
+	mutateAsync.mockReset().mockResolvedValue(undefined);
+	mutationState.isPending = false;
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("useRepresentationDraft — autosave", () => {
+	it("groups successive edits into a single debounced save", () => {
+		const { result } = renderDraft();
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+		act(() => result.current.setDraftValues({ executiveMenPercent: 40 }));
+		act(() => vi.advanceTimersByTime(DEBOUNCE_MS - 1));
+
+		expect(mutate).not.toHaveBeenCalled();
+
+		act(() => vi.advanceTimersByTime(1));
+
+		expect(mutate).toHaveBeenCalledTimes(1);
+		expect(mutate).toHaveBeenCalledWith({
+			year: YEAR,
+			currentStep: 2,
+			draft: {
+				currentStep: 2,
+				executiveWomenPercent: 60,
+				executiveMenPercent: 40,
+			},
+		});
+	});
+
+	it("flags a pending save after the visual delay and clears it once flushed", () => {
+		const { result } = renderDraft();
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+		expect(result.current.isPendingSave).toBe(false);
+
+		act(() => vi.advanceTimersByTime(VISUAL_DELAY_MS));
+		expect(result.current.isPendingSave).toBe(true);
+
+		act(() => vi.advanceTimersByTime(DEBOUNCE_MS - VISUAL_DELAY_MS));
+		expect(result.current.isPendingSave).toBe(false);
+	});
+
+	it("advances the stored progress to the step being filled", () => {
+		const { result } = renderDraft({
+			step: 3,
+			initialDraft: { currentStep: 1 },
+		});
+
+		act(() => result.current.setDraftValues({ hasManagementBody: true }));
+
+		expect(result.current.draft.currentStep).toBe(3);
+	});
+
+	it("never rewinds the stored progress when an earlier step is edited", () => {
+		const { result } = renderDraft({
+			step: 2,
+			initialDraft: { currentStep: 4 },
+		});
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+
+		expect(result.current.draft.currentStep).toBe(4);
+	});
+
+	it("saves the pending draft when the step unmounts before the debounce fires", () => {
+		const { result, unmount } = renderDraft();
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+		act(() => unmount());
+
+		expect(mutate).toHaveBeenCalledTimes(1);
+		expect(mutate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				draft: { currentStep: 2, executiveWomenPercent: 60 },
+			}),
+		);
+	});
+
+	it("does not save twice when the debounce already flushed before unmount", () => {
+		const { result, unmount } = renderDraft();
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+		act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+		act(() => unmount());
+
+		expect(mutate).toHaveBeenCalledTimes(1);
+	});
+
+	it("exposes the mutation pending state as isSaving", () => {
+		mutationState.isPending = true;
+		const { result } = renderDraft();
+
+		expect(result.current.isSaving).toBe(true);
+	});
+});
+
+describe("useRepresentationDraft — closed campaign (S23)", () => {
+	it("never fires a mutation when autosave is disabled", () => {
+		const { result, unmount } = renderDraft({ enabled: false });
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+		act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+
+		expect(mutate).not.toHaveBeenCalled();
+		expect(result.current.isPendingSave).toBe(false);
+		expect(result.current.draft.executiveWomenPercent).toBe(60);
+
+		act(() => unmount());
+		expect(mutate).not.toHaveBeenCalled();
+	});
+
+	it("does not persist progress when autosave is disabled", async () => {
+		const { result } = renderDraft({ enabled: false });
+
+		await act(async () => {
+			await result.current.saveProgress(3);
+		});
+
+		expect(mutateAsync).not.toHaveBeenCalled();
+		expect(result.current.draft.currentStep).toBe(3);
+	});
+});
+
+describe("useRepresentationDraft — saveProgress", () => {
+	it("persists the draft with the requested step", async () => {
+		const { result } = renderDraft();
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+		await act(async () => {
+			await result.current.saveProgress(3);
+		});
+
+		expect(mutateAsync).toHaveBeenCalledWith({
+			year: YEAR,
+			currentStep: 3,
+			draft: { currentStep: 3, executiveWomenPercent: 60 },
+		});
+		expect(result.current.draft.currentStep).toBe(3);
+	});
+
+	it("cancels the pending debounced save it supersedes", async () => {
+		const { result } = renderDraft();
+
+		act(() => result.current.setDraftValues({ executiveWomenPercent: 60 }));
+		await act(async () => {
+			await result.current.saveProgress(3);
+		});
+		act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+
+		expect(mutate).not.toHaveBeenCalled();
+		expect(result.current.isPendingSave).toBe(false);
+	});
+
+	it("propagates a failed save to the caller", async () => {
+		mutateAsync.mockRejectedValueOnce(new Error("network"));
+		const { result } = renderDraft();
+
+		await expect(result.current.saveProgress(3)).rejects.toThrow("network");
+	});
+});

--- a/packages/app/src/modules/declaration-representation/shared/draft/useRepresentationDraft.ts
+++ b/packages/app/src/modules/declaration-representation/shared/draft/useRepresentationDraft.ts
@@ -1,9 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-
+import type { RepresentationDraft } from "~/modules/declaration-representation/types";
 import { api } from "~/trpc/react";
-import type { RepresentationDraft } from "../../types";
 
 const DEBOUNCE_MS = 600;
 const VISUAL_DELAY_MS = 400;

--- a/packages/app/src/modules/declaration-representation/shared/draft/useRepresentationDraft.ts
+++ b/packages/app/src/modules/declaration-representation/shared/draft/useRepresentationDraft.ts
@@ -1,0 +1,139 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { api } from "~/trpc/react";
+import type { RepresentationDraft } from "../../types";
+
+const DEBOUNCE_MS = 600;
+const VISUAL_DELAY_MS = 400;
+
+type UseRepresentationDraftOptions = {
+	year: number;
+	step: number;
+	initialDraft: RepresentationDraft;
+	enabled?: boolean;
+};
+
+type UseRepresentationDraftResult = {
+	draft: RepresentationDraft;
+	setDraftValues: (values: Partial<RepresentationDraft>) => void;
+	saveProgress: (currentStep: number) => Promise<void>;
+	isSaving: boolean;
+	isPendingSave: boolean;
+};
+
+export function useRepresentationDraft({
+	year,
+	step,
+	initialDraft,
+	enabled = true,
+}: UseRepresentationDraftOptions): UseRepresentationDraftResult {
+	const [draft, setDraft] = useState<RepresentationDraft>(initialDraft);
+	const [isPendingSave, setIsPendingSave] = useState(false);
+
+	const mutation = api.representationDeclaration.saveDraft.useMutation();
+
+	const contextRef = useRef({
+		year,
+		enabled,
+		mutate: mutation.mutate,
+		mutateAsync: mutation.mutateAsync,
+	});
+	contextRef.current = {
+		year,
+		enabled,
+		mutate: mutation.mutate,
+		mutateAsync: mutation.mutateAsync,
+	};
+
+	const draftRef = useRef(draft);
+	draftRef.current = draft;
+
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const visualTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const pendingRef = useRef<RepresentationDraft | null>(null);
+
+	const cancelTimers = useCallback(() => {
+		if (timerRef.current !== null) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+		if (visualTimerRef.current !== null) {
+			clearTimeout(visualTimerRef.current);
+			visualTimerRef.current = null;
+		}
+	}, []);
+
+	const flush = useCallback(() => {
+		cancelTimers();
+		setIsPendingSave(false);
+		const pending = pendingRef.current;
+		pendingRef.current = null;
+		if (pending === null || !contextRef.current.enabled) return;
+		contextRef.current.mutate({
+			year: contextRef.current.year,
+			draft: pending,
+			currentStep: pending.currentStep,
+		});
+	}, [cancelTimers]);
+
+	const flushRef = useRef(flush);
+	flushRef.current = flush;
+
+	useEffect(() => {
+		return () => {
+			flushRef.current();
+		};
+	}, []);
+
+	const setDraftValues = useCallback(
+		(values: Partial<RepresentationDraft>) => {
+			const next: RepresentationDraft = {
+				...draftRef.current,
+				...values,
+				currentStep: Math.max(draftRef.current.currentStep, step),
+			};
+			draftRef.current = next;
+			setDraft(next);
+			if (!contextRef.current.enabled) return;
+			pendingRef.current = next;
+			cancelTimers();
+			visualTimerRef.current = setTimeout(() => {
+				visualTimerRef.current = null;
+				setIsPendingSave(true);
+			}, VISUAL_DELAY_MS);
+			timerRef.current = setTimeout(() => {
+				timerRef.current = null;
+				flushRef.current();
+			}, DEBOUNCE_MS);
+		},
+		[cancelTimers, step],
+	);
+
+	const saveProgress = useCallback(
+		async (currentStep: number) => {
+			cancelTimers();
+			setIsPendingSave(false);
+			pendingRef.current = null;
+			const next: RepresentationDraft = { ...draftRef.current, currentStep };
+			draftRef.current = next;
+			setDraft(next);
+			if (!contextRef.current.enabled) return;
+			await contextRef.current.mutateAsync({
+				year: contextRef.current.year,
+				draft: next,
+				currentStep,
+			});
+		},
+		[cancelTimers],
+	);
+
+	return {
+		draft,
+		setDraftValues,
+		saveProgress,
+		isSaving: mutation.isPending,
+		isPendingSave,
+	};
+}

--- a/packages/app/src/modules/declaration-representation/steps/StepPlaceholder.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/StepPlaceholder.tsx
@@ -1,0 +1,9 @@
+export function StepPlaceholder() {
+	return (
+		<div className="fr-callout">
+			<p className="fr-callout__text">
+				Cette étape est en construction et sera disponible prochainement.
+			</p>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/steps/index.ts
+++ b/packages/app/src/modules/declaration-representation/steps/index.ts
@@ -1,0 +1,54 @@
+import type { ComponentType } from "react";
+
+import type { RepresentationStepSlug } from "../types";
+import {
+	REPRESENTATION_STEP_SLUGS,
+	TOTAL_REPRESENTATION_STEPS,
+} from "../types";
+import { StepPlaceholder } from "./StepPlaceholder";
+
+export type StepDefinition = {
+	slug: RepresentationStepSlug;
+	title: string;
+	Component: ComponentType;
+};
+
+export const REPRESENTATION_FUNNEL_ROOT = "/declaration-representation";
+
+const STEP_TITLES: Record<RepresentationStepSlug, string> = {
+	"periode-de-reference": "Période de référence",
+	"ecarts-cadres-dirigeants": "Écarts de représentation - Cadres dirigeants",
+	"ecarts-instances-dirigeantes":
+		"Écarts de représentation - Instances dirigeantes",
+	"informations-de-publication": "Informations de publication",
+	recapitulatif: "Récapitulatif",
+};
+
+export const REPRESENTATION_STEPS: StepDefinition[] =
+	REPRESENTATION_STEP_SLUGS.map((slug) => ({
+		slug,
+		title: STEP_TITLES[slug],
+		Component: StepPlaceholder,
+	}));
+
+export function isValidStep(step: number): boolean {
+	return (
+		Number.isInteger(step) && step >= 1 && step <= TOTAL_REPRESENTATION_STEPS
+	);
+}
+
+export function getStepDefinition(step: number): StepDefinition | undefined {
+	return isValidStep(step) ? REPRESENTATION_STEPS[step - 1] : undefined;
+}
+
+export function stepHref(step: number): string {
+	return `${REPRESENTATION_FUNNEL_ROOT}/etape/${step}`;
+}
+
+export function getPreviousStepHref(step: number): string {
+	return step <= 1 ? REPRESENTATION_FUNNEL_ROOT : stepHref(step - 1);
+}
+
+export function getNextStepHref(step: number): string | undefined {
+	return step >= TOTAL_REPRESENTATION_STEPS ? undefined : stepHref(step + 1);
+}

--- a/packages/app/src/modules/declaration-representation/steps/index.ts
+++ b/packages/app/src/modules/declaration-representation/steps/index.ts
@@ -37,6 +37,12 @@ export function isValidStep(step: number): boolean {
 	);
 }
 
+export function parseStepParam(raw: string): number | undefined {
+	if (!/^\d+$/.test(raw)) return undefined;
+	const step = Number.parseInt(raw, 10);
+	return isValidStep(step) ? step : undefined;
+}
+
 export function getStepDefinition(step: number): StepDefinition | undefined {
 	return isValidStep(step) ? REPRESENTATION_STEPS[step - 1] : undefined;
 }

--- a/packages/app/src/modules/declaration-representation/types.ts
+++ b/packages/app/src/modules/declaration-representation/types.ts
@@ -25,3 +25,15 @@ export type RepresentationDraft = z.infer<typeof representationDraftSchema>;
 export type SubmitRepresentationInput = z.infer<
 	ReturnType<typeof submitRepresentationSchema>
 >;
+
+export const TOTAL_REPRESENTATION_STEPS = 5;
+
+export const REPRESENTATION_STEP_SLUGS = [
+	"periode-de-reference",
+	"ecarts-cadres-dirigeants",
+	"ecarts-instances-dirigeantes",
+	"informations-de-publication",
+	"recapitulatif",
+] as const;
+
+export type RepresentationStepSlug = (typeof REPRESENTATION_STEP_SLUGS)[number];

--- a/packages/app/src/server/api/routers/representationDeclaration.ts
+++ b/packages/app/src/server/api/routers/representationDeclaration.ts
@@ -6,7 +6,7 @@ import {
 	saveRepresentationDraftSchema,
 	submitRepresentationDeclarationSchema,
 	submitRepresentationSchema,
-} from "~/modules/declaration-representation";
+} from "~/modules/declaration-representation/schemas";
 import {
 	deriveExecutivesNotComputableReason,
 	getRepresentationCampaignYear,

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
 				// Dev-only playground for visually testing the declaration process panel.
 				"src/app/test-panel/**",
 				"src/modules/my-space/PanelPlayground.tsx",
+				"src/modules/declaration-representation/RepresentationPlayground.tsx",
 			],
 			thresholds: {
 				statements: 75,


### PR DESCRIPTION
Closes #4157

Squelette du funnel `/declaration-representation` : layout, stepper 5 étapes, mécanique de brouillon, navigation, gardes de campagne, et les deux composants partagés consommés par les tickets d'étapes. Les étapes métier arrivent par tickets dédiés — ce ticket pose des placeholders.

## Ce que fait la PR

**Routes**
- `/declaration-representation` — racine hors stepper (écran d'assujettissement, contenu livré par un ticket dédié). Redirige vers l'étape courante si un brouillon existe, vers le récapitulatif si la campagne est close.
- `/declaration-representation/etape/[1-5]` — étapes du funnel. Le paramètre est parsé strictement (`^\d+$` puis borne 1–5, sinon `notFound()`).
- `layout.tsx` — authentification, SIREN de session, et frame commune (Company Overview + fil d'Ariane + conteneur), identique à `declaration-remuneration`. Le header/nav, le bloc Ressources et le footer viennent déjà du `PublicChrome` global.

**Stepper** — composant DSFR « Indicateur d'étape » (node `10546:135484`) : « Étape X sur 5 », titre exact de l'étape, barres de progression, mention « Étape suivante : … » masquée à la dernière étape.

| # | Étape |
|---|---|
| 1 | Période de référence |
| 2 | Écarts de représentation - Cadres dirigeants |
| 3 | Écarts de représentation - Instances dirigeantes |
| 4 | Informations de publication |
| 5 | Récapitulatif |

**Brouillon** — hydratation côté serveur via `representationDeclaration.get`, autosave débouncé (600 ms, flush au démontage) via `saveDraft`, exposés aux composants d'étape par un contexte `RepresentationDraftProvider`. Le registre `steps/index.ts` résout `StepDefinition { slug, title, Component }` et sert un placeholder « étape en construction » tant que l'étape n'est pas livrée.

**Gardes**
- **S21 — reprise à l'étape courante** : accéder à `/etape/n` avec `currentStep < n` renvoie vers l'étape courante ; entrer par la racine avec un brouillon existant mène directement à l'étape courante.
- **S23 — campagne close** : toute route du funnel redirige vers l'étape 5 en lecture seule, avec une bannière l'indiquant ; l'autosave et le bouton « Suivant » sont neutralisés côté client (le serveur refuse déjà les mutations, gate posée par #4167).

**Composants partagés**
- `ComplianceBadge` — les 3 verdicts de `computeRepresentationVerdict`, aucun calcul interne.
- `PercentagePairFields` — paire de pourcentages femmes/hommes (0–100, 1 décimale max). La saisie d'un champ auto-remplit l'autre à `100 − x`, **et le champ auto-rempli reste modifiable** : une fois retouché à la main il n'est plus recalculé, ce qui garde S5 **et** S6 jouables.

Les deux sont enregistrés dans le harness dev-only `/test-panel/representation` pour la gate visuelle sur composants isolés.

## Rendu

![Composants partagés rendus dans le harness /test-panel/representation](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-4157/4157-shared-components.png)

`ComplianceBadge` dans ses 3 états, et `PercentagePairFields` après la saisie de `35` côté femmes (S5 : le champ hommes affiche `65`).

## Écarts assumés

- **Couleurs du badge** : le body du ticket écrit « succès » / « erreur », mais les deux nodes Figma cités en référence (`10546:136002` et `10546:136042`) utilisent les tokens `$background-contrast-info` / `$text-default-info` et `$background-contrast-warning` / `$text-default-warning`, soit exactement `fr-badge--info` et `fr-badge--warning` (sans icône, taille `sm`). La maquette fait foi — c'est elle que re-mesure la gate visuelle.
- **Import du routeur tRPC** : `src/server/api/routers/representationDeclaration.ts` cible désormais `~/modules/declaration-representation/schemas` au lieu du barrel du module. Exposer `DeclarationLayout` dans ce barrel refermait un cycle `~/trpc/server → appRouter → routeur → barrel → layout → CompanyBanner → Header → ~/trpc/server`, qui rendait `createCaller` inaccessible (TDZ) et faisait échouer `saveDraft` en 500 — détecté par `functional-validator`, corrigé en `6ce2623cb`. C'est aussi la convention documentée dans `packages/app/CLAUDE.md` (« routers ← `~/modules/{domain}/schemas` »), et ce qui protège déjà `declaration-remuneration` (son mapping serveur n'importe le barrel qu'en `import type`).
- **`CompanyBanner`** gagne une ligne d'export dans le barrel de `declaration-remuneration` : le ticket demande explicitement de réutiliser les composants transverses existants plutôt que d'en dupliquer un.

## Test plan

- `pnpm test` — 4856 tests verts (422 fichiers), dont 150 ajoutés sur ce périmètre : gardes de route (S21 / S23, step invalide, hydratation du brouillon), navigation Précédent/Suivant, stepper, registre d'étapes, les 3 états du badge, l'auto-remplissage et son override manuel, le hook de brouillon (debounce, flush au démontage, inactif quand la campagne est close).
- `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` — verts.
- Gates : `structural-auditor`, `rgaa-auditor` (RGAA 4.1.2 / WCAG 2.2 AA via ultra11y), `security-auditor` (OWASP + RGS) — passés.
- Vérification manuelle sur le dev server : `/test-panel/representation` rend les deux composants, `/declaration-representation` redirige vers `/login` sans session.

## Hors périmètre

Aucune logique métier d'étape n'est implémentée ici (placeholders). Les écrans complets sont validés sur les tickets d'étapes ; les tests E2E sont livrés en fin de pipeline par `e2e-dev`.
