### PR TITLE
fix(declaration-remuneration): #4215 — déplace la phrase Source avant la mention des champs obligatoires

### DIFF
--- a/packages/app/src/e2e/helpers/compliance-flows.ts
+++ b/packages/app/src/e2e/helpers/compliance-flows.ts
@@ -191,6 +191,25 @@ export async function completeSecondDeclaration(
 		await page.getByRole("link", { name: "Suivant" }).click();
 		await page.waitForURL(`**${COMPLIANCE_PATH}/etape/2`);
 
+		// #4215 — on the read-only second declaration, the source line sits between the
+		// intro and "Tous les champs sont obligatoires.", not after the reference period.
+		const categoryBlock = page.locator("#content");
+		const sourceLine = categoryBlock.getByText(
+			"Source utilisée pour déterminer les catégories d'emplois",
+		);
+		const mandatoryLine = categoryBlock.getByText(
+			"Tous les champs sont obligatoires",
+		);
+		await expect(sourceLine).toBeVisible();
+		await expect(mandatoryLine).toBeVisible();
+		const [sourceBox, mandatoryBox] = await Promise.all([
+			sourceLine.boundingBox(),
+			mandatoryLine.boundingBox(),
+		]);
+		expect(sourceBox?.y ?? Number.POSITIVE_INFINITY).toBeLessThan(
+			mandatoryBox?.y ?? Number.NEGATIVE_INFINITY,
+		);
+
 		// Step 2: Edit correction employee category data
 		// women=1000, men=1100 → 9% gap | women=1000, men=1020 → 2% gap
 		const menSalary = options.hasGap ? "1100" : "1020";

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -107,6 +107,61 @@ describe("SecondDeclarationStep2Form", () => {
 		).not.toBeInTheDocument();
 	});
 
+	it("places the source paragraph immediately after the intro paragraph (#4215)", () => {
+		render(
+			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialFirstDeclarationCategories={mockCategories}
+				initialSource="accord-entreprise"
+			/>,
+		);
+		const introParagraph = screen.getByText(
+			/Cette seconde déclaration reprend les catégories/,
+		);
+		const sourceParagraph = screen
+			.getByText(/Source utilisée pour déterminer/)
+			.closest("p");
+		expect(introParagraph.nextElementSibling).toBe(sourceParagraph);
+	});
+
+	it("places the source paragraph before the obligatoires mention (#4215)", () => {
+		render(
+			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialFirstDeclarationCategories={mockCategories}
+				initialSource="accord-entreprise"
+			/>,
+		);
+		const sourceParagraph = screen
+			.getByText(/Source utilisée pour déterminer/)
+			.closest("p") as HTMLElement;
+		const obligatoiresParagraph = screen.getByText(
+			"Tous les champs sont obligatoires.",
+		);
+		expect(sourceParagraph.nextElementSibling).toBe(obligatoiresParagraph);
+	});
+
+	it("keeps the source paragraph out of the reference period block (#4215)", () => {
+		render(
+			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialFirstDeclarationCategories={mockCategories}
+				initialSource="accord-entreprise"
+			/>,
+		);
+		const startDateField = screen.getByLabelText(/Date de début/);
+		const sourceParagraph = screen
+			.getByText(/Source utilisée pour déterminer/)
+			.closest("p") as HTMLElement;
+		expect(
+			startDateField.compareDocumentPosition(sourceParagraph) &
+				Node.DOCUMENT_POSITION_PRECEDING,
+		).toBeTruthy();
+	});
+
 	it("renders reference period date pickers", () => {
 		render(
 			<SecondDeclarationStep2Form

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -400,6 +400,14 @@ export function CategoryForm({
 
 			<div className={stepStyles.categoryBlock}>
 				<p className="fr-mb-0">{descriptionText}</p>
+				{readOnlyLabel && (
+					<p className="fr-mb-0">
+						Source utilisée pour déterminer les catégories d&apos;emplois :{" "}
+						<span className="fr-text--bold">
+							{formatCategorySource(form.watch("source"))}
+						</span>
+					</p>
+				)}
 				<p className="fr-mb-0">Tous les champs sont obligatoires.</p>
 
 				{referencePeriodPicker ?? (
@@ -417,14 +425,7 @@ export function CategoryForm({
 					</div>
 				)}
 
-				{readOnlyLabel ? (
-					<p className="fr-mb-0">
-						Source utilisée pour déterminer les catégories d&apos;emplois :{" "}
-						<span className="fr-text--bold">
-							{formatCategorySource(form.watch("source"))}
-						</span>
-					</p>
-				) : (
+				{!readOnlyLabel && (
 					<div
 						className={`fr-select-group ${
 							sourceError ? "fr-select-group--error" : ""


### PR DESCRIPTION
Closes #4215

## Résumé

Sur la page « Seconde déclaration des écarts de rémunération par catégorie de salariés » (`/declaration-remuneration/parcours-conformite/etape/2`), la phrase **« Source utilisée pour déterminer les catégories d'emplois »** apparaissait après les champs de période de référence.

Elle est désormais placée **entre le paragraphe d'introduction et « Tous les champs sont obligatoires. »**, conformément au node Figma `9943:142622` (ordre vertical mesuré : intro y=0 → Source y=88 → obligatoires y=128 → datepickers y=168).

### Fichier modifié

`packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx` — déplacement JSX conditionnel uniquement :
- `{readOnlyLabel && <p>Source...</p>}` déplacé avant `<p>Tous les champs sont obligatoires.</p>`
- `{!readOnlyLabel && <div select...>}` reste après le bloc période (non-régression étape 5 première déclaration)

Aucun changement de logique, de props, ni de CSS.

## Test plan

- [x] Typecheck vert (`pnpm typecheck`)
- [x] Suite complète verte : 4471 tests passent (4468 existants + 3 nouveaux)
- [x] 3 nouveaux tests DOM-order dans `SecondDeclarationStep2Form.test.tsx` (#4215) :
  - la phrase Source est le `nextElementSibling` du paragraphe d'intro
  - la phrase Source précède « Tous les champs sont obligatoires. »
  - la phrase Source apparaît avant le champ « Date de début » (plus dans le bloc période)
- [x] Lint et format Biome : aucune erreur (1120 fichiers vérifiés)
- [x] Non-régression `Step5EmployeeCategories.test.tsx:155` : « obligatoires » immédiatement après l'intro dans la première déclaration (select source reste après la période)
- [x] RGAA : PASS (aucune violation statique ni de jugement)
- [x] Sécurité : SECURE (composant client uniquement, pas de surface serveur)
- [x] `functional-validator` et `design-validator` (gate 9a/9a-bis) à venir

## Note technique

`CategoryForm.tsx` est à 600 lignes (threshold CLAUDE.md : 400). C'est une dette technique **pré-existante** avant ce ticket (le diff ajoute 1 ligne nette) — un ticket de refactoring dédié est recommandé.