### PR TITLE
Représentation équilibrée — étape Écarts instances dirigeantes

### DIFF
--- a/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
@@ -10,6 +10,7 @@ import {
 	REPRESENTATION_STEPS,
 	stepHref,
 } from "../steps";
+import { Step3Members } from "../steps/Step3Members";
 import { StepPlaceholder } from "../steps/StepPlaceholder";
 import {
 	REPRESENTATION_STEP_SLUGS,
@@ -31,10 +32,16 @@ describe("REPRESENTATION_STEPS", () => {
 		]);
 	});
 
-	it("renders every step with the placeholder until the step tickets land", () => {
-		for (const step of REPRESENTATION_STEPS) {
-			expect(step.Component).toBe(StepPlaceholder);
-		}
+	it("wires each slug to its own step component, the placeholder covering the steps still to land", () => {
+		expect(
+			REPRESENTATION_STEPS.map((step) => [step.slug, step.Component]),
+		).toEqual([
+			["periode-de-reference", StepPlaceholder],
+			["ecarts-cadres-dirigeants", StepPlaceholder],
+			["ecarts-instances-dirigeantes", Step3Members],
+			["informations-de-publication", StepPlaceholder],
+			["recapitulatif", StepPlaceholder],
+		]);
 	});
 });
 

--- a/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useId, useState } from "react";
+
+import {
+	computeRepresentationVerdict,
+	getRepresentationCampaignYear,
+	REPRESENTATION_TARGET_INITIAL,
+	REPRESENTATION_TARGET_RAISED,
+	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
+} from "~/modules/domain";
+import { ComplianceBadge } from "../shared/ComplianceBadge";
+import { useRepresentationDraftContext } from "../shared/draft/DraftContext";
+import type { PercentagePairValues } from "../shared/PercentagePairFields";
+import { PercentagePairFields } from "../shared/PercentagePairFields";
+
+function toPercentString(value: number | undefined): string {
+	return value === undefined ? "" : String(value);
+}
+
+function parsePercent(raw: string): number | undefined {
+	if (raw === "") return undefined;
+	const parsed = Number(raw.replace(",", "."));
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function Step3Members() {
+	const { draft, setDraftValues, year, isReadOnly } =
+		useRepresentationDraftContext();
+	const baseId = useId();
+
+	const hasManagementBody = draft.hasManagementBody;
+	const campaignYear = getRepresentationCampaignYear(year);
+
+	// Kept as raw strings (not re-derived from the draft on every render): the
+	// draft only stores parsed numbers, which would silently drop an in-progress
+	// decimal separator (e.g. typing "33," would redisplay as "33").
+	const [percentageValues, setPercentageValues] =
+		useState<PercentagePairValues>(() => ({
+			womenPercent: toPercentString(draft.memberWomenPercent),
+			menPercent: toPercentString(draft.memberMenPercent),
+		}));
+
+	function handleSelect(next: boolean) {
+		if (next) {
+			setDraftValues({ hasManagementBody: true });
+			return;
+		}
+		setDraftValues({
+			hasManagementBody: false,
+			memberWomenPercent: undefined,
+			memberMenPercent: undefined,
+		});
+		setPercentageValues({ womenPercent: "", menPercent: "" });
+	}
+
+	function handlePercentageChange(values: PercentagePairValues) {
+		setPercentageValues(values);
+		setDraftValues({
+			memberWomenPercent: parsePercent(values.womenPercent),
+			memberMenPercent: parsePercent(values.menPercent),
+		});
+	}
+
+	const verdict =
+		hasManagementBody === true &&
+		draft.memberWomenPercent !== undefined &&
+		draft.memberMenPercent !== undefined
+			? computeRepresentationVerdict(
+					draft.memberWomenPercent,
+					draft.memberMenPercent,
+					campaignYear,
+				)
+			: undefined;
+
+	return (
+		<div className="fr-mb-4w">
+			<fieldset className="fr-fieldset">
+				<legend className="fr-fieldset__legend--regular fr-fieldset__legend">
+					Indiquez si votre entreprise a mis en place une ou plusieurs instances
+					dirigeantes pour déterminer si l'écart de représentation est
+					calculable.
+				</legend>
+				<p className="fr-mb-2w">Tous les champs sont obligatoires.</p>
+				<div className="fr-fieldset__element">
+					<div className="fr-radio-group fr-radio-rich">
+						<input
+							checked={hasManagementBody === false}
+							disabled={isReadOnly}
+							id={`${baseId}-none`}
+							name={`${baseId}-has-management-body`}
+							onChange={() => handleSelect(false)}
+							type="radio"
+						/>
+						<label className="fr-label" htmlFor={`${baseId}-none`}>
+							Aucune instance dirigeante
+							<span className="fr-hint-text">
+								L'écart ne peut pas être calculé.
+							</span>
+						</label>
+					</div>
+				</div>
+				<div className="fr-fieldset__element">
+					<div className="fr-radio-group fr-radio-rich">
+						<input
+							checked={hasManagementBody === true}
+							disabled={isReadOnly}
+							id={`${baseId}-some`}
+							name={`${baseId}-has-management-body`}
+							onChange={() => handleSelect(true)}
+							type="radio"
+						/>
+						<label className="fr-label" htmlFor={`${baseId}-some`}>
+							Au moins une instance dirigeante
+							<span className="fr-hint-text">L'écart doit être calculé.</span>
+						</label>
+					</div>
+				</div>
+			</fieldset>
+
+			{hasManagementBody === true ? (
+				<div className="fr-mt-4w">
+					<PercentagePairFields
+						legend="Indiquez le pourcentage de représentation des femmes et des hommes parmi les membres des instances dirigeantes."
+						onChange={handlePercentageChange}
+						readOnly={isReadOnly}
+						values={percentageValues}
+					/>
+					{verdict === "compliant" || verdict === "non_compliant" ? (
+						<div className="fr-mt-2w">
+							<ComplianceBadge verdict={verdict} />
+						</div>
+					) : null}
+				</div>
+			) : null}
+
+			<section className="fr-accordion fr-mt-4w">
+				<h3 className="fr-accordion__title">
+					<button
+						aria-controls={`${baseId}-definitions`}
+						aria-expanded="false"
+						className="fr-accordion__btn"
+						type="button"
+					>
+						Définitions membres des instances dirigeantes et seuils
+						réglementaires
+					</button>
+				</h3>
+				<div className="fr-collapse" id={`${baseId}-definitions`}>
+					<p>
+						Sont concernés les membres des instances dirigeantes telles que
+						définies à l'article L.23-12-1 du Code de commerce.
+					</p>
+					<p>
+						La loi impose un quota minimum de {REPRESENTATION_TARGET_INITIAL} %
+						de chaque sexe parmi les membres des instances dirigeantes, porté à{" "}
+						{REPRESENTATION_TARGET_RAISED} % à compter de la campagne{" "}
+						{REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR}.
+					</p>
+				</div>
+			</section>
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step3Members.tsx
@@ -2,9 +2,11 @@
 
 import { useId, useState } from "react";
 
+import type { RepresentationComplianceVerdict } from "~/modules/domain";
 import {
 	computeRepresentationVerdict,
 	getRepresentationCampaignYear,
+	parseNumber,
 	REPRESENTATION_TARGET_INITIAL,
 	REPRESENTATION_TARGET_RAISED,
 	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
@@ -20,8 +22,14 @@ function toPercentString(value: number | undefined): string {
 
 function parsePercent(raw: string): number | undefined {
 	if (raw === "") return undefined;
-	const parsed = Number(raw.replace(",", "."));
+	const parsed = parseNumber(raw);
 	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isDecidedVerdict(
+	verdict: RepresentationComplianceVerdict | undefined,
+): verdict is "compliant" | "non_compliant" {
+	return verdict === "compliant" || verdict === "non_compliant";
 }
 
 export function Step3Members() {
@@ -32,9 +40,7 @@ export function Step3Members() {
 	const hasManagementBody = draft.hasManagementBody;
 	const campaignYear = getRepresentationCampaignYear(year);
 
-	// Kept as raw strings (not re-derived from the draft on every render): the
-	// draft only stores parsed numbers, which would silently drop an in-progress
-	// decimal separator (e.g. typing "33," would redisplay as "33").
+	// Raw strings, not re-derived from the draft on render (would drop an in-progress decimal separator).
 	const [percentageValues, setPercentageValues] =
 		useState<PercentagePairValues>(() => ({
 			womenPercent: toPercentString(draft.memberWomenPercent),
@@ -126,13 +132,13 @@ export function Step3Members() {
 						readOnly={isReadOnly}
 						values={percentageValues}
 					/>
-					{verdict === "compliant" || verdict === "non_compliant" ? (
-						<div className="fr-mt-2w">
-							<ComplianceBadge verdict={verdict} />
-						</div>
-					) : null}
 				</div>
 			) : null}
+			<div aria-atomic="true" aria-live="polite" className="fr-mt-2w">
+				{isDecidedVerdict(verdict) ? (
+					<ComplianceBadge verdict={verdict} />
+				) : null}
+			</div>
 
 			<section className="fr-accordion fr-mt-4w">
 				<h3 className="fr-accordion__title">

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
@@ -1,0 +1,354 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+	COMPUTABLE_MEMBERS,
+	REPRESENTATION_YEAR,
+} from "~/modules/declaration-representation/__tests__/fixtures";
+import { RepresentationDraftProvider } from "~/modules/declaration-representation/shared/draft/DraftContext";
+import type { RepresentationDraft } from "~/modules/declaration-representation/types";
+import {
+	REPRESENTATION_TARGET_INITIAL,
+	REPRESENTATION_TARGET_RAISED,
+	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
+} from "~/modules/domain";
+import { Step3Members } from "../Step3Members";
+
+const STEP = 3;
+
+const RAISED_TARGET_YEAR = REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR - 1;
+
+const NON_COMPLIANT_MEMBERS = {
+	hasManagementBody: true,
+	memberWomenPercent: 75,
+	memberMenPercent: 25,
+} as const;
+
+const BETWEEN_TARGETS_MEMBERS = {
+	hasManagementBody: true,
+	memberWomenPercent: 65,
+	memberMenPercent: 35,
+} as const;
+
+const NON_COMPLIANT_EXECUTIVES = {
+	executivesCount: "two_or_more",
+	executiveWomenPercent: 75,
+	executiveMenPercent: 25,
+} as const;
+
+type HarnessProps = {
+	draft?: Partial<RepresentationDraft>;
+	isReadOnly?: boolean;
+	year?: number;
+	onSetDraftValues?: (values: Partial<RepresentationDraft>) => void;
+};
+
+function Harness({
+	draft: initialDraft = {},
+	isReadOnly = false,
+	year = REPRESENTATION_YEAR,
+	onSetDraftValues,
+}: HarnessProps) {
+	const [draft, setDraft] = useState<RepresentationDraft>({
+		currentStep: STEP,
+		...initialDraft,
+	});
+
+	function setDraftValues(values: Partial<RepresentationDraft>) {
+		onSetDraftValues?.(values);
+		setDraft((previous) => ({ ...previous, ...values }));
+	}
+
+	return (
+		<RepresentationDraftProvider
+			value={{
+				year,
+				step: STEP,
+				draft,
+				setDraftValues,
+				isSaving: false,
+				isPendingSave: false,
+				isReadOnly,
+			}}
+		>
+			<Step3Members />
+		</RepresentationDraftProvider>
+	);
+}
+
+function noneRadio() {
+	return screen.getByRole("radio", { name: /Aucune instance dirigeante/ });
+}
+
+function someRadio() {
+	return screen.getByRole("radio", {
+		name: /Au moins une instance dirigeante/,
+	});
+}
+
+function percentageFields() {
+	return {
+		women: screen.queryByLabelText(/Femmes/),
+		men: screen.queryByLabelText(/Hommes/),
+	};
+}
+
+function queryBadge() {
+	return screen.queryByText(/^(Conforme|Non conforme|Non applicable)$/);
+}
+
+function spy() {
+	return vi.fn<(values: Partial<RepresentationDraft>) => void>();
+}
+
+describe("Step3Members — existence d'instances dirigeantes (S8)", () => {
+	it("n'affiche ni champ de pourcentage ni badge tant qu'aucun choix n'est fait", () => {
+		render(<Harness />);
+
+		expect(noneRadio()).not.toBeChecked();
+		expect(someRadio()).not.toBeChecked();
+		expect(percentageFields().women).not.toBeInTheDocument();
+		expect(percentageFields().men).not.toBeInTheDocument();
+		expect(queryBadge()).not.toBeInTheDocument();
+	});
+
+	it("révèle la paire de pourcentages quand au moins une instance dirigeante est déclarée", async () => {
+		const setDraftValues = spy();
+		render(<Harness onSetDraftValues={setDraftValues} />);
+
+		await userEvent.click(someRadio());
+
+		expect(setDraftValues).toHaveBeenCalledExactlyOnceWith({
+			hasManagementBody: true,
+		});
+		expect(someRadio()).toBeChecked();
+		expect(percentageFields().women).toHaveValue("");
+		expect(percentageFields().men).toHaveValue("");
+		expect(queryBadge()).not.toBeInTheDocument();
+	});
+
+	it("retire les champs et efface les pourcentages déjà saisis quand aucune instance n'est déclarée", async () => {
+		const setDraftValues = spy();
+		render(
+			<Harness draft={COMPUTABLE_MEMBERS} onSetDraftValues={setDraftValues} />,
+		);
+
+		expect(percentageFields().women).toHaveValue(
+			String(COMPUTABLE_MEMBERS.memberWomenPercent),
+		);
+
+		await userEvent.click(noneRadio());
+
+		expect(setDraftValues).toHaveBeenCalledExactlyOnceWith({
+			hasManagementBody: false,
+			memberWomenPercent: undefined,
+			memberMenPercent: undefined,
+		});
+		expect(noneRadio()).toBeChecked();
+		expect(percentageFields().women).not.toBeInTheDocument();
+		expect(queryBadge()).not.toBeInTheDocument();
+
+		await userEvent.click(someRadio());
+
+		expect(percentageFields().women).toHaveValue("");
+		expect(percentageFields().men).toHaveValue("");
+	});
+});
+
+describe("Step3Members — saisie des pourcentages", () => {
+	it("répercute la saisie et son complément automatique dans le brouillon", async () => {
+		const setDraftValues = spy();
+		render(
+			<Harness
+				draft={{ hasManagementBody: true }}
+				onSetDraftValues={setDraftValues}
+			/>,
+		);
+
+		const women = screen.getByLabelText(/Femmes/);
+		await userEvent.type(women, "45");
+
+		expect(setDraftValues).toHaveBeenLastCalledWith({
+			memberWomenPercent: 45,
+			memberMenPercent: 55,
+		});
+		expect(women).toHaveValue("45");
+		expect(screen.getByLabelText(/Hommes/)).toHaveValue("55");
+	});
+
+	it.each([
+		["une virgule", "33,3"],
+		["un point", "33.3"],
+	])("enregistre un pourcentage à une décimale saisi avec %s", async (_separator, typed) => {
+		const setDraftValues = spy();
+		render(
+			<Harness
+				draft={{ hasManagementBody: true }}
+				onSetDraftValues={setDraftValues}
+			/>,
+		);
+
+		await userEvent.type(screen.getByLabelText(/Femmes/), typed);
+
+		expect(setDraftValues).toHaveBeenLastCalledWith({
+			memberWomenPercent: 33.3,
+			memberMenPercent: 66.7,
+		});
+	});
+
+	it("vide la valeur du brouillon et le verdict quand le champ est effacé", async () => {
+		const setDraftValues = spy();
+		render(
+			<Harness draft={COMPUTABLE_MEMBERS} onSetDraftValues={setDraftValues} />,
+		);
+
+		expect(queryBadge()).toBeInTheDocument();
+
+		await userEvent.clear(screen.getByLabelText(/Femmes/));
+
+		expect(setDraftValues).toHaveBeenCalledExactlyOnceWith({
+			memberWomenPercent: undefined,
+			memberMenPercent: COMPUTABLE_MEMBERS.memberMenPercent,
+		});
+		expect(queryBadge()).not.toBeInTheDocument();
+	});
+
+	it("réaffiche les pourcentages décimaux d'un brouillon rechargé", () => {
+		render(
+			<Harness
+				draft={{
+					hasManagementBody: true,
+					memberWomenPercent: 33.3,
+					memberMenPercent: 66.7,
+				}}
+			/>,
+		);
+
+		expect(screen.getByLabelText(/Femmes/)).toHaveValue("33.3");
+		expect(screen.getByLabelText(/Hommes/)).toHaveValue("66.7");
+		expect(screen.getByText("Conforme")).toBeInTheDocument();
+	});
+});
+
+describe("Step3Members — verdict de conformité (S13–S15)", () => {
+	it("présente l'indicateur comme conforme quand les deux sexes atteignent le seuil", () => {
+		render(<Harness draft={COMPUTABLE_MEMBERS} />);
+
+		expect(screen.getByText("Conforme")).toBeInTheDocument();
+	});
+
+	it("présente l'indicateur comme non conforme quand le sexe sous-représenté est sous le seuil", () => {
+		render(<Harness draft={NON_COMPLIANT_MEMBERS} />);
+
+		expect(screen.getByText("Non conforme")).toBeInTheDocument();
+	});
+
+	it("applique le seuil relevé à partir de la campagne concernée", () => {
+		const { rerender } = render(
+			<Harness draft={BETWEEN_TARGETS_MEMBERS} year={REPRESENTATION_YEAR} />,
+		);
+
+		expect(BETWEEN_TARGETS_MEMBERS.memberMenPercent).toBeGreaterThanOrEqual(
+			REPRESENTATION_TARGET_INITIAL,
+		);
+		expect(BETWEEN_TARGETS_MEMBERS.memberMenPercent).toBeLessThan(
+			REPRESENTATION_TARGET_RAISED,
+		);
+		expect(screen.getByText("Conforme")).toBeInTheDocument();
+
+		rerender(
+			<Harness draft={BETWEEN_TARGETS_MEMBERS} year={RAISED_TARGET_YEAR} />,
+		);
+
+		expect(screen.getByText("Non conforme")).toBeInTheDocument();
+	});
+
+	it.each([
+		["seul le pourcentage de femmes", { memberWomenPercent: 55 }],
+		["seul le pourcentage d'hommes", { memberMenPercent: 45 }],
+	])("n'affiche aucun badge quand %s est renseigné", (_label, percentages) => {
+		render(<Harness draft={{ hasManagementBody: true, ...percentages }} />);
+
+		expect(queryBadge()).not.toBeInTheDocument();
+	});
+});
+
+describe("Step3Members — indépendance des verdicts (S16)", () => {
+	it("reste conforme malgré des cadres dirigeants non conformes et ne touche que ses propres champs", async () => {
+		const setDraftValues = spy();
+		render(
+			<Harness
+				draft={{ ...NON_COMPLIANT_EXECUTIVES, ...COMPUTABLE_MEMBERS }}
+				onSetDraftValues={setDraftValues}
+			/>,
+		);
+
+		expect(screen.getByText("Conforme")).toBeInTheDocument();
+
+		await userEvent.click(noneRadio());
+		await userEvent.click(someRadio());
+		await userEvent.type(screen.getByLabelText(/Femmes/), "45");
+
+		const touchedKeys = [
+			...new Set(
+				setDraftValues.mock.calls.flatMap(([values]) => Object.keys(values)),
+			),
+		].sort();
+		expect(touchedKeys).toEqual([
+			"hasManagementBody",
+			"memberMenPercent",
+			"memberWomenPercent",
+		]);
+	});
+});
+
+describe("Step3Members — campagne close (S23)", () => {
+	it("désactive les choix et verrouille les pourcentages", async () => {
+		const setDraftValues = spy();
+		render(
+			<Harness
+				draft={COMPUTABLE_MEMBERS}
+				isReadOnly
+				onSetDraftValues={setDraftValues}
+			/>,
+		);
+
+		expect(noneRadio()).toBeDisabled();
+		expect(someRadio()).toBeDisabled();
+
+		const women = screen.getByLabelText(/Femmes/);
+		expect(women).toHaveAttribute("readonly");
+		expect(screen.getByLabelText(/Hommes/)).toHaveAttribute("readonly");
+
+		await userEvent.click(noneRadio());
+		await userEvent.type(women, "9");
+
+		expect(setDraftValues).not.toHaveBeenCalled();
+		expect(women).toHaveValue(String(COMPUTABLE_MEMBERS.memberWomenPercent));
+		expect(screen.getByText("Conforme")).toBeInTheDocument();
+	});
+});
+
+describe("Step3Members — repères réglementaires", () => {
+	it("expose l'accordéon des définitions et rappelle les seuils de la loi", () => {
+		render(<Harness />);
+
+		const trigger = screen.getByRole("button", {
+			name: /Définitions membres des instances dirigeantes et seuils réglementaires/,
+		});
+		const panelId = trigger.getAttribute("aria-controls") ?? "";
+
+		expect(document.getElementById(panelId)).not.toBeNull();
+		expect(
+			screen.getByText(/article L\.23-12-1 du Code de commerce/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				new RegExp(
+					`${REPRESENTATION_TARGET_INITIAL} %.+${REPRESENTATION_TARGET_RAISED} %.+${REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR}`,
+				),
+			),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/steps/index.ts
+++ b/packages/app/src/modules/declaration-representation/steps/index.ts
@@ -5,6 +5,7 @@ import {
 	REPRESENTATION_STEP_SLUGS,
 	TOTAL_REPRESENTATION_STEPS,
 } from "../types";
+import { Step3Members } from "./Step3Members";
 import { StepPlaceholder } from "./StepPlaceholder";
 
 export type StepDefinition = {
@@ -24,11 +25,19 @@ const STEP_TITLES: Record<RepresentationStepSlug, string> = {
 	recapitulatif: "Récapitulatif",
 };
 
+const STEP_COMPONENTS: Record<RepresentationStepSlug, ComponentType> = {
+	"periode-de-reference": StepPlaceholder,
+	"ecarts-cadres-dirigeants": StepPlaceholder,
+	"ecarts-instances-dirigeantes": Step3Members,
+	"informations-de-publication": StepPlaceholder,
+	recapitulatif: StepPlaceholder,
+};
+
 export const REPRESENTATION_STEPS: StepDefinition[] =
 	REPRESENTATION_STEP_SLUGS.map((slug) => ({
 		slug,
 		title: STEP_TITLES[slug],
-		Component: StepPlaceholder,
+		Component: STEP_COMPONENTS[slug],
 	}));
 
 export function isValidStep(step: number): boolean {


### PR DESCRIPTION
Closes #4160

## Résumé

Ajoute l'étape 3 du funnel de représentation équilibrée (« Écarts de représentation - Instances dirigeantes ») :

- Radio 2 choix : « Aucune instance dirigeante » / « Au moins une instance dirigeante » (libellés + descriptions exacts du Figma).
- « Aucune » → aucun champ de pourcentage ; le motif `aucune_instance_dirigeante` est déjà retenu automatiquement côté serveur (router `submit`, ticket #4152).
- « Au moins une » → `PercentagePairFields` (auto-remplissage 100−x, somme = 100) + `ComplianceBadge`, verdict calculé via `computeRepresentationVerdict` avec l'année de campagne — strictement indépendant de l'étape cadres dirigeants (aucun champ `executive*` touché).
- Accordéon « Définitions membres des instances dirigeantes et seuils réglementaires » (art. L.23-12-1 du Code de commerce, seuils 30 %/40 % via les constantes du domaine).
- Enregistrement de l'étape dans `steps/index.ts` (mapping slug → composant).

## Test plan

- `pnpm typecheck` : vert
- `pnpm test` (module `declaration-representation`) : vert, 18/18 fichiers — couverture ajoutée par `tu-dev` (S8, S13–S16, lecture seule, accordéon, brouillon rechargé)
- Lint / format : vert
- 4 quality gates (validator, structural-auditor, rgaa-auditor) : PASS après corrections (réutilisation du parseur de nombre du domaine, région `aria-live` stable pour l'annonce du badge de conformité aux lecteurs d'écran)
- `security-auditor` : non déclenché (aucun fichier serveur modifié)

## Fidélité Figma

Construction fidèle aux 5 frames citées dans le ticket (lecture structurelle via `get_design_context`) : libellés radio, légende du champ pourcentage, badge de conformité. La vérification indépendante est faite par le gate `design-validator`.