### PR TITLE
Représentation équilibrée — étape Informations de publication

### DIFF
--- a/packages/app/src/modules/declaration-representation/StepPageClient.tsx
+++ b/packages/app/src/modules/declaration-representation/StepPageClient.tsx
@@ -2,15 +2,19 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { isRepresentationPublicationRequired } from "~/modules/domain";
 import { Stepper } from "./Stepper";
 import type { StepValidator } from "./shared/draft/DraftContext";
 import { RepresentationDraftProvider } from "./shared/draft/DraftContext";
 import { useRepresentationDraft } from "./shared/draft/useRepresentationDraft";
 import {
+	getNextStep,
 	getNextStepHref,
 	getPreviousStepHref,
 	getStepDefinition,
+	PUBLICATION_STEP_NUMBER,
+	stepHref,
 } from "./steps";
 import type { RepresentationDraft } from "./types";
 
@@ -21,6 +25,19 @@ type StepPageClientProps = {
 	initialDraft: RepresentationDraft;
 	campaignOpen: boolean;
 };
+
+function isPublicationStepRequired(draft: RepresentationDraft): boolean {
+	if (
+		draft.executivesCount === undefined ||
+		draft.hasManagementBody === undefined
+	) {
+		return true;
+	}
+	return isRepresentationPublicationRequired(
+		draft.executivesCount,
+		draft.hasManagementBody,
+	);
+}
 
 export function StepPageClient({
 	step,
@@ -49,16 +66,28 @@ export function StepPageClient({
 		[],
 	);
 
+	const skipPublicationStep = !isPublicationStepRequired(draft);
 	const definition = getStepDefinition(step);
-	const previousHref = getPreviousStepHref(step);
-	const nextHref = getNextStepHref(step);
+	const previousHref = getPreviousStepHref(step, skipPublicationStep);
+	const nextHref = getNextStepHref(step, skipPublicationStep);
+	const bypassHref = getNextStepHref(PUBLICATION_STEP_NUMBER - 1, true);
+	const mustBypassPublicationStep =
+		step === PUBLICATION_STEP_NUMBER && skipPublicationStep;
+
+	useEffect(() => {
+		if (mustBypassPublicationStep && bypassHref !== undefined) {
+			router.replace(bypassHref);
+		}
+	}, [mustBypassPublicationStep, bypassHref, router]);
 
 	if (definition === undefined) return null;
+	if (mustBypassPublicationStep) return null;
 
 	const StepComponent = definition.Component;
 
 	async function handleNext() {
-		if (nextHref === undefined) return;
+		const nextStep = getNextStep(step, skipPublicationStep);
+		if (nextStep === undefined) return;
 		if (stepValidatorRef.current) {
 			const isValid = await stepValidatorRef.current();
 			if (!isValid) return;
@@ -66,8 +95,8 @@ export function StepPageClient({
 		setNavigationError(null);
 		setIsAdvancing(true);
 		try {
-			await saveProgress(step + 1);
-			router.push(nextHref);
+			await saveProgress(nextStep);
+			router.push(stepHref(nextStep));
 		} catch {
 			setNavigationError(
 				"L'enregistrement de votre progression a échoué. Veuillez réessayer.",

--- a/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.stepValidator.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.stepValidator.test.tsx
@@ -29,13 +29,13 @@ vi.mock("~/trpc/react", () => ({
 }));
 
 // Stands in for any funnel step wired to the shared validator extension point.
-vi.mock("../steps/StepPlaceholder", async () => {
+vi.mock("../steps/Step4Publication", async () => {
 	const { useEffect } = await import("react");
 	const { useRepresentationDraftContext } = await import(
 		"../shared/draft/DraftContext"
 	);
 	return {
-		StepPlaceholder: function ValidatedStep() {
+		Step4Publication: function ValidatedStep() {
 			const { registerStepValidator } = useRepresentationDraftContext();
 			useEffect(() => {
 				registerStepValidator(
@@ -52,8 +52,7 @@ import { StepPageClient } from "~/modules/declaration-representation";
 
 const CAMPAIGN_YEAR = 2026;
 const YEAR = 2025;
-// Step still backed by StepPlaceholder, so the mock below drives the whole step.
-const PLACEHOLDER_STEP = 4;
+const VALIDATED_STEP = 4;
 const NEXT_STEP_HREF = "/declaration-representation/etape/5";
 
 function renderStep() {
@@ -61,8 +60,8 @@ function renderStep() {
 		<StepPageClient
 			campaignOpen
 			campaignYear={CAMPAIGN_YEAR}
-			initialDraft={{ currentStep: PLACEHOLDER_STEP }}
-			step={PLACEHOLDER_STEP}
+			initialDraft={{ currentStep: VALIDATED_STEP }}
+			step={VALIDATED_STEP}
 			year={YEAR}
 		/>,
 	);

--- a/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/StepPageClient.test.tsx
@@ -2,8 +2,9 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { push, mutate, mutateAsync } = vi.hoisted(() => ({
+const { push, replace, mutate, mutateAsync } = vi.hoisted(() => ({
 	push: vi.fn(),
+	replace: vi.fn(),
 	mutate: vi.fn(),
 	mutateAsync: vi.fn(),
 }));
@@ -12,7 +13,7 @@ vi.mock("next/navigation", () => ({
 	usePathname: vi.fn(),
 	useRouter: () => ({
 		push,
-		replace: vi.fn(),
+		replace,
 		back: vi.fn(),
 		refresh: vi.fn(),
 	}),
@@ -31,9 +32,13 @@ vi.mock("~/trpc/react", () => ({
 import { StepPageClient } from "../StepPageClient";
 import type { RepresentationDraft } from "../types";
 import {
+	COMPUTABLE_EXECUTIVES,
 	MISMATCHED_EXECUTIVES,
 	NO_EXECUTIVES,
+	NO_MANAGEMENT_BODY,
+	VALID_REFERENCE_PERIOD,
 	VALIDATION_MESSAGES,
+	WEBSITE_PUBLICATION,
 } from "./fixtures";
 
 const CAMPAIGN_YEAR = 2026;
@@ -41,9 +46,12 @@ const YEAR = 2025;
 const CLOSED_BANNER = "La campagne de représentation équilibrée est close";
 const TWO_OR_MORE = /^Deux cadres dirigeants ou plus/;
 const NONE = /^Aucun cadre dirigeant/;
-const PLACEHOLDER_STEP = 4;
+const NO_MANAGEMENT_BODY_LABEL = /^Aucune instance dirigeante/;
+const SUMMARY_STEP = 5;
 const STEP_3_HREF = "/declaration-representation/etape/3";
+const STEP_4_HREF = "/declaration-representation/etape/4";
 const STEP_5_HREF = "/declaration-representation/etape/5";
+const NO_COMPUTABLE_GAP = { ...NO_EXECUTIVES, ...NO_MANAGEMENT_BODY };
 
 const SAVED_MISMATCHED_EXECUTIVES: RepresentationDraft = {
 	currentStep: 2,
@@ -96,6 +104,7 @@ async function retypeMenPercent(value: string) {
 
 beforeEach(() => {
 	push.mockReset();
+	replace.mockReset();
 	mutate.mockReset();
 	mutateAsync.mockReset().mockResolvedValue(undefined);
 });
@@ -117,7 +126,7 @@ describe("StepPageClient — rendering", () => {
 	});
 
 	it("falls back to the placeholder on a step that has no screen yet", () => {
-		renderStep({ step: PLACEHOLDER_STEP, currentStep: PLACEHOLDER_STEP });
+		renderStep({ step: SUMMARY_STEP, currentStep: SUMMARY_STEP });
 
 		expect(
 			screen.getByText(
@@ -242,14 +251,17 @@ describe("StepPageClient — étape invalide (S6)", () => {
 			<StepPageClient
 				campaignOpen
 				campaignYear={CAMPAIGN_YEAR}
-				initialDraft={{ currentStep: PLACEHOLDER_STEP }}
-				step={PLACEHOLDER_STEP}
+				initialDraft={{ currentStep: 3 }}
+				step={3}
 				year={YEAR}
 			/>,
 		);
+		await userEvent.click(
+			screen.getByRole("radio", { name: NO_MANAGEMENT_BODY_LABEL }),
+		);
 		await userEvent.click(nextButton());
 
-		expect(push).toHaveBeenCalledWith(STEP_5_HREF);
+		expect(push).toHaveBeenCalledWith(STEP_4_HREF);
 	});
 
 	it("blocks the next step while the percentages do not sum to 100", async () => {
@@ -299,9 +311,91 @@ describe("StepPageClient — étape invalide (S6)", () => {
 		expect(mutateAsync).not.toHaveBeenCalled();
 		expect(push).not.toHaveBeenCalled();
 	});
+});
 
-	it("advances on a step that never reports its validity", async () => {
-		renderStep({ step: PLACEHOLDER_STEP, currentStep: PLACEHOLDER_STEP });
+describe("StepPageClient — publication step skipped (S12)", () => {
+	const PUBLICATION_REQUIRED: RepresentationDraft = {
+		currentStep: 4,
+		...VALID_REFERENCE_PERIOD,
+		...COMPUTABLE_EXECUTIVES,
+		...NO_MANAGEMENT_BODY,
+	};
+
+	function publicationDateField() {
+		return screen.queryByLabelText(
+			/Date de publication des écarts calculables/,
+		);
+	}
+
+	it("jumps from the gaps step straight to the summary when no gap is computable", async () => {
+		renderStep({
+			step: 3,
+			initialDraft: { currentStep: 3, ...NO_COMPUTABLE_GAP },
+		});
+
+		await userEvent.click(nextButton());
+
+		expect(mutateAsync).toHaveBeenCalledWith({
+			year: YEAR,
+			currentStep: 5,
+			draft: { currentStep: 5, ...NO_COMPUTABLE_GAP },
+		});
+		expect(push).toHaveBeenCalledWith(STEP_5_HREF);
+	});
+
+	it("links the summary back to the gaps step", () => {
+		renderStep({
+			step: 5,
+			initialDraft: { currentStep: 5, ...NO_COMPUTABLE_GAP },
+		});
+
+		expect(screen.getByRole("link", { name: "Précédent" })).toHaveAttribute(
+			"href",
+			STEP_3_HREF,
+		);
+	});
+
+	it("redirects to the summary when the publication step is opened directly", () => {
+		const { container } = renderStep({
+			step: 4,
+			initialDraft: { currentStep: 4, ...NO_COMPUTABLE_GAP },
+		});
+
+		expect(replace).toHaveBeenCalledWith(STEP_5_HREF);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("presents the publication step as soon as one gap is computable", () => {
+		renderStep({ step: 4, initialDraft: PUBLICATION_REQUIRED });
+
+		expect(replace).not.toHaveBeenCalled();
+		expect(publicationDateField()).toBeInTheDocument();
+	});
+
+	it("presents the publication step while the computable gaps are still unknown", () => {
+		renderStep({ step: 4, currentStep: 4 });
+
+		expect(replace).not.toHaveBeenCalled();
+		expect(publicationDateField()).toBeInTheDocument();
+	});
+
+	it("keeps the user on the publication step while its guard rejects the entries", async () => {
+		renderStep({ step: 4, initialDraft: PUBLICATION_REQUIRED });
+
+		await userEvent.click(nextButton());
+
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.publishDateRequired),
+		).toBeInTheDocument();
+		expect(mutateAsync).not.toHaveBeenCalled();
+		expect(push).not.toHaveBeenCalled();
+	});
+
+	it("advances to the summary once the publication step is complete", async () => {
+		renderStep({
+			step: 4,
+			initialDraft: { ...PUBLICATION_REQUIRED, ...WEBSITE_PUBLICATION },
+		});
 
 		await userEvent.click(nextButton());
 

--- a/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/fixtures.ts
@@ -79,7 +79,13 @@ export const VALIDATION_MESSAGES = {
 		"Aucune information de publication n'est requise lorsqu'aucun écart n'est calculable.",
 	publishDateAfterPeriod:
 		"La date de publication doit être postérieure à la fin de la période de référence.",
+	publishDateRequired:
+		"Indiquez la date de publication des écarts calculables.",
+	websiteAnswerRequired:
+		"Précisez si l'entreprise a un site Internet pour publier les écarts calculables.",
 } as const;
+
+export const ZOD_UNTRANSLATED_MESSAGE = "Invalid input";
 
 export function issues(result: { success: boolean; error?: ZodError }) {
 	return (

--- a/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
+++ b/packages/app/src/modules/declaration-representation/__tests__/steps.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	getNextStep,
 	getNextStepHref,
 	getPreviousStepHref,
 	getStepDefinition,
 	isValidStep,
+	PUBLICATION_STEP_NUMBER,
 	parseStepParam,
 	REPRESENTATION_FUNNEL_ROOT,
 	REPRESENTATION_STEPS,
@@ -13,6 +15,7 @@ import {
 import { Step1ReferencePeriod } from "../steps/Step1ReferencePeriod";
 import { Step2Executives } from "../steps/Step2Executives";
 import { Step3Members } from "../steps/Step3Members";
+import { Step4Publication } from "../steps/Step4Publication";
 import { StepPlaceholder } from "../steps/StepPlaceholder";
 import {
 	REPRESENTATION_STEP_SLUGS,
@@ -42,10 +45,19 @@ describe("REPRESENTATION_STEPS", () => {
 		).toEqual({
 			"ecarts-cadres-dirigeants": Step2Executives,
 			"ecarts-instances-dirigeantes": Step3Members,
-			"informations-de-publication": StepPlaceholder,
+			"informations-de-publication": Step4Publication,
 			"periode-de-reference": Step1ReferencePeriod,
 			recapitulatif: StepPlaceholder,
 		});
+	});
+});
+
+describe("PUBLICATION_STEP_NUMBER", () => {
+	it("points at the publication slot of the funnel", () => {
+		expect(PUBLICATION_STEP_NUMBER).toBe(4);
+		expect(REPRESENTATION_STEPS[PUBLICATION_STEP_NUMBER - 1]?.slug).toBe(
+			"informations-de-publication",
+		);
 	});
 });
 
@@ -121,5 +133,56 @@ describe("navigation hrefs", () => {
 
 	it("has no next step on the last step", () => {
 		expect(getNextStepHref(TOTAL_REPRESENTATION_STEPS)).toBeUndefined();
+	});
+
+	it("resolves the next step number", () => {
+		expect(getNextStep(1)).toBe(2);
+		expect(getNextStep(PUBLICATION_STEP_NUMBER - 1)).toBe(
+			PUBLICATION_STEP_NUMBER,
+		);
+		expect(getNextStep(TOTAL_REPRESENTATION_STEPS)).toBeUndefined();
+	});
+});
+
+describe("navigation hrefs — publication step skipped (S12)", () => {
+	it("jumps over the publication step when moving forward", () => {
+		expect(getNextStep(PUBLICATION_STEP_NUMBER - 1, true)).toBe(
+			PUBLICATION_STEP_NUMBER + 1,
+		);
+		expect(getNextStepHref(PUBLICATION_STEP_NUMBER - 1, true)).toBe(
+			`${REPRESENTATION_FUNNEL_ROOT}/etape/${PUBLICATION_STEP_NUMBER + 1}`,
+		);
+	});
+
+	it("jumps over the publication step when moving backward", () => {
+		expect(getPreviousStepHref(PUBLICATION_STEP_NUMBER + 1, true)).toBe(
+			`${REPRESENTATION_FUNNEL_ROOT}/etape/${PUBLICATION_STEP_NUMBER - 1}`,
+		);
+	});
+
+	it("leaves every other transition untouched", () => {
+		expect(getNextStep(1, true)).toBe(2);
+		expect(getNextStepHref(1, true)).toBe(
+			`${REPRESENTATION_FUNNEL_ROOT}/etape/2`,
+		);
+		expect(getNextStep(2, true)).toBe(3);
+		expect(getPreviousStepHref(3, true)).toBe(
+			`${REPRESENTATION_FUNNEL_ROOT}/etape/2`,
+		);
+		expect(getPreviousStepHref(2, true)).toBe(
+			`${REPRESENTATION_FUNNEL_ROOT}/etape/1`,
+		);
+		expect(getPreviousStepHref(1, true)).toBe(REPRESENTATION_FUNNEL_ROOT);
+	});
+
+	it("still stops at the end of the funnel", () => {
+		expect(getNextStep(TOTAL_REPRESENTATION_STEPS, true)).toBeUndefined();
+		expect(getNextStepHref(TOTAL_REPRESENTATION_STEPS, true)).toBeUndefined();
+	});
+
+	it("moves forward normally when the publication step is the current one", () => {
+		expect(getNextStep(PUBLICATION_STEP_NUMBER, true)).toBe(
+			PUBLICATION_STEP_NUMBER + 1,
+		);
 	});
 });

--- a/packages/app/src/modules/declaration-representation/index.ts
+++ b/packages/app/src/modules/declaration-representation/index.ts
@@ -31,10 +31,12 @@ export {
 } from "./shared/PercentagePairFields";
 export type { StepDefinition } from "./steps";
 export {
+	getNextStep,
 	getNextStepHref,
 	getPreviousStepHref,
 	getStepDefinition,
 	isValidStep,
+	PUBLICATION_STEP_NUMBER,
 	parseStepParam,
 	REPRESENTATION_FUNNEL_ROOT,
 	REPRESENTATION_STEPS,

--- a/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useCallback, useEffect, useId } from "react";
+import { Controller } from "react-hook-form";
+
+import { useZodForm } from "~/modules/shared/useZodForm";
+import { publicationSchema } from "../schemas";
+import { useRepresentationDraftContext } from "../shared/draft/DraftContext";
+
+type PublicationFieldErrors = Partial<
+	Record<
+		"publishDate" | "hasWebsite" | "publishUrl" | "publishModalities",
+		{ message?: string }
+	>
+>;
+
+export function Step4Publication() {
+	const { draft, setDraftValues, isReadOnly, registerStepValidator } =
+		useRepresentationDraftContext();
+	const referencePeriodEnd = draft.referencePeriodEnd;
+
+	const baseId = useId();
+	const dateId = `${baseId}-date`;
+	const dateMessagesId = `${dateId}-messages`;
+	const websiteLegendId = `${baseId}-website-legend`;
+	const websiteMessagesId = `${baseId}-website-messages`;
+	const websiteYesId = `${baseId}-website-yes`;
+	const websiteNoId = `${baseId}-website-no`;
+	const urlId = `${baseId}-url`;
+	const urlMessagesId = `${urlId}-messages`;
+	const modalitiesId = `${baseId}-modalities`;
+	const modalitiesMessagesId = `${modalitiesId}-messages`;
+
+	const form = useZodForm(publicationSchema, {
+		defaultValues: {
+			publishDate: draft.publishDate,
+			hasWebsite: draft.hasWebsite,
+			publishUrl: draft.publishUrl,
+			publishModalities: draft.publishModalities,
+		},
+	});
+
+	const hasWebsite = form.watch("hasWebsite");
+
+	useEffect(() => {
+		const subscription = form.watch((values) => {
+			setDraftValues(values);
+		});
+		return () => subscription.unsubscribe();
+	}, [form, setDraftValues]);
+
+	const guard = useCallback(async () => {
+		const values = form.getValues();
+
+		if (!values.publishDate) {
+			form.setError("publishDate", {
+				type: "manual",
+				message: "Indiquez la date de publication des écarts calculables.",
+			});
+			return false;
+		}
+
+		if (
+			referencePeriodEnd !== undefined &&
+			values.publishDate <= referencePeriodEnd
+		) {
+			form.setError("publishDate", {
+				type: "manual",
+				message:
+					"La date de publication doit être postérieure à la fin de la période de référence.",
+			});
+			return false;
+		}
+
+		if (values.hasWebsite === undefined) {
+			form.setError("hasWebsite", {
+				type: "manual",
+				message:
+					"Précisez si l'entreprise a un site Internet pour publier les écarts calculables.",
+			});
+			return false;
+		}
+
+		return form.trigger();
+	}, [form, referencePeriodEnd]);
+
+	useEffect(() => {
+		registerStepValidator(guard);
+		return () => registerStepValidator(null);
+	}, [registerStepValidator, guard]);
+
+	const errors = form.formState.errors as PublicationFieldErrors;
+	const dateError = errors.publishDate?.message;
+	const websiteError = errors.hasWebsite?.message;
+	const urlError = errors.publishUrl?.message;
+	const modalitiesError = errors.publishModalities?.message;
+
+	return (
+		<div>
+			<p className="fr-mb-2w">
+				Vous devez publier vos écarts chaque année, au plus tard le 1er mars.
+			</p>
+			<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
+
+			<div
+				className={`fr-input-group fr-mb-4w ${dateError ? "fr-input-group--error" : ""}`}
+			>
+				<label className="fr-label" htmlFor={dateId}>
+					Date de publication des écarts calculables
+					<span className="fr-hint-text">Format attendu : JJ/MM/AAAA</span>
+				</label>
+				<input
+					aria-describedby={dateMessagesId}
+					aria-invalid={dateError ? true : undefined}
+					className="fr-input"
+					id={dateId}
+					readOnly={isReadOnly}
+					required
+					type="date"
+					{...form.register("publishDate")}
+				/>
+				<div
+					aria-live="polite"
+					className="fr-messages-group"
+					id={dateMessagesId}
+				>
+					{dateError ? (
+						<p className="fr-message fr-message--error">{dateError}</p>
+					) : null}
+				</div>
+			</div>
+
+			<fieldset
+				aria-labelledby={`${websiteLegendId} ${websiteMessagesId}`}
+				className={`fr-fieldset fr-mb-4w ${websiteError ? "fr-fieldset--error" : ""}`}
+			>
+				<legend
+					className="fr-fieldset__legend--regular fr-fieldset__legend"
+					id={websiteLegendId}
+				>
+					Avez-vous un site Internet pour publier les écarts calculables ?
+				</legend>
+				<Controller
+					control={form.control}
+					name="hasWebsite"
+					render={({ field }) => (
+						<>
+							<div className="fr-fieldset__element fr-fieldset__element--inline">
+								<div className="fr-radio-group">
+									<input
+										checked={field.value === true}
+										disabled={isReadOnly}
+										id={websiteYesId}
+										name={field.name}
+										onChange={() => field.onChange(true)}
+										required
+										type="radio"
+										value="true"
+									/>
+									<label className="fr-label" htmlFor={websiteYesId}>
+										Oui
+									</label>
+								</div>
+							</div>
+							<div className="fr-fieldset__element fr-fieldset__element--inline">
+								<div className="fr-radio-group">
+									<input
+										checked={field.value === false}
+										disabled={isReadOnly}
+										id={websiteNoId}
+										name={field.name}
+										onChange={() => field.onChange(false)}
+										required
+										type="radio"
+										value="false"
+									/>
+									<label className="fr-label" htmlFor={websiteNoId}>
+										Non
+									</label>
+								</div>
+							</div>
+						</>
+					)}
+				/>
+				<div
+					aria-live="polite"
+					className="fr-messages-group"
+					id={websiteMessagesId}
+				>
+					{websiteError ? (
+						<p className="fr-message fr-message--error">{websiteError}</p>
+					) : null}
+				</div>
+			</fieldset>
+
+			{hasWebsite === true ? (
+				<div
+					className={`fr-input-group ${urlError ? "fr-input-group--error" : ""}`}
+				>
+					<label className="fr-label" htmlFor={urlId}>
+						Indiquez l'adresse de la page Internet (URL) sur laquelle seront
+						publiés les écarts calculables.
+					</label>
+					<input
+						aria-describedby={urlMessagesId}
+						aria-invalid={urlError ? true : undefined}
+						aria-required="true"
+						className="fr-input"
+						id={urlId}
+						readOnly={isReadOnly}
+						type="text"
+						{...form.register("publishUrl")}
+					/>
+					<div
+						aria-live="polite"
+						className="fr-messages-group"
+						id={urlMessagesId}
+					>
+						{urlError ? (
+							<p className="fr-message fr-message--error">{urlError}</p>
+						) : null}
+					</div>
+				</div>
+			) : null}
+
+			{hasWebsite === false ? (
+				<div
+					className={`fr-input-group ${modalitiesError ? "fr-input-group--error" : ""}`}
+				>
+					<label className="fr-label" htmlFor={modalitiesId}>
+						Indiquer les modalités de communication des écarts calculables
+						auprès de vos salariés.
+					</label>
+					<textarea
+						aria-describedby={modalitiesMessagesId}
+						aria-invalid={modalitiesError ? true : undefined}
+						aria-required="true"
+						className="fr-input"
+						id={modalitiesId}
+						readOnly={isReadOnly}
+						{...form.register("publishModalities")}
+					/>
+					<div
+						aria-live="polite"
+						className="fr-messages-group"
+						id={modalitiesMessagesId}
+					>
+						{modalitiesError ? (
+							<p className="fr-message fr-message--error">{modalitiesError}</p>
+						) : null}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
@@ -120,6 +120,7 @@ export function Step4Publication() {
 					{...form.register("publishDate")}
 				/>
 				<div
+					aria-atomic="true"
 					aria-live="polite"
 					className="fr-messages-group"
 					id={dateMessagesId}
@@ -183,6 +184,7 @@ export function Step4Publication() {
 					)}
 				/>
 				<div
+					aria-atomic="true"
 					aria-live="polite"
 					className="fr-messages-group"
 					id={websiteMessagesId}
@@ -212,6 +214,7 @@ export function Step4Publication() {
 						{...form.register("publishUrl")}
 					/>
 					<div
+						aria-atomic="true"
 						aria-live="polite"
 						className="fr-messages-group"
 						id={urlMessagesId}
@@ -241,6 +244,7 @@ export function Step4Publication() {
 						{...form.register("publishModalities")}
 					/>
 					<div
+						aria-atomic="true"
 						aria-live="polite"
 						className="fr-messages-group"
 						id={modalitiesMessagesId}

--- a/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useId } from "react";
 import { Controller } from "react-hook-form";
 
 import { TrackedLink } from "~/modules/analytics";
-import { NewTabNotice } from "~/modules/layout";
+import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { publicationSchema } from "../schemas";
 import { useRepresentationDraftContext } from "../shared/draft/DraftContext";

--- a/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step4Publication.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useId } from "react";
 import { Controller } from "react-hook-form";
 
+import { TrackedLink } from "~/modules/analytics";
+import { NewTabNotice } from "~/modules/layout";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { publicationSchema } from "../schemas";
 import { useRepresentationDraftContext } from "../shared/draft/DraftContext";
@@ -30,6 +32,7 @@ export function Step4Publication() {
 	const urlMessagesId = `${urlId}-messages`;
 	const modalitiesId = `${baseId}-modalities`;
 	const modalitiesMessagesId = `${modalitiesId}-messages`;
+	const accordionId = `${baseId}-transparency-obligation`;
 
 	const form = useZodForm(publicationSchema, {
 		defaultValues: {
@@ -255,6 +258,40 @@ export function Step4Publication() {
 					</div>
 				</div>
 			) : null}
+
+			<section className="fr-accordion fr-mt-4w">
+				<h3 className="fr-accordion__title">
+					<button
+						aria-controls={accordionId}
+						aria-expanded="false"
+						className="fr-accordion__btn"
+						type="button"
+					>
+						Obligation de transparence
+					</button>
+				</h3>
+				<div className="fr-collapse" id={accordionId}>
+					<p>
+						Les entreprises doivent publier chaque année, au plus tard le 1er
+						mars, leurs écarts éventuels de représentation femmes-hommes pour
+						les cadres dirigeants et au sein des instances dirigeantes de
+						manière visible et lisible sur leur site internet, et les laisser en
+						ligne jusqu'à la publication de leurs écarts l'année suivante. Si
+						l'entreprise ne dispose pas de site internet, elle doit porter ces
+						informations à la connaissance des salariés par tout moyen.
+					</p>
+					<TrackedLink
+						className="fr-link"
+						href="https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle"
+						rel="noopener noreferrer"
+						target="_blank"
+						trackingId="representation_publication_transparency_obligation"
+					>
+						En savoir plus
+						<NewTabNotice />
+					</TrackedLink>
+				</div>
+			</section>
 		</div>
 	);
 }

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step4Publication.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step4Publication.test.tsx
@@ -1,0 +1,324 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	OFFLINE_PUBLICATION,
+	REPRESENTATION_YEAR,
+	VALID_REFERENCE_PERIOD,
+	VALIDATION_MESSAGES,
+	WEBSITE_PUBLICATION,
+	ZOD_UNTRANSLATED_MESSAGE,
+} from "~/modules/declaration-representation/__tests__/fixtures";
+import type {
+	RepresentationDraftContextValue,
+	StepValidator,
+} from "~/modules/declaration-representation/shared/draft/DraftContext";
+import { RepresentationDraftProvider } from "~/modules/declaration-representation/shared/draft/DraftContext";
+import { PUBLICATION_STEP_NUMBER } from "~/modules/declaration-representation/steps";
+import type { RepresentationDraft } from "~/modules/declaration-representation/types";
+import { Step4Publication } from "../Step4Publication";
+
+const setDraftValues = vi.fn();
+
+let latestValidator: StepValidator | null = null;
+
+const registerStepValidator = vi.fn((validator: StepValidator | null) => {
+	latestValidator = validator;
+});
+
+function renderStep({
+	draft = {},
+	isReadOnly = false,
+}: {
+	draft?: Partial<RepresentationDraft>;
+	isReadOnly?: boolean;
+} = {}) {
+	const value: RepresentationDraftContextValue = {
+		year: REPRESENTATION_YEAR,
+		step: PUBLICATION_STEP_NUMBER,
+		draft: {
+			currentStep: PUBLICATION_STEP_NUMBER,
+			...VALID_REFERENCE_PERIOD,
+			...draft,
+		},
+		setDraftValues,
+		isSaving: false,
+		isPendingSave: false,
+		isReadOnly,
+		registerStepValidator,
+	};
+
+	return render(
+		<RepresentationDraftProvider value={value}>
+			<Step4Publication />
+		</RepresentationDraftProvider>,
+	);
+}
+
+function dateField() {
+	return screen.getByLabelText(/Date de publication des écarts calculables/);
+}
+
+function websiteFieldset() {
+	return screen.getByRole("group", { name: /site Internet/ });
+}
+
+function urlField() {
+	return screen.queryByLabelText(/adresse de la page Internet/);
+}
+
+function modalitiesField() {
+	return screen.queryByLabelText(/modalités de communication/);
+}
+
+async function runStepValidator(): Promise<boolean> {
+	const validator = latestValidator;
+	if (validator === null) throw new Error("No step validator was registered.");
+
+	let result = false;
+	await act(async () => {
+		result = await validator();
+	});
+	return result;
+}
+
+beforeEach(() => {
+	setDraftValues.mockReset();
+	registerStepValidator.mockClear();
+	latestValidator = null;
+});
+
+describe("Step4Publication — fields", () => {
+	it("asks for the publication date and the website question", () => {
+		renderStep();
+
+		expect(dateField()).toHaveAttribute("type", "date");
+		expect(screen.getByLabelText("Oui")).toBeInTheDocument();
+		expect(screen.getByLabelText("Non")).toBeInTheDocument();
+		expect(urlField()).not.toBeInTheDocument();
+		expect(modalitiesField()).not.toBeInTheDocument();
+	});
+
+	it("exposes the date and the website answer as required", () => {
+		renderStep();
+
+		expect(dateField()).toBeRequired();
+		expect(screen.getByLabelText("Oui")).toBeRequired();
+		expect(screen.getByLabelText("Non")).toBeRequired();
+	});
+
+	it("prefills the fields from the draft", () => {
+		renderStep({ draft: WEBSITE_PUBLICATION });
+
+		expect(dateField()).toHaveValue(WEBSITE_PUBLICATION.publishDate);
+		expect(screen.getByLabelText("Oui")).toBeChecked();
+		expect(urlField()).toHaveValue(WEBSITE_PUBLICATION.publishUrl);
+	});
+
+	it("reveals the page address when the company has a website (S9)", async () => {
+		renderStep();
+
+		await userEvent.click(screen.getByLabelText("Oui"));
+
+		expect(urlField()).toBeInTheDocument();
+		expect(urlField()).toHaveAttribute("aria-required", "true");
+		expect(modalitiesField()).not.toBeInTheDocument();
+	});
+
+	it("reveals the communication modalities when the company has no website (S10)", async () => {
+		renderStep();
+
+		await userEvent.click(screen.getByLabelText("Non"));
+
+		expect(modalitiesField()).toBeInTheDocument();
+		expect(modalitiesField()).toHaveAttribute("aria-required", "true");
+		expect(urlField()).not.toBeInTheDocument();
+	});
+
+	it("syncs every entry into the shared draft", async () => {
+		renderStep();
+
+		await userEvent.click(screen.getByLabelText("Non"));
+
+		expect(setDraftValues).toHaveBeenCalledWith(
+			expect.objectContaining({ hasWebsite: false }),
+		);
+	});
+
+	it("locks every field while the campaign is read-only", () => {
+		renderStep({ draft: WEBSITE_PUBLICATION, isReadOnly: true });
+
+		expect(dateField()).toHaveAttribute("readonly");
+		expect(dateField()).not.toBeDisabled();
+		expect(screen.getByLabelText("Oui")).toBeDisabled();
+		expect(screen.getByLabelText("Non")).toBeDisabled();
+		expect(urlField()).toHaveAttribute("readonly");
+		expect(urlField()).not.toBeDisabled();
+	});
+
+	it("locks the communication modalities while the campaign is read-only", () => {
+		renderStep({ draft: OFFLINE_PUBLICATION, isReadOnly: true });
+
+		expect(modalitiesField()).toHaveAttribute("readonly");
+		expect(modalitiesField()).not.toBeDisabled();
+	});
+});
+
+describe("Step4Publication — step validator", () => {
+	it("registers its validator with the step page and releases it on unmount", () => {
+		const { unmount } = renderStep();
+
+		expect(registerStepValidator).toHaveBeenCalledWith(expect.any(Function));
+
+		unmount();
+
+		expect(registerStepValidator).toHaveBeenLastCalledWith(null);
+	});
+
+	it("blocks the step and asks for the publication date in plain French", async () => {
+		renderStep();
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.publishDateRequired),
+		).toBeInTheDocument();
+		expect(screen.queryByText(/ISO date/i)).not.toBeInTheDocument();
+		expect(dateField()).toHaveAttribute("aria-invalid", "true");
+	});
+
+	it("clears the missing-date error once the date is filled in", async () => {
+		renderStep({
+			draft: { hasWebsite: true, publishUrl: WEBSITE_PUBLICATION.publishUrl },
+		});
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.publishDateRequired),
+		).toBeInTheDocument();
+
+		fireEvent.change(dateField(), {
+			target: { value: WEBSITE_PUBLICATION.publishDate },
+		});
+
+		expect(await runStepValidator()).toBe(true);
+		expect(
+			screen.queryByText(VALIDATION_MESSAGES.publishDateRequired),
+		).not.toBeInTheDocument();
+	});
+
+	it("requires an answer to the website question in plain French once the date is filled", async () => {
+		renderStep({ draft: { publishDate: WEBSITE_PUBLICATION.publishDate } });
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.queryByText(VALIDATION_MESSAGES.publishDateRequired),
+		).not.toBeInTheDocument();
+		expect(websiteFieldset()).toHaveClass("fr-fieldset--error");
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.websiteAnswerRequired),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(ZOD_UNTRANSLATED_MESSAGE),
+		).not.toBeInTheDocument();
+	});
+
+	it("stops at the website question before asking for the publication details", async () => {
+		renderStep({ draft: { publishDate: WEBSITE_PUBLICATION.publishDate } });
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.queryByText(VALIDATION_MESSAGES.urlRequired),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(VALIDATION_MESSAGES.modalitiesRequired),
+		).not.toBeInTheDocument();
+	});
+
+	it("requires the page address when the company has a website (S9)", async () => {
+		renderStep({
+			draft: { publishDate: WEBSITE_PUBLICATION.publishDate, hasWebsite: true },
+		});
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.urlRequired),
+		).toBeInTheDocument();
+	});
+
+	it("requires the communication modalities when there is no website (S10)", async () => {
+		renderStep({
+			draft: {
+				publishDate: OFFLINE_PUBLICATION.publishDate,
+				hasWebsite: false,
+			},
+		});
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.modalitiesRequired),
+		).toBeInTheDocument();
+	});
+
+	it("lets the step proceed once the website publication is complete (S9)", async () => {
+		renderStep({ draft: WEBSITE_PUBLICATION });
+
+		expect(await runStepValidator()).toBe(true);
+	});
+
+	it("lets the step proceed with the offline communication modalities (S10)", async () => {
+		renderStep({ draft: OFFLINE_PUBLICATION });
+
+		expect(await runStepValidator()).toBe(true);
+	});
+});
+
+describe("Step4Publication — publication date after the reference period (S11)", () => {
+	it("blocks a publication date equal to the end of the reference period", async () => {
+		renderStep({
+			draft: {
+				...WEBSITE_PUBLICATION,
+				publishDate: VALID_REFERENCE_PERIOD.referencePeriodEnd,
+			},
+		});
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.publishDateAfterPeriod),
+		).toBeInTheDocument();
+	});
+
+	it("blocks a publication date before the end of the reference period", async () => {
+		renderStep({
+			draft: { ...WEBSITE_PUBLICATION, publishDate: "2025-06-30" },
+		});
+
+		expect(await runStepValidator()).toBe(false);
+		expect(
+			screen.getByText(VALIDATION_MESSAGES.publishDateAfterPeriod),
+		).toBeInTheDocument();
+	});
+
+	it("accepts the day right after the end of the reference period", async () => {
+		renderStep({
+			draft: { ...WEBSITE_PUBLICATION, publishDate: "2026-01-01" },
+		});
+
+		expect(await runStepValidator()).toBe(true);
+		expect(
+			screen.queryByText(VALIDATION_MESSAGES.publishDateAfterPeriod),
+		).not.toBeInTheDocument();
+	});
+
+	it("skips the comparison while the reference period is unknown", async () => {
+		renderStep({
+			draft: {
+				...WEBSITE_PUBLICATION,
+				publishDate: "2020-01-01",
+				referencePeriodEnd: undefined,
+			},
+		});
+
+		expect(await runStepValidator()).toBe(true);
+	});
+});

--- a/packages/app/src/modules/declaration-representation/steps/__tests__/Step4Publication.test.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/__tests__/Step4Publication.test.tsx
@@ -19,6 +19,11 @@ import { PUBLICATION_STEP_NUMBER } from "~/modules/declaration-representation/st
 import type { RepresentationDraft } from "~/modules/declaration-representation/types";
 import { Step4Publication } from "../Step4Publication";
 
+const ACCORDION_TITLE = "Obligation de transparence";
+
+const LEARN_MORE_HREF =
+	"https://travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle";
+
 const setDraftValues = vi.fn();
 
 let latestValidator: StepValidator | null = null;
@@ -70,6 +75,10 @@ function urlField() {
 
 function modalitiesField() {
 	return screen.queryByLabelText(/modalités de communication/);
+}
+
+function accordionTrigger() {
+	return screen.getByRole("button", { name: ACCORDION_TITLE });
 }
 
 async function runStepValidator(): Promise<boolean> {
@@ -320,5 +329,59 @@ describe("Step4Publication — publication date after the reference period (S11)
 		});
 
 		expect(await runStepValidator()).toBe(true);
+	});
+});
+
+describe("Step4Publication — obligation de transparence", () => {
+	it("offers the obligation in a collapsed accordion", () => {
+		renderStep();
+
+		expect(accordionTrigger()).toHaveAttribute("aria-expanded", "false");
+	});
+
+	it("wires the accordion button to the panel holding the obligation", () => {
+		renderStep();
+
+		const panelId = accordionTrigger().getAttribute("aria-controls");
+
+		expect(document.getElementById(panelId ?? "")).toContainElement(
+			screen.getByText(/par tout moyen/),
+		);
+	});
+
+	it("recalls the yearly publication duty and the fallback without a website", () => {
+		renderStep();
+
+		expect(
+			screen.getByText(
+				/au plus tard le 1er mars.*visible et lisible sur leur site internet/,
+			),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/porter ces informations à la connaissance des salariés par tout moyen/,
+			),
+		).toBeInTheDocument();
+	});
+
+	it("points to the ministry page in a new tab", () => {
+		renderStep();
+
+		const link = screen.getByRole("link", {
+			name: /En savoir plus.*nouvelle fenêtre/i,
+		});
+
+		expect(link).toHaveAttribute("href", LEARN_MORE_HREF);
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("keeps the obligation available whichever publication channel is picked", async () => {
+		renderStep();
+
+		await userEvent.click(screen.getByLabelText("Non"));
+
+		expect(modalitiesField()).toBeInTheDocument();
+		expect(accordionTrigger()).toBeInTheDocument();
 	});
 });

--- a/packages/app/src/modules/declaration-representation/steps/index.ts
+++ b/packages/app/src/modules/declaration-representation/steps/index.ts
@@ -8,6 +8,7 @@ import {
 import { Step1ReferencePeriod } from "./Step1ReferencePeriod";
 import { Step2Executives } from "./Step2Executives";
 import { Step3Members } from "./Step3Members";
+import { Step4Publication } from "./Step4Publication";
 import { StepPlaceholder } from "./StepPlaceholder";
 
 export type StepDefinition = {
@@ -17,6 +18,9 @@ export type StepDefinition = {
 };
 
 export const REPRESENTATION_FUNNEL_ROOT = "/declaration-representation";
+
+export const PUBLICATION_STEP_NUMBER =
+	REPRESENTATION_STEP_SLUGS.indexOf("informations-de-publication") + 1;
 
 const STEP_TITLES: Record<RepresentationStepSlug, string> = {
 	"periode-de-reference": "Période de référence",
@@ -31,7 +35,7 @@ const STEP_COMPONENTS: Record<RepresentationStepSlug, ComponentType> = {
 	"periode-de-reference": Step1ReferencePeriod,
 	"ecarts-cadres-dirigeants": Step2Executives,
 	"ecarts-instances-dirigeantes": Step3Members,
-	"informations-de-publication": StepPlaceholder,
+	"informations-de-publication": Step4Publication,
 	recapitulatif: StepPlaceholder,
 };
 
@@ -62,10 +66,35 @@ export function stepHref(step: number): string {
 	return `${REPRESENTATION_FUNNEL_ROOT}/etape/${step}`;
 }
 
-export function getPreviousStepHref(step: number): string {
-	return step <= 1 ? REPRESENTATION_FUNNEL_ROOT : stepHref(step - 1);
+export function getPreviousStepHref(
+	step: number,
+	skipPublicationStep = false,
+): string {
+	if (step <= 1) return REPRESENTATION_FUNNEL_ROOT;
+	const candidate = step - 1;
+	const previous =
+		skipPublicationStep && candidate === PUBLICATION_STEP_NUMBER
+			? candidate - 1
+			: candidate;
+	return previous < 1 ? REPRESENTATION_FUNNEL_ROOT : stepHref(previous);
 }
 
-export function getNextStepHref(step: number): string | undefined {
-	return step >= TOTAL_REPRESENTATION_STEPS ? undefined : stepHref(step + 1);
+export function getNextStep(
+	step: number,
+	skipPublicationStep = false,
+): number | undefined {
+	const candidate = step + 1;
+	const next =
+		skipPublicationStep && candidate === PUBLICATION_STEP_NUMBER
+			? candidate + 1
+			: candidate;
+	return next > TOTAL_REPRESENTATION_STEPS ? undefined : next;
+}
+
+export function getNextStepHref(
+	step: number,
+	skipPublicationStep = false,
+): string | undefined {
+	const next = getNextStep(step, skipPublicationStep);
+	return next === undefined ? undefined : stepHref(next);
 }


### PR DESCRIPTION
Closes #4161

## Résumé

Implémente l'étape 4/5 du funnel de représentation équilibrée : informations de publication des écarts calculables.

- Champ date de publication + radio « site internet » (Oui → URL, Non → modalités de communication)
- S9/S10 : validation via le `publicationSchema` existant (aucune modification de `schemas.ts`)
- S11 : erreur bloquante si la date de publication ≤ fin de période de référence, message exact du ticket
- S12 : saut de l'étape (navigation « Suivant » depuis l'étape 3 ET accès direct à `/etape/4`) quand aucun écart n'est calculable ; le stepper reste affiché à 5 étapes
- Accordéon « Obligation de transparence » (texte réglementaire + lien externe), présent sur les 4 frames Figma, ajouté suite au `RETRY` de `design-validator`

## Fidélité Figma

Construit à partir des 4 frames citées (base / avec site / sans site / erreurs), lecture structurelle + copie vérifiée verbatim contre les nœuds Figma. Le hint de format de date a été corrigé en `JJ/MM/AAAA` suite à une revue (le design source comportait un typo `JJ/MM/AAA`). `design-validator` PASS (mesures DOM ±1px + overlay onion-skin + vision, 2 hauteurs de viewport) — voir commentaires sur le ticket.

## Décision d'architecture assumée

`structural-auditor` a relevé que la comparaison S11 (`publishDate` > `referencePeriodEnd`) duplique une règle déjà présente dans `submitRepresentationSchema` (schemas.ts). Le fix propre (extraire une fonction domaine partagée) nécessiterait de toucher `~/modules/domain` et/ou `schemas.ts`, tous deux **hors du scope de fichiers autorisé pour ce ticket** (`Fichiers impactés` : `Step4Publication.tsx`, `steps/index.ts`, `StepPageClient.tsx` uniquement). Compromis assumé : la comparaison est réimplémentée localement (comparaison de chaînes ISO, `publishDate <= referencePeriodEnd`) avec le message exact du ticket. Recommandation : ticket de fast-follow pour extraire une fonction domaine unique réutilisée par les deux emplacements.

`structural-auditor` a également relevé deux compromis mineurs sur le round d'ajout de l'accordéon, assumés en fast-follow : le skeleton `fr-accordion` est dupliqué 3× dans le module (composant partagé `DefinitionAccordion` existant dans `declaration-remuneration` mais pas encore relocalisé) ; l'URL `travail-emploi.gouv.fr/droit-du-travail/egalite-professionnelle` reste codée en dur (pas de constante partagée).

## Fix CI

`App · Build` échouait (`Module not found: Can't resolve 'tls'`) : `Step4Publication.tsx` importait `NewTabNotice` via le barrel `~/modules/layout`, qui ré-exporte aussi `Header`/`MobileMenu` → chaîne transitive vers `server/db` (postgres) bundlée côté client par erreur. Corrigé en important directement `~/modules/layout/shared/NewTabNotice`, comme le fait déjà le reste du codebase (`NextStepsBox`, `CompliancePathChoice`, `ProConnectButton`, etc.). Build + typecheck + suite de tests `declaration-representation` reconfirmés verts localement.

## Vérifications manuelles

Testé en local (dev-login + manipulation directe du brouillon en DB) : rendu conforme aux 4 frames Figma, navigation avant/arrière avec saut d'étape, accès direct `/etape/4` → redirection `/etape/5`, persistance du brouillon (`currentStep` correct après saut), messages d'erreur S9/S10/S11 conformes.

## Tests

Délégués à `tu-dev` : 29 tests ajoutés (Step4Publication, steps/index skip-logic, StepPageClient bypass + guard, accordéon), 0 régression, suite complète verte.

## Revue

Les 4 findings `revu-bot` du premier passage ont été traités (guard logic S11, typo hint date, vérification de stabilité de `setDraftValues`, underflow `getPreviousStepHref`) — voir réponses inline sur chaque thread.
