### PR TITLE
feat(my-space): active la ligne Représentation équilibrée & panneau latéral

### DIFF
--- a/packages/app/src/modules/domain/__tests__/representation.test.ts
+++ b/packages/app/src/modules/domain/__tests__/representation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	computeRepresentationDeclarationStatus,
 	computeRepresentationVerdict,
 	deriveExecutivesNotComputableReason,
 	getRepresentationCampaignYear,
@@ -306,6 +307,62 @@ describe("isRepresentationPublicationRequired", () => {
 	});
 });
 
+describe("computeRepresentationDeclarationStatus", () => {
+	it("returns done for a submitted declaration, whatever its current step", () => {
+		expect(
+			computeRepresentationDeclarationStatus({
+				status: "submitted",
+				currentStep: 5,
+			}),
+		).toBe("done");
+		expect(
+			computeRepresentationDeclarationStatus({
+				status: "submitted",
+				currentStep: 0,
+			}),
+		).toBe("done");
+		expect(
+			computeRepresentationDeclarationStatus({
+				status: "submitted",
+				currentStep: null,
+			}),
+		).toBe("done");
+	});
+
+	it("returns to_complete for a draft still on step 0", () => {
+		expect(
+			computeRepresentationDeclarationStatus({
+				status: "draft",
+				currentStep: 0,
+			}),
+		).toBe("to_complete");
+	});
+
+	it("returns to_complete for a draft row carrying no current step", () => {
+		expect(
+			computeRepresentationDeclarationStatus({
+				status: "draft",
+				currentStep: null,
+			}),
+		).toBe("to_complete");
+	});
+
+	it("returns in_progress for a draft past step 0", () => {
+		expect(
+			computeRepresentationDeclarationStatus({
+				status: "draft",
+				currentStep: 1,
+			}),
+		).toBe("in_progress");
+		expect(
+			computeRepresentationDeclarationStatus({
+				status: "draft",
+				currentStep: 4,
+			}),
+		).toBe("in_progress");
+	});
+});
+
 describe("verdict independence (S16)", () => {
 	// An aggregated verdict would let a compliant indicator mask a failing one.
 	it("exposes no aggregated verdict helper", async () => {
@@ -316,6 +373,7 @@ describe("verdict independence (S16)", () => {
 			"REPRESENTATION_TARGET_INITIAL",
 			"REPRESENTATION_TARGET_RAISED",
 			"REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR",
+			"computeRepresentationDeclarationStatus",
 			"computeRepresentationVerdict",
 			"deriveExecutivesNotComputableReason",
 			"getRepresentationCampaignYear",

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -230,6 +230,7 @@ export type {
 	WorkforceHistoryEntry,
 } from "./shared/representation";
 export {
+	computeRepresentationDeclarationStatus,
 	computeRepresentationVerdict,
 	deriveExecutivesNotComputableReason,
 	getRepresentationCampaignYear,

--- a/packages/app/src/modules/domain/shared/representation.ts
+++ b/packages/app/src/modules/domain/shared/representation.ts
@@ -1,3 +1,5 @@
+import type { DeclarationStatus } from "../types";
+
 export const REPRESENTATION_TARGET_INITIAL = 30;
 export const REPRESENTATION_TARGET_RAISED = 40;
 export const REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR = 2029;
@@ -64,4 +66,12 @@ export function isRepresentationPublicationRequired(
 	hasManagementBody: boolean,
 ): boolean {
 	return executivesCount === "two_or_more" || hasManagementBody === true;
+}
+
+export function computeRepresentationDeclarationStatus(declaration: {
+	status: "draft" | "submitted";
+	currentStep: number | null;
+}): DeclarationStatus {
+	if (declaration.status === "submitted") return "done";
+	return (declaration.currentStep ?? 0) === 0 ? "to_complete" : "in_progress";
 }

--- a/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
+++ b/packages/app/src/modules/my-space/CompanyDeclarationsPage.tsx
@@ -1,4 +1,7 @@
-import type { CampaignDeadlines } from "~/modules/domain";
+import type {
+	CampaignDeadlines,
+	RepresentationCampaign,
+} from "~/modules/domain";
 import {
 	getCurrentYear,
 	getDeclarationDisplayContext,
@@ -28,6 +31,7 @@ type Props = {
 	declarations: DeclarationItem[];
 	lockedByOther: boolean;
 	lockHolder: LockHolderDisplay | null;
+	representationCampaign: RepresentationCampaign;
 	userPhone: string | null;
 };
 
@@ -53,6 +57,7 @@ export function CompanyDeclarationsPage({
 	declarations,
 	lockedByOther,
 	lockHolder,
+	representationCampaign,
 	userPhone,
 }: Props) {
 	const currentYear = getCurrentYear();
@@ -89,6 +94,7 @@ export function CompanyDeclarationsPage({
 				cseApplicable={cseApplicable}
 				declarations={declarations}
 				hasCse={company.hasCse}
+				representationCampaign={representationCampaign}
 				userPhone={userPhone}
 			/>
 			<ArchivesSection />

--- a/packages/app/src/modules/my-space/DeclarationLink.tsx
+++ b/packages/app/src/modules/my-space/DeclarationLink.tsx
@@ -9,6 +9,7 @@ import { useIsImpersonating } from "~/modules/auth";
 import { hasRequiredDeclarationInfo } from "~/modules/domain";
 import { DECLARATION_PROCESS_PANEL_ID } from "./DeclarationProcessPanel";
 import styles from "./DeclarationsSection.module.scss";
+import { REPRESENTATION_PROCESS_PANEL_ID } from "./RepresentationProcessPanel";
 import type { DeclarationType } from "./types";
 
 const MISSING_INFO_MODAL_ID = "missing-info-modal";
@@ -50,30 +51,26 @@ export function DeclarationLink({
 		);
 	}
 
-	// Remuneration: open the declaration process side panel
-	if (type === "remuneration") {
-		return (
-			<button
-				aria-controls={DECLARATION_PROCESS_PANEL_ID}
-				className={linkClass}
-				data-fr-opened="false"
-				onClick={() =>
-					trackEvent({
-						category: MATOMO_EVENT_CATEGORY.DASHBOARD,
-						action: MATOMO_ACTION.DECLARATION_START,
-						name: type,
-					})
-				}
-				type="button"
-			>
-				{children}
-			</button>
-		);
-	}
+	// Open the declaration process side panel (one per type)
+	const panelId =
+		type === "remuneration"
+			? DECLARATION_PROCESS_PANEL_ID
+			: REPRESENTATION_PROCESS_PANEL_ID;
 
-	// Representation: placeholder (no route yet)
 	return (
-		<button className={linkClass} type="button">
+		<button
+			aria-controls={panelId}
+			className={linkClass}
+			data-fr-opened="false"
+			onClick={() =>
+				trackEvent({
+					category: MATOMO_EVENT_CATEGORY.DASHBOARD,
+					action: MATOMO_ACTION.DECLARATION_START,
+					name: type,
+				})
+			}
+			type="button"
+		>
 			{children}
 		</button>
 	);

--- a/packages/app/src/modules/my-space/DeclarationStepLabel.ts
+++ b/packages/app/src/modules/my-space/DeclarationStepLabel.ts
@@ -1,4 +1,5 @@
-import { REPRESENTATION_STEPS } from "~/modules/declaration-representation";
+// Submodule import, not the barrel — the barrel drags declaration-remuneration's (server-touching) tree into this client bundle.
+import { REPRESENTATION_STEPS } from "~/modules/declaration-representation/steps";
 import type {
 	DeclarationFsmStatus,
 	DeclarationStatus,

--- a/packages/app/src/modules/my-space/DeclarationStepLabel.ts
+++ b/packages/app/src/modules/my-space/DeclarationStepLabel.ts
@@ -1,4 +1,9 @@
-import type { DeclarationFsmStatus, DeclarationType } from "~/modules/domain";
+import { REPRESENTATION_STEPS } from "~/modules/declaration-representation";
+import type {
+	DeclarationFsmStatus,
+	DeclarationStatus,
+	DeclarationType,
+} from "~/modules/domain";
 
 const PROCESS_STEP_LABELS: Record<DeclarationFsmStatus, string> = {
 	draft: "Déclaration des indicateurs de rémunération",
@@ -14,12 +19,31 @@ const PROCESS_STEP_LABELS: Record<DeclarationFsmStatus, string> = {
 	demarche_completed: "Finalisation - Démarche des indicateurs de rémunération",
 };
 
+const REPRESENTATION_START_LABEL = "Vérification de l'assujettissement";
+
+function getRepresentationStepLabel(
+	status: DeclarationStatus,
+	currentStep: number,
+): string {
+	if (status === "done") {
+		return "Finalisation - Démarche des indicateurs de représentation";
+	}
+	if (status === "to_complete") {
+		return REPRESENTATION_START_LABEL;
+	}
+	return (
+		REPRESENTATION_STEPS[currentStep - 1]?.title ?? REPRESENTATION_START_LABEL
+	);
+}
+
 export function getDeclarationProcessStepLabel(d: {
 	type: DeclarationType;
 	fsmStatus: DeclarationFsmStatus | null;
+	status: DeclarationStatus;
+	currentStep: number;
 }): string {
-	// The représentation équilibrée journey has no state machine yet, so every row
-	// sits on its first step: checking whether the company is in scope.
-	if (d.type === "representation") return "Vérification de l'assujettissement";
+	if (d.type === "representation") {
+		return getRepresentationStepLabel(d.status, d.currentStep);
+	}
 	return PROCESS_STEP_LABELS[d.fsmStatus ?? "draft"];
 }

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -2,12 +2,14 @@
 
 import { useState } from "react";
 
-import type { CampaignDeadlines } from "~/modules/domain";
+import type {
+	CampaignDeadlines,
+	RepresentationCampaign,
+} from "~/modules/domain";
 import {
 	formatShortDate,
 	getCurrentYear,
 	getDeclarationProcessStepDeadline,
-	getRepresentationDeadline,
 } from "~/modules/domain";
 
 import { Pagination } from "~/modules/shared/Pagination";
@@ -20,6 +22,7 @@ import {
 	getDocumentResourceCount,
 	getDocumentsPanelId,
 } from "./DocumentsPanel";
+import { RepresentationProcessPanel } from "./RepresentationProcessPanel";
 import { StatusBadge } from "./StatusBadge";
 import type { DeclarationItem, DeclarationType } from "./types";
 
@@ -34,14 +37,16 @@ type Props = {
 	userPhone: string | null;
 	hasCse: boolean | null;
 	cseApplicable: boolean;
+	representationCampaign: RepresentationCampaign;
 };
 
 function getDeadlineCell(
 	declaration: DeclarationItem,
 	campaignDeadlines: CampaignDeadlines,
+	representationCampaign: RepresentationCampaign,
 ): string {
 	if (declaration.type === "representation") {
-		return getRepresentationDeadline(declaration.year);
+		return formatShortDate(representationCampaign.declarationDeadline);
 	}
 	const deadline = getDeclarationProcessStepDeadline(
 		declaration.fsmStatus,
@@ -60,12 +65,16 @@ export function DeclarationsSection({
 	userPhone,
 	hasCse,
 	cseApplicable,
+	representationCampaign,
 }: Props) {
 	const currentYear = getCurrentYear();
 	const currentYearDeclarations = declarations.filter(
 		(d) => d.year >= currentYear,
 	);
 	const previousDeclarations = declarations.filter((d) => d.year < currentYear);
+	const currentRepresentationDeclaration = declarations.find(
+		(d) => d.type === "representation" && d.year === currentYear,
+	);
 
 	const [pageSize, setPageSize] = useState(PAGE_SIZE_OPTIONS[0] ?? 10);
 	const [currentPage, setCurrentPage] = useState(1);
@@ -107,6 +116,7 @@ export function DeclarationsSection({
 					declarations={visibleCurrentDeclarations}
 					hasCse={hasCse}
 					labelledById="demarches-en-cours-title"
+					representationCampaign={representationCampaign}
 					userPhone={userPhone}
 				/>
 			)}
@@ -121,6 +131,7 @@ export function DeclarationsSection({
 						declarations={visiblePreviousDeclarations}
 						hasCse={hasCse}
 						labelledById="annees-precedentes-title"
+						representationCampaign={representationCampaign}
 						userPhone={userPhone}
 					/>
 				</>
@@ -155,6 +166,11 @@ export function DeclarationsSection({
 					totalPages={totalPages}
 				/>
 			)}
+			<RepresentationProcessPanel
+				campaign={representationCampaign}
+				campaignYear={currentYear}
+				declaration={currentRepresentationDeclaration}
+			/>
 		</div>
 	);
 }
@@ -166,6 +182,7 @@ type DeclarationsTableProps = {
 	userPhone: string | null;
 	hasCse: boolean | null;
 	cseApplicable: boolean;
+	representationCampaign: RepresentationCampaign;
 };
 
 function DeclarationsTable({
@@ -175,6 +192,7 @@ function DeclarationsTable({
 	userPhone,
 	hasCse,
 	cseApplicable,
+	representationCampaign,
 }: DeclarationsTableProps) {
 	return (
 		<div className={`fr-table ${styles.tableNoCaptionOffset}`}>
@@ -209,7 +227,13 @@ function DeclarationsTable({
 											</td>
 											<td>{declaration.year}</td>
 											<td>{getDeclarationProcessStepLabel(declaration)}</td>
-											<td>{getDeadlineCell(declaration, campaignDeadlines)}</td>
+											<td>
+												{getDeadlineCell(
+													declaration,
+													campaignDeadlines,
+													representationCampaign,
+												)}
+											</td>
 											<td>
 												<StatusBadge status={declaration.status} />
 											</td>

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -12,6 +12,7 @@ import { api } from "~/trpc/react";
 
 import { DECLARATION_PROCESS_PANEL_ID } from "./DeclarationProcessPanel";
 import styles from "./DeclarationProcessPanel.module.scss";
+import { REPRESENTATION_PROCESS_PANEL_ID } from "./RepresentationProcessPanel";
 import { createMissingInfoSchema } from "./schemas";
 import { useUpdateHasCse } from "./useUpdateHasCse";
 
@@ -107,26 +108,23 @@ export function MissingInfoModal({
 				await updateHasCseMutation.mutateAsync({ siren, hasCse: hasCseValue });
 			}
 			router.refresh();
-			if (openerTypeRef.current === "remuneration") {
-				// Register listener BEFORE closing so we catch the dsfr.conceal event
-				const dialog = dialogRef.current;
-				if (dialog) {
-					dialog.addEventListener(
-						"dsfr.conceal",
-						() => {
-							const panel = document.getElementById(
-								DECLARATION_PROCESS_PANEL_ID,
-							);
-							if (panel) getDsfrModal(panel)?.disclose();
-						},
-						{ once: true },
-					);
-				}
-				closeModal();
-			} else {
-				closeModal();
-				window.location.href = `/declaration-remuneration?siren=${siren}`;
+			// Register listener BEFORE closing so we catch the dsfr.conceal event
+			const dialog = dialogRef.current;
+			if (dialog) {
+				const targetPanelId =
+					openerTypeRef.current === "remuneration"
+						? DECLARATION_PROCESS_PANEL_ID
+						: REPRESENTATION_PROCESS_PANEL_ID;
+				dialog.addEventListener(
+					"dsfr.conceal",
+					() => {
+						const panel = document.getElementById(targetPanelId);
+						if (panel) getDsfrModal(panel)?.disclose();
+					},
+					{ once: true },
+				);
 			}
+			closeModal();
 		} catch {
 			setSubmitError(
 				"Une erreur est survenue lors de l'enregistrement. Veuillez réessayer.",

--- a/packages/app/src/modules/my-space/MonEspacePage.tsx
+++ b/packages/app/src/modules/my-space/MonEspacePage.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import { getCurrentYear, parseSiren } from "~/modules/domain";
 import { getCampaignDeadlines } from "~/server/db/getCampaignDeadlines";
+import { getRepresentationCampaign } from "~/server/db/getRepresentationCampaign";
 import { api } from "~/trpc/server";
 
 import { CompanyDeclarationsPage } from "./CompanyDeclarationsPage";
@@ -18,11 +19,13 @@ export async function MonEspacePage({ siret, userPhone }: Props) {
 	if (siren === null) {
 		redirect("/mon-espace/mes-entreprises");
 	}
-	const [data, campaignDeadlines, lockState] = await Promise.all([
-		api.company.getWithDeclarations({ siren }),
-		getCampaignDeadlines(getCurrentYear()),
-		api.declarationLock.getActiveLockForCurrentDeclaration(),
-	]);
+	const [data, campaignDeadlines, representationCampaign, lockState] =
+		await Promise.all([
+			api.company.getWithDeclarations({ siren }),
+			getCampaignDeadlines(getCurrentYear()),
+			getRepresentationCampaign(getCurrentYear()),
+			api.declarationLock.getActiveLockForCurrentDeclaration(),
+		]);
 
 	return (
 		<CompanyDeclarationsPage
@@ -31,6 +34,7 @@ export async function MonEspacePage({ siret, userPhone }: Props) {
 			declarations={data.declarations}
 			lockedByOther={lockState.lockedByOther}
 			lockHolder={lockState.holder}
+			representationCampaign={representationCampaign}
 			userPhone={userPhone}
 		/>
 	);

--- a/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useRef } from "react";
+
+import type { RepresentationCampaign } from "~/modules/domain";
+import {
+	formatLongDate,
+	isRepresentationCampaignOpen,
+	REPRESENTATION_TARGET_INITIAL,
+	REPRESENTATION_TARGET_RAISED,
+	REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR,
+} from "~/modules/domain";
+import styles from "./DeclarationProcessPanel.module.scss";
+import {
+	computeRepresentationCtaHref,
+	computeRepresentationPanelVariant,
+	type RepresentationPanelVariant,
+} from "./declarationProcessState";
+import type { DeclarationItem } from "./types";
+
+export const REPRESENTATION_PROCESS_PANEL_ID = "representation-process-panel";
+const PANEL_TITLE_ID = "representation-process-panel-title";
+
+type Props = {
+	campaign: RepresentationCampaign;
+	campaignYear: number;
+	declaration: DeclarationItem | undefined;
+};
+
+type StepStatus = "pending" | "current" | "complete";
+
+function getStepStatuses(
+	variant: RepresentationPanelVariant,
+): [StepStatus, StepStatus] {
+	switch (variant) {
+		case "start":
+			return ["current", "pending"];
+		case "draft":
+			return ["complete", "current"];
+		case "submitted":
+		case "closed":
+			return ["complete", "complete"];
+	}
+}
+
+function getCtaLabel(variant: RepresentationPanelVariant): string {
+	if (variant === "start") return "Commencer";
+	if (variant === "draft") return "Reprendre";
+	return "Voir la déclaration";
+}
+
+export function RepresentationProcessPanel({
+	campaign,
+	campaignYear,
+	declaration,
+}: Props) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const campaignOpen = isRepresentationCampaignOpen(campaign, new Date());
+	const variant = computeRepresentationPanelVariant(declaration, campaignOpen);
+	const ctaHref = computeRepresentationCtaHref(declaration, campaignOpen);
+	const [step1, step2] = getStepStatuses(variant);
+	const lastActionDate = declaration?.updatedAt
+		? formatLongDate(declaration.updatedAt)
+		: null;
+
+	return (
+		<dialog
+			aria-labelledby={PANEL_TITLE_ID}
+			aria-modal="true"
+			className={`fr-modal ${styles.sidePanel}`}
+			id={REPRESENTATION_PROCESS_PANEL_ID}
+			ref={dialogRef}
+		>
+			<div className={styles.panelContainer}>
+				<div className={styles.panelHeader}>
+					<button
+						aria-controls={REPRESENTATION_PROCESS_PANEL_ID}
+						className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-btn--icon-right fr-icon-close-line"
+						title="Fermer"
+						type="button"
+					>
+						Fermer
+					</button>
+				</div>
+				<div className={styles.panelContent}>
+					<div>
+						<PanelHeader
+							campaignYear={campaignYear}
+							lastActionDate={lastActionDate}
+						/>
+						<RixainAlert />
+						<div className={`${styles.stepper} fr-mb-4w`}>
+							<Step1Row status={step1} />
+							<Step2Row
+								deadline={campaign.declarationDeadline}
+								status={step2}
+							/>
+						</div>
+						{variant === "closed" && <ClosedMessage />}
+					</div>
+					<div>
+						<HelpSection />
+						<div className={styles.footer}>
+							<a
+								aria-describedby={PANEL_TITLE_ID}
+								className="fr-btn"
+								href={ctaHref}
+							>
+								{getCtaLabel(variant)}
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		</dialog>
+	);
+}
+
+function PanelHeader({
+	campaignYear,
+	lastActionDate,
+}: {
+	campaignYear: number;
+	lastActionDate: string | null;
+}) {
+	return (
+		<div className="fr-mb-4w">
+			<h2 className="fr-h5 fr-mb-1w" id={PANEL_TITLE_ID}>
+				Démarche des indicateurs de représentation {campaignYear}
+			</h2>
+			{lastActionDate && (
+				<div className={styles.lastAction}>
+					<span aria-hidden="true" className="fr-icon-time-line fr-icon--sm" />
+					<span>Dernière action le {lastActionDate}</span>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function RixainAlert() {
+	return (
+		<div className="fr-alert fr-alert--info fr-mb-4w">
+			<p>
+				La loi Rixain (n° 2021-1774) impose aux entreprises de 1 000 salariés et
+				plus, pendant trois années consécutives, de publier chaque année les
+				écarts de représentation entre les femmes et les hommes parmi les cadres
+				dirigeants et au sein des instances dirigeantes. Les seuils à atteindre
+				sont de{" "}
+				<strong>
+					{REPRESENTATION_TARGET_INITIAL} % minimum de chaque sexe
+				</strong>{" "}
+				dès l'entrée en vigueur de l'obligation, puis de{" "}
+				<strong>{REPRESENTATION_TARGET_RAISED} % minimum de chaque sexe</strong>{" "}
+				à compter du 1ᵉʳ mars {REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR}.
+			</p>
+		</div>
+	);
+}
+
+function StepCircle({
+	status,
+	number,
+}: {
+	status: StepStatus;
+	number: number;
+}) {
+	const statusClass =
+		status === "complete"
+			? styles.stepCircleComplete
+			: status === "current"
+				? styles.stepCircleCurrent
+				: styles.stepCirclePending;
+
+	const statusLabel =
+		status === "complete"
+			? "Étape terminée"
+			: status === "current"
+				? "Étape en cours"
+				: "Étape à venir";
+
+	return (
+		<div className={`${styles.stepCircle} ${statusClass}`}>
+			<span className="fr-sr-only">{statusLabel}</span>
+			{status === "complete" ? (
+				<span aria-hidden="true" className="fr-icon-check-line fr-icon--sm" />
+			) : (
+				<span aria-hidden="true">{number}</span>
+			)}
+		</div>
+	);
+}
+
+function stepRowClass(status: StepStatus): string {
+	if (status === "complete") return styles.stepRowComplete ?? "";
+	if (status === "current") return styles.stepRowCurrent ?? "";
+	return "";
+}
+
+function StepTitle({
+	children,
+	status,
+}: {
+	children: React.ReactNode;
+	status: StepStatus;
+}) {
+	return (
+		<p
+			className={`fr-text--bold fr-mb-0 ${status === "pending" ? "fr-text-mention--grey" : ""}`.trim()}
+		>
+			{children}
+		</p>
+	);
+}
+
+function Step1Row({ status }: { status: StepStatus }) {
+	return (
+		<div className={`${styles.stepRow} ${stepRowClass(status)}`}>
+			<StepCircle number={1} status={status} />
+			<StepTitle status={status}>Vérification de l'assujettissement</StepTitle>
+		</div>
+	);
+}
+
+const STEP2_ITEMS = [
+	"Cadres dirigeants",
+	"Instances dirigeantes",
+	"Informations de publication",
+];
+
+function Step2Row({
+	deadline,
+	status,
+}: {
+	deadline: Date;
+	status: StepStatus;
+}) {
+	return (
+		<div className={`${styles.stepRow} ${stepRowClass(status)}`}>
+			<StepCircle number={2} status={status} />
+			<div className={styles.stepContent}>
+				<StepTitle status={status}>
+					{status === "pending"
+						? "Déclaration des écarts de représentation"
+						: "Écarts de représentation"}
+				</StepTitle>
+				{status !== "pending" &&
+					STEP2_ITEMS.map((item) => (
+						<div className={styles.bulletItem} key={item}>
+							<span aria-hidden="true" className={styles.bullet} />
+							<p className="fr-mb-0">{item}</p>
+						</div>
+					))}
+				<div className={styles.deadlineRow}>
+					<span
+						aria-hidden="true"
+						className="fr-icon-calendar-line fr-icon--sm"
+					/>
+					<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
+						Échéance : {formatLongDate(deadline)}
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function ClosedMessage() {
+	return (
+		<div className={styles.closedMessage}>
+			<p className="fr-text--bold fr-mb-0">Démarche close</p>
+			<p className="fr-mb-0">Cette démarche est terminée.</p>
+		</div>
+	);
+}
+
+function HelpSection() {
+	return (
+		<div className={styles.helpSection}>
+			<hr className="fr-hr" />
+			<p className="fr-text--lg fr-text--bold fr-mb-0">Pour vous aider</p>
+			<div className={styles.helpLinks}>
+				<button className="fr-link" type="button">
+					Détail des étapes
+				</button>
+				<button className="fr-link" type="button">
+					Centre d'aide
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
+++ b/packages/app/src/modules/my-space/RepresentationProcessPanel.tsx
@@ -192,9 +192,7 @@ function StepCircle({
 }
 
 function stepRowClass(status: StepStatus): string {
-	if (status === "complete") return styles.stepRowComplete ?? "";
-	if (status === "current") return styles.stepRowCurrent ?? "";
-	return "";
+	return status === "complete" ? (styles.stepRowComplete ?? "") : "";
 }
 
 function StepTitle({

--- a/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyDeclarationsPage.test.tsx
@@ -24,7 +24,11 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
-import { getCurrentYear, getDefaultCampaignDeadlines } from "~/modules/domain";
+import {
+	getCurrentYear,
+	getDefaultCampaignDeadlines,
+	getDefaultRepresentationCampaign,
+} from "~/modules/domain";
 import { CompanyDeclarationsPage } from "../CompanyDeclarationsPage";
 import type { CompanyDetail, DeclarationItem } from "../types";
 
@@ -90,6 +94,7 @@ const BASE_PROPS = {
 	declarations,
 	lockedByOther: false,
 	lockHolder: null as LockHolder | null,
+	representationCampaign: getDefaultRepresentationCampaign(currentYear),
 	userPhone: "0122334455" as string | null,
 };
 

--- a/packages/app/src/modules/my-space/__tests__/DeclarationLink.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationLink.test.tsx
@@ -1,15 +1,68 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { useSession } from "next-auth/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import {
+	MATOMO_ACTION,
+	MATOMO_EVENT_CATEGORY,
+	trackEvent,
+} from "~/modules/analytics";
 import { mockImpersonatingSession } from "~/test/impersonationMock";
 import { DeclarationLink } from "../DeclarationLink";
 
+vi.mock("~/modules/analytics", async (importOriginal) => ({
+	...(await importOriginal<typeof import("~/modules/analytics")>()),
+	trackEvent: vi.fn(),
+}));
+
 const mockedUseSession = vi.mocked(useSession);
+const mockedTrackEvent = vi.mocked(trackEvent);
 
 describe("DeclarationLink", () => {
 	afterEach(() => {
 		mockedUseSession.mockReset();
+		mockedTrackEvent.mockReset();
+	});
+
+	it.each([
+		"remuneration",
+		"representation",
+	] as const)("tracks the démarche start when the %s panel is opened", (type) => {
+		render(
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={true}
+				type={type}
+				userPhone="0122334455"
+			>
+				Démarche
+			</DeclarationLink>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Démarche" }));
+
+		expect(mockedTrackEvent).toHaveBeenCalledWith({
+			category: MATOMO_EVENT_CATEGORY.DASHBOARD,
+			action: MATOMO_ACTION.DECLARATION_START,
+			name: type,
+		});
+	});
+
+	it("does not track a démarche start when the missing info modal is opened instead", () => {
+		render(
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={true}
+				type="representation"
+				userPhone={null}
+			>
+				Démarche
+			</DeclarationLink>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Démarche" }));
+
+		expect(mockedTrackEvent).not.toHaveBeenCalled();
 	});
 
 	it("renders remuneration as a button opening the process panel when info is present", () => {
@@ -111,7 +164,7 @@ describe("DeclarationLink", () => {
 		expect(button).toHaveAttribute("data-declaration-type", "remuneration");
 	});
 
-	it("renders representation as a button placeholder when info is present", () => {
+	it("renders representation as a button opening the representation panel when info is present", () => {
 		render(
 			<DeclarationLink
 				cseApplicable={true}
@@ -124,6 +177,27 @@ describe("DeclarationLink", () => {
 		);
 		const button = screen.getByRole("button", { name: "Représentation" });
 		expect(button).toBeInTheDocument();
+		expect(button).toHaveAttribute(
+			"aria-controls",
+			"representation-process-panel",
+		);
+		expect(button).toHaveAttribute("data-fr-opened", "false");
+	});
+
+	it("still opens the missing info modal for representation when info is missing", () => {
+		render(
+			<DeclarationLink
+				cseApplicable={true}
+				hasCse={true}
+				type="representation"
+				userPhone={null}
+			>
+				Représentation
+			</DeclarationLink>,
+		);
+		const button = screen.getByRole("button", { name: "Représentation" });
+		expect(button).toHaveAttribute("aria-controls", "missing-info-modal");
+		expect(button).toHaveAttribute("data-declaration-type", "representation");
 	});
 
 	it("bypasses missing info modal during admin impersonation", () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { REPRESENTATION_STEPS } from "~/modules/declaration-representation";
+import { REPRESENTATION_STEPS as STEPS_FROM_SUBMODULE } from "~/modules/declaration-representation/steps";
 import type { DeclarationFsmStatus, DeclarationStatus } from "~/modules/domain";
 
 import { getDeclarationProcessStepLabel } from "../DeclarationStepLabel";
@@ -110,6 +111,13 @@ describe("getDeclarationProcessStepLabel", () => {
 			expect(getDeclarationProcessStepLabel(representation("done", 5))).toBe(
 				"Finalisation - Démarche des indicateurs de représentation",
 			);
+		});
+
+		// The source imports the steps submodule, not the barrel, to keep the
+		// declaration-remuneration tree out of this client bundle; the labels
+		// asserted above come from the barrel, so both must stay the same object.
+		it("reads the same steps through the barrel and the steps submodule", () => {
+			expect(REPRESENTATION_STEPS).toBe(STEPS_FROM_SUBMODULE);
 		});
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationStepLabel.test.ts
@@ -1,31 +1,34 @@
 import { describe, expect, it } from "vitest";
-import type { DeclarationFsmStatus } from "~/modules/domain";
+import { REPRESENTATION_STEPS } from "~/modules/declaration-representation";
+import type { DeclarationFsmStatus, DeclarationStatus } from "~/modules/domain";
 
 import { getDeclarationProcessStepLabel } from "../DeclarationStepLabel";
 
+const REPRESENTATION_START_LABEL = "Vérification de l'assujettissement";
+
+function remuneration(fsmStatus: DeclarationFsmStatus | null) {
+	return {
+		type: "remuneration" as const,
+		fsmStatus,
+		status: "in_progress" as DeclarationStatus,
+		currentStep: 1,
+	};
+}
+
+function representation(status: DeclarationStatus, currentStep: number) {
+	return {
+		type: "representation" as const,
+		fsmStatus: null,
+		status,
+		currentStep,
+	};
+}
+
 describe("getDeclarationProcessStepLabel", () => {
 	it("returns the first remuneration step label when fsmStatus is null", () => {
-		expect(
-			getDeclarationProcessStepLabel({ type: "remuneration", fsmStatus: null }),
-		).toBe("Déclaration des indicateurs de rémunération");
-	});
-
-	it("returns the first representation step for a representation declaration", () => {
-		expect(
-			getDeclarationProcessStepLabel({
-				type: "representation",
-				fsmStatus: null,
-			}),
-		).toBe("Vérification de l'assujettissement");
-	});
-
-	it("returns the first representation step even when fsmStatus is set", () => {
-		expect(
-			getDeclarationProcessStepLabel({
-				type: "representation",
-				fsmStatus: "draft",
-			}),
-		).toBe("Vérification de l'assujettissement");
+		expect(getDeclarationProcessStepLabel(remuneration(null))).toBe(
+			"Déclaration des indicateurs de rémunération",
+		);
 	});
 
 	const cases: Array<{ fsm: DeclarationFsmStatus; label: string }> = [
@@ -59,12 +62,54 @@ describe("getDeclarationProcessStepLabel", () => {
 
 	for (const { fsm, label } of cases) {
 		it(`returns "${label}" for fsmStatus="${fsm}"`, () => {
-			expect(
-				getDeclarationProcessStepLabel({
-					type: "remuneration",
-					fsmStatus: fsm,
-				}),
-			).toBe(label);
+			expect(getDeclarationProcessStepLabel(remuneration(fsm))).toBe(label);
 		});
 	}
+
+	describe("representation", () => {
+		it("returns the subjection check for a démarche not started yet", () => {
+			expect(
+				getDeclarationProcessStepLabel(representation("to_complete", 0)),
+			).toBe(REPRESENTATION_START_LABEL);
+		});
+
+		it("ignores the remuneration state machine even when fsmStatus is set", () => {
+			expect(
+				getDeclarationProcessStepLabel({
+					...representation("to_complete", 0),
+					fsmStatus: "demarche_completed",
+				}),
+			).toBe(REPRESENTATION_START_LABEL);
+		});
+
+		for (const [index, step] of REPRESENTATION_STEPS.entries()) {
+			it(`returns "${step.title}" for a draft sitting on step ${index + 1}`, () => {
+				expect(
+					getDeclarationProcessStepLabel(
+						representation("in_progress", index + 1),
+					),
+				).toBe(step.title);
+			});
+		}
+
+		it("falls back to the subjection check when the draft step is out of range", () => {
+			expect(
+				getDeclarationProcessStepLabel(
+					representation("in_progress", REPRESENTATION_STEPS.length + 1),
+				),
+			).toBe(REPRESENTATION_START_LABEL);
+		});
+
+		it("falls back to the subjection check when an in-progress draft has no step yet", () => {
+			expect(
+				getDeclarationProcessStepLabel(representation("in_progress", 0)),
+			).toBe(REPRESENTATION_START_LABEL);
+		});
+
+		it("returns the completion label for a submitted démarche", () => {
+			expect(getDeclarationProcessStepLabel(representation("done", 5))).toBe(
+				"Finalisation - Démarche des indicateurs de représentation",
+			);
+		});
+	});
 });

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -1,13 +1,19 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { getCurrentYear, getDefaultCampaignDeadlines } from "~/modules/domain";
+import type { RepresentationCampaign } from "~/modules/domain";
+import {
+	getCurrentYear,
+	getDefaultCampaignDeadlines,
+	getDefaultRepresentationCampaign,
+} from "~/modules/domain";
 import { DeclarationsSection } from "../DeclarationsSection";
 import type { DeclarationItem } from "../types";
 
 const SIREN = "532847196";
 const currentYear = getCurrentYear();
 const campaignDeadlines = getDefaultCampaignDeadlines(currentYear);
+const representationCampaign = getDefaultRepresentationCampaign(currentYear);
 
 const NO_COMPLIANCE = {
 	fsmStatus: null,
@@ -53,7 +59,10 @@ const declarations: DeclarationItem[] = [
 ];
 
 function renderSection(
-	overrides?: Partial<{ declarations: DeclarationItem[] }>,
+	overrides?: Partial<{
+		declarations: DeclarationItem[];
+		representationCampaign: RepresentationCampaign;
+	}>,
 ) {
 	return render(
 		<DeclarationsSection
@@ -61,6 +70,9 @@ function renderSection(
 			cseApplicable={true}
 			declarations={overrides?.declarations ?? declarations}
 			hasCse={true}
+			representationCampaign={
+				overrides?.representationCampaign ?? representationCampaign
+			}
 			userPhone="0122334455"
 		/>,
 	);
@@ -162,9 +174,57 @@ describe("DeclarationsSection", () => {
 
 	it("shows the first representation step in the 'Étape' column", () => {
 		renderSection();
+		const [currentTable] = screen.getAllByRole("table");
 		expect(
-			screen.getByText("Vérification de l'assujettissement"),
+			within(currentTable as HTMLElement).getByText(
+				"Vérification de l'assujettissement",
+			),
 		).toBeInTheDocument();
+	});
+
+	it("shows the draft step title in the 'Étape' column of an in-progress representation row", () => {
+		renderSection({
+			declarations: [
+				{
+					type: "representation",
+					siren: SIREN,
+					year: currentYear,
+					status: "in_progress",
+					currentStep: 3,
+					updatedAt: new Date("2026-02-10"),
+					...NO_COMPLIANCE,
+				},
+			],
+		});
+		const [currentTable] = screen.getAllByRole("table");
+		expect(
+			within(currentTable as HTMLElement).getByText(
+				"Écarts de représentation - Instances dirigeantes",
+			),
+		).toBeInTheDocument();
+	});
+
+	it("takes the representation deadline from the campaign, not from a fixed 1st of March", () => {
+		renderSection({
+			representationCampaign: {
+				...representationCampaign,
+				declarationDeadline: new Date(currentYear, 3, 15),
+			},
+		});
+		const [currentTable] = screen.getAllByRole("table");
+		expect(
+			within(currentTable as HTMLElement).getByText(`15/04/${currentYear}`),
+		).toBeInTheDocument();
+	});
+
+	it("renders the representation side panel once, wired to the representation link", () => {
+		const { container } = renderSection();
+		expect(
+			container.querySelectorAll("#representation-process-panel"),
+		).toHaveLength(1);
+		expect(
+			screen.getByRole("button", { name: "Représentation" }),
+		).toHaveAttribute("aria-controls", "representation-process-panel");
 	});
 
 	it("does not render the page size selector when there are 20 rows or fewer", () => {

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.refresh.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.refresh.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { updateHasCseAsync, updatePhoneAsync, mockRefresh } = vi.hoisted(() => ({
 	updateHasCseAsync: vi.fn().mockResolvedValue(undefined),
@@ -43,13 +43,67 @@ vi.mock("~/trpc/react", () => ({
 	},
 }));
 
-import { MissingInfoModal } from "../MissingInfoModal";
+import { DECLARATION_PROCESS_PANEL_ID } from "../DeclarationProcessPanel";
+import { MISSING_INFO_PANEL_ID, MissingInfoModal } from "../MissingInfoModal";
+import { REPRESENTATION_PROCESS_PANEL_ID } from "../RepresentationProcessPanel";
+
+const appended: HTMLElement[] = [];
+
+function appendElement<T extends HTMLElement>(element: T): T {
+	document.body.appendChild(element);
+	appended.push(element);
+	return element;
+}
+
+function appendPanel(id: string): HTMLElement {
+	const panel = document.createElement("div");
+	panel.id = id;
+	return appendElement(panel);
+}
+
+function appendOpener(declarationType?: string): HTMLButtonElement {
+	const opener = document.createElement("button");
+	opener.setAttribute("aria-controls", MISSING_INFO_PANEL_ID);
+	if (declarationType) opener.dataset.declarationType = declarationType;
+	return appendElement(opener);
+}
+
+// Spies capture the resolved element id so tests assert *which* panel was disclosed.
+function stubDsfrModal() {
+	const conceal = vi.fn();
+	const disclose = vi.fn();
+	(
+		window as unknown as {
+			dsfr: (el: HTMLElement) => {
+				modal: { conceal: () => void; disclose: () => void };
+			};
+		}
+	).dsfr = (el) => ({
+		modal: {
+			conceal: () => conceal(el.id),
+			disclose: () => disclose(el.id),
+		},
+	});
+	return { conceal, disclose };
+}
+
+function getDialog(container: HTMLElement): HTMLDialogElement {
+	return container.querySelector(
+		`#${MISSING_INFO_PANEL_ID}`,
+	) as HTMLDialogElement;
+}
 
 describe("MissingInfoModal — refreshes the RSC props after saving (#4056)", () => {
 	beforeEach(() => {
 		mockRefresh.mockClear();
 		updateHasCseAsync.mockClear();
 		updatePhoneAsync.mockClear();
+	});
+
+	afterEach(() => {
+		for (const element of appended) element.remove();
+		appended.length = 0;
+		delete (window as unknown as { dsfr?: unknown }).dsfr;
 	});
 
 	it("calls router.refresh after the CSE mutation resolves", async () => {
@@ -150,131 +204,147 @@ describe("MissingInfoModal — refreshes the RSC props after saving (#4056)", ()
 	});
 
 	it("discloses the declaration process panel once the remuneration modal is concealed", async () => {
-		const disclose = vi.fn();
-		const conceal = vi.fn();
-		(
-			window as unknown as {
-				dsfr: () => { modal: { conceal: () => void; disclose: () => void } };
-			}
-		).dsfr = () => ({ modal: { conceal, disclose } });
+		const { conceal, disclose } = stubDsfrModal();
+		appendPanel(DECLARATION_PROCESS_PANEL_ID);
 
-		const panel = document.createElement("div");
-		panel.id = "declaration-process-panel";
-		document.body.appendChild(panel);
+		const { container } = render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+		const dialog = getDialog(container);
 
-		try {
-			const { container } = render(
-				<MissingInfoModal
-					cseApplicable={true}
-					hasCse={null}
-					siren="532847196"
-					userPhone="0122334455"
-				/>,
-			);
-			const dialog = container.querySelector(
-				"#missing-info-modal",
-			) as HTMLDialogElement;
+		fireEvent.click(screen.getByLabelText("Non"));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
 
-			fireEvent.click(screen.getByLabelText("Non"));
-			fireEvent.click(
-				screen.getByRole("button", { name: "Enregistrer", hidden: true }),
-			);
-
-			await waitFor(() => {
-				expect(conceal).toHaveBeenCalled();
-			});
-			// The disclosure listener only fires on the DSFR conceal event.
-			expect(disclose).not.toHaveBeenCalled();
-			dialog.dispatchEvent(new Event("dsfr.conceal"));
-			expect(disclose).toHaveBeenCalled();
-		} finally {
-			document.body.removeChild(panel);
-			delete (window as unknown as { dsfr?: unknown }).dsfr;
-		}
+		await waitFor(() => {
+			expect(conceal).toHaveBeenCalledWith(MISSING_INFO_PANEL_ID);
+		});
+		// The disclosure listener only fires on the DSFR conceal event.
+		expect(disclose).not.toHaveBeenCalled();
+		dialog.dispatchEvent(new Event("dsfr.conceal"));
+		expect(disclose).toHaveBeenCalledWith(DECLARATION_PROCESS_PANEL_ID);
 	});
 
 	it("does not disclose anything on conceal when the process panel is absent", async () => {
-		const disclose = vi.fn();
-		const conceal = vi.fn();
-		(
-			window as unknown as {
-				dsfr: () => { modal: { conceal: () => void; disclose: () => void } };
-			}
-		).dsfr = () => ({ modal: { conceal, disclose } });
+		const { conceal, disclose } = stubDsfrModal();
 
-		try {
-			const { container } = render(
-				<MissingInfoModal
-					cseApplicable={true}
-					hasCse={null}
-					siren="532847196"
-					userPhone="0122334455"
-				/>,
-			);
-			const dialog = container.querySelector(
-				"#missing-info-modal",
-			) as HTMLDialogElement;
+		const { container } = render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+		const dialog = getDialog(container);
 
-			fireEvent.click(screen.getByLabelText("Non"));
-			fireEvent.click(
-				screen.getByRole("button", { name: "Enregistrer", hidden: true }),
-			);
+		fireEvent.click(screen.getByLabelText("Non"));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
 
-			await waitFor(() => {
-				expect(conceal).toHaveBeenCalled();
-			});
-			dialog.dispatchEvent(new Event("dsfr.conceal"));
-			expect(disclose).not.toHaveBeenCalled();
-		} finally {
-			delete (window as unknown as { dsfr?: unknown }).dsfr;
-		}
+		await waitFor(() => {
+			expect(conceal).toHaveBeenCalledWith(MISSING_INFO_PANEL_ID);
+		});
+		dialog.dispatchEvent(new Event("dsfr.conceal"));
+		expect(disclose).not.toHaveBeenCalled();
 	});
 
-	it("redirects to declaration-remuneration when opened from the representation entry", async () => {
-		const originalLocation = window.location;
-		const hrefSetter = vi.fn();
-		Object.defineProperty(window, "location", {
-			configurable: true,
-			value: {
-				...originalLocation,
-				set href(value: string) {
-					hrefSetter(value);
-				},
-			},
+	it("discloses the representation process panel when opened from the representation entry", async () => {
+		const { conceal, disclose } = stubDsfrModal();
+		appendPanel(REPRESENTATION_PROCESS_PANEL_ID);
+		appendPanel(DECLARATION_PROCESS_PANEL_ID);
+		const opener = appendOpener("representation");
+
+		const { container } = render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+		const dialog = getDialog(container);
+
+		opener.click();
+		fireEvent.click(screen.getByLabelText("Non"));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+
+		await waitFor(() => {
+			expect(conceal).toHaveBeenCalledWith(MISSING_INFO_PANEL_ID);
 		});
+		expect(disclose).not.toHaveBeenCalled();
+		dialog.dispatchEvent(new Event("dsfr.conceal"));
 
-		try {
-			render(
-				<MissingInfoModal
-					cseApplicable={true}
-					hasCse={null}
-					siren="532847196"
-					userPhone="0122334455"
-				/>,
-			);
+		expect(disclose).toHaveBeenCalledWith(REPRESENTATION_PROCESS_PANEL_ID);
+		expect(disclose).not.toHaveBeenCalledWith(DECLARATION_PROCESS_PANEL_ID);
+	});
 
-			const opener = document.createElement("button");
-			opener.setAttribute("aria-controls", "missing-info-modal");
-			opener.dataset.declarationType = "representation";
-			document.body.appendChild(opener);
-			opener.click();
+	it("does not disclose anything on conceal when the representation panel is absent", async () => {
+		const { conceal, disclose } = stubDsfrModal();
+		const opener = appendOpener("representation");
 
-			fireEvent.click(screen.getByLabelText("Non"));
-			fireEvent.click(
-				screen.getByRole("button", { name: "Enregistrer", hidden: true }),
-			);
+		const { container } = render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+		const dialog = getDialog(container);
 
-			await waitFor(() => {
-				expect(hrefSetter).toHaveBeenCalledWith(
-					"/declaration-remuneration?siren=532847196",
-				);
-			});
-			document.body.removeChild(opener);
-		} finally {
-			Object.defineProperty(window, "location", {
-				configurable: true,
-				value: originalLocation,
-			});
-		}
+		opener.click();
+		fireEvent.click(screen.getByLabelText("Non"));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+
+		await waitFor(() => {
+			expect(conceal).toHaveBeenCalledWith(MISSING_INFO_PANEL_ID);
+		});
+		dialog.dispatchEvent(new Event("dsfr.conceal"));
+		expect(disclose).not.toHaveBeenCalled();
+	});
+
+	it("targets the declaration process panel again when reopened from the remuneration entry", async () => {
+		const { conceal, disclose } = stubDsfrModal();
+		appendPanel(REPRESENTATION_PROCESS_PANEL_ID);
+		appendPanel(DECLARATION_PROCESS_PANEL_ID);
+		const representationOpener = appendOpener("representation");
+		const remunerationOpener = appendOpener("remuneration");
+
+		const { container } = render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone="0122334455"
+			/>,
+		);
+		const dialog = getDialog(container);
+
+		representationOpener.click();
+		remunerationOpener.click();
+		fireEvent.click(screen.getByLabelText("Non"));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+
+		await waitFor(() => {
+			expect(conceal).toHaveBeenCalledWith(MISSING_INFO_PANEL_ID);
+		});
+		dialog.dispatchEvent(new Event("dsfr.conceal"));
+
+		expect(disclose).toHaveBeenCalledWith(DECLARATION_PROCESS_PANEL_ID);
+		expect(disclose).not.toHaveBeenCalledWith(REPRESENTATION_PROCESS_PANEL_ID);
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MonEspacePage.test.tsx
@@ -51,6 +51,15 @@ vi.mock("~/server/db/getCampaignDeadlines", async () => {
 	};
 });
 
+vi.mock("~/server/db/getRepresentationCampaign", async () => {
+	const { getDefaultRepresentationCampaign } = await import("~/modules/domain");
+	return {
+		getRepresentationCampaign: vi
+			.fn()
+			.mockResolvedValue(getDefaultRepresentationCampaign(2026)),
+	};
+});
+
 vi.mock("~/trpc/server", () => ({
 	api: {
 		company: {

--- a/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/RepresentationProcessPanel.test.tsx
@@ -1,0 +1,256 @@
+import { render, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+	REPRESENTATION_FUNNEL_ROOT,
+	stepHref,
+	TOTAL_REPRESENTATION_STEPS,
+} from "~/modules/declaration-representation";
+import type { RepresentationCampaign } from "~/modules/domain";
+import { RepresentationProcessPanel } from "../RepresentationProcessPanel";
+import type { DeclarationItem } from "../types";
+
+const SIREN = "532847196";
+const CAMPAIGN_YEAR = 2026;
+const RECAP_HREF = stepHref(TOTAL_REPRESENTATION_STEPS);
+
+// The panel resolves the campaign window against the real clock, so the open
+// window is stretched wide enough to stay open whenever the suite runs.
+const OPEN_CAMPAIGN: RepresentationCampaign = {
+	campaignStartDate: new Date(2000, 0, 1),
+	campaignEndDate: new Date(2099, 11, 31),
+	declarationDeadline: new Date(CAMPAIGN_YEAR, 2, 1),
+};
+
+const CLOSED_CAMPAIGN: RepresentationCampaign = {
+	campaignStartDate: new Date(2019, 0, 1),
+	campaignEndDate: new Date(2019, 11, 31),
+	declarationDeadline: new Date(2019, 2, 1),
+};
+
+function makeDeclaration(
+	overrides: Partial<DeclarationItem> = {},
+): DeclarationItem {
+	return {
+		type: "representation",
+		siren: SIREN,
+		year: CAMPAIGN_YEAR,
+		status: "to_complete",
+		fsmStatus: null,
+		currentStep: 0,
+		updatedAt: null,
+		firstDeclarationPathChoice: null,
+		secondDeclarationPathChoice: null,
+		hasSubmittedSecondDeclaration: false,
+		hasSubmittedCseOpinion: false,
+		cseRequired: false,
+		hasJointEvaluationFile: false,
+		hasPrefillData: false,
+		...overrides,
+	};
+}
+
+const DRAFT = makeDeclaration({ status: "in_progress", currentStep: 3 });
+const SUBMITTED = makeDeclaration({
+	status: "done",
+	currentStep: TOTAL_REPRESENTATION_STEPS,
+});
+
+function renderPanel({
+	campaign = OPEN_CAMPAIGN,
+	declaration,
+}: {
+	campaign?: RepresentationCampaign;
+	declaration?: DeclarationItem;
+} = {}) {
+	const { container } = render(
+		<RepresentationProcessPanel
+			campaign={campaign}
+			campaignYear={CAMPAIGN_YEAR}
+			declaration={declaration}
+		/>,
+	);
+	const dialog = container.querySelector("dialog") as HTMLElement;
+	return { panel: within(dialog), dialog };
+}
+
+function getCta(dialog: HTMLElement) {
+	return dialog.querySelector("a.fr-btn");
+}
+
+describe("RepresentationProcessPanel", () => {
+	it("renders a labelled modal dialog carrying the panel id", () => {
+		const { dialog } = renderPanel();
+		expect(dialog).toHaveAttribute("id", "representation-process-panel");
+		expect(dialog).toHaveAttribute("aria-modal", "true");
+		const titleId = dialog.getAttribute("aria-labelledby");
+		expect(dialog.querySelector(`#${titleId}`)?.tagName).toBe("H2");
+	});
+
+	it("renders the title with the campaign year", () => {
+		const { panel } = renderPanel();
+		const title = panel.getByText(
+			`Démarche des indicateurs de représentation ${CAMPAIGN_YEAR}`,
+		);
+		expect(title).toBeInTheDocument();
+		expect(title.tagName).toBe("H2");
+	});
+
+	it("renders the Rixain reminder with both representation targets", () => {
+		const { panel } = renderPanel();
+		expect(panel.getByText(/loi Rixain/)).toBeInTheDocument();
+		expect(panel.getByText("30 % minimum de chaque sexe")).toBeInTheDocument();
+		expect(panel.getByText("40 % minimum de chaque sexe")).toBeInTheDocument();
+	});
+
+	it("renders the campaign deadline on the declaration step", () => {
+		const { panel } = renderPanel();
+		expect(panel.getByText("Échéance : 1ᵉʳ mars 2026")).toBeInTheDocument();
+	});
+
+	it("renders the deadline overridden by the back-office campaign", () => {
+		const { panel } = renderPanel({
+			campaign: {
+				...OPEN_CAMPAIGN,
+				declarationDeadline: new Date(CAMPAIGN_YEAR, 3, 15),
+			},
+		});
+		expect(panel.getByText("Échéance : 15 avril 2026")).toBeInTheDocument();
+	});
+
+	it("renders help section buttons", () => {
+		const { dialog } = renderPanel();
+		const texts = [...dialog.querySelectorAll("button.fr-link")].map(
+			(b) => b.textContent,
+		);
+		expect(texts).toContain("Détail des étapes");
+		expect(texts).toContain("Centre d'aide");
+	});
+
+	it("describes the CTA link by the panel title", () => {
+		const { dialog } = renderPanel();
+		const describedBy = getCta(dialog)?.getAttribute("aria-describedby");
+		expect(describedBy).toBeTruthy();
+		expect(dialog.querySelector(`#${describedBy}`)).toHaveTextContent(
+			/Démarche des indicateurs de représentation/,
+		);
+	});
+
+	describe("variant: start", () => {
+		it('renders a "Commencer" CTA pointing to the funnel entry point', () => {
+			const { dialog } = renderPanel();
+			const cta = getCta(dialog);
+			expect(cta).toHaveTextContent(/^Commencer$/);
+			expect(cta).toHaveAttribute("href", REPRESENTATION_FUNNEL_ROOT);
+		});
+
+		it("marks the subjection check as the current step", () => {
+			const { panel } = renderPanel();
+			expect(panel.getAllByText("Étape en cours")).toHaveLength(1);
+			expect(
+				panel.getByText("Vérification de l'assujettissement"),
+			).toBeInTheDocument();
+		});
+
+		it("keeps the declaration step collapsed to its heading", () => {
+			const { panel } = renderPanel();
+			expect(
+				panel.getByText("Déclaration des écarts de représentation"),
+			).toBeInTheDocument();
+			expect(panel.queryByText("Cadres dirigeants")).not.toBeInTheDocument();
+		});
+
+		it("does not render a last action date when the démarche was never touched", () => {
+			const { panel } = renderPanel({ declaration: makeDeclaration() });
+			expect(panel.queryByText(/Dernière action/)).not.toBeInTheDocument();
+		});
+	});
+
+	describe("variant: draft", () => {
+		it('renders a "Reprendre" CTA pointing to the step the draft stopped at', () => {
+			const { dialog } = renderPanel({ declaration: DRAFT });
+			const cta = getCta(dialog);
+			expect(cta).toHaveTextContent(/^Reprendre$/);
+			expect(cta).toHaveAttribute("href", stepHref(3));
+		});
+
+		it("expands the declaration step into its three bullets", () => {
+			const { panel } = renderPanel({ declaration: DRAFT });
+			expect(panel.getByText("Écarts de représentation")).toBeInTheDocument();
+			expect(panel.getByText("Cadres dirigeants")).toBeInTheDocument();
+			expect(panel.getByText("Instances dirigeantes")).toBeInTheDocument();
+			expect(
+				panel.getByText("Informations de publication"),
+			).toBeInTheDocument();
+		});
+
+		it("marks the subjection check as done and the declaration as current", () => {
+			const { panel } = renderPanel({ declaration: DRAFT });
+			expect(panel.getAllByText("Étape terminée")).toHaveLength(1);
+			expect(panel.getAllByText("Étape en cours")).toHaveLength(1);
+		});
+
+		it("renders the last action date of the draft", () => {
+			const { panel } = renderPanel({
+				declaration: makeDeclaration({
+					status: "in_progress",
+					currentStep: 3,
+					updatedAt: new Date(2026, 1, 10),
+				}),
+			});
+			expect(
+				panel.getByText("Dernière action le 10 février 2026"),
+			).toBeInTheDocument();
+		});
+
+		it("does not announce the démarche as closed", () => {
+			const { panel } = renderPanel({ declaration: DRAFT });
+			expect(panel.queryByText("Démarche close")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("variant: submitted", () => {
+		it('renders a "Voir la déclaration" CTA pointing to the recap', () => {
+			const { dialog } = renderPanel({ declaration: SUBMITTED });
+			const cta = getCta(dialog);
+			expect(cta).toHaveTextContent(/^Voir la déclaration$/);
+			expect(cta).toHaveAttribute("href", RECAP_HREF);
+		});
+
+		it("marks both steps as done", () => {
+			const { panel } = renderPanel({ declaration: SUBMITTED });
+			expect(panel.getAllByText("Étape terminée")).toHaveLength(2);
+			expect(panel.queryByText("Étape en cours")).not.toBeInTheDocument();
+		});
+
+		it("does not announce the démarche as closed while the campaign is open", () => {
+			const { panel } = renderPanel({ declaration: SUBMITTED });
+			expect(panel.queryByText("Démarche close")).not.toBeInTheDocument();
+		});
+	});
+
+	describe("campaign closed", () => {
+		const declarations: Array<[string, DeclarationItem | undefined]> = [
+			["no démarche", undefined],
+			["an untouched démarche", makeDeclaration()],
+			["a draft", DRAFT],
+			["a submitted démarche", SUBMITTED],
+		];
+
+		for (const [label, declaration] of declarations) {
+			it(`announces the démarche as closed with ${label}`, () => {
+				const { panel, dialog } = renderPanel({
+					campaign: CLOSED_CAMPAIGN,
+					declaration,
+				});
+				expect(panel.getByText("Démarche close")).toBeInTheDocument();
+				expect(
+					panel.getByText("Cette démarche est terminée."),
+				).toBeInTheDocument();
+				const cta = getCta(dialog);
+				expect(cta).toHaveTextContent(/^Voir la déclaration$/);
+				expect(cta).toHaveAttribute("href", RECAP_HREF);
+			});
+		}
+	});
+});

--- a/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
@@ -5,6 +5,11 @@ import {
 	stepHref,
 	TOTAL_REPRESENTATION_STEPS,
 } from "~/modules/declaration-representation";
+import {
+	REPRESENTATION_FUNNEL_ROOT as FUNNEL_ROOT_FROM_SUBMODULE,
+	stepHref as stepHrefFromSubmodule,
+} from "~/modules/declaration-representation/steps";
+import { TOTAL_REPRESENTATION_STEPS as TOTAL_STEPS_FROM_SUBMODULE } from "~/modules/declaration-representation/types";
 import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
 import {
 	computeCtaHref,
@@ -192,5 +197,14 @@ describe("computeRepresentationCtaHref", () => {
 				RECAP_HREF,
 			);
 		}
+	});
+
+	// The source imports the steps/types submodules, not the barrel, to keep the
+	// declaration-remuneration tree out of this client bundle; the hrefs asserted
+	// above come from the barrel, so both must stay the same values.
+	it("reads the same funnel constants through the barrel and the submodules", () => {
+		expect(REPRESENTATION_FUNNEL_ROOT).toBe(FUNNEL_ROOT_FROM_SUBMODULE);
+		expect(TOTAL_REPRESENTATION_STEPS).toBe(TOTAL_STEPS_FROM_SUBMODULE);
+		expect(stepHref).toBe(stepHrefFromSubmodule);
 	});
 });

--- a/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
+++ b/packages/app/src/modules/my-space/__tests__/declarationProcessState.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
 
+import {
+	REPRESENTATION_FUNNEL_ROOT,
+	stepHref,
+	TOTAL_REPRESENTATION_STEPS,
+} from "~/modules/declaration-representation";
 import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
 import {
 	computeCtaHref,
 	computePanelVariant,
+	computeRepresentationCtaHref,
+	computeRepresentationPanelVariant,
 } from "../declarationProcessState";
 import type { DeclarationItem } from "../types";
 
 const SIREN = "532847196";
+const RECAP_HREF = stepHref(TOTAL_REPRESENTATION_STEPS);
+const CAMPAIGN_OPEN = true;
+const CAMPAIGN_CLOSED = false;
 
 function makeDeclaration(
 	overrides: Partial<DeclarationItem> = {},
@@ -67,6 +77,119 @@ describe("computeCtaHref", () => {
 		for (const fsmStatus of DECLARATION_FSM_STATUSES) {
 			expect(computeCtaHref(makeDeclaration({ fsmStatus }), SIREN)).toContain(
 				`?siren=${SIREN}`,
+			);
+		}
+	});
+});
+
+function makeRepresentation(
+	overrides: Partial<DeclarationItem> = {},
+): DeclarationItem {
+	return makeDeclaration({
+		type: "representation",
+		fsmStatus: null,
+		status: "to_complete",
+		currentStep: 0,
+		...overrides,
+	});
+}
+
+describe("computeRepresentationPanelVariant", () => {
+	it('returns "start" when no démarche exists yet', () => {
+		expect(computeRepresentationPanelVariant(undefined, CAMPAIGN_OPEN)).toBe(
+			"start",
+		);
+	});
+
+	it('returns "start" for a démarche that is only listed, never opened', () => {
+		expect(
+			computeRepresentationPanelVariant(makeRepresentation(), CAMPAIGN_OPEN),
+		).toBe("start");
+	});
+
+	it('returns "draft" for a démarche in progress', () => {
+		expect(
+			computeRepresentationPanelVariant(
+				makeRepresentation({ status: "in_progress", currentStep: 3 }),
+				CAMPAIGN_OPEN,
+			),
+		).toBe("draft");
+	});
+
+	it('returns "submitted" once the démarche is transmitted', () => {
+		expect(
+			computeRepresentationPanelVariant(
+				makeRepresentation({ status: "done", currentStep: 5 }),
+				CAMPAIGN_OPEN,
+			),
+		).toBe("submitted");
+	});
+
+	it('returns "closed" for every démarche state once the campaign is closed', () => {
+		const declarations = [
+			undefined,
+			makeRepresentation(),
+			makeRepresentation({ status: "in_progress", currentStep: 3 }),
+			makeRepresentation({ status: "done", currentStep: 5 }),
+		];
+		for (const declaration of declarations) {
+			expect(
+				computeRepresentationPanelVariant(declaration, CAMPAIGN_CLOSED),
+			).toBe("closed");
+		}
+	});
+});
+
+describe("computeRepresentationCtaHref", () => {
+	it("sends a company with no démarche to the funnel entry point", () => {
+		expect(computeRepresentationCtaHref(undefined, CAMPAIGN_OPEN)).toBe(
+			REPRESENTATION_FUNNEL_ROOT,
+		);
+	});
+
+	it("sends a listed-but-unopened démarche to the funnel entry point", () => {
+		expect(
+			computeRepresentationCtaHref(makeRepresentation(), CAMPAIGN_OPEN),
+		).toBe(REPRESENTATION_FUNNEL_ROOT);
+	});
+
+	it("resumes a draft on the step it stopped at", () => {
+		expect(
+			computeRepresentationCtaHref(
+				makeRepresentation({ status: "in_progress", currentStep: 3 }),
+				CAMPAIGN_OPEN,
+			),
+		).toBe(stepHref(3));
+	});
+
+	it("resumes on the first step when an in-progress draft has no step yet", () => {
+		expect(
+			computeRepresentationCtaHref(
+				makeRepresentation({ status: "in_progress", currentStep: 0 }),
+				CAMPAIGN_OPEN,
+			),
+		).toBe(stepHref(1));
+	});
+
+	it("sends a transmitted démarche to its recap", () => {
+		expect(
+			computeRepresentationCtaHref(
+				makeRepresentation({ status: "done", currentStep: 5 }),
+				CAMPAIGN_OPEN,
+			),
+		).toBe(RECAP_HREF);
+	});
+
+	it("sends every démarche state to the recap once the campaign is closed", () => {
+		const declarations = [
+			undefined,
+			makeRepresentation(),
+			makeRepresentation({ status: "in_progress", currentStep: 3 }),
+			makeRepresentation({ status: "done", currentStep: 5 }),
+		];
+		for (const declaration of declarations) {
+			expect(computeRepresentationCtaHref(declaration, CAMPAIGN_CLOSED)).toBe(
+				RECAP_HREF,
 			);
 		}
 	});

--- a/packages/app/src/modules/my-space/buildDeclarationList.ts
+++ b/packages/app/src/modules/my-space/buildDeclarationList.ts
@@ -9,7 +9,7 @@ import type {
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
-type DbDeclaration = {
+export type DbDeclaration = {
 	type: DeclarationType;
 	year: number;
 	status: DeclarationStatus;

--- a/packages/app/src/modules/my-space/declarationProcessState.ts
+++ b/packages/app/src/modules/my-space/declarationProcessState.ts
@@ -78,20 +78,24 @@ export type RepresentationPanelVariant =
 	| "submitted"
 	| "closed";
 
-/**
- * Variant for the representation panel. Unlike remuneration, representation
- * has no FSM yet (~/modules/domain) — its progression is the 3-bucket
- * `DeclarationItem.status` computed in `company.ts` from the raw
- * draft/submitted DB status.
- */
+// Representation has no FSM yet — progression is this 3-bucket DeclarationItem.status.
+type RepresentationProgress = "not_started" | "draft" | "submitted";
+
+function getRepresentationProgress(
+	declaration: DeclarationItem | undefined,
+): RepresentationProgress {
+	if (declaration?.status === "done") return "submitted";
+	if (declaration?.status === "in_progress") return "draft";
+	return "not_started";
+}
+
 export function computeRepresentationPanelVariant(
 	declaration: DeclarationItem | undefined,
 	campaignOpen: boolean,
 ): RepresentationPanelVariant {
 	if (!campaignOpen) return "closed";
-	if (declaration?.status === "done") return "submitted";
-	if (declaration?.status === "in_progress") return "draft";
-	return "start";
+	const progress = getRepresentationProgress(declaration);
+	return progress === "not_started" ? "start" : progress;
 }
 
 export function computeRepresentationCtaHref(
@@ -99,10 +103,10 @@ export function computeRepresentationCtaHref(
 	campaignOpen: boolean,
 ): string {
 	if (!campaignOpen) return stepHref(TOTAL_REPRESENTATION_STEPS);
-	if (declaration?.status === "done")
-		return stepHref(TOTAL_REPRESENTATION_STEPS);
-	if (declaration?.status === "in_progress") {
-		return stepHref(Math.max(declaration.currentStep, 1));
+	const progress = getRepresentationProgress(declaration);
+	if (progress === "submitted") return stepHref(TOTAL_REPRESENTATION_STEPS);
+	if (progress === "draft") {
+		return stepHref(Math.max(declaration?.currentStep ?? 1, 1));
 	}
 	return REPRESENTATION_FUNNEL_ROOT;
 }

--- a/packages/app/src/modules/my-space/declarationProcessState.ts
+++ b/packages/app/src/modules/my-space/declarationProcessState.ts
@@ -1,3 +1,8 @@
+import {
+	REPRESENTATION_FUNNEL_ROOT,
+	stepHref,
+	TOTAL_REPRESENTATION_STEPS,
+} from "~/modules/declaration-representation";
 import { isCseOpinionResolved } from "~/modules/domain";
 import type { PanelVariant } from "./DeclarationProcessPanel";
 import type { DeclarationItem } from "./types";
@@ -65,4 +70,39 @@ export function computeCtaHref(
 				? `/declaration-remuneration?siren=${siren}`
 				: `/avis-cse?siren=${siren}`;
 	}
+}
+
+export type RepresentationPanelVariant =
+	| "start"
+	| "draft"
+	| "submitted"
+	| "closed";
+
+/**
+ * Variant for the representation panel. Unlike remuneration, representation
+ * has no FSM yet (~/modules/domain) — its progression is the 3-bucket
+ * `DeclarationItem.status` computed in `company.ts` from the raw
+ * draft/submitted DB status.
+ */
+export function computeRepresentationPanelVariant(
+	declaration: DeclarationItem | undefined,
+	campaignOpen: boolean,
+): RepresentationPanelVariant {
+	if (!campaignOpen) return "closed";
+	if (declaration?.status === "done") return "submitted";
+	if (declaration?.status === "in_progress") return "draft";
+	return "start";
+}
+
+export function computeRepresentationCtaHref(
+	declaration: DeclarationItem | undefined,
+	campaignOpen: boolean,
+): string {
+	if (!campaignOpen) return stepHref(TOTAL_REPRESENTATION_STEPS);
+	if (declaration?.status === "done")
+		return stepHref(TOTAL_REPRESENTATION_STEPS);
+	if (declaration?.status === "in_progress") {
+		return stepHref(Math.max(declaration.currentStep, 1));
+	}
+	return REPRESENTATION_FUNNEL_ROOT;
 }

--- a/packages/app/src/modules/my-space/declarationProcessState.ts
+++ b/packages/app/src/modules/my-space/declarationProcessState.ts
@@ -1,8 +1,9 @@
+// Submodule imports, not the barrel — the barrel drags declaration-remuneration's (server-touching) tree into this client bundle.
 import {
 	REPRESENTATION_FUNNEL_ROOT,
 	stepHref,
-	TOTAL_REPRESENTATION_STEPS,
-} from "~/modules/declaration-representation";
+} from "~/modules/declaration-representation/steps";
+import { TOTAL_REPRESENTATION_STEPS } from "~/modules/declaration-representation/types";
 import { isCseOpinionResolved } from "~/modules/domain";
 import type { PanelVariant } from "./DeclarationProcessPanel";
 import type { DeclarationItem } from "./types";

--- a/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/company.getWithDeclarations.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getCurrentYear } from "~/modules/domain";
+import { getCurrentYear, getReferenceYearFor } from "~/modules/domain";
 import {
 	companies,
 	declarationStatusHistory,
@@ -115,8 +115,21 @@ function makeDeclRow(year: number) {
 	};
 }
 
-function makeRepresentationDeclarationRow(year: number) {
-	return { year };
+/** Shaped like the router's select: the mock builder does not filter, so the
+ * reference year the row is stored under is asserted on the query instead. */
+function makeRepresentationDeclarationRow(
+	overrides: Partial<{
+		status: "draft" | "submitted";
+		currentStep: number | null;
+		updatedAt: Date | null;
+	}> = {},
+) {
+	return {
+		status: "draft" as const,
+		currentStep: 0,
+		updatedAt: null,
+		...overrides,
+	};
 }
 
 /** Flattens a Drizzle `and(eq(col, value), …)` condition into a
@@ -264,9 +277,7 @@ describe("companyRouter.getWithDeclarations", () => {
 			workforceBelowThreshold,
 		);
 		const { caller } = await makeCaller({
-			representationDeclarationRows: [
-				makeRepresentationDeclarationRow(getCurrentYear()),
-			],
+			representationDeclarationRows: [makeRepresentationDeclarationRow()],
 		});
 
 		const result = await caller.getWithDeclarations({ siren: SIREN });
@@ -294,9 +305,7 @@ describe("companyRouter.getWithDeclarations", () => {
 			workforceAboveThreshold,
 		);
 		const { caller } = await makeCaller({
-			representationDeclarationRows: [
-				makeRepresentationDeclarationRow(getCurrentYear()),
-			],
+			representationDeclarationRows: [makeRepresentationDeclarationRow()],
 		});
 
 		const result = await caller.getWithDeclarations({ siren: SIREN });
@@ -306,11 +315,9 @@ describe("companyRouter.getWithDeclarations", () => {
 		).toHaveLength(1);
 	});
 
-	it("scopes the existing-declaration lookup to the company and the current year", async () => {
+	it("scopes the existing-declaration lookup to the company and the reference year", async () => {
 		const { caller, queries } = await makeCaller({
-			representationDeclarationRows: [
-				makeRepresentationDeclarationRow(getCurrentYear()),
-			],
+			representationDeclarationRows: [makeRepresentationDeclarationRow()],
 		});
 
 		await caller.getWithDeclarations({ siren: SIREN });
@@ -318,26 +325,50 @@ describe("companyRouter.getWithDeclarations", () => {
 		const query = findQuery(queries, representationDeclarations);
 		const filters = collectEqualityFilters(query?.where);
 		expect(filters.get(representationDeclarations.siren)).toBe(SIREN);
-		expect(filters.get(representationDeclarations.year)).toBe(getCurrentYear());
+		// The représentation funnel stores the reference year (N-1), not the
+		// campaign year: filtering on the campaign year never matches a real row.
+		expect(filters.get(representationDeclarations.year)).toBe(
+			getReferenceYearFor(getCurrentYear()),
+		);
+		expect(filters.get(representationDeclarations.year)).not.toBe(
+			getCurrentYear(),
+		);
 		// Exactly two filters: no status predicate, so a draft counts as much as a
 		// submitted declaration — the line must never disappear once started.
 		expect(filters.size).toBe(2);
 	});
 
-	it("shows the existing representation declaration with the generic stub state", async () => {
+	it("shows the stub state when the démarche is only offered, with no row yet", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceAboveThreshold,
+		);
+		const { caller } = await makeCaller({ representationDeclarationRows: [] });
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "representation"),
+		).toMatchObject({
+			year: getCurrentYear(),
+			status: "to_complete",
+			fsmStatus: null,
+			currentStep: 0,
+			updatedAt: null,
+		});
+	});
+
+	it("keeps a started draft at 'to_complete' until it leaves the subjection check", async () => {
 		getRepresentationWorkforceHistoryMock.mockResolvedValue(
 			workforceBelowThreshold,
 		);
 		const { caller } = await makeCaller({
 			representationDeclarationRows: [
-				makeRepresentationDeclarationRow(getCurrentYear()),
+				makeRepresentationDeclarationRow({ status: "draft", currentStep: 0 }),
 			],
 		});
 
 		const result = await caller.getWithDeclarations({ siren: SIREN });
 
-		// Visibility only: mapping the representation state machine onto the row is
-		// owned by the "panneau latéral & activation" ticket, not this one.
 		expect(
 			result.declarations.find((d) => d.type === "representation"),
 		).toMatchObject({
@@ -346,5 +377,94 @@ describe("companyRouter.getWithDeclarations", () => {
 			fsmStatus: null,
 			currentStep: 0,
 		});
+	});
+
+	it("maps a draft past the subjection check to 'in_progress' on its current step", async () => {
+		const updatedAt = new Date("2026-02-10T09:00:00.000Z");
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow({
+					status: "draft",
+					currentStep: 3,
+					updatedAt,
+				}),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "representation"),
+		).toMatchObject({
+			year: getCurrentYear(),
+			status: "in_progress",
+			fsmStatus: null,
+			currentStep: 3,
+			updatedAt,
+		});
+	});
+
+	it("maps a submitted row to 'done'", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow({
+					status: "submitted",
+					currentStep: 5,
+				}),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "representation"),
+		).toMatchObject({
+			year: getCurrentYear(),
+			status: "done",
+			fsmStatus: null,
+			currentStep: 5,
+		});
+	});
+
+	it("keeps the démarche listed under the campaign year, not the stored reference year", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow({ status: "draft", currentStep: 3 }),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		const representation = result.declarations.filter(
+			(d) => d.type === "representation",
+		);
+		expect(representation).toHaveLength(1);
+		expect(representation[0]?.year).toBe(getCurrentYear());
+	});
+
+	it("falls back to step 0 when the row carries no current step", async () => {
+		getRepresentationWorkforceHistoryMock.mockResolvedValue(
+			workforceBelowThreshold,
+		);
+		const { caller } = await makeCaller({
+			representationDeclarationRows: [
+				makeRepresentationDeclarationRow({ currentStep: null }),
+			],
+		});
+
+		const result = await caller.getWithDeclarations({ siren: SIREN });
+
+		expect(
+			result.declarations.find((d) => d.type === "representation"),
+		).toMatchObject({ status: "to_complete", currentStep: 0 });
 	});
 });

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, inArray, isNull } from "drizzle-orm";
 import type { Session } from "next-auth";
 import {
 	computeDeclarationStatus,
+	computeRepresentationDeclarationStatus,
 	getCurrentYear,
 	getObligationWorkforce,
 	getReferenceYearFor,
@@ -314,12 +315,10 @@ export const companyRouter = createTRPCRouter({
 				mappedDeclarations.push({
 					type: "representation" as const,
 					year,
-					status:
-						representationRow.status === "submitted"
-							? "done"
-							: representationCurrentStep === 0
-								? "to_complete"
-								: "in_progress",
+					status: computeRepresentationDeclarationStatus({
+						status: representationRow.status,
+						currentStep: representationRow.currentStep,
+					}),
 					fsmStatus: null,
 					currentStep: representationCurrentStep,
 					updatedAt: representationRow.updatedAt,

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -5,11 +5,15 @@ import {
 	computeDeclarationStatus,
 	getCurrentYear,
 	getObligationWorkforce,
+	getReferenceYearFor,
 	isCseRequired,
 	isPresumedSubjectToRepresentation,
 	parseGipWorkforce,
 } from "~/modules/domain";
-import { buildDeclarationList } from "~/modules/my-space/buildDeclarationList";
+import {
+	buildDeclarationList,
+	type DbDeclaration,
+} from "~/modules/my-space/buildDeclarationList";
 import {
 	sirenInputSchema,
 	updateHasCseSchema,
@@ -253,12 +257,19 @@ export const companyRouter = createTRPCRouter({
 					),
 				getRepresentationWorkforceHistory(input.siren, year),
 				ctx.db
-					.select({ year: representationDeclarations.year })
+					.select({
+						status: representationDeclarations.status,
+						currentStep: representationDeclarations.currentStep,
+						updatedAt: representationDeclarations.updatedAt,
+					})
 					.from(representationDeclarations)
 					.where(
 						and(
 							eq(representationDeclarations.siren, input.siren),
-							eq(representationDeclarations.year, year),
+							// The représentation funnel stores the *reference* year
+							// (~/app/declaration-representation/page.tsx), not the
+							// campaign year used everywhere else in this router.
+							eq(representationDeclarations.year, getReferenceYearFor(year)),
 						),
 					)
 					.limit(1),
@@ -277,12 +288,11 @@ export const companyRouter = createTRPCRouter({
 					.map((r) => r.declarationId),
 			);
 
-			const hasCurrentYearRepresentationDeclaration =
-				currentYearRepresentationDeclarationRows.length > 0;
+			const representationRow = currentYearRepresentationDeclarationRows[0];
 			const representationVisible =
-				hasCurrentYearRepresentationDeclaration ||
+				representationRow !== undefined ||
 				isPresumedSubjectToRepresentation(representationWorkforceHistory, year);
-			const mappedDeclarations = declarationRows.map((d) => ({
+			const mappedDeclarations: DbDeclaration[] = declarationRows.map((d) => ({
 				type: "remuneration" as const,
 				year: d.year,
 				status: computeDeclarationStatus({
@@ -300,6 +310,30 @@ export const companyRouter = createTRPCRouter({
 				hasJointEvaluationFile: yearsWithJointEval.has(d.year),
 				hasPrefillData: yearsWithPrefill.has(d.year),
 			}));
+
+			if (representationRow) {
+				const representationCurrentStep = representationRow.currentStep ?? 0;
+				mappedDeclarations.push({
+					type: "representation" as const,
+					year,
+					status:
+						representationRow.status === "submitted"
+							? "done"
+							: representationCurrentStep === 0
+								? "to_complete"
+								: "in_progress",
+					fsmStatus: null,
+					currentStep: representationCurrentStep,
+					updatedAt: representationRow.updatedAt,
+					firstDeclarationPathChoice: null,
+					secondDeclarationPathChoice: null,
+					hasSubmittedSecondDeclaration: false,
+					hasSubmittedCseOpinion: false,
+					cseRequired: false,
+					hasJointEvaluationFile: false,
+					hasPrefillData: false,
+				});
+			}
 
 			const declarationItems = buildDeclarationList(
 				input.siren,

--- a/packages/app/src/server/api/routers/company.ts
+++ b/packages/app/src/server/api/routers/company.ts
@@ -266,9 +266,7 @@ export const companyRouter = createTRPCRouter({
 					.where(
 						and(
 							eq(representationDeclarations.siren, input.siren),
-							// The représentation funnel stores the *reference* year
-							// (~/app/declaration-representation/page.tsx), not the
-							// campaign year used everywhere else in this router.
+							// The représentation funnel stores the *reference* year, not the campaign year.
 							eq(representationDeclarations.year, getReferenceYearFor(year)),
 						),
 					)


### PR DESCRIPTION
Closes #4162

## Résumé

Active la ligne « Représentation » de Mon espace : elle ouvre désormais le panneau latéral dédié (`RepresentationProcessPanel`, nouveau composant calqué sur `DeclarationProcessPanel`) au lieu du bouton inerte.

- Panneau « Démarche des indicateurs de représentation {année} » : échéance de campagne via `getRepresentationCampaign` (surchargeable en back-office, défaut 1er mars), progression (vérification de l'assujettissement → écarts de représentation), CTA selon l'état (Commencer / Reprendre / Voir la déclaration).
- États de la ligne (`StatusBadge` + libellé d'étape réel) reflètent maintenant l'état DB réel (brouillon à l'étape N / transmise), plus le stub générique "à commencer" toujours renvoyé jusqu'ici.
- Gate `MissingInfoModal` (informations manquantes) conservée : même déclenchement, même formulaire. Son routage post-sauvegarde a dû être corrigé — voir bug fix ci-dessous.
- **Bug fix au passage** : `company.getWithDeclarations` filtrait la déclaration de représentation par année de campagne, alors que le funnel (`/declaration-representation`) persiste l'année de référence (N-1) — la déclaration n'était donc jamais retrouvée. Corrigé.
- **Bug fix critique découvert en vérification manuelle** : `DeclarationStepLabel.ts` / `declarationProcessState.ts` importaient `REPRESENTATION_STEPS` / `REPRESENTATION_FUNNEL_ROOT` / `stepHref` / `TOTAL_REPRESENTATION_STEPS` depuis le barrel `~/modules/declaration-representation`, qui ré-exporte `DeclarationLayout` — celui-ci importe `CompanyBanner` depuis le barrel `~/modules/declaration-remuneration`, qui entraîne dans le bundle client de `DeclarationsSection.tsx` ("use client") tout l'arbre `declaration-remuneration`, y compris du code server-only (`next/headers`, `pg-boss`). Résultat : **toutes les pages de l'app renvoyaient 500** dès que cette ligne du diff était compilée côté client. Corrigé en important depuis les sous-modules légers `~/modules/declaration-representation/steps` et `.../types` plutôt que le barrel (tests de non-régression ajoutés : identité barrel ↔ sous-module).
- **Bug fix trouvé par `functional-validator`** : `MissingInfoModal.tsx::handleSave` redirigeait en dur vers `/declaration-remuneration?siren=...` après sauvegarde, quel que soit le point d'entrée ayant ouvert la gate. Latent avant ce ticket (la ligne Représentation ne menait nulle part d'utile), devenu bloquant une fois la ligne activée : une entreprise avec un profil incomplet cliquant sur Représentation était redirigée vers la démarche Rémunération après avoir renseigné son téléphone/CSE. Corrigé en unifiant les deux branches : chaque opener (`remuneration` / `representation`) rouvre désormais son propre panneau via l'événement `dsfr.conceal`, au lieu d'un hard redirect pour le cas représentation.

## Déviation du périmètre fichiers du ticket

Fichiers hors de la liste « Fichiers impactés » qui ont dû être touchés :
- `src/server/api/routers/company.ts` : c'est là que vit la requête DB représentation (déjà présente pour la visibilité #3898) — il fallait l'enrichir (status/currentStep/updatedAt) et corriger le filtre d'année pour alimenter réellement le panneau.
- `src/modules/my-space/CompanyDeclarationsPage.tsx` : pur plumbing (nouvelle prop `representationCampaign` threadée de `MonEspacePage` vers `DeclarationsSection`), aucune logique ajoutée.
- `src/modules/domain/shared/representation.ts` + `src/modules/domain/index.ts` : extraction de `computeRepresentationDeclarationStatus` (single source of truth pour la classification de statut représentation, suite à un finding `structural-auditor` sur une ternaire inline dans `company.ts`).
- `src/modules/my-space/MissingInfoModal.tsx` : fix du routage post-sauvegarde (voir bug fix ci-dessus), trouvé par `functional-validator` en rejouant les scénarios PO — ce fichier n'était pas dans la liste initiale mais le bug n'était consécutif qu'à l'activation de la ligne Représentation par ce ticket.

## Fidélité visuelle (`design-validator`)

1 RETRY, 2 écarts relevés vs Figma (node `10546:136265`) :

- **Connecteur du stepper** : corrigé — un step "en cours mais non terminé" reprenait la couleur pleine (bleu) du connecteur au lieu du gris par défaut ; seul un step **complet** doit colorer son connecteur (vert). Fix scoped à `RepresentationProcessPanel.tsx` (fonction locale `stepRowClass`), sans toucher au SCSS partagé avec `DeclarationProcessPanel` (dont le connecteur "en cours" bleu reste inchangé — déjà validé sur son propre Figma).
- **Lien « Voir l'historique »** : présent sur les 2 frames Figma, absent du panneau représentation. **Non ajouté dans cette PR** : la route existante `/mon-espace/historique/{siren}/{year}` (utilisée par `DeclarationProcessPanel`) interroge `declarations` / `declarationStatusHistory` — des tables strictement **rémunération**, sans équivalent représentation. Wirer le même lien afficherait soit une page mal titrée (« Démarche des indicateurs de rémunération »), soit un 404 (`NOT_FOUND` côté `declaration.getStatusHistory`). Construire l'historique représentation (nouvelle procédure tRPC + éventuelle généralisation de `DeclarationHistoryPage`) est hors du périmètre « Fichiers impactés » / « Critères d'acceptation » de ce ticket — à traiter en ticket dédié.

## Test plan

- [x] `pnpm typecheck` / `pnpm test` / `pnpm lint:check` / `pnpm format:check` verts (tu-dev)
- [x] Couverture 100% sur les fichiers de logique du diff
- [x] Vérification manuelle dev server (homepage/Mon espace) après le fix de régression bundling
- [x] `functional-validator` (scénarios PO) — 1 RETRY (routage `MissingInfoModal`), corrigé, re-vérifié
- [x] `design-validator` (fidélité Figma, 2 frames du panneau) — 1 RETRY, connecteur corrigé (re-vérifié PASS), lien historique documenté comme hors périmètre (voir ci-dessus)
- [x] CI / SonarCloud verts

## Référence Figma

- Panneau latéral - Commencer : https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=10546-136248
- Panneau latéral - variante : https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=10546-136285

Note : les deux frames Figma affichent un CTA "Commencer" identique dans leurs deux états (probable artefact de copie non mis à jour côté maquette) ; le libellé "Reprendre" pour l'état brouillon suit le texte explicite du ticket (Critères d'acceptation), pas la valeur littérale du composant Figma.


