### PR TITLE
feat(profile): modale Mon profil conforme au Figma + mentions d'obligation

### DIFF
--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -48,6 +48,7 @@ export const AUDIT_ACTIONS = {
 
 	// ── Profile mutations ──────────────────────────────────
 	PROFILE_UPDATE_PHONE: "profile.update_phone",
+	PROFILE_UPDATE: "profile.update",
 
 	// ── GIP MDS ────────────────────────────────────────────
 	GIP_MDS_IMPORT: "gip_mds.import",
@@ -168,6 +169,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.COMPANY_UPDATE_HAS_CSE]: "mutation",
 
 	[AUDIT_ACTIONS.PROFILE_UPDATE_PHONE]: "mutation",
+	[AUDIT_ACTIONS.PROFILE_UPDATE]: "mutation",
 
 	[AUDIT_ACTIONS.GIP_MDS_IMPORT]: "system",
 

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
@@ -8,8 +8,9 @@
 // utility — only light (300), regular (400), bold (700) and heavy (900).
 .introText {
 	font-weight: 500;
-	// Figma: "$text-title-grey". DSFR ships the token as a custom property but
-	// no utility class for it — `fr-text-title--grey` does not exist.
+	// Figma: "$text-title-grey". The DSFR utility class `fr-text-title--grey`
+	// exists, but this rule already overrides font-weight, so the color lives
+	// here too rather than splitting the two across a class and a module rule.
 	color: var(--text-title-grey);
 }
 

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.module.scss
@@ -8,9 +8,7 @@
 // utility — only light (300), regular (400), bold (700) and heavy (900).
 .introText {
 	font-weight: 500;
-	// Figma: "$text-title-grey". The DSFR utility class `fr-text-title--grey`
-	// exists, but this rule already overrides font-weight, so the color lives
-	// here too rather than splitting the two across a class and a module rule.
+	// Figma: "$text-title-grey" — kept here since this rule already overrides font-weight.
 	color: var(--text-title-grey);
 }
 

--- a/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
+++ b/packages/app/src/modules/cseOpinion/Step1Opinions.tsx
@@ -244,7 +244,9 @@ export function Step1Opinions({
 					soumettre votre déclaration aux services du ministère chargé du
 					Travail.
 				</p>
-				<p className="fr-mb-4w">Tous les champs sont obligatoires.</p>
+				<p className="fr-mb-4w fr-text-title--grey">
+					Tous les champs sont obligatoires.
+				</p>
 
 				{/* A single declaration has nothing to be told apart from, so the
 				    per-declaration headings only earn their place in pairs. */}

--- a/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/Step1Opinions.test.tsx
@@ -181,6 +181,16 @@ describe("Step1Opinions", () => {
 		expect(heading).toHaveTextContent("Transmettre l'avis ou les avis du CSE");
 	});
 
+	it("renders the obligatory-fields mention in the title grey of the intro text", () => {
+		render(
+			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,
+		);
+
+		expect(screen.getByText("Tous les champs sont obligatoires.")).toHaveClass(
+			"fr-text-title--grey",
+		);
+	});
+
 	it("renders the stepper at step 1", () => {
 		render(
 			<Step1Opinions cseDeadline={cseDeadline} siren="123456789" year={2026} />,

--- a/packages/app/src/modules/my-space/CompanyEditModal.module.scss
+++ b/packages/app/src/modules/my-space/CompanyEditModal.module.scss
@@ -32,11 +32,6 @@
 	gap: 0.5rem;
 }
 
-.requiredHint {
-	font-size: 0.875rem;
-	color: var(--text-mention-grey);
-}
-
 .cseFieldset {
 	// A non-zero flex-basis keeps both rich radios at equal widths on wide
 	// screens (same rendering as flex-basis 0) but lets them wrap on their own

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -231,8 +231,7 @@ function CseRadioGroup({ hasCse, setHasCse }: CseRadioGroupProps) {
 	return (
 		<fieldset className={`fr-fieldset ${styles.cseFieldset}`}>
 			<legend className="fr-fieldset__legend--regular fr-fieldset__legend">
-				Existence d'un CSE{" "}
-				<span className={styles.requiredHint}>(obligatoire)</span>
+				Existence d'un CSE (obligatoire)
 			</legend>
 			<div className="fr-fieldset__element fr-fieldset__element--inline">
 				<div className="fr-radio-group fr-radio-rich">

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -170,6 +170,9 @@ export function MissingInfoModal({
 						<p className="fr-text--regular fr-mb-3w">
 							{getDescription(needsPhone, needsCse)}
 						</p>
+						<p className="fr-text--regular fr-text-title--grey fr-mb-3w">
+							Tous les champs sont obligatoires.
+						</p>
 						{needsPhone && (
 							<PhoneField
 								error={phoneError}

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -188,6 +188,14 @@ describe("CompanyEditModal", () => {
 		expect(screen.getByLabelText("Non", { exact: true })).toBeInTheDocument();
 	});
 
+	it("renders the obligatory mention as plain legend text so it inherits the label typography", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		const legend = container.querySelector("legend");
+		expect(legend).toHaveTextContent("Existence d'un CSE (obligatoire)");
+		expect(legend?.childElementCount).toBe(0);
+	});
+
 	describe("when the CSE is not applicable (gipWorkforce below 100 or unknown)", () => {
 		it("hides the CSE fieldset and the Enregistrer button, and shows a Fermer button", () => {
 			const { container } = render(

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
@@ -115,6 +115,26 @@ describe("MissingInfoModal", () => {
 		).toBeInTheDocument();
 	});
 
+	// The shared PhoneField label carries no "(obligatoire)" suffix, so this
+	// sentence is what states the obligation on this screen.
+	it("states that every field is required", () => {
+		render(
+			<MissingInfoModal
+				cseApplicable={true}
+				hasCse={null}
+				siren="532847196"
+				userPhone={null}
+			/>,
+		);
+		expect(
+			screen.getByText("Tous les champs sont obligatoires."),
+		).toBeInTheDocument();
+		expect(screen.getByLabelText(/Numéro de téléphone/)).toHaveAttribute(
+			"aria-required",
+			"true",
+		);
+	});
+
 	it("renders phone field when userPhone is null", () => {
 		render(
 			<MissingInfoModal

--- a/packages/app/src/modules/profile/ProfileModal.module.scss
+++ b/packages/app/src/modules/profile/ProfileModal.module.scss
@@ -1,30 +1,7 @@
-.readonlyField {
+.emailBlock {
 	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
-}
-
-.readonlyLabel {
-	display: flex;
-	align-items: center;
-	gap: 0.5rem;
-	font-size: 1rem;
-	line-height: 1.5;
-	color: var(--text-title-grey);
-}
-
-.readonlyValue {
-	width: 100%;
-	box-sizing: border-box;
-	padding: 0.5rem 1rem;
-	background-color: var(--background-contrast-grey);
-	border: none;
-	border-radius: 0.25rem 0.25rem 0 0;
-	border-bottom: 2px solid var(--border-default-grey);
-	font-family: inherit;
-	font-size: 1rem;
-	line-height: 1.5;
-	color: var(--text-mention-grey);
 }
 
 .narrowField {

--- a/packages/app/src/modules/profile/ProfileModal.tsx
+++ b/packages/app/src/modules/profile/ProfileModal.tsx
@@ -104,10 +104,13 @@ export function ProfileModal() {
 										</span>
 									</div>
 								</div>
-								<p className="fr-text--regular fr-mb-3w">
+								<p className="fr-text--regular fr-text-title--grey fr-mb-1w">
 									Les informations sont issues de votre compte ProConnect. Merci
 									de vérifier les données affichées et de compléter les
 									informations manquantes si nécessaire.
+								</p>
+								<p className="fr-text--regular fr-text-title--grey fr-mb-3w">
+									Tous les champs sont obligatoires.
 								</p>
 								<form autoComplete="off" id="profile-form" onSubmit={onSubmit}>
 									<div className="fr-grid-row fr-grid-row--gutters fr-mb-3w">

--- a/packages/app/src/modules/profile/ProfileModal.tsx
+++ b/packages/app/src/modules/profile/ProfileModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useId, useRef } from "react";
+import { useCallback, useRef } from "react";
+import type { UseFormRegisterReturn } from "react-hook-form";
 
 import { getDsfrModal } from "~/modules/shared";
 import { PhoneField } from "~/modules/shared/PhoneField";
@@ -8,26 +9,26 @@ import { useDsfrDialogOpen } from "~/modules/shared/useDsfrDialogOpen";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 import styles from "./ProfileModal.module.scss";
-import { updatePhoneSchema } from "./schemas";
+import { updateProfileSchema } from "./schemas";
 
 const MODAL_ID = "profile-modal";
 const MODAL_TITLE_ID = "profile-modal-title";
 
-/** DSFR modal displaying user profile with editable phone field. */
+/** DSFR modal displaying the declarant profile with editable identity fields. */
 export function ProfileModal() {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 
-	const form = useZodForm(updatePhoneSchema, {
-		defaultValues: { phone: "" },
+	const form = useZodForm(updateProfileSchema, {
+		defaultValues: { firstName: "", lastName: "", phone: "" },
 	});
 
-	const phoneError = form.formState.errors.phone?.message ?? null;
+	const { errors } = form.formState;
 
 	const profileQuery = api.profile.get.useQuery(undefined, {
 		enabled: false,
 	});
 
-	const updatePhoneMutation = api.profile.updatePhone.useMutation({
+	const updateProfileMutation = api.profile.updateProfile.useMutation({
 		onSuccess: () => {
 			closeModal();
 		},
@@ -43,8 +44,11 @@ export function ProfileModal() {
 			.refetch()
 			.then((result) => {
 				if (result.data) {
-					form.setValue("phone", result.data.phone ?? "");
-					form.clearErrors();
+					form.reset({
+						firstName: result.data.firstName ?? "",
+						lastName: result.data.lastName ?? "",
+						phone: result.data.phone ?? "",
+					});
 				}
 			})
 			.catch(() => {
@@ -55,12 +59,13 @@ export function ProfileModal() {
 	useDsfrDialogOpen(dialogRef, handleDialogOpen);
 
 	const onSubmit = form.handleSubmit((data) => {
-		updatePhoneMutation.mutate(data);
+		updateProfileMutation.mutate(data);
 	});
 
 	return (
 		<dialog
 			aria-labelledby={MODAL_TITLE_ID}
+			aria-modal="true"
 			className="fr-modal"
 			id={MODAL_ID}
 			ref={dialogRef}
@@ -80,7 +85,7 @@ export function ProfileModal() {
 								</button>
 							</div>
 							<div className="fr-modal__content">
-								<div className="fr-grid-row fr-grid-row--middle">
+								<div className="fr-grid-row fr-grid-row--middle fr-mb-4w">
 									<div className="fr-col">
 										<h2 className="fr-modal__title fr-mb-0" id={MODAL_TITLE_ID}>
 											Mon profil
@@ -104,39 +109,44 @@ export function ProfileModal() {
 										</span>
 									</div>
 								</div>
-								<p className="fr-text--regular fr-text-title--grey fr-mb-1w">
-									Les informations sont issues de votre compte ProConnect. Merci
-									de vérifier les données affichées et de compléter les
-									informations manquantes si nécessaire.
+								<p className="fr-text--regular fr-text-title--grey fr-mb-2w">
+									Vérifier les données affichées et compléter les informations
+									manquantes si nécessaire.
 								</p>
-								<p className="fr-text--regular fr-text-title--grey fr-mb-3w">
+								<p className="fr-text--regular fr-text-title--grey fr-mb-4w">
 									Tous les champs sont obligatoires.
 								</p>
 								<form autoComplete="off" id="profile-form" onSubmit={onSubmit}>
-									<div className="fr-grid-row fr-grid-row--gutters fr-mb-3w">
+									<div className="fr-grid-row fr-grid-row--gutters fr-mb-4w">
 										<div className="fr-col-12 fr-col-md-6">
-											<ReadonlyField
+											<IdentityField
+												error={errors.lastName?.message ?? null}
+												inputId="profile-last-name"
 												label="Nom"
-												value={profileQuery.data?.lastName}
+												registration={form.register("lastName")}
 											/>
 										</div>
 										<div className="fr-col-12 fr-col-md-6">
-											<ReadonlyField
+											<IdentityField
+												error={errors.firstName?.message ?? null}
+												inputId="profile-first-name"
 												label="Prénom"
-												value={profileQuery.data?.firstName}
+												registration={form.register("firstName")}
 											/>
 										</div>
 									</div>
-									<div className={`fr-mb-3w ${styles.narrowField}`}>
-										<ReadonlyField
-											label="Email du déclarant"
-											showEditIcon={false}
-											value={profileQuery.data?.email}
-										/>
+									<div className={`fr-mb-4w ${styles.emailBlock}`}>
+										<p className="fr-mb-0">
+											E-mail :{" "}
+											<strong>{profileQuery.data?.email || "—"}</strong>
+										</p>
+										<p className="fr-text--sm fr-text-mention--grey fr-mb-0">
+											Source : ProConnect.
+										</p>
 									</div>
 									<PhoneField
 										className={styles.narrowField}
-										error={phoneError}
+										error={errors.phone?.message ?? null}
 										inputId="profile-phone"
 										registration={form.register("phone")}
 									/>
@@ -147,7 +157,7 @@ export function ProfileModal() {
 									<li>
 										<button
 											className="fr-btn"
-											disabled={updatePhoneMutation.isPending}
+											disabled={updateProfileMutation.isPending}
 											form="profile-form"
 											type="submit"
 										>
@@ -173,32 +183,46 @@ export function ProfileModal() {
 	);
 }
 
-type ReadonlyFieldProps = {
+type IdentityFieldProps = {
+	error: string | null;
+	inputId: string;
 	label: string;
-	showEditIcon?: boolean;
-	value: string | null | undefined;
+	registration: UseFormRegisterReturn;
 };
 
-function ReadonlyField({
+function IdentityField({
+	error,
+	inputId,
 	label,
-	showEditIcon = true,
-	value,
-}: ReadonlyFieldProps) {
-	const fieldId = useId();
+	registration,
+}: IdentityFieldProps) {
+	const messagesId = `${inputId}-messages`;
 	return (
-		<div className={styles.readonlyField}>
-			<label className={styles.readonlyLabel} htmlFor={fieldId}>
-				<span>{label}</span>
-				{showEditIcon && (
-					<span aria-hidden="true" className="fr-icon-edit-line fr-icon--sm" />
-				)}
+		<div
+			className={
+				error ? "fr-input-group fr-input-group--error" : "fr-input-group"
+			}
+		>
+			<label className="fr-label" htmlFor={inputId}>
+				{label}
 			</label>
 			<input
-				className={styles.readonlyValue}
-				id={fieldId}
-				readOnly
-				value={value || "—"}
+				aria-describedby={messagesId}
+				aria-invalid={error ? "true" : undefined}
+				aria-required="true"
+				className="fr-input"
+				id={inputId}
+				type="text"
+				{...registration}
 			/>
+			<div
+				aria-atomic="true"
+				aria-live="polite"
+				className="fr-messages-group"
+				id={messagesId}
+			>
+				{error && <p className="fr-message fr-message--error">{error}</p>}
+			</div>
 		</div>
 	);
 }

--- a/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
+++ b/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
@@ -86,6 +86,27 @@ describe("ProfileModal", () => {
 		).toBeInTheDocument();
 	});
 
+	it("renders the obligatory-fields mention right after the description paragraph", () => {
+		render(<ProfileModal />);
+		const description = screen.getByText(
+			/Les informations sont issues de votre compte ProConnect/,
+		);
+		const mention = screen.getByText("Tous les champs sont obligatoires.");
+		expect(description.nextElementSibling).toBe(mention);
+	});
+
+	it("renders both intro paragraphs in the title grey of their host label", () => {
+		render(<ProfileModal />);
+		expect(
+			screen.getByText(
+				/Les informations sont issues de votre compte ProConnect/,
+			),
+		).toHaveClass("fr-text-title--grey");
+		expect(screen.getByText("Tous les champs sont obligatoires.")).toHaveClass(
+			"fr-text-title--grey",
+		);
+	});
+
 	it("renders the close button", () => {
 		render(<ProfileModal />);
 		const closeButton = screen.getByTitle("Fermer");
@@ -156,6 +177,20 @@ describe("ProfileModal", () => {
 		expect(
 			screen.getByRole("button", { name: "Annuler", ...hiddenOpt }),
 		).toHaveAttribute("aria-controls", "profile-modal");
+	});
+
+	it("refetches the profile and discards unsaved phone edits when the dialog reopens", async () => {
+		render(<ProfileModal />);
+		fireEvent.change(getPhoneInput(), { target: { value: "09 99 99 99 99" } });
+
+		document.getElementById("profile-modal")?.setAttribute("open", "");
+
+		await waitFor(() => {
+			expect(mockRefetch).toHaveBeenCalled();
+		});
+		await waitFor(() => {
+			expect(getPhoneInput()).toHaveValue("01 22 33 44 55");
+		});
 	});
 
 	it("shows validation error when submitting empty phone", async () => {

--- a/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
+++ b/packages/app/src/modules/profile/__tests__/ProfileModal.test.tsx
@@ -1,38 +1,40 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockRefetch = vi.fn().mockResolvedValue({
-	data: {
-		firstName: "Julien",
-		lastName: "Martin",
-		email: "julien.martin@alpha-solution.fr",
-		phone: "01 22 33 44 55",
+type ProfileData = {
+	firstName: string | null;
+	lastName: string | null;
+	email: string | null;
+	phone: string | null;
+};
+
+const { mockMutate, mockRefetch, trpcState } = vi.hoisted(() => ({
+	mockMutate: vi.fn(),
+	mockRefetch: vi.fn(),
+	trpcState: {
+		profile: null as {
+			firstName: string | null;
+			lastName: string | null;
+			email: string | null;
+			phone: string | null;
+		} | null,
+		isPending: false,
 	},
-});
-
-const mockMutate = vi.fn();
+}));
 
 vi.mock("~/trpc/react", () => ({
 	api: {
 		profile: {
 			get: {
-				useQuery: () => ({
-					data: {
-						firstName: "Julien",
-						lastName: "Martin",
-						email: "julien.martin@alpha-solution.fr",
-						phone: "01 22 33 44 55",
-					},
-					refetch: mockRefetch,
-				}),
+				useQuery: () => ({ data: trpcState.profile, refetch: mockRefetch }),
 			},
-			updatePhone: {
+			updateProfile: {
 				useMutation: ({ onSuccess }: { onSuccess?: () => void }) => ({
-					mutate: (input: { phone: string }) => {
+					mutate: (input: unknown) => {
 						mockMutate(input);
 						onSuccess?.();
 					},
-					isPending: false,
+					isPending: trpcState.isPending,
 				}),
 			},
 		},
@@ -41,31 +43,66 @@ vi.mock("~/trpc/react", () => ({
 
 import { ProfileModal } from "../ProfileModal";
 
+const PROFILE: ProfileData = {
+	firstName: "Julien",
+	lastName: "Martin",
+	email: "julien.martin@alpha-solution.fr",
+	phone: "01 22 33 44 55",
+};
+
+const MODAL_ID = "profile-modal";
+
 // Dialog elements are hidden when not open, so role queries need { hidden: true }.
 const hiddenOpt = { hidden: true } as const;
 
-function getPhoneInput() {
-	const input = document.getElementById("profile-phone");
-	if (!input) throw new Error("Phone input not found");
-	return input;
+const identityFields = [
+	{ inputId: "profile-last-name", label: "Nom" },
+	{ inputId: "profile-first-name", label: "Prénom" },
+];
+
+function getElement(id: string) {
+	const element = document.getElementById(id);
+	if (!element) throw new Error(`Element #${id} not found`);
+	return element;
 }
 
-function getForm() {
-	const form = document.getElementById("profile-form");
-	if (!form) throw new Error("Form not found");
-	return form;
+function openDialog() {
+	const callsBefore = mockRefetch.mock.calls.length;
+	getElement(MODAL_ID).setAttribute("open", "");
+	return waitFor(() => {
+		expect(mockRefetch.mock.calls.length).toBeGreaterThan(callsBefore);
+		expect(getElement("profile-phone")).toHaveValue(
+			trpcState.profile?.phone ?? "",
+		);
+	});
+}
+
+function closeDialog() {
+	getElement(MODAL_ID).removeAttribute("open");
+}
+
+async function renderOpenModal() {
+	render(<ProfileModal />);
+	await openDialog();
 }
 
 beforeEach(() => {
+	trpcState.profile = { ...PROFILE };
+	trpcState.isPending = false;
 	mockMutate.mockClear();
-	mockRefetch.mockClear();
+	mockRefetch
+		.mockReset()
+		.mockImplementation(() => Promise.resolve({ data: trpcState.profile }));
 });
 
-describe("ProfileModal", () => {
+afterEach(() => {
+	delete (window as unknown as { dsfr?: unknown }).dsfr;
+});
+
+describe("ProfileModal — shell", () => {
 	it("renders a dialog element with correct id and aria attributes", () => {
 		render(<ProfileModal />);
-		const dialog = document.getElementById("profile-modal");
-		expect(dialog).toBeInTheDocument();
+		const dialog = document.getElementById(MODAL_ID);
 		expect(dialog?.tagName).toBe("DIALOG");
 		expect(dialog).toHaveAttribute("aria-labelledby", "profile-modal-title");
 		expect(dialog).toHaveClass("fr-modal");
@@ -73,45 +110,15 @@ describe("ProfileModal", () => {
 
 	it("renders the modal title", () => {
 		render(<ProfileModal />);
-		expect(screen.getByText("Mon profil")).toBeInTheDocument();
 		expect(screen.getByText("Mon profil").id).toBe("profile-modal-title");
-	});
-
-	it("renders the description paragraph", () => {
-		render(<ProfileModal />);
-		expect(
-			screen.getByText(
-				/Les informations sont issues de votre compte ProConnect/,
-			),
-		).toBeInTheDocument();
-	});
-
-	it("renders the obligatory-fields mention right after the description paragraph", () => {
-		render(<ProfileModal />);
-		const description = screen.getByText(
-			/Les informations sont issues de votre compte ProConnect/,
-		);
-		const mention = screen.getByText("Tous les champs sont obligatoires.");
-		expect(description.nextElementSibling).toBe(mention);
-	});
-
-	it("renders both intro paragraphs in the title grey of their host label", () => {
-		render(<ProfileModal />);
-		expect(
-			screen.getByText(
-				/Les informations sont issues de votre compte ProConnect/,
-			),
-		).toHaveClass("fr-text-title--grey");
-		expect(screen.getByText("Tous les champs sont obligatoires.")).toHaveClass(
-			"fr-text-title--grey",
-		);
 	});
 
 	it("renders the close button", () => {
 		render(<ProfileModal />);
-		const closeButton = screen.getByTitle("Fermer");
-		expect(closeButton).toBeInTheDocument();
-		expect(closeButton).toHaveAttribute("aria-controls", "profile-modal");
+		expect(screen.getByTitle("Fermer")).toHaveAttribute(
+			"aria-controls",
+			MODAL_ID,
+		);
 	});
 
 	it("renders the help tooltip button", () => {
@@ -120,150 +127,274 @@ describe("ProfileModal", () => {
 			name: "Aide",
 			...hiddenOpt,
 		});
-		expect(helpButton).toBeInTheDocument();
 		expect(helpButton).toHaveAttribute("aria-describedby", "profile-tooltip");
-
-		const tooltip = container.querySelector("#profile-tooltip");
-		expect(tooltip).toBeInTheDocument();
-		expect(tooltip).toHaveTextContent(
+		expect(container.querySelector("#profile-tooltip")).toHaveTextContent(
 			"Vous pouvez aussi modifier ces informations directement sur votre profil ProConnect.",
 		);
-	});
-
-	it("renders the readonly Nom field with label and edit icon", () => {
-		render(<ProfileModal />);
-		expect(screen.getByText("Nom")).toBeInTheDocument();
-		expect(screen.getByDisplayValue("Martin")).toBeInTheDocument();
-	});
-
-	it("renders the readonly Prénom field with label and edit icon", () => {
-		render(<ProfileModal />);
-		expect(screen.getByText("Prénom")).toBeInTheDocument();
-		expect(screen.getByDisplayValue("Julien")).toBeInTheDocument();
-	});
-
-	it("renders the readonly Email field", () => {
-		render(<ProfileModal />);
-		expect(screen.getByText("Email du déclarant")).toBeInTheDocument();
-		expect(
-			screen.getByDisplayValue("julien.martin@alpha-solution.fr"),
-		).toBeInTheDocument();
-	});
-
-	it("renders the phone input with label and hint", () => {
-		render(<ProfileModal />);
-		expect(
-			screen.getByText("Numéro de téléphone (obligatoire)"),
-		).toBeInTheDocument();
-		expect(
-			screen.getByText("Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55"),
-		).toBeInTheDocument();
-		const input = getPhoneInput();
-		expect(input).toHaveAttribute("type", "tel");
 	});
 
 	it("renders the Enregistrer and Annuler buttons", () => {
 		render(<ProfileModal />);
 		expect(
 			screen.getByRole("button", { name: "Enregistrer", ...hiddenOpt }),
-		).toBeInTheDocument();
+		).toBeEnabled();
 		expect(
 			screen.getByRole("button", { name: "Annuler", ...hiddenOpt }),
-		).toBeInTheDocument();
+		).toHaveAttribute("aria-controls", MODAL_ID);
 	});
 
-	it("renders the Annuler button with aria-controls for the modal", () => {
+	it("disables the submit button while the mutation is pending", () => {
+		trpcState.isPending = true;
 		render(<ProfileModal />);
 		expect(
-			screen.getByRole("button", { name: "Annuler", ...hiddenOpt }),
-		).toHaveAttribute("aria-controls", "profile-modal");
+			screen.getByRole("button", { name: "Enregistrer", ...hiddenOpt }),
+		).toBeDisabled();
+	});
+});
+
+describe("ProfileModal — intro copy", () => {
+	it("renders the instruction paragraph followed by the obligatory-fields mention", () => {
+		render(<ProfileModal />);
+		const instruction = screen.getByText(
+			"Vérifier les données affichées et compléter les informations manquantes si nécessaire.",
+		);
+		const mention = screen.getByText("Tous les champs sont obligatoires.");
+
+		expect(instruction.nextElementSibling).toBe(mention);
+		expect(instruction).toHaveClass("fr-text-title--grey");
+		expect(mention).toHaveClass("fr-text-title--grey");
+	});
+});
+
+describe("ProfileModal — identity fields", () => {
+	it.each(identityFields)("renders $label as an editable DSFR text input", ({
+		inputId,
+		label,
+	}) => {
+		render(<ProfileModal />);
+		const input = screen.getByLabelText(label);
+
+		expect(input).toHaveAttribute("id", inputId);
+		expect(input).toHaveAttribute("type", "text");
+		expect(input).toHaveAttribute("aria-required", "true");
+		expect(input).toHaveAttribute("aria-describedby", `${inputId}-messages`);
+		expect(input).toHaveClass("fr-input");
+		expect(input).not.toHaveAttribute("readonly");
+		expect(input).not.toHaveAttribute("aria-invalid");
+		expect(getElement(`${inputId}-messages`)).toHaveAttribute(
+			"aria-live",
+			"polite",
+		);
 	});
 
-	it("refetches the profile and discards unsaved phone edits when the dialog reopens", async () => {
-		render(<ProfileModal />);
-		fireEvent.change(getPhoneInput(), { target: { value: "09 99 99 99 99" } });
+	it("prefills the identity fields from the profile query when the dialog opens", async () => {
+		await renderOpenModal();
 
-		document.getElementById("profile-modal")?.setAttribute("open", "");
+		expect(screen.getByLabelText("Nom")).toHaveValue("Martin");
+		expect(screen.getByLabelText("Prénom")).toHaveValue("Julien");
+	});
+
+	it("clears every field when the stored profile is empty", async () => {
+		trpcState.profile = {
+			...PROFILE,
+			firstName: null,
+			lastName: null,
+			phone: null,
+		};
+		render(<ProfileModal />);
+		fireEvent.change(screen.getByLabelText("Nom"), {
+			target: { value: "stale" },
+		});
+		fireEvent.change(getElement("profile-phone"), {
+			target: { value: "09 99 99 99 99" },
+		});
+
+		getElement(MODAL_ID).setAttribute("open", "");
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Nom")).toHaveValue("");
+		});
+		expect(screen.getByLabelText("Prénom")).toHaveValue("");
+		expect(getElement("profile-phone")).toHaveValue("");
+	});
+
+	it("leaves the form on its defaults when the profile query returns nothing", async () => {
+		trpcState.profile = null;
+		await renderOpenModal();
+
+		expect(screen.getByLabelText("Nom")).toHaveValue("");
+		expect(getElement("profile-phone")).toHaveValue("");
+	});
+
+	it("survives a failing profile query", async () => {
+		mockRefetch.mockRejectedValue(new Error("network down"));
+		render(<ProfileModal />);
+		getElement(MODAL_ID).setAttribute("open", "");
 
 		await waitFor(() => {
 			expect(mockRefetch).toHaveBeenCalled();
 		});
-		await waitFor(() => {
-			expect(getPhoneInput()).toHaveValue("01 22 33 44 55");
-		});
+		expect(screen.getByLabelText("Nom")).toHaveValue("");
+		expect(
+			screen.getByRole("button", { name: "Enregistrer", ...hiddenOpt }),
+		).toBeEnabled();
 	});
 
-	it("shows validation error when submitting empty phone", async () => {
-		render(<ProfileModal />);
-		fireEvent.change(getPhoneInput(), { target: { value: "" } });
-		fireEvent.submit(getForm());
-		await waitFor(() => {
-			const errorMessage = document.querySelector(
-				"#profile-phone-messages .fr-message--error",
-			);
-			expect(errorMessage).toBeInTheDocument();
+	it("discards unsaved edits when the dialog is reopened", async () => {
+		await renderOpenModal();
+		fireEvent.change(screen.getByLabelText("Nom"), {
+			target: { value: "Dupont" },
 		});
+		fireEvent.change(getElement("profile-phone"), {
+			target: { value: "09 99 99 99 99" },
+		});
+
+		closeDialog();
+		await openDialog();
+
+		expect(screen.getByLabelText("Nom")).toHaveValue("Martin");
+		expect(getElement("profile-phone")).toHaveValue("01 22 33 44 55");
 	});
+});
 
-	it("shows validation error for invalid phone format", async () => {
+describe("ProfileModal — email block", () => {
+	it("renders the e-mail in bold with the ProConnect source mention", () => {
 		render(<ProfileModal />);
-		fireEvent.change(getPhoneInput(), { target: { value: "012233" } });
-		fireEvent.submit(getForm());
-		await waitFor(() => {
-			const errorMessage = document.querySelector(
-				"#profile-phone-messages .fr-message--error",
-			);
-			expect(errorMessage).toBeInTheDocument();
-			expect(errorMessage).toHaveTextContent(
-				"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55",
-			);
-		});
-	});
+		const value = screen.getByText("julien.martin@alpha-solution.fr");
 
-	it("calls mutation with valid phone on form submit", async () => {
-		render(<ProfileModal />);
-		fireEvent.change(getPhoneInput(), {
-			target: { value: "01 22 33 44 55" },
-		});
-		fireEvent.submit(getForm());
-		await waitFor(() => {
-			expect(mockMutate).toHaveBeenCalledWith({ phone: "+33122334455" });
-		});
-	});
-
-	it("clears error when form is resubmitted with valid data", async () => {
-		render(<ProfileModal />);
-		const input = getPhoneInput();
-
-		// First submit with invalid data to trigger error
-		fireEvent.change(input, { target: { value: "" } });
-		fireEvent.submit(getForm());
-		await waitFor(() => {
-			expect(
-				document.querySelector("#profile-phone-messages .fr-message--error"),
-			).toBeInTheDocument();
-		});
-
-		// Then submit with valid data — error should clear
-		fireEvent.change(input, { target: { value: "01 22 33 44 55" } });
-		fireEvent.submit(getForm());
-		await waitFor(() => {
-			expect(mockMutate).toHaveBeenCalled();
-		});
-	});
-
-	it("has proper aria-describedby on the phone input", () => {
-		render(<ProfileModal />);
-		expect(getPhoneInput()).toHaveAttribute(
-			"aria-describedby",
-			"profile-phone-messages",
+		expect(value.tagName).toBe("STRONG");
+		expect(value.parentElement).toHaveTextContent(
+			"E-mail : julien.martin@alpha-solution.fr",
+		);
+		expect(screen.getByText("Source : ProConnect.")).toHaveClass(
+			"fr-text--sm",
+			"fr-text-mention--grey",
 		);
 	});
 
-	it("has a messages group with aria-live polite for phone field", () => {
+	it("falls back to a dash when the profile carries no e-mail", () => {
+		trpcState.profile = { ...PROFILE, email: null };
 		render(<ProfileModal />);
-		const messagesGroup = document.getElementById("profile-phone-messages");
-		expect(messagesGroup).toBeInTheDocument();
-		expect(messagesGroup).toHaveAttribute("aria-live", "polite");
+
+		expect(screen.getByText("—").tagName).toBe("STRONG");
+	});
+
+	it("exposes no editable e-mail control", () => {
+		render(<ProfileModal />);
+
+		expect(screen.queryByLabelText(/e-?mail/i)).not.toBeInTheDocument();
+	});
+});
+
+describe("ProfileModal — phone field", () => {
+	it("renders the phone input with its label and hint", () => {
+		render(<ProfileModal />);
+		const input = screen.getByLabelText(/Numéro de téléphone/);
+
+		expect(input).toHaveAttribute("type", "tel");
+		expect(screen.getByText("Numéro de téléphone")).toBeInTheDocument();
+		expect(
+			screen.getByText("Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55"),
+		).toBeInTheDocument();
+	});
+});
+
+describe("ProfileModal — validation", () => {
+	it.each(
+		identityFields,
+	)("blocks the submit and flags $label when it is emptied", async ({
+		inputId,
+		label,
+	}) => {
+		await renderOpenModal();
+		fireEvent.change(screen.getByLabelText(label), { target: { value: "" } });
+		fireEvent.submit(getElement("profile-form"));
+
+		await waitFor(() => {
+			expect(
+				document.querySelector(`#${inputId}-messages .fr-message--error`),
+			).toHaveTextContent("Ce champ est obligatoire");
+		});
+		expect(getElement(inputId).closest(".fr-input-group")).toHaveClass(
+			"fr-input-group--error",
+		);
+		expect(getElement(inputId)).toHaveAttribute("aria-invalid", "true");
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("blocks the submit and flags the phone when its format is invalid", async () => {
+		await renderOpenModal();
+		fireEvent.change(getElement("profile-phone"), {
+			target: { value: "012233" },
+		});
+		fireEvent.submit(getElement("profile-form"));
+
+		await waitFor(() => {
+			expect(
+				document.querySelector("#profile-phone-messages .fr-message--error"),
+			).toHaveTextContent(
+				"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55",
+			);
+		});
+		expect(getElement("profile-phone")).toHaveAttribute("aria-invalid", "true");
+		expect(mockMutate).not.toHaveBeenCalled();
+	});
+
+	it("clears the errors once the form is resubmitted with valid data", async () => {
+		await renderOpenModal();
+		fireEvent.change(screen.getByLabelText("Nom"), { target: { value: "" } });
+		fireEvent.submit(getElement("profile-form"));
+		await waitFor(() => {
+			expect(
+				document.querySelector(
+					"#profile-last-name-messages .fr-message--error",
+				),
+			).toBeInTheDocument();
+		});
+
+		fireEvent.change(screen.getByLabelText("Nom"), {
+			target: { value: "Martin" },
+		});
+		fireEvent.submit(getElement("profile-form"));
+
+		await waitFor(() => {
+			expect(mockMutate).toHaveBeenCalled();
+		});
+		expect(
+			document.querySelector("#profile-last-name-messages .fr-message--error"),
+		).not.toBeInTheDocument();
+	});
+});
+
+describe("ProfileModal — submission", () => {
+	it("sends the edited identity along with the canonical phone", async () => {
+		await renderOpenModal();
+		fireEvent.change(screen.getByLabelText("Nom"), {
+			target: { value: "Durand" },
+		});
+		fireEvent.change(screen.getByLabelText("Prénom"), {
+			target: { value: "Camille" },
+		});
+		fireEvent.submit(getElement("profile-form"));
+
+		await waitFor(() => {
+			expect(mockMutate).toHaveBeenCalledWith({
+				firstName: "Camille",
+				lastName: "Durand",
+				phone: "+33122334455",
+			});
+		});
+	});
+
+	it("closes the modal through the DSFR API once the mutation succeeds", async () => {
+		const conceal = vi.fn();
+		Object.assign(window, { dsfr: () => ({ modal: { conceal } }) });
+		await renderOpenModal();
+
+		fireEvent.submit(getElement("profile-form"));
+
+		await waitFor(() => {
+			expect(conceal).toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/app/src/modules/profile/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/profile/__tests__/schemas.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { updatePhoneSchema, updateProfileSchema } from "../schemas";
+
+const NAME_MAX_LENGTH = 255;
+
+const validProfile = {
+	firstName: "Julien",
+	lastName: "Martin",
+	phone: "01 22 33 44 55",
+};
+
+const identityFields = ["firstName", "lastName"] as const;
+
+describe("updateProfileSchema", () => {
+	it("keeps both identity fields and canonicalizes the phone", () => {
+		expect(updateProfileSchema.parse(validProfile)).toEqual({
+			firstName: "Julien",
+			lastName: "Martin",
+			phone: "+33122334455",
+		});
+	});
+
+	it("trims surrounding whitespace on both identity fields", () => {
+		const result = updateProfileSchema.parse({
+			...validProfile,
+			firstName: "  Julien  ",
+			lastName: "\tMartin\n",
+		});
+
+		expect(result.firstName).toBe("Julien");
+		expect(result.lastName).toBe("Martin");
+	});
+
+	it.each(identityFields)("rejects an empty %s", (field) => {
+		const result = updateProfileSchema.safeParse({
+			...validProfile,
+			[field]: "",
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]).toMatchObject({
+			path: [field],
+			message: "Ce champ est obligatoire",
+		});
+	});
+
+	it.each(identityFields)("rejects a whitespace-only %s", (field) => {
+		const result = updateProfileSchema.safeParse({
+			...validProfile,
+			[field]: "   ",
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe("Ce champ est obligatoire");
+	});
+
+	it.each(identityFields)("accepts a %s at the column width", (field) => {
+		const result = updateProfileSchema.safeParse({
+			...validProfile,
+			[field]: "a".repeat(NAME_MAX_LENGTH),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it.each(
+		identityFields,
+	)("rejects a %s longer than the column width", (field) => {
+		const result = updateProfileSchema.safeParse({
+			...validProfile,
+			[field]: "a".repeat(NAME_MAX_LENGTH + 1),
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]).toMatchObject({
+			path: [field],
+			message: `Ce champ est limité à ${NAME_MAX_LENGTH} caractères`,
+		});
+	});
+
+	it("rejects an invalid phone number", () => {
+		const result = updateProfileSchema.safeParse({
+			...validProfile,
+			phone: "012233",
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]).toMatchObject({
+			path: ["phone"],
+			message: "Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55",
+		});
+	});
+});
+
+describe("updatePhoneSchema", () => {
+	// Still the contract of MissingInfoModal, which collects the phone alone.
+	it("validates the phone without requiring the identity fields", () => {
+		expect(updatePhoneSchema.parse({ phone: "01 22 33 44 55" })).toEqual({
+			phone: "+33122334455",
+		});
+	});
+});

--- a/packages/app/src/modules/profile/index.ts
+++ b/packages/app/src/modules/profile/index.ts
@@ -1,2 +1,2 @@
 export { ProfileModal } from "./ProfileModal";
-export { updatePhoneSchema } from "./schemas";
+export { updatePhoneSchema, updateProfileSchema } from "./schemas";

--- a/packages/app/src/modules/profile/schemas.ts
+++ b/packages/app/src/modules/profile/schemas.ts
@@ -2,6 +2,21 @@ import { z } from "zod";
 
 import { phoneSchema } from "./phone";
 
+// Matches the varchar(255) width of users.firstName / users.lastName.
+const NAME_MAX_LENGTH = 255;
+
+const nameSchema = z
+	.string()
+	.trim()
+	.min(1, "Ce champ est obligatoire")
+	.max(NAME_MAX_LENGTH, `Ce champ est limité à ${NAME_MAX_LENGTH} caractères`);
+
 export const updatePhoneSchema = z.object({
+	phone: phoneSchema,
+});
+
+export const updateProfileSchema = z.object({
+	firstName: nameSchema,
+	lastName: nameSchema,
 	phone: phoneSchema,
 });

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -30,13 +30,14 @@ export function PhoneField({
 			className={`${error ? "fr-input-group fr-input-group--error" : "fr-input-group"}${className ? ` ${className}` : ""}`}
 		>
 			<label className="fr-label" htmlFor={inputId}>
-				Numéro de téléphone (obligatoire)
+				Numéro de téléphone
 				<span className="fr-hint-text">
 					Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55
 				</span>
 			</label>
 			<input
 				aria-describedby={messagesId}
+				aria-invalid={error ? "true" : undefined}
 				aria-required="true"
 				autoComplete="tel"
 				className="fr-input"
@@ -45,7 +46,12 @@ export function PhoneField({
 				{...registration}
 				onChange={handleChange}
 			/>
-			<div aria-live="polite" className="fr-messages-group" id={messagesId}>
+			<div
+				aria-atomic="true"
+				aria-live="polite"
+				className="fr-messages-group"
+				id={messagesId}
+			>
 				{error && <p className="fr-message fr-message--error">{error}</p>}
 			</div>
 		</div>

--- a/packages/app/src/server/api/routers/__tests__/profile.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/profile.test.ts
@@ -1,0 +1,140 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { users } from "~/server/db/schema";
+
+vi.mock("~/server/auth", () => ({
+	auth: vi.fn(),
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {},
+}));
+
+const mockLogAction = vi.fn();
+vi.mock("~/server/audit/log", () => ({
+	logAction: (...args: unknown[]) => mockLogAction(...args),
+}));
+
+import { profileRouter } from "../profile";
+
+const USER_ID = "user-1";
+
+const PROFILE_ROW = {
+	firstName: "Julien",
+	lastName: "Martin",
+	email: "julien.martin@example.fr",
+	phone: "+33122334455",
+};
+
+const VALID_INPUT = {
+	firstName: "Julien",
+	lastName: "Martin",
+	phone: "01 22 33 44 55",
+};
+
+function buildDb(selectRows: unknown[] = [PROFILE_ROW]) {
+	const where = vi.fn().mockResolvedValue(undefined);
+	const set = vi.fn().mockReturnValue({ where });
+	return {
+		select: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					limit: vi.fn().mockResolvedValue(selectRows),
+				}),
+			}),
+		}),
+		update: vi.fn().mockReturnValue({ set }),
+		__set: set,
+		__where: where,
+	};
+}
+
+function createCaller(db: unknown) {
+	return profileRouter.createCaller({
+		db,
+		session: { user: { id: USER_ID, siret: "12345678900012" }, expires: "" },
+		headers: new Headers(),
+	} as never);
+}
+
+beforeEach(() => {
+	mockLogAction.mockClear();
+});
+
+describe("profileRouter — get", () => {
+	it("returns the identity, e-mail and phone of the session user", async () => {
+		const caller = createCaller(buildDb());
+		await expect(caller.get()).resolves.toEqual(PROFILE_ROW);
+	});
+
+	it("throws NOT_FOUND when the session user has no row", async () => {
+		const caller = createCaller(buildDb([]));
+		await expect(caller.get()).rejects.toMatchObject({ code: "NOT_FOUND" });
+	});
+});
+
+describe("profileRouter — updateProfile", () => {
+	it("persists both identity fields and the canonical phone for the session user", async () => {
+		const db = buildDb();
+		const caller = createCaller(db);
+
+		await expect(caller.updateProfile(VALID_INPUT)).resolves.toEqual({
+			success: true,
+		});
+		expect(db.__set).toHaveBeenCalledWith({
+			firstName: "Julien",
+			lastName: "Martin",
+			phone: "+33122334455",
+		});
+		expect(db.__where).toHaveBeenCalledWith(eq(users.id, USER_ID));
+	});
+
+	it("trims the identity fields before persisting them", async () => {
+		const db = buildDb();
+		const caller = createCaller(db);
+
+		await caller.updateProfile({ ...VALID_INPUT, firstName: "  Julien  " });
+
+		expect(db.__set).toHaveBeenCalledWith(
+			expect.objectContaining({ firstName: "Julien" }),
+		);
+	});
+
+	it.each([
+		"firstName",
+		"lastName",
+	])("rejects an empty %s without touching the database", async (field) => {
+		const db = buildDb();
+		const caller = createCaller(db);
+
+		await expect(
+			caller.updateProfile({ ...VALID_INPUT, [field]: "" }),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+		expect(db.update).not.toHaveBeenCalled();
+	});
+
+	it("rejects an invalid phone without touching the database", async () => {
+		const db = buildDb();
+		const caller = createCaller(db);
+
+		await expect(
+			caller.updateProfile({ ...VALID_INPUT, phone: "012233" }),
+		).rejects.toMatchObject({ code: "BAD_REQUEST" });
+		expect(db.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("profileRouter — updatePhone", () => {
+	// Kept alongside updateProfile because MissingInfoModal still collects the
+	// phone on its own.
+	it("persists the phone alone", async () => {
+		const db = buildDb();
+		const caller = createCaller(db);
+
+		await expect(
+			caller.updatePhone({ phone: "01 22 33 44 55" }),
+		).resolves.toEqual({ success: true });
+		expect(db.__set).toHaveBeenCalledWith({ phone: "+33122334455" });
+	});
+});

--- a/packages/app/src/server/api/routers/profile.ts
+++ b/packages/app/src/server/api/routers/profile.ts
@@ -1,7 +1,10 @@
 import { TRPCError } from "@trpc/server";
 import { eq } from "drizzle-orm";
 
-import { updatePhoneSchema } from "~/modules/profile/schemas";
+import {
+	updatePhoneSchema,
+	updateProfileSchema,
+} from "~/modules/profile/schemas";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { users } from "~/server/db/schema";
 
@@ -34,6 +37,21 @@ export const profileRouter = createTRPCRouter({
 			await ctx.db
 				.update(users)
 				.set({ phone: input.phone })
+				.where(eq(users.id, ctx.session.user.id));
+
+			return { success: true };
+		}),
+
+	updateProfile: protectedProcedure
+		.input(updateProfileSchema)
+		.mutation(async ({ ctx, input }) => {
+			await ctx.db
+				.update(users)
+				.set({
+					firstName: input.firstName,
+					lastName: input.lastName,
+					phone: input.phone,
+				})
 				.where(eq(users.id, ctx.session.user.id));
 
 			return { success: true };

--- a/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
+++ b/packages/app/src/server/audit/__tests__/trpcMiddleware.test.ts
@@ -126,6 +126,40 @@ describe("auditMiddleware", () => {
 		});
 	});
 
+	it("logs the profile update mutation (profile.updateProfile)", async () => {
+		const next = vi.fn(async () => ({ success: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "profile.updateProfile",
+			getRawInput: buildGetRawInput({
+				firstName: "Julien",
+				lastName: "Martin",
+				phone: "+33122334455",
+			}),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "profile.update",
+			status: "success",
+		});
+	});
+
+	it("keeps the phone-only profile mutation on its own action key", async () => {
+		const next = vi.fn(async () => ({ success: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "profile.updatePhone",
+			getRawInput: buildGetRawInput({ phone: "+33122334455" }),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "profile.update_phone",
+			status: "success",
+		});
+	});
+
 	it("logs sensitive query reads (declaration.getOrCreate)", async () => {
 		const next = vi.fn(async () => ({ declaration: {} }));
 		await auditMiddleware({
@@ -195,6 +229,64 @@ describe("auditMiddleware", () => {
 			credentials: { expiresIn: 3600 },
 			items: [{ name: "ok" }, { name: "ok2" }],
 		});
+	});
+
+	// audit-logging.md forbids duplicating PII that is not already carried by
+	// user_email or siren — the identity of a profile update must never reach
+	// the 365-day `mutation` retention bucket.
+	it("strips the identity PII of a profile update and keeps the rest", async () => {
+		const next = vi.fn(async () => ({ success: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "profile.updateProfile",
+			getRawInput: buildGetRawInput({
+				firstName: "Julien",
+				lastName: "Martin",
+				phone: "+33122334455",
+			}),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]?.metadata).toEqual({
+			phone: "+33122334455",
+		});
+	});
+
+	it("strips the identity keys whatever their casing", async () => {
+		const next = vi.fn(async () => ({ success: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "profile.updateProfile",
+			getRawInput: buildGetRawInput({
+				FirstName: "Julien",
+				LASTNAME: "Martin",
+				phone: "+33122334455",
+			}),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]?.metadata).toEqual({
+			phone: "+33122334455",
+		});
+	});
+
+	it("logs a null metadata rather than an empty object when every key is stripped", async () => {
+		const next = vi.fn(async () => ({ success: true }));
+		await auditMiddleware({
+			ctx: buildCtx(),
+			path: "profile.updateProfile",
+			getRawInput: buildGetRawInput({
+				firstName: "Julien",
+				lastName: "Martin",
+			}),
+			next,
+		});
+
+		expect(mockLogAction.mock.calls[0]?.[0]).toMatchObject({
+			action: "profile.update",
+			status: "success",
+		});
+		expect(mockLogAction.mock.calls[0]?.[0]?.metadata).toBeNull();
 	});
 
 	it("returns null metadata when input is empty", async () => {

--- a/packages/app/src/server/audit/trpcMiddleware.ts
+++ b/packages/app/src/server/audit/trpcMiddleware.ts
@@ -51,6 +51,7 @@ const PROCEDURE_TO_ACTION: Record<string, AuditActionKey> = {
 
 	// ── profile mutations + sensitive read ─────────────────
 	"profile.updatePhone": AUDIT_ACTIONS.PROFILE_UPDATE_PHONE,
+	"profile.updateProfile": AUDIT_ACTIONS.PROFILE_UPDATE,
 	"profile.get": AUDIT_ACTIONS.PROFILE_READ,
 
 	// ── admin sensitive reads ─────────────────────────────
@@ -270,4 +271,8 @@ const SENSITIVE_KEYS = new Set([
 	"access_key",
 	"private_key",
 	"data",
+	// Identity PII: the row already carries user_email, and audit-logging.md
+	// forbids duplicating PII that is not the email or the siren.
+	"firstname",
+	"lastname",
 ]);

--- a/packages/app/src/server/auth/__tests__/config.test.ts
+++ b/packages/app/src/server/auth/__tests__/config.test.ts
@@ -1,6 +1,6 @@
 import type { Account, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFindFirst = vi.fn();
 const mockInsert = vi.fn();
@@ -51,6 +51,13 @@ function callSession(params: Record<string, unknown>) {
 }
 
 describe("auth config", () => {
+	beforeEach(() => {
+		mockFindFirst.mockReset();
+		mockInsert.mockReset();
+		mockUpdate.mockReset();
+		mockTransaction.mockReset();
+	});
+
 	describe("jwt callback", () => {
 		it("upserts user and populates token on sign-in (existing user)", async () => {
 			const dbUser = {
@@ -150,6 +157,129 @@ describe("auth config", () => {
 			expect(result.siret).toBe("12345678901234");
 			expect(result.phone).toBe("0123456789");
 			expect(result.id_token).toBe("stored-token");
+		});
+	});
+
+	const DECLARANT_EMAIL = "declarant@example.fr";
+
+	const proconnectUser = {
+		id: "proconnect-sub",
+		email: DECLARANT_EMAIL,
+		name: "Alice Martin",
+		firstName: "Alice",
+		lastName: "Martin",
+	} as User & { firstName: string; lastName: string };
+
+	const namelessProconnectUser = {
+		id: "proconnect-sub",
+		email: DECLARANT_EMAIL,
+	} as User;
+
+	function signIn(
+		existingUser: Record<string, unknown>,
+		user: User = proconnectUser,
+		token: JWT = { sub: "sub-123" } as JWT,
+	) {
+		mockFindFirst.mockResolvedValue({
+			id: "uuid-123",
+			phone: null,
+			isAdmin: false,
+			...existingUser,
+		});
+		return callJwt({
+			token,
+			user,
+			account: {} as Account,
+			trigger: "signIn",
+		});
+	}
+
+	describe("jwt callback — ProConnect identity seeding", () => {
+		function armUpdate() {
+			const where = vi.fn().mockResolvedValue(undefined);
+			const set = vi.fn().mockReturnValue({ where });
+			mockUpdate.mockReturnValue({ set });
+			return set;
+		}
+
+		it("seeds both names when the DB row carries none", async () => {
+			const set = armUpdate();
+
+			await signIn({ firstName: null, lastName: null });
+
+			expect(set).toHaveBeenCalledWith({
+				firstName: "Alice",
+				lastName: "Martin",
+			});
+		});
+
+		it("seeds only the half that is missing", async () => {
+			const set = armUpdate();
+
+			await signIn({ firstName: "Camille", lastName: null });
+
+			expect(set).toHaveBeenCalledWith({ lastName: "Martin" });
+		});
+
+		it("never overwrites a name already stored, so a Mon profil edit survives the next login", async () => {
+			armUpdate();
+
+			await signIn({ firstName: "Camille", lastName: "Durand" });
+
+			expect(mockUpdate).not.toHaveBeenCalled();
+		});
+
+		it("leaves the DB row untouched when ProConnect sends no name", async () => {
+			armUpdate();
+
+			await signIn({ firstName: null, lastName: null }, namelessProconnectUser);
+
+			expect(mockUpdate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("jwt callback — display name", () => {
+		it("derives the display name from the DB row, overriding the ProConnect one", async () => {
+			const result = await signIn(
+				{ firstName: "Camille", lastName: "Durand" },
+				proconnectUser,
+				{ sub: "sub-123", name: "Alice Martin" } as JWT,
+			);
+
+			expect(result.name).toBe("Camille Durand");
+		});
+
+		it("orders the display name as firstName then lastName", async () => {
+			const result = await signIn(
+				{ firstName: "Martin", lastName: "Camille" },
+				namelessProconnectUser,
+			);
+
+			expect(result.name).toBe("Martin Camille");
+		});
+
+		it("reflects the name just seeded from ProConnect on a first login", async () => {
+			const result = await signIn({ firstName: null, lastName: null });
+
+			expect(result.name).toBe("Alice Martin");
+		});
+
+		it.each([
+			["firstName", { firstName: "Camille", lastName: null }, "Camille"],
+			["lastName", { firstName: null, lastName: "Durand" }, "Durand"],
+		])("joins without a stray space when only %s is stored", async (_field, existingUser, expected) => {
+			const result = await signIn(existingUser, namelessProconnectUser);
+
+			expect(result.name).toBe(expected);
+		});
+
+		it("falls back to the e-mail when the DB row carries no name", async () => {
+			const result = await signIn(
+				{ firstName: null, lastName: null },
+				namelessProconnectUser,
+			);
+
+			expect(result.name).toBe(DECLARANT_EMAIL);
 		});
 	});
 

--- a/packages/app/src/server/auth/config.ts
+++ b/packages/app/src/server/auth/config.ts
@@ -398,9 +398,12 @@ export const authConfig = {
 					}
 					dbUser = inserted;
 				} else {
+					// ProConnect only seeds a name the DB does not have yet.
 					const updates: Record<string, string | null> = {};
-					if (profileData.firstName) updates.firstName = profileData.firstName;
-					if (profileData.lastName) updates.lastName = profileData.lastName;
+					if (profileData.firstName && !existingUser.firstName)
+						updates.firstName = profileData.firstName;
+					if (profileData.lastName && !existingUser.lastName)
+						updates.lastName = profileData.lastName;
 
 					if (Object.keys(updates).length > 0) {
 						await db
@@ -477,6 +480,10 @@ export const authConfig = {
 				}
 
 				token.id = dbUser.id;
+				// The DB wins over the ProConnect name NextAuth put on the token.
+				token.name =
+					[dbUser.firstName, dbUser.lastName].filter(Boolean).join(" ") ||
+					email;
 				token.siret = profileData.siret ?? null;
 				token.phone = dbUser.phone ?? null;
 				token.id_token = account?.id_token ?? null;


### PR DESCRIPTION
Closes #3661
Closes #4190

## Résumé

Deux tickets sur la même zone, livrés ensemble parce que le second réécrit les fichiers que le premier venait de toucher.

**#3661 — mentions d'obligation.** Une règle de design enfreinte à trois endroits : une mention d'obligation doit hériter de la taille (16px) et de la couleur (`#161616` / `--text-title-grey`) de son libellé hôte, pas d'une typographie de mention grise réduite.

- **CompanyEditModal** (modale « Modifier les informations ») : la mention « (obligatoire) » du champ CSE était enveloppée dans un `<span>` forçant `14px` / `--text-mention-grey`. Le wrapper et la classe `.requiredHint` sont supprimés ; le texte hérite désormais nativement du style de la `<legend>`.
- **ProfileModal** : la phrase « Tous les champs sont obligatoires. » était absente. Ajoutée.
- **Step1Opinions** (étape 1 du parcours avis CSE) : même phrase, sans classe de couleur. Classe `fr-text-title--grey` ajoutée. Un commentaire SCSS erroné affirmant que cette classe utilitaire n'existe pas a été corrigé au passage.

**#4190 — nom et prénom modifiables.** La modale « Mon profil » est alignée sur le node Figma `8470-95359` :

- **Nom et Prénom** passent de `<input readOnly>` grisés à de vrais champs de saisie DSFR, validés (non vides, 255 caractères max — la largeur du `varchar` en base).
- **Bloc e-mail** : le champ readonly « Email du déclarant » devient du texte inline « E-mail : **valeur** » suivi de la mention « Source : ProConnect. ». L'e-mail reste non modifiable, conformément au Figma.
- **Texte d'intro** et espacements (16px / 32px) alignés sur la maquette.
- **Libellé du téléphone** : le suffixe « (obligatoire) » est retiré (le Figma ne le porte pas).

### Backend

- Mutation `profile.updateProfile` (nom + prénom + téléphone). `profile.updatePhone` est conservée : `MissingInfoModal` l'utilise toujours pour un update téléphone seul.
- Action d'audit `PROFILE_UPDATE` avec ses 3 points de câblage.
- `firstName` / `lastName` ajoutés aux clés strippées du `metadata` d'audit — `rules/audit-logging.md` interdit d'y dupliquer du PII qui n'est pas déjà porté par `user_email` ou `siren`, et la rétention `mutation` est de 365 jours.
- **Callback jwt** (`server/auth/config.ts`), deux changements sans lesquels la fonctionnalité ne tenait pas :
  - ProConnect ne renseigne plus `firstName`/`lastName` que si la valeur en base est **absente**. Auparavant l'écrasement était systématique à chaque connexion : une saisie utilisateur aurait disparu au login suivant.
  - `token.name` dérive désormais de la base et non du profil ProConnect. Sans ça, le nom édité restait masqué dans l'en-tête, le menu mobile et le `declarantName` du récapitulatif, y compris après reconnexion.

## Points de décision assumés

- **`PhoneField` est partagé** avec `MissingInfoModal`, qui n'a pas de phrase d'obligation globale. En retirant le suffixe, cet écran perdait l'information — la phrase « Tous les champs sont obligatoires. » y a donc été ajoutée. RGAA 11.10 reste satisfait : `aria-required="true"` côté programmatique, instruction en tête de formulaire côté visuel (technique WCAG G184).
- **Pied de modale** : le Figma dessine la zone d'action avec 48px de padding haut et 32px bas. `fr-modal__footer` est conservé — s'en écarter reviendrait à surcharger le pied de modale DSFR pour un écart de padding.
- **`phone` reste dans le `metadata` d'audit** : exposition antérieure à ces tickets (via `updatePhone`) et explicitement assertée par des tests existants, donc voulue. Non modifiée ici.

## À arbitrer par le métier (hors code)

Rendre le nom éditable le détache de l'identité vérifiée par ProConnect. Ce champ alimente le **PDF officiel de déclaration** transmis au ministère, l'historique de statut, le verrou de déclaration vu par les collègues du même SIREN, et les exports admin. Ni faille d'autorisation (le nom ne sert à aucune décision de droits) ni injection (rendu `@react-pdf/renderer`, JSX échappé, e-mail IdP affiché à côté partout) — mais un enjeu d'intégrité et de non-répudiation. Trois issues possibles : l'accepter, figer un instantané du nom ProConnect à la soumission pour le PDF et l'historique, ou signaler le nom comme auto-déclaré là où des tiers le lisent.

## Vérification (one-shot, avant/après mesurés au DOM)

| Écran | Propriété | Avant | Après |
|---|---|---|---|
| CompanyEditModal — mention CSE | `font-size` | `14px` | `16px` |
| CompanyEditModal — mention CSE | `color` | `rgb(102, 102, 102)` | `rgb(22, 22, 22)` |
| ProfileModal — phrase obligation | présence | absente | présente, `16px` / `rgb(22, 22, 22)` |
| ProfileModal — paragraphe d'intro | `color` | `rgb(58, 58, 58)` | `rgb(22, 22, 22)` |
| ProfileModal — Nom / Prénom | saisie | `readOnly` | éditables |
| Step1Opinions — phrase obligation | `color` | `rgb(58, 58, 58)` | `rgb(22, 22, 22)` |
| Step1Opinions — `.introText` (référence) | `color` | `rgb(22, 22, 22)` (déjà correct) | inchangé |

Mesures relevées via un script Playwright standalone sur le dev server.

## Tests

**+40 tests**, dont deux fichiers créés (`modules/profile/__tests__/schemas.test.ts` et `server/api/routers/__tests__/profile.test.ts` — le routeur `profile` n'avait aucune couverture). Chaque garde ajoutée a été validée par matrice de mutation : le fix `config.ts` sur l'identité, la dérivation de `token.name` (5 variantes, dont l'ordre prénom/nom et le fallback e-mail), et le strip PII du `metadata` d'audit (retirer une seule des deux clés suffit à faire tomber les tests).

Suite complète : 4396 tests verts.

## Accessibilité

Corrections issues de l'audit RGAA : `aria-modal="true"` sur la modale profil (ses deux sœurs `MissingInfoModal` et `SubmitModal` l'avaient déjà), `aria-invalid` conditionnel et `aria-atomic="true"` sur les champs identité et téléphone — ces deux derniers sont prescrits par les règles du projet et manquaient.
