### PR TITLE
feat(declaration-representation): #4158 — écran d'assujettissement & étape période de référence

### DIFF
--- a/packages/app/src/app/declaration-representation/page.tsx
+++ b/packages/app/src/app/declaration-representation/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import {
+	SubjectionScreen,
 	stepHref,
 	TOTAL_REPRESENTATION_STEPS,
 } from "~/modules/declaration-representation";
@@ -30,31 +30,5 @@ export default async function RepresentationHomePage() {
 		redirect(stepHref(currentStep));
 	}
 
-	return (
-		<>
-			<h1 className="fr-h4">
-				Démarche des indicateurs de représentation {campaignYear}
-			</h1>
-			<p>
-				Cette démarche concerne les entreprises d'au moins 1 000 salariés. Elle
-				porte sur la représentation équilibrée des femmes et des hommes parmi
-				les cadres dirigeants et les membres des instances dirigeantes au titre
-				de l'année {year}.
-			</p>
-			<div className="fr-callout">
-				<p className="fr-callout__text">
-					L'écran d'assujettissement est en construction et sera disponible
-					prochainement.
-				</p>
-			</div>
-			<div className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-6w">
-				<Link
-					className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
-					href={stepHref(1)}
-				>
-					Commencer la démarche
-				</Link>
-			</div>
-		</>
-	);
+	return <SubjectionScreen campaignYear={campaignYear} />;
 }

--- a/packages/app/src/modules/declaration-representation/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-representation/StepPageClient.tsx
@@ -2,8 +2,9 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Stepper } from "./Stepper";
+import type { StepValidator } from "./shared/draft/DraftContext";
 import { RepresentationDraftProvider } from "./shared/draft/DraftContext";
 import { useRepresentationDraft } from "./shared/draft/useRepresentationDraft";
 import {
@@ -40,6 +41,14 @@ export function StepPageClient({
 			enabled: campaignOpen,
 		});
 
+	const stepValidatorRef = useRef<StepValidator | null>(null);
+	const registerStepValidator = useCallback(
+		(validator: StepValidator | null) => {
+			stepValidatorRef.current = validator;
+		},
+		[],
+	);
+
 	const definition = getStepDefinition(step);
 	const previousHref = getPreviousStepHref(step);
 	const nextHref = getNextStepHref(step);
@@ -50,6 +59,10 @@ export function StepPageClient({
 
 	async function handleNext() {
 		if (nextHref === undefined) return;
+		if (stepValidatorRef.current) {
+			const isValid = await stepValidatorRef.current();
+			if (!isValid) return;
+		}
 		setNavigationError(null);
 		setIsAdvancing(true);
 		try {
@@ -74,6 +87,7 @@ export function StepPageClient({
 				isSaving,
 				isPendingSave,
 				isReadOnly: !campaignOpen,
+				registerStepValidator,
 			}}
 		>
 			<h1 className="fr-h4">

--- a/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
+++ b/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
@@ -23,6 +23,7 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 
 	const answer = form.watch("answer");
 	const hasSubjectionError = Boolean(form.formState.errors.answer);
+	const canGoBack = answer === null && !hasSubjectionError;
 
 	const onSubmit = form.handleSubmit((data) => {
 		if (data.answer === "concerned") {
@@ -141,7 +142,7 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 				) : null}
 
 				<div className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-4w">
-					{answer === null && !hasSubjectionError ? (
+					{canGoBack ? (
 						<Link className="fr-btn fr-btn--tertiary" href="/mon-espace">
 							Retour
 						</Link>

--- a/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
+++ b/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useId } from "react";
+import { Controller } from "react-hook-form";
+import { useZodForm } from "~/modules/shared/useZodForm";
+import { subjectionSchema } from "./schemas";
+import { stepHref } from "./steps";
+
+type SubjectionScreenProps = {
+	campaignYear: number;
+};
+
+export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
+	const router = useRouter();
+	const legendId = useId();
+	const messagesId = useId();
+
+	const form = useZodForm(subjectionSchema, {
+		defaultValues: { answer: null },
+	});
+
+	const answer = form.watch("answer");
+
+	const onSubmit = form.handleSubmit((data) => {
+		if (data.answer === "concerned") {
+			router.push(stepHref(1));
+		}
+	});
+
+	return (
+		<>
+			<h1 className="fr-h4">
+				Démarche des indicateurs de représentation {campaignYear}
+			</h1>
+			<h2 className="fr-h6">L'entreprise est-elle concernée ?</h2>
+
+			<form onSubmit={onSubmit}>
+				<p>
+					Ce seuil détermine si votre entreprise est tenue de déclarer ses
+					écarts de représentation femmes-hommes parmi les cadres dirigeants et
+					les membres des instances dirigeantes.
+				</p>
+				<p>Tous les champs sont obligatoires.</p>
+
+				<Controller
+					control={form.control}
+					name="answer"
+					render={({ field, fieldState }) => (
+						<fieldset
+							aria-labelledby={`${legendId} ${messagesId}`}
+							className={
+								fieldState.error
+									? "fr-fieldset fr-fieldset--error"
+									: "fr-fieldset"
+							}
+						>
+							<legend
+								className="fr-fieldset__legend--regular fr-fieldset__legend"
+								id={legendId}
+							>
+								Indiquez si votre entreprise emploie au moins 1 000 salariés
+								durant les trois derniers exercices consécutifs.
+							</legend>
+							<div className="fr-fieldset__element">
+								<div className="fr-radio-group">
+									<input
+										checked={field.value === "concerned"}
+										id="subjection-concerned"
+										name={field.name}
+										onChange={() => field.onChange("concerned")}
+										type="radio"
+									/>
+									<label className="fr-label" htmlFor="subjection-concerned">
+										1 000 salariés ou plus sur les trois exercices
+										<span className="fr-hint-text">
+											Votre entreprise est tenue de déclarer ses écarts de
+											représentation.
+										</span>
+									</label>
+								</div>
+							</div>
+							<div className="fr-fieldset__element">
+								<div className="fr-radio-group">
+									<input
+										checked={field.value === "not_concerned"}
+										id="subjection-not-concerned"
+										name={field.name}
+										onChange={() => field.onChange("not_concerned")}
+										type="radio"
+									/>
+									<label
+										className="fr-label"
+										htmlFor="subjection-not-concerned"
+									>
+										Moins de 1 000 salariés sur au moins un exercice
+										<span className="fr-hint-text">
+											Votre entreprise n'est pas concernée par cette
+											déclaration.
+										</span>
+									</label>
+								</div>
+							</div>
+							<div
+								aria-atomic="true"
+								aria-live="polite"
+								className="fr-messages-group"
+								id={messagesId}
+							>
+								{fieldState.error ? (
+									<p className="fr-message fr-message--error">
+										{fieldState.error.message}
+									</p>
+								) : null}
+							</div>
+						</fieldset>
+					)}
+				/>
+
+				{answer === "not_concerned" ? (
+					<div className="fr-background-alt--blue-france fr-p-4w">
+						<p className="fr-mb-0">
+							Vous n'êtes pas assujetti à la publication et à la déclaration des
+							écarts éventuels de représentation entre les femmes et les hommes.
+							<br />
+							Vous pouvez valider pour achever votre déclaration de
+							représentation {campaignYear}.
+						</p>
+					</div>
+				) : null}
+
+				<div className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-4w">
+					{answer === null ? (
+						<Link className="fr-btn fr-btn--tertiary" href="/mon-espace">
+							Retour
+						</Link>
+					) : null}
+					{answer === "not_concerned" ? (
+						<Link className="fr-btn" href="/mon-espace">
+							Valider
+						</Link>
+					) : (
+						<button
+							className="fr-btn fr-icon-arrow-right-line fr-btn--icon-right"
+							type="submit"
+						>
+							Suivant
+						</button>
+					)}
+				</div>
+			</form>
+		</>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
+++ b/packages/app/src/modules/declaration-representation/SubjectionScreen.tsx
@@ -22,6 +22,7 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 	});
 
 	const answer = form.watch("answer");
+	const hasSubjectionError = Boolean(form.formState.errors.answer);
 
 	const onSubmit = form.handleSubmit((data) => {
 		if (data.answer === "concerned") {
@@ -36,14 +37,20 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 			</h1>
 			<h2 className="fr-h6">L'entreprise est-elle concernée ?</h2>
 
-			<form onSubmit={onSubmit}>
-				<p>
-					Ce seuil détermine si votre entreprise est tenue de déclarer ses
-					écarts de représentation femmes-hommes parmi les cadres dirigeants et
-					les membres des instances dirigeantes.
-				</p>
-				<p>Tous les champs sont obligatoires.</p>
+			<p className="fr-text-title--grey fr-mt-4w fr-mb-2w">
+				Indiquez si votre entreprise emploie au moins 1 000 salariés durant les
+				trois derniers exercices consécutifs.
+			</p>
+			<p className="fr-text-title--grey fr-mb-2w">
+				Ce seuil détermine si votre entreprise est tenue de déclarer ses écarts
+				de représentation femmes-hommes parmi les cadres dirigeants et les
+				membres des instances dirigeantes.
+			</p>
+			<p className="fr-text-title--grey fr-mb-4w">
+				Tous les champs sont obligatoires.
+			</p>
 
+			<form onSubmit={onSubmit}>
 				<Controller
 					control={form.control}
 					name="answer"
@@ -56,12 +63,8 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 									: "fr-fieldset"
 							}
 						>
-							<legend
-								className="fr-fieldset__legend--regular fr-fieldset__legend"
-								id={legendId}
-							>
-								Indiquez si votre entreprise emploie au moins 1 000 salariés
-								durant les trois derniers exercices consécutifs.
+							<legend className="fr-sr-only" id={legendId}>
+								Nombre de salariés de l'entreprise
 							</legend>
 							<div className="fr-fieldset__element">
 								<div className="fr-radio-group">
@@ -72,7 +75,12 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 										onChange={() => field.onChange("concerned")}
 										type="radio"
 									/>
-									<label className="fr-label" htmlFor="subjection-concerned">
+									<label
+										className={
+											fieldState.error ? "fr-label fr-label--error" : "fr-label"
+										}
+										htmlFor="subjection-concerned"
+									>
 										1 000 salariés ou plus sur les trois exercices
 										<span className="fr-hint-text">
 											Votre entreprise est tenue de déclarer ses écarts de
@@ -91,7 +99,9 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 										type="radio"
 									/>
 									<label
-										className="fr-label"
+										className={
+											fieldState.error ? "fr-label fr-label--error" : "fr-label"
+										}
 										htmlFor="subjection-not-concerned"
 									>
 										Moins de 1 000 salariés sur au moins un exercice
@@ -131,7 +141,7 @@ export function SubjectionScreen({ campaignYear }: SubjectionScreenProps) {
 				) : null}
 
 				<div className="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-4w">
-					{answer === null ? (
+					{answer === null && !hasSubjectionError ? (
 						<Link className="fr-btn fr-btn--tertiary" href="/mon-espace">
 							Retour
 						</Link>

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -98,15 +98,20 @@ describe("RepresentationHomePage", () => {
 		expect(getDeclaration).toHaveBeenCalledWith({ year: YEAR });
 	});
 
-	it("serves the entry screen when no draft has been started", async () => {
+	it("serves the subjection screen when no draft has been started", async () => {
 		mockFunnelState();
 
 		render(await RepresentationHomePage());
 
 		expect(mockRedirect).not.toHaveBeenCalled();
 		expect(
-			screen.getByRole("link", { name: "Commencer la démarche" }),
-		).toHaveAttribute("href", "/declaration-representation/etape/1");
+			screen.getByRole("heading", {
+				level: 2,
+				name: "L'entreprise est-elle concernée ?",
+			}),
+		).toBeInTheDocument();
+		expect(screen.getAllByRole("radio")).toHaveLength(2);
+		expect(screen.getByRole("button", { name: "Suivant" })).toBeInTheDocument();
 	});
 
 	it("keeps serving the entry screen when the draft has not reached a step yet", async () => {

--- a/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.stepValidator.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.stepValidator.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { push, mutateAsync, step } = vi.hoisted(() => ({
+	push: vi.fn(),
+	mutateAsync: vi.fn(),
+	step: { validate: null as null | (() => boolean | Promise<boolean>) },
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push,
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		representationDeclaration: {
+			saveDraft: {
+				useMutation: () => ({ mutate: vi.fn(), mutateAsync, isPending: false }),
+			},
+		},
+	},
+}));
+
+// Stands in for any funnel step wired to the shared validator extension point.
+vi.mock("../steps/StepPlaceholder", async () => {
+	const { useEffect } = await import("react");
+	const { useRepresentationDraftContext } = await import(
+		"../shared/draft/DraftContext"
+	);
+	return {
+		StepPlaceholder: function ValidatedStep() {
+			const { registerStepValidator } = useRepresentationDraftContext();
+			useEffect(() => {
+				registerStepValidator(
+					step.validate === null ? null : () => step.validate?.() ?? true,
+				);
+				return () => registerStepValidator(null);
+			}, [registerStepValidator]);
+			return <p>Étape validée par le composant</p>;
+		},
+	};
+});
+
+import { StepPageClient } from "~/modules/declaration-representation";
+
+const CAMPAIGN_YEAR = 2026;
+const YEAR = 2025;
+const STEP_3_HREF = "/declaration-representation/etape/3";
+
+function renderStep() {
+	return render(
+		<StepPageClient
+			campaignOpen
+			campaignYear={CAMPAIGN_YEAR}
+			initialDraft={{ currentStep: 2 }}
+			step={2}
+			year={YEAR}
+		/>,
+	);
+}
+
+function clickNext() {
+	return userEvent.click(screen.getByRole("button", { name: "Suivant" }));
+}
+
+beforeEach(() => {
+	push.mockReset();
+	mutateAsync.mockReset().mockResolvedValue(undefined);
+	step.validate = null;
+});
+
+describe("StepPageClient — step validator", () => {
+	it("advances when the step registers no validator", async () => {
+		renderStep();
+
+		await clickNext();
+
+		expect(mutateAsync).toHaveBeenCalledOnce();
+		expect(push).toHaveBeenCalledWith(STEP_3_HREF);
+	});
+
+	it("advances when the registered validator accepts the step", async () => {
+		const validate = vi.fn(() => true);
+		step.validate = validate;
+		renderStep();
+
+		await clickNext();
+
+		expect(validate).toHaveBeenCalledOnce();
+		expect(mutateAsync).toHaveBeenCalledOnce();
+		expect(push).toHaveBeenCalledWith(STEP_3_HREF);
+	});
+
+	it("saves nothing and stays on the step when the validator rejects it", async () => {
+		step.validate = () => false;
+		renderStep();
+
+		await clickNext();
+
+		expect(mutateAsync).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+		expect(screen.getByRole("button", { name: "Suivant" })).toBeEnabled();
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("waits for an asynchronous validator before deciding", async () => {
+		step.validate = () => Promise.resolve(false);
+		renderStep();
+
+		await clickNext();
+
+		expect(mutateAsync).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("advances on a later attempt once the validator accepts the step", async () => {
+		const validate = vi.fn(() => false);
+		step.validate = validate;
+		renderStep();
+		await clickNext();
+
+		validate.mockReturnValue(true);
+		await clickNext();
+
+		expect(validate).toHaveBeenCalledTimes(2);
+		expect(push).toHaveBeenCalledWith(STEP_3_HREF);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { push, apiAccess } = vi.hoisted(() => ({
+	push: vi.fn(),
+	apiAccess: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push,
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+}));
+
+// The subjection answer is deliberately not persisted: any access to the tRPC
+// client from this screen is a product regression, not an implementation detail.
+vi.mock("~/trpc/react", () => ({
+	api: new Proxy(
+		{},
+		{
+			get: (_target, property) => {
+				apiAccess(property);
+				return undefined;
+			},
+		},
+	),
+}));
+
+import { SubjectionScreen } from "../SubjectionScreen";
+
+const CAMPAIGN_YEAR = 2026;
+const STEP_1_HREF = "/declaration-representation/etape/1";
+const SELECTION_ERROR = "Veuillez sélectionner une option pour continuer.";
+const NOT_CONCERNED_INFO = /Vous n'êtes pas assujetti à la publication/;
+
+function renderScreen() {
+	return render(<SubjectionScreen campaignYear={CAMPAIGN_YEAR} />);
+}
+
+function concernedRadio() {
+	return screen.getByRole("radio", {
+		name: /1 000 salariés ou plus sur les trois exercices/,
+	});
+}
+
+function notConcernedRadio() {
+	return screen.getByRole("radio", {
+		name: /Moins de 1 000 salariés sur au moins un exercice/,
+	});
+}
+
+function nextButton() {
+	return screen.getByRole("button", { name: "Suivant" });
+}
+
+beforeEach(() => {
+	push.mockReset();
+	apiAccess.mockReset();
+});
+
+describe("SubjectionScreen — rendering", () => {
+	it("asks the subjection question with the two exclusive answers", () => {
+		renderScreen();
+
+		expect(
+			screen.getByRole("heading", {
+				level: 1,
+				name: `Démarche des indicateurs de représentation ${CAMPAIGN_YEAR}`,
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", {
+				level: 2,
+				name: "L'entreprise est-elle concernée ?",
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/Indiquez si votre entreprise emploie au moins 1 000 salariés/,
+			),
+		).toBeInTheDocument();
+		expect(concernedRadio()).not.toBeChecked();
+		expect(notConcernedRadio()).not.toBeChecked();
+		expect(screen.getAllByRole("radio")).toHaveLength(2);
+	});
+
+	it("offers a way back to the personal space before any answer", () => {
+		renderScreen();
+
+		expect(screen.getByRole("link", { name: "Retour" })).toHaveAttribute(
+			"href",
+			"/mon-espace",
+		);
+		expect(screen.queryByText(NOT_CONCERNED_INFO)).not.toBeInTheDocument();
+		expect(screen.queryByText(SELECTION_ERROR)).not.toBeInTheDocument();
+	});
+});
+
+describe("SubjectionScreen — no answer selected", () => {
+	it("blocks the submission and explains that an option is required", async () => {
+		renderScreen();
+
+		await userEvent.click(nextButton());
+
+		expect(screen.getByText(SELECTION_ERROR)).toBeInTheDocument();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("clears the error as soon as an option is selected", async () => {
+		renderScreen();
+		await userEvent.click(nextButton());
+
+		await userEvent.click(concernedRadio());
+
+		expect(screen.queryByText(SELECTION_ERROR)).not.toBeInTheDocument();
+	});
+});
+
+describe("SubjectionScreen — company concerned", () => {
+	it("enters the funnel at the first step", async () => {
+		renderScreen();
+
+		await userEvent.click(concernedRadio());
+		await userEvent.click(nextButton());
+
+		expect(push).toHaveBeenCalledWith(STEP_1_HREF);
+		expect(screen.queryByText(SELECTION_ERROR)).not.toBeInTheDocument();
+		expect(screen.queryByText(NOT_CONCERNED_INFO)).not.toBeInTheDocument();
+	});
+});
+
+describe("SubjectionScreen — company not concerned", () => {
+	it("explains the exemption and closes the démarche without entering the funnel", async () => {
+		renderScreen();
+
+		await userEvent.click(notConcernedRadio());
+
+		expect(screen.getByText(NOT_CONCERNED_INFO)).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Valider" })).toHaveAttribute(
+			"href",
+			"/mon-espace",
+		);
+		expect(
+			screen.queryByRole("button", { name: "Suivant" }),
+		).not.toBeInTheDocument();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("restores the funnel entry when the answer is changed back", async () => {
+		renderScreen();
+		await userEvent.click(notConcernedRadio());
+
+		await userEvent.click(concernedRadio());
+
+		expect(screen.queryByText(NOT_CONCERNED_INFO)).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("link", { name: "Valider" }),
+		).not.toBeInTheDocument();
+		expect(nextButton()).toBeInTheDocument();
+	});
+});
+
+describe("SubjectionScreen — no persistence", () => {
+	it("never stores the answer, whichever option is submitted", async () => {
+		const { unmount } = renderScreen();
+
+		await userEvent.click(nextButton());
+		await userEvent.click(concernedRadio());
+		await userEvent.click(nextButton());
+		unmount();
+
+		renderScreen();
+		await userEvent.click(notConcernedRadio());
+
+		expect(apiAccess).not.toHaveBeenCalled();
+	});
+
+	it("asks the question again on every visit", async () => {
+		const { unmount } = renderScreen();
+		await userEvent.click(concernedRadio());
+		unmount();
+
+		renderScreen();
+
+		expect(concernedRadio()).not.toBeChecked();
+		expect(notConcernedRadio()).not.toBeChecked();
+	});
+});

--- a/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
@@ -115,6 +115,19 @@ describe("SubjectionScreen — rendering", () => {
 		expect(screen.queryByText(NOT_CONCERNED_INFO)).not.toBeInTheDocument();
 		expect(screen.queryByText(SELECTION_ERROR)).not.toBeInTheDocument();
 	});
+
+	it.each([
+		["concerned", concernedRadio],
+		["not concerned", notConcernedRadio],
+	])("withdraws the way back once the %s answer is picked", async (_answer, radio) => {
+		renderScreen();
+
+		await userEvent.click(radio());
+
+		expect(
+			screen.queryByRole("link", { name: "Retour" }),
+		).not.toBeInTheDocument();
+	});
 });
 
 describe("SubjectionScreen — no answer selected", () => {

--- a/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/SubjectionScreen.test.tsx
@@ -37,6 +37,9 @@ const CAMPAIGN_YEAR = 2026;
 const STEP_1_HREF = "/declaration-representation/etape/1";
 const SELECTION_ERROR = "Veuillez sélectionner une option pour continuer.";
 const NOT_CONCERNED_INFO = /Vous n'êtes pas assujetti à la publication/;
+const SUBJECTION_QUESTION =
+	/Indiquez si votre entreprise emploie au moins 1 000 salariés/;
+const SUBJECTION_FIELDSET_NAME = /Nombre de salariés de l'entreprise/;
 
 function renderScreen() {
 	return render(<SubjectionScreen campaignYear={CAMPAIGN_YEAR} />);
@@ -80,13 +83,26 @@ describe("SubjectionScreen — rendering", () => {
 			}),
 		).toBeInTheDocument();
 		expect(
-			screen.getByText(
-				/Indiquez si votre entreprise emploie au moins 1 000 salariés/,
-			),
+			screen.getByText(SUBJECTION_QUESTION, { selector: "p" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("group", { name: SUBJECTION_FIELDSET_NAME }),
 		).toBeInTheDocument();
 		expect(concernedRadio()).not.toBeChecked();
 		expect(notConcernedRadio()).not.toBeChecked();
 		expect(screen.getAllByRole("radio")).toHaveLength(2);
+	});
+
+	it("states the question first, before its rationale and the answer options", () => {
+		const { container } = renderScreen();
+
+		const paragraphs = Array.from(container.querySelectorAll("p")).map(
+			(paragraph) => paragraph.textContent ?? "",
+		);
+
+		expect(paragraphs[0]).toMatch(SUBJECTION_QUESTION);
+		expect(paragraphs[1]).toMatch(/Ce seuil détermine/);
+		expect(paragraphs[2]).toMatch(/Tous les champs sont obligatoires/);
 	});
 
 	it("offers a way back to the personal space before any answer", () => {
@@ -109,6 +125,42 @@ describe("SubjectionScreen — no answer selected", () => {
 
 		expect(screen.getByText(SELECTION_ERROR)).toBeInTheDocument();
 		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("keeps the rejected question as the only way forward", async () => {
+		renderScreen();
+
+		await userEvent.click(nextButton());
+
+		expect(
+			screen.queryByRole("link", { name: "Retour" }),
+		).not.toBeInTheDocument();
+		expect(nextButton()).toBeInTheDocument();
+	});
+
+	it("flags both options as erroneous until one is picked", async () => {
+		renderScreen();
+
+		await userEvent.click(nextButton());
+
+		for (const radio of screen.getAllByRole("radio")) {
+			expect(document.querySelector(`label[for="${radio.id}"]`)).toHaveClass(
+				"fr-label--error",
+			);
+		}
+	});
+
+	it("clears the erroneous styling once an option is picked", async () => {
+		renderScreen();
+		await userEvent.click(nextButton());
+
+		await userEvent.click(concernedRadio());
+
+		for (const radio of screen.getAllByRole("radio")) {
+			expect(
+				document.querySelector(`label[for="${radio.id}"]`),
+			).not.toHaveClass("fr-label--error");
+		}
 	});
 
 	it("clears the error as soon as an option is selected", async () => {

--- a/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
@@ -58,8 +58,8 @@ export const VALIDATION_MESSAGES = {
 	sum: "La somme des pourcentages doit être égale à 100 %.",
 	range: "Le pourcentage doit être compris entre 0 et 100.",
 	decimal: "Le pourcentage ne peut comporter plus d'une décimale.",
-	periodYear:
-		"L'année de la date de fin de la période de référence doit correspondre à l'année au titre de laquelle les écarts sont calculés.",
+	periodYear: (year: number) =>
+		`La date sélectionnée ne correspond pas à l'année de référence ${year}.`,
 	periodLength: "La période de référence doit couvrir 12 mois consécutifs.",
 	urlRequired: "L'adresse de la page internet est obligatoire.",
 	urlInvalid: "L'adresse de la page internet est invalide.",

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.referencePeriod.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.referencePeriod.test.ts
@@ -8,6 +8,14 @@ import {
 	REPRESENTATION_YEAR as YEAR,
 } from "./fixtures";
 
+const DATE_FIELDS = ["referencePeriodStart", "referencePeriodEnd"] as const;
+
+const MALFORMED_DATES = [
+	["unreadable", "not-a-date"],
+	["Date-parsable but non-ISO", "01/01/2025"],
+	["ISO-shaped but non-existent", "2025-02-30"],
+] as const;
+
 describe("referencePeriodSchema", () => {
 	it("accepts a calendar year ending in the declaration year", () => {
 		expect(referencePeriodSchema(YEAR).safeParse(VALID_PERIOD).success).toBe(
@@ -77,12 +85,40 @@ describe("referencePeriodSchema", () => {
 		});
 	});
 
-	it("rejects a date that is not an ISO calendar date", () => {
-		const result = referencePeriodSchema(YEAR).safeParse({
-			referencePeriodStart: "01/01/2025",
-			referencePeriodEnd: "2025-12-31",
-		});
+	it.each(
+		MALFORMED_DATES.flatMap(([shape, value]) =>
+			DATE_FIELDS.map((field) => ({ shape, value, field })),
+		),
+	)("reports a $shape $field once, without stacking the period rules on top", ({
+		value,
+		field,
+	}) => {
+		const reported = issues(
+			referencePeriodSchema(YEAR).safeParse({
+				...VALID_PERIOD,
+				[field]: value,
+			}),
+		);
 
-		expect(result.success).toBe(false);
+		expect(reported).toHaveLength(1);
+		expect(reported[0]?.path).toBe(field);
+		expect([
+			VALIDATION_MESSAGES.periodYear(YEAR),
+			VALIDATION_MESSAGES.periodLength,
+		]).not.toContain(reported[0]?.message);
+	});
+
+	it("reports one error per malformed date when neither can be read", () => {
+		const reported = issues(
+			referencePeriodSchema(YEAR).safeParse({
+				referencePeriodStart: "not-a-date",
+				referencePeriodEnd: "neither-is-this",
+			}),
+		);
+
+		expect(reported.map((issue) => issue.path)).toEqual([
+			"referencePeriodStart",
+			"referencePeriodEnd",
+		]);
 	});
 });

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.referencePeriod.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.referencePeriod.test.ts
@@ -41,7 +41,23 @@ describe("referencePeriodSchema", () => {
 
 		expect(issues(result)).toContainEqual({
 			path: "referencePeriodEnd",
-			message: VALIDATION_MESSAGES.periodYear,
+			message: VALIDATION_MESSAGES.periodYear(YEAR),
+		});
+	});
+
+	it.each([
+		["after the reference year", "2027-04-03"],
+		["on the calendar year right after it", "2026-01-01"],
+		["more than one year before it", "2023-01-02"],
+	])("rejects a start date %s", (_label, start) => {
+		const result = referencePeriodSchema(YEAR).safeParse({
+			referencePeriodStart: start,
+			referencePeriodEnd: VALID_PERIOD.referencePeriodEnd,
+		});
+
+		expect(issues(result)).toContainEqual({
+			path: "referencePeriodStart",
+			message: VALIDATION_MESSAGES.periodYear(YEAR),
 		});
 	});
 

--- a/packages/app/src/modules/declaration-representation/__tests__/schemas.submit.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/schemas.submit.test.ts
@@ -114,11 +114,14 @@ describe("submitRepresentationSchema", () => {
 	});
 
 	it("reports the reference period issue when the year does not match (S4)", () => {
-		const result = submitRepresentationSchema(2026).safeParse(FULL_PAYLOAD);
+		const otherYear = YEAR + 1;
+
+		const result =
+			submitRepresentationSchema(otherYear).safeParse(FULL_PAYLOAD);
 
 		expect(issues(result)).toContainEqual({
 			path: "referencePeriodEnd",
-			message: VALIDATION_MESSAGES.periodYear,
+			message: VALIDATION_MESSAGES.periodYear(otherYear),
 		});
 	});
 

--- a/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
@@ -10,6 +10,7 @@ import {
 	REPRESENTATION_STEPS,
 	stepHref,
 } from "../steps";
+import { Step1ReferencePeriod } from "../steps/Step1ReferencePeriod";
 import { Step3Members } from "../steps/Step3Members";
 import { StepPlaceholder } from "../steps/StepPlaceholder";
 import {
@@ -36,7 +37,7 @@ describe("REPRESENTATION_STEPS", () => {
 		expect(
 			REPRESENTATION_STEPS.map((step) => [step.slug, step.Component]),
 		).toEqual([
-			["periode-de-reference", StepPlaceholder],
+			["periode-de-reference", Step1ReferencePeriod],
 			["ecarts-cadres-dirigeants", StepPlaceholder],
 			["ecarts-instances-dirigeantes", Step3Members],
 			["informations-de-publication", StepPlaceholder],

--- a/packages/app/src/modules/declaration-representation/index.ts
+++ b/packages/app/src/modules/declaration-representation/index.ts
@@ -2,6 +2,7 @@ export { DeclarationLayout } from "./DeclarationLayout";
 export { RepresentationPlayground } from "./RepresentationPlayground";
 export { StepPageClient } from "./StepPageClient";
 export { Stepper } from "./Stepper";
+export { SubjectionScreen } from "./SubjectionScreen";
 export {
 	executivesCountSchema,
 	executivesSchema,
@@ -11,6 +12,7 @@ export {
 	referencePeriodSchema,
 	representationDraftSchema,
 	saveRepresentationDraftSchema,
+	subjectionSchema,
 	submitRepresentationDeclarationSchema,
 	submitRepresentationSchema,
 } from "./schemas";

--- a/packages/app/src/modules/declaration-representation/schemas.ts
+++ b/packages/app/src/modules/declaration-representation/schemas.ts
@@ -32,6 +32,15 @@ const percentSchema = z
 	.max(100, "Le pourcentage doit être compris entre 0 et 100.")
 	.multipleOf(0.1, "Le pourcentage ne peut comporter plus d'une décimale.");
 
+export const subjectionSchema = z
+	.object({
+		answer: z.enum(["concerned", "not_concerned"]).nullable(),
+	})
+	.refine((data) => data.answer !== null, {
+		message: "Veuillez sélectionner une option pour continuer.",
+		path: ["answer"],
+	});
+
 export function referencePeriodSchema(year: number) {
 	return z
 		.object({

--- a/packages/app/src/modules/declaration-representation/schemas.ts
+++ b/packages/app/src/modules/declaration-representation/schemas.ts
@@ -14,6 +14,12 @@ function parseIsoDate(value: string): Date {
 	return new Date(value);
 }
 
+const isoDateStringSchema = z.string().date();
+
+function isValidIsoDate(value: string): boolean {
+	return isoDateStringSchema.safeParse(value).success;
+}
+
 function isTwelveConsecutiveMonths(start: string, end: string): boolean {
 	const startDate = parseIsoDate(start);
 	const expectedEnd = new Date(startDate);
@@ -46,11 +52,12 @@ export function referencePeriodSchema(year: number) {
 
 	return z
 		.object({
-			referencePeriodStart: z.string().date(),
-			referencePeriodEnd: z.string().date(),
+			referencePeriodStart: isoDateStringSchema,
+			referencePeriodEnd: isoDateStringSchema,
 		})
 		.refine(
 			(period) => {
+				if (!isValidIsoDate(period.referencePeriodStart)) return true;
 				const startYear = parseIsoDate(
 					period.referencePeriodStart,
 				).getUTCFullYear();
@@ -62,19 +69,29 @@ export function referencePeriodSchema(year: number) {
 			},
 		)
 		.refine(
-			(period) =>
-				parseIsoDate(period.referencePeriodEnd).getUTCFullYear() === year,
+			(period) => {
+				if (!isValidIsoDate(period.referencePeriodEnd)) return true;
+				return (
+					parseIsoDate(period.referencePeriodEnd).getUTCFullYear() === year
+				);
+			},
 			{
 				message: yearMismatchMessage,
 				path: ["referencePeriodEnd"],
 			},
 		)
 		.refine(
-			(period) =>
-				isTwelveConsecutiveMonths(
+			(period) => {
+				if (
+					!isValidIsoDate(period.referencePeriodStart) ||
+					!isValidIsoDate(period.referencePeriodEnd)
+				)
+					return true;
+				return isTwelveConsecutiveMonths(
 					period.referencePeriodStart,
 					period.referencePeriodEnd,
-				),
+				);
+			},
 			{
 				message: "La période de référence doit couvrir 12 mois consécutifs.",
 				path: ["referencePeriodEnd"],

--- a/packages/app/src/modules/declaration-representation/schemas.ts
+++ b/packages/app/src/modules/declaration-representation/schemas.ts
@@ -42,17 +42,30 @@ export const subjectionSchema = z
 	});
 
 export function referencePeriodSchema(year: number) {
+	const yearMismatchMessage = `La date sélectionnée ne correspond pas à l'année de référence ${year}.`;
+
 	return z
 		.object({
 			referencePeriodStart: z.string().date(),
 			referencePeriodEnd: z.string().date(),
 		})
 		.refine(
+			(period) => {
+				const startYear = parseIsoDate(
+					period.referencePeriodStart,
+				).getUTCFullYear();
+				return startYear === year || startYear === year - 1;
+			},
+			{
+				message: yearMismatchMessage,
+				path: ["referencePeriodStart"],
+			},
+		)
+		.refine(
 			(period) =>
 				parseIsoDate(period.referencePeriodEnd).getUTCFullYear() === year,
 			{
-				message:
-					"L'année de la date de fin de la période de référence doit correspondre à l'année au titre de laquelle les écarts sont calculés.",
+				message: yearMismatchMessage,
 				path: ["referencePeriodEnd"],
 			},
 		)

--- a/packages/app/src/modules/declaration-representation/shared/draft/DraftContext.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/draft/DraftContext.tsx
@@ -4,6 +4,8 @@ import { createContext, useContext } from "react";
 
 import type { RepresentationDraft } from "~/modules/declaration-representation/types";
 
+export type StepValidator = () => boolean | Promise<boolean>;
+
 export type RepresentationDraftContextValue = {
 	year: number;
 	step: number;
@@ -12,6 +14,7 @@ export type RepresentationDraftContextValue = {
 	isSaving: boolean;
 	isPendingSave: boolean;
 	isReadOnly: boolean;
+	registerStepValidator: (validator: StepValidator | null) => void;
 };
 
 const RepresentationDraftContext =

--- a/packages/app/src/modules/declaration-representation/shared/draft/__tests__/DraftContext.test.tsx
+++ b/packages/app/src/modules/declaration-representation/shared/draft/__tests__/DraftContext.test.tsx
@@ -15,6 +15,7 @@ const value: RepresentationDraftContextValue = {
 	isSaving: false,
 	isPendingSave: true,
 	isReadOnly: true,
+	registerStepValidator: vi.fn(),
 };
 
 function Consumer() {

--- a/packages/app/src/modules/declaration-representation/steps/Step1ReferencePeriod.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step1ReferencePeriod.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect } from "react";
+import { useZodForm } from "~/modules/shared/useZodForm";
+import { referencePeriodSchema } from "../schemas";
+import { useRepresentationDraftContext } from "../shared/draft/DraftContext";
+
+const REQUIRED_DATES_MESSAGE =
+	"Sélectionner une date de début ou une date de fin.";
+
+export function Step1ReferencePeriod() {
+	const { year, draft, setDraftValues, isReadOnly, registerStepValidator } =
+		useRepresentationDraftContext();
+
+	const form = useZodForm(referencePeriodSchema(year), {
+		defaultValues: {
+			referencePeriodStart: draft.referencePeriodStart ?? "",
+			referencePeriodEnd: draft.referencePeriodEnd ?? "",
+		},
+	});
+
+	const referencePeriodStart = form.watch("referencePeriodStart") ?? "";
+	const referencePeriodEnd = form.watch("referencePeriodEnd") ?? "";
+	const { errors } = form.formState;
+
+	useEffect(() => {
+		registerStepValidator(async () => {
+			const start = form.getValues("referencePeriodStart");
+			const end = form.getValues("referencePeriodEnd");
+
+			if (!start || !end) {
+				form.setError(start ? "referencePeriodEnd" : "referencePeriodStart", {
+					message: REQUIRED_DATES_MESSAGE,
+					type: "manual",
+				});
+				return false;
+			}
+
+			return form.trigger();
+		});
+		return () => registerStepValidator(null);
+	}, [form, registerStepValidator]);
+
+	function handleStartChange(event: React.ChangeEvent<HTMLInputElement>) {
+		const value = event.target.value;
+		form.setValue("referencePeriodStart", value);
+		setDraftValues({
+			referencePeriodEnd,
+			referencePeriodStart: value,
+		});
+	}
+
+	function handleEndChange(event: React.ChangeEvent<HTMLInputElement>) {
+		const value = event.target.value;
+		form.setValue("referencePeriodEnd", value);
+		setDraftValues({
+			referencePeriodEnd: value,
+			referencePeriodStart,
+		});
+	}
+
+	return (
+		<>
+			<p>
+				Année de référence : <strong>{year}</strong>
+			</p>
+			<p>
+				Sélectionnez la période de l'exercice comptable utilisé pour le calcul
+				des écarts.
+			</p>
+			<p>Tous les champs sont obligatoires.</p>
+
+			<fieldset className="fr-fieldset">
+				<legend className="fr-sr-only">Dates de la période de référence</legend>
+				<div className="fr-fieldset__content">
+					<div className="fr-grid-row fr-grid-row--gutters">
+						<div className="fr-col-12 fr-col-md-6">
+							<div
+								className={
+									errors.referencePeriodStart
+										? "fr-input-group fr-input-group--error"
+										: "fr-input-group"
+								}
+							>
+								<label className="fr-label" htmlFor="reference-period-start">
+									Date de début
+									<span className="fr-hint-text">
+										Format attendu : JJ/MM/AAAA
+									</span>
+								</label>
+								<input
+									aria-describedby="reference-period-start-messages"
+									aria-invalid={errors.referencePeriodStart ? true : undefined}
+									className={
+										errors.referencePeriodStart
+											? "fr-input fr-input--error"
+											: "fr-input"
+									}
+									id="reference-period-start"
+									onChange={handleStartChange}
+									readOnly={isReadOnly}
+									type="date"
+									value={referencePeriodStart}
+								/>
+								<div
+									aria-atomic="true"
+									aria-live="polite"
+									className="fr-messages-group"
+									id="reference-period-start-messages"
+								>
+									{errors.referencePeriodStart ? (
+										<p className="fr-message fr-message--error">
+											{errors.referencePeriodStart.message}
+										</p>
+									) : null}
+								</div>
+							</div>
+						</div>
+						<div className="fr-col-12 fr-col-md-6">
+							<div
+								className={
+									errors.referencePeriodEnd
+										? "fr-input-group fr-input-group--error"
+										: "fr-input-group"
+								}
+							>
+								<label className="fr-label" htmlFor="reference-period-end">
+									Date de fin
+									<span className="fr-hint-text">
+										Format attendu : JJ/MM/AAAA
+									</span>
+								</label>
+								<input
+									aria-describedby="reference-period-end-messages"
+									aria-invalid={errors.referencePeriodEnd ? true : undefined}
+									className={
+										errors.referencePeriodEnd
+											? "fr-input fr-input--error"
+											: "fr-input"
+									}
+									id="reference-period-end"
+									onChange={handleEndChange}
+									readOnly={isReadOnly}
+									type="date"
+									value={referencePeriodEnd}
+								/>
+								<div
+									aria-atomic="true"
+									aria-live="polite"
+									className="fr-messages-group"
+									id="reference-period-end-messages"
+								>
+									{errors.referencePeriodEnd ? (
+										<p className="fr-message fr-message--error">
+											{errors.referencePeriodEnd.message}
+										</p>
+									) : null}
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</fieldset>
+
+			<div aria-atomic="true" aria-live="polite" className="fr-messages-group">
+				<p className="fr-message fr-message--info">
+					La période couvre 12 mois consécutifs.
+				</p>
+			</div>
+		</>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/steps/Step1ReferencePeriod.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step1ReferencePeriod.tsx
@@ -61,14 +61,14 @@ export function Step1ReferencePeriod() {
 
 	return (
 		<>
-			<p>
+			<p className="fr-text-title--grey">
 				Année de référence : <strong>{year}</strong>
 			</p>
-			<p>
+			<p className="fr-text-title--grey">
 				Sélectionnez la période de l'exercice comptable utilisé pour le calcul
 				des écarts.
 			</p>
-			<p>Tous les champs sont obligatoires.</p>
+			<p className="fr-text-title--grey">Tous les champs sont obligatoires.</p>
 
 			<fieldset className="fr-fieldset">
 				<legend className="fr-sr-only">Dates de la période de référence</legend>

--- a/packages/app/src/modules/declaration-representation/steps/Step1ReferencePeriod.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step1ReferencePeriod.tsx
@@ -162,7 +162,7 @@ export function Step1ReferencePeriod() {
 				</div>
 			</fieldset>
 
-			<div aria-atomic="true" aria-live="polite" className="fr-messages-group">
+			<div className="fr-messages-group">
 				<p className="fr-message fr-message--info">
 					La période couvre 12 mois consécutifs.
 				</p>

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step1ReferencePeriod.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step1ReferencePeriod.test.tsx
@@ -1,0 +1,229 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { push, mutate, mutateAsync } = vi.hoisted(() => ({
+	push: vi.fn(),
+	mutate: vi.fn(),
+	mutateAsync: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	usePathname: vi.fn(),
+	useRouter: () => ({
+		push,
+		replace: vi.fn(),
+		back: vi.fn(),
+		refresh: vi.fn(),
+	}),
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		representationDeclaration: {
+			saveDraft: {
+				useMutation: () => ({ mutate, mutateAsync, isPending: false }),
+			},
+		},
+	},
+}));
+
+import type { RepresentationDraft } from "~/modules/declaration-representation";
+import { StepPageClient } from "~/modules/declaration-representation";
+
+const CAMPAIGN_YEAR = 2026;
+const YEAR = 2025;
+const STEP_2_HREF = "/declaration-representation/etape/2";
+const REQUIRED_MESSAGE = "Sélectionner une date de début ou une date de fin.";
+const TWELVE_MONTHS_MESSAGE =
+	"La période de référence doit couvrir 12 mois consécutifs.";
+const REFERENCE_YEAR_MESSAGE =
+	"L'année de la date de fin de la période de référence doit correspondre à l'année au titre de laquelle les écarts sont calculés.";
+const VALID_START = "2025-01-01";
+const VALID_END = "2025-12-31";
+
+function renderStep1({
+	campaignOpen = true,
+	initialDraft = { currentStep: 1 } as RepresentationDraft,
+} = {}) {
+	return render(
+		<StepPageClient
+			campaignOpen={campaignOpen}
+			campaignYear={CAMPAIGN_YEAR}
+			initialDraft={initialDraft}
+			step={1}
+			year={YEAR}
+		/>,
+	);
+}
+
+function startInput() {
+	return screen.getByLabelText(/Date de début/);
+}
+
+function endInput() {
+	return screen.getByLabelText(/Date de fin/);
+}
+
+function fillPeriod({ start, end }: { start?: string; end?: string }) {
+	if (start !== undefined) {
+		fireEvent.change(startInput(), { target: { value: start } });
+	}
+	if (end !== undefined) {
+		fireEvent.change(endInput(), { target: { value: end } });
+	}
+}
+
+function clickNext() {
+	return userEvent.click(screen.getByRole("button", { name: "Suivant" }));
+}
+
+beforeEach(() => {
+	push.mockReset();
+	mutate.mockReset();
+	mutateAsync.mockReset().mockResolvedValue(undefined);
+});
+
+describe("Step1ReferencePeriod — rendering", () => {
+	it("announces the reference year and asks for both dates", () => {
+		renderStep1();
+
+		expect(screen.getByText("Période de référence")).toBeInTheDocument();
+		expect(screen.getByText(String(YEAR))).toBeInTheDocument();
+		expect(startInput()).toHaveValue("");
+		expect(endInput()).toHaveValue("");
+	});
+
+	it("pre-fills both dates from the stored draft (S22)", () => {
+		renderStep1({
+			initialDraft: {
+				currentStep: 2,
+				referencePeriodEnd: VALID_END,
+				referencePeriodStart: VALID_START,
+			},
+		});
+
+		expect(startInput()).toHaveValue(VALID_START);
+		expect(endInput()).toHaveValue(VALID_END);
+	});
+
+	it("locks the dates when the campaign is closed (S23)", () => {
+		renderStep1({
+			campaignOpen: false,
+			initialDraft: {
+				currentStep: 1,
+				referencePeriodEnd: VALID_END,
+				referencePeriodStart: VALID_START,
+			},
+		});
+
+		expect(startInput()).toHaveAttribute("readonly");
+		expect(endInput()).toHaveAttribute("readonly");
+		expect(
+			screen.queryByRole("button", { name: "Suivant" }),
+		).not.toBeInTheDocument();
+	});
+});
+
+describe("Step1ReferencePeriod — submit validation", () => {
+	it("requires both dates before advancing", async () => {
+		renderStep1();
+
+		await clickNext();
+
+		expect(screen.getByText(REQUIRED_MESSAGE)).toBeInTheDocument();
+		expect(mutateAsync).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("requires the end date when only the start date is filled", async () => {
+		renderStep1();
+
+		fillPeriod({ start: VALID_START });
+		await clickNext();
+
+		expect(screen.getByText(REQUIRED_MESSAGE)).toBeInTheDocument();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("requires the start date when only the end date is filled", async () => {
+		renderStep1();
+
+		fillPeriod({ end: VALID_END });
+		await clickNext();
+
+		expect(screen.getByText(REQUIRED_MESSAGE)).toBeInTheDocument();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("rejects a period shorter than twelve consecutive months", async () => {
+		renderStep1();
+
+		fillPeriod({ end: VALID_END, start: "2025-02-01" });
+		await clickNext();
+
+		expect(screen.getByText(TWELVE_MONTHS_MESSAGE)).toBeInTheDocument();
+		expect(mutateAsync).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("rejects a period ending outside the reference year", async () => {
+		renderStep1();
+
+		fillPeriod({ end: "2024-12-31", start: "2024-01-01" });
+		await clickNext();
+
+		expect(screen.getByText(REFERENCE_YEAR_MESSAGE)).toBeInTheDocument();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("advances once a rejected period has been corrected", async () => {
+		renderStep1();
+		fillPeriod({ end: VALID_END, start: "2025-02-01" });
+		await clickNext();
+
+		fillPeriod({ start: VALID_START });
+		await clickNext();
+
+		expect(screen.queryByText(TWELVE_MONTHS_MESSAGE)).not.toBeInTheDocument();
+		expect(screen.queryByText(REQUIRED_MESSAGE)).not.toBeInTheDocument();
+		expect(push).toHaveBeenCalledWith(STEP_2_HREF);
+	});
+});
+
+describe("Step1ReferencePeriod — valid period", () => {
+	it("saves the period with the progress and moves to the next step", async () => {
+		renderStep1();
+
+		fillPeriod({ end: VALID_END, start: VALID_START });
+		await clickNext();
+
+		expect(mutateAsync).toHaveBeenCalledWith({
+			year: YEAR,
+			currentStep: 2,
+			draft: {
+				currentStep: 2,
+				referencePeriodEnd: VALID_END,
+				referencePeriodStart: VALID_START,
+			},
+		});
+		expect(push).toHaveBeenCalledWith(STEP_2_HREF);
+	});
+
+	it("hands the typed period to the autosave draft", async () => {
+		const { unmount } = renderStep1();
+
+		fillPeriod({ end: VALID_END, start: VALID_START });
+		unmount();
+
+		expect(mutate).toHaveBeenCalledWith({
+			year: YEAR,
+			currentStep: 1,
+			draft: {
+				currentStep: 1,
+				referencePeriodEnd: VALID_END,
+				referencePeriodStart: VALID_START,
+			},
+		});
+	});
+});

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step1ReferencePeriod.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step1ReferencePeriod.test.tsx
@@ -38,6 +38,7 @@ const REQUIRED_MESSAGE = "Sélectionner une date de début ou une date de fin.";
 const TWELVE_MONTHS_MESSAGE =
 	"La période de référence doit couvrir 12 mois consécutifs.";
 const REFERENCE_YEAR_MESSAGE = `La date sélectionnée ne correspond pas à l'année de référence ${YEAR}.`;
+const TWELVE_MONTHS_HINT = "La période couvre 12 mois consécutifs.";
 const VALID_START = "2025-01-01";
 const VALID_END = "2025-12-31";
 
@@ -121,6 +122,23 @@ describe("Step1ReferencePeriod — rendering", () => {
 		expect(
 			screen.queryByRole("button", { name: "Suivant" }),
 		).not.toBeInTheDocument();
+	});
+
+	it("announces the date errors but leaves the twelve-month hint silent", async () => {
+		renderStep1();
+
+		expect(
+			screen.getByText(TWELVE_MONTHS_HINT).closest("[aria-live]"),
+		).toBeNull();
+
+		await clickNext();
+
+		expect(
+			screen.getByText(REQUIRED_MESSAGE).closest("[aria-live='polite']"),
+		).not.toBeNull();
+		expect(
+			screen.getByText(TWELVE_MONTHS_HINT).closest("[aria-live]"),
+		).toBeNull();
 	});
 });
 

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step1ReferencePeriod.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step1ReferencePeriod.test.tsx
@@ -37,8 +37,7 @@ const STEP_2_HREF = "/declaration-representation/etape/2";
 const REQUIRED_MESSAGE = "Sélectionner une date de début ou une date de fin.";
 const TWELVE_MONTHS_MESSAGE =
 	"La période de référence doit couvrir 12 mois consécutifs.";
-const REFERENCE_YEAR_MESSAGE =
-	"L'année de la date de fin de la période de référence doit correspondre à l'année au titre de laquelle les écarts sont calculés.";
+const REFERENCE_YEAR_MESSAGE = `La date sélectionnée ne correspond pas à l'année de référence ${YEAR}.`;
 const VALID_START = "2025-01-01";
 const VALID_END = "2025-12-31";
 
@@ -174,6 +173,18 @@ describe("Step1ReferencePeriod — submit validation", () => {
 		await clickNext();
 
 		expect(screen.getByText(REFERENCE_YEAR_MESSAGE)).toBeInTheDocument();
+		expect(endInput()).toHaveAttribute("aria-invalid", "true");
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("rejects a start date whose year cannot open the reference period", async () => {
+		renderStep1();
+
+		fillPeriod({ end: VALID_END, start: "2027-04-03" });
+		await clickNext();
+
+		expect(screen.getByText(REFERENCE_YEAR_MESSAGE)).toBeInTheDocument();
+		expect(startInput()).toHaveAttribute("aria-invalid", "true");
 		expect(push).not.toHaveBeenCalled();
 	});
 

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step3Members.test.tsx
@@ -19,6 +19,8 @@ const STEP = 3;
 
 const RAISED_TARGET_YEAR = REPRESENTATION_TARGET_RAISED_FROM_CAMPAIGN_YEAR - 1;
 
+const registerStepValidator = vi.fn();
+
 const NON_COMPLIANT_MEMBERS = {
 	hasManagementBody: true,
 	memberWomenPercent: 75,
@@ -70,6 +72,7 @@ function Harness({
 				isSaving: false,
 				isPendingSave: false,
 				isReadOnly,
+				registerStepValidator,
 			}}
 		>
 			<Step3Members />

--- a/packages/app/src/modules/declaration-representation/steps/index.ts
+++ b/packages/app/src/modules/declaration-representation/steps/index.ts
@@ -5,6 +5,7 @@ import {
 	REPRESENTATION_STEP_SLUGS,
 	TOTAL_REPRESENTATION_STEPS,
 } from "../types";
+import { Step1ReferencePeriod } from "./Step1ReferencePeriod";
 import { Step3Members } from "./Step3Members";
 import { StepPlaceholder } from "./StepPlaceholder";
 
@@ -26,7 +27,7 @@ const STEP_TITLES: Record<RepresentationStepSlug, string> = {
 };
 
 const STEP_COMPONENTS: Record<RepresentationStepSlug, ComponentType> = {
-	"periode-de-reference": StepPlaceholder,
+	"periode-de-reference": Step1ReferencePeriod,
 	"ecarts-cadres-dirigeants": StepPlaceholder,
 	"ecarts-instances-dirigeantes": Step3Members,
 	"informations-de-publication": StepPlaceholder,

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.submit.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.submit.test.ts
@@ -200,7 +200,7 @@ describe("representationDeclarationRouter.submit", () => {
 				referencePeriodStart: "2024-01-01",
 				referencePeriodEnd: "2024-12-31",
 			},
-			VALIDATION_MESSAGES.periodYear,
+			VALIDATION_MESSAGES.periodYear(YEAR),
 		],
 	])("rejects %s", async (_label, payload, message) => {
 		const mock = createMockDb();


### PR DESCRIPTION
Closes #4158

## Résumé

Ajoute l'écran d'entrée du parcours de représentation équilibrée (`/declaration-representation`, hors stepper — question d'assujettissement) et l'étape 1 du funnel (« Période de référence »).

### Écran d'assujettissement (`SubjectionScreen.tsx`)

- Question radio à 2 choix (libellés Figma exacts).
- « 1 000 ou plus » → navigation vers l'étape 1.
- « Moins de 1 000 » → message d'exemption + lien « Valider » vers `/mon-espace`.
- **Aucune persistance** (arbitrage produit du ticket) : rien n'est écrit en base, la question est reposée à chaque visite.
- État d'erreur (aucune sélection) conforme à la frame « erreurs ».

### Étape 1 — Période de référence (`Step1ReferencePeriod.tsx`)

- Rappel de l'année de référence, deux champs date (début/fin), aide « La période couvre 12 mois consécutifs. ».
- Validation à la soumission via `referencePeriodSchema` : 12 mois consécutifs + année de fin **et** année de début cohérentes avec l'année de référence (`{year, year-1}` / `{year}`), message d'erreur partagé et rattaché au bon champ.
- Brouillon sauvegardé/rechargé (pré-remplissage).

### Extension partagée (`StepPageClient.tsx` / `DraftContext.tsx`)

Le bouton « Suivant » partagé du funnel (posé par #4157) avançait sans jamais valider les données de l'étape. Ajout d'un point d'extension minimal et rétrocompatible — `registerStepValidator` — qu'une étape peut utiliser pour bloquer l'avancée le temps de sa validation (no-op pour les étapes encore en placeholder). Nécessaire pour cette étape et pour les tickets soeurs #4159/#4160 (mêmes contraintes de validation bloquante).

## Vérification visuelle

Gate `design-validator` (indépendant) : **PASS** au 3ᵉ passage (2 RETRY intermédiaires ont corrigé : ordre du paragraphe d'intro sorti du `<legend>`, bouton « Retour » masqué à tort sur l'état d'erreur, couleur d'erreur appliquée aux labels radio plutôt qu'à la legend, validation de l'année de début en plus de l'année de fin avec message partagé, token de couleur + rythme vertical des paragraphes). Mesure DOM + overlay onion-skin sur les 7 frames Figma citées, 2 hauteurs de viewport, aucune régression sur les états déjà validés.

![assujettissement - erreurs](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-4158/validator/4158-overlay-subjection-erreurs-v3.png)
![période de référence - erreur année](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/ticket-4158/validator/4158-overlay-step1-erreur-debut-v3.png)

Détail complet (mesures avant/après, 7 écrans, overlays) : voir le commentaire `design-validator: PASS` sur #4158.

## Test plan

- `pnpm test` — suite complète verte (4890 tests), coverage 100% sur les fichiers source modifiés (`tu-dev`, revert-verify effectué sur les 4 correctifs comportementaux du fix-round design-validator).
- `pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` — verts.
- Gates : `validator` — PASS. `structural-auditor` — MINOR (aucun ERROR ; nit corrigé : extraction d'une condition JSX en const nommée `canGoBack`). `rgaa-auditor` — MINOR (aucun ERROR ; pattern legend sr-only distincte du paragraphe visible confirmé sain, 2 WARN adjudiqués documentés ci-dessous).
- `security-auditor` — skip (aucun fichier serveur touché).
- `design-validator` — **PASS** (3ᵉ et dernier passage autorisé).
- CI GitHub Actions — verte.

### Points d'attention RGAA relevés, non corrigés dans ce ticket

- `Step1ReferencePeriod.tsx` : quand les deux champs date sont vides, seul `referencePeriodStart` reçoit l'erreur/`aria-invalid` alors que le message concerne les deux champs — comportement intentionnel qui reproduit exactement la frame Figma « erreur champs vides » (validé par `design-validator`), donc non modifié pour ne pas rompre la fidélité visuelle déjà actée.
- `StepPageClient.tsx` : désactiver le bouton « Suivant » focus pendant l'enregistrement (`disabled={isAdvancing}`) peut faire perdre le focus clavier le temps de l'appel réseau — comportement **hérité du squelette partagé (#4157/#4175)**, hors du périmètre « Fichiers impactés » de ce ticket ; à traiter dans un ticket dédié si confirmé.
