### PR TITLE
fix(my-space): table Démarche en cours en typo SM 14px (#3665)

### DIFF
--- a/packages/app/src/modules/my-space/DeclarationLink.tsx
+++ b/packages/app/src/modules/my-space/DeclarationLink.tsx
@@ -12,7 +12,7 @@ import styles from "./DeclarationsSection.module.scss";
 import type { DeclarationType } from "./types";
 
 const MISSING_INFO_MODAL_ID = "missing-info-modal";
-const linkClass = `fr-link ${styles.linkUnderlined}`;
+const linkClass = `fr-link fr-link--sm ${styles.linkUnderlined}`;
 
 type Props = {
 	type: DeclarationType;

--- a/packages/app/src/modules/my-space/DeclarationsSection.module.scss
+++ b/packages/app/src/modules/my-space/DeclarationsSection.module.scss
@@ -7,6 +7,12 @@
 		font-size: 0.875rem;
 		line-height: 1.5rem;
 	}
+
+	// DSFR .fr-link defaults to 16px (MD); Figma table copy is SM 14px.
+	:global(.fr-link) {
+		font-size: 0.875rem;
+		line-height: 1.5rem;
+	}
 }
 
 // DSFR JS sets --table-offset: calc(1px + 1rem) on .fr-table__wrapper to

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -97,7 +97,7 @@ export function DeclarationsSection({
 
 	return (
 		<div className="fr-container fr-my-6w">
-			<h2 className="fr-mb-4w" id="demarches-en-cours-title">
+			<h2 className="fr-h3 fr-mb-4w" id="demarches-en-cours-title">
 				Démarche en cours
 			</h2>
 			{visibleCurrentDeclarations.length > 0 && (
@@ -112,7 +112,7 @@ export function DeclarationsSection({
 			)}
 			{visiblePreviousDeclarations.length > 0 && (
 				<>
-					<h2 className="fr-mt-6w fr-mb-3w" id="annees-precedentes-title">
+					<h2 className="fr-h3 fr-mt-6w fr-mb-3w" id="annees-precedentes-title">
 						Années précédentes
 					</h2>
 					<DeclarationsTable

--- a/packages/app/src/modules/my-space/DeclarationsSection.tsx
+++ b/packages/app/src/modules/my-space/DeclarationsSection.tsx
@@ -218,7 +218,7 @@ function DeclarationsTable({
 													<>
 														<button
 															aria-controls={getDocumentsPanelId(declaration)}
-															className={`fr-link ${styles.linkUnderlined}`}
+															className={`fr-link fr-link--sm ${styles.linkUnderlined}`}
 															data-fr-opened="false"
 															type="button"
 														>

--- a/packages/app/src/modules/my-space/__tests__/DeclarationLink.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationLink.test.tsx
@@ -25,6 +25,7 @@ describe("DeclarationLink", () => {
 		);
 		const button = screen.getByRole("button", { name: "Rémunération" });
 		expect(button).toBeInTheDocument();
+		expect(button).toHaveClass("fr-link", "fr-link--sm");
 		expect(button).toHaveAttribute(
 			"aria-controls",
 			"declaration-process-panel",
@@ -124,6 +125,7 @@ describe("DeclarationLink", () => {
 		);
 		const button = screen.getByRole("button", { name: "Représentation" });
 		expect(button).toBeInTheDocument();
+		expect(button).toHaveClass("fr-link", "fr-link--sm");
 	});
 
 	it("bypasses missing info modal during admin impersonation", () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -69,9 +69,12 @@ function renderSection(
 describe("DeclarationsSection", () => {
 	it("renders the 'Démarche en cours' heading", () => {
 		renderSection();
-		expect(
-			screen.getByRole("heading", { level: 2, name: "Démarche en cours" }),
-		).toBeInTheDocument();
+		const heading = screen.getByRole("heading", {
+			level: 2,
+			name: "Démarche en cours",
+		});
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveClass("fr-h3");
 	});
 
 	it("renders the table column headers including Échéance and Ressources", () => {
@@ -143,9 +146,12 @@ describe("DeclarationsSection", () => {
 
 	it("renders 'Années précédentes' heading when there are past declarations", () => {
 		renderSection();
-		expect(
-			screen.getByRole("heading", { level: 2, name: "Années précédentes" }),
-		).toBeInTheDocument();
+		const heading = screen.getByRole("heading", {
+			level: 2,
+			name: "Années précédentes",
+		});
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveClass("fr-h3");
 	});
 
 	it("renders 'Rémunération' and 'Représentation' buttons", () => {

--- a/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DeclarationsSection.test.tsx
@@ -160,6 +160,17 @@ describe("DeclarationsSection", () => {
 		expect(represButtons).toHaveLength(1);
 	});
 
+	it("uses DSFR SM (14px) link size on every table link", () => {
+		renderSection();
+		const tableLinks = screen.getAllByRole("button", {
+			name: /^(Rémunération|Représentation|Documents \(\d+\))$/,
+		});
+		expect(tableLinks.length).toBeGreaterThan(0);
+		for (const link of tableLinks) {
+			expect(link).toHaveClass("fr-link", "fr-link--sm");
+		}
+	});
+
 	it("shows the first representation step in the 'Étape' column", () => {
 		renderSection();
 		expect(


### PR DESCRIPTION
Closes #3665

## Contexte

Dans le tableau **Démarche en cours** (Mon espace), la typo n'était pas homogène. Le Figma impose le corps **SM (14 px / 24 px)** pour les en-têtes, les cellules et les liens.

Référence Figma : [D/Mon espace — Entreprise sélectionnée](https://www.figma.com/design/axsrSDEVqsrFvHdWrZJIkQ/-Refonte--Egapro?node-id=8470-95271) (tableau `8470:95304`)

## Cause

`.fr-table__content th, td` est déjà en 14 px. En revanche `.fr-link` (sans modificateur) force **16 px (MD)**. Les libellés « Rémunération » / « Représentation » et le bouton « Documents (N) » sortaient donc du rythme du tableau.

Le Figma utilise le composant Lien **Taille = SM** (14 px). Les badges restent en XS 12 px, comme sur la maquette.

## Correctif

- `fr-link--sm` sur `DeclarationLink` et sur le bouton Documents
- `.tableSm :global(.fr-link)` pour verrouiller le 14 px au niveau du tableau

## Tests

- TU `DeclarationLink` : les boutons portent `fr-link--sm`
- TU `DeclarationsSection` : tous les liens du tableau (déclaration + Documents) portent `fr-link--sm`

## Vérification one-shot

Mesure DOM (DSFR chargé, thème clair) — desktop 1280 et mobile 375 :

| Élément | Avant | Après | Figma |
|---|---|---|---|
| En-tête `th` | 14 px | 14 px | SM Bold 14 |
| Année / étape / échéance | 14 px | 14 px | SM Regular 14 |
| Lien « Rémunération » | **16 px** | **14 px** | Lien SM 14 |
| Lien « Documents » | **16 px** | **14 px** | Lien SM 14 |
| Badge « À compléter » | 12 px | 12 px | XS 12 (inchangé) |

## Titre du tableau

Le Figma pose « Démarches en cours » / « Années précédentes » en **H3 28px / 36px**. Le `<h2>` DSFR par défaut rendait **32px**. Ajout de `fr-h3` (niveau sémantique `h2` conservé).

| | Avant (h2) | Après (h2.fr-h3) | Figma |
|---|---|---|---|
| Desktop | 32 px / 40 px | **28 px / 36 px** | H3 28 / 36 |
| Mobile | 28 px / 36 px | 24 px / 32 px | H3 mobile DSFR |