### PR TITLE
fix(declaration-remuneration): renvoyer Précédent vers le récap de 2e déclaration (#4216)

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/__tests__/complianceNavigation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	getCompliancePathPreviousHref,
 	getCseOpinionPreviousHref,
 	getCurrentStageHref,
 	getPostComplianceDestination,
@@ -90,6 +91,20 @@ describe("getCseOpinionPreviousHref", () => {
 			}),
 		).toBe(
 			"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
+		);
+	});
+});
+
+describe("getCompliancePathPreviousHref", () => {
+	it("returns the first-declaration recap when the path choice is still round 1", () => {
+		expect(getCompliancePathPreviousHref(false)).toBe(
+			"/declaration-remuneration/etape/6",
+		);
+	});
+
+	it("returns the second-declaration recap when the path choice is round 2", () => {
+		expect(getCompliancePathPreviousHref(true)).toBe(
+			"/declaration-remuneration/parcours-conformite/etape/3",
 		);
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/complianceNavigation.ts
@@ -98,3 +98,9 @@ export function getCseOpinionPreviousHref({
 	}
 	return FIRST_DECLARATION_RECAP_PATH;
 }
+
+export function getCompliancePathPreviousHref(isSecondRound: boolean): string {
+	return isSecondRound
+		? SECOND_DECLARATION_RECAP_PATH
+		: FIRST_DECLARATION_RECAP_PATH;
+}

--- a/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/CompliancePathChoice.tsx
@@ -22,7 +22,10 @@ import { useZodForm } from "~/modules/shared/useZodForm";
 import { api } from "~/trpc/react";
 
 import common from "../shared/common.module.scss";
-import { getPostComplianceDestination } from "../shared/complianceNavigation";
+import {
+	getCompliancePathPreviousHref,
+	getPostComplianceDestination,
+} from "../shared/complianceNavigation";
 import { FormActions } from "../shared/FormActions";
 import { FormErrors } from "../shared/FormErrors";
 import { SavedIndicator } from "../shared/SavedIndicator";
@@ -279,7 +282,7 @@ export function CompliancePathChoice({
 							: undefined
 					}
 					nextLabel="Suivant"
-					previousHref="/declaration-remuneration/etape/6"
+					previousHref={getCompliancePathPreviousHref(isSecondRound)}
 				/>
 			</fieldset>
 		</form>

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/CompliancePathChoice.test.tsx
@@ -341,6 +341,14 @@ describe("CompliancePathChoice", () => {
 		);
 	});
 
+	it("renders previous link pointing to the second-declaration recap in round 2", () => {
+		render(compliancePathChoice({ isSecondRound: true }));
+		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/parcours-conformite/etape/3",
+		);
+	});
+
 	it("renders the email in the success banner", () => {
 		render(compliancePathChoice({ email: "john@company.fr" }));
 		expect(screen.getByText("john@company.fr")).toBeInTheDocument();

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/DraftLoadingGate.test.tsx
@@ -221,6 +221,7 @@ describe("DraftLoadingGate", () => {
 				declarationSiren="123456789"
 				declarationYear={2026}
 				initialFirstDeclarationCategories={[]}
+				status="corrective_actions_chosen"
 			/>,
 		);
 		expectLoadingState();

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -7,7 +7,11 @@ import { DraftLoadingState } from "~/modules/declaration-remuneration/shared/dra
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { useDraftHydration } from "~/modules/declaration-remuneration/shared/draft/useDraftHydration";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
-import { getReferenceYearFor } from "~/modules/domain";
+import {
+	type DeclarationFsmStatus,
+	getReferenceYearFor,
+	isSecondDeclarationWritable,
+} from "~/modules/domain";
 import { api } from "~/trpc/react";
 import { CategoryForm } from "../step5/CategoryForm";
 import { BASE_PATH } from "./constants";
@@ -22,6 +26,7 @@ type Props = {
 	initialSource?: string;
 	initialStartDate?: string;
 	initialEndDate?: string;
+	status: DeclarationFsmStatus | null;
 };
 
 export function SecondDeclarationStep2Form({
@@ -32,9 +37,12 @@ export function SecondDeclarationStep2Form({
 	initialSource,
 	initialStartDate = "",
 	initialEndDate = "",
+	status,
 }: Props) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const isWritable = isSecondDeclarationWritable(status);
+	const isFormDisabled = isImpersonating || !isWritable;
 	const [startDate, setStartDate] = useState(initialStartDate);
 	const [endDate, setEndDate] = useState(initialEndDate);
 	const [periodError, setPeriodError] = useState("");
@@ -82,19 +90,23 @@ export function SecondDeclarationStep2Form({
 
 	if (!draftHydrated) return <DraftLoadingState />;
 
+	const recapHref = `${BASE_PATH}/etape/3`;
+	const nextHref = isWritable ? undefined : recapHref;
+	const mimoquageNextHref = hasSavedSecondDeclaration ? recapHref : undefined;
+
 	return (
 		<CategoryForm
 			accordionId="accordion-second-decl"
 			descriptionText="Cette seconde déclaration reprend les catégories de salariés définies lors de la première déclaration. Elle permet de mesurer les écarts de rémunération entre les femmes et les hommes au sein de chaque catégorie, en distinguant le salaire de base des composantes variables ou complémentaires."
-			disabled={isImpersonating}
+			disabled={isFormDisabled}
 			initialCategories={sourceData}
 			initialSource={initialSource}
 			instructionText="Modifiez les données de votre première déclaration avant de valider votre indicateur."
 			isSubmitting={mutation.isPending}
-			mimoquageNextHref={
-				hasSavedSecondDeclaration ? `${BASE_PATH}/etape/3` : undefined
-			}
+			mimoquageNextHref={mimoquageNextHref}
+			nextHref={nextHref}
 			onSubmit={(data) => {
+				if (!isWritable) return;
 				if (!startDate || !endDate) {
 					setPeriodError(
 						"La période de référence est obligatoire. Veuillez renseigner les dates de début et de fin.",
@@ -114,7 +126,7 @@ export function SecondDeclarationStep2Form({
 			readOnlyLabel
 			referencePeriodPicker={
 				<ReferencePeriodPicker
-					disabled={isImpersonating}
+					disabled={isFormDisabled}
 					endDate={endDate}
 					onEndDateChange={setEndDate}
 					onStartDateChange={setStartDate}

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep3Review.tsx
@@ -3,14 +3,21 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
 import common from "~/modules/declaration-remuneration/shared/common.module.scss";
-import { getPostComplianceDestination } from "~/modules/declaration-remuneration/shared/complianceNavigation";
+import {
+	getCurrentStageHref,
+	getPostComplianceDestination,
+} from "~/modules/declaration-remuneration/shared/complianceNavigation";
 import { FormActions } from "~/modules/declaration-remuneration/shared/FormActions";
 import { FormErrors } from "~/modules/declaration-remuneration/shared/FormErrors";
 import { NextStepsBox } from "~/modules/declaration-remuneration/shared/NextStepsBox";
 import { SavedIndicator } from "~/modules/declaration-remuneration/shared/SavedIndicator";
 import { SubmitDeclarationModal } from "~/modules/declaration-remuneration/shared/SubmitDeclarationModal";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
-import { hasHighGap } from "~/modules/domain";
+import {
+	type DeclarationFsmStatus,
+	hasHighGap,
+	isSecondDeclarationWritable,
+} from "~/modules/domain";
 import { getDsfrModal } from "~/modules/shared";
 import { api } from "~/trpc/react";
 import stepStyles from "../Step6Review.module.scss";
@@ -26,6 +33,7 @@ type Props = {
 	declarationYear: number;
 	secondDeclarationCategories: EmployeeCategoryRow[];
 	siren: string;
+	status: DeclarationFsmStatus | null;
 };
 
 export function SecondDeclarationStep3Review({
@@ -34,9 +42,11 @@ export function SecondDeclarationStep3Review({
 	declarationYear,
 	secondDeclarationCategories,
 	siren,
+	status,
 }: Props) {
 	const router = useRouter();
 	const modalRef = useRef<HTMLDialogElement>(null);
+	const isWritable = isSecondDeclarationWritable(status);
 
 	const parsed = parseEmployeeCategories(secondDeclarationCategories);
 	const gapsExist = parsed.some((cat) =>
@@ -72,8 +82,14 @@ export function SecondDeclarationStep3Review({
 
 	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault();
+		if (!isWritable) return;
 		openModal();
 	}
+
+	const nextHref = isWritable
+		? undefined
+		: getCurrentStageHref(status, cseOpinionRequired);
+	const nextLabel = isWritable ? "Soumettre" : "Suivant";
 
 	return (
 		<form
@@ -158,18 +174,21 @@ export function SecondDeclarationStep3Review({
 			<FormErrors mutationError={mutation.error?.message} />
 
 			<FormActions
-				nextLabel="Soumettre"
+				nextHref={nextHref}
+				nextLabel={nextLabel}
 				previousHref={`${BASE_PATH}/etape/2`}
 			/>
 
-			<SubmitDeclarationModal
-				isPending={mutation.isPending}
-				isSecondDeclaration
-				modalRef={modalRef}
-				onClose={closeModal}
-				onSubmit={() => mutation.mutate()}
-				year={declarationYear}
-			/>
+			{isWritable ? (
+				<SubmitDeclarationModal
+					isPending={mutation.isPending}
+					isSecondDeclaration
+					modalRef={modalRef}
+					onClose={closeModal}
+					onSubmit={() => mutation.mutate()}
+					year={declarationYear}
+				/>
+			) : null}
 		</form>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStepPage.tsx
@@ -119,6 +119,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 						initialStartDate={
 							data.declaration.secondDeclReferencePeriodStart ?? undefined
 						}
+						status={data.declaration.status}
 					/>
 				</HydrateClient>
 			</>
@@ -144,6 +145,7 @@ export async function SecondDeclarationStepPage({ step }: Props) {
 					declarationYear={currentYear}
 					secondDeclarationCategories={reviewCategories}
 					siren={data.declaration.siren}
+					status={data.declaration.status}
 				/>
 			</HydrateClient>
 		</>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { SecondDeclarationStep2Form } from "../SecondDeclarationStep2Form";
@@ -52,15 +53,23 @@ const mockCategories: EmployeeCategoryRow[] = [
 	}),
 ];
 
+function renderStep2(
+	overrides: Partial<ComponentProps<typeof SecondDeclarationStep2Form>> = {},
+) {
+	return render(
+		<SecondDeclarationStep2Form
+			declarationSiren="123456789"
+			declarationYear={2025}
+			initialFirstDeclarationCategories={mockCategories}
+			status="corrective_actions_chosen"
+			{...overrides}
+		/>,
+	);
+}
+
 describe("SecondDeclarationStep2Form", () => {
 	it("renders the title and step indicator", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-			/>,
-		);
+		renderStep2();
 		expect(
 			screen.getByText(
 				/Parcours de mise en conformité pour l.indicateur par catégorie de salariés/,
@@ -70,13 +79,7 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("displays category label as read-only text", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-			/>,
-		);
+		renderStep2();
 		// The category label is now carried by the accordion heading and the
 		// table <caption> (RGAA 5.2) — no redundant read-only <p>, no editable input.
 		expect(
@@ -90,14 +93,7 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("displays source as read-only text", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-				initialSource="accord-entreprise"
-			/>,
-		);
+		renderStep2({ initialSource: "accord-entreprise" });
 		expect(
 			screen.getByText(/Source utilisée pour déterminer/),
 		).toBeInTheDocument();
@@ -108,13 +104,7 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("renders reference period date pickers", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-			/>,
-		);
+		renderStep2();
 		expect(screen.getByLabelText(/Date de début/)).toBeInTheDocument();
 		expect(screen.getByLabelText(/Date de fin/)).toBeInTheDocument();
 		expect(
@@ -123,26 +113,14 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("does not render add category button (read-only categories)", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-			/>,
-		);
+		renderStep2();
 		expect(
 			screen.queryByRole("button", { name: /Ajouter une catégorie/ }),
 		).not.toBeInTheDocument();
 	});
 
 	it("renders previous link to step 1", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-			/>,
-		);
+		renderStep2();
 		expect(screen.getByRole("link", { name: /précédent/i })).toHaveAttribute(
 			"href",
 			"/declaration-remuneration/parcours-conformite/etape/1",
@@ -166,18 +144,38 @@ describe("SecondDeclarationStep2Form", () => {
 			}),
 		];
 
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-				initialSecondDeclarationCategories={secondDeclData}
-			/>,
-		);
+		renderStep2({ initialSecondDeclarationCategories: secondDeclData });
 		expect(
 			screen.getByRole("button", {
 				name: "Catégorie d'emplois n°1 : Techniciens",
 			}),
 		).toBeInTheDocument();
+	});
+
+	it("keeps Suivant as a submit button while the second declaration is writable", () => {
+		renderStep2();
+		expect(
+			screen.getByRole("button", { name: /suivant/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("link", { name: /suivant/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders Suivant as a recap link when the second declaration is no longer writable", () => {
+		renderStep2({ status: "revised_joint_evaluation_chosen" });
+		expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/parcours-conformite/etape/3",
+		);
+		expect(
+			screen.queryByRole("button", { name: /suivant/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("disables the reference period pickers when the second declaration is no longer writable", () => {
+		renderStep2({ status: "revised_joint_evaluation_chosen" });
+		expect(screen.getByLabelText(/Date de début/)).toBeDisabled();
+		expect(screen.getByLabelText(/Date de fin/)).toBeDisabled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -106,6 +106,7 @@ function renderStep3(
 			declarationYear={2025}
 			secondDeclarationCategories={mockCategories}
 			siren="532847196"
+			status="corrective_actions_chosen"
 			{...overrides}
 		/>,
 	);
@@ -305,6 +306,34 @@ describe("SecondDeclarationStep3Review", () => {
 	it("renders empty state when no categories", () => {
 		renderStep3({ secondDeclarationCategories: [] });
 		expect(screen.getByText("Aucune donnée renseignée.")).toBeInTheDocument();
+	});
+
+	it("keeps Soumettre while the second declaration is still writable", () => {
+		renderStep3();
+		expect(
+			screen.getByRole("button", { name: /soumettre/i }),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole("link", { name: /suivant/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders Suivant to the joint evaluation when the revision path is already chosen", () => {
+		renderStep3({ status: "revised_joint_evaluation_chosen" });
+		expect(screen.getByRole("link", { name: /suivant/i })).toHaveAttribute(
+			"href",
+			"/declaration-remuneration/parcours-conformite/evaluation-conjointe",
+		);
+		expect(
+			screen.queryByRole("button", { name: /soumettre/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("keeps Soumettre while awaiting a revision choice", () => {
+		renderStep3({ status: "awaiting_revision_choice" });
+		expect(
+			screen.getByRole("button", { name: /soumettre/i }),
+		).toBeInTheDocument();
 	});
 
 	describe("CSE consultation section gating (issue #3945)", () => {

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -85,6 +85,7 @@ type Props = {
 	referencePeriodPicker?: ReactNode;
 	descriptionText?: string;
 	disabled?: boolean;
+	nextHref?: string;
 	mimoquageNextHref?: string;
 	hasDataOverride?: boolean;
 	isSavingOverride?: boolean;
@@ -142,6 +143,7 @@ export function CategoryForm({
 	referencePeriodPicker,
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 	disabled = false,
+	nextHref,
 	mimoquageNextHref,
 	hasDataOverride,
 	isSavingOverride = false,
@@ -581,6 +583,7 @@ export function CategoryForm({
 				className="fr-mt-0"
 				isSubmitting={isSubmitting}
 				mimoquageNextHref={mimoquageNextHref}
+				nextHref={nextHref}
 				previousHref={previousHref}
 			/>
 


### PR DESCRIPTION
Closes #4216

## Résumé

Après une 2ᵉ déclaration de l'indicateur par catégorie encore en écart ≥ 5 % :

1. **Précédent** sur « Parcours de mise en conformité » renvoyait vers le récap de la **1ʳᵉ** déclaration (`/declaration-remuneration/etape/6`) au lieu de celui de la 2ᵉ (`/declaration-remuneration/parcours-conformite/etape/3`).
2. Une fois revenu au récap puis à l'édition, **Suivant** tentait d'enregistrer et affichait « La seconde déclaration n'est pas ouverte à la saisie. », ce qui bloquait le retour vers l'évaluation conjointe.

Correctifs :

- `getCompliancePathPreviousHref(isSecondRound)` pour le bouton Précédent du choix de parcours.
- Quand la 2ᵉ déclaration n'est plus saisissable (`isSecondDeclarationWritable` faux, ex. évaluation conjointe déjà choisie) : **Suivant** sur l'édition devient un lien vers le récap, et **Suivant** sur le récap mène à l'étape courante de la démarche (`getCurrentStageHref`, ex. évaluation conjointe). Tant que la révision est encore ouverte, Soumettre reste disponible.

## Vérification

- Précédent round 2, revert-verify : sans fix → `etape/6` ; avec fix → `parcours-conformite/etape/3`.
- Suivant édition close, revert-verify : sans fix → bouton submit ; avec fix → lien vers `etape/3`.
- Récap déjà engagé en évaluation conjointe → lien vers `evaluation-conjointe`.
- Round 1 / déclaration encore saisissable : comportement inchangé (Précédent vers étape 6, Soumettre conservé).

## Plan de test

- [ ] 1ʳᵉ déclaration, écarts ≥ 5 %, page Parcours de mise en conformité → Précédent = récap étape 6
- [ ] 2ᵉ déclaration soumise, encore des écarts ≥ 5 %, même page → Précédent = récap 2ᵉ déclaration
- [ ] Depuis ce récap, Précédent puis Suivant revient au récap **sans** l'erreur « n'est pas ouverte à la saisie »
- [ ] Suivant depuis ce récap (parcours révision déjà choisi) ramène à l'évaluation conjointe
- [ ] Tant que la 2ᵉ déclaration est encore saisissable, Soumettre reste disponible sur le récap

## Qualité

- Typecheck, lint, format, tests unitaires ciblés : OK
- Audit structurel / RGAA (1er commit) : PASS
- Audit sécurité : non applicable (aucun fichier serveur)
