### PR TITLE
fix(declaration): vérifie l'ownership sur oldSiren avant suppression dans updateCompanyInfos

### DIFF
--- a/packages/app/src/app/(default)/index-egapro/declaration/[siren]/[year]/actions.ts
+++ b/packages/app/src/app/(default)/index-egapro/declaration/[siren]/[year]/actions.ts
@@ -22,6 +22,18 @@ export async function updateCompanyInfos(
     staff: true,
   });
 
+  // Si oldSiren est fourni (changement de SIREN), vérifier également l'autorisation sur l'ancien SIREN
+  // avant de supprimer la déclaration associée.
+  if (oldSiren && oldSiren !== declaration.commencer?.siren) {
+    await assertServerSession({
+      owner: {
+        check: oldSiren,
+        message: "Not authorized to delete the declaration for the original Siren.",
+      },
+      staff: true,
+    });
+  }
+
   try {
     const useCase = new SaveDeclaration(declarationRepo, entrepriseService);
     await useCase.execute({ declaration, override: session?.user?.staff });


### PR DESCRIPTION
## Contexte

Point critique n°4 du rapport d'audit sécurité (`.audit/RAPPORT-AUDIT-SECURITE-master.md`).

Dans `packages/app/src/app/(default)/index-egapro/declaration/[siren]/[year]/actions.ts`, la server action `updateCompanyInfos(declaration, oldSiren)` vérifiait l'autorisation uniquement sur le **nouveau** SIREN (`declaration.commencer?.siren`), puis supprimait sans contrôle la déclaration associée à `oldSiren` (paramètre fourni par le client). Un utilisateur authentifié pouvait ainsi supprimer la déclaration de n'importe quel SIREN/année.

## Correctif

Avant toute écriture/suppression, si `oldSiren` est fourni et différent du nouveau SIREN, on vérifie désormais l'ownership (ou le rôle staff) sur `oldSiren` via `assertServerSession` — même pattern que la variante représentation équilibrée (`representation-equilibree/actions.ts`), déjà correcte.

Le seul appelant (`RecapDeclaration.tsx`) passe `void 0` pour `oldSiren` : le comportement nominal est inchangé, la garde ne s'active que lors d'un changement de SIREN.

## Vérifications

- `npx eslint` sur le fichier modifié : OK
- `npx jest index-egapro` : 29 suites, 221 tests, tous verts