### PR TITLE
fix(declaration-remuneration): #4205 — retire l'écart de la ligne Total du 7e indicateur

### DIFF
--- a/packages/app/src/e2e/export-declarations.e2e.ts
+++ b/packages/app/src/e2e/export-declarations.e2e.ts
@@ -7,11 +7,15 @@ import { completeDeclaration } from "./helpers/declaration-flows";
  * End-to-end test for the SUIT declarations export contract
  * (`GET /api/v1/export/declarations`).
  *
- * Non-regression guard for #3942: the indicator G (indicateur 7) categories
- * used to serialize only the raw declared amounts, never the computed pay
- * gaps. This exercises the full HTTP + gateway auth + DB + serialization
- * chain against a real running server to prove the six `*_ecart` fields are
- * now emitted per category — something the DB-mocking unit tests cannot.
+ * Non-regression guard for #3942 and #4205: the indicator G (indicateur 7)
+ * categories used to serialize only the raw declared amounts, never the
+ * computed pay gaps. #3942 added the per-category `*_ecart` fields; #4205
+ * then deliberately dropped the two `*_total_ecart` fields (the total-row gap
+ * was removed from the declaration UI as it is decorative and enters no
+ * business rule), leaving four `*_ecart` fields per category. This exercises
+ * the full HTTP + gateway auth + DB + serialization chain against a real
+ * running server to prove the four fields are emitted — and the two total
+ * fields are absent — something the DB-mocking unit tests cannot.
  *
  * A declaration is submitted through the real 6-step funnel so the indicator
  * G category carries known base amounts (women 1000 / men 1100), then read
@@ -26,13 +30,18 @@ test.describe.configure({ mode: "serial" });
 // the `X-Gateway-Forwarded` header. Not a secret.
 const DEV_GATEWAY_SHARED_SECRET = "dev-gateway-shared-secret-minimum-32-chars";
 
-// The six computed gap fields the export must expose per indicator G category.
+// The four computed gap fields the export must expose per indicator G category.
 const ECART_KEYS = [
 	"Rem_annuelle_base_ecart",
 	"Rem_annuelle_variable_ecart",
-	"Rem_annuelle_total_ecart",
 	"Taux_horaire_base_ecart",
 	"Taux_horaire_variable_ecart",
+] as const;
+
+// Dropped in #4205: the total-row gap is decorative and enters no business
+// rule, so the export contract no longer exposes these two fields.
+const REMOVED_ECART_KEYS = [
+	"Rem_annuelle_total_ecart",
 	"Taux_horaire_total_ecart",
 ] as const;
 
@@ -53,7 +62,7 @@ test.describe("SUIT declarations export — indicator G computed gaps", () => {
 		await resetDeclarationToDraft();
 	});
 
-	test("emits the six *_ecart fields per indicator G category with the signed (H−F)/H convention", async ({
+	test("emits the four *_ecart fields per indicator G category with the signed (H−F)/H convention and no total gap", async ({
 		page,
 		browser,
 	}) => {
@@ -78,10 +87,15 @@ test.describe("SUIT declarations export — indicator G computed gaps", () => {
 			expect(Array.isArray(categories)).toBe(true);
 			expect(categories.length).toBeGreaterThan(0);
 
-			// Every category must carry the six computed-gap fields (the bug: absent).
+			// Every category must carry the four computed-gap fields (the #3942
+			// bug: absent) and must NOT carry the two total-gap fields dropped
+			// in #4205 (regression guard for the deliberate contract change).
 			for (const category of categories) {
 				for (const key of ECART_KEYS) {
 					expect(category).toHaveProperty(key);
+				}
+				for (const key of REMOVED_ECART_KEYS) {
+					expect(category).not.toHaveProperty(key);
 				}
 			}
 
@@ -96,9 +110,8 @@ test.describe("SUIT declarations export — indicator G computed gaps", () => {
 			);
 			expect(filled).toBeDefined();
 
-			// Every measure carries the same pair, so every gap is the same:
-			// (1100 − 1000) / 1100 = 0.0909, rounded to 4 decimals. The totals
-			// (base + variable) scale identically: (2200 − 2000) / 2200.
+			// Every measure carries the same pair, so every remaining gap is the
+			// same: (1100 − 1000) / 1100 = 0.0909, rounded to 4 decimals.
 			for (const key of ECART_KEYS) {
 				expect(filled[key]).toBe(0.0909);
 			}

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/CategoryRecapTable.tsx
@@ -1,7 +1,6 @@
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import {
 	computeGap,
-	computeGapBetween,
 	computeTotal,
 	computeWorkforceTotal,
 	formatCurrency,
@@ -64,10 +63,6 @@ export function CategoryRecapTable({
 		category.annualVariableWomen ?? "",
 		category.annualVariableMen ?? "",
 	);
-	const annualTotalGap =
-		annualWomenSum !== null && annualMenSum !== null
-			? computeGapBetween(annualWomenSum, annualMenSum)
-			: null;
 
 	const hourlyBaseGap = computeGap(
 		category.hourlyBaseWomen ?? "",
@@ -77,10 +72,6 @@ export function CategoryRecapTable({
 		category.hourlyVariableWomen ?? "",
 		category.hourlyVariableMen ?? "",
 	);
-	const hourlyTotalGap =
-		hourlyWomenSum !== null && hourlyMenSum !== null
-			? computeGapBetween(hourlyWomenSum, hourlyMenSum)
-			: null;
 
 	const heading = `Catégorie d'emplois n°${index + 1}${category.name ? ` : ${category.name}` : ""}`;
 
@@ -95,7 +86,9 @@ export function CategoryRecapTable({
 								<caption>{`${heading} – ${declarationYear}`}</caption>
 								<thead>
 									<tr>
-										<th scope="col" />
+										<th scope="col">
+											<span className="fr-sr-only">Donnée</span>
+										</th>
 										<th scope="col">Femmes</th>
 										<th scope="col">Hommes</th>
 										<th scope="col">
@@ -162,8 +155,8 @@ export function CategoryRecapTable({
 										<td className={indicatorStyles.numeric}>
 											<strong>{formatTotal(annualMenSum, "€")}</strong>
 										</td>
-										<td className={indicatorStyles.gapNumeric}>
-											<GapCell gap={annualTotalGap} />
+										<td>
+											<span className="fr-sr-only">Non applicable</span>
 										</td>
 									</tr>
 
@@ -208,8 +201,8 @@ export function CategoryRecapTable({
 										<td className={indicatorStyles.numeric}>
 											<strong>{formatTotal(hourlyMenSum, "€")}</strong>
 										</td>
-										<td className={indicatorStyles.gapNumeric}>
-											<GapCell gap={hourlyTotalGap} />
+										<td>
+											<span className="fr-sr-only">Non applicable</span>
 										</td>
 									</tr>
 								</tbody>

--- a/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/recapitulatif/__tests__/CategoryRecapTable.test.tsx
@@ -125,7 +125,7 @@ describe("CategoryRecapTable", () => {
 		expect(screen.queryByText("élevé")).not.toBeInTheDocument();
 	});
 
-	it("computes annual and hourly total gaps from base + variable components", () => {
+	it("flags 'élevé' badges on base/variable rows without computing a Total gap (#4205)", () => {
 		render(
 			<CategoryRecapTable
 				category={makeCategory({
@@ -142,25 +142,32 @@ describe("CategoryRecapTable", () => {
 				index={0}
 			/>,
 		);
-		// Annual total gap: |((35000 - 32000) / 35000) * 100| = 8,6 % → élevé.
-		// Hourly total gap: |((22 - 19) / 22) * 100| = 13,6 % → élevé.
-		expect(screen.getAllByText("élevé").length).toBeGreaterThanOrEqual(2);
-		expect(screen.getAllByRole("row").length).toBeGreaterThan(0);
+		// Annual base 6,25 % + variable 33 % + hourly base 10 % + hourly variable 50 %
+		// → 4 base/variable badges, none from the (removed) Total gap.
+		expect(screen.getAllByText("élevé")).toHaveLength(4);
 	});
 
-	it("renders '- %' for the total gap when the men total is zero", () => {
+	it("renders no Total gap value, only the 'Non applicable' alternative (#4205)", () => {
 		render(
 			<CategoryRecapTable
 				category={makeCategory({
-					annualBaseWomen: "1000",
-					annualBaseMen: "0",
+					annualBaseWomen: "90",
+					annualBaseMen: "100",
+					annualVariableWomen: "40",
+					annualVariableMen: "50",
+					hourlyBaseWomen: "18",
+					hourlyBaseMen: "20",
+					hourlyVariableWomen: "1",
+					hourlyVariableMen: "2",
 				})}
 				declarationYear={2025}
 				index={0}
 			/>,
 		);
-		const [annualTotalGapCell, hourlyTotalGapCell] = totalRowGapCell();
-		expect(annualTotalGapCell).toHaveTextContent("- %");
-		expect(hourlyTotalGapCell).toHaveTextContent("- %");
+		for (const cell of totalRowGapCell()) {
+			expect(cell).toHaveTextContent("Non applicable");
+			expect(cell).not.toHaveTextContent("%");
+			expect(within(cell as HTMLElement).queryByText("élevé")).toBeNull();
+		}
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -158,10 +158,6 @@ function RemunerationTable({
 		cat[fields.variableWomen],
 	);
 	const totalMen = computeTotal(cat[fields.baseMen], cat[fields.variableMen]);
-	const totalGap =
-		totalWomen !== null && totalMen !== null
-			? computeGap(totalWomen.toString(), totalMen.toString())
-			: null;
 
 	const scopeId = scope === "annuel" ? "annual" : "hourly";
 	const variableScope = scope === "annuel" ? "annuelles" : "horaires";
@@ -247,7 +243,7 @@ function RemunerationTable({
 							{formatTotal(totalMen, "€")}
 						</td>
 						<td className={stepStyles.gapCell}>
-							<GapBadge gap={totalGap} layout="cell" />
+							<span className="fr-sr-only">Non applicable</span>
 						</td>
 					</tr>
 				</tbody>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
 	CATEGORY_NAME_MAX_LENGTH,
@@ -95,5 +95,40 @@ describe("CategoryAccordionItem — name length cap (#3943)", () => {
 			"aria-describedby",
 			"cat-0-name-hint cat-0-name-error",
 		);
+	});
+});
+
+describe("CategoryAccordionItem — Total row gap (#4205)", () => {
+	function totalRowGapCells() {
+		return screen.getAllByRole("rowheader", { name: "Total" }).map(
+			(th) =>
+				within(th.parentElement as HTMLElement)
+					.getAllByRole("cell")
+					.at(-1) as HTMLElement,
+		);
+	}
+
+	it("keeps a gap badge on base/variable rows but not on the Total row", () => {
+		renderItem({
+			category: {
+				...category,
+				annualBaseWomen: "24000",
+				annualBaseMen: "25500",
+				annualVariableWomen: "1200",
+				annualVariableMen: "1500",
+				hourlyBaseWomen: "12.50",
+				hourlyBaseMen: "13.20",
+				hourlyVariableWomen: "0.62",
+				hourlyVariableMen: "0.78",
+			},
+		});
+
+		const totalCells = totalRowGapCells();
+		expect(totalCells.length).toBeGreaterThanOrEqual(2);
+		for (const cell of totalCells) {
+			expect(cell).toHaveTextContent("Non applicable");
+			expect(cell).not.toHaveTextContent("%");
+			expect(within(cell).queryByText("élevé")).toBeNull();
+		}
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
@@ -124,7 +124,7 @@ describe("CategoryAccordionItem — Total row gap (#4205)", () => {
 		});
 
 		const totalCells = totalRowGapCells();
-		expect(totalCells.length).toBeGreaterThanOrEqual(2);
+		expect(totalCells).toHaveLength(2);
 		for (const cell of totalCells) {
 			expect(cell).toHaveTextContent("Non applicable");
 			expect(cell).not.toHaveTextContent("%");

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -309,15 +309,21 @@ describe("buildIndicatorG", () => {
 		...overrides,
 	});
 
-	it("should compute the six signed gap ratios rounded to 4 decimals", () => {
+	it("should compute the four signed base/variable gap ratios rounded to 4 decimals", () => {
 		const [category] = buildIndicatorG([gEntry({})]).initial;
 
 		expect(category?.Rem_annuelle_base_ecart).toBe(0.0909);
 		expect(category?.Rem_annuelle_variable_ecart).toBe(0.0099);
-		expect(category?.Rem_annuelle_total_ecart).toBe(0.0841);
 		expect(category?.Taux_horaire_base_ecart).toBe(0.0909);
 		expect(category?.Taux_horaire_variable_ecart).toBe(0.2);
-		expect(category?.Taux_horaire_total_ecart).toBe(0.102);
+	});
+
+	// #4205: the Total gap is not computed anywhere (UI or export).
+	it("does not expose any Total gap ratio in the export payload", () => {
+		const [category] = buildIndicatorG([gEntry({})]).initial;
+
+		expect(category).not.toHaveProperty("Rem_annuelle_total_ecart");
+		expect(category).not.toHaveProperty("Taux_horaire_total_ecart");
 	});
 
 	it("nulls a component gap when one of its salary values is missing", () => {
@@ -335,43 +341,6 @@ describe("buildIndicatorG", () => {
 		]).initial;
 
 		expect(category?.Rem_annuelle_base_ecart).toBeNull();
-	});
-
-	it("nulls the total gap when the men total is zero", () => {
-		const [category] = buildIndicatorG([
-			gEntry({ annualBaseMen: "0", annualVariableMen: "0" }),
-		]).initial;
-
-		expect(category?.Rem_annuelle_total_ecart).toBeNull();
-	});
-
-	it("nulls the total gap when both men components are missing", () => {
-		const [category] = buildIndicatorG([
-			gEntry({ annualBaseMen: null, annualVariableMen: null }),
-		]).initial;
-
-		expect(category?.Rem_annuelle_total_ecart).toBeNull();
-	});
-
-	it("nulls the total gap when both women components are missing", () => {
-		const [category] = buildIndicatorG([
-			gEntry({ annualBaseWomen: null, annualVariableWomen: null }),
-		]).initial;
-
-		expect(category?.Rem_annuelle_total_ecart).toBeNull();
-	});
-
-	it("computes the total gap from a single present component (null-safe sum)", () => {
-		const [category] = buildIndicatorG([
-			gEntry({
-				annualBaseWomen: "10000",
-				annualVariableWomen: null,
-				annualBaseMen: "11000",
-				annualVariableMen: null,
-			}),
-		]).initial;
-
-		expect(category?.Rem_annuelle_total_ecart).toBe(0.0909);
 	});
 });
 

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -15,7 +15,6 @@ export {
 
 import {
 	computeGapRatio,
-	computeTotal,
 	floorWorkforce,
 	getObligationWorkforce,
 	hasGapsAboveThreshold,
@@ -242,18 +241,6 @@ function roundRatio(r: number | null): number | null {
 	return r === null ? null : Math.round(r * 10000) / 10000;
 }
 
-function computeTotalGapRatio(
-	baseW: string | null,
-	varW: string | null,
-	baseM: string | null,
-	varM: string | null,
-): number | null {
-	const w = computeTotal(baseW ?? "", varW ?? "");
-	const m = computeTotal(baseM ?? "", varM ?? "");
-	if (w === null || m === null || m === 0) return null;
-	return (m - w) / m;
-}
-
 function toIndicatorGCategory(entry: IndicatorGEntry) {
 	const {
 		annualBaseWomen: abW,
@@ -281,15 +268,9 @@ function toIndicatorGCategory(entry: IndicatorGEntry) {
 		Rem_annuelle_variable_ecart: roundRatio(
 			computeGapRatio(avW ?? "", avM ?? ""),
 		),
-		Rem_annuelle_total_ecart: roundRatio(
-			computeTotalGapRatio(abW, avW, abM, avM),
-		),
 		Taux_horaire_base_ecart: roundRatio(computeGapRatio(hbW ?? "", hbM ?? "")),
 		Taux_horaire_variable_ecart: roundRatio(
 			computeGapRatio(hvW ?? "", hvM ?? ""),
-		),
-		Taux_horaire_total_ecart: roundRatio(
-			computeTotalGapRatio(hbW, hvW, hbM, hvM),
 		),
 	};
 }

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -42,11 +42,6 @@ const indicatorGCategorySchema = {
 			description:
 				"Écart de rémunération annuelle variable : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
 		},
-		Rem_annuelle_total_ecart: {
-			type: ["number", "null"],
-			description:
-				"Écart de rémunération annuelle totale (base + variable) : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
-		},
 		Taux_horaire_base_ecart: {
 			type: ["number", "null"],
 			description:
@@ -56,11 +51,6 @@ const indicatorGCategorySchema = {
 			type: ["number", "null"],
 			description:
 				"Écart de taux horaire variable : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
-		},
-		Taux_horaire_total_ecart: {
-			type: ["number", "null"],
-			description:
-				"Écart de taux horaire total (base + variable) : ratio signé (H−F)/H, arrondi à 4 décimales. Null si données manquantes ou effectif H nul.",
 		},
 	},
 } as const;


### PR DESCRIPTION
Closes #4205

## Contexte

Le 7ᵉ indicateur (indicateur G) affichait un **écart calculé sur la ligne « Total »** des tableaux de rémunération, alors que la maquette n'en prévoit aucun. L'app était de fait incohérente avec son propre **PDF de déclaration** (cellule déjà vide) et son propre **écran de revue** (étape 6, qui n'expose jamais le total). L'écart du Total est purement décoratif : il n'entre dans **aucune règle de conformité** (`hasGapsAboveThreshold` n'évalue que les paires base/variable), donc son retrait ne change ni le parcours, ni les données stockées.

## Changements

**Affichage (étape 5 initiale + 2ᵉ déclaration + récapitulatif)**
- La cellule « Écart » de la ligne `Total` devient **vide** — ni valeur, ni « - % », ni badge — avec une alternative lecteur d'écran `<span class="fr-sr-only">Non applicable</span>`, sur le modèle déjà appliqué à la ligne « Effectif physique » du récapitulatif.
- `CategoryDataTable` (partagé par l'étape 5 et la 2ᵉ déclaration via `CategoryForm`) et `CategoryRecapTable` couvrent les trois parcours d'un seul correctif.
- Les écarts `Salaire de base` et `Composantes variables` restent inchangés.

**⚠️ Export SUIT — changement cassant assumé du contrat public**
- Retrait de `Rem_annuelle_total_ecart` et `Taux_horaire_total_ecart` du payload de `GET /api/v1/export/declarations` et du schéma OpenAPI `indicatorGCategorySchema` (partagé `Indicateurs.G` + `Seconde_declaration.Correction`).
- Les **4** autres champs d'écart (`*_base_ecart`, `*_variable_ecart`) restent inchangés.
- Ces deux champs avaient été ajoutés en #3942 à la demande de l'équipe SUIT, pour aligner l'API sur l'UI qui affichait alors 6 écarts. Leur retrait est **cohérent** avec la présente correction mais **revient sur une demande d'un consommateur externe** : **à annoncer à l'équipe SUIT avant livraison**. `docs/SUIT-API.md` n'énumère pas les champs (renvoi à la spec/Swagger) → aucune retouche de doc.

Aucune fonction du domaine n'est modifiée (`computeGap`, `computeGapBetween`, `computeTotal` intactes, utilisées ailleurs).

**A11y (annexe, même fichier)** : le premier en-tête de colonne du récapitulatif (`<th scope="col" />`, vide) reçoit son alternative `<span class="fr-sr-only">Donnée</span>`, alignée sur le composant frère `CategoryDataTable` — corrige un WARN RGAA pré-existant relevé pendant l'audit.

## Vérification (one-shot + rendu mesuré)

Rejoué sur le dev server par le validateur fonctionnel (mesure DOM, saisie prescrite : annuel base 24 000/25 500, variable 1 200/1 500 F/H) :

| Ligne | Écart — avant fix | Écart — après fix |
|---|---|---|
| Salaire de base (annuel) | `5,88 %` ÉLEVÉ | `5,88 %` ÉLEVÉ — inchangé |
| Composantes variables (annuel) | `20,00 %` ÉLEVÉ | `20,00 %` ÉLEVÉ — inchangé |
| **Total (annuel)** — 25 200 € / 27 000 € | `6,66 %` ÉLEVÉ | **vide** — `<span class="fr-sr-only">Non applicable</span>`, ni valeur ni badge |
| **Total (horaire)** — 13,85 € / 14,83 € | (valeur d'écart) | **vide** |

Confirmé au DOM (`… get html` → seul `<span class="fr-sr-only">Non applicable</span>` dans la cellule, aucun badge). Étape 6 (revue) : inchangée, n'exposait déjà que base/variable. PDF : inchangé, déjà conforme. Aucune erreur console ni runtime Next.js. Capture desktop annotée (données seedées fictives) jointe au commentaire du validateur fonctionnel sur le ticket.

Export : chaque catégorie de `Indicateurs.G` / `Seconde_declaration.Correction` expose désormais **4** clés `*_ecart` (au lieu de 6), valeurs des 4 restantes inchangées.

## Test plan / gates

- Suite vitest complète verte (4551 tests). Nouveaux tests (par `tu-dev`) : garde d'absence des 2 clés d'écart Total dans l'export + couverture de la ligne Total step5 (alternative sr-only, pas de badge).
- Typecheck / lint / format verts. CI verte (Build, Test, Typecheck, RGAA statique, SonarCloud Quality Gate ✅).
- Audits : structural (MINOR, aucun ERROR introduit), RGAA (MINOR, WARN pré-existant corrigé), security (SECURE, surface d'export réduite), fonctionnel (PASS).
- Gate visuelle `design-validator` : **dégradée** — aucun node Figma de référence n'est identifiable dans le ticket ; la fidélité est établie par corroboration interne (PDF + écran de revue) + la mesure DOM du validateur fonctionnel.
- **E2E** : le check CI `Test e2e` reste rouge sur `export-declarations.e2e.ts` (garde `ECART_KEYS` de #3942, qui asserte encore 6 champs). C'est la **conséquence attendue** du changement de contrat ; sa mise au format 4 champs relève de `e2e-dev` (fin de pipeline), qui possède `src/e2e/**`. Les 2 autres échecs E2E du run (`declaration-process-panel`, `public-referents`) sont **flaky** (passés au retry, hors périmètre).
