### PR TITLE
fix(joint-evaluation): #4211 — réaligner les espacements sur la maquette Figma

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -80,15 +80,13 @@ export function JointEvaluationForm({
 
 	return (
 		<>
-			<form
-				autoComplete="off"
-				className={common.flexColumnGap2}
-				onSubmit={handleSubmit}
-			>
+			<form autoComplete="off" onSubmit={handleSubmit}>
 				{/* Read-only mode is enforced per control (disabled upload and submit
 				    button): a fieldset-level `disabled` would hide the content from
 				    some assistive technologies (#3803). */}
-				<fieldset className={common.readOnlyFieldset}>
+				<fieldset
+					className={`${common.readOnlyFieldset} ${common.flexColumnGap2}`}
+				>
 					<legend className="fr-sr-only">
 						Évaluation conjointe des rémunérations
 					</legend>
@@ -127,8 +125,8 @@ export function JointEvaluationForm({
 					</p>
 
 					<div className="fr-highlight">
-						<p className="fr-mb-1v fr-text--md">Date limite</p>
-						<p className="fr-h6 fr-mb-1v">
+						<p className="fr-mb-2v fr-text--md">Date limite</p>
+						<p className="fr-h6 fr-mb-2v">
 							{formatLongDate(jointEvaluationDeadline)}
 						</p>
 						<p className="fr-mb-0 fr-text--sm fr-text--mention-grey">
@@ -140,7 +138,7 @@ export function JointEvaluationForm({
 						<label className="fr-label" htmlFor="joint-evaluation-file-upload">
 							Veuillez importer/déposer le rapport de l&apos;évaluation
 							conjointe.
-							<span className="fr-hint-text">
+							<span className="fr-hint-text fr-mt-1v">
 								Taille maximale : 10 Mo. Format supporté : pdf.
 							</span>
 						</label>
@@ -159,7 +157,7 @@ export function JointEvaluationForm({
 
 					<div>
 						<div className={styles.panelBlue}>
-							<h3 className="fr-h6">
+							<h3 className="fr-h6 fr-mb-2w">
 								Ce que vous devez faire dans un délai de 2 mois
 							</h3>
 							<ul className="fr-mb-0">
@@ -170,7 +168,7 @@ export function JointEvaluationForm({
 							</ul>
 						</div>
 						<div className={styles.panelWhite}>
-							<h3 className="fr-h6">Après dépôt du rapport</h3>
+							<h3 className="fr-h6 fr-mb-2w">Après dépôt du rapport</h3>
 							<ul className="fr-mb-2w">
 								<li>
 									Réaliser l&apos;analyse conjointe et définir des actions
@@ -200,7 +198,7 @@ export function JointEvaluationForm({
 						mutationError={submitJointEvaluationMutation.error?.message}
 					/>
 
-					<div className={`fr-mt-4w ${common.flexBetween}`}>
+					<div className={common.flexBetween}>
 						<Link
 							className="fr-btn fr-btn--tertiary fr-icon-arrow-left-line fr-btn--icon-left"
 							href="/declaration-remuneration/parcours-conformite"

--- a/packages/app/src/modules/shared/FileUpload.module.scss
+++ b/packages/app/src/modules/shared/FileUpload.module.scss
@@ -61,3 +61,14 @@
 	flex-direction: column;
 	gap: 0.25rem;
 }
+
+.dropzoneActions {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 0.25rem;
+}
+
+.messagesGroup:not(:empty) {
+	margin-top: 0.5rem;
+}

--- a/packages/app/src/modules/shared/FileUpload.tsx
+++ b/packages/app/src/modules/shared/FileUpload.tsx
@@ -157,25 +157,27 @@ export function FileUpload({
 				ref={dropzoneRef}
 			>
 				<span aria-hidden="true" className="fr-icon-file-add-fill" />
-				<span>
-					<button
-						className={styles.selectButton}
-						disabled={!canAddMore}
-						onClick={() => fileInputRef.current?.click()}
-						type="button"
-					>
-						{maxFileCount === 1
-							? "Sélectionner un fichier"
-							: "Sélectionner des fichiers"}
-						<span
-							aria-hidden="true"
-							className="fr-icon-upload-line fr-icon--sm"
-						/>
-					</button>
-				</span>
-				<p className="fr-text--sm fr-mb-0">
-					{maxFileCount === 1 ? "ou glisser-le ici" : "ou glisser-les ici"}
-				</p>
+				<div className={styles.dropzoneActions}>
+					<span>
+						<button
+							className={styles.selectButton}
+							disabled={!canAddMore}
+							onClick={() => fileInputRef.current?.click()}
+							type="button"
+						>
+							{maxFileCount === 1
+								? "Sélectionner un fichier"
+								: "Sélectionner des fichiers"}
+							<span
+								aria-hidden="true"
+								className="fr-icon-upload-line fr-icon--sm"
+							/>
+						</button>
+					</span>
+					<p className="fr-text--sm fr-mb-0">
+						{maxFileCount === 1 ? "ou glisser-le ici" : "ou glisser-les ici"}
+					</p>
+				</div>
 			</section>
 
 			{selectedFiles.map((file, index) => (
@@ -224,7 +226,7 @@ export function FileUpload({
 
 			<div
 				aria-live="polite"
-				className="fr-messages-group fr-mt-1w"
+				className={`fr-messages-group ${styles.messagesGroup}`}
 				id={messagesId}
 			>
 				{error && <p className="fr-message fr-message--error">{error}</p>}


### PR DESCRIPTION
Closes #4211

## Résumé

Réalignement complet des espacements de la page « Évaluation conjointe des rémunérations » sur la maquette Figma (node 7548:86957).

**Root cause** : `common.flexColumnGap2` était posé sur le `<form>` qui n'a qu'un seul enfant (`<fieldset>`). Le `gap: 2rem` ne s'appliquait à rien. Le `<fieldset>` restait `display:block` et ses 8 enfants s'empilaient en flux normal sans espacement.

**Fix** : porter `flexColumnGap2` sur le `<fieldset>` et corriger les écarts intra-blocs. Trois pièges traités :

1. **Redondance du `fr-mt-4w`** : retiré de la barre d'actions (le `gap` flex le remplace, sinon 64 px).
2. **`fr-messages-group` vide dans flex** : en flex, la `margin-top: 0.5rem` de `fr-mt-1w` ne fusionne plus → `dépôt→panneaux` = 40 px. Résolu en remplaçant `fr-mt-1w` par une classe scopée `.messagesGroup:not(:empty) { margin-top: 0.5rem }` — la marge n'apparaît que quand il y a un message d'erreur.
3. **`common.readOnlyFieldset` partagé** : aucune modification de la classe partagée (7 formulaires utilisant déjà leurs propres marges).

**Décision retenue** : ajout d'un `.dropzoneActions` (gap 0.25rem) dans `FileUpload` pour aligner le 4 px Figma entre bouton et « ou glisser-le ici » — impacte les 3 écrans appelants (`/avis-cse`, étape 5, évaluation conjointe), tous améliorés.

## Vérification (one-shot — viewport 1440 px)

Harnais statique avec DSFR 1.14.4 — avant (branche de base) / après (ce PR) :

| Mesure | Avant | Après | Cible Figma |
|---|---|---|---|
| Niveau 1 — 7 frontières du fieldset | `[0,0,0,0,0,8,32]` | `[32,32,32,32,32,32,32]` ✅ | 32 px chacune |
| Encadré Date limite : l1→l2 | 4 px | 8 px ✅ | 8 px |
| Encadré Date limite : l2→l3 | 4 px | 8 px ✅ | 8 px |
| Panneau h3 → liste | 24 px | 16 px ✅ | 16 px |
| Dépôt → panneaux (contrôle décisif piège n°2) | 8 px | **32 px ✅** | 32 px |
| `fr-messages-group` `marginTop` (vide) | 8 px | 0 px ✅ | 0 px |

## Test plan

- [ ] Ouvrir la page `/declaration-remuneration/parcours-conformite/evaluation-conjointe` (déclaration avec parcours « évaluation conjointe ») en viewport 1440 px
- [ ] Vérifier visuellement que tous les blocs du fieldset sont espacés de 32 px
- [ ] Vérifier que l'encadré « Date limite » a des interlignes de 8 px
- [ ] Vérifier que les panneaux ont h3 → liste = 16 px
- [ ] Ouvrir `/avis-cse` et l'étape 5 de déclaration : vérifier que `FileUpload` est intact (dropzone 160 px, message d'erreur toujours affiché quand il y en a un)