### PR TITLE
fix(declaration): #4206 — reformuler les libellés du bloc Prochaines étapes

### DIFF
--- a/packages/app/src/e2e/compliance.e2e.ts
+++ b/packages/app/src/e2e/compliance.e2e.ts
@@ -432,8 +432,9 @@ test.describe("[ANX-05] Path 13: 50-99 tranche — indicator G gated by the pinn
 // is asserted in missing-info-modal.e2e.ts, and the recap's own null-like-false
 // rendering by Step6Review.test.tsx ("CSE consultation section gating (issue #3945)").
 
-const CSE_OPINION_RECAP_TEXT = /avis du CSE devront être transmis/;
-const CSE_JUSTIFY_PARENTHESIS = /avis à transmettre sur le portail/;
+const CSE_OPINION_RECAP_TEXT = /avis du CSE devra être transmis/;
+const CSE_JUSTIFY_PARENTHESIS =
+	/avis à transmettre lors de la dernière étape de la démarche/;
 const UPDATE_CSE_BUTTON = /Mettre à jour l.existence d.un CSE/;
 
 test.describe("[#3945] gap + workforce >= 100 + hasCse=false → no CSE opinion mention", () => {
@@ -511,6 +512,16 @@ test.describe("[#3945] gap + workforce >= 100 + hasCse=true → CSE opinion stil
 		).toBeVisible();
 		await expect(page.getByText(CSE_OPINION_RECAP_TEXT)).toBeVisible();
 		await expect(page.getByText(CSE_JUSTIFY_PARENTHESIS)).toBeVisible();
+
+		// First declaration renders both alternative paths, each prefixed "Soit"
+		await expect(
+			page.getByText(/Soit mettre en place des actions correctives/),
+		).toBeVisible();
+		await expect(
+			page.getByText(
+				"Soit réaliser une évaluation conjointe des rémunérations",
+			),
+		).toBeVisible();
 	});
 
 	test("compliance choice page keeps the CSE opinion bullet", async ({

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -113,8 +113,9 @@ export function NextStepsBox({
 								</strong>{" "}
 								Si vous choisissez ce parcours, vous devez informer et consulter
 								le CSE sur cette justification
-								{cseOpinionRequired &&
-									" (avis à transmettre lors de la dernière étape de la démarche)"}
+								{cseOpinionRequired
+									? " (avis à transmettre lors de la dernière étape de la démarche)."
+									: "."}
 							</li>
 						</ul>
 						<p className="fr-mb-0">

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -44,8 +44,8 @@ export function NextStepsBox({
 
 						<div className={styles.ctaGroup}>
 							<p className="fr-mb-0">
-								Le ou les avis du CSE devront être transmis sur le portail lors
-								de la dernière étape.
+								L&apos;avis du CSE devra être transmis lors de la dernière étape
+								de la démarche.
 							</p>
 							<TrackedLink
 								className="fr-link"
@@ -99,8 +99,8 @@ export function NextStepsBox({
 						</div>
 
 						<p className="fr-mb-0">
-							Suite à l&apos;analyse de vos données de l&apos;indicateur par
-							catégorie de salariés, des écarts &ge; 5 % ont été identifiés.
+							À la suite de l&apos;analyse de vos données de l&apos;indicateur
+							par catégorie de salariés, des écarts &ge; 5 % ont été identifiés.
 							Vous devez engager un des parcours de mise en conformité
 							suivant&nbsp;:
 						</p>
@@ -112,9 +112,9 @@ export function NextStepsBox({
 									sexistes.
 								</strong>{" "}
 								Si vous choisissez ce parcours, vous devez informer et consulter
-								le CSE
+								le CSE sur cette justification
 								{cseOpinionRequired &&
-									" (avis à transmettre sur le portail lors de la dernière étape)"}
+									" (avis à transmettre lors de la dernière étape de la démarche)"}
 							</li>
 						</ul>
 						<p className="fr-mb-0">
@@ -125,14 +125,16 @@ export function NextStepsBox({
 							{!isSecondDeclaration && (
 								<li>
 									<strong>
-										Mettre en place des actions correctives et effectuer une
-										seconde déclaration dans un délai de 6 mois
+										Soit mettre en place des actions correctives et effectuer
+										une seconde déclaration dans un délai de 6 mois
 									</strong>
 								</li>
 							)}
 							<li>
 								<strong>
-									Réaliser une évaluation conjointe des rémunérations
+									{isSecondDeclaration
+										? "Réaliser une évaluation conjointe des rémunérations"
+										: "Soit réaliser une évaluation conjointe des rémunérations"}
 								</strong>
 							</li>
 						</ul>

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -882,10 +882,10 @@ describe("Step6Review", () => {
 				screen.queryByText(/obligatoirement informer et consulter le CSE/),
 			).not.toBeInTheDocument();
 			expect(
-				screen.queryByText(/avis du CSE devront être transmis sur le portail/),
+				screen.queryByText(/avis du CSE devra être transmis/),
 			).not.toBeInTheDocument();
 			expect(
-				screen.queryByText(/avis à transmettre sur le portail/),
+				screen.queryByText(/avis à transmettre lors de la dernière étape/),
 			).not.toBeInTheDocument();
 
 			expect(screen.getByText("Écarts détectés")).toBeInTheDocument();
@@ -897,6 +897,23 @@ describe("Step6Review", () => {
 					name: "Mettre à jour l'existence d'un CSE",
 				}),
 			).toBeInTheDocument();
+
+			expect(
+				screen.getByText(/À la suite de l'analyse de vos données/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/vous devez informer et consulter le CSE sur cette justification/,
+				),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/Soit mettre en place des actions correctives/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					"Soit réaliser une évaluation conjointe des rémunérations",
+				),
+			).toBeInTheDocument();
 		});
 
 		it("shows the CSE consultation section when hasCse is true", () => {
@@ -906,10 +923,27 @@ describe("Step6Review", () => {
 				screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
 			).toBeInTheDocument();
 			expect(
-				screen.getByText(/avis du CSE devront être transmis sur le portail/),
+				screen.getByText(/avis du CSE devra être transmis/),
 			).toBeInTheDocument();
 			expect(
-				screen.getByText(/avis à transmettre sur le portail/),
+				screen.getByText(/avis à transmettre lors de la dernière étape/),
+			).toBeInTheDocument();
+
+			expect(
+				screen.getByText(/À la suite de l'analyse de vos données/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/vous devez informer et consulter le CSE sur cette justification/,
+				),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/Soit mettre en place des actions correctives/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					"Soit réaliser une évaluation conjointe des rémunérations",
+				),
 			).toBeInTheDocument();
 		});
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -882,7 +882,7 @@ describe("Step6Review", () => {
 				screen.queryByText(/obligatoirement informer et consulter le CSE/),
 			).not.toBeInTheDocument();
 			expect(
-				screen.queryByText(/avis du CSE devra être transmis/),
+				screen.queryByText(/L'avis du CSE devra être transmis/),
 			).not.toBeInTheDocument();
 			expect(
 				screen.queryByText(/avis à transmettre lors de la dernière étape/),
@@ -923,7 +923,7 @@ describe("Step6Review", () => {
 				screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
 			).toBeInTheDocument();
 			expect(
-				screen.getByText(/avis du CSE devra être transmis/),
+				screen.getByText(/L'avis du CSE devra être transmis/),
 			).toBeInTheDocument();
 			expect(
 				screen.getByText(/avis à transmettre lors de la dernière étape/),

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -335,7 +335,7 @@ describe("SecondDeclarationStep3Review", () => {
 			).toBeInTheDocument();
 		});
 
-		it("shows the CSE consultation section when cseOpinionRequired is true", () => {
+		it("shows the CSE consultation section and renders the joint evaluation bullet without the 'Soit' prefix when cseOpinionRequired is true", () => {
 			renderStep3({
 				cseOpinionRequired: true,
 				secondDeclarationCategories: highGapCategories,
@@ -361,13 +361,6 @@ describe("SecondDeclarationStep3Review", () => {
 					/vous devez informer et consulter le CSE sur cette justification/,
 				),
 			).toBeInTheDocument();
-		});
-
-		it("renders the joint evaluation bullet without the 'Soit' prefix and omits the corrective-actions bullet in the second declaration", () => {
-			renderStep3({
-				cseOpinionRequired: true,
-				secondDeclarationCategories: highGapCategories,
-			});
 
 			expect(
 				screen.getByText("Réaliser une évaluation conjointe des rémunérations"),

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -321,7 +321,7 @@ describe("SecondDeclarationStep3Review", () => {
 				screen.queryByText(/obligatoirement informer et consulter le CSE/),
 			).not.toBeInTheDocument();
 			expect(
-				screen.queryByText(/avis à transmettre sur le portail/),
+				screen.queryByText(/avis à transmettre lors de la dernière étape/),
 			).not.toBeInTheDocument();
 
 			expect(screen.getByText("Écarts détectés")).toBeInTheDocument();
@@ -345,13 +345,39 @@ describe("SecondDeclarationStep3Review", () => {
 				screen.getByRole("heading", { name: "Informer et consulter le CSE" }),
 			).toBeInTheDocument();
 			expect(
-				screen.getByText(/avis à transmettre sur le portail/),
+				screen.getByText(/avis à transmettre lors de la dernière étape/),
 			).toBeInTheDocument();
 			expect(
 				screen.getByRole("button", {
 					name: "Mettre à jour l'existence d'un CSE",
 				}),
 			).toBeInTheDocument();
+
+			expect(
+				screen.getByText(/À la suite de l'analyse de vos données/),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(
+					/vous devez informer et consulter le CSE sur cette justification/,
+				),
+			).toBeInTheDocument();
+		});
+
+		it("renders the joint evaluation bullet without the 'Soit' prefix and omits the corrective-actions bullet in the second declaration", () => {
+			renderStep3({
+				cseOpinionRequired: true,
+				secondDeclarationCategories: highGapCategories,
+			});
+
+			expect(
+				screen.getByText("Réaliser une évaluation conjointe des rémunérations"),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText(/Soit réaliser une évaluation conjointe/),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByText(/mettre en place des actions correctives/),
+			).not.toBeInTheDocument();
 		});
 	});
 


### PR DESCRIPTION
Closes #4206

## Résumé

Reformulation de 4 libellés dans le bloc « Prochaines étapes » du récapitulatif de déclaration (`NextStepsBox.tsx`).

| # | Changement | Avant | Après |
|---|---|---|---|
| 1 | Transmission avis CSE | « Le ou les avis du CSE devront être transmis sur le portail lors de la dernière étape. » | « L'avis du CSE devra être transmis lors de la dernière étape de la démarche. » |
| 2 | Début du paragraphe écarts | « Suite à l'analyse… » | « À la suite de l'analyse… » (majuscule accentuée, convention codebase) |
| 3 | Puce « Justifier les écarts » | « …consulter le CSE (avis à transmettre sur le portail lors de la dernière étape) » | « …consulter le CSE sur cette justification (avis à transmettre lors de la dernière étape de la démarche) » |
| 4 | Puces alternatives | « Mettre en place… » / « Réaliser… » | « Soit mettre en place… » / « Soit réaliser… » ; sur la seconde déclaration, ternaire sans « Soit » |

La propagation sur le récapitulatif de la seconde déclaration est assumée (composant partagé, cohérence voulue). Le ternaire au changement 4 garantit « Réaliser une évaluation conjointe… » sans préfixe « Soit » quand `isSecondDeclaration` est vrai.

## Plan de test

Branche rebasée sur `alpha` (rebase propre, aucun conflit avec `#4205` / `#4207` entre-temps).

- [x] Typecheck vert (`tsc --noEmit`)
- [x] Tests vitest 4460/4460 verts (396 fichiers) — assertions de wording réalignées dans `Step6Review.test.tsx` et `SecondDeclarationStep3Review.test.tsx` ; couverture 100 % sur `NextStepsBox.tsx`
- [x] Lint/format Biome vert
- [x] Audit structurel PASS (17 règles)
- [x] Audit RGAA 4.1.2 / WCAG 2.2 AA PASS
- [x] CI GitHub Actions verte (build, typecheck, test, lint/format, RGAA statique, Lighthouse)
- [x] Suite E2E Playwright verte (`compliance.e2e.ts` couvre les 4 reformulations + les puces « Soit »)
- [x] SonarCloud Quality Gate

> Le run E2E précédent échouait sur deux tests hors périmètre (`public-referents` recherche par région, `declaration-process-panel` variante close), verts au re-run. La variante close dépend d'un état ambiant : son `beforeAll` est le seul du fichier à ne pas poser `setGipWorkforce` / `setCompanyHasCse`, et hérite donc de l'état de sortie de `compliance.e2e.ts`. À durcir hors de cette PR.
