### PR TITLE
fix(mon-espace): contrôle d'accès owner/staff sur la gestion des responsables

### DIFF
--- a/packages/app/src/app/(default)/mon-espace/actions.ts
+++ b/packages/app/src/app/(default)/mon-espace/actions.ts
@@ -6,6 +6,7 @@ import { GetDeclarationOpmcBySirenAndYear } from "@api/core-domain/useCases/GetD
 import { GetRepresentationEquilibreeBySiren } from "@api/core-domain/useCases/GetRepresentationEquilibreeBySiren";
 import { assertServerSession } from "@api/utils/auth";
 import { Siren } from "@common/core-domain/domain/valueObjects/Siren";
+import { UnexpectedSessionError } from "@common/shared-domain";
 import { Email } from "@common/shared-domain/domain/valueObjects";
 import assert from "assert";
 
@@ -70,26 +71,34 @@ export async function getAllEmailsBySiren(siren: string) {
   return await ownershipRepo.getAllEmailsBySiren(new Siren(siren), session.user.email);
 }
 
+/**
+ * A responsable may only manage the responsable list of a SIREN they already
+ * own; staff may manage any SIREN. Mirrors the owner/staff guard used by the
+ * read actions above.
+ *
+ * Without this check any authenticated account could attach itself to — or
+ * detach the legitimate responsable from — an arbitrary SIREN.
+ */
+async function assertCanManageResponsables(sirens: string[]) {
+  const session = await assertServerSession();
+  if (session.user.staff) return;
+
+  const ownsEverySiren = sirens.every(siren =>
+    session.user.companies.some(company => company.siren === siren),
+  );
+  if (!ownsEverySiren) {
+    throw new UnexpectedSessionError("Not authorized to manage responsables for this siren.");
+  }
+}
+
 export async function removeSirens(email: string, sirens: string[], username?: string) {
-  // await assertServerSession({
-  //   owner: {
-  //     check: email,
-  //     message: "Not authorized to fetch owners for this siren.",
-  //   },
-  //   staff: true,
-  // });
+  await assertCanManageResponsables(sirens);
 
   return await ownershipRepo.removeSirens(new Email(email), sirens, username || email);
 }
 
 export async function addSirens(email: string, sirens: string[], username?: string) {
-  // await assertServerSession({
-  //   owner: {
-  //     check: email,
-  //     message: "Not authorized to fetch owners for this siren.",
-  //   },
-  //   staff: true,
-  // });
+  await assertCanManageResponsables(sirens);
 
   return await ownershipRepo.addSirens(new Email(email), sirens, username || email);
 }


### PR DESCRIPTION
Aligne `addSirens` / `removeSirens` (`mon-espace/actions.ts`) sur le contrôle owner/staff déjà appliqué par les autres actions du fichier.

## Changement
- Ajoute un garde `assertCanManageResponsables(sirens)` : seul un responsable du SIREN concerné (ou un compte staff) peut modifier la liste des responsables.
- `addSirens` et `removeSirens` passent par ce garde avant l'appel au repo.

## Non affecté
- Rattachements initiaux (sync à la connexion, `/rattachement`, `/admin/rattachements`) : chemins distincts, inchangés.
- Gestion des responsables par un propriétaire du SIREN ou le staff : comportement identique.

Base : `master`.
