### PR TITLE
Représentation équilibrée — récapitulatif PDF & accusé de réception email

### DIFF
--- a/packages/app/src/app/api/representation-pdf/__tests__/route.test.ts
+++ b/packages/app/src/app/api/representation-pdf/__tests__/route.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	auth: vi.fn(),
+	logAction: vi.fn().mockResolvedValue(undefined),
+	buildRepresentationPdfData: vi.fn(),
+	renderToBuffer: vi.fn(),
+	RepresentationPdfDocument: vi.fn(),
+}));
+
+vi.mock("~/server/auth", () => ({ auth: mocks.auth }));
+
+vi.mock("~/server/audit/log", () => ({ logAction: mocks.logAction }));
+
+vi.mock("~/server/db", () => ({ db: {} }));
+
+vi.mock("@react-pdf/renderer", () => ({
+	renderToBuffer: mocks.renderToBuffer,
+}));
+
+vi.mock("~/modules/declarationPdf/RepresentationPdfDocument", () => ({
+	RepresentationPdfDocument: mocks.RepresentationPdfDocument,
+}));
+
+// Only the query is stubbed: the route branches on the real error class, so it
+// has to be the very one the builder module exports.
+vi.mock(
+	"~/modules/declarationPdf/buildRepresentationPdfData",
+	async (importOriginal) => ({
+		...(await importOriginal<
+			typeof import("~/modules/declarationPdf/buildRepresentationPdfData")
+		>()),
+		buildRepresentationPdfData: mocks.buildRepresentationPdfData,
+	}),
+);
+
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import { RepresentationDeclarationNotFoundError } from "~/modules/declarationPdf/buildRepresentationPdfData";
+import { getCurrentYear, getReferenceYearFor } from "~/modules/domain";
+import { GET } from "../route";
+
+const SIREN = "123456789";
+const SIRET = `${SIREN}00015`;
+const YEAR = 2025;
+const PDF_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46]);
+const DOCUMENT = { marker: "representation-pdf" };
+
+function request(query = `?year=${YEAR}`) {
+	return new Request(`https://egapro.test/api/representation-pdf${query}`);
+}
+
+function signedIn() {
+	mocks.auth.mockResolvedValue({
+		user: { id: "user-1", email: "declarant@exemple.fr", siret: SIRET },
+	});
+}
+
+function auditRow(): Record<string, unknown> {
+	return (mocks.logAction.mock.calls[0]?.[0] ?? {}) as Record<string, unknown>;
+}
+
+describe("GET /api/representation-pdf", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.renderToBuffer.mockResolvedValue(PDF_BYTES);
+		mocks.RepresentationPdfDocument.mockReturnValue(DOCUMENT);
+		mocks.buildRepresentationPdfData.mockResolvedValue({
+			campaignYear: YEAR + 1,
+		});
+		signedIn();
+	});
+
+	it("streams the recap of the requested year as a PDF attachment (S20)", async () => {
+		const response = await GET(request());
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe("application/pdf");
+		expect(response.headers.get("Content-Disposition")).toBe(
+			`attachment; filename="representation-equilibree-${SIREN}-${YEAR + 1}.pdf"`,
+		);
+		expect(Buffer.from(await response.arrayBuffer())).toEqual(PDF_BYTES);
+	});
+
+	it("renders the document built from the session siren and the requested year", async () => {
+		await GET(request());
+
+		expect(mocks.buildRepresentationPdfData).toHaveBeenCalledWith(
+			SIREN,
+			YEAR,
+			expect.any(Date),
+		);
+		expect(mocks.RepresentationPdfDocument).toHaveBeenCalledWith({
+			data: { campaignYear: YEAR + 1 },
+		});
+		expect(mocks.renderToBuffer).toHaveBeenCalledWith(DOCUMENT);
+	});
+
+	it("falls back on the current reference year when none is requested", async () => {
+		await GET(request(""));
+
+		expect(mocks.buildRepresentationPdfData).toHaveBeenCalledWith(
+			SIREN,
+			getReferenceYearFor(getCurrentYear()),
+			expect.any(Date),
+		);
+	});
+
+	it("ignores a siren passed in the query string", async () => {
+		await GET(request(`?year=${YEAR}&siren=999999999`));
+
+		expect(mocks.buildRepresentationPdfData).toHaveBeenCalledWith(
+			SIREN,
+			YEAR,
+			expect.any(Date),
+		);
+	});
+
+	it.each([
+		["no session at all", null],
+		["a session without a siret", { user: { id: "user-1" } }],
+	])("refuses the download with %s", async (_label, session) => {
+		mocks.auth.mockResolvedValue(session);
+
+		const response = await GET(request());
+
+		expect(response.status).toBe(401);
+		expect(mocks.buildRepresentationPdfData).not.toHaveBeenCalled();
+	});
+
+	it("answers 404 when no declaration was transmitted for the year", async () => {
+		mocks.buildRepresentationPdfData.mockRejectedValue(
+			new RepresentationDeclarationNotFoundError(),
+		);
+
+		const response = await GET(request());
+
+		expect(response.status).toBe(404);
+		expect(mocks.renderToBuffer).not.toHaveBeenCalled();
+	});
+
+	it("answers 400 when the recap cannot be rendered", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+		mocks.renderToBuffer.mockRejectedValue(new Error("pdf worker died"));
+
+		const response = await GET(request());
+
+		expect(response.status).toBe(400);
+	});
+
+	it("audits the download as a sensitive read", async () => {
+		await GET(request());
+
+		expect(auditRow()).toMatchObject({
+			action: AUDIT_ACTIONS.PDF_REPRESENTATION_DOWNLOAD,
+			status: "success",
+			userId: "user-1",
+			userEmail: "declarant@exemple.fr",
+			siren: SIREN,
+			metadata: { year: String(YEAR) },
+		});
+	});
+
+	it("audits a refused download as a failure without a siren", async () => {
+		mocks.auth.mockResolvedValue(null);
+
+		await GET(request());
+
+		expect(auditRow()).toMatchObject({
+			action: AUDIT_ACTIONS.PDF_REPRESENTATION_DOWNLOAD,
+			status: "failure",
+			siren: null,
+			errorMessage: "HTTP 401",
+		});
+	});
+});

--- a/packages/app/src/app/api/representation-pdf/route.ts
+++ b/packages/app/src/app/api/representation-pdf/route.ts
@@ -38,8 +38,9 @@ export const GET = withAuditedRoute(
 		const siren = extractSiren(session.user.siret);
 		const url = new URL(request.url);
 		const yearParam = url.searchParams.get("year");
-		const year = yearParam
-			? Number.parseInt(yearParam, 10)
+		const parsedYear = yearParam ? Number.parseInt(yearParam, 10) : Number.NaN;
+		const year = Number.isInteger(parsedYear)
+			? parsedYear
 			: getReferenceYearFor(getCurrentYear());
 
 		try {

--- a/packages/app/src/app/api/representation-pdf/route.ts
+++ b/packages/app/src/app/api/representation-pdf/route.ts
@@ -1,0 +1,64 @@
+import { renderToBuffer } from "@react-pdf/renderer";
+import { AUDIT_ACTIONS } from "~/modules/audit";
+import {
+	buildRepresentationPdfData,
+	RepresentationDeclarationNotFoundError,
+} from "~/modules/declarationPdf/buildRepresentationPdfData";
+import { RepresentationPdfDocument } from "~/modules/declarationPdf/RepresentationPdfDocument";
+import {
+	extractSiren,
+	getCurrentYear,
+	getReferenceYearFor,
+} from "~/modules/domain";
+import { cachedAuth } from "~/server/audit/cachedAuth";
+import { withAuditedRoute } from "~/server/audit/withAuditedRoute";
+
+export const GET = withAuditedRoute(
+	{
+		action: AUDIT_ACTIONS.PDF_REPRESENTATION_DOWNLOAD,
+		resolveContext: async (request) => {
+			const session = await cachedAuth(request);
+			const url = new URL(request.url);
+			return {
+				userId: session?.user?.id ?? null,
+				userEmail: session?.user?.email ?? null,
+				siren: session?.user?.siret ? extractSiren(session.user.siret) : null,
+				metadata: {
+					year: url.searchParams.get("year") ?? null,
+				},
+			};
+		},
+	},
+	async (request) => {
+		const session = await cachedAuth(request);
+		if (!session?.user?.siret) {
+			return new Response("Non autorisé", { status: 401 });
+		}
+
+		const siren = extractSiren(session.user.siret);
+		const url = new URL(request.url);
+		const yearParam = url.searchParams.get("year");
+		const year = yearParam
+			? Number.parseInt(yearParam, 10)
+			: getReferenceYearFor(getCurrentYear());
+
+		try {
+			const data = await buildRepresentationPdfData(siren, year, new Date());
+			const buffer = await renderToBuffer(RepresentationPdfDocument({ data }));
+			const filename = `representation-equilibree-${siren}-${data.campaignYear}.pdf`;
+
+			return new Response(new Uint8Array(buffer), {
+				headers: {
+					"Content-Type": "application/pdf",
+					"Content-Disposition": `attachment; filename="${filename}"`,
+				},
+			});
+		} catch (error) {
+			if (error instanceof RepresentationDeclarationNotFoundError) {
+				return new Response("Déclaration introuvable", { status: 404 });
+			}
+			console.error("[representation-pdf]", error);
+			return new Response("Impossible de générer le PDF", { status: 400 });
+		}
+	},
+);

--- a/packages/app/src/modules/audit/shared/actionKeys.ts
+++ b/packages/app/src/modules/audit/shared/actionKeys.ts
@@ -101,6 +101,7 @@ export const AUDIT_ACTIONS = {
 	DECLARATION_READ_GIP_DATA: "declaration.read_gip_data",
 	PDF_DECLARATION_DOWNLOAD: "pdf.declaration_download",
 	PDF_TRANSMITTED_DOWNLOAD: "pdf.transmitted_download",
+	PDF_REPRESENTATION_DOWNLOAD: "pdf.representation_download",
 	USER_FILE_DOWNLOAD: "user.file_download",
 
 	// ── Exports & external API consumers ──────────────────
@@ -218,6 +219,7 @@ export const AUDIT_ACTION_CATEGORIES: Record<AuditActionKey, AuditCategory> = {
 	[AUDIT_ACTIONS.DECLARATION_READ_GIP_DATA]: "read_sensitive",
 	[AUDIT_ACTIONS.PDF_DECLARATION_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.PDF_TRANSMITTED_DOWNLOAD]: "read_sensitive",
+	[AUDIT_ACTIONS.PDF_REPRESENTATION_DOWNLOAD]: "read_sensitive",
 	[AUDIT_ACTIONS.USER_FILE_DOWNLOAD]: "read_sensitive",
 
 	[AUDIT_ACTIONS.EXPORT_DOWNLOAD]: "export",

--- a/packages/app/src/modules/declaration-representation/Confirmation.tsx
+++ b/packages/app/src/modules/declaration-representation/Confirmation.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { DsfrPictogram } from "~/modules/layout";
 import { ResendReceiptButton } from "~/modules/mail";
-import { FileDownloadLink } from "~/modules/shared/FileDownloadLink";
+import { DownloadCard } from "~/modules/shared/DownloadCard";
 import styles from "./Confirmation.module.scss";
 
 type ConfirmationProps = {
@@ -45,21 +45,14 @@ export function Confirmation({
 				<ResendReceiptButton kind="representation" year={referenceYear} />
 			</div>
 
-			<div className={styles.block}>
-				<h2 className="fr-h6 fr-mb-0">
-					Télécharger le récapitulatif de la déclaration
-				</h2>
-				<p className="fr-text--sm fr-mb-0">
-					Année {campaignYear} au titre des données {referenceYear}
-				</p>
-				<FileDownloadLink
-					className="fr-btn fr-btn--secondary"
-					href={`/api/representation-pdf?year=${referenceYear}`}
-					pendingLabel="Génération du récapitulatif en cours…"
-				>
-					Télécharger le récapitulatif (PDF)
-				</FileDownloadLink>
-			</div>
+			{/* Visually hidden: bridges h1 → h3 (DownloadCard's own title) without adding a visible heading the Figma frame doesn't show. */}
+			<h2 className="fr-sr-only">Documents récapitulatifs de la déclaration</h2>
+			<DownloadCard
+				dataYear={referenceYear}
+				href={`/api/representation-pdf?year=${referenceYear}`}
+				title="Télécharger le récapitulatif de la déclaration"
+				year={campaignYear}
+			/>
 
 			<div>
 				<Link className="fr-btn" href="/mon-espace">

--- a/packages/app/src/modules/declaration-representation/Confirmation.tsx
+++ b/packages/app/src/modules/declaration-representation/Confirmation.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 
 import { DsfrPictogram } from "~/modules/layout";
+import { ResendReceiptButton } from "~/modules/mail";
+import { FileDownloadLink } from "~/modules/shared";
 import styles from "./Confirmation.module.scss";
 
 type ConfirmationProps = {
@@ -40,14 +42,7 @@ export function Confirmation({
 					Si ce n&apos;est pas le cas, vérifiez vos courriers indésirables ou
 					SPAM. Sinon, cliquez sur le bouton ci-dessous.
 				</p>
-				<button
-					aria-disabled="true"
-					className="fr-btn fr-btn--tertiary fr-btn--sm"
-					disabled
-					type="button"
-				>
-					Renvoyer l&apos;accusé de réception
-				</button>
+				<ResendReceiptButton kind="representation" year={referenceYear} />
 			</div>
 
 			<div className={styles.block}>
@@ -57,14 +52,13 @@ export function Confirmation({
 				<p className="fr-text--sm fr-mb-0">
 					Année {campaignYear} au titre des données {referenceYear}
 				</p>
-				<button
-					aria-disabled="true"
+				<FileDownloadLink
 					className="fr-btn fr-btn--secondary"
-					disabled
-					type="button"
+					href={`/api/representation-pdf?year=${referenceYear}`}
+					pendingLabel="Génération du récapitulatif en cours…"
 				>
 					Télécharger le récapitulatif (PDF)
-				</button>
+				</FileDownloadLink>
 			</div>
 
 			<div>

--- a/packages/app/src/modules/declaration-representation/Confirmation.tsx
+++ b/packages/app/src/modules/declaration-representation/Confirmation.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import { DsfrPictogram } from "~/modules/layout";
 import { ResendReceiptButton } from "~/modules/mail";
-import { FileDownloadLink } from "~/modules/shared";
+import { FileDownloadLink } from "~/modules/shared/FileDownloadLink";
 import styles from "./Confirmation.module.scss";
 
 type ConfirmationProps = {

--- a/packages/app/src/modules/declaration-representation/__tests__/Confirmation.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/Confirmation.test.tsx
@@ -40,7 +40,7 @@ function renderConfirmation({
 
 function pdfLink() {
 	return screen.getByRole("link", {
-		name: "Télécharger le récapitulatif (PDF)",
+		name: "Télécharger le récapitulatif de la déclaration",
 	});
 }
 
@@ -82,6 +82,23 @@ describe("Confirmation — fin de démarche", () => {
 		expect(screen.getByText("renseignée sur votre compte")).toBeInTheDocument();
 	});
 
+	it("nests the recap card under a section heading, skipping no level", () => {
+		renderConfirmation();
+
+		expect(
+			screen.getByRole("heading", {
+				level: 2,
+				name: "Documents récapitulatifs de la déclaration",
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("heading", {
+				level: 3,
+				name: "Télécharger le récapitulatif de la déclaration",
+			}),
+		).toContainElement(pdfLink());
+	});
+
 	it("recalls the campaign and the reference year of the recap", () => {
 		renderConfirmation();
 
@@ -110,11 +127,14 @@ describe("Confirmation — actions de fin de parcours", () => {
 	it("downloads the recap of the reference year from the representation route (S20)", () => {
 		renderConfirmation();
 
-		expect(pdfLink()).toHaveAttribute(
+		const link = pdfLink();
+
+		expect(link).toHaveAttribute(
 			"href",
 			`/api/representation-pdf?year=${REPRESENTATION_YEAR}`,
 		);
-		expect(pdfLink()).not.toHaveAttribute("aria-disabled");
+		expect(link).toHaveAttribute("download");
+		expect(link).not.toHaveAttribute("aria-disabled");
 	});
 
 	it("offers an actionable acknowledgement resend", () => {

--- a/packages/app/src/modules/declaration-representation/__tests__/Confirmation.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/Confirmation.test.tsx
@@ -1,5 +1,23 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	resendReceipt: vi.fn(),
+}));
+
+vi.mock("~/trpc/react", () => ({
+	api: {
+		mail: {
+			resendReceipt: {
+				useMutation: () => ({
+					mutate: mocks.resendReceipt,
+					isPending: false,
+				}),
+			},
+		},
+	},
+}));
 
 import { Confirmation } from "../Confirmation";
 import { REPRESENTATION_CAMPAIGN_YEAR, REPRESENTATION_YEAR } from "./fixtures";
@@ -20,8 +38,8 @@ function renderConfirmation({
 	);
 }
 
-function pdfButton() {
-	return screen.getByRole("button", {
+function pdfLink() {
+	return screen.getByRole("link", {
 		name: "Télécharger le récapitulatif (PDF)",
 	});
 }
@@ -84,18 +102,37 @@ describe("Confirmation — fin de démarche", () => {
 	});
 });
 
-describe("Confirmation — actions à venir", () => {
-	it("offers the recap download, disabled until the PDF ticket lands", () => {
-		renderConfirmation();
-
-		expect(pdfButton()).toBeDisabled();
-		expect(pdfButton()).toHaveAttribute("aria-disabled", "true");
+describe("Confirmation — actions de fin de parcours", () => {
+	beforeEach(() => {
+		mocks.resendReceipt.mockClear();
 	});
 
-	it("offers the acknowledgement resend, disabled until the e-mail ticket lands", () => {
+	it("downloads the recap of the reference year from the representation route (S20)", () => {
 		renderConfirmation();
 
-		expect(resendButton()).toBeDisabled();
-		expect(resendButton()).toHaveAttribute("aria-disabled", "true");
+		expect(pdfLink()).toHaveAttribute(
+			"href",
+			`/api/representation-pdf?year=${REPRESENTATION_YEAR}`,
+		);
+		expect(pdfLink()).not.toHaveAttribute("aria-disabled");
+	});
+
+	it("offers an actionable acknowledgement resend", () => {
+		renderConfirmation();
+
+		expect(resendButton()).toBeEnabled();
+		expect(resendButton()).not.toHaveAttribute("aria-disabled");
+	});
+
+	it("resends the acknowledgement of the representation declaration (S20)", async () => {
+		const user = userEvent.setup();
+		renderConfirmation();
+
+		await user.click(resendButton());
+
+		expect(mocks.resendReceipt).toHaveBeenCalledWith({
+			kind: "representation",
+			year: REPRESENTATION_YEAR,
+		});
 	});
 });

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -27,6 +27,16 @@ vi.mock("~/trpc/server", () => ({
 	api: { representationDeclaration: { get: vi.fn() } },
 }));
 
+vi.mock("~/trpc/react", () => ({
+	api: {
+		mail: {
+			resendReceipt: {
+				useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+			},
+		},
+	},
+}));
+
 vi.mock("~/server/auth", () => ({ auth: mockAuth }));
 
 // The client funnel itself is exercised by StepPageClient.test.tsx.
@@ -327,6 +337,19 @@ describe("RepresentationConfirmationPage", () => {
 		render(await RepresentationConfirmationPage());
 
 		expect(screen.getByText("renseignée sur votre compte")).toBeInTheDocument();
+	});
+
+	it("hands the reference year to the recap download and the resend button (S20)", async () => {
+		mockSubmittedState("submitted");
+
+		render(await RepresentationConfirmationPage());
+
+		expect(
+			screen.getByRole("link", { name: "Télécharger le récapitulatif (PDF)" }),
+		).toHaveAttribute("href", `/api/representation-pdf?year=${YEAR}`);
+		expect(
+			screen.getByRole("button", { name: "Renvoyer l'accusé de réception" }),
+		).toBeEnabled();
 	});
 
 	it("sends a declaration still in draft back to the summary", async () => {

--- a/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/RepresentationRoutes.test.tsx
@@ -345,7 +345,9 @@ describe("RepresentationConfirmationPage", () => {
 		render(await RepresentationConfirmationPage());
 
 		expect(
-			screen.getByRole("link", { name: "Télécharger le récapitulatif (PDF)" }),
+			screen.getByRole("link", {
+				name: "Télécharger le récapitulatif de la déclaration",
+			}),
 		).toHaveAttribute("href", `/api/representation-pdf?year=${YEAR}`);
 		expect(
 			screen.getByRole("button", { name: "Renvoyer l'accusé de réception" }),

--- a/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
+++ b/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
@@ -1,0 +1,145 @@
+import { Document, Page, Text, View } from "@react-pdf/renderer";
+import {
+	formatLongDate,
+	formatPercentage,
+	formatShortDate,
+} from "~/modules/domain";
+import type {
+	RepresentationPdfData,
+	RepresentationPdfIndicator,
+} from "./buildRepresentationPdfData";
+import { ensurePdfFontsRegistered } from "./pdfFonts";
+import { styles } from "./pdfStyles";
+
+type Props = {
+	data: RepresentationPdfData;
+};
+
+const VERDICT_LABELS = {
+	compliant: "Conforme",
+	non_compliant: "Non conforme",
+	not_applicable: "Non applicable",
+} as const;
+
+function formatOptionalDate(value: string | null): string {
+	return value === null ? "Non renseignée" : formatShortDate(new Date(value));
+}
+
+function IndicatorCard({
+	indicator,
+}: {
+	indicator: RepresentationPdfIndicator;
+}) {
+	return (
+		<View style={styles.card}>
+			<Text style={styles.cardTitle}>{indicator.title}</Text>
+			{indicator.notComputableReason === null ? (
+				<View style={styles.proportionRow}>
+					<View style={styles.proportionItem}>
+						<Text style={styles.proportionLabel}>Femmes</Text>
+						<Text style={styles.proportionValue}>
+							{formatPercentage(indicator.womenPercent)}
+						</Text>
+					</View>
+					<View style={styles.proportionItem}>
+						<Text style={styles.proportionLabel}>Hommes</Text>
+						<Text style={styles.proportionValue}>
+							{formatPercentage(indicator.menPercent)}
+						</Text>
+					</View>
+				</View>
+			) : (
+				<Text style={styles.noData}>{indicator.notComputableReason}</Text>
+			)}
+			<Text style={styles.sectionLabel}>
+				Verdict : {VERDICT_LABELS[indicator.verdict]}
+			</Text>
+		</View>
+	);
+}
+
+export function RepresentationPdfDocument({ data }: Props) {
+	ensurePdfFontsRegistered();
+
+	return (
+		<Document>
+			<Page size="A4" style={styles.page}>
+				<View style={styles.header}>
+					<Text style={styles.title}>
+						Démarche des indicateurs de représentation {data.campaignYear}
+					</Text>
+					<Text style={styles.subtitle}>
+						Au titre de la période de référence {data.year}
+					</Text>
+					<Text style={styles.companyInfo}>
+						{data.companyName} — SIREN {data.siren}
+					</Text>
+				</View>
+
+				<View style={styles.card}>
+					<Text style={styles.cardTitle}>Période de référence</Text>
+					<View style={styles.tableRow}>
+						<Text style={styles.tableCellLabel}>Début de la période</Text>
+						<Text style={styles.tableCellValue}>
+							{formatOptionalDate(data.referencePeriodStart)}
+						</Text>
+					</View>
+					<View style={styles.tableRowLast}>
+						<Text style={styles.tableCellLabel}>Fin de la période</Text>
+						<Text style={styles.tableCellValue}>
+							{formatOptionalDate(data.referencePeriodEnd)}
+						</Text>
+					</View>
+				</View>
+
+				{data.indicators.map((indicator) => (
+					<IndicatorCard indicator={indicator} key={indicator.title} />
+				))}
+
+				<View style={styles.card}>
+					<Text style={styles.cardTitle}>Publication</Text>
+					{data.publicationApplicable ? (
+						<>
+							<View style={styles.tableRow}>
+								<Text style={styles.tableCellLabel}>Date de publication</Text>
+								<Text style={styles.tableCellValue}>
+									{formatOptionalDate(data.publishDate)}
+								</Text>
+							</View>
+							{data.hasWebsite ? (
+								<View style={styles.tableRowLast}>
+									<Text style={styles.tableCellLabel}>
+										Adresse de la page (URL)
+									</Text>
+									<Text style={styles.tableCellValue}>
+										{data.publishUrl ?? "—"}
+									</Text>
+								</View>
+							) : (
+								<View style={styles.tableRowLast}>
+									<Text style={styles.tableCellLabel}>
+										Modalités de communication
+									</Text>
+									<Text style={styles.tableCellValue}>
+										{data.publishModalities ?? "—"}
+									</Text>
+								</View>
+							)}
+						</>
+					) : (
+						<Text style={styles.noData}>
+							Non applicable — aucun écart calculable
+						</Text>
+					)}
+				</View>
+
+				<Text style={styles.footer}>
+					{data.submittedAt
+						? `Déclaration transmise le ${formatLongDate(data.submittedAt)} — `
+						: ""}
+					Document généré le {formatLongDate(data.generatedAt)}
+				</Text>
+			</Page>
+		</Document>
+	);
+}

--- a/packages/app/src/modules/declarationPdf/__tests__/RepresentationPdfDocument.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/RepresentationPdfDocument.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RepresentationPdfData } from "../buildRepresentationPdfData";
+
+const mocks = vi.hoisted(() => ({
+	ensurePdfFontsRegistered: vi.fn(),
+}));
+
+vi.mock("@react-pdf/renderer", async () => {
+	const React = await import("react");
+
+	return {
+		Document: ({ children }: { children: React.ReactNode }) =>
+			React.createElement("div", { "data-testid": "pdf-document" }, children),
+		Page: ({ children, size }: { children: React.ReactNode; size: string }) =>
+			React.createElement(
+				"section",
+				{ "data-size": size, "data-testid": "pdf-page" },
+				children,
+			),
+		Text: ({ children }: { children: React.ReactNode }) =>
+			React.createElement("span", null, children),
+		View: ({ children }: { children: React.ReactNode }) =>
+			React.createElement("div", null, children),
+		StyleSheet: {
+			create: <T,>(styles: T) => styles,
+		},
+	};
+});
+
+vi.mock("../pdfFonts", () => ({
+	PDF_FONT_FAMILY: "Marianne",
+	ensurePdfFontsRegistered: mocks.ensurePdfFontsRegistered,
+}));
+
+import { RepresentationPdfDocument } from "../RepresentationPdfDocument";
+
+const representationPdfData: RepresentationPdfData = {
+	companyName: "Société Représentation",
+	siren: "123456789",
+	year: 2025,
+	campaignYear: 2026,
+	referencePeriodStart: "2025-01-01",
+	referencePeriodEnd: "2025-12-31",
+	indicators: [
+		{
+			title: "Cadres dirigeants",
+			notComputableReason: null,
+			womenPercent: 60,
+			menPercent: 40,
+			verdict: "compliant",
+		},
+		{
+			title: "Membres des instances dirigeantes",
+			notComputableReason: null,
+			womenPercent: 25.5,
+			menPercent: 74.5,
+			verdict: "non_compliant",
+		},
+	],
+	publicationApplicable: true,
+	publishDate: "2026-03-01",
+	hasWebsite: true,
+	publishUrl: "https://exemple.fr/egalite-professionnelle",
+	publishModalities: null,
+	submittedAt: new Date("2026-03-10T08:00:00.000Z"),
+	generatedAt: new Date("2026-06-15T09:30:00.000Z"),
+};
+
+function renderDocument(overrides: Partial<RepresentationPdfData> = {}) {
+	return render(
+		<RepresentationPdfDocument
+			data={{ ...representationPdfData, ...overrides }}
+		/>,
+	);
+}
+
+describe("RepresentationPdfDocument", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders an A4 page titled with the campaign and the reference year", () => {
+		renderDocument();
+
+		expect(mocks.ensurePdfFontsRegistered).toHaveBeenCalledTimes(1);
+		expect(screen.getByTestId("pdf-document")).toBeInTheDocument();
+		expect(screen.getByTestId("pdf-page")).toHaveAttribute("data-size", "A4");
+		expect(
+			screen.getByText("Démarche des indicateurs de représentation 2026"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Au titre de la période de référence 2025"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Société Représentation — SIREN 123456789"),
+		).toBeInTheDocument();
+	});
+
+	it("renders the reference period in short French dates", () => {
+		renderDocument();
+
+		expect(screen.getByText("Période de référence")).toBeInTheDocument();
+		expect(screen.getByText("01/01/2025")).toBeInTheDocument();
+		expect(screen.getByText("31/12/2025")).toBeInTheDocument();
+	});
+
+	it("marks an unfilled reference period boundary as not provided", () => {
+		renderDocument({ referencePeriodStart: null, referencePeriodEnd: null });
+
+		expect(screen.getAllByText("Non renseignée")).toHaveLength(2);
+	});
+
+	it("renders both indicators with their proportions and verdicts", () => {
+		renderDocument();
+
+		expect(screen.getByText("Cadres dirigeants")).toBeInTheDocument();
+		expect(
+			screen.getByText("Membres des instances dirigeantes"),
+		).toBeInTheDocument();
+		expect(screen.getByText("60 %")).toBeInTheDocument();
+		expect(screen.getByText("40 %")).toBeInTheDocument();
+		expect(screen.getByText("25,5 %")).toBeInTheDocument();
+		expect(screen.getByText("74,5 %")).toBeInTheDocument();
+		expect(screen.getByText("Verdict : Conforme")).toBeInTheDocument();
+		expect(screen.getByText("Verdict : Non conforme")).toBeInTheDocument();
+	});
+
+	it("replaces the proportions with the motive when the gap is not computable", () => {
+		renderDocument({
+			indicators: [
+				{
+					title: "Cadres dirigeants",
+					notComputableReason: "Aucun cadre dirigeant",
+					womenPercent: null,
+					menPercent: null,
+					verdict: "not_applicable",
+				},
+			],
+		});
+
+		expect(screen.getByText("Aucun cadre dirigeant")).toBeInTheDocument();
+		expect(screen.queryByText("Femmes")).not.toBeInTheDocument();
+		expect(screen.getByText("Verdict : Non applicable")).toBeInTheDocument();
+	});
+
+	it("renders the publication page address when the company has a website", () => {
+		renderDocument();
+
+		expect(screen.getByText("Publication")).toBeInTheDocument();
+		expect(screen.getByText("01/03/2026")).toBeInTheDocument();
+		expect(screen.getByText("Adresse de la page (URL)")).toBeInTheDocument();
+		expect(
+			screen.getByText("https://exemple.fr/egalite-professionnelle"),
+		).toBeInTheDocument();
+	});
+
+	it("renders the communication modalities when the company has no website", () => {
+		renderDocument({
+			hasWebsite: false,
+			publishUrl: null,
+			publishModalities: "Affichage dans les locaux.",
+		});
+
+		expect(screen.getByText("Modalités de communication")).toBeInTheDocument();
+		expect(screen.getByText("Affichage dans les locaux.")).toBeInTheDocument();
+	});
+
+	it.each([
+		true,
+		false,
+	])("dashes out the publication detail left empty (website: %s)", (hasWebsite) => {
+		renderDocument({
+			hasWebsite,
+			publishDate: null,
+			publishUrl: null,
+			publishModalities: null,
+		});
+
+		expect(screen.getByText("Non renseignée")).toBeInTheDocument();
+		expect(screen.getByText("—")).toBeInTheDocument();
+	});
+
+	it("states that no publication is due when no gap is computable", () => {
+		renderDocument({ publicationApplicable: false });
+
+		expect(
+			screen.getByText("Non applicable — aucun écart calculable"),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Date de publication")).not.toBeInTheDocument();
+	});
+
+	it("footers the transmission date alongside the generation date", () => {
+		renderDocument();
+
+		expect(
+			screen.getByText(/Déclaration transmise le 10 mars 2026/),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/Document généré le 15 juin 2026/),
+		).toBeInTheDocument();
+	});
+
+	it("footers the generation date alone when the transmission date is unknown", () => {
+		renderDocument({ submittedAt: null });
+
+		expect(screen.queryByText(/Déclaration transmise/)).not.toBeInTheDocument();
+		expect(
+			screen.getByText(/Document généré le 15 juin 2026/),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/app/src/modules/declarationPdf/__tests__/buildRepresentationPdfData.integration.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildRepresentationPdfData.integration.test.ts
@@ -1,0 +1,144 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { env } from "~/env.js";
+import {
+	buildRepresentationPdfData,
+	RepresentationDeclarationNotFoundError,
+} from "~/modules/declarationPdf/buildRepresentationPdfData";
+
+describe("buildRepresentationPdfData against a real Postgres", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const SIREN = "222333444";
+	const YEAR = 2025;
+	const CAMPAIGN_YEAR = YEAR + 1;
+	const NOW = new Date("2026-06-15T09:30:00.000Z");
+	const DECLARATION_ID = "representation-pdf-integration";
+
+	async function insertDeclaration(columns: Record<string, unknown>) {
+		await sql`
+			INSERT INTO app_representation_declaration ${sql({
+				id: DECLARATION_ID,
+				siren: SIREN,
+				year: YEAR,
+				...columns,
+			})}
+		`;
+	}
+
+	beforeAll(async () => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+		await sql`INSERT INTO app_company (siren, name) VALUES (${SIREN}, 'Société Récapitulatif')`;
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await sql`DELETE FROM app_representation_declaration WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await sql`DELETE FROM app_representation_declaration WHERE siren = ${SIREN}`;
+	});
+
+	it("reads the numeric and date columns back as usable values (S20)", async () => {
+		await insertDeclaration({
+			status: "submitted",
+			submitted_at: new Date("2026-03-10T08:00:00.000Z"),
+			reference_period_start: "2025-01-01",
+			reference_period_end: "2025-12-31",
+			executive_women_percent: 60,
+			executive_men_percent: 40,
+			member_women_percent: 55.5,
+			member_men_percent: 44.5,
+			publish_date: "2026-03-01",
+			publish_url: "https://exemple.fr/egalite-professionnelle",
+		});
+
+		const data = await buildRepresentationPdfData(SIREN, YEAR, NOW);
+
+		expect(data).toMatchObject({
+			companyName: "Société Récapitulatif",
+			siren: SIREN,
+			year: YEAR,
+			campaignYear: CAMPAIGN_YEAR,
+			referencePeriodStart: "2025-01-01",
+			referencePeriodEnd: "2025-12-31",
+			publicationApplicable: true,
+			hasWebsite: true,
+			publishDate: "2026-03-01",
+		});
+		// `numeric` comes back as a string from the driver: the percentages have to
+		// survive as numbers or the PDF renders "NaN %".
+		expect(data.indicators.map((indicator) => indicator.womenPercent)).toEqual([
+			60, 55.5,
+		]);
+		expect(data.indicators.map((indicator) => indicator.menPercent)).toEqual([
+			40, 44.5,
+		]);
+		expect(data.indicators.map((indicator) => indicator.verdict)).toEqual([
+			"compliant",
+			"compliant",
+		]);
+		expect(data.submittedAt).toBeInstanceOf(Date);
+	});
+
+	it("reflects the last transmitted version after a new submission (S22)", async () => {
+		await insertDeclaration({
+			status: "submitted",
+			submitted_at: new Date("2026-03-10T08:00:00.000Z"),
+			executive_women_percent: 60,
+			executive_men_percent: 40,
+			member_women_percent: 55,
+			member_men_percent: 45,
+		});
+
+		await sql`
+			UPDATE app_representation_declaration
+			SET executive_women_percent = 25, executive_men_percent = 75,
+				submitted_at = '2026-04-02T08:00:00.000Z'
+			WHERE id = ${DECLARATION_ID}
+		`;
+
+		const data = await buildRepresentationPdfData(SIREN, YEAR, NOW);
+
+		expect(data.indicators[0]).toMatchObject({
+			womenPercent: 25,
+			menPercent: 75,
+			verdict: "non_compliant",
+		});
+		expect(data.submittedAt).toEqual(new Date("2026-04-02T08:00:00.000Z"));
+	});
+
+	it("keeps the not-computable motives readable in the recap", async () => {
+		await insertDeclaration({
+			status: "submitted",
+			submitted_at: new Date("2026-03-10T08:00:00.000Z"),
+			not_computable_reason_executives: "un_seul_cadre_dirigeant",
+			not_computable_reason_members: "aucune_instance_dirigeante",
+		});
+
+		const data = await buildRepresentationPdfData(SIREN, YEAR, NOW);
+
+		expect(
+			data.indicators.map((indicator) => indicator.notComputableReason),
+		).toEqual(["Un cadre dirigeant", "Aucune instance dirigeante"]);
+		expect(data.publicationApplicable).toBe(false);
+	});
+
+	it("refuses a declaration still in draft", async () => {
+		await insertDeclaration({ status: "draft", current_step: 3 });
+
+		await expect(
+			buildRepresentationPdfData(SIREN, YEAR, NOW),
+		).rejects.toBeInstanceOf(RepresentationDeclarationNotFoundError);
+	});
+
+	it("refuses a year with no declaration at all", async () => {
+		await expect(
+			buildRepresentationPdfData(SIREN, YEAR, NOW),
+		).rejects.toBeInstanceOf(RepresentationDeclarationNotFoundError);
+	});
+});

--- a/packages/app/src/modules/declarationPdf/__tests__/buildRepresentationPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildRepresentationPdfData.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	rows: [] as unknown[][],
+	selectCalls: 0,
+}));
+
+vi.mock("~/server/db", () => ({
+	db: {
+		select: () => {
+			const index = mocks.selectCalls++;
+			return {
+				from: () => ({
+					where: () => ({
+						limit: () => Promise.resolve(mocks.rows[index] ?? []),
+					}),
+				}),
+			};
+		},
+	},
+}));
+
+import {
+	buildRepresentationPdfData,
+	RepresentationDeclarationNotFoundError,
+} from "../buildRepresentationPdfData";
+
+const SIREN = "123456789";
+const YEAR = 2025;
+const CAMPAIGN_YEAR = YEAR + 1;
+const NOW = new Date("2026-06-15T09:30:00.000Z");
+const SUBMITTED_AT = new Date("2026-03-10T08:00:00.000Z");
+
+const COMPANY = { name: "Société Représentation" };
+
+const SUBMITTED_DECLARATION = {
+	status: "submitted",
+	referencePeriodStart: "2025-01-01",
+	referencePeriodEnd: "2025-12-31",
+	executiveWomenPercent: "60",
+	executiveMenPercent: "40",
+	notComputableReasonExecutives: null,
+	memberWomenPercent: "55",
+	memberMenPercent: "45",
+	notComputableReasonMembers: null,
+	publishDate: "2026-03-01",
+	publishUrl: "https://exemple.fr/egalite-professionnelle",
+	publishModalities: null,
+	submittedAt: SUBMITTED_AT,
+};
+
+function stubDb(
+	declaration: Record<string, unknown> | null,
+	company: Record<string, unknown> | null = COMPANY,
+) {
+	// The builder fires both selects in a single Promise.all: company first.
+	mocks.rows = [company ? [company] : [], declaration ? [declaration] : []];
+	mocks.selectCalls = 0;
+}
+
+function build() {
+	return buildRepresentationPdfData(SIREN, YEAR, NOW);
+}
+
+describe("buildRepresentationPdfData", () => {
+	beforeEach(() => {
+		stubDb(SUBMITTED_DECLARATION);
+	});
+
+	it("assembles the last transmitted declaration of the reference year (S20)", async () => {
+		const data = await build();
+
+		expect(data).toMatchObject({
+			companyName: "Société Représentation",
+			siren: SIREN,
+			year: YEAR,
+			campaignYear: CAMPAIGN_YEAR,
+			referencePeriodStart: "2025-01-01",
+			referencePeriodEnd: "2025-12-31",
+			submittedAt: SUBMITTED_AT,
+			generatedAt: NOW,
+		});
+	});
+
+	it("reads the two indicators as percentages and grades them against the campaign target", async () => {
+		const data = await build();
+
+		expect(data.indicators).toEqual([
+			{
+				title: "Cadres dirigeants",
+				notComputableReason: null,
+				womenPercent: 60,
+				menPercent: 40,
+				verdict: "compliant",
+			},
+			{
+				title: "Membres des instances dirigeantes",
+				notComputableReason: null,
+				womenPercent: 55,
+				menPercent: 45,
+				verdict: "compliant",
+			},
+		]);
+	});
+
+	it("grades an indicator below the target as non compliant", async () => {
+		stubDb({
+			...SUBMITTED_DECLARATION,
+			executiveWomenPercent: "80",
+			executiveMenPercent: "20",
+		});
+
+		const data = await build();
+
+		expect(data.indicators[0]).toMatchObject({
+			womenPercent: 80,
+			menPercent: 20,
+			verdict: "non_compliant",
+		});
+	});
+
+	it.each([
+		["aucun_cadre_dirigeant", "Aucun cadre dirigeant"],
+		["un_seul_cadre_dirigeant", "Un cadre dirigeant"],
+	])("spells out the %s motive on the executives indicator", async (reason, label) => {
+		stubDb({
+			...SUBMITTED_DECLARATION,
+			executiveWomenPercent: null,
+			executiveMenPercent: null,
+			notComputableReasonExecutives: reason,
+			publishDate: null,
+			publishUrl: null,
+		});
+
+		const data = await build();
+
+		expect(data.indicators[0]).toMatchObject({
+			notComputableReason: label,
+			womenPercent: null,
+			menPercent: null,
+			verdict: "not_applicable",
+		});
+	});
+
+	it("spells out the missing management body on the members indicator", async () => {
+		stubDb({
+			...SUBMITTED_DECLARATION,
+			memberWomenPercent: null,
+			memberMenPercent: null,
+			notComputableReasonMembers: "aucune_instance_dirigeante",
+		});
+
+		const data = await build();
+
+		expect(data.indicators[1]).toMatchObject({
+			notComputableReason: "Aucune instance dirigeante",
+			womenPercent: null,
+			menPercent: null,
+			verdict: "not_applicable",
+		});
+	});
+
+	it("carries the website publication when one was declared", async () => {
+		const data = await build();
+
+		expect(data).toMatchObject({
+			publicationApplicable: true,
+			publishDate: "2026-03-01",
+			hasWebsite: true,
+			publishUrl: "https://exemple.fr/egalite-professionnelle",
+			publishModalities: null,
+		});
+	});
+
+	it("carries the offline modalities when no website was declared", async () => {
+		stubDb({
+			...SUBMITTED_DECLARATION,
+			publishUrl: null,
+			publishModalities: "Affichage dans les locaux.",
+		});
+
+		const data = await build();
+
+		expect(data).toMatchObject({
+			publicationApplicable: true,
+			hasWebsite: false,
+			publishUrl: null,
+			publishModalities: "Affichage dans les locaux.",
+		});
+	});
+
+	it("keeps the publication applicable when only the management body is computable", async () => {
+		stubDb({
+			...SUBMITTED_DECLARATION,
+			executiveWomenPercent: null,
+			executiveMenPercent: null,
+			notComputableReasonExecutives: "aucun_cadre_dirigeant",
+		});
+
+		const data = await build();
+
+		expect(data.publicationApplicable).toBe(true);
+	});
+
+	it("drops the publication when no gap is computable at all", async () => {
+		stubDb({
+			...SUBMITTED_DECLARATION,
+			executiveWomenPercent: null,
+			executiveMenPercent: null,
+			notComputableReasonExecutives: "aucun_cadre_dirigeant",
+			memberWomenPercent: null,
+			memberMenPercent: null,
+			notComputableReasonMembers: "aucune_instance_dirigeante",
+			publishDate: null,
+			publishUrl: null,
+			publishModalities: null,
+		});
+
+		const data = await build();
+
+		expect(data.publicationApplicable).toBe(false);
+	});
+
+	it("falls back on the siren when the company row is missing", async () => {
+		stubDb(SUBMITTED_DECLARATION, null);
+
+		await expect(build()).resolves.toMatchObject({
+			companyName: `Entreprise ${SIREN}`,
+		});
+	});
+
+	it("refuses to build a recap for a declaration that was never transmitted", async () => {
+		stubDb({ ...SUBMITTED_DECLARATION, status: "draft", submittedAt: null });
+
+		await expect(build()).rejects.toBeInstanceOf(
+			RepresentationDeclarationNotFoundError,
+		);
+	});
+
+	it("refuses to build a recap when no declaration exists for the year", async () => {
+		stubDb(null);
+
+		await expect(build()).rejects.toBeInstanceOf(
+			RepresentationDeclarationNotFoundError,
+		);
+	});
+});

--- a/packages/app/src/modules/declarationPdf/buildRepresentationPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildRepresentationPdfData.ts
@@ -5,6 +5,7 @@ import {
 	computeRepresentationVerdict,
 	type ExecutivesCount,
 	getRepresentationCampaignYear,
+	isRepresentationDeclarationSubmitted,
 	isRepresentationPublicationRequired,
 	type RepresentationComplianceVerdict,
 } from "~/modules/domain";
@@ -76,7 +77,10 @@ export async function buildRepresentationPdfData(
 			.limit(1),
 	]);
 
-	if (!declaration || declaration.status !== "submitted") {
+	if (
+		!declaration ||
+		!isRepresentationDeclarationSubmitted(declaration.status)
+	) {
 		throw new RepresentationDeclarationNotFoundError();
 	}
 

--- a/packages/app/src/modules/declarationPdf/buildRepresentationPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildRepresentationPdfData.ts
@@ -1,0 +1,148 @@
+import "server-only";
+
+import { and, eq } from "drizzle-orm";
+import {
+	computeRepresentationVerdict,
+	type ExecutivesCount,
+	getRepresentationCampaignYear,
+	isRepresentationPublicationRequired,
+	type RepresentationComplianceVerdict,
+} from "~/modules/domain";
+import { db } from "~/server/db";
+import { companies, representationDeclarations } from "~/server/db/schema";
+
+export class RepresentationDeclarationNotFoundError extends Error {
+	constructor() {
+		super("Déclaration de représentation équilibrée introuvable");
+		this.name = "RepresentationDeclarationNotFoundError";
+	}
+}
+
+export type RepresentationPdfIndicator = {
+	title: string;
+	notComputableReason: string | null;
+	womenPercent: number | null;
+	menPercent: number | null;
+	verdict: RepresentationComplianceVerdict;
+};
+
+export type RepresentationPdfData = {
+	companyName: string;
+	siren: string;
+	year: number;
+	campaignYear: number;
+	referencePeriodStart: string | null;
+	referencePeriodEnd: string | null;
+	indicators: RepresentationPdfIndicator[];
+	publicationApplicable: boolean;
+	publishDate: string | null;
+	hasWebsite: boolean;
+	publishUrl: string | null;
+	publishModalities: string | null;
+	submittedAt: Date | null;
+	generatedAt: Date;
+};
+
+const NOT_COMPUTABLE_EXECUTIVES_LABELS: Record<
+	"aucun_cadre_dirigeant" | "un_seul_cadre_dirigeant",
+	string
+> = {
+	aucun_cadre_dirigeant: "Aucun cadre dirigeant",
+	un_seul_cadre_dirigeant: "Un cadre dirigeant",
+};
+
+const NOT_COMPUTABLE_MEMBERS_LABEL = "Aucune instance dirigeante";
+
+function toPercent(value: string | null): number | null {
+	return value === null ? null : Number(value);
+}
+
+export async function buildRepresentationPdfData(
+	siren: string,
+	year: number,
+	now: Date,
+): Promise<RepresentationPdfData> {
+	const [[company], [declaration]] = await Promise.all([
+		db.select().from(companies).where(eq(companies.siren, siren)).limit(1),
+		db
+			.select()
+			.from(representationDeclarations)
+			.where(
+				and(
+					eq(representationDeclarations.siren, siren),
+					eq(representationDeclarations.year, year),
+				),
+			)
+			.limit(1),
+	]);
+
+	if (!declaration || declaration.status !== "submitted") {
+		throw new RepresentationDeclarationNotFoundError();
+	}
+
+	const campaignYear = getRepresentationCampaignYear(year);
+
+	const executivesWomenPercent = toPercent(declaration.executiveWomenPercent);
+	const executivesMenPercent = toPercent(declaration.executiveMenPercent);
+	const membersWomenPercent = toPercent(declaration.memberWomenPercent);
+	const membersMenPercent = toPercent(declaration.memberMenPercent);
+
+	const executivesCount: ExecutivesCount =
+		declaration.notComputableReasonExecutives === "aucun_cadre_dirigeant"
+			? "none"
+			: declaration.notComputableReasonExecutives === "un_seul_cadre_dirigeant"
+				? "one"
+				: "two_or_more";
+	const hasManagementBody = declaration.notComputableReasonMembers === null;
+
+	const indicators: RepresentationPdfIndicator[] = [
+		{
+			title: "Cadres dirigeants",
+			notComputableReason: declaration.notComputableReasonExecutives
+				? NOT_COMPUTABLE_EXECUTIVES_LABELS[
+						declaration.notComputableReasonExecutives
+					]
+				: null,
+			womenPercent: executivesWomenPercent,
+			menPercent: executivesMenPercent,
+			verdict: computeRepresentationVerdict(
+				executivesWomenPercent,
+				executivesMenPercent,
+				campaignYear,
+			),
+		},
+		{
+			title: "Membres des instances dirigeantes",
+			notComputableReason: hasManagementBody
+				? null
+				: NOT_COMPUTABLE_MEMBERS_LABEL,
+			womenPercent: membersWomenPercent,
+			menPercent: membersMenPercent,
+			verdict: computeRepresentationVerdict(
+				membersWomenPercent,
+				membersMenPercent,
+				campaignYear,
+			),
+		},
+	];
+
+	return {
+		companyName: company?.name ?? `Entreprise ${siren}`,
+		siren,
+		year,
+		campaignYear,
+		referencePeriodStart: declaration.referencePeriodStart,
+		referencePeriodEnd: declaration.referencePeriodEnd,
+		indicators,
+		publicationApplicable: isRepresentationPublicationRequired(
+			executivesCount,
+			hasManagementBody,
+		),
+		publishDate: declaration.publishDate,
+		hasWebsite: declaration.publishUrl !== null,
+		publishUrl: declaration.publishUrl,
+		publishModalities: declaration.publishModalities,
+		submittedAt: declaration.submittedAt,
+		generatedAt: now,
+	};
+}

--- a/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
+++ b/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
@@ -182,6 +182,41 @@ describe("enqueueReceipt", () => {
 		expect(call.attachments).toBeUndefined();
 	});
 
+	it("maps representation to representation_receipt without attachments", async () => {
+		await enqueueReceipt({ ...baseInput, kind: "representation" });
+
+		expect(mocks.buildDeclarationAttachments).not.toHaveBeenCalled();
+		expect(mocks.buildSecondDeclarationAttachments).not.toHaveBeenCalled();
+		expect(mocks.enqueueNotification).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: "representation_receipt",
+				payload: {
+					siren: "552100554",
+					year: 2025,
+					raisonSociale: "Société Démo",
+				},
+			}),
+		);
+		const call = mocks.enqueueNotification.mock.calls[0]?.[0] as {
+			attachments?: unknown;
+		};
+		expect(call.attachments).toBeUndefined();
+	});
+
+	it("keeps the variant out of the audit row of a receipt that has none", async () => {
+		await enqueueReceipt({ ...baseInput, kind: "representation" });
+
+		// The representation receipt is the only one with a variant-free payload:
+		// stamping `variant: undefined` on the jsonb would make it unqueryable.
+		expect(auditMetadataOf()).not.toHaveProperty("variant");
+		expect(auditMetadataOf()).toMatchObject({
+			type: "representation_receipt",
+			kind: "representation",
+			year: 2025,
+			isResend: false,
+		});
+	});
+
 	it("logs failure with errorMessage when publisher returns error", async () => {
 		mocks.enqueueNotification.mockResolvedValue({
 			status: "error",

--- a/packages/app/src/modules/mail/__tests__/schemas.test.ts
+++ b/packages/app/src/modules/mail/__tests__/schemas.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { resendReceiptSchema } from "../schemas";
+
+const YEAR = 2025;
+
+describe("resendReceiptSchema", () => {
+	it.each([
+		"declaration",
+		"secondDeclaration",
+		"cseOpinion",
+		"representation",
+	])("accepts a resend of the %s receipt", (kind) => {
+		expect(resendReceiptSchema.safeParse({ kind, year: YEAR }).success).toBe(
+			true,
+		);
+	});
+
+	it.each([
+		"jointEvaluation",
+		"",
+		"Representation",
+	])("rejects the unsupported kind %s", (kind) => {
+		expect(resendReceiptSchema.safeParse({ kind, year: YEAR }).success).toBe(
+			false,
+		);
+	});
+
+	it.each([2018, 2101, 2025.5])("rejects the year %s", (year) => {
+		expect(
+			resendReceiptSchema.safeParse({ kind: "representation", year }).success,
+		).toBe(false);
+	});
+});

--- a/packages/app/src/modules/mail/enqueueReceipt.ts
+++ b/packages/app/src/modules/mail/enqueueReceipt.ts
@@ -30,7 +30,8 @@ export type ReceiptKind =
 	| "declaration"
 	| "secondDeclaration"
 	| "cseOpinion"
-	| "jointEvaluation";
+	| "jointEvaluation"
+	| "representation";
 
 export type EnqueueReceiptInput = {
 	kind: ReceiptKind;
@@ -46,6 +47,7 @@ const KIND_TO_TYPE = {
 	secondDeclaration: "second_declaration_confirmation",
 	cseOpinion: "cse_opinion_receipt",
 	jointEvaluation: "joint_evaluation_submitted",
+	representation: "representation_receipt",
 } as const satisfies Record<ReceiptKind, NotificationType>;
 
 type ConfirmationType = (typeof KIND_TO_TYPE)[ReceiptKind];
@@ -146,6 +148,9 @@ async function buildConfirmationPayload(
 					hasGapAboveThreshold: context.hasGapAboveThreshold,
 				}),
 			};
+		}
+		case "representation_receipt": {
+			return base;
 		}
 	}
 }
@@ -278,7 +283,7 @@ export async function enqueueReceipt(
 				kind,
 				year,
 				isResend,
-				variant: payload.variant,
+				...("variant" in payload ? { variant: payload.variant } : {}),
 				...(droppedReason === null ? {} : { attachmentsDropped: true }),
 			},
 		});

--- a/packages/app/src/modules/mail/schemas.ts
+++ b/packages/app/src/modules/mail/schemas.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 
 export const resendReceiptSchema = z.object({
-	kind: z.enum(["declaration", "secondDeclaration", "cseOpinion"]),
+	kind: z.enum([
+		"declaration",
+		"secondDeclaration",
+		"cseOpinion",
+		"representation",
+	]),
 	year: z.number().int().min(2019).max(2100),
 });
 

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.integration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.integration.test.ts
@@ -260,6 +260,13 @@ describe("representationDeclarationRouter against a real Postgres", () => {
 				ORDER BY action
 			`;
 			expect([...rows]).toEqual([
+				// The submission acknowledgement is enqueued by `submit` itself, so
+				// its own audit row belongs to the same procedure run.
+				{
+					action: "notification.enqueue",
+					category: "mutation",
+					siren: SIREN,
+				},
 				{
 					action: "representation_declaration.get",
 					category: "read_sensitive",

--- a/packages/app/src/server/api/routers/__tests__/representationDeclaration.submit.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/representationDeclaration.submit.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	enqueueReceipt: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("~/modules/mail/server", () => ({
+	enqueueReceipt: mocks.enqueueReceipt,
+}));
 
 import {
 	COMPUTABLE_EXECUTIVES,
@@ -14,6 +22,7 @@ import {
 	REPRESENTATION_YEAR as YEAR,
 } from "~/modules/declaration-representation/__tests__/fixtures";
 import {
+	buildSession,
 	CLOSED_CAMPAIGN,
 	CLOSED_MESSAGE,
 	conflictSet,
@@ -233,5 +242,66 @@ describe("representationDeclarationRouter.submit", () => {
 			message: IMPERSONATION_MESSAGE,
 		});
 		expect(mock.insert).not.toHaveBeenCalled();
+	});
+
+	describe("accusé de réception", () => {
+		beforeEach(() => {
+			mocks.enqueueReceipt.mockClear().mockResolvedValue(undefined);
+		});
+
+		it("acknowledges the transmission to the declarant (S20)", async () => {
+			const mock = createMockDb();
+
+			await submit(mock, FULL_PAYLOAD);
+
+			expect(mocks.enqueueReceipt).toHaveBeenCalledWith({
+				kind: "representation",
+				to: "declarant@exemple.fr",
+				siren: SIREN,
+				year: YEAR,
+				userId: USER_ID,
+				isResend: false,
+			});
+		});
+
+		it("stores the declaration before acknowledging it", async () => {
+			const mock = createMockDb();
+
+			await submit(mock, FULL_PAYLOAD);
+
+			expect(mock.onConflictDoUpdate).toHaveBeenCalledBefore(
+				mocks.enqueueReceipt,
+			);
+		});
+
+		it("skips the acknowledgement when the account carries no e-mail", async () => {
+			const mock = createMockDb();
+
+			await submit(mock, FULL_PAYLOAD, buildSession({ email: null }));
+
+			expect(mock.insert).toHaveBeenCalled();
+			expect(mocks.enqueueReceipt).not.toHaveBeenCalled();
+		});
+
+		it("sends no acknowledgement when the payload is rejected", async () => {
+			const mock = createMockDb();
+
+			await expect(
+				submit(mock, { ...FULL_PAYLOAD, executiveMenPercent: 30 }),
+			).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+			expect(mocks.enqueueReceipt).not.toHaveBeenCalled();
+		});
+
+		it("sends no acknowledgement once the campaign is closed", async () => {
+			mockGetRepresentationCampaign.mockResolvedValue(CLOSED_CAMPAIGN);
+			const mock = createMockDb();
+
+			await expect(submit(mock, FULL_PAYLOAD)).rejects.toMatchObject({
+				code: "FORBIDDEN",
+			});
+
+			expect(mocks.enqueueReceipt).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/app/src/server/api/routers/mail.ts
+++ b/packages/app/src/server/api/routers/mail.ts
@@ -1,9 +1,9 @@
 import { TRPCError } from "@trpc/server";
 import { resendReceiptSchema } from "~/modules/mail/schemas";
-import { companyProcedure, createTRPCRouter } from "~/server/api/trpc";
+import { companyWriteProcedure, createTRPCRouter } from "~/server/api/trpc";
 
 export const mailRouter = createTRPCRouter({
-	resendReceipt: companyProcedure
+	resendReceipt: companyWriteProcedure
 		.input(resendReceiptSchema)
 		.mutation(async ({ ctx, input }) => {
 			const email = ctx.session.user.email;

--- a/packages/app/src/server/api/routers/representationDeclaration.ts
+++ b/packages/app/src/server/api/routers/representationDeclaration.ts
@@ -205,6 +205,19 @@ export const representationDeclarationRouter = createTRPCRouter({
 					set: columns,
 				});
 
+			const email = ctx.session.user.email;
+			if (email) {
+				const { enqueueReceipt } = await import("~/modules/mail/server");
+				await enqueueReceipt({
+					kind: "representation",
+					to: email,
+					siren,
+					year,
+					userId: ctx.session.user.id,
+					isResend: false,
+				});
+			}
+
 			return { success: true as const };
 		}),
 });

--- a/packages/notifications/src/__tests__/queue.test.ts
+++ b/packages/notifications/src/__tests__/queue.test.ts
@@ -360,4 +360,37 @@ describe("validateJobData — confirmation variants", () => {
 			if (!result.ok) expect(result.reason).toContain("siren");
 		});
 	});
+
+	describe("representation_receipt", () => {
+		it("accepts a company-scoped payload without any variant", () => {
+			const result = validateJobData(
+				buildConfirmation("representation_receipt", {
+					...BASE_SCOPE,
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(true);
+		});
+
+		it("rejects an empty raisonSociale", () => {
+			const result = validateJobData(
+				buildConfirmation("representation_receipt", {
+					...BASE_SCOPE,
+					raisonSociale: "",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("raisonSociale");
+		});
+
+		it("rejects a payload missing siren/year", () => {
+			const result = validateJobData(
+				buildConfirmation("representation_receipt", {
+					raisonSociale: "Société Démo",
+				}),
+			);
+			expect(result.ok).toBe(false);
+			if (!result.ok) expect(result.reason).toContain("siren");
+		});
+	});
 });

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -51,6 +51,11 @@ const PAYLOADS: NotificationPayloadMap = {
 		variant: "completed",
 		raisonSociale: RAISON_SOCIALE,
 	},
+	representation_receipt: {
+		siren: SIREN,
+		year: YEAR,
+		raisonSociale: RAISON_SOCIALE,
+	},
 	cycle_opening_info: { siren: SIREN, year: YEAR, deadline: DEADLINE },
 	declaration_deadline_reminder: {
 		siren: SIREN,
@@ -284,6 +289,50 @@ describe("per-type rendering details", () => {
 				raisonSociale: RAISON_SOCIALE,
 			}),
 		).rejects.toThrow(/Unknown joint_evaluation_submitted variant/);
+	});
+
+	it("representation_receipt acknowledges the balanced representation declaration", async () => {
+		const mail = await buildMail("representation_receipt", {
+			siren: SIREN,
+			year: YEAR,
+			raisonSociale: RAISON_SOCIALE,
+		});
+
+		expect(mail.subject).toBe(
+			"Egapro - Représentation équilibrée : accusé de réception",
+		);
+		expect(mail.html).toContain(
+			"la déclaration des indicateurs de représentation équilibrée",
+		);
+		expect(mail.html).toContain(RAISON_SOCIALE);
+		expect(mail.html).toContain("SIREN :");
+		expect(mail.html).toContain(SIREN);
+		expect(mail.html).toContain(String(YEAR));
+		expect(mail.html).toContain("accuse réception de cette transmission");
+		expect(mail.html).toContain("démarche est désormais terminée");
+	});
+
+	it("representation_receipt closes the journey on the user space without any CSE follow-up", async () => {
+		const mail = await buildMail("representation_receipt", {
+			siren: SIREN,
+			year: YEAR,
+			raisonSociale: RAISON_SOCIALE,
+		});
+
+		expect(mail.html).toContain("Mon espace");
+		expect(mail.html).toContain(getMySpaceUrl());
+		expect(mail.html).not.toContain("/avis-cse");
+		expect(mail.html).not.toContain("/declaration-remuneration");
+	});
+
+	it("representation_receipt escapes the raisonSociale", async () => {
+		const mail = await buildMail("representation_receipt", {
+			siren: SIREN,
+			year: YEAR,
+			raisonSociale: "<script>alert(1)</script>",
+		});
+
+		expect(mail.html).not.toContain("<script>alert(1)</script>");
 	});
 
 	it("cycle_opening_info announces the declaration period", async () => {

--- a/packages/notifications/src/mails/builders/index.ts
+++ b/packages/notifications/src/mails/builders/index.ts
@@ -7,5 +7,6 @@ export { buildDeclarationDeadlineReminderMail } from "./declarationDeadlineRemin
 export { buildJointEvaluationReminderMail } from "./jointEvaluationReminder.js";
 export { buildJointEvaluationSubmittedMail } from "./jointEvaluationSubmitted.js";
 export { buildNextCycleHandoverMail } from "./nextCycleHandover.js";
+export { buildRepresentationReceiptMail } from "./representationReceipt.js";
 export { buildSecondDeclarationConfirmationMail } from "./secondDeclarationConfirmation.js";
 export { buildSecondDeclarationReminderMail } from "./secondDeclarationReminder.js";

--- a/packages/notifications/src/mails/builders/representationReceipt.tsx
+++ b/packages/notifications/src/mails/builders/representationReceipt.tsx
@@ -1,0 +1,44 @@
+import { renderEmail } from "../shared/render.js";
+import { getMySpaceUrl } from "../shared/urls.js";
+import {
+	EmailContactParagraph,
+	EmailCtaWithLink,
+	EmailGreeting,
+	EmailParagraph,
+	EmailReceiptDisclaimer,
+	EmailShell,
+	EmailSignature,
+} from "../template/index.js";
+import type { MailBuilder } from "../types.js";
+
+export const buildRepresentationReceiptMail: MailBuilder<
+	"representation_receipt"
+> = async ({ siren, year, raisonSociale }) => {
+	const subject = "Egapro - Représentation équilibrée : accusé de réception";
+	const previewText =
+		"L'administration du travail accuse réception de votre déclaration des indicateurs de représentation équilibrée.";
+
+	const { html, text } = await renderEmail(
+		<EmailShell previewText={previewText}>
+			<EmailGreeting>Bonjour,</EmailGreeting>
+			<EmailParagraph>
+				Vous avez transmis aux services du ministre chargé du Travail{" "}
+				<strong>
+					la déclaration des indicateurs de représentation équilibrée
+				</strong>{" "}
+				au titre de la période de référence {year}, concernant l&apos;entreprise{" "}
+				<strong>{raisonSociale}</strong> (SIREN : {siren}).
+			</EmailParagraph>
+			<EmailReceiptDisclaimer receiptNoun="déclaration" />
+			<EmailParagraph>
+				Votre démarche est désormais terminée. Vous pouvez à tout moment
+				consulter et télécharger le récapitulatif de cette déclaration depuis
+				votre espace.
+			</EmailParagraph>
+			<EmailCtaWithLink href={getMySpaceUrl()} label="Mon espace" />
+			<EmailContactParagraph />
+			<EmailSignature />
+		</EmailShell>,
+	);
+	return { subject, html, text };
+};

--- a/packages/notifications/src/mails/index.ts
+++ b/packages/notifications/src/mails/index.ts
@@ -8,6 +8,7 @@ import {
 	buildJointEvaluationReminderMail,
 	buildJointEvaluationSubmittedMail,
 	buildNextCycleHandoverMail,
+	buildRepresentationReceiptMail,
 	buildSecondDeclarationConfirmationMail,
 	buildSecondDeclarationReminderMail,
 } from "./builders/index.js";
@@ -31,6 +32,7 @@ export const MAIL_BUILDERS: MailBuilderRegistry = {
 	joint_evaluation_reminder: buildJointEvaluationReminderMail,
 	cse_opinion_reminder: buildCseOpinionReminderMail,
 	next_cycle_handover: buildNextCycleHandoverMail,
+	representation_receipt: buildRepresentationReceiptMail,
 };
 
 export function isNotificationType(value: unknown): value is NotificationType {

--- a/packages/notifications/src/mails/types.ts
+++ b/packages/notifications/src/mails/types.ts
@@ -1,9 +1,10 @@
 export const NOTIFICATION_TYPES = [
-	// Event-driven (4 — déclenchés par mutation tRPC / upload)
+	// Event-driven (5 — déclenchés par mutation tRPC / upload)
 	"declaration_confirmation",
 	"second_declaration_confirmation",
 	"cse_opinion_receipt",
 	"joint_evaluation_submitted",
+	"representation_receipt",
 	// Schedule-driven (7 — déclenchés par pg-boss cron)
 	"cycle_opening_info",
 	"declaration_deadline_reminder",
@@ -113,11 +114,16 @@ export type NextCycleHandoverPayload = {
 	nextYear: number;
 };
 
+export type RepresentationReceiptPayload = CompanyScopedPayload & {
+	raisonSociale: string;
+};
+
 export type NotificationPayloadMap = {
 	declaration_confirmation: DeclarationConfirmationPayload;
 	second_declaration_confirmation: SecondDeclarationConfirmationPayload;
 	cse_opinion_receipt: CseOpinionReceiptPayload;
 	joint_evaluation_submitted: JointEvaluationSubmittedPayload;
+	representation_receipt: RepresentationReceiptPayload;
 	cycle_opening_info: DeadlinePayload;
 	declaration_deadline_reminder: DeclarationDeadlineReminderPayload;
 	compliance_path_choice_reminder: CompliancePathChoiceReminderPayload;

--- a/packages/notifications/src/queue.ts
+++ b/packages/notifications/src/queue.ts
@@ -140,6 +140,14 @@ function validatePayloadForType(
 				? null
 				: "payload.raisonSociale must be a non-empty string";
 		}
+		case "representation_receipt": {
+			if (!isCompanyScoped(p)) {
+				return "payload requires { siren: string, year: number }";
+			}
+			return isNonEmptyString(p.raisonSociale)
+				? null
+				: "payload.raisonSociale must be a non-empty string";
+		}
 		case "cycle_opening_info": {
 			return isDeadlinePayload(p)
 				? null


### PR DESCRIPTION
Closes #4164

## Résumé

- **PDF récapitulatif** de la déclaration de représentation équilibrée (dernière version transmise) : `buildRepresentationPdfData.ts` + `RepresentationPdfDocument.tsx` (react-pdf, réutilise `pdfStyles`/`pdfFonts`), route auditée `/api/representation-pdf` (`AUDIT_ACTIONS.PDF_REPRESENTATION_DOWNLOAD`, catégorie `read_sensitive`, 401 sans session, 404 si aucune déclaration soumise, siren exclusivement dérivé de la session).
- **Accusé de réception email** à la soumission : nouveau type de notification `representation_receipt` (package `notifications`, template FR, sans variant), nouveau `ReceiptKind "representation"` dans `enqueueReceipt.ts`, enqueue dans `representationDeclaration.submit` (uniquement si succès de la mutation et email de session présent). Renvoi possible via le bouton de l'écran de confirmation (`ResendReceiptButton`, déjà générique).
- **Écran de confirmation** : les deux boutons posés désactivés par le ticket précédent (#4163) sont activés. Le lien de téléchargement PDF est rendu en **tuile de téléchargement DSFR** (composant partagé `DownloadCard`, déjà utilisé par les écrans jumeaux) suite à un correctif de fidélité Figma (`design-validator` REFACTO → PASS), avec un `h2` masqué ajouté pour préserver la hiérarchie de titres (h1 → h2 → h3).
- **Hardening sécurité** (suite audit) : `mail.resendReceipt` bascule sur `companyWriteProcedure` (bloque le renvoi d'accusé pendant une impersonation admin) ; la route PDF ignore désormais un paramètre `year` non numérique au lieu de le propager tel quel.

## Écran de confirmation

![Écran de confirmation — récapitulatif PDF](https://raw.githubusercontent.com/SocialGouv/egapro/design-assets/epic-3702/ticket-4164/confirmation-full-h1024.png)

## Vérification

- `pnpm typecheck` / `pnpm lint:check` / `pnpm format:check` verts sur `app` et `notifications`.
- `pnpm test` vert (5250 tests app + 163 notifications, 100% coverage sur les fichiers de logique du ticket).
- `functional-validator` : PASS (S20 vérifié en direct : PDF téléchargeable, job d'accusé enqueue en base ; S22/404/no-email-on-invalid-submit vérifiés par lecture de code).
- `design-validator` : PASS — mesures DOM vs node Figma `10546:135460` dans la tolérance, overlay onion-skin sans écart notable, sur 2 hauteurs de viewport.

## Test plan

- [x] S20 : soumission → PDF téléchargeable, accusé enqueue, renvoi possible
- [ ] S22 : re-soumission → le PDF reflète la dernière version transmise (vérifié par lecture de code, non rejoué en direct)
- [x] Route PDF : 401 sans session
- [ ] Route PDF : 404 si aucune déclaration soumise (vérifié par lecture de code)
- [ ] Aucun accusé envoyé si `submit` échoue la validation (vérifié par lecture de code)