### PR TITLE
fix(declaration-pdf): #4210 — évite les titres orphelins en bas de page du récapitulatif

### DIFF
--- a/packages/app/src/modules/declarationPdf/__tests__/helpers/registerPdfFonts.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/helpers/registerPdfFonts.ts
@@ -1,0 +1,31 @@
+import { createRequire } from "node:module";
+
+import { Font } from "@react-pdf/renderer";
+
+import { PDF_FONT_FAMILY, splitOnSoftHyphen } from "../../pdfFonts";
+
+const resolve = createRequire(import.meta.url).resolve;
+
+// Resolves Marianne from node_modules rather than through
+// ensurePdfFontsRegistered(), which reads public/dsfr/fonts — generated at
+// dev/build time and git-ignored. Real glyph metrics matter: a stand-in font
+// shifts every measured height and line break.
+export function registerPdfFonts({ hyphenation = false } = {}): void {
+	Font.register({
+		family: PDF_FONT_FAMILY,
+		fonts: [
+			{
+				src: resolve("@gouvfr/dsfr/dist/fonts/Marianne-Regular.woff"),
+				fontWeight: 400,
+			},
+			{
+				src: resolve("@gouvfr/dsfr/dist/fonts/Marianne-Bold.woff"),
+				fontWeight: 700,
+			},
+		],
+	});
+
+	// Opt-in: the hyphenation specs need the production callback, since a local
+	// stand-in would let them pass while the real PDF still hyphenates.
+	if (hyphenation) Font.registerHyphenationCallback(splitOnSoftHyphen);
+}

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfAccentRendering.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfAccentRendering.test.tsx
@@ -1,10 +1,7 @@
 // @vitest-environment node
 
-import { createRequire } from "node:module";
-
 import {
 	Document,
-	Font,
 	Page,
 	renderToBuffer,
 	StyleSheet,
@@ -18,18 +15,12 @@ import {
 	extractTextStream,
 	type PositionedRun,
 } from "./helpers/pdfTextStream";
+import { registerPdfFonts } from "./helpers/registerPdfFonts";
 
 const FONT_SIZE = 100;
 const FRENCH_DIACRITICS = "éèêëàâùûîïôöçÉÈÊÀÇ";
 
-const marianneRegular = createRequire(import.meta.url).resolve(
-	"@gouvfr/dsfr/dist/fonts/Marianne-Regular.woff",
-);
-
-Font.register({
-	family: PDF_FONT_FAMILY,
-	fonts: [{ src: marianneRegular, fontWeight: 400 }],
-});
+registerPdfFonts();
 
 const styles = StyleSheet.create({
 	page: { fontFamily: PDF_FONT_FAMILY, padding: 0 },

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfCategoryPagination.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfCategoryPagination.test.tsx
@@ -143,13 +143,15 @@ describe("PDF category pagination", () => {
 	it("never leaves a category or section banner at the bottom of a page", async () => {
 		const offenders: { filler: number; banners: string[] }[] = [];
 
-		for (let fillerHeight = 560; fillerHeight <= 700; fillerHeight += 1) {
+		// Step 3pt: the regression spans ~75pt of filler, so a coarser sweep still
+		// samples it dozens of times while keeping the render count affordable.
+		for (let fillerHeight = 560; fillerHeight <= 700; fillerHeight += 3) {
 			const banners = orphanedBanners(await renderWithFiller(fillerHeight));
 			if (banners.length > 0) offenders.push({ filler: fillerHeight, banners });
 		}
 
 		expect(offenders).toEqual([]);
-	}, 30_000); // 141 full PDF renders on real fonts — well over the 5s default.
+	}, 120_000); // 47 full PDF renders on real fonts, slower again under coverage.
 
 	it("keeps each category heading on the same page as its effectif table", async () => {
 		// At this filler the first category no longer fits: wrap={false} must hold.

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfCategoryPagination.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfCategoryPagination.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment node
+
+import type { OnRenderProps } from "@react-pdf/renderer";
+import { Document, Page, pdf, View } from "@react-pdf/renderer";
+import { describe, expect, it } from "vitest";
+
+import { makeCategory } from "~/modules/declaration-remuneration/recapitulatif/__tests__/fixtures";
+import { noPayGapReferences } from "~/test/gipGapFixtures";
+
+import { styles } from "../recapPdfStyles";
+import { CategorySection } from "../sections/CategorySection";
+import type { DeclarationPdfData } from "../types";
+import { registerPdfFonts } from "./helpers/registerPdfFonts";
+
+registerPdfFonts();
+
+// Banners that must never end up alone at a page bottom.
+const BANNER =
+	/^(Catégorie d'emplois n°\d+|Écart de rémunération par catégories)/;
+
+// A @react-pdf LayoutNode: box.top is parent-relative, only TEXT carries height.
+type LayoutNode = {
+	type: string;
+	value?: string;
+	box?: { top?: number; height?: number };
+	children?: LayoutNode[];
+};
+
+// react-pdf exposes the laid-out tree on onRender but omits it from its public type.
+function readLayout(props: OnRenderProps): LayoutNode {
+	const layout = (props as { _INTERNAL__LAYOUT__DATA_?: LayoutNode })
+		._INTERNAL__LAYOUT__DATA_;
+	if (!layout) throw new Error("onRender did not expose the layout data");
+	return layout;
+}
+
+type PageText = { text: string; bottom: number };
+
+function textOf(node: LayoutNode): string {
+	if (node.type === "TEXT_INSTANCE") return node.value ?? "";
+	return (node.children ?? []).map(textOf).join("");
+}
+
+function collectPageTexts(
+	node: LayoutNode,
+	parentTop: number,
+	out: PageText[],
+): void {
+	const top = parentTop + (node.box?.top ?? 0);
+	if (node.type === "TEXT" && node.box?.height !== undefined) {
+		out.push({ text: textOf(node).trim(), bottom: top + node.box.height });
+	}
+	for (const child of node.children ?? []) collectPageTexts(child, top, out);
+}
+
+// A banner as the bottom-most text of a page means its block wrapped without it.
+function orphanedBanners(layout: LayoutNode): string[] {
+	const orphans: string[] = [];
+	for (const page of layout.children ?? []) {
+		const texts: PageText[] = [];
+		for (const child of page.children ?? []) collectPageTexts(child, 0, texts);
+		const printed = texts.filter((entry) => entry.text.length > 0);
+		if (printed.length === 0) continue;
+		const last = printed.reduce((a, b) => (b.bottom > a.bottom ? b : a));
+		if (BANNER.test(last.text)) orphans.push(last.text);
+	}
+	return orphans;
+}
+
+function makeData(): DeclarationPdfData {
+	return {
+		year: 2026,
+		workforceYear: 2025,
+		isSecondDeclaration: false,
+		transmittedAt: "05/03/2026",
+		referencePeriod: "01/01/2025 - 31/12/2025",
+		declarant: { name: "Jean Martin", email: "email@example.fr", phone: "" },
+		company: {
+			name: "Société Démo",
+			siren: "123456789",
+			address: "",
+			nafCode: null,
+			nafLabel: null,
+			workforceDisplay: "250",
+		},
+		totalWomen: 0,
+		totalMen: 0,
+		step2Data: {} as DeclarationPdfData["step2Data"],
+		step3Data: {} as DeclarationPdfData["step3Data"],
+		step4Data: { annual: [], hourly: [] },
+		step2Gaps: noPayGapReferences(),
+		step3Gaps: noPayGapReferences(),
+		// Varied heights so the sweep lands banners at many distances from the bottom.
+		categories: [
+			makeCategory({ name: "Ouvriers", womenCount: 10, menCount: 15 }),
+			makeCategory({
+				name: "Employés",
+				womenCount: 30,
+				menCount: 20,
+				annualBaseWomen: "40000",
+				annualBaseMen: "42000",
+				annualVariableWomen: "1000",
+				annualVariableMen: "2000",
+			}),
+			makeCategory({ name: "Techniciens", womenCount: 5, menCount: 8 }),
+			makeCategory({
+				name: "Cadres",
+				womenCount: 12,
+				menCount: 18,
+				hourlyBaseWomen: "22",
+				hourlyBaseMen: "24",
+			}),
+		],
+		source: "Accord d'entreprise",
+	};
+}
+
+async function renderWithFiller(fillerHeight: number): Promise<LayoutNode> {
+	let layout: LayoutNode | null = null;
+	// Mirrors DeclarationPdfDocument; the filler stands in for the sections above.
+	const document = (
+		<Document
+			onRender={(props) => {
+				layout = readLayout(props);
+			}}
+		>
+			<Page size="A4" style={styles.page} wrap>
+				<View style={{ height: fillerHeight }} />
+				<View style={styles.content}>
+					<CategorySection data={makeData()} />
+				</View>
+			</Page>
+		</Document>
+	);
+
+	await pdf(document).toBuffer();
+
+	if (!layout) throw new Error("onRender never delivered the layout data");
+	return layout;
+}
+
+describe("PDF category pagination", () => {
+	it("never leaves a category or section banner at the bottom of a page", async () => {
+		const offenders: { filler: number; banners: string[] }[] = [];
+
+		for (let fillerHeight = 560; fillerHeight <= 700; fillerHeight += 1) {
+			const banners = orphanedBanners(await renderWithFiller(fillerHeight));
+			if (banners.length > 0) offenders.push({ filler: fillerHeight, banners });
+		}
+
+		expect(offenders).toEqual([]);
+	}, 30_000); // 141 full PDF renders on real fonts — well over the 5s default.
+
+	it("keeps each category heading on the same page as its effectif table", async () => {
+		// At this filler the first category no longer fits: wrap={false} must hold.
+		const layout = await renderWithFiller(600);
+
+		const bannerPage = new Map<string, number>();
+		const tablePage = new Map<string, number>();
+		let pageIndex = 0;
+		for (const page of layout.children ?? []) {
+			const texts: PageText[] = [];
+			for (const child of page.children ?? [])
+				collectPageTexts(child, 0, texts);
+			const headings = texts
+				.map((entry) => entry.text)
+				.filter((text) => /^Catégorie d'emplois n°\d+/.test(text));
+			for (const heading of headings) bannerPage.set(heading, pageIndex);
+			// The effectif table's row label marks the page holding the table body.
+			if (texts.some((entry) => entry.text === "Nombre de salariés")) {
+				for (const heading of headings) tablePage.set(heading, pageIndex);
+			}
+			pageIndex += 1;
+		}
+
+		expect(bannerPage.size).toBeGreaterThan(0);
+		for (const [heading, page] of bannerPage) {
+			expect(tablePage.get(heading)).toBe(page);
+		}
+	});
+});

--- a/packages/app/src/modules/declarationPdf/__tests__/pdfHyphenation.test.tsx
+++ b/packages/app/src/modules/declarationPdf/__tests__/pdfHyphenation.test.tsx
@@ -1,7 +1,5 @@
 // @vitest-environment node
 
-import { createRequire } from "node:module";
-
 import { Document, Font, Page, renderToBuffer } from "@react-pdf/renderer";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -13,28 +11,9 @@ import {
 	extractPositionedRuns,
 	extractTextStream,
 } from "./helpers/pdfTextStream";
+import { registerPdfFonts } from "./helpers/registerPdfFonts";
 
-// Fonts are resolved from node_modules rather than through
-// ensurePdfFontsRegistered(), which reads public/dsfr/fonts — generated at
-// dev/build time and git-ignored. The hyphenation callback, however, IS the
-// production one: registering a local stand-in would let this file pass while
-// the real PDF still hyphenates.
-const resolve = createRequire(import.meta.url).resolve;
-
-Font.register({
-	family: PDF_FONT_FAMILY,
-	fonts: [
-		{
-			src: resolve("@gouvfr/dsfr/dist/fonts/Marianne-Regular.woff"),
-			fontWeight: 400,
-		},
-		{
-			src: resolve("@gouvfr/dsfr/dist/fonts/Marianne-Bold.woff"),
-			fontWeight: 700,
-		},
-	],
-});
-Font.registerHyphenationCallback(splitOnSoftHyphen);
+registerPdfFonts({ hyphenation: true });
 
 const REGULAR = 400;
 const BOLD = 700;

--- a/packages/app/src/modules/declarationPdf/recapPdfStyles.ts
+++ b/packages/app/src/modules/declarationPdf/recapPdfStyles.ts
@@ -241,6 +241,4 @@ export const styles = StyleSheet.create({
 		fontStyle: "italic",
 		marginTop: 4,
 	},
-
-	categoryBlock: {},
 });

--- a/packages/app/src/modules/declarationPdf/sections/CategorySection.tsx
+++ b/packages/app/src/modules/declarationPdf/sections/CategorySection.tsx
@@ -135,9 +135,9 @@ function CategoryBlock({
 }) {
 	const heading = `Catégorie d'emplois n°${index + 1}${category.name ? ` : ${category.name}` : ""}`;
 	return (
-		<View style={styles.categoryBlock}>
-			<CategoryBanner title={heading} />
+		<>
 			<View wrap={false}>
+				<CategoryBanner title={heading} />
 				<SubTitle title="Effectifs physiques" />
 				<EffectifTable category={category} />
 			</View>
@@ -159,13 +159,13 @@ function CategoryBlock({
 					variableWomen={category.hourlyVariableWomen}
 				/>
 			</View>
-		</View>
+		</>
 	);
 }
 
 export function CategorySection({ data }: { data: DeclarationPdfData }) {
 	return (
-		<View>
+		<>
 			<View minPresenceAhead={80} wrap={false}>
 				<SectionBanner title="Écart de rémunération par catégories de salariés" />
 				{data.categories.length > 0 ? (
@@ -188,6 +188,6 @@ export function CategorySection({ data }: { data: DeclarationPdfData }) {
 					key={category.name}
 				/>
 			))}
-		</View>
+		</>
 	);
 }

--- a/packages/app/src/modules/declarationPdf/sections/headings.tsx
+++ b/packages/app/src/modules/declarationPdf/sections/headings.tsx
@@ -12,7 +12,7 @@ export function SectionBanner({ title }: { title: string }) {
 
 export function CategoryBanner({ title }: { title: string }) {
 	return (
-		<View minPresenceAhead={60} style={styles.categoryBanner}>
+		<View style={styles.categoryBanner}>
 			<Text style={styles.categoryBannerText}>{title}</Text>
 		</View>
 	);


### PR DESCRIPTION
Closes #4210

## Problème

Dans le PDF « Récapitulatif de la déclaration des indicateurs de rémunération », un bandeau de titre pouvait rester seul en bas de page pendant que le tableau qui lui appartient basculait sur la page suivante (cas signalé : `Catégorie d'emplois n°2 : Employés`).

## Cause

Le bandeau de catégorie était un **frère** du `<View wrap={false}>` qui le suit, et son `minPresenceAhead={60}` était **silencieusement inerte** : `@react-pdf/layout` n'applique `minPresenceAhead` que si le nœud a au moins un frère **avant** lui dans son conteneur (garde `breakingImprovesPresence` — « if the child is already at the top of the page, breaking won't improve its presence »). Or les deux bandeaux concernés étaient premiers enfants d'un `<View>` de regroupement sans style.

Deux blocs étaient touchés, pas un seul : corriger uniquement le bloc catégorie faisait **remonter l'orphelin d'un cran** sur le bandeau `Écart de rémunération par catégories de salariés`, dont le `minPresenceAhead={80}` était inerte pour la même raison.

## Correctif

- Le `CategoryBanner` entre **dans** le `<View wrap={false}>` avec le sous-titre « Effectifs physiques » et son tableau → le couple titre + tableau devient atomique.
- Les deux `<View>` de regroupement sans style deviennent des fragments → le bandeau de section retrouve un frère précédent et son `minPresenceAhead={80}` redevient actif.
- `minPresenceAhead={60}` retiré du `CategoryBanner`, désormais inutile (et de toute façon sous-dimensionné : le bloc à réserver fait ~83 pt).
- Suppression du style mort `categoryBlock: {}`.

Le récapitulatif étant aussi joint à l'accusé de réception, le correctif couvre les deux surfaces.

## Vérification

Test de non-régression `pdfCategoryPagination.test.tsx` : balayage 1 pt par 1 pt (560 → 700 pt) de la hauteur du contenu précédant la section des catégories, avec assertion sur l'arbre paginé exposé par `onRender`. **84 positions orphelines avant le correctif, 0 après.**

Vérifié en plus, hors suite, sur le document complet `DeclarationPdfDocument` (1→6 catégories × 7 longueurs d'adresse) : plusieurs bandeaux orphelins avant le correctif, aucun après.

## Note

La registration des polices Marianne dans les specs PDF était réimplémentée à l'identique dans trois fichiers ; elle est extraite dans `__tests__/helpers/registerPdfFonts.ts`.
