### PR TITLE
fix(declaration-remuneration): #4186 — réconcilie le lock au retour d'un onglet inactif

### DIFF
--- a/packages/app/src/app/api/upload/route.ts
+++ b/packages/app/src/app/api/upload/route.ts
@@ -1,6 +1,9 @@
 import { and, eq } from "drizzle-orm";
 import { AUDIT_ACTIONS, type AuditActionKey } from "~/modules/audit";
-import { getCurrentYear } from "~/modules/domain";
+import {
+	DECLARATION_LOCK_CONFLICT_MESSAGE,
+	getCurrentYear,
+} from "~/modules/domain";
 import { validateFileName } from "~/modules/shared/fileNameValidation";
 import { parseSiren } from "~/modules/shared/parseSiren";
 import {
@@ -243,7 +246,7 @@ export async function POST(request: Request): Promise<Response> {
 				startedAt,
 			});
 			return Response.json(
-				{ error: "Déclaration verrouillée par un autre utilisateur." },
+				{ error: DECLARATION_LOCK_CONFLICT_MESSAGE },
 				{ status: 409 },
 			);
 		}

--- a/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/__tests__/DeclarationLayout.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { useSession } from "next-auth/react";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
@@ -42,16 +43,23 @@ function LockProbe() {
 }
 
 function declarationLayout(lockAcquisitionSuspended = false) {
+	// The lock hook watches the mutation cache for lock-conflict rejections, so
+	// it needs a query client just like it does under `TRPCReactProvider`.
+	const queryClient = new QueryClient({
+		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+	});
 	return (
-		<DeclarationLayout
-			company={company}
-			declarationId="decl-1"
-			declarationYear={2024}
-			lockAcquisitionSuspended={lockAcquisitionSuspended}
-		>
-			<p>Step content</p>
-			<LockProbe />
-		</DeclarationLayout>
+		<QueryClientProvider client={queryClient}>
+			<DeclarationLayout
+				company={company}
+				declarationId="decl-1"
+				declarationYear={2024}
+				lockAcquisitionSuspended={lockAcquisitionSuspended}
+			>
+				<p>Step content</p>
+				<LockProbe />
+			</DeclarationLayout>
+		</QueryClientProvider>
 	);
 }
 

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/useDeclarationLock.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/__tests__/useDeclarationLock.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { useSession } from "next-auth/react";
 import {
@@ -10,7 +11,10 @@ import {
 	vi,
 } from "vitest";
 
-import { LOCK_HEARTBEAT_INTERVAL_MS } from "~/modules/domain";
+import {
+	DECLARATION_LOCK_CONFLICT_MESSAGE,
+	LOCK_HEARTBEAT_INTERVAL_MS,
+} from "~/modules/domain";
 
 const acquireMutateAsync = vi.fn();
 const heartbeatMutateAsync = vi.fn();
@@ -89,12 +93,46 @@ async function advance(ms: number) {
 }
 
 function renderLockHook(options: { modificationClosed?: boolean } = {}) {
-	return renderHook(() =>
-		useDeclarationLock({
-			declarationId: DECLARATION_ID,
-			modificationClosed: options.modificationClosed,
-		}),
+	const queryClient = new QueryClient({
+		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+	});
+	const rendered = renderHook(
+		() =>
+			useDeclarationLock({
+				declarationId: DECLARATION_ID,
+				modificationClosed: options.modificationClosed,
+			}),
+		{
+			wrapper: ({ children }) => (
+				<QueryClientProvider client={queryClient}>
+					{children}
+				</QueryClientProvider>
+			),
+		},
 	);
+	return { ...rendered, queryClient };
+}
+
+// Drive a real mutation to failure so the hook sees the same mutation-cache
+// "error" action a rejected step submit produces.
+async function failMutation(queryClient: QueryClient, message: string) {
+	const mutation = queryClient.getMutationCache().build(queryClient, {
+		mutationFn: async () => {
+			throw new Error(message);
+		},
+	});
+	await act(async () => {
+		await mutation.execute(undefined).catch(() => {});
+		await vi.advanceTimersByTimeAsync(0);
+	});
+}
+
+function firePageShow(persisted: boolean) {
+	const event = new Event("pageshow");
+	Object.defineProperty(event, "persisted", { value: persisted });
+	act(() => {
+		window.dispatchEvent(event);
+	});
 }
 
 describe("useDeclarationLock", () => {
@@ -372,6 +410,165 @@ describe("useDeclarationLock", () => {
 		await advance(LOCK_HEARTBEAT_INTERVAL_MS);
 		expect(heartbeatMutateAsync).not.toHaveBeenCalled();
 		expect(releaseMutate).not.toHaveBeenCalled();
+	});
+
+	describe("stale ownership after an idle tab (#4186)", () => {
+		it("re-acquires the lock when the tab becomes visible again", async () => {
+			sendBeaconSpy();
+			acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+			const { result } = renderLockHook();
+			await flush();
+			expect(acquireMutateAsync).toHaveBeenCalledTimes(1);
+
+			// Hiding the tab releases the lock through the beacon, so coming back
+			// must re-take it instead of assuming the tab still holds it.
+			act(() => {
+				setVisibility("hidden");
+				document.dispatchEvent(new Event("visibilitychange"));
+			});
+			act(() => {
+				setVisibility("visible");
+				document.dispatchEvent(new Event("visibilitychange"));
+			});
+			await flush();
+
+			expect(acquireMutateAsync).toHaveBeenCalledTimes(2);
+			expect(result.current.isReadOnly).toBe(false);
+		});
+
+		it("becomes read-only when a colleague took the lock while the tab was hidden", async () => {
+			sendBeaconSpy();
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: true,
+				holder: HOLDER,
+			});
+			const { result } = renderLockHook();
+			await flush();
+			expect(result.current.isReadOnly).toBe(false);
+
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: false,
+				holder: HOLDER,
+			});
+			act(() => {
+				setVisibility("hidden");
+				document.dispatchEvent(new Event("visibilitychange"));
+			});
+			act(() => {
+				setVisibility("visible");
+				document.dispatchEvent(new Event("visibilitychange"));
+			});
+			await flush();
+
+			expect(result.current.isReadOnly).toBe(true);
+			expect(result.current.holder).toEqual(HOLDER);
+		});
+
+		it("resumes the heartbeat after winning the lock back on return", async () => {
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: true,
+				holder: HOLDER,
+			});
+			heartbeatMutateAsync.mockResolvedValue({ held: false });
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: false,
+				holder: HOLDER,
+			});
+			const { result } = renderLockHook();
+			await flush();
+
+			await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+			expect(result.current.isReadOnly).toBe(true);
+			const heartbeatsWhileLost = heartbeatMutateAsync.mock.calls.length;
+
+			heartbeatMutateAsync.mockResolvedValue({ held: true });
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: true,
+				holder: HOLDER,
+			});
+			act(() => {
+				document.dispatchEvent(new Event("visibilitychange"));
+			});
+			await flush();
+			expect(result.current.isReadOnly).toBe(false);
+
+			await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+			expect(heartbeatMutateAsync.mock.calls.length).toBeGreaterThan(
+				heartbeatsWhileLost,
+			);
+		});
+
+		it("re-acquires the lock on a bfcache restore", async () => {
+			acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+			renderLockHook();
+			await flush();
+
+			firePageShow(true);
+			await flush();
+			expect(acquireMutateAsync).toHaveBeenCalledTimes(2);
+		});
+
+		it("ignores a pageshow that is not a bfcache restore", async () => {
+			acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+			renderLockHook();
+			await flush();
+
+			firePageShow(false);
+			await flush();
+			expect(acquireMutateAsync).toHaveBeenCalledTimes(1);
+		});
+
+		it("restores the editable state when a heartbeat proves the lock is still held", async () => {
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: true,
+				holder: HOLDER,
+			});
+			const { result } = renderLockHook();
+			await flush();
+
+			// Transient failure while re-checking on tab return: pessimistically
+			// read-only, but the lock was never actually lost.
+			acquireMutateAsync.mockRejectedValueOnce(new Error("network"));
+			act(() => {
+				document.dispatchEvent(new Event("visibilitychange"));
+			});
+			await flush();
+			expect(result.current.isReadOnly).toBe(true);
+
+			heartbeatMutateAsync.mockResolvedValue({ held: true });
+			await advance(LOCK_HEARTBEAT_INTERVAL_MS);
+			expect(result.current.isReadOnly).toBe(false);
+		});
+
+		it("re-reads ownership when a write is rejected for a lock conflict", async () => {
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: true,
+				holder: HOLDER,
+			});
+			const { result, queryClient } = renderLockHook();
+			await flush();
+			expect(result.current.isReadOnly).toBe(false);
+
+			acquireMutateAsync.mockResolvedValueOnce({
+				acquired: false,
+				holder: HOLDER,
+			});
+			await failMutation(queryClient, DECLARATION_LOCK_CONFLICT_MESSAGE);
+
+			expect(result.current.isReadOnly).toBe(true);
+			expect(result.current.holder).toEqual(HOLDER);
+		});
+
+		it("ignores a mutation error that is not a lock conflict", async () => {
+			acquireMutateAsync.mockResolvedValue({ acquired: true, holder: HOLDER });
+			const { result, queryClient } = renderLockHook();
+			await flush();
+
+			await failMutation(queryClient, "Une erreur de validation");
+
+			expect(acquireMutateAsync).toHaveBeenCalledTimes(1);
+			expect(result.current.isReadOnly).toBe(false);
+		});
 	});
 
 	describe("modification closed (#3716)", () => {

--- a/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
+++ b/packages/app/src/modules/declaration-remuneration/shared/lock/useDeclarationLock.ts
@@ -1,9 +1,13 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useSession } from "next-auth/react";
 import { useEffect, useRef, useState } from "react";
 
-import { LOCK_HEARTBEAT_INTERVAL_MS } from "~/modules/domain";
+import {
+	DECLARATION_LOCK_CONFLICT_MESSAGE,
+	LOCK_HEARTBEAT_INTERVAL_MS,
+} from "~/modules/domain";
 import { api, type RouterOutputs } from "~/trpc/react";
 
 export type LockHolder = NonNullable<
@@ -31,6 +35,7 @@ export function useDeclarationLock({
 	modificationClosed = false,
 }: UseDeclarationLockOptions): DeclarationLockState {
 	const session = useSession();
+	const queryClient = useQueryClient();
 	const isImpersonating = Boolean(session.data?.user?.impersonation);
 	const isEnabled =
 		session.status === "authenticated" &&
@@ -100,12 +105,35 @@ export function useDeclarationLock({
 				void heartbeatRef
 					.current({ declarationId })
 					.then((result) => {
-						if (cancelled || result.held) return;
+						if (cancelled) return;
+						if (result.held) {
+							// A heartbeat the server accepts proves this tab still owns the
+							// lock: restore the editable state if a transient acquire
+							// failure had pessimistically flipped it to read-only, which
+							// nothing else would ever undo.
+							isHolderRef.current = true;
+							setIsReadOnly(false);
+							return;
+						}
 						// Lock lost (expired or taken over): re-read the current holder.
 						void refreshOwnership();
 					})
 					.catch(() => {});
 			}, LOCK_HEARTBEAT_INTERVAL_MS);
+		};
+
+		// Re-reads ownership, then resumes the heartbeat if this tab won the lock
+		// back. Called whenever the tab may have drifted from the server state
+		// while it was away: `handleHide` releases the lock as soon as the tab is
+		// hidden, and the heartbeat that would notice is throttled in a background
+		// tab and frozen while the machine sleeps. Without this, a tab left open
+		// overnight comes back believing it still holds a lock the server dropped,
+		// and the first write is rejected with a bogus "locked by another user"
+		// (issue #4186).
+		const reconcileOwnership = async () => {
+			await refreshOwnership();
+			if (cancelled) return;
+			if (isHolderRef.current) startHeartbeat();
 		};
 
 		const handleHide = () => {
@@ -116,8 +144,36 @@ export function useDeclarationLock({
 		};
 
 		const handleVisibilityChange = () => {
-			if (document.visibilityState === "hidden") handleHide();
+			if (document.visibilityState === "hidden") {
+				handleHide();
+				return;
+			}
+			void reconcileOwnership();
 		};
+
+		// Symmetric to the `pagehide` beacon: a bfcache restore resumes a page
+		// whose lock was released on the way out.
+		const handlePageShow = (event: PageTransitionEvent) => {
+			if (!event.persisted) return;
+			void reconcileOwnership();
+		};
+
+		// A write rejected because the lock is not held is the authoritative
+		// signal that this tab's ownership is stale — the step form would
+		// otherwise keep showing an editable form under a red lock error.
+		const unsubscribeFromMutations = queryClient
+			.getMutationCache()
+			.subscribe((event) => {
+				if (event.type !== "updated" || event.action.type !== "error") return;
+				const error = event.action.error;
+				if (
+					!(error instanceof Error) ||
+					error.message !== DECLARATION_LOCK_CONFLICT_MESSAGE
+				) {
+					return;
+				}
+				void reconcileOwnership();
+			});
 
 		setIsLoading(true);
 		void (async () => {
@@ -128,12 +184,15 @@ export function useDeclarationLock({
 		})();
 
 		window.addEventListener("pagehide", handleHide);
+		window.addEventListener("pageshow", handlePageShow);
 		document.addEventListener("visibilitychange", handleVisibilityChange);
 
 		return () => {
 			cancelled = true;
 			stopHeartbeat();
+			unsubscribeFromMutations();
 			window.removeEventListener("pagehide", handleHide);
+			window.removeEventListener("pageshow", handlePageShow);
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 			// Intentionally NOT releasing on unmount: step-to-step navigation
 			// unmounts then remounts this hook, and a release racing the next step's
@@ -147,6 +206,7 @@ export function useDeclarationLock({
 		isEnabled,
 		isImpersonating,
 		modificationClosed,
+		queryClient,
 		session.status,
 	]);
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -79,6 +79,7 @@ export {
 } from "./shared/declarationFlags";
 // Declaration edit lock constants
 export {
+	DECLARATION_LOCK_CONFLICT_MESSAGE,
 	DEFAULT_LOCK_TIMEOUT_MINUTES,
 	LOCK_HEARTBEAT_INTERVAL_MS,
 } from "./shared/declarationLock";

--- a/packages/app/src/modules/domain/shared/declarationLock.ts
+++ b/packages/app/src/modules/domain/shared/declarationLock.ts
@@ -1,3 +1,12 @@
 export const DEFAULT_LOCK_TIMEOUT_MINUTES = 30;
 
 export const LOCK_HEARTBEAT_INTERVAL_MS = 10_000;
+
+/**
+ * Rejection message for a declaration write attempted without holding the edit
+ * lock. Shared by the tRPC lock guard, the draft autosave and the upload route
+ * so the client recognises a lock conflict by value rather than by matching a
+ * duplicated literal that could drift (issue #4186).
+ */
+export const DECLARATION_LOCK_CONFLICT_MESSAGE =
+	"Déclaration verrouillée par un autre utilisateur.";

--- a/packages/app/src/server/api/routers/declarationDraft.ts
+++ b/packages/app/src/server/api/routers/declarationDraft.ts
@@ -7,6 +7,7 @@ import {
 	getDraftInput,
 	saveDraftInput,
 } from "~/modules/declaration-remuneration/shared/draft/schemas";
+import { DECLARATION_LOCK_CONFLICT_MESSAGE } from "~/modules/domain";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 import { isImpersonatingSiren } from "~/server/auth/companyAccess";
 import type { DB } from "~/server/db";
@@ -111,7 +112,7 @@ export const declarationDraftRouter = createTRPCRouter({
 				if (lock && lock.userId !== ctx.session.user.id) {
 					throw new TRPCError({
 						code: "CONFLICT",
-						message: "Déclaration verrouillée par un autre utilisateur.",
+						message: DECLARATION_LOCK_CONFLICT_MESSAGE,
 					});
 				}
 			}

--- a/packages/app/src/server/api/trpc.ts
+++ b/packages/app/src/server/api/trpc.ts
@@ -12,6 +12,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import superjson from "superjson";
 import { ZodError } from "zod";
 import {
+	DECLARATION_LOCK_CONFLICT_MESSAGE,
 	getCurrentYear,
 	isDeadlinePassed,
 	isDeclarationSubmitted,
@@ -290,7 +291,7 @@ export const declarationLockedWriteProcedure = declarationWriteProcedure.use(
 		if (!lock || lock.userId !== ctx.session.user.id) {
 			throw new TRPCError({
 				code: "CONFLICT",
-				message: "Déclaration verrouillée par un autre utilisateur.",
+				message: DECLARATION_LOCK_CONFLICT_MESSAGE,
 			});
 		}
 		return next();


### PR DESCRIPTION
Closes #4186

## Le bug

Un onglet laissé ouvert sur une étape de déclaration finit par afficher l'erreur rouge **« Déclaration verrouillée par un autre utilisateur. »** sur un formulaire resté **éditable** (champs saisissables, bouton « Suivant » actif), puis tout se remet à fonctionner quelques secondes plus tard.

Le message de la capture n'est pas l'alerte orange de lock : c'est le `CONFLICT` de `declarationLockedWriteProcedure`, rendu par `FormErrors` comme n'importe quelle erreur de mutation.

## Cause

`handleVisibilityChange` **libère le lock par beacon dès que l'onglet passe en `hidden`** (verrouillage d'écran, changement d'application, nuit) — et **rien ne le réacquiert au retour**. L'asymétrie est le défaut.

Le seul rattrapage était le `setInterval` de heartbeat (10 s), or il est throttlé à ~1/min dans un onglet caché et gelé pendant la veille machine. Au matin, l'onglet est visible et croit détenir un lock que le serveur a supprimé : le premier « Suivant » part, se fait rejeter en `CONFLICT`, mais `isReadOnly` reste `false`. Le heartbeat rattrape ensuite et réacquiert → « on peut continuer sans soucis », d'où une erreur qui semble sortie de nulle part.

> L'analyse initialement postée sur l'issue partait d'une prémisse fausse (« le tunnel rend les étapes sans cycle client `acquireLock`/`heartbeat`/`releaseLock` »). Ce cycle existe depuis `DeclarationLayout`, et `isReadOnly` est déjà consommé par les 6 étapes et `FormActions`. Le commentaire a été corrigé.

## Le correctif

`useDeclarationLock` gagne un `reconcileOwnership()` (ré-acquisition + reprise du heartbeat), déclenché sur :

- `visibilitychange` → `visible` — le pendant symétrique du beacon de release ;
- `pageshow` avec `persisted` — restauration bfcache, pendant de `pagehide` ;
- toute mutation rejetée avec le message de conflit de lock, via la `MutationCache` — l'UI ne peut plus afficher une erreur de lock sur un formulaire éditable. Couvre aussi l'autosave de brouillon, silencieuse jusqu'ici.

Un **heartbeat accepté par le serveur vaut preuve de possession** et restaure l'état éditable : sans ça, un échec réseau transitoire pendant la ré-acquisition figeait le formulaire en lecture seule **sans alerte** (le gate exige un `holder`) et sans rien pour l'annuler — une régression que la ré-acquisition au retour d'onglet rendait atteignable.

Côté serveur, `DECLARATION_LOCK_CONFLICT_MESSAGE` remplace le littéral dupliqué dans `trpc.ts`, `declarationDraft.ts` et `upload/route.ts`. C'est ce qui permet au client de distinguer ce `CONFLICT` de celui de `PATH_LOCKED_ERROR` sans matcher une chaîne qui pourrait dériver. Aucun changement de comportement côté serveur.

## Comportement attendu après le correctif

| Situation au retour sur l'onglet | Avant | Après |
|---|---|---|
| Le lock est libre (cas courant, notre propre beacon l'a relâché) | erreur rouge au 1er « Suivant », puis ça repasse | ré-acquisition immédiate, aucune erreur |
| Un collègue a pris le lock | formulaire éditable + erreur rouge au submit | lecture seule + alerte « Déclaration en cours de modification » avec l'identité du détenteur |

## Tests

8 tests ajoutés sur `useDeclarationLock` (retour d'onglet, reprise du heartbeat, bfcache, réconciliation sur conflit d'écriture, non-régression sur une erreur non liée au lock).

`DeclarationLayout.test.tsx` reçoit un `QueryClientProvider` : le hook en dépend maintenant, comme il dépendait déjà de `TRPCReactProvider` en production — le mock de `~/trpc/react` masquait la contrainte.

`typecheck` · `lint:check` · `format:check` · 396 fichiers / 4477 tests : verts.
