### PR TITLE
Page Récapitulatif 2ème déclaration - wording

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -100,9 +100,10 @@ export function NextStepsBox({
 
 						<p className="fr-mb-0">
 							À la suite de l&apos;analyse de vos données de l&apos;indicateur
-							par catégorie de salariés, des écarts &ge; 5 % ont
-							{isSecondDeclaration ? " encore" : ""} été identifiés. Vous devez
-							engager un des parcours de mise en conformité suivant&nbsp;:
+							par catégorie de salariés, des écarts &ge; 5 % ont{" "}
+							{isSecondDeclaration ? "encore été identifiés" : "été identifiés"}
+							. Vous devez engager un des parcours de mise en conformité
+							suivant&nbsp;:
 						</p>
 
 						<ul>

--- a/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/NextStepsBox.tsx
@@ -100,9 +100,9 @@ export function NextStepsBox({
 
 						<p className="fr-mb-0">
 							À la suite de l&apos;analyse de vos données de l&apos;indicateur
-							par catégorie de salariés, des écarts &ge; 5 % ont été identifiés.
-							Vous devez engager un des parcours de mise en conformité
-							suivant&nbsp;:
+							par catégorie de salariés, des écarts &ge; 5 % ont
+							{isSecondDeclaration ? " encore" : ""} été identifiés. Vous devez
+							engager un des parcours de mise en conformité suivant&nbsp;:
 						</p>
 
 						<ul>
@@ -120,7 +120,8 @@ export function NextStepsBox({
 						</ul>
 						<p className="fr-mb-0">
 							Si la justification n&apos;est pas possible par des critères
-							objectifs et non sexistes, vous pouvez&nbsp;:
+							objectifs et non sexistes, vous{" "}
+							{isSecondDeclaration ? "devez" : "pouvez"}&nbsp;:
 						</p>
 						<ul>
 							{!isSecondDeclaration && (

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/Step6Review.test.tsx
@@ -637,6 +637,11 @@ describe("Step6Review", () => {
 		expect(
 			screen.getByText(/des écarts ≥ 5 % ont été identifiés/),
 		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/ont encore été identifiés/),
+		).not.toBeInTheDocument();
+		expect(screen.getByText(/vous pouvez :/)).toBeInTheDocument();
+		expect(screen.queryByText(/vous devez :/)).not.toBeInTheDocument();
 		expect(screen.getByText("Pour vous aider")).toBeInTheDocument();
 		expect(
 			screen.getByRole("link", { name: /critères objectifs/ }),

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep3Review.test.tsx
@@ -374,6 +374,35 @@ describe("SecondDeclarationStep3Review", () => {
 		});
 	});
 
+	describe("second declaration wording (issue #4214)", () => {
+		it("states that gaps were identified again and that the remaining action is mandatory", () => {
+			renderStep3({ secondDeclarationCategories: highGapCategories });
+
+			expect(
+				screen.getByText(/des écarts ≥ 5 % ont encore été identifiés/),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText(/des écarts ≥ 5 % ont été identifiés/),
+			).not.toBeInTheDocument();
+
+			expect(screen.getByText(/vous devez :/)).toBeInTheDocument();
+			expect(screen.queryByText(/vous pouvez :/)).not.toBeInTheDocument();
+		});
+
+		it("keeps the mandatory wording when the CSE consultation section is shown", () => {
+			renderStep3({
+				cseOpinionRequired: true,
+				secondDeclarationCategories: highGapCategories,
+			});
+
+			expect(
+				screen.getByText(/des écarts ≥ 5 % ont encore été identifiés/),
+			).toBeInTheDocument();
+			expect(screen.getByText(/vous devez :/)).toBeInTheDocument();
+			expect(screen.queryByText(/vous pouvez :/)).not.toBeInTheDocument();
+		});
+	});
+
 	it("closes the modal without submitting when Annuler is clicked", async () => {
 		const user = userEvent.setup();
 		renderStep3();


### PR DESCRIPTION
Closes #4214

## Résumé

Deux libellés du bloc « Prochaines étapes » (récapitulatif de la 2ème déclaration) sont désormais conditionnels à la prop existante `isSecondDeclaration` du composant partagé `NextStepsBox` :

- « …des écarts ≥ 5 % ont **encore** été identifiés. » (en 2ème déclaration uniquement)
- « …vous **devez** : » au lieu de « vous pouvez : » (en 2ème déclaration uniquement)

La 1ère déclaration (`Step6Review`) reste strictement inchangée : « ont été identifiés » et « vous pouvez : » (deux parcours au choix y sont proposés).

Note : 3 des 5 items du body initial de l'issue étaient déjà livrés par #4206 (PR #4239). Seuls les items 3 et 5 restaient à faire — voir le commentaire « Analyse architecte » sur l'issue pour le détail.

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (suite complète, tests ajoutés pour les deux nouveaux comportements + gardes de non-régression 1ère déclaration)
- [x] `pnpm lint:check` / `pnpm format:check` verts
- [ ] Scénarios S1 (2ème déclaration avec écarts) / S2 (non-régression 1ère déclaration) rejoués par le validateur fonctionnel