### PR TITLE
fix(my-space): #4209 — échéance de choix de parcours et document récap conditionnel

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -337,7 +337,7 @@ L'application génère plusieurs documents officiels et expose une API publique 
 | Type | Quand | Module |
 |---|---|---|
 | `DeclarationPdfDocument` | Pre-fill / aperçu | `~/modules/declarationPdf` |
-| `TransmittedPdfDocument` | Reçu officiel après soumission | `~/modules/declarationPdf` |
+| `TransmittedPdfDocument` | Récapitulatif des avis CSE et de l'évaluation conjointe transmis | `~/modules/declarationPdf` |
 
 Téléchargement déclenché depuis :
 

--- a/packages/app/src/e2e/declaration-process-panel.e2e.ts
+++ b/packages/app/src/e2e/declaration-process-panel.e2e.ts
@@ -295,6 +295,12 @@ test.describe("Declaration process panel", () => {
 // linked it. The guard now reads "the declaration is submitted", pinned here end
 // to end — seeded FSM state → server payload → cell count → panel → an endpoint
 // that really returns the PDF — which the DocumentsPanel unit tests cannot observe.
+//
+// #4209 — submission alone no longer opens the *transmitted* recap: that PDF only
+// ever carries CSE opinions and the joint evaluation file, so before the démarche
+// produces one it rendered as empty blocks. Both branches are seeded from real
+// rows, because the server derives the two flags gating it from app_file and the
+// status history, not from the declaration record the unit tests hand the panel.
 test.describe("Mon espace — Ressources cell of the rémunération row", () => {
 	test.describe.configure({ mode: "serial" });
 	test.setTimeout(90_000);
@@ -336,23 +342,24 @@ test.describe("Mon espace — Ressources cell of the rémunération row", () => 
 		return page.locator(`#${DOCUMENTS_PANEL_ID}`);
 	}
 
-	test.describe("declaration submitted, démarche still running", () => {
+	test.describe("declaration submitted, nothing transmitted yet", () => {
 		test.beforeAll(async () => {
 			await setDeclarationComplianceState({
 				status: "awaiting_compliance_path_choice",
 				currentStep: 6,
 			});
+			await deleteJointEvaluationFiles();
+			await deleteCseOpinions();
 		});
 
-		test("both recaps sit next to the prefill file, and each endpoint serves a PDF", async ({
+		test("the indicators recap sits next to the prefill file, and the transmitted recap stays out until it has content", async ({
 			page,
 		}) => {
 			const panel = await openDocumentsPanel(page);
 
-			await expect(documentsTrigger(page)).toHaveText("Documents (3)");
+			await expect(documentsTrigger(page)).toHaveText("Documents (2)");
 
 			const indicatorsHref = `/api/declaration-pdf?year=${CURRENT_YEAR}`;
-			const transmittedHref = `/api/transmitted-pdf?year=${CURRENT_YEAR}`;
 
 			await expect(
 				panel.getByRole("link", { name: PREFILL_TITLE }),
@@ -362,13 +369,48 @@ test.describe("Mon espace — Ressources cell of the rémunération row", () => 
 			).toHaveAttribute("href", indicatorsHref);
 			await expect(
 				panel.getByRole("link", { name: RECAP_TRANSMITTED_TITLE }),
+			).toHaveCount(0);
+
+			const response = await page.request.get(indicatorsHref, {
+				timeout: 30_000,
+			});
+			expect(response.status(), `GET ${indicatorsHref}`).toBe(200);
+			expect(response.headers()["content-type"]).toContain("pdf");
+		});
+	});
+
+	test.describe("joint evaluation path chosen, its file deposited", () => {
+		test.beforeAll(async () => {
+			await setDeclarationComplianceState({
+				status: "joint_evaluation_chosen",
+				currentStep: 6,
+				firstDeclarationPathChoice: "joint_evaluation",
+			});
+			await insertJointEvaluationFile(CURRENT_YEAR);
+		});
+
+		test.afterAll(async () => {
+			await deleteJointEvaluationFiles();
+		});
+
+		test("the transmitted recap joins the two others, and its endpoint serves a PDF", async ({
+			page,
+		}) => {
+			const panel = await openDocumentsPanel(page);
+
+			await expect(documentsTrigger(page)).toHaveText("Documents (3)");
+
+			const transmittedHref = `/api/transmitted-pdf?year=${CURRENT_YEAR}`;
+
+			await expect(
+				panel.getByRole("link", { name: RECAP_TRANSMITTED_TITLE }),
 			).toHaveAttribute("href", transmittedHref);
 
-			for (const href of [indicatorsHref, transmittedHref]) {
-				const response = await page.request.get(href, { timeout: 30_000 });
-				expect(response.status(), `GET ${href}`).toBe(200);
-				expect(response.headers()["content-type"]).toContain("pdf");
-			}
+			const response = await page.request.get(transmittedHref, {
+				timeout: 30_000,
+			});
+			expect(response.status(), `GET ${transmittedHref}`).toBe(200);
+			expect(response.headers()["content-type"]).toContain("pdf");
 		});
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -14,7 +14,7 @@ import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/L
 import {
 	type CampaignDeadlines,
 	formatLongDate,
-	getPathChoiceRound1Deadline,
+	selectPathChoiceDeadline,
 } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
 import { scrollToTop } from "~/modules/shared/scrollToTop";
@@ -134,9 +134,10 @@ export function CompliancePathChoice({
 	const modificationDeadline = isSecondRound
 		? campaignDeadlines.decl2ModificationDeadline
 		: campaignDeadlines.decl1ModificationDeadline;
-	const pathChoiceDeadline = isSecondRound
-		? campaignDeadlines.pathChoiceDeadline
-		: getPathChoiceRound1Deadline(currentYear);
+	const pathChoiceDeadline = selectPathChoiceDeadline(
+		campaignDeadlines,
+		isSecondRound,
+	);
 	const gapNoticeText = isSecondRound
 		? "Des écarts ≥ 5 % ont de nouveau été détectés, vous devez engager l'un des parcours suivants."
 		: "Des écarts ≥ 5 % ont été constatés, vous devez engager l'un des parcours suivants.";

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathPage.tsx
@@ -133,6 +133,8 @@ export async function CompliancePathPage() {
 		hasSubmittedSecondDeclaration: data.hasSubmittedSecondDeclaration,
 		hasSubmittedCseOpinion: data.hasSubmittedCseOpinion,
 		hasSubmittedJointEvaluation: data.hasSubmittedJointEvaluation,
+		// Round 2's date on purpose, both rounds: the round-1 date is shown to nudge,
+		// it must not close the choice. Do not swap in selectPathChoiceDeadline.
 		pathChoiceDeadline: campaignDeadlines.pathChoiceDeadline,
 	});
 

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.redirect.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.redirect.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import type React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockRedirect, mockAuth } = vi.hoisted(() => ({
 	mockRedirect: vi.fn<(url: string) => never>().mockImplementation(() => {
@@ -163,5 +163,50 @@ describe("CompliancePathPage — skipping the choice page", () => {
 
 		expect(mockRedirect).not.toHaveBeenCalled();
 		expect(screen.getByTestId("path-choice")).toBeInTheDocument();
+	});
+});
+
+// The page must keep feeding the read-only gate the round-2 deadline for BOTH
+// rounds. Rebranching it on `selectPathChoiceDeadline` (the display helper) would
+// close the choice on 1 July N instead of 1 January N+1 — 5 months too early —
+// and typecheck would stay green. These two tests are that safety net.
+describe("CompliancePathPage — the path-choice deadline is indicative", () => {
+	beforeEach(() => {
+		mockRedirect.mockClear();
+		mockAuth.mockReset();
+		vi.mocked(CompliancePathChoice).mockClear();
+		vi.useFakeTimers({ toFake: ["Date"] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	async function renderRound1ChoiceAt(now: Date) {
+		vi.setSystemTime(now);
+		mockPage({
+			gipWorkforce: 250,
+			hasCse: true,
+			employeeCategories: [HIGH_GAP_CATEGORY],
+		});
+
+		render(await CompliancePathPage());
+
+		return vi.mocked(CompliancePathChoice).mock.calls[0]?.[0];
+	}
+
+	it("leaves the round-1 choice open past 1 July: the deadline nudges, it never closes the action", async () => {
+		const props = await renderRound1ChoiceAt(new Date(2026, 8, 15));
+
+		expect(
+			props?.readOnlyReason,
+			"the round-1 path choice must stay open past 1 July — the gate has to keep reading campaignDeadlines.pathChoiceDeadline (1 January N+1), never selectPathChoiceDeadline",
+		).toBeUndefined();
+	});
+
+	it("closes the choice only once 1 January N+1 has passed", async () => {
+		const props = await renderRound1ChoiceAt(new Date(2027, 0, 15));
+
+		expect(props?.readOnlyReason).toBe("path_choice_deadline_passed");
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathPage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { getDefaultCampaignDeadlines } from "~/modules/domain";
 import {
 	getCompliancePathReadOnlyReason,
 	getComplianceState,
@@ -197,6 +198,30 @@ describe("getCompliancePathReadOnlyReason", () => {
 				pathChoice: null,
 				pathChoiceDeadline: new Date("2026-06-01T00:00:00"),
 				now: new Date("2026-06-02T00:00:00"),
+			}),
+		).toBe("path_choice_deadline_passed");
+	});
+
+	// The gate is fed the round-2 deadline for both rounds on purpose: the round-1
+	// date (1 July) is a nudge shown to the user, not a lock. The wiring that keeps
+	// it that way is pinned in CompliancePathPage.redirect.test.tsx.
+	it("keeps the round-1 choice open past 1 July: the path-choice deadline is indicative, never blocking", () => {
+		const deadlines = getDefaultCampaignDeadlines(2026);
+		const afterRound1Nudge = new Date(2026, 8, 15);
+
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoiceDeadline: deadlines.pathChoiceDeadline,
+				now: afterRound1Nudge,
+			}),
+		).toBeNull();
+
+		expect(
+			getCompliancePathReadOnlyReason({
+				...baseParams,
+				pathChoiceDeadline: deadlines.pathChoiceRound1Deadline,
+				now: afterRound1Nudge,
 			}),
 		).toBe("path_choice_deadline_passed");
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -190,6 +190,7 @@ describe("DraftLoadingGate", () => {
 					decl2JustificationDeadline: new Date("2026-09-01"),
 					decl2JointEvaluationDeadline: new Date("2026-11-01"),
 					pathChoiceDeadline: new Date("2027-01-01"),
+					pathChoiceRound1Deadline: new Date("2026-07-01"),
 				}}
 				cseOpinionRequired={true}
 				currentYear={2026}

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -12,6 +12,7 @@ import {
 	getSecondDeclarationDeadline,
 	getWorkforceYear,
 	isDeadlinePassed,
+	selectPathChoiceDeadline,
 	shouldRedirectSubmittedToRecap,
 } from "../shared/campaign";
 
@@ -134,6 +135,25 @@ describe("getPathChoiceRound1Deadline", () => {
 		expect(getPathChoiceRound1Deadline(year)).not.toEqual(
 			getPathChoiceDeadline(year),
 		);
+	});
+});
+
+describe("selectPathChoiceDeadline", () => {
+	const ROUND_1_DEADLINE = new Date("2027-05-15T00:00:00");
+	const ROUND_2_DEADLINE = new Date("2027-11-20T00:00:00");
+	// Values that differ from the derived defaults prove the selector reads the given deadlines instead of recomputing them.
+	const deadlines = {
+		...getDefaultCampaignDeadlines(2027),
+		pathChoiceRound1Deadline: ROUND_1_DEADLINE,
+		pathChoiceDeadline: ROUND_2_DEADLINE,
+	};
+
+	it("returns the round-1 deadline when the company is not in the second round", () => {
+		expect(selectPathChoiceDeadline(deadlines, false)).toBe(ROUND_1_DEADLINE);
+	});
+
+	it("returns the round-2 deadline when the company is in the second round", () => {
+		expect(selectPathChoiceDeadline(deadlines, true)).toBe(ROUND_2_DEADLINE);
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/declarationProcessStep.test.ts
+++ b/packages/app/src/modules/domain/__tests__/declarationProcessStep.test.ts
@@ -27,7 +27,7 @@ describe("getDeclarationProcessStepDeadline", () => {
 		{ fsm: "draft", deadlineKey: "decl1ModificationDeadline" },
 		{
 			fsm: "awaiting_compliance_path_choice",
-			deadlineKey: "decl2ModificationDeadline",
+			deadlineKey: "pathChoiceRound1Deadline",
 		},
 		{
 			fsm: "corrective_actions_chosen",
@@ -35,7 +35,7 @@ describe("getDeclarationProcessStepDeadline", () => {
 		},
 		{
 			fsm: "awaiting_revision_choice",
-			deadlineKey: "decl2JointEvaluationDeadline",
+			deadlineKey: "pathChoiceDeadline",
 		},
 		{
 			fsm: "joint_evaluation_chosen",

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -13,6 +13,7 @@ export {
 	getSecondDeclarationDeadline,
 	getWorkforceYear,
 	isDeadlinePassed,
+	selectPathChoiceDeadline,
 	shouldRedirectSubmittedToRecap,
 } from "./shared/campaign";
 // Campaign alignment — temporary recette bridge mapping 2026 → 2027, delete when 2027 arrives

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -50,7 +50,12 @@ export function getPathChoiceRound1Deadline(year: number): Date {
 	return new Date(year, 6, 1);
 }
 
-/** Returns the deadline to choose a compliance path for the round the company is in. */
+/**
+ * Returns the deadline to choose a compliance path for the round the company is in.
+ *
+ * Display only — never feed a read-only gate or a write guard with it: the path
+ * choice stays open past the round-1 date (see CompliancePathPage).
+ */
 export function selectPathChoiceDeadline(
 	deadlines: CampaignDeadlines,
 	isSecondRound: boolean,

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -62,6 +62,7 @@ export function getDefaultCampaignDeadlines(year: number): CampaignDeadlines {
 		decl2JustificationDeadline: new Date(year, 11, 1),
 		decl2JointEvaluationDeadline: new Date(year + 1, 1, 1),
 		pathChoiceDeadline: getPathChoiceDeadline(year),
+		pathChoiceRound1Deadline: getPathChoiceRound1Deadline(year),
 	};
 }
 

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -50,6 +50,16 @@ export function getPathChoiceRound1Deadline(year: number): Date {
 	return new Date(year, 6, 1);
 }
 
+/** Returns the deadline to choose a compliance path for the round the company is in. */
+export function selectPathChoiceDeadline(
+	deadlines: CampaignDeadlines,
+	isSecondRound: boolean,
+): Date {
+	return isSecondRound
+		? deadlines.pathChoiceDeadline
+		: deadlines.pathChoiceRound1Deadline;
+}
+
 /** Returns default campaign deadlines for a given year (fallback when no DB config exists). */
 export function getDefaultCampaignDeadlines(year: number): CampaignDeadlines {
 	return {

--- a/packages/app/src/modules/domain/shared/declarationProcessStep.ts
+++ b/packages/app/src/modules/domain/shared/declarationProcessStep.ts
@@ -20,11 +20,11 @@ export function getDeclarationProcessStepDeadline(
 		case "draft":
 			return deadlines.decl1ModificationDeadline;
 		case "awaiting_compliance_path_choice":
-			return deadlines.decl2ModificationDeadline;
+			return deadlines.pathChoiceRound1Deadline;
 		case "corrective_actions_chosen":
 			return deadlines.decl2ModificationDeadline;
 		case "awaiting_revision_choice":
-			return deadlines.decl2JointEvaluationDeadline;
+			return deadlines.pathChoiceDeadline;
 		case "joint_evaluation_chosen":
 			return deadlines.decl1JointEvaluationDeadline;
 		case "revised_joint_evaluation_chosen":

--- a/packages/app/src/modules/domain/types.ts
+++ b/packages/app/src/modules/domain/types.ts
@@ -49,4 +49,5 @@ export type CampaignDeadlines = {
 	decl2JustificationDeadline: Date;
 	decl2JointEvaluationDeadline: Date;
 	pathChoiceDeadline: Date;
+	pathChoiceRound1Deadline: Date;
 };

--- a/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
+++ b/packages/app/src/modules/mail/__tests__/enqueueReceipt.test.ts
@@ -45,7 +45,7 @@ vi.mock("~/server/db", () => ({
 }));
 
 import { AUDIT_ACTIONS } from "~/modules/audit";
-import { getPathChoiceRound1Deadline } from "~/modules/domain";
+import { getDefaultCampaignDeadlines } from "~/modules/domain";
 import { enqueueReceipt } from "../enqueueReceipt";
 
 const PDF_ATTACHMENT = {
@@ -60,6 +60,12 @@ const baseInput = {
 	year: 2025,
 	userId: "user-1",
 	isResend: false,
+};
+
+const CAMPAIGN_DEADLINES = {
+	...getDefaultCampaignDeadlines(baseInput.year),
+	// Not the derived default: round 2 is administrable, so the payload must read it from the campaign config.
+	pathChoiceDeadline: new Date("2025-09-01T00:00:00.000Z"),
 };
 
 const declarationRow = {
@@ -91,9 +97,7 @@ describe("enqueueReceipt", () => {
 		vi.clearAllMocks();
 		mocks.buildDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
 		mocks.buildSecondDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
-		mocks.getCampaignDeadlines.mockResolvedValue({
-			pathChoiceDeadline: new Date("2025-09-01T00:00:00.000Z"),
-		});
+		mocks.getCampaignDeadlines.mockResolvedValue(CAMPAIGN_DEADLINES);
 		mocks.enqueueNotification.mockResolvedValue({
 			status: "enqueued",
 			id: "job-1",
@@ -360,9 +364,7 @@ describe("enqueueReceipt — variant derivation", () => {
 		vi.clearAllMocks();
 		mocks.buildDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
 		mocks.buildSecondDeclarationAttachments.mockResolvedValue([PDF_ATTACHMENT]);
-		mocks.getCampaignDeadlines.mockResolvedValue({
-			pathChoiceDeadline: new Date("2025-09-01T00:00:00.000Z"),
-		});
+		mocks.getCampaignDeadlines.mockResolvedValue(CAMPAIGN_DEADLINES);
 		mocks.enqueueNotification.mockResolvedValue({
 			status: "enqueued",
 			id: "job-1",
@@ -385,7 +387,7 @@ describe("enqueueReceipt — variant derivation", () => {
 		expect(mocks.getCampaignDeadlines).not.toHaveBeenCalled();
 	});
 
-	it("attaches the round-1 deadline to a first declaration and never reads the campaign config", async () => {
+	it("attaches the round-1 deadline to a first declaration", async () => {
 		stubContext({
 			...declarationRow,
 			firstDeclarationPathChoice: "justify",
@@ -395,9 +397,9 @@ describe("enqueueReceipt — variant derivation", () => {
 
 		expect(payloadOf().variant).toBe("path_to_select");
 		expect(payloadOf().complianceDeadline).toBe(
-			getPathChoiceRound1Deadline(2025).toISOString(),
+			CAMPAIGN_DEADLINES.pathChoiceRound1Deadline.toISOString(),
 		);
-		expect(mocks.getCampaignDeadlines).not.toHaveBeenCalled();
+		expect(mocks.getCampaignDeadlines).toHaveBeenCalledWith(2025);
 	});
 
 	it("attaches the administrable round-2 deadline to a second declaration", async () => {
@@ -409,7 +411,9 @@ describe("enqueueReceipt — variant derivation", () => {
 		await enqueueReceipt({ ...baseInput, kind: "secondDeclaration" });
 
 		expect(payloadOf().variant).toBe("path_to_select");
-		expect(payloadOf().complianceDeadline).toBe("2025-09-01T00:00:00.000Z");
+		expect(payloadOf().complianceDeadline).toBe(
+			CAMPAIGN_DEADLINES.pathChoiceDeadline.toISOString(),
+		);
 		expect(mocks.getCampaignDeadlines).toHaveBeenCalledWith(2025);
 	});
 

--- a/packages/app/src/modules/mail/enqueueReceipt.ts
+++ b/packages/app/src/modules/mail/enqueueReceipt.ts
@@ -8,9 +8,9 @@ import type {
 } from "notifications/queue";
 import { AUDIT_ACTIONS } from "~/modules/audit";
 import {
-	getPathChoiceRound1Deadline,
 	hasStartedSecondDeclaration,
 	isInComplianceProcess,
+	selectPathChoiceDeadline,
 } from "~/modules/domain";
 import { logAction } from "~/server/audit/log";
 import { db } from "~/server/db";
@@ -122,10 +122,10 @@ async function buildConfirmationPayload(
 			});
 			if (variant === "path_to_select") {
 				// The first declaration acknowledges round 1, the second round 2.
-				const complianceDeadline =
-					type === "declaration_confirmation"
-						? getPathChoiceRound1Deadline(year)
-						: (await getCampaignDeadlines(year)).pathChoiceDeadline;
+				const complianceDeadline = selectPathChoiceDeadline(
+					await getCampaignDeadlines(year),
+					type !== "declaration_confirmation",
+				);
 				return {
 					...base,
 					variant,

--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -37,6 +37,12 @@ function getResources(declaration: DeclarationItem): DocumentResource[] {
 			subtitle,
 			href: `/api/declaration-pdf?year=${declaration.year}`,
 		});
+	}
+
+	if (
+		declaration.hasSubmittedCseOpinion ||
+		declaration.hasJointEvaluationFile
+	) {
 		resources.push({
 			title: "Télécharger le récapitulatif des éléments transmis",
 			subtitle,

--- a/packages/app/src/modules/my-space/VerticalStepper.tsx
+++ b/packages/app/src/modules/my-space/VerticalStepper.tsx
@@ -242,6 +242,9 @@ function Step2Content({
 	}
 
 	if (variant === "compliance_choice") {
+		const pathChoiceDeadline = secondDeclarationSubmitted
+			? campaignDeadlines.pathChoiceDeadline
+			: campaignDeadlines.pathChoiceRound1Deadline;
 		return (
 			<div className={styles.stepContent}>
 				{title}
@@ -253,7 +256,7 @@ function Step2Content({
 						viewHref={`/declaration-remuneration/recapitulatif?siren=${siren}&type=correction`}
 					/>
 				)}
-				<DeadlineRow date={campaignDeadlines.decl2ModificationDeadline} />
+				<DeadlineRow date={pathChoiceDeadline} />
 			</div>
 		);
 	}

--- a/packages/app/src/modules/my-space/VerticalStepper.tsx
+++ b/packages/app/src/modules/my-space/VerticalStepper.tsx
@@ -5,7 +5,11 @@ import type {
 	CampaignDeadlines,
 	DeclarationDisplayContext,
 } from "~/modules/domain";
-import { getReferenceYearFor, isDeadlinePassed } from "~/modules/domain";
+import {
+	getReferenceYearFor,
+	isDeadlinePassed,
+	selectPathChoiceDeadline,
+} from "~/modules/domain";
 import type { PanelVariant } from "./DeclarationProcessPanel";
 import styles from "./DeclarationProcessPanel.module.scss";
 
@@ -242,9 +246,10 @@ function Step2Content({
 	}
 
 	if (variant === "compliance_choice") {
-		const pathChoiceDeadline = secondDeclarationSubmitted
-			? campaignDeadlines.pathChoiceDeadline
-			: campaignDeadlines.pathChoiceRound1Deadline;
+		const pathChoiceDeadline = selectPathChoiceDeadline(
+			campaignDeadlines,
+			secondDeclarationSubmitted,
+		);
 		return (
 			<div className={styles.stepContent}>
 				{title}

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -117,7 +117,7 @@ describe("DeclarationsSection", () => {
 	it("renders a Documents link for completed declarations", () => {
 		renderSection();
 		expect(
-			screen.getByRole("button", { name: "Documents (2)" }),
+			screen.getByRole("button", { name: "Documents (1)" }),
 		).toBeInTheDocument();
 	});
 
@@ -137,7 +137,7 @@ describe("DeclarationsSection", () => {
 			],
 		});
 		expect(
-			screen.getByRole("button", { name: "Documents (2)" }),
+			screen.getByRole("button", { name: "Documents (1)" }),
 		).toBeInTheDocument();
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
@@ -132,11 +132,27 @@ describe("getDocumentResourceCount", () => {
 
 	it.each(
 		SUBMITTED_FSM_STATUSES,
-	)("counts both recap resources once the declaration is submitted (%s)", (fsmStatus) => {
-		expect(getDocumentResourceCount(makeDeclaration({ fsmStatus }))).toBe(2);
+	)("counts the declaration recap alone once submitted, without any transmitted element (%s)", (fsmStatus) => {
+		expect(getDocumentResourceCount(makeDeclaration({ fsmStatus }))).toBe(1);
 	});
 
-	it("counts the prefill and both recaps while the compliance path choice is pending", () => {
+	it("adds the transmitted-elements recap once a CSE opinion has been submitted", () => {
+		expect(
+			getDocumentResourceCount(
+				makeDeclaration({ hasSubmittedCseOpinion: true }),
+			),
+		).toBe(2);
+	});
+
+	it("adds the transmitted-elements recap once a joint evaluation file has been deposited", () => {
+		expect(
+			getDocumentResourceCount(
+				makeDeclaration({ hasJointEvaluationFile: true }),
+			),
+		).toBe(2);
+	});
+
+	it("counts only the prefill and the declaration recap while the compliance path choice is pending", () => {
 		expect(
 			getDocumentResourceCount(
 				makeDeclaration({
@@ -144,15 +160,16 @@ describe("getDocumentResourceCount", () => {
 					hasPrefillData: true,
 				}),
 			),
-		).toBe(3);
+		).toBe(2);
 	});
 
-	it("counts every resource when the second declaration was submitted", () => {
+	it("counts every resource when the second declaration and a transmitted element are present", () => {
 		expect(
 			getDocumentResourceCount(
 				makeDeclaration({
 					hasPrefillData: true,
 					hasSubmittedSecondDeclaration: true,
+					hasJointEvaluationFile: true,
 				}),
 			),
 		).toBe(4);
@@ -193,6 +210,7 @@ describe("DocumentsPanel", () => {
 	it("renders one card per available resource, in order", () => {
 		const { links } = renderPanel({
 			hasPrefillData: true,
+			hasJointEvaluationFile: true,
 			hasSubmittedSecondDeclaration: true,
 		});
 
@@ -207,6 +225,7 @@ describe("DocumentsPanel", () => {
 	it("points each card at its own PDF route and dates it with the reference year", () => {
 		const { panel, links } = renderPanel({
 			hasPrefillData: true,
+			hasJointEvaluationFile: true,
 			hasSubmittedSecondDeclaration: true,
 		});
 
@@ -223,10 +242,7 @@ describe("DocumentsPanel", () => {
 	it("omits the prefill card when no DSN data is available", () => {
 		const { links } = renderPanel();
 
-		expect(links().map((link) => link.textContent)).toEqual([
-			RECAP_TITLE,
-			TRANSMITTED_TITLE,
-		]);
+		expect(links().map((link) => link.textContent)).toEqual([RECAP_TITLE]);
 	});
 
 	it.each(
@@ -237,7 +253,7 @@ describe("DocumentsPanel", () => {
 		expect(links().map((link) => link.textContent)).toEqual([PREFILL_TITLE]);
 	});
 
-	it("offers both recap cards as soon as the declaration is submitted, long before the démarche ends", () => {
+	it("hides the transmitted-elements recap while the compliance path choice is pending and nothing has been transmitted", () => {
 		const { links } = renderPanel({
 			fsmStatus: "awaiting_compliance_path_choice",
 			hasPrefillData: true,
@@ -245,6 +261,17 @@ describe("DocumentsPanel", () => {
 
 		expect(links().map((link) => link.textContent)).toEqual([
 			PREFILL_TITLE,
+			RECAP_TITLE,
+		]);
+	});
+
+	it("offers the transmitted-elements recap once a transmitted element exists", () => {
+		const { links } = renderPanel({
+			fsmStatus: "awaiting_cse_opinion",
+			hasSubmittedCseOpinion: true,
+		});
+
+		expect(links().map((link) => link.textContent)).toEqual([
 			RECAP_TITLE,
 			TRANSMITTED_TITLE,
 		]);
@@ -291,7 +318,9 @@ describe("DocumentsPanel", () => {
 
 	it("announces the pending state and marks the card busy while downloading", () => {
 		vi.stubGlobal("fetch", pendingFetch());
-		const { dialog, panel, links } = renderPanel();
+		const { dialog, panel, links } = renderPanel({
+			hasJointEvaluationFile: true,
+		});
 
 		fireEvent.click(links()[0] as HTMLAnchorElement);
 
@@ -307,7 +336,7 @@ describe("DocumentsPanel", () => {
 
 	it("keeps each card's download state independent", () => {
 		vi.stubGlobal("fetch", pendingFetch());
-		const { links } = renderPanel();
+		const { links } = renderPanel({ hasJointEvaluationFile: true });
 
 		fireEvent.click(links()[0] as HTMLAnchorElement);
 

--- a/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
@@ -1,6 +1,7 @@
 import { render, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { OrdinalLongDate } from "~/modules/declaration-remuneration/shared/OrdinalLongDate";
 import type { DeclarationDisplayContext } from "~/modules/domain";
 import { getDefaultCampaignDeadlines } from "~/modules/domain";
 import type { PanelVariant } from "../DeclarationProcessPanel";
@@ -8,6 +9,14 @@ import { DeclarationProcessPanel } from "../DeclarationProcessPanel";
 
 const FUTURE_YEAR = 2099;
 const PAST_YEAR = 2020;
+
+// `OrdinalLongDate` formats in UTC, so the rendered string is timezone-sensitive.
+// Deriving the expected label through the same component keeps the deadline
+// assertions robust to the runner's timezone.
+function longDateText(date: Date): string {
+	const { container } = render(<OrdinalLongDate date={date} />);
+	return container.textContent ?? "";
+}
 
 type CompliancePath = "justify" | "corrective_action" | "joint_evaluation";
 
@@ -148,6 +157,36 @@ describe("VerticalStepper — bouton œil (viewHref)", () => {
 			expect(
 				panel.queryByText("Votre seconde déclaration a été transmise"),
 			).not.toBeInTheDocument();
+		});
+
+		it("shows the round-1 path-choice deadline while the second declaration is not submitted", () => {
+			const deadlines = getDefaultCampaignDeadlines(FUTURE_YEAR);
+			const { panel } = renderPanel("compliance_choice", {
+				campaignDeadlines: deadlines,
+				hasSubmittedSecondDeclaration: false,
+			});
+
+			const deadlineRow = panel.getByText(/^Échéance :/);
+			expect(deadlineRow).toHaveTextContent(
+				`Échéance : ${longDateText(deadlines.pathChoiceRound1Deadline)}`,
+			);
+			expect(deadlineRow).not.toHaveTextContent(
+				longDateText(deadlines.decl2ModificationDeadline),
+			);
+		});
+
+		it("shows the round-2 path-choice deadline once the second declaration is submitted", () => {
+			const deadlines = getDefaultCampaignDeadlines(FUTURE_YEAR);
+			const { panel } = renderPanel("compliance_choice", {
+				campaignDeadlines: deadlines,
+				displayContext: makeDisplayContext("corrective_action"),
+				hasSubmittedSecondDeclaration: true,
+			});
+
+			const deadlineRow = panel.getByText(/^Échéance :/);
+			expect(deadlineRow).toHaveTextContent(
+				`Échéance : ${longDateText(deadlines.pathChoiceDeadline)}`,
+			);
 		});
 	});
 

--- a/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/VerticalStepper.test.tsx
@@ -10,9 +10,7 @@ import { DeclarationProcessPanel } from "../DeclarationProcessPanel";
 const FUTURE_YEAR = 2099;
 const PAST_YEAR = 2020;
 
-// `OrdinalLongDate` formats in UTC, so the rendered string is timezone-sensitive.
-// Deriving the expected label through the same component keeps the deadline
-// assertions robust to the runner's timezone.
+// `OrdinalLongDate` formats in UTC, so a hardcoded label would break on other timezones.
 function longDateText(date: Date): string {
 	const { container } = render(<OrdinalLongDate date={date} />);
 	return container.textContent ?? "";

--- a/packages/app/src/server/api/routers/__tests__/declaration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declaration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDefaultCampaignDeadlines } from "~/modules/domain";
 import {
 	createCaller,
 	mockDeclaration,
@@ -23,6 +24,14 @@ vi.mock("~/server/auth", () => ({
 
 vi.mock("~/server/db", () => ({
 	db: {},
+}));
+
+const { mockGetCampaignDeadlines } = vi.hoisted(() => ({
+	mockGetCampaignDeadlines: vi.fn(),
+}));
+
+vi.mock("~/server/db/getCampaignDeadlines", () => ({
+	getCampaignDeadlines: mockGetCampaignDeadlines,
 }));
 
 vi.mock("../declarationHelpers", async (importOriginal) => {
@@ -1181,6 +1190,32 @@ describe("declarationRouter", () => {
 			expect(purgeCall).toBeDefined();
 			expect(purgeCall?.draft).toBeNull();
 			expect(purgeCall?.draftUpdatedAt).toBeNull();
+		});
+
+		// The path-choice deadline nudges, it never closes the action. Concretely:
+		// `saveCompliancePath` must stay a `declarationLockedWriteProcedure` —
+		// promoting it to `declarationModifiableWriteProcedure` would add the
+		// modification-deadline guard and lock the choice out from 1 June N.
+		it("still saves a compliance path once every campaign deadline has passed", async () => {
+			// A campaign old enough that all of its deadlines are behind us.
+			mockGetCampaignDeadlines.mockResolvedValue(
+				getDefaultCampaignDeadlines(2019),
+			);
+			const declaration = buildDeclaration({
+				status: "awaiting_compliance_path_choice",
+				cseRequired: false,
+			});
+			const ctx = createSimpleSelectDb(declaration);
+			const caller = await createCaller(
+				withLockMiddleware(ctx.db, {
+					declarationStatus: declaration.status,
+					declarationYear: declaration.year,
+				}),
+			);
+
+			await expect(
+				caller.saveCompliancePath({ path: "justify" }),
+			).resolves.toEqual({ success: true });
 		});
 	});
 

--- a/packages/app/src/server/api/routers/__tests__/declarationDeadlineGuard.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDeadlineGuard.test.ts
@@ -51,6 +51,7 @@ function deadlines(
 		decl2JustificationDeadline: future,
 		decl2JointEvaluationDeadline: future,
 		pathChoiceDeadline: past,
+		pathChoiceRound1Deadline: past,
 		...overrides,
 	};
 }

--- a/packages/app/src/server/db/getCampaignDeadlines.ts
+++ b/packages/app/src/server/db/getCampaignDeadlines.ts
@@ -5,6 +5,7 @@ import type { CampaignDeadlines } from "~/modules/domain";
 import {
 	getDefaultCampaignDeadlines,
 	getPathChoiceDeadline,
+	getPathChoiceRound1Deadline,
 } from "~/modules/domain";
 
 import { db } from ".";
@@ -47,6 +48,7 @@ export const getCampaignDeadlines = cache(
 			decl2JustificationDeadline: parseDate(row.decl2JustificationDeadline),
 			decl2JointEvaluationDeadline: parseDate(row.decl2JointEvaluationDeadline),
 			pathChoiceDeadline: getPathChoiceDeadline(year),
+			pathChoiceRound1Deadline: getPathChoiceRound1Deadline(year),
 		};
 	},
 );


### PR DESCRIPTION
Closes #4209

## Contexte

Entreprise > 250 salariés, déclaration des indicateurs de rémunération soumise avec des écarts > 5 %, choix du parcours de mise en conformité pas encore renseigné. Deux défauts sur Mon espace, diagnostiqués dans le commentaire `## Analyse du bug` de l'issue.

## Point 1 — échéance de choix de parcours (régression fonctionnelle)

La règle est round-dépendante : **1ᵉʳ juillet N** au round 1, **1ᵉʳ janvier N+1** au round 2. Elle était déjà correctement appliquée dans le tunnel de déclaration (`CompliancePathChoice`) et dans les accusés de réception (`enqueueReceipt`), mais les deux surfaces de Mon espace l'ignoraient et retombaient sur `decl2ModificationDeadline` — soit **01/12/2026 au lieu du 01/07/2026**, cinq mois d'écart sur une obligation réglementaire.

- `pathChoiceRound1Deadline` est exposé comme **champ dérivé** de `CampaignDeadlines` (à l'image de `pathChoiceDeadline`, qui n'est pas non plus une colonne DB) — pas de migration
- `getDeclarationProcessStepDeadline` (tableau) : `awaiting_compliance_path_choice` → round 1 ; `awaiting_revision_choice` → `pathChoiceDeadline` au lieu de `decl2JointEvaluationDeadline`, qui donnait **01/02/2027 au lieu du 01/01/2027** — même classe de bug sur le round 2, non signalée dans l'issue
- `VerticalStepper` (panneau latéral) : discrimination round 1 / round 2 via `secondDeclarationSubmitted`, déjà utilisé quelques lignes plus haut dans le même bloc

Les deux surfaces lisent désormais la même source.

## Point 2 — document « Récapitulatif des éléments transmis »

Le document était proposé dès la transmission de la 1ʳᵉ déclaration, alors que `buildTransmittedPdfData` ne remonte que les avis CSE et le fichier d'évaluation conjointe : tant que le parcours de conformité n'a pas démarré, le PDF se réduit à un en-tête suivi de blocs « Aucun avis enregistré ».

Il n'est plus proposé qu'en présence réelle de contenu (`hasSubmittedCseOpinion || hasJointEvaluationFile`) — décision produit : **affichage conditionnel** plutôt que suppression, pour que les entreprises qui vont au bout du parcours conservent leur récapitulatif. Dans l'état décrit par l'issue, le compteur passe de « Documents (3) » à « Documents (2) ».

`docs/features.md` décrivait ce PDF comme un « Reçu officiel après soumission », ce qui ne correspond pas à son contenu — ligne corrigée.

## Hors périmètre

Le 3ᵉ point de l'issue — « Modification close depuis le 1ᵉʳ juin 2026 » qui s'affiche dès le 1ᵉʳ juin à 00:00 au lieu du 2 — est un bug confirmé mais à portée plus large : `isDeadlinePassed` garde aussi l'écriture réelle côté serveur, et le rendre inclusif rallonge de 24 h la fenêtre de modification réglementaire. Suivi dans #4252.

## Tests

Couverture unitaire ajoutée sur les deux fonctions pures (mapping FSM → échéance, construction de la liste de ressources) et sur le panneau latéral aux deux rounds. Suite complète verte : 4473 tests / 396 fichiers.
