### PR TITLE
fix(preprod): aligne ProConnect sur Charon

### DIFF
--- a/.kontinuous/env/preprod/templates/egapro.configmap.yaml
+++ b/.kontinuous/env/preprod/templates/egapro.configmap.yaml
@@ -4,11 +4,11 @@ metadata:
   name: egapro
 data:
   EGAPRO_PROCONNECT_SCOPE: "openid email given_name usual_name siret phone"
-  EGAPRO_PROCONNECT_DISCOVERY_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2"
-  EGAPRO_PROCONNECT_SIGN_IN_URL: "https://identite-sandbox.proconnect.gouv.fr/users/start-sign-in"
-  EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL: "https://identite-sandbox.proconnect.gouv.fr/manage-organizations"
-  EGAPRO_PROCONNECT_PERSONAL_INFORMATION_URL: "https://identite-sandbox.proconnect.gouv.fr/personal-information"
+  EGAPRO_PROCONNECT_DISCOVERY_URL: "https://egapro-charon.ovh.fabrique.social.gouv.fr/proconnecttest"
+  EGAPRO_PROCONNECT_SIGN_IN_URL: ""
+  EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL: "https://identite.proconnect.gouv.fr/manage-organizations"
+  EGAPRO_PROCONNECT_PERSONAL_INFORMATION_URL: "https://identite.proconnect.gouv.fr/personal-information"
   # Keep SECURITY_CHARON_URL empty: it defaults to the charon proxy URL when
   # unset, which would re-enable useCharon on preprod (env != "prod").
   SECURITY_CHARON_URL: ""
-  SECURITY_MONCOMPTEPRO_TEST: "false"
+  SECURITY_MONCOMPTEPRO_TEST: "true"

--- a/.kontinuous/env/preprod/values.yaml
+++ b/.kontinuous/env/preprod/values.yaml
@@ -33,9 +33,9 @@ app:
     MAILER_SMTP_SSL: "False"
     NODE_ENV: production
 #    EMAIL_LOGIN: "True"
-    EGAPRO_PROCONNECT_DISCOVERY_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2"
-    EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL: "https://identite-sandbox.proconnect.gouv.fr/manage-organizations"
-    EGAPRO_PROCONNECT_PERSONAL_INFORMATION_URL: "https://identite-sandbox.proconnect.gouv.fr/personal-information"
+    EGAPRO_PROCONNECT_DISCOVERY_URL: "https://egapro-charon.ovh.fabrique.social.gouv.fr/proconnecttest"
+    EGAPRO_PROCONNECT_MANAGE_ORGANISATIONS_URL: "https://identite.proconnect.gouv.fr/manage-organizations"
+    EGAPRO_PROCONNECT_PERSONAL_INFORMATION_URL: "https://identite.proconnect.gouv.fr/personal-information"
     REDIS_SENTINEL_MASTER_NAME: "mymaster"
     REDIS_SENTINEL_HOSTS: |
       [


### PR DESCRIPTION
## Contexte

Après la bascule de la préprod vers le bac à sable ProConnect (#4242), le flux OIDC échoue avec `invalid_redirect_uri` pour :

`https://egapro-preprod.ovh.fabrique.social.gouv.fr/api/auth/callback/proconnect`

Les credentials sont les mêmes que sur alpha, mais la préprod appelait directement le endpoint FCA sandbox alors que alpha passe par Charon.

## Changements

- aligne `EGAPRO_PROCONNECT_DISCOVERY_URL` sur le provider Charon utilisé par alpha ;
- aligne les URLs ProConnect annexes sur alpha ;
- active `SECURITY_MONCOMPTEPRO_TEST` en préprod ;
- conserve les credentials existants, déjà identiques à ceux de alpha.

## Validation

- le callback préprod est accepté par Charon (`HTTP 302`) ;
- les valeurs ProConnect/Charon de la préprod correspondent à celles de alpha ;
- `git diff --check` passe.