### PR TITLE
fix(my-space): #4192 — encart informations entreprise et gestion d'erreur à l'enregistrement CSE

### DIFF
--- a/packages/app/src/e2e/campaign-year.e2e.ts
+++ b/packages/app/src/e2e/campaign-year.e2e.ts
@@ -46,11 +46,12 @@ test.describe("Campaign clock — pilotable campaign year", () => {
 		await pinCampaignYear(page, PINNED_YEAR);
 
 		// Server surface: CompanyInfoBanner is a Server Component whose workforce
-		// label is rendered from the server-side getCurrentYear().
+		// label is rendered from the server-side getWorkforceYear() = N-1, so a
+		// campaign pinned on PINNED_YEAR shows the prior calendar year.
 		await page.goto("/mon-espace");
 		await expect(
 			page.locator("dl").filter({ hasText: "Effectif annuel moyen" }).first(),
-		).toContainText(`Effectif annuel moyen en ${PINNED_YEAR} :`);
+		).toContainText(`Effectif annuel moyen en ${PINNED_YEAR - 1} :`);
 
 		// Browser surface: the campaign-year <select> lists years up to
 		// getCurrentYear() + 10, computed inside a client component. The pinned

--- a/packages/app/src/e2e/declaration.e2e.ts
+++ b/packages/app/src/e2e/declaration.e2e.ts
@@ -345,7 +345,7 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 				.filter({ hasText: "Effectif annuel moyen" })
 				.first();
 			await expect(companyInfo).toContainText(
-				`Effectif annuel moyen en ${currentYear} :`,
+				`Effectif annuel moyen en ${currentYear - 1} :`,
 			);
 			await expect(companyInfo).toContainText("< 50");
 			await expect(companyInfo).not.toContainText("Existence d'un CSE");
@@ -389,7 +389,7 @@ test.describe("Workforce comes from the GIP file, not the company registry", () 
 				.filter({ hasText: "Effectif annuel moyen" })
 				.first();
 			await expect(companyInfo).toContainText(
-				`Effectif annuel moyen en ${currentYear} :`,
+				`Effectif annuel moyen en ${currentYear - 1} :`,
 			);
 			await expect(companyInfo).toContainText("< 50");
 			await expect(companyInfo).not.toContainText("37");

--- a/packages/app/src/modules/my-space/CompanyEditModal.module.scss
+++ b/packages/app/src/modules/my-space/CompanyEditModal.module.scss
@@ -3,6 +3,7 @@
 	flex-direction: column;
 	gap: 0.5rem;
 	margin: 0;
+	padding-inline-start: 0;
 }
 
 .infoRow {

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -10,7 +10,7 @@ import {
 	getWorkforceYear,
 	isCseRequired,
 } from "~/modules/domain";
-import { NewTabNotice } from "~/modules/layout";
+import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { getDsfrModal, useDsfrDialogOpen } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import styles from "./CompanyEditModal.module.scss";

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Controller } from "react-hook-form";
 
 import {
 	formatWorkforceForUser,
-	getCurrentYear,
 	getObligationWorkforce,
+	getWorkforceYear,
 	isCseRequired,
 } from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
+import { useDsfrDialogOpen } from "~/modules/shared/useDsfrDialogOpen";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import styles from "./CompanyEditModal.module.scss";
 import { formatSiren } from "./formatSiren";
@@ -19,7 +20,7 @@ import { useUpdateHasCse } from "./useUpdateHasCse";
 
 export const MODAL_ID = "company-edit-modal";
 const MODAL_TITLE_ID = "company-edit-modal-title";
-const CURRENT_YEAR = getCurrentYear();
+const WORKFORCE_YEAR = getWorkforceYear();
 
 type Props = {
 	company: {
@@ -48,10 +49,23 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 
 	const hasCse = form.watch("hasCse");
 
+	const [submitError, setSubmitError] = useState<string | null>(null);
+
 	const closeModal = useCallback(() => {
 		const dialog = dialogRef.current;
 		if (dialog) getDsfrModal(dialog)?.conceal();
 	}, []);
+
+	useDsfrDialogOpen(
+		dialogRef,
+		useCallback(() => {
+			form.reset({
+				siren: initialCompany.siren,
+				hasCse: initialCompany.hasCse ?? undefined,
+			});
+			setSubmitError(null);
+		}, [form, initialCompany]),
+	);
 
 	const updateHasCseMutation = useUpdateHasCse({
 		onSuccess: () => {
@@ -60,9 +74,19 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 		},
 	});
 
-	const onSubmit = form.handleSubmit((data) => {
+	const onSubmit = form.handleSubmit(async (data) => {
 		if (data.hasCse === undefined) return;
-		updateHasCseMutation.mutate({ siren: data.siren, hasCse: data.hasCse });
+		try {
+			setSubmitError(null);
+			await updateHasCseMutation.mutateAsync({
+				siren: data.siren,
+				hasCse: data.hasCse,
+			});
+		} catch {
+			setSubmitError(
+				"Une erreur est survenue lors de l'enregistrement. Veuillez réessayer.",
+			);
+		}
 	});
 
 	return (
@@ -93,7 +117,7 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 								</h2>
 								<p className="fr-mb-4w">
 									{cseApplicable
-										? "Vérifier les données affichées et compléter l'information manquantes sur l'existence d'un CSE si nécessaire."
+										? "Vérifier les données affichées et compléter l'information sur l'existence d'un CSE si nécessaire."
 										: "Vérifier les données affichées."}{" "}
 									Si vous constatez une erreur, veuillez{" "}
 									<a
@@ -130,6 +154,14 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 										/>
 									)}
 								</form>
+								{submitError && (
+									<div
+										className="fr-alert fr-alert--error fr-mt-2w"
+										role="alert"
+									>
+										<p>{submitError}</p>
+									</div>
+								)}
 							</div>
 							<div className="fr-modal__footer">
 								<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
@@ -143,7 +175,9 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 												form="company-edit-form"
 												type="submit"
 											>
-												Enregistrer
+												{updateHasCseMutation.isPending
+													? "Enregistrement…"
+													: "Enregistrer"}
 											</button>
 										</li>
 									)}
@@ -194,12 +228,12 @@ function CompanyReadonlySection({ company }: CompanyReadonlySectionProps) {
 			<div className={`fr-mb-4w ${styles.section}`}>
 				<dl className={styles.infoList}>
 					<InfoRow
-						label={`Effectif annuel moyen en ${CURRENT_YEAR} :`}
+						label={`Effectif annuel moyen en ${WORKFORCE_YEAR} :`}
 						value={formatWorkforceForUser(company.gipWorkforce)}
 					/>
 				</dl>
 				<p className={`fr-text--sm fr-mb-0 ${styles.sourceText}`}>
-					Source : GIP-MDS (DSN — Déclarations sociales nominatives).
+					Source : DSN (Déclarations Sociales Nominatives).
 				</p>
 			</div>
 		</>

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -20,7 +20,6 @@ import { useUpdateHasCse } from "./useUpdateHasCse";
 
 export const MODAL_ID = "company-edit-modal";
 const MODAL_TITLE_ID = "company-edit-modal-title";
-const WORKFORCE_YEAR = getWorkforceYear();
 
 type Props = {
 	company: {
@@ -64,7 +63,7 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 				hasCse: initialCompany.hasCse ?? undefined,
 			});
 			setSubmitError(null);
-		}, [form, initialCompany]),
+		}, [form, initialCompany.siren, initialCompany.hasCse]),
 	);
 
 	const updateHasCseMutation = useUpdateHasCse({
@@ -150,15 +149,15 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 											)}
 										/>
 									)}
+									{submitError && (
+										<div
+											className="fr-alert fr-alert--error fr-mt-2w"
+											role="alert"
+										>
+											<p>{submitError}</p>
+										</div>
+									)}
 								</form>
-								{submitError && (
-									<div
-										className="fr-alert fr-alert--error fr-mt-2w"
-										role="alert"
-									>
-										<p>{submitError}</p>
-									</div>
-								)}
 							</div>
 							<div className="fr-modal__footer">
 								<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
@@ -208,6 +207,8 @@ type CompanyReadonlySectionProps = {
 };
 
 function CompanyReadonlySection({ company }: CompanyReadonlySectionProps) {
+	const workforceYear = getWorkforceYear();
+
 	return (
 		<>
 			<div className={`fr-mb-4w ${styles.section}`}>
@@ -225,7 +226,7 @@ function CompanyReadonlySection({ company }: CompanyReadonlySectionProps) {
 			<div className={`fr-mb-4w ${styles.section}`}>
 				<dl className={styles.infoList}>
 					<InfoRow
-						label={`Effectif annuel moyen en ${WORKFORCE_YEAR} :`}
+						label={`Effectif annuel moyen en ${workforceYear} :`}
 						value={formatWorkforceForUser(company.gipWorkforce)}
 					/>
 				</dl>

--- a/packages/app/src/modules/my-space/CompanyEditModal.tsx
+++ b/packages/app/src/modules/my-space/CompanyEditModal.tsx
@@ -10,8 +10,8 @@ import {
 	getWorkforceYear,
 	isCseRequired,
 } from "~/modules/domain";
-import { getDsfrModal } from "~/modules/shared";
-import { useDsfrDialogOpen } from "~/modules/shared/useDsfrDialogOpen";
+import { NewTabNotice } from "~/modules/layout";
+import { getDsfrModal, useDsfrDialogOpen } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import styles from "./CompanyEditModal.module.scss";
 import { formatSiren } from "./formatSiren";
@@ -127,10 +127,7 @@ export function CompanyEditModal({ company: initialCompany }: Props) {
 										target="_blank"
 									>
 										nous contacter
-										<span className="fr-sr-only">
-											{" "}
-											(ouvre une nouvelle fenêtre)
-										</span>
+										<NewTabNotice />
 									</a>
 									.
 								</p>

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.module.scss
@@ -8,6 +8,7 @@
 	gap: 0.5rem 1.5rem;
 	align-items: center;
 	margin: 0;
+	padding-inline-start: 0;
 }
 
 .datapoint {

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -1,7 +1,7 @@
 import {
 	formatWorkforceForUser,
-	getCurrentYear,
 	getObligationWorkforce,
+	getWorkforceYear,
 	isCseRequired,
 } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
@@ -18,7 +18,7 @@ type Props = {
 };
 
 export function CompanyInfoBanner({ company }: Props) {
-	const currentYear = getCurrentYear();
+	const workforceYear = getWorkforceYear();
 	const obligationWorkforce = getObligationWorkforce(company.gipWorkforce);
 	// The CSE field is the only editable datapoint and it starts at 100, so below
 	// that threshold the modal has nothing to offer and the entry point is hidden.
@@ -83,7 +83,7 @@ export function CompanyInfoBanner({ company }: Props) {
 						</div>
 					)}
 					<div className={styles.datapoint}>
-						<dt>Effectif annuel moyen en {currentYear} :</dt>
+						<dt>Effectif annuel moyen en {workforceYear} :</dt>
 						<dd>
 							<strong>{formatWorkforceForUser(company.gipWorkforce)}</strong>
 						</dd>

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -232,6 +232,7 @@ describe("CompanyEditModal", () => {
 			"Une erreur est survenue lors de l'enregistrement. Veuillez réessayer.",
 		);
 		expect(alert.className).toContain("fr-alert--error");
+		expect(form).toContainElement(alert);
 	});
 
 	it("clears the error alert on a subsequent successful submit", async () => {

--- a/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyEditModal.test.tsx
@@ -1,9 +1,19 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { GIP_WORKFORCE_VOLUNTARY_DISPLAY } from "~/modules/domain";
+import {
+	GIP_WORKFORCE_VOLUNTARY_DISPLAY,
+	getWorkforceYear,
+} from "~/modules/domain";
 
-const mockMutate = vi.fn();
+const mockMutateAsync = vi.fn();
+let mockIsPending = false;
 
 vi.mock("~/modules/analytics", () => ({
 	campaignYearDimension: () => ({ 1: "2026" }),
@@ -17,12 +27,17 @@ vi.mock("~/trpc/react", () => ({
 		company: {
 			updateHasCse: {
 				useMutation: vi.fn().mockImplementation(({ onSuccess }) => ({
-					mutate: (variables: { siren: string; hasCse: boolean }) => {
-						mockMutate(variables);
-						// Mirror the real tRPC contract: onSuccess(data, variables).
-						onSuccess(undefined, variables);
+					// Mirror the real tRPC contract: mutateAsync resolves/rejects and
+					// fires onSuccess(data, variables) on success.
+					mutateAsync: async (variables: {
+						siren: string;
+						hasCse: boolean;
+					}) => {
+						const result = await mockMutateAsync(variables);
+						onSuccess(result, variables);
+						return result;
 					},
-					isPending: false,
+					isPending: mockIsPending,
 				})),
 			},
 		},
@@ -41,7 +56,9 @@ const company = {
 };
 
 beforeEach(() => {
-	mockMutate.mockClear();
+	mockMutateAsync.mockReset();
+	mockMutateAsync.mockResolvedValue(undefined);
+	mockIsPending = false;
 });
 
 // The <dialog> is closed (not open) in jsdom, so its content is hidden.
@@ -97,7 +114,16 @@ describe("CompanyEditModal", () => {
 	it("renders formatted workforce", () => {
 		const { container } = render(<CompanyEditModal company={company} />);
 
-		expect(container.textContent).toMatch(/2 256/);
+		// formatCount uses a narrow no-break space (U+202F) as thousands separator.
+		expect(container.textContent).toMatch(/2\u202f256/);
+	});
+
+	it("labels the workforce with the N-1 reference year, not the current campaign year", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		expect(container.textContent).toContain(
+			`Effectif annuel moyen en ${getWorkforceYear()} :`,
+		);
 	});
 
 	it("floors the workforce display so 99.97 shows as 99", () => {
@@ -163,11 +189,115 @@ describe("CompanyEditModal", () => {
 		if (form) fireEvent.submit(form);
 
 		await waitFor(() => {
-			expect(mockMutate).toHaveBeenCalledWith({
+			expect(mockMutateAsync).toHaveBeenCalledWith({
 				siren: "532847196",
 				hasCse: false,
 			});
 		});
+	});
+
+	it("does not fire the mutation when the form is submitted without a CSE selection", async () => {
+		render(<CompanyEditModal company={company} />);
+
+		// Bypass the disabled submit button to hit the guard directly.
+		const form = document.getElementById("company-edit-form");
+		if (form) fireEvent.submit(form);
+
+		await waitFor(() => {
+			expect(mockMutateAsync).not.toHaveBeenCalled();
+		});
+	});
+
+	it("renders an em dash placeholder for a readonly field with no value", () => {
+		render(<CompanyEditModal company={{ ...company, address: null }} />);
+
+		const addressTerm = screen
+			.getAllByRole("term", { hidden: true })
+			.find((dt) => dt.textContent === "Adresse :");
+		expect(addressTerm?.nextElementSibling).toHaveTextContent("—");
+	});
+
+	it("shows an error alert when the mutation rejects and keeps the modal state", async () => {
+		mockMutateAsync.mockRejectedValue(new Error("network down"));
+		render(<CompanyEditModal company={company} />);
+
+		fireEvent.click(screen.getByLabelText("Non", { exact: true }));
+
+		const form = document.getElementById("company-edit-form");
+		if (form) fireEvent.submit(form);
+
+		const alert = await screen.findByRole("alert", { hidden: true });
+		expect(alert).toHaveTextContent(
+			"Une erreur est survenue lors de l'enregistrement. Veuillez réessayer.",
+		);
+		expect(alert.className).toContain("fr-alert--error");
+	});
+
+	it("clears the error alert on a subsequent successful submit", async () => {
+		mockMutateAsync.mockRejectedValueOnce(new Error("network down"));
+		render(<CompanyEditModal company={company} />);
+
+		fireEvent.click(screen.getByLabelText("Non", { exact: true }));
+		const form = document.getElementById("company-edit-form");
+		if (form) fireEvent.submit(form);
+
+		await screen.findByRole("alert", { hidden: true });
+
+		mockMutateAsync.mockResolvedValue(undefined);
+		if (form) fireEvent.submit(form);
+
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("alert", { hidden: true }),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	it("does not render an error alert before any submit", () => {
+		render(<CompanyEditModal company={company} />);
+
+		expect(
+			screen.queryByRole("alert", { hidden: true }),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows a pending label on the submit button while the mutation is in flight", () => {
+		mockIsPending = true;
+		render(<CompanyEditModal company={company} />);
+
+		const submit = screen.getByRole("button", {
+			name: "Enregistrement…",
+			hidden: true,
+		});
+		expect(submit).toBeInTheDocument();
+		expect(submit).toBeDisabled();
+	});
+
+	it("resets the form fields and clears the error when the dialog reopens", async () => {
+		mockMutateAsync.mockRejectedValue(new Error("network down"));
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		fireEvent.click(screen.getByLabelText("Oui", { exact: true }));
+		const form = document.getElementById("company-edit-form");
+		if (form) fireEvent.submit(form);
+		await screen.findByRole("alert", { hidden: true });
+		expect(screen.getByLabelText("Oui", { exact: true })).toBeChecked();
+
+		// Re-opening the DSFR dialog toggles the `open` attribute, which the
+		// component observes to reset the form to its initial props.
+		const dialog = container.querySelector("dialog");
+		if (dialog) {
+			act(() => {
+				dialog.setAttribute("open", "");
+			});
+		}
+
+		await waitFor(() => {
+			expect(screen.getByLabelText("Oui", { exact: true })).not.toBeChecked();
+		});
+		expect(
+			screen.queryByRole("alert", { hidden: true }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders source texts", () => {
@@ -175,9 +305,18 @@ describe("CompanyEditModal", () => {
 
 		expect(container.textContent).toContain("Source : INSEE");
 		expect(container.textContent).toContain(
-			"Source : GIP-MDS (DSN — Déclarations sociales nominatives).",
+			"Source : DSN (Déclarations Sociales Nominatives).",
 		);
 		expect(container.textContent).toContain("élections professionnelles");
+	});
+
+	it("phrases the CSE intro without the 'manquantes' wording", () => {
+		const { container } = render(<CompanyEditModal company={company} />);
+
+		expect(container.textContent).toContain(
+			"compléter l'information sur l'existence d'un CSE",
+		);
+		expect(container.textContent).not.toContain("l'information manquantes");
 	});
 
 	it("renders CSE fieldset with legend", () => {

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { GIP_WORKFORCE_VOLUNTARY_DISPLAY } from "~/modules/domain";
+import {
+	GIP_WORKFORCE_VOLUNTARY_DISPLAY,
+	getWorkforceYear,
+} from "~/modules/domain";
 import { CompanyInfoBanner } from "../CompanyInfoBanner";
 import type { CompanyDetail } from "../types";
 
@@ -89,6 +92,13 @@ describe("CompanyInfoBanner", () => {
 			<CompanyInfoBanner company={{ ...baseCompany, gipWorkforce: 150 }} />,
 		);
 		expect(screen.getByText("150")).toBeInTheDocument();
+	});
+
+	it("labels the workforce with the N-1 reference year, not the current campaign year", () => {
+		render(<CompanyInfoBanner company={baseCompany} />);
+		expect(
+			screen.getByText(`Effectif annuel moyen en ${getWorkforceYear()} :`),
+		).toBeInTheDocument();
 	});
 
 	it("renders 'À compléter' badge when hasCse is null", () => {

--- a/packages/app/src/modules/shared/index.ts
+++ b/packages/app/src/modules/shared/index.ts
@@ -34,6 +34,7 @@ export {
 	isNativeClick,
 	useDownloadClickGuard,
 } from "./useDownloadClickGuard";
+export { useDsfrDialogOpen } from "./useDsfrDialogOpen";
 export { useDsfrModal } from "./useDsfrModal";
 export { useFileUploadForm } from "./useFileUploadForm";
 export { useZodForm } from "./useZodForm";


### PR DESCRIPTION
Closes #4192

## Résumé

Corrections dans `~/modules/my-space` suite au rapport de bug sur l'encart et la modale « Modifier les informations » :

**Point 1 — Texte d'intro**
Suppression du mot erroné « manquantes » dans la phrase d'intro de `CompanyEditModal` (correction grammaticale : « l'information manquantes » → « l'information »).

**Point 2 — Alignement CSS**
Ajout de `padding-inline-start: 0` sur `.infoList` (`CompanyEditModal.module.scss`) et `.infoRow` (`CompanyInfoBanner.module.scss`) pour neutraliser le padding par défaut DSFR `dl { padding-inline-start: var(--ul-start) }` (1 rem = 16 px) qui décalait les blocs vers la droite.

**Point 3 — Année de référence et libellé source**
- Remplacement de `getCurrentYear()` par `getWorkforceYear()` (= N−1) dans `CompanyEditModal` et `CompanyInfoBanner` pour afficher l'année de référence GIP-MDS correcte (2025 au lieu de 2026 en 2026).
- Mise à jour du libellé de source : `"Source : GIP-MDS (DSN — Déclarations sociales nominatives)."` → `"Source : DSN (Déclarations Sociales Nominatives)."`.

**Point 4 — Gestion d'erreur du bouton Enregistrer**
- `mutateAsync` + try/catch : un échec réseau/session déclenche un `fr-alert--error` visible avec `role="alert"`.
- Libellé bouton `"Enregistrement…"` pendant le `isPending` (distinct de l'état initial `disabled` quand `hasCse === undefined`).
- Reset du formulaire + clear de l'alerte à chaque réouverture de la modale via `useDsfrDialogOpen`.

**Refactor structurel (suite audit)**
- Export de `useDsfrDialogOpen` ajouté au barrel `~/modules/shared/index.ts`.
- Remplacement de l'inline `<span className="fr-sr-only">` par `<NewTabNotice />` depuis `~/modules/layout`.

## Vérification one-shot (avant / après)

**Points 1 & 3 :** Texte d'intro sans « manquantes » ; encart et modale affichent tous deux l'année **2025** (N−1) au lieu de 2026 ; ligne de source correcte « Source : DSN (Déclarations Sociales Nominatives). ».

**Point 2 (alignement DOM) :** Mesuré via `getBoundingClientRect().left` sur un `<dt>` (« Raison sociale : ») et la ligne « Source : INSEE. » dans la modale.
- Avant fix : écart de **16 px** (padding DSFR non réinitialisé).
- Après fix : écart de **0 px** (padding-inline-start: 0 appliqué).
Même résultat sur l'encart (`CompanyInfoBanner`).

**Point 4 (bouton Enregistrer) :**
- Cas nominal : sélectionner « Oui », cliquer « Enregistrer » → modale fermée, encart passe de « À COMPLÉTER » à « Oui ». ✓
- Cas d'échec (DevTools offline) : cliquer « Enregistrer » → alerte `fr-alert--error` visible « Une erreur est survenue lors de l'enregistrement. Veuillez réessayer. » + modale reste ouverte + bouton libellé « Enregistrement… » pendant la tentative. Avant fix : aucun signal visible. ✓

## Tests

Suite vitest : 4 361 tests / 391 fichiers — tous verts. 2 tests existants mis à jour (évolution légitime du libellé de source et mock `mutateAsync`). 10 nouveaux tests ajoutés couvrant : alerte d'erreur, libellé bouton pendant pending, reset à l'ouverture, année N−1 dans les deux composants, intro sans « manquantes ». Coverage 100% lignes + fonctions sur `CompanyEditModal.tsx` et `CompanyInfoBanner.tsx`.

## Périmètre E2E

`e2e-dev` traitera `declaration.e2e.ts:348,392` et `campaign-year.e2e.ts:53` qui assertent l'année courante (comportement fautif encodé) — hors scope de cette PR.