### PR TITLE
fix(gip-mds): #4184 — réconcilier les démarches CSE après l'import GIP

### DIFF
--- a/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationFlags.test.ts
@@ -4,6 +4,7 @@ import { COMPANY_SIZE_ANNUAL_MIN } from "../shared/constants";
 import {
 	isComplianceProcessRequired,
 	isCseOpinionRequired,
+	resolveCseReconciliation,
 } from "../shared/declarationFlags";
 
 // Composed behavior (nominal, G guard, gap guard, revision boundaries) lives in
@@ -106,5 +107,88 @@ describe("isCseOpinionRequired", () => {
 				hasCse: true,
 			}),
 		).toBe(true);
+	});
+});
+
+// The reconciliation exists because the CSE requirement is snapshotted at
+// submission: when the GIP file later moves a company across the threshold, the
+// snapshot goes stale and only this rule says what the démarche owes (#4184).
+describe("resolveCseReconciliation", () => {
+	const parked = {
+		status: "awaiting_cse_opinion",
+		storedCseRequired: true,
+	} as const;
+
+	it("does nothing while the snapshot still matches the live answer", () => {
+		expect(
+			resolveCseReconciliation({ ...parked, workforce: 250, hasCse: true }),
+		).toBe("none");
+	});
+
+	it("releases a démarche parked on the CSE step once the headcount drops", () => {
+		expect(
+			resolveCseReconciliation({ ...parked, workforce: 87, hasCse: true }),
+		).toBe("release");
+	});
+
+	it("releases it too when the company left the GIP file", () => {
+		// A missing GIP row reads as a 0 headcount upstream, so the absence and a
+		// drop below the threshold are the same case — not two.
+		expect(
+			resolveCseReconciliation({ ...parked, workforce: 0, hasCse: true }),
+		).toBe("release");
+	});
+
+	it("releases it when the company answers it has no CSE", () => {
+		expect(
+			resolveCseReconciliation({ ...parked, workforce: 250, hasCse: false }),
+		).toBe("release");
+	});
+
+	it("keeps the démarche at the exact threshold", () => {
+		expect(
+			resolveCseReconciliation({
+				...parked,
+				workforce: COMPANY_SIZE_ANNUAL_MIN,
+				hasCse: true,
+			}),
+		).toBe("none");
+	});
+
+	it("only refreshes the snapshot away from the CSE step", () => {
+		// Elsewhere the engine reads the snapshot downstream, so realigning the
+		// column is enough — no transition to force.
+		expect(
+			resolveCseReconciliation({
+				status: "demarche_completed",
+				storedCseRequired: true,
+				workforce: 87,
+				hasCse: true,
+			}),
+		).toBe("refresh-snapshot");
+	});
+
+	it("refreshes the snapshot when a company becomes subject again", () => {
+		// The opposite direction needs no transition: the engine already accepts
+		// submit_cse_opinion from demarche_completed.
+		expect(
+			resolveCseReconciliation({
+				status: "demarche_completed",
+				storedCseRequired: false,
+				workforce: 250,
+				hasCse: true,
+			}),
+		).toBe("refresh-snapshot");
+	});
+
+	it("never releases a démarche that still owes its opinion", () => {
+		expect(
+			resolveCseReconciliation({
+				status: "awaiting_cse_opinion",
+				storedCseRequired: false,
+				workforce: 250,
+				hasCse: true,
+			}),
+		).toBe("refresh-snapshot");
 	});
 });

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -61,12 +61,15 @@ export type {
 	ComplianceProcessRequiredInput,
 	ComplianceProcessRevisionRequiredInput,
 	CseOpinionRequiredInput,
+	CseReconciliationInput,
+	CseReconciliationOutcome,
 	DeclarationForFlags,
 } from "./shared/declarationFlags";
 export {
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isCseOpinionRequired,
+	resolveCseReconciliation,
 } from "./shared/declarationFlags";
 // Declaration edit lock constants
 export {

--- a/packages/app/src/modules/domain/shared/declarationFlags.ts
+++ b/packages/app/src/modules/domain/shared/declarationFlags.ts
@@ -1,3 +1,4 @@
+import type { DeclarationFsmStatus } from "../types";
 import { COMPANY_SIZE_ANNUAL_MIN } from "./constants";
 import {
 	type DeclarationStatusEvent,
@@ -23,6 +24,38 @@ export type CseOpinionRequiredInput = {
  */
 export function isCseOpinionRequired(input: CseOpinionRequiredInput): boolean {
 	return input.workforce >= COMPANY_SIZE_ANNUAL_MIN && input.hasCse === true;
+}
+
+export type CseReconciliationInput = CseOpinionRequiredInput & {
+	status: DeclarationFsmStatus;
+	storedCseRequired: boolean;
+};
+
+/**
+ * What a démarche owes when its stored CSE requirement no longer matches the
+ * company's current headcount and CSE answer.
+ *
+ * `release` is the case the snapshot cannot recover from on its own: the
+ * démarche is parked on the CSE step, the opinion is no longer owed, and only a
+ * FSM transition gets it out. Everywhere else the snapshot is simply stale and
+ * refreshing it is enough, because the engine reads it downstream.
+ *
+ * Kept here rather than in the sync service so the per-company path and the
+ * post-import batch decide from the same rule — the batch selects a superset in
+ * SQL and asks this function, instead of re-expressing the rule as a predicate
+ * that could drift from it.
+ */
+export type CseReconciliationOutcome = "none" | "refresh-snapshot" | "release";
+
+export function resolveCseReconciliation(
+	input: CseReconciliationInput,
+): CseReconciliationOutcome {
+	const cseRequired = isCseOpinionRequired(input);
+	if (input.storedCseRequired === cseRequired) return "none";
+	if (cseRequired || input.status !== "awaiting_cse_opinion") {
+		return "refresh-snapshot";
+	}
+	return "release";
 }
 
 export type ComplianceProcessRequiredInput = {

--- a/packages/app/src/server/services/__tests__/gipMdsReconciliation.integration.test.ts
+++ b/packages/app/src/server/services/__tests__/gipMdsReconciliation.integration.test.ts
@@ -1,0 +1,196 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "~/env.js";
+import { db } from "~/server/db";
+import { importGipCsvToDb } from "../gipMds";
+
+// `importGipCsvToDb` had no coverage at all, and the bug it now fixes is only
+// observable against a real engine: the reconciliation runs after the import
+// transaction commits, and the "company left the file" case is produced by the
+// import's own DELETE, not by anything a mocked driver would replay (#4184).
+describe("importGipCsvToDb — CSE reconciliation (real Postgres, #4184)", () => {
+	let sql!: ReturnType<typeof postgres>;
+
+	const YEAR = 2033;
+	const SIREN_DROPS = "811111111";
+	const SIREN_REMOVED = "822222222";
+	const SIREN_STAYS = "833333333";
+	const SIREN_COMPLETED = "844444444";
+	const ALL_SIRENS = [SIREN_DROPS, SIREN_REMOVED, SIREN_STAYS, SIREN_COMPLETED];
+	const USER_ID = "cse-reconciliation-user";
+	const DECL_IDS = [
+		"cse-recon-drops",
+		"cse-recon-removed",
+		"cse-recon-stays",
+		"cse-recon-completed",
+	];
+
+	function buildCsv(entries: Array<{ siren: string; workforce: string }>) {
+		return [
+			"destinataire;projet;horodatage;date_debut;date_fin;nb_lignes",
+			`DGT;DTS;${YEAR}-08-04T16:31:32;${YEAR}-01-01;${YEAR}-12-31;${entries.length}`,
+			"SIREN;Effectif_RCD",
+			...entries.map((e) => `${e.siren};${e.workforce}`),
+		].join("\n");
+	}
+
+	// Every company stays in the file except the removed one, so the only
+	// difference between the two release cases is how the headcount vanished.
+	const csvAfterDrop = buildCsv([
+		{ siren: SIREN_DROPS, workforce: "87,00" },
+		{ siren: SIREN_STAYS, workforce: "150,00" },
+		{ siren: SIREN_COMPLETED, workforce: "80,00" },
+	]);
+
+	async function cleanup() {
+		await sql`DELETE FROM app_declaration_status_history WHERE declaration_id IN ${sql(DECL_IDS)}`;
+		await sql`DELETE FROM app_declaration WHERE id IN ${sql(DECL_IDS)}`;
+		await sql`DELETE FROM app_gip_mds_data WHERE year = ${YEAR}`;
+		await sql`DELETE FROM app_company WHERE siren IN ${sql(ALL_SIRENS)}`;
+		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
+	}
+
+	async function readDeclaration(id: string) {
+		const [row] = await sql`
+			SELECT d.status, d.cse_required,
+				(SELECT count(*)::int FROM app_declaration_status_history h
+				  WHERE h.declaration_id = d.id) AS history_count
+			FROM app_declaration d WHERE d.id = ${id}
+		`;
+		return row as {
+			status: string;
+			cse_required: boolean;
+			history_count: number;
+		};
+	}
+
+	beforeAll(() => {
+		sql = postgres(env.DATABASE_URL, { max: 1 });
+	});
+
+	afterAll(async () => {
+		if (!sql) return;
+		await cleanup();
+		await sql.end();
+	});
+
+	beforeEach(async () => {
+		await cleanup();
+
+		await sql`
+			INSERT INTO app_user (id, email, first_name, last_name)
+			VALUES (${USER_ID}, 'dir.rh@example.fr', 'Dir', 'RH')
+		`;
+		await sql`
+			INSERT INTO app_company (siren, name, workforce, has_cse)
+			VALUES
+				(${SIREN_DROPS},     'Entreprise Effectif En Baisse', 110, true),
+				(${SIREN_REMOVED},   'Entreprise Retiree Du Fichier', 130, true),
+				(${SIREN_STAYS},     'Entreprise Temoin',             150, true),
+				(${SIREN_COMPLETED}, 'Entreprise Deja Terminee',      120, true)
+		`;
+		await sql`
+			INSERT INTO app_gip_mds_data (siren, year, workforce_ema)
+			VALUES
+				(${SIREN_DROPS},     ${YEAR}, 110.00),
+				(${SIREN_REMOVED},   ${YEAR}, 130.00),
+				(${SIREN_STAYS},     ${YEAR}, 150.00),
+				(${SIREN_COMPLETED}, ${YEAR}, 120.00)
+		`;
+		await sql`
+			INSERT INTO app_declaration (id, siren, year, declarant_id, status, cse_required, created_at, updated_at)
+			VALUES
+				('cse-recon-drops',     ${SIREN_DROPS},     ${YEAR}, ${USER_ID}, 'awaiting_cse_opinion', true, NOW(), NOW()),
+				('cse-recon-removed',   ${SIREN_REMOVED},   ${YEAR}, ${USER_ID}, 'awaiting_cse_opinion', true, NOW(), NOW()),
+				('cse-recon-stays',     ${SIREN_STAYS},     ${YEAR}, ${USER_ID}, 'awaiting_cse_opinion', true, NOW(), NOW()),
+				('cse-recon-completed', ${SIREN_COMPLETED}, ${YEAR}, ${USER_ID}, 'demarche_completed',   true, NOW(), NOW())
+		`;
+	});
+
+	it("releases a démarche whose headcount fell under the CSE threshold", async () => {
+		await importGipCsvToDb(db, csvAfterDrop);
+
+		const row = await readDeclaration("cse-recon-drops");
+		expect(row.status).toBe("demarche_completed");
+		expect(row.cse_required).toBe(false);
+		expect(row.history_count).toBe(1);
+	});
+
+	it("releases a démarche whose company left the GIP file", async () => {
+		// The import's own DELETE removes the row; a missing headcount reads as 0,
+		// which is the same rule as a drop — this is the half a naive predicate
+		// filtering on `workforce_ema < threshold` silently misses.
+		await importGipCsvToDb(db, csvAfterDrop);
+
+		const row = await readDeclaration("cse-recon-removed");
+		expect(row.status).toBe("demarche_completed");
+		expect(row.cse_required).toBe(false);
+		expect(row.history_count).toBe(1);
+	});
+
+	it("leaves a démarche that still owes its opinion untouched", async () => {
+		await importGipCsvToDb(db, csvAfterDrop);
+
+		const row = await readDeclaration("cse-recon-stays");
+		expect(row.status).toBe("awaiting_cse_opinion");
+		expect(row.cse_required).toBe(true);
+		expect(row.history_count).toBe(0);
+	});
+
+	it("refreshes the stale snapshot without transitioning a finished démarche", async () => {
+		await importGipCsvToDb(db, csvAfterDrop);
+
+		const row = await readDeclaration("cse-recon-completed");
+		expect(row.status).toBe("demarche_completed");
+		expect(row.cse_required).toBe(false);
+		expect(row.history_count).toBe(0);
+	});
+
+	it("counts the démarches it realigned", async () => {
+		const result = await importGipCsvToDb(db, csvAfterDrop);
+
+		expect(result).toMatchObject({ year: YEAR, reconciled: 3, failed: 0 });
+	});
+
+	it("changes nothing when the same file is imported twice", async () => {
+		await importGipCsvToDb(db, csvAfterDrop);
+		const afterFirst = await Promise.all(DECL_IDS.map(readDeclaration));
+
+		const second = await importGipCsvToDb(db, csvAfterDrop);
+
+		expect(second.reconciled).toBe(0);
+		expect(await Promise.all(DECL_IDS.map(readDeclaration))).toEqual(
+			afterFirst,
+		);
+	});
+
+	it("reconciles nothing when no headcount crossed the threshold", async () => {
+		const unchanged = buildCsv([
+			{ siren: SIREN_DROPS, workforce: "110,00" },
+			{ siren: SIREN_REMOVED, workforce: "130,00" },
+			{ siren: SIREN_STAYS, workforce: "150,00" },
+			{ siren: SIREN_COMPLETED, workforce: "120,00" },
+		]);
+
+		const result = await importGipCsvToDb(db, unchanged);
+
+		expect(result.reconciled).toBe(0);
+		const row = await readDeclaration("cse-recon-drops");
+		expect(row.status).toBe("awaiting_cse_opinion");
+		expect(row.cse_required).toBe(true);
+	});
+
+	it("attributes the release to no user, since a batch triggered it", async () => {
+		await importGipCsvToDb(db, csvAfterDrop);
+
+		const [event] = await sql`
+			SELECT event_type, actor_user_id
+			FROM app_declaration_status_history
+			WHERE declaration_id = 'cse-recon-drops'
+		`;
+		expect(event).toMatchObject({
+			event_type: "demarche_complete",
+			actor_user_id: null,
+		});
+	});
+});

--- a/packages/app/src/server/services/cseRequirementSync.ts
+++ b/packages/app/src/server/services/cseRequirementSync.ts
@@ -1,13 +1,25 @@
 import "server-only";
 
-import { isCseOpinionRequired } from "~/modules/domain";
+import { and, eq } from "drizzle-orm";
+import {
+	getObligationWorkforce,
+	isCseOpinionRequired,
+	parseGipWorkforce,
+	resolveCseReconciliation,
+} from "~/modules/domain";
 import { activeDeclarationFilter } from "~/server/api/routers/declarationHelpers";
 import {
 	buildHistoryInserts,
 	computeProjectionUpdates,
 } from "~/server/api/routers/statusHistoryHelpers";
 import type { DB } from "~/server/db";
-import { declarationStatusHistory, declarations } from "~/server/db/schema";
+import { notCancelledCondition } from "~/server/db/declarationConditions";
+import {
+	companies,
+	declarationStatusHistory,
+	declarations,
+	gipMdsData,
+} from "~/server/db/schema";
 import { applyAction, loadRules } from "~/server/rules/engine";
 
 type SyncArgs = {
@@ -18,6 +30,53 @@ type SyncArgs = {
 	hasCse: boolean | null;
 	actorUserId: string | null;
 };
+
+type ReconcileTarget = {
+	id: string;
+	siren: string;
+	status: Parameters<typeof resolveCseReconciliation>[0]["status"];
+	rulesVersion: string;
+	storedCseRequired: boolean;
+	workforce: number;
+	hasCse: boolean | null;
+};
+
+async function applyOutcome(
+	db: DB,
+	target: ReconcileTarget,
+	year: number,
+	actorUserId: string | null,
+): Promise<boolean> {
+	const outcome = resolveCseReconciliation(target);
+	if (outcome === "none") return false;
+
+	const cseRequired = isCseOpinionRequired(target);
+
+	if (outcome === "refresh-snapshot") {
+		await db
+			.update(declarations)
+			.set({ cseRequired, updatedAt: new Date() })
+			.where(activeDeclarationFilter(target.siren, year));
+		return true;
+	}
+
+	const { nextStatus, events } = applyAction(
+		{ currentState: target.status, cseRequired },
+		"sync_cse_requirement",
+		loadRules(target.rulesVersion),
+	);
+	const projection = computeProjectionUpdates(events, nextStatus);
+	const historyInserts = buildHistoryInserts(target.id, events, actorUserId);
+
+	await db.transaction(async (tx) => {
+		await tx.insert(declarationStatusHistory).values(historyInserts);
+		await tx
+			.update(declarations)
+			.set({ ...projection, cseRequired, updatedAt: new Date() })
+			.where(activeDeclarationFilter(target.siren, year));
+	});
+	return true;
+}
 
 /**
  * Realign the active declaration on the company's current CSE answer.
@@ -42,43 +101,119 @@ export async function syncCseRequirement({
 	hasCse,
 	actorUserId,
 }: SyncArgs): Promise<void> {
-	const cseRequired = isCseOpinionRequired({ workforce, hasCse });
-
 	const [declaration] = await db
 		.select()
 		.from(declarations)
 		.where(activeDeclarationFilter(siren, year))
 		.limit(1);
 
-	if (!declaration || declaration.cseRequired === cseRequired) return;
+	if (!declaration) return;
 
-	// Only a démarche parked on the CSE step needs to be unblocked; anywhere
-	// else refreshing the snapshot is enough, the engine reads it downstream.
-	if (cseRequired || declaration.status !== "awaiting_cse_opinion") {
-		await db
-			.update(declarations)
-			.set({ cseRequired, updatedAt: new Date() })
-			.where(activeDeclarationFilter(siren, year));
-		return;
-	}
-
-	const { nextStatus, events } = applyAction(
-		{ currentState: declaration.status, cseRequired },
-		"sync_cse_requirement",
-		loadRules(declaration.rulesVersion),
-	);
-	const projection = computeProjectionUpdates(events, nextStatus);
-	const historyInserts = buildHistoryInserts(
-		declaration.id,
-		events,
+	await applyOutcome(
+		db,
+		{
+			id: declaration.id,
+			siren,
+			status: declaration.status,
+			rulesVersion: declaration.rulesVersion,
+			storedCseRequired: declaration.cseRequired,
+			workforce,
+			hasCse,
+		},
+		year,
 		actorUserId,
 	);
+}
 
-	await db.transaction(async (tx) => {
-		await tx.insert(declarationStatusHistory).values(historyInserts);
-		await tx
-			.update(declarations)
-			.set({ ...projection, cseRequired, updatedAt: new Date() })
-			.where(activeDeclarationFilter(siren, year));
-	});
+/**
+ * Realign every démarche of a campaign year after the GIP file has been
+ * reimported.
+ *
+ * This is the trigger the per-company path cannot be: a headcount changes
+ * because a batch reimported the GIP file, not because a user answered a
+ * question — and `updateHasCse`, the only other caller, sits behind a guard that
+ * rejects any company under the CSE threshold. A démarche parked on the CSE step
+ * whose headcount then drops below the threshold had no way out at all.
+ *
+ * Selection stays deliberately dumb: every active declaration of the year whose
+ * snapshot still claims an opinion is owed. That is a small superset — the rule
+ * itself is applied by `resolveCseReconciliation`, so the batch and the
+ * per-company path cannot disagree, and no SQL predicate can drift from the
+ * domain the day the threshold moves.
+ *
+ * A company that disappeared from the file is covered by the same rule as one
+ * whose headcount dropped: the left join yields no row, and
+ * `getObligationWorkforce` reads a missing headcount as 0.
+ *
+ * Runs after the import transaction commits, so a failure here cannot roll the
+ * import back. Failures are per-declaration and non-fatal: a concurrent import
+ * may have released the same démarche already, which the engine rejects because
+ * `awaiting_cse_opinion` is no longer the current state.
+ */
+export async function reconcileCseRequirementForYear({
+	db,
+	year,
+}: {
+	db: DB;
+	year: number;
+}): Promise<{ reconciled: number; failed: number }> {
+	const rows = await db
+		.select({
+			id: declarations.id,
+			siren: declarations.siren,
+			status: declarations.status,
+			rulesVersion: declarations.rulesVersion,
+			storedCseRequired: declarations.cseRequired,
+			workforceEma: gipMdsData.workforceEma,
+			hasCse: companies.hasCse,
+		})
+		.from(declarations)
+		.innerJoin(companies, eq(companies.siren, declarations.siren))
+		.leftJoin(
+			gipMdsData,
+			and(
+				eq(gipMdsData.siren, declarations.siren),
+				eq(gipMdsData.year, declarations.year),
+			),
+		)
+		.where(
+			and(
+				eq(declarations.year, year),
+				eq(declarations.cseRequired, true),
+				notCancelledCondition(),
+			),
+		);
+
+	let reconciled = 0;
+	let failed = 0;
+
+	for (const row of rows) {
+		try {
+			const changed = await applyOutcome(
+				db,
+				{
+					id: row.id,
+					siren: row.siren,
+					status: row.status,
+					rulesVersion: row.rulesVersion,
+					storedCseRequired: row.storedCseRequired,
+					workforce: getObligationWorkforce(
+						parseGipWorkforce(row.workforceEma),
+					),
+					hasCse: row.hasCse,
+				},
+				year,
+				null,
+			);
+			if (changed) reconciled += 1;
+		} catch (error) {
+			failed += 1;
+			console.error(
+				`[cse-requirement-sync] reconciliation failed for declaration ${row.id}`,
+				error,
+			);
+		}
+	}
+
+	return { reconciled, failed };
 }

--- a/packages/app/src/server/services/gipMds.ts
+++ b/packages/app/src/server/services/gipMds.ts
@@ -5,6 +5,7 @@ import type { GipMdsRow } from "~/modules/declaration-remuneration/shared/gipMds
 import { CSV_TO_SCHEMA_MAP } from "~/modules/declaration-remuneration/shared/gipMdsMapping";
 import type { DB } from "~/server/db";
 import { campaignDeadlines, companies, gipMdsData } from "~/server/db/schema";
+import { reconcileCseRequirementForYear } from "./cseRequirementSync";
 import { suitAwareFetch } from "./suitClient";
 import { fetchCompanyBySiren } from "./weez";
 
@@ -248,6 +249,10 @@ export type GipImportResult = {
 	gipPublicationDate: string | null;
 	gipPublicationDateUpdated: boolean;
 	gipPublicationDateSkipReason?: GipPublicationSkipReason;
+	/** Démarches whose CSE requirement the import realigned. */
+	reconciled: number;
+	/** Démarches the reconciliation could not realign; the import still stands. */
+	failed: number;
 };
 
 /**
@@ -265,11 +270,15 @@ export async function importGipCsvToDb(
 	const year = yearFromPeriodEnd(metadata.periodEnd);
 
 	if (rows.length === 0) {
+		// An empty file leaves every headcount untouched, so nothing can have
+		// become stale — the reconciliation would have no candidate to find.
 		return {
 			year,
 			rowCount: 0,
 			gipPublicationDate: null,
 			gipPublicationDateUpdated: false,
+			reconciled: 0,
+			failed: 0,
 		};
 	}
 
@@ -344,9 +353,15 @@ export async function importGipCsvToDb(
 		},
 	);
 
+	// After the commit, never inside it: the reconciliation reads the headcounts
+	// this import just wrote, and a failure to realign a démarche must not roll
+	// back the import itself.
+	const reconciliation = await reconcileCseRequirementForYear({ db, year });
+
 	return {
 		year,
 		rowCount: rows.length,
 		...publicationOutcome,
+		...reconciliation,
 	};
 }


### PR DESCRIPTION
Closes #4184

Une démarche parquée en `awaiting_cse_opinion` dont l'effectif GIP repasse sous 100 salariés ne pouvait plus jamais en sortir.

## Le déclencheur était le mauvais

`declarations.cse_required` est snapshotté à la soumission, pour que les gardes du moteur restent stables sur tout le cycle. Quand l'assujettissement change ensuite, seul `syncCseRequirement` peut réaligner ce snapshot — et son **unique appelant** est `updateHasCse`, situé **après** le `throw` de la garde des 100 salariés. À l'effectif où la réconciliation devient nécessaire, la garde rejette systématiquement l'appel qui la déclencherait.

Le vrai sujet n'était donc pas la garde : un effectif change parce qu'un **batch réimporte le fichier GIP**, pas parce qu'un usager répond à une question. La réconciliation est câblée sur l'import.

Aucun changement du moteur FSM : la transition `cse_no_longer_required` existait déjà et fonctionne. Elle n'était simplement jamais atteinte.

## Symptôme côté usager

Ce n'est pas une boucle de redirection. `/avis-cse` recalcule le besoin d'avis sur les données **live** et redirige vers la page de confirmation du parcours — une page terminale — pendant que `mon-espace` câble son CTA sur le **snapshot** stocké. L'usager voyait donc indéfiniment « Continuer », chaque clic aboutissant à un écran lui annonçant que le parcours était terminé. L'étape CSE était même masquée du stepper alors que le CTA persistait. Aucune surface usager ne pouvait nettoyer le snapshot : les trois appelants de `updateHasCse` sont tous gatés côté client sur le même seuil.

## Ce qui change

- **`importGipCsvToDb`** appelle la réconciliation **après le commit** de sa transaction — jamais dedans : elle lit les effectifs que l'import vient d'écrire, et un échec de réalignement ne doit pas annuler l'import.
- **`reconcileCseRequirementForYear`** réaligne toutes les démarches de l'année importée, en une passe.
- **`resolveCseReconciliation`** rejoint le domaine : c'est elle qui dit ce qu'une démarche doit (`none` / `refresh-snapshot` / `release`).
- **`GipImportResult`** expose `reconciled` et `failed`, pour que le cron et l'admin aient une trace du travail fait.
- **`docs/features.md`** n'est pas touchée par cette PR. La ligne « pas de cron en V2 » est factuellement périmée (le CronJob quotidien existe dans `.kontinuous/templates/gip-mds-import-cron.yaml`), mais la mise à jour de la doc est laissée hors périmètre : ce correctif ne change que le comportement.

## Deux décisions qui méritent le détour

**1. La sélection SQL reste volontairement bête.** Elle prend toutes les déclarations actives de l'année dont le snapshot prétend encore qu'un avis est dû — un petit sur-ensemble — et c'est la **fonction de domaine** qui tranche ensuite, déclaration par déclaration.

L'alternative était un prédicat SQL exprimant la règle, doublé d'un test de parité pour l'empêcher de dériver. Sélectionner un sur-ensemble et déléguer la décision au domaine supprime le problème au lieu de le tester : il n'y a **qu'une** implémentation de la règle, donc rien ne peut diverger le jour où le seuil bouge. Le coût est proportionnel au nombre de candidats, pas à la taille du fichier GIP.

**2. Le piège que cette approche évite.** Un prédicat naïf du type `INNER JOIN` sur le GIP + `workforce_ema < seuil` trouve **un candidat au lieu de deux** : il rate le cas « entreprise retirée du fichier », et cette moitié du bug est silencieuse — elle ne casse aucun test existant. En laissant `getObligationWorkforce` lire un effectif manquant comme 0, l'absence et la baisse deviennent le même cas, ce qu'elles sont métier.

Les échecs sont par déclaration et non fatals : un import concurrent peut avoir déjà libéré la même démarche, ce que le moteur rejette puisque `awaiting_cse_opinion` n'est alors plus l'état courant. L'import ne doit pas tomber pour autant.

## Vérification

`importGipCsvToDb` n'avait **aucun test** — elle n'apparaissait que mockée. Le correctif arrive avec un test d'intégration sur un vrai Postgres, qui appelle la **vraie** fonction d'import avec un fichier GIP reconstruit :

| Cas | Attendu | Vérifié |
|---|---|---|
| Effectif 110 → 87 | libérée, snapshot à `false`, +1 ligne d'historique | ✅ |
| Entreprise **retirée** du fichier | idem — l'absence vaut un effectif 0 | ✅ |
| Effectif 150 inchangé (témoin) | reste en `awaiting_cse_opinion` | ✅ |
| Démarche déjà terminée, effectif 120 → 80 | snapshot rafraîchi, **aucune** transition ni ligne d'historique | ✅ |
| Même fichier réimporté | idempotent, `reconciled: 0`, état identique | ✅ |
| Aucun franchissement de seuil | `reconciled: 0` | ✅ |
| Acteur de la transition | `actor_user_id` nul — c'est un batch | ✅ |

`pnpm typecheck`, `pnpm lint:check`, `pnpm format:check` verts. **4405 tests** unitaires (app) + **156** (notifications) verts, plus 8 tests d'intégration.

`audit-domain-leaks.sh` : conforme à la baseline d'`alpha` (1 ERROR pré-existante hors périmètre dans `modules/declaration/schemas.ts`, 7 WARN), **aucune entrée nouvelle**.

## Ce que je n'ai pas fait, et pourquoi

- **Pas de backfill.** Le CronJob tourne chaque nuit : sur review et préprod, l'existant se débloque sous 24 h. Et en **production**, il n'y a aujourd'hui pas de ConfigMap `gip-mds`, donc `EGAPRO_GIP_MDS_API_URL` est absente et les deux entrées de l'import répondent 412 — choix délibéré pour ne pas écraser les données déclarantes. Il n'existe donc **aucune population échouée à rattraper**. Corollaire à connaître : le correctif restera **dormant en prod** jusqu'à ce que l'URL soit configurée ; le jour où elle le sera, le premier import créera le risque et le résoudra dans la même passe.
- **Pas d'assouplissement de la garde `updateHasCse`.** Elle reste légitime à effectif ≥ 100, et l'appel à `syncCseRequirement` y reste : il couvre le changement de réponse CSE, qui est bien une action usager.
- **Pas de nouvelle clé d'audit.** La transition écrit déjà `declaration_status_history` avec un `actor_user_id` nul, ce qui est la trace canonique. À noter comme suite possible : la route d'import est tracée par `GIP_MDS_IMPORT` mais sans `resolveContext`, donc sans aucune métadonnée — ni année, ni nombre de lignes, ni désormais nombre de réconciliations.

## Constaté au passage, hors périmètre

- `DbLike` (`statusHistoryHelpers.ts:167`) résout à `never` — une précédence d'opérateurs — et n'a aucun consommateur. C'est pourquoi il n'a pas été réutilisé ici.
- Le `curl` du CronJob plafonne à `--max-time 120` sans `activeDeadlineSeconds`, alors que la route est synchrone et que l'import fait déjà un `DELETE`+`INSERT` complet plus un appel externe par SIREN inconnu. Si le client abandonne, la transaction serveur continue. Préexistant, sans lien avec ce correctif.

