### PR TITLE
fix(my-space): radios CSE Oui/Non sur la même ligne (#3666)

### DIFF
--- a/packages/app/src/modules/my-space/MissingInfoModal.module.scss
+++ b/packages/app/src/modules/my-space/MissingInfoModal.module.scss
@@ -1,0 +1,5 @@
+.cseFieldset {
+	:global(.fr-fieldset__element--inline) {
+		flex: 1 1 0;
+	}
+}

--- a/packages/app/src/modules/my-space/MissingInfoModal.tsx
+++ b/packages/app/src/modules/my-space/MissingInfoModal.tsx
@@ -11,7 +11,8 @@ import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 
 import { DECLARATION_PROCESS_PANEL_ID } from "./DeclarationProcessPanel";
-import styles from "./DeclarationProcessPanel.module.scss";
+import panelStyles from "./DeclarationProcessPanel.module.scss";
+import styles from "./MissingInfoModal.module.scss";
 import { createMissingInfoSchema } from "./schemas";
 import { useUpdateHasCse } from "./useUpdateHasCse";
 
@@ -147,12 +148,12 @@ export function MissingInfoModal({
 		<dialog
 			aria-labelledby={PANEL_TITLE_ID}
 			aria-modal="true"
-			className={`fr-modal ${styles.sidePanel}`}
+			className={`fr-modal ${panelStyles.sidePanel}`}
 			id={MISSING_INFO_PANEL_ID}
 			ref={dialogRef}
 		>
-			<div className={styles.panelContainer}>
-				<div className={styles.panelHeader}>
+			<div className={panelStyles.panelContainer}>
+				<div className={panelStyles.panelHeader}>
 					<button
 						aria-controls={MISSING_INFO_PANEL_ID}
 						className="fr-btn fr-btn--tertiary-no-outline fr-btn--sm fr-btn--icon-right fr-icon-close-line"
@@ -162,7 +163,7 @@ export function MissingInfoModal({
 						Fermer
 					</button>
 				</div>
-				<div className={styles.panelContent}>
+				<div className={panelStyles.panelContent}>
 					<div>
 						<h2 className="fr-h5 fr-mb-3w" id={PANEL_TITLE_ID}>
 							Informations manquantes
@@ -186,13 +187,15 @@ export function MissingInfoModal({
 									cseError ? "missing-info-cse-error" : undefined
 								}
 								className={
-									cseError ? "fr-fieldset fr-fieldset--error" : "fr-fieldset"
+									cseError
+										? `fr-fieldset fr-fieldset--error ${styles.cseFieldset}`
+										: `fr-fieldset ${styles.cseFieldset}`
 								}
 							>
 								<legend className="fr-fieldset__legend fr-text--regular">
 									Un CSE a-t-il été mis en place dans votre entreprise ?
 								</legend>
-								<div className="fr-fieldset__element">
+								<div className="fr-fieldset__element fr-fieldset__element--inline">
 									<div className="fr-radio-group fr-radio-rich">
 										<input
 											id="missing-info-cse-yes"
@@ -205,7 +208,7 @@ export function MissingInfoModal({
 										</label>
 									</div>
 								</div>
-								<div className="fr-fieldset__element">
+								<div className="fr-fieldset__element fr-fieldset__element--inline">
 									<div className="fr-radio-group fr-radio-rich">
 										<input
 											id="missing-info-cse-no"
@@ -236,12 +239,12 @@ export function MissingInfoModal({
 						)}
 					</div>
 					<div>
-						<div className={styles.helpSection}>
+						<div className={panelStyles.helpSection}>
 							<hr className="fr-hr" />
 							<p className="fr-text--lg fr-text--bold fr-mb-0">
 								Pour vous aider
 							</p>
-							<div className={styles.helpLinks}>
+							<div className={panelStyles.helpLinks}>
 								<button className="fr-link" type="button">
 									Détail des étapes
 								</button>
@@ -250,7 +253,7 @@ export function MissingInfoModal({
 								</button>
 							</div>
 						</div>
-						<div className={styles.footer}>
+						<div className={panelStyles.footer}>
 							<ul className="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg">
 								<li>
 									<button

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
@@ -177,6 +177,12 @@ describe("MissingInfoModal", () => {
 				"Un CSE a-t-il été mis en place dans votre entreprise ?",
 			),
 		).toBeInTheDocument();
+		expect(
+			screen.getByLabelText("Oui").closest(".fr-fieldset__element"),
+		).toHaveClass("fr-fieldset__element--inline");
+		expect(
+			screen.getByLabelText("Non").closest(".fr-fieldset__element"),
+		).toHaveClass("fr-fieldset__element--inline");
 	});
 
 	it("does not render CSE radio buttons when hasCse is provided", () => {


### PR DESCRIPTION
Closes #3666

## Contexte

Dans le panneau **Informations manquantes** (Mon espace), les radios riches « Oui » / « Non » pour l'existence d'un CSE s'affichaient l'un **sous** l'autre. Le Figma les place sur **une seule ligne**, à largeur égale.

Référence Figma : [D/Panneau latéral — Informations manquantes](https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=8470-95443)

## Cause

`.fr-fieldset__element` a `flex: 1 1 100%` : chaque option prend toute la largeur. Il manquait la variante DSFR `fr-fieldset__element--inline`.

## Correctif

- Ajout de `fr-fieldset__element--inline` sur les deux options
- Largeurs égales (`flex: 1 1 0`) pour coller à la rangée Figma (289 px + 8 px + 289 px)

## Tests

- TU `MissingInfoModal` : les deux radios ont la classe `--inline`
- Mesure DOM (preview DSFR 640 px) : même `y`, largeurs égales, côte à côte

## Vérification one-shot

| | Avant | Après |
|---|---|---|
| Layout | stacked (flex-basis 100 %) | inline, largeurs égales |