### PR TITLE
fix(mail): #4207 — aligne la date de l'AR de 1ʳᵉ déclaration sur le round 1 et retire le récap redondant

### DIFF
--- a/packages/app/src/e2e/notifications-email-flow.e2e.ts
+++ b/packages/app/src/e2e/notifications-email-flow.e2e.ts
@@ -91,8 +91,7 @@ test.describe("notifications email flow (publisher → pg-boss → worker → SM
 				(m) => /Transmission de la déclaration/i.test(m.subject),
 				{ since: startedAt },
 			);
-			// Round 1 deadline = 1st July of the campaign year, formatted in French —
-			// not the round-2 January deadline, and never a raw ISO string.
+			// Round 1 is July 1st, not the round-2 January deadline.
 			expect(firstReceipt.html).toMatch(/1ᵉʳ juillet/);
 			expect(firstReceipt.html).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
 		});

--- a/packages/app/src/e2e/notifications-email-flow.e2e.ts
+++ b/packages/app/src/e2e/notifications-email-flow.e2e.ts
@@ -84,6 +84,19 @@ test.describe("notifications email flow (publisher → pg-boss → worker → SM
 
 		const startedAt = new Date();
 		await completeDeclaration(page, { hasGap: true });
+
+		await test.step("first-declaration receipt states the round-1 path-choice deadline in French (#4207)", async () => {
+			const firstReceipt = await waitForEmail(
+				TEST_USER_EMAIL,
+				(m) => /Transmission de la déclaration/i.test(m.subject),
+				{ since: startedAt },
+			);
+			// Round 1 deadline = 1st July of the campaign year, formatted in French —
+			// not the round-2 January deadline, and never a raw ISO string.
+			expect(firstReceipt.html).toMatch(/1ᵉʳ juillet/);
+			expect(firstReceipt.html).not.toMatch(/\d{4}-\d{2}-\d{2}T/);
+		});
+
 		await selectCompliancePath(page, "path-corrective");
 		await completeSecondDeclaration(page, { hasGap: false });
 

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -11,7 +11,11 @@ import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/d
 import { useDraftAutoSave } from "~/modules/declaration-remuneration/shared/draft/useDraftAutoSave";
 import { useDraftHydration } from "~/modules/declaration-remuneration/shared/draft/useDraftHydration";
 import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
-import { type CampaignDeadlines, formatLongDate } from "~/modules/domain";
+import {
+	type CampaignDeadlines,
+	formatLongDate,
+	getPathChoiceRound1Deadline,
+} from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { scrollToTop } from "~/modules/shared/scrollToTop";
 import { useZodForm } from "~/modules/shared/useZodForm";
@@ -185,7 +189,11 @@ export function CompliancePathChoice({
 							Date limite pour choisir un parcours de mise en conformité
 						</p>
 						<p className="fr-text--xl fr-text--bold fr-mb-0">
-							{formatLongDate(campaignDeadlines.pathChoiceDeadline)}
+							{formatLongDate(
+								isSecondRound
+									? campaignDeadlines.pathChoiceDeadline
+									: getPathChoiceRound1Deadline(currentYear),
+							)}
 						</p>
 					</div>
 				</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -131,6 +131,16 @@ export function CompliancePathChoice({
 
 	if (!draftHydrated) return <DraftLoadingState />;
 
+	const modificationDeadline = isSecondRound
+		? campaignDeadlines.decl2ModificationDeadline
+		: campaignDeadlines.decl1ModificationDeadline;
+	const pathChoiceDeadline = isSecondRound
+		? campaignDeadlines.pathChoiceDeadline
+		: getPathChoiceRound1Deadline(currentYear);
+	const gapNoticeText = isSecondRound
+		? "Des écarts ≥ 5 % ont de nouveau été détectés, vous devez engager l'un des parcours suivants."
+		: "Des écarts ≥ 5 % ont été constatés, vous devez engager l'un des parcours suivants.";
+
 	const onSubmit = form.handleSubmit((data) => {
 		if (isReadOnly || !data.path) return;
 		mutation.mutate({ path: data.path });
@@ -159,11 +169,7 @@ export function CompliancePathChoice({
 				<DeclarationSuccessBanner
 					email={email}
 					isSecondDeclaration={isSecondRound}
-					modificationDeadline={
-						isSecondRound
-							? campaignDeadlines.decl2ModificationDeadline
-							: campaignDeadlines.decl1ModificationDeadline
-					}
+					modificationDeadline={modificationDeadline}
 					pdfDownloadHref={pdfDownloadHref}
 					year={currentYear}
 				/>
@@ -178,22 +184,14 @@ export function CompliancePathChoice({
 				</h2>
 
 				<div className={common.flexColumnGap1}>
-					<p className={`fr-mb-0 ${styles.instructions}`}>
-						{isSecondRound
-							? "Des écarts ≥ 5 % ont de nouveau été détectés, vous devez engager l'un des parcours suivants."
-							: "Des écarts ≥ 5 % ont été constatés, vous devez engager l'un des parcours suivants."}
-					</p>
+					<p className={`fr-mb-0 ${styles.instructions}`}>{gapNoticeText}</p>
 
 					<div className="fr-highlight fr-mb-0">
 						<p className="fr-mb-1w">
 							Date limite pour choisir un parcours de mise en conformité
 						</p>
 						<p className="fr-text--xl fr-text--bold fr-mb-0">
-							{formatLongDate(
-								isSecondRound
-									? campaignDeadlines.pathChoiceDeadline
-									: getPathChoiceRound1Deadline(currentYear),
-							)}
+							{formatLongDate(pathChoiceDeadline)}
 						</p>
 					</div>
 				</div>

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -316,14 +316,21 @@ describe("CompliancePathChoice", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders the path choice deadline highlight block", () => {
+	it("renders the round-1 path choice deadline highlight block (July 1st of the campaign year)", () => {
 		render(compliancePathChoice());
 		expect(
 			screen.getByText(
 				"Date limite pour choisir un parcours de mise en conformité",
 			),
 		).toBeInTheDocument();
+		expect(screen.getByText("1ᵉʳ juillet 2026")).toBeInTheDocument();
+		expect(screen.queryByText("1ᵉʳ janvier 2027")).not.toBeInTheDocument();
+	});
+
+	it("renders the round-2 path choice deadline (January 1st of the following year) when isSecondRound", () => {
+		render(compliancePathChoice({ isSecondRound: true }));
 		expect(screen.getByText("1ᵉʳ janvier 2027")).toBeInTheDocument();
+		expect(screen.queryByText("1ᵉʳ juillet 2026")).not.toBeInTheDocument();
 	});
 
 	it("renders previous link pointing to step 6", () => {

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -131,8 +131,6 @@ describe("getPathChoiceRound1Deadline", () => {
 	it("stays within the campaign year, unlike the round-2 deadline", () => {
 		const year = 2027;
 		expect(getPathChoiceRound1Deadline(year)).toEqual(new Date(year, 6, 1));
-		// Round 1 is July 1st of N; round 2 is January 1st of N+1 — they must not
-		// collapse onto the same date.
 		expect(getPathChoiceRound1Deadline(year)).not.toEqual(
 			getPathChoiceDeadline(year),
 		);

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -5,6 +5,7 @@ import {
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
 	getPathChoiceDeadline,
+	getPathChoiceRound1Deadline,
 	getReferencePeriod,
 	getReferenceYearFor,
 	getRepresentationDeadline,
@@ -119,6 +120,22 @@ describe("getPathChoiceDeadline", () => {
 
 	it("rolls over the year boundary", () => {
 		expect(getPathChoiceDeadline(2026)).toEqual(new Date(2027, 0, 1));
+	});
+});
+
+describe("getPathChoiceRound1Deadline", () => {
+	it("returns July 1st of the campaign year", () => {
+		expect(getPathChoiceRound1Deadline(2026)).toEqual(new Date(2026, 6, 1));
+	});
+
+	it("stays within the campaign year, unlike the round-2 deadline", () => {
+		const year = 2027;
+		expect(getPathChoiceRound1Deadline(year)).toEqual(new Date(year, 6, 1));
+		// Round 1 is July 1st of N; round 2 is January 1st of N+1 — they must not
+		// collapse onto the same date.
+		expect(getPathChoiceRound1Deadline(year)).not.toEqual(
+			getPathChoiceDeadline(year),
+		);
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -6,6 +6,7 @@ export {
 	getDeclarationDeadline,
 	getDefaultCampaignDeadlines,
 	getPathChoiceDeadline,
+	getPathChoiceRound1Deadline,
 	getReferencePeriod,
 	getReferenceYearFor,
 	getRepresentationDeadline,

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -45,6 +45,11 @@ export function getPathChoiceDeadline(year: number): Date {
 	return new Date(year + 1, 0, 1);
 }
 
+/** Returns the derived round-1 deadline to choose a compliance path (July 1st of the campaign year). */
+export function getPathChoiceRound1Deadline(year: number): Date {
+	return new Date(year, 6, 1);
+}
+
 /** Returns default campaign deadlines for a given year (fallback when no DB config exists). */
 export function getDefaultCampaignDeadlines(year: number): CampaignDeadlines {
 	return {

--- a/packages/app/src/modules/mail/__tests__/buildReceiptAttachments.test.ts
+++ b/packages/app/src/modules/mail/__tests__/buildReceiptAttachments.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	renderToBuffer: vi.fn(),
+	buildPdfData: vi.fn(),
+	buildTransmittedPdfData: vi.fn(),
+	DeclarationPdfDocument: vi.fn(),
+	TransmittedPdfDocument: vi.fn(),
+}));
+
+vi.mock("@react-pdf/renderer", () => ({
+	renderToBuffer: mocks.renderToBuffer,
+}));
+
+vi.mock("~/modules/declarationPdf/buildPdfData", () => ({
+	buildPdfData: mocks.buildPdfData,
+}));
+
+vi.mock("~/modules/declarationPdf/buildTransmittedPdfData", () => ({
+	buildTransmittedPdfData: mocks.buildTransmittedPdfData,
+}));
+
+vi.mock("~/modules/declarationPdf/DeclarationPdfDocument", () => ({
+	DeclarationPdfDocument: mocks.DeclarationPdfDocument,
+}));
+
+vi.mock("~/modules/declarationPdf/TransmittedPdfDocument", () => ({
+	TransmittedPdfDocument: mocks.TransmittedPdfDocument,
+}));
+
+import {
+	buildDeclarationAttachments,
+	buildSecondDeclarationAttachments,
+} from "../buildReceiptAttachments";
+
+const SIREN = "552100554";
+const YEAR = 2025;
+
+describe("buildReceiptAttachments", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.buildPdfData.mockResolvedValue({ year: YEAR });
+		mocks.buildTransmittedPdfData.mockResolvedValue({ year: YEAR });
+		mocks.DeclarationPdfDocument.mockReturnValue("declaration-doc");
+		mocks.TransmittedPdfDocument.mockReturnValue("transmitted-doc");
+		mocks.renderToBuffer.mockImplementation((doc: unknown) =>
+			Promise.resolve(Buffer.from(String(doc))),
+		);
+	});
+
+	describe("buildDeclarationAttachments", () => {
+		it("attaches only the declaration recap and never renders the transmitted recap", async () => {
+			const attachments = await buildDeclarationAttachments(SIREN, YEAR);
+
+			expect(attachments).toHaveLength(1);
+			expect(attachments[0]).toMatchObject({
+				filename: `declaration-remuneration-${SIREN}-${YEAR}.pdf`,
+				contentType: "application/pdf",
+			});
+			expect(mocks.buildTransmittedPdfData).not.toHaveBeenCalled();
+			expect(mocks.TransmittedPdfDocument).not.toHaveBeenCalled();
+		});
+
+		it("renders the declaration recap as an initial declaration", async () => {
+			await buildDeclarationAttachments(SIREN, YEAR);
+
+			expect(mocks.buildPdfData).toHaveBeenCalledWith(
+				SIREN,
+				YEAR,
+				expect.any(Date),
+				"initial",
+			);
+		});
+	});
+
+	describe("buildSecondDeclarationAttachments", () => {
+		it("attaches the correction recap and the transmitted recap", async () => {
+			const attachments = await buildSecondDeclarationAttachments(SIREN, YEAR);
+
+			expect(attachments).toHaveLength(2);
+			expect(attachments.map((a) => a.filename)).toEqual([
+				`seconde-declaration-${SIREN}-${YEAR}.pdf`,
+				`recapitulatif-elements-transmis-${SIREN}-${YEAR + 1}.pdf`,
+			]);
+			expect(
+				attachments.every((a) => a.contentType === "application/pdf"),
+			).toBe(true);
+		});
+
+		it("renders the declaration recap as a correction", async () => {
+			await buildSecondDeclarationAttachments(SIREN, YEAR);
+
+			expect(mocks.buildPdfData).toHaveBeenCalledWith(
+				SIREN,
+				YEAR,
+				expect.any(Date),
+				"correction",
+			);
+			expect(mocks.buildTransmittedPdfData).toHaveBeenCalledWith(
+				SIREN,
+				YEAR,
+				expect.any(Date),
+			);
+		});
+	});
+});

--- a/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
+++ b/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
@@ -394,8 +394,6 @@ describe("enqueueReceipt — variant derivation", () => {
 		await enqueueReceipt({ ...baseInput, kind: "declaration" });
 
 		expect(payloadOf().variant).toBe("path_to_select");
-		// Round 1 is the July 1st derived deadline, computed from the campaign year
-		// itself — not the administrable round-2 deadline in the campaign config.
 		expect(payloadOf().complianceDeadline).toBe(
 			getPathChoiceRound1Deadline(2025).toISOString(),
 		);

--- a/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
+++ b/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
@@ -45,6 +45,7 @@ vi.mock("~/server/db", () => ({
 }));
 
 import { AUDIT_ACTIONS } from "~/modules/audit";
+import { getPathChoiceRound1Deadline } from "~/modules/domain";
 import { enqueueReceipt } from "../enqueueReceipt";
 
 const PDF_ATTACHMENT = {
@@ -323,6 +324,21 @@ describe("enqueueReceipt", () => {
 		);
 	});
 
+	it("carries a thrown Error's message onto the audit row when the enqueue fails fatally", async () => {
+		mocks.enqueueNotification.mockRejectedValueOnce(
+			new Error("redis connection lost"),
+		);
+
+		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(mocks.logAction).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: "failure",
+				errorMessage: "redis connection lost",
+			}),
+		);
+	});
+
 	it("passes a null userId through when the session has no user id", async () => {
 		await enqueueReceipt({
 			...baseInput,
@@ -369,13 +385,30 @@ describe("enqueueReceipt — variant derivation", () => {
 		expect(mocks.getCampaignDeadlines).not.toHaveBeenCalled();
 	});
 
-	it("selects path_to_select and attaches the compliance deadline when a compliance path was chosen", async () => {
+	it("attaches the round-1 deadline to a first declaration and never reads the campaign config", async () => {
 		stubContext({
 			...declarationRow,
 			firstDeclarationPathChoice: "justify",
 		});
 
 		await enqueueReceipt({ ...baseInput, kind: "declaration" });
+
+		expect(payloadOf().variant).toBe("path_to_select");
+		// Round 1 is the July 1st derived deadline, computed from the campaign year
+		// itself — not the administrable round-2 deadline in the campaign config.
+		expect(payloadOf().complianceDeadline).toBe(
+			getPathChoiceRound1Deadline(2025).toISOString(),
+		);
+		expect(mocks.getCampaignDeadlines).not.toHaveBeenCalled();
+	});
+
+	it("attaches the administrable round-2 deadline to a second declaration", async () => {
+		stubContext({
+			...declarationRow,
+			secondDeclarationPathChoice: "justify",
+		});
+
+		await enqueueReceipt({ ...baseInput, kind: "secondDeclaration" });
 
 		expect(payloadOf().variant).toBe("path_to_select");
 		expect(payloadOf().complianceDeadline).toBe("2025-09-01T00:00:00.000Z");

--- a/packages/app/src/modules/mail/buildReceiptAttachments.ts
+++ b/packages/app/src/modules/mail/buildReceiptAttachments.ts
@@ -42,7 +42,7 @@ export async function buildDeclarationAttachments(
 	year: number,
 ): Promise<MailAttachment[]> {
 	// The transmitted recap is structurally empty at first declaration.
-	return Promise.all([renderDeclarationPdf(siren, year, "initial")]);
+	return [await renderDeclarationPdf(siren, year, "initial")];
 }
 
 export async function buildSecondDeclarationAttachments(

--- a/packages/app/src/modules/mail/buildReceiptAttachments.ts
+++ b/packages/app/src/modules/mail/buildReceiptAttachments.ts
@@ -41,10 +41,11 @@ export async function buildDeclarationAttachments(
 	siren: string,
 	year: number,
 ): Promise<MailAttachment[]> {
-	return Promise.all([
-		renderDeclarationPdf(siren, year, "initial"),
-		renderTransmittedPdf(siren, year),
-	]);
+	// The "éléments transmis" recap is structurally empty at first declaration
+	// (no CSE opinion nor joint evaluation deposited yet), so only the
+	// declaration recap is attached here. The transmitted recap stays available
+	// on demand and in the second-declaration receipt.
+	return Promise.all([renderDeclarationPdf(siren, year, "initial")]);
 }
 
 export async function buildSecondDeclarationAttachments(

--- a/packages/app/src/modules/mail/buildReceiptAttachments.ts
+++ b/packages/app/src/modules/mail/buildReceiptAttachments.ts
@@ -41,10 +41,7 @@ export async function buildDeclarationAttachments(
 	siren: string,
 	year: number,
 ): Promise<MailAttachment[]> {
-	// The "éléments transmis" recap is structurally empty at first declaration
-	// (no CSE opinion nor joint evaluation deposited yet), so only the
-	// declaration recap is attached here. The transmitted recap stays available
-	// on demand and in the second-declaration receipt.
+	// The transmitted recap is structurally empty at first declaration.
 	return Promise.all([renderDeclarationPdf(siren, year, "initial")]);
 }
 

--- a/packages/app/src/modules/mail/enqueueReceipt.ts
+++ b/packages/app/src/modules/mail/enqueueReceipt.ts
@@ -8,6 +8,7 @@ import type {
 } from "notifications/queue";
 import { AUDIT_ACTIONS } from "~/modules/audit";
 import {
+	getPathChoiceRound1Deadline,
 	hasStartedSecondDeclaration,
 	isInComplianceProcess,
 } from "~/modules/domain";
@@ -120,11 +121,17 @@ async function buildConfirmationPayload(
 				cseRequired: context.cseRequired,
 			});
 			if (variant === "path_to_select") {
-				const deadlines = await getCampaignDeadlines(year);
+				// The first declaration acknowledges round 1 (July 1st of the
+				// campaign year); the second declaration acknowledges round 2, whose
+				// administrable deadline lives in the campaign config.
+				const complianceDeadline =
+					type === "declaration_confirmation"
+						? getPathChoiceRound1Deadline(year)
+						: (await getCampaignDeadlines(year)).pathChoiceDeadline;
 				return {
 					...base,
 					variant,
-					complianceDeadline: deadlines.pathChoiceDeadline.toISOString(),
+					complianceDeadline: complianceDeadline.toISOString(),
 				};
 			}
 			return { ...base, variant };

--- a/packages/app/src/modules/mail/enqueueReceipt.ts
+++ b/packages/app/src/modules/mail/enqueueReceipt.ts
@@ -121,9 +121,7 @@ async function buildConfirmationPayload(
 				cseRequired: context.cseRequired,
 			});
 			if (variant === "path_to_select") {
-				// The first declaration acknowledges round 1 (July 1st of the
-				// campaign year); the second declaration acknowledges round 2, whose
-				// administrable deadline lives in the campaign config.
+				// The first declaration acknowledges round 1, the second round 2.
 				const complianceDeadline =
 					type === "declaration_confirmation"
 						? getPathChoiceRound1Deadline(year)

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -505,6 +505,17 @@ describe("declaration_confirmation variants", () => {
 		expect(mail.html).toContain(`href="${compliancePathUrl}"`);
 		expect(mail.html).toContain(`>${loginUrl}<`);
 	});
+
+	it("path_to_select: requires the compliance deadline", async () => {
+		await expect(
+			buildMail("declaration_confirmation", {
+				siren: SIREN,
+				year: YEAR,
+				variant: "path_to_select",
+				raisonSociale: RAISON_SOCIALE,
+			}),
+		).rejects.toThrow(/complianceDeadline is required/);
+	});
 });
 
 describe("cse_opinion_receipt variants", () => {

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -24,7 +24,8 @@ const SIREN = "552100554";
 const YEAR = 2027;
 const DEADLINE = "2027-06-01T00:00:00.000Z";
 const RAISON_SOCIALE = "Société Démo";
-const COMPLIANCE_DEADLINE = "1er septembre 2028";
+const COMPLIANCE_DEADLINE = "2028-09-01T00:00:00.000Z";
+const COMPLIANCE_DEADLINE_FR = "1ᵉʳ septembre 2028";
 
 const PAYLOADS: NotificationPayloadMap = {
 	declaration_confirmation: {
@@ -498,7 +499,10 @@ describe("declaration_confirmation variants", () => {
 		expect(mail.subject).toBe("Egapro - Transmission de la déclaration");
 		expect(mail.html).toContain("Sélectionner le parcours");
 		expect(mail.html).toContain("supérieurs ou égaux à 5 %");
-		expect(mail.html).toContain(COMPLIANCE_DEADLINE);
+		// The ISO input is rendered through the French formatter, not interpolated
+		// raw — the verbatim ISO leaking into the mail was the reported bug.
+		expect(mail.html).toContain(COMPLIANCE_DEADLINE_FR);
+		expect(mail.html).not.toContain(COMPLIANCE_DEADLINE);
 		expect(mail.html).toContain(`href="${compliancePathUrl}"`);
 		expect(mail.html).toContain(`>${loginUrl}<`);
 	});

--- a/packages/notifications/src/mails/__tests__/builders.test.ts
+++ b/packages/notifications/src/mails/__tests__/builders.test.ts
@@ -499,8 +499,7 @@ describe("declaration_confirmation variants", () => {
 		expect(mail.subject).toBe("Egapro - Transmission de la déclaration");
 		expect(mail.html).toContain("Sélectionner le parcours");
 		expect(mail.html).toContain("supérieurs ou égaux à 5 %");
-		// The ISO input is rendered through the French formatter, not interpolated
-		// raw — the verbatim ISO leaking into the mail was the reported bug.
+		// The verbatim ISO leaking into the mail was the reported bug.
 		expect(mail.html).toContain(COMPLIANCE_DEADLINE_FR);
 		expect(mail.html).not.toContain(COMPLIANCE_DEADLINE);
 		expect(mail.html).toContain(`href="${compliancePathUrl}"`);

--- a/packages/notifications/src/mails/builders/declarationConfirmation.tsx
+++ b/packages/notifications/src/mails/builders/declarationConfirmation.tsx
@@ -84,6 +84,11 @@ export const buildDeclarationConfirmationMail: MailBuilder<
 			return { subject, html, text };
 		}
 		case "path_to_select": {
+			if (!complianceDeadline) {
+				throw new Error(
+					"complianceDeadline is required for path_to_select variant",
+				);
+			}
 			const formattedDeadline = formatFrenchDate(complianceDeadline);
 			const subject = "Egapro - Transmission de la déclaration";
 			const previewText =

--- a/packages/notifications/src/mails/builders/declarationConfirmation.tsx
+++ b/packages/notifications/src/mails/builders/declarationConfirmation.tsx
@@ -1,3 +1,4 @@
+import { formatFrenchDate } from "../shared/formatters.js";
 import { renderEmail } from "../shared/render.js";
 import {
 	getAvisCseUrl,
@@ -83,6 +84,7 @@ export const buildDeclarationConfirmationMail: MailBuilder<
 			return { subject, html, text };
 		}
 		case "path_to_select": {
+			const formattedDeadline = formatFrenchDate(complianceDeadline);
 			const subject = "Egapro - Transmission de la déclaration";
 			const previewText =
 				"Un ou plusieurs écarts de rémunération supérieurs ou égaux à 5 % ont été constatés. Vous devez sélectionner un parcours de mise en conformité.";
@@ -96,7 +98,7 @@ export const buildDeclarationConfirmationMail: MailBuilder<
 						salariée fait apparaître un ou plusieurs écarts de rémunération
 						supérieurs ou égaux à 5 %. Vous devez, en conséquence, sélectionner
 						un parcours de mise en conformité au plus tard le{" "}
-						{complianceDeadline}.
+						{formattedDeadline}.
 					</EmailParagraph>
 					<EmailCtaWithLink
 						href={getCompliancePathUrl()}


### PR DESCRIPTION
Closes #4207

L'accusé de réception de la 1ʳᵉ déclaration annonçait une date limite de choix de parcours **fausse de six mois**, et l'affichait sous forme d'horodatage ISO brut.

## Ce qui n'allait pas

Deux causes distinctes se cumulaient sur la même ligne du mail :

1. **Mauvaise échéance.** `enqueueReceipt` traitait `declaration_confirmation` et `second_declaration_confirmation` dans un `case` fusionné et servait à tous deux `pathChoiceDeadline`, qui vaut le 1ᵉʳ janvier N+1 — l'échéance du **round 2**. Le round 1 relève du **1ᵉʳ juillet de l'année de campagne**, échéance que le worker de rappels implémentait déjà correctement de son côté (`pathChoiceRound1`). L'AR contredisait donc le rappel J-15 envoyé sur le même jalon.
2. **Pas de formatage.** `declarationConfirmation.tsx` était le seul builder de mail à interpoler la date brute au lieu de la passer par `formatFrenchDate`, d'où le `2027-01-01T00:00:00.000Z` visible dans le mail.

Le même écran de choix de parcours affichait la même mauvaise date, sans distinguer les rounds alors que toutes ses autres dates le font.

Par ailleurs, l'AR embarquait deux PDF, dont un « Récapitulatif des éléments transmis » structurellement vide à ce stade du parcours (ni avis CSE ni évaluation conjointe n'ont encore pu être déposés).

## Ce que fait cette PR

- Ajoute `getPathChoiceRound1Deadline(year)` à la couche domaine (1ᵉʳ juillet de l'année de campagne, dérivée — les échéances `pathChoice*` ne sont pas administrables).
- Dissocie le `case` fusionné de `enqueueReceipt` : le round 1 pour l'AR de 1ʳᵉ déclaration, l'échéance administrable pour la seconde.
- Fait passer la date du mail par `formatFrenchDate`, comme les autres builders.
- Aligne l'**affichage** de l'écran de choix de parcours sur le round 1 quand `isSecondRound` est faux.
- Retire le récapitulatif des éléments transmis des pièces jointes de l'AR de 1ʳᵉ déclaration. Seul l'attachement disparaît : le document reste généré, téléchargeable depuis Mon espace, et joint à l'AR de seconde déclaration.

## Décision d'architecture à ne pas « recorriger »

Le **verrou de lecture seule reste volontairement sur le 1ᵉʳ janvier N+1** (`CompliancePathPage.tsx`, `isDeadlinePassed(pathChoiceDeadline)`). Seul l'affichage bascule sur le round 1.

Conséquence assumée : entre le 1ᵉʳ juillet et le 1ᵉʳ janvier suivant, l'écran de round 1 affiche une date limite dépassée alors que le formulaire reste modifiable. Aligner le verrou aurait fermé de six mois une fenêtre de choix ouverte aujourd'hui — c'est un changement de règle métier, pas une correction d'affichage, et il n'est pas dans le périmètre de ce ticket. Le message de lecture seule ne cite aucune date, il ne peut donc pas contredire le bloc d'échéance.

## Tests

La fixture de `builders.test.ts` était **déjà formatée en français** (`"1er septembre 2028"`), ce qui rendait l'assertion `toContain` trivialement vraie et masquait entièrement le bug : le builder recopiait son entrée telle quelle. Elle bascule sur une date ISO, avec une assertion négative sur la présence de l'ISO dans le rendu.

Ajouts : le helper de domaine, la dissociation round 1 / round 2 dans `enqueueReceipt`, la composition des pièces jointes des deux AR, et les deux rendus de l'écran de choix de parcours (round 1 et round 2, avec assertions négatives croisées).

## Vérification manuelle

`docker compose up -d maildev` puis `pnpm --filter notifications preview` : la variante `declaration_confirmation/path_to_select` affiche désormais « au plus tard le 1ᵉʳ juillet … » au lieu de l'horodatage ISO, pendant que `second_declaration_confirmation/path_to_select` reste inchangée sur le 1ᵉʳ janvier N+1.

## Hors périmètre

`TransmittedPdfDocument` titre le PDF « Récapitulatif des éléments transmis {year + 1} », soit 2027 pour une campagne 2026 portant sur les données 2025. Ce document reste téléchargeable depuis Mon espace, donc le libellé reste visible. Non traité ici — à confirmer et à filer séparément si le millésime est effectivement faux.
