### PR TITLE
refactor(api): retire le chemin d'authentification hérité de PUT /simulation/{uuid}

### DIFF
--- a/packages/api/egapro/db.py
+++ b/packages/api/egapro/db.py
@@ -466,7 +466,7 @@ class simulation(table):
 
     @classmethod
     async def create(cls, data):
-        uid = str(uuid.uuid1())
+        uid = str(uuid.uuid4())
         try:
             await cls.get(uid)
         except NoData:

--- a/packages/api/egapro/views.py
+++ b/packages/api/egapro/views.py
@@ -465,11 +465,6 @@ class SimulationResource:
         record = await db.simulation.get(uuid)
         response.json = record.as_resource()
         response.status = 200
-        draft = data.get("declaration", {}).get("formValidated") != "Valid"
-        email = data.get("informationsDeclarant", {}).get("email")
-        if email and not draft:
-            token = tokens.create(email)
-            response.cookies.set(name="api-key", value=token)
 
     async def on_get(self, request, response, uuid):
         record = await db.simulation.get(uuid)

--- a/packages/api/test/api/test_simulation.py
+++ b/packages/api/test/api/test_simulation.py
@@ -324,7 +324,9 @@ async def test_send_code_endpoint(client, monkeypatch, body):
     assert recipient == "foo@bar.org"
 
 
-async def test_put_simulation_set_cookie_if_email_is_given(client, monkeypatch):
+async def test_put_simulation_never_sets_session_cookie(client):
+    # Non regression: saving a simulation is an anonymous operation, it must
+    # not return any credential, whatever the body contains.
     resp = await client.put(
         "/simulation/12345678-1234-5678-9012-123456789012", body={"foo": "bar"}
     )
@@ -342,7 +344,31 @@ async def test_put_simulation_set_cookie_if_email_is_given(client, monkeypatch):
         body=body,
     )
     assert resp.status == 200
-    assert resp.cookies["api-key"]
+    assert not resp.cookies
+
+
+async def test_put_simulation_does_not_grant_access_to_protected_endpoints(
+    client, monkeypatch
+):
+    monkeypatch.setattr("egapro.config.STAFF", ["staff@email.com"])
+    client.logout()
+
+    body = {
+        "data": {
+            "informationsDeclarant": {"email": "staff@email.com"},
+            "declaration": {"formValidated": "Valid"},
+        }
+    }
+    resp = await client.put(
+        "/simulation/12345678-1234-5678-9012-123456789012",
+        body=body,
+    )
+    assert resp.status == 200
+    assert not resp.cookies
+
+    # Nothing was handed out, the caller is still anonymous.
+    resp = await client.get("/me")
+    assert resp.status == 401
 
 
 async def test_put_simulation_with_empty_body(client):

--- a/packages/api/test/test_db.py
+++ b/packages/api/test/test_db.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from uuid import UUID
 
 import pytest
 
@@ -30,6 +31,13 @@ async def test_simulation_create():
     async with db.table.pool.acquire() as conn:
         count = await conn.fetchval("SELECT COUNT(*) FROM simulation WHERE id=$1", uuid)
     assert count == 1
+
+
+async def test_simulation_create_uses_random_uuid():
+    # Simulation ids are the only thing keeping a simulation private, they
+    # must not be derived from a timestamp and a MAC address.
+    uid = await db.simulation.create({"foo": "baré"})
+    assert UUID(uid).version == 4
 
 
 async def test_simulation_get():


### PR DESCRIPTION
Nettoyage d'un reliquat de l'ancien simulateur SPA.

`PUT /simulation/{uuid}` embarquait encore un chemin d'authentification hérité du front historique : lorsque le corps contenait un email et un formulaire marqué validé, la réponse posait un cookie `api-key`.

Plus aucun client ne s'en sert — l'app Next n'appelle pas `/simulation/*` et ne lit pas ce cookie, le simulateur étant entièrement côté navigateur depuis la V2 du front. L'accès authentifié reste le magic link (`POST /token`) et le permalien envoyé par `POST /simulation` / `POST /simulation/{uuid}/send-code`. Après ce PR, l'API ne pose plus aucun cookie (elle continue de lire `api-key` pour les sessions déjà émises).

Au passage, les identifiants de simulation passent de `uuid1` (horodatage + adresse MAC) à `uuid4` : ces identifiants sont ce qui garde une simulation privée, ils ne devraient pas être dérivables.

Tests mis à jour en conséquence.

## Vérifications locales

Stack docker (`api` + `test_db`), suite complète `py.test` sur `packages/api` : **259 passed**.
