### PR TITLE
fix: respect declaration lock in step 2

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/Step5EmployeeCategories.tsx
@@ -112,7 +112,7 @@ export function Step5EmployeeCategories({
 		<CategoryForm
 			accordionId="accordion-step5"
 			defaultValuesOverride={categoryFormDefaultOverride}
-			disabled={isImpersonating || isLocked}
+			disabled={isImpersonating}
 			hasDataOverride={hasInitialData || hasDraft}
 			initialCategories={initialCategories ?? []}
 			initialSource={initialSource}
@@ -134,6 +134,7 @@ export function Step5EmployeeCategories({
 			}
 			onValuesChange={(values) => setField(values)}
 			previousHref="/declaration-remuneration/etape/4"
+			readOnly={isLocked}
 			referenceYear={getReferenceYearFor(declarationYear)}
 			stepper={
 				<StepIndicator

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/ReferencePeriodPicker.tsx
@@ -7,6 +7,7 @@ type Props = {
 	onStartDateChange: (value: string) => void;
 	onEndDateChange: (value: string) => void;
 	disabled?: boolean;
+	readOnly?: boolean;
 };
 
 export function ReferencePeriodPicker({
@@ -15,6 +16,7 @@ export function ReferencePeriodPicker({
 	onStartDateChange,
 	onEndDateChange,
 	disabled = false,
+	readOnly = false,
 }: Props) {
 	return (
 		<fieldset className={styles.fieldset}>
@@ -40,6 +42,7 @@ export function ReferencePeriodPicker({
 							disabled={disabled}
 							id="period-start-date"
 							onChange={(e) => onStartDateChange(e.target.value)}
+							readOnly={readOnly}
 							type="date"
 							value={startDate}
 						/>
@@ -56,6 +59,7 @@ export function ReferencePeriodPicker({
 							disabled={disabled}
 							id="period-end-date"
 							onChange={(e) => onEndDateChange(e.target.value)}
+							readOnly={readOnly}
 							type="date"
 							value={endDate}
 						/>

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/SecondDeclarationStep2Form.tsx
@@ -6,6 +6,7 @@ import { useIsImpersonating } from "~/modules/auth";
 import { DraftLoadingState } from "~/modules/declaration-remuneration/shared/draft/DraftLoadingState";
 import { useDeclarationDraft } from "~/modules/declaration-remuneration/shared/draft/useDeclarationDraft";
 import { useDraftHydration } from "~/modules/declaration-remuneration/shared/draft/useDraftHydration";
+import { useLockContext } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import {
 	type DeclarationFsmStatus,
@@ -41,6 +42,7 @@ export function SecondDeclarationStep2Form({
 }: Props) {
 	const router = useRouter();
 	const isImpersonating = useIsImpersonating();
+	const { isReadOnly: isLocked } = useLockContext();
 	const isWritable = isSecondDeclarationWritable(status);
 	const isFormDisabled = isImpersonating || !isWritable;
 	const [startDate, setStartDate] = useState(initialStartDate);
@@ -77,9 +79,9 @@ export function SecondDeclarationStep2Form({
 	});
 
 	useEffect(() => {
-		if (!draftHydrated) return;
+		if (!draftHydrated || isFormDisabled || isLocked) return;
 		setField({ startDate, endDate });
-	}, [draftHydrated, startDate, endDate, setField]);
+	}, [draftHydrated, endDate, isFormDisabled, isLocked, setField, startDate]);
 
 	const mutation = api.declaration.updateEmployeeCategories.useMutation({
 		onSuccess: () => {
@@ -130,6 +132,7 @@ export function SecondDeclarationStep2Form({
 					endDate={endDate}
 					onEndDateChange={setEndDate}
 					onStartDateChange={setStartDate}
+					readOnly={isLocked}
 					startDate={startDate}
 				/>
 			}
@@ -143,6 +146,7 @@ export function SecondDeclarationStep2Form({
 				</h1>
 			}
 			tooltipPrefix="tooltip-second-decl"
+			readOnly={isLocked}
 		/>
 	);
 }

--- a/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LockProvider } from "~/modules/declaration-remuneration/shared/lock/LockContext";
 import type { EmployeeCategoryRow } from "~/modules/declaration-remuneration/types";
 import { SecondDeclarationStep2Form } from "../SecondDeclarationStep2Form";
+
+const { setFieldMock, clearDraftMock } = vi.hoisted(() => ({
+	setFieldMock: vi.fn(),
+	clearDraftMock: vi.fn(),
+}));
 
 vi.mock("~/trpc/react", () => ({
 	api: {
@@ -17,6 +23,25 @@ vi.mock("~/trpc/react", () => ({
 		},
 	},
 }));
+
+vi.mock(
+	"~/modules/declaration-remuneration/shared/draft/useDeclarationDraft",
+	() => ({
+		useDeclarationDraft: () => ({
+			draft: {},
+			setField: setFieldMock,
+			clearDraft: clearDraftMock,
+			isLoadingDraft: false,
+		}),
+	}),
+);
+
+vi.mock(
+	"~/modules/declaration-remuneration/shared/draft/useDraftHydration",
+	() => ({
+		useDraftHydration: () => true,
+	}),
+);
 
 function makeCategory(
 	overrides: Partial<EmployeeCategoryRow> = {},
@@ -57,15 +82,38 @@ function renderStep2(
 	overrides: Partial<ComponentProps<typeof SecondDeclarationStep2Form>> = {},
 ) {
 	return render(
-		<SecondDeclarationStep2Form
-			declarationSiren="123456789"
-			declarationYear={2025}
-			initialFirstDeclarationCategories={mockCategories}
-			status="corrective_actions_chosen"
-			{...overrides}
-		/>,
+		<LockProvider>
+			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialFirstDeclarationCategories={mockCategories}
+				status="corrective_actions_chosen"
+				{...overrides}
+			/>
+		</LockProvider>,
 	);
 }
+
+function renderStep2ReadOnly(
+	overrides: Partial<ComponentProps<typeof SecondDeclarationStep2Form>> = {},
+) {
+	return render(
+		<LockProvider isReadOnly>
+			<SecondDeclarationStep2Form
+				declarationSiren="123456789"
+				declarationYear={2025}
+				initialFirstDeclarationCategories={mockCategories}
+				status="corrective_actions_chosen"
+				{...overrides}
+			/>
+		</LockProvider>,
+	);
+}
+
+beforeEach(() => {
+	setFieldMock.mockClear();
+	clearDraftMock.mockClear();
+});
 
 describe("SecondDeclarationStep2Form", () => {
 	it("renders the title and step indicator", () => {
@@ -104,14 +152,7 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("places the source paragraph immediately after the intro paragraph (#4215)", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-				initialSource="accord-entreprise"
-			/>,
-		);
+		renderStep2({ initialSource: "accord-entreprise" });
 		const introParagraph = screen.getByText(
 			/Cette seconde déclaration reprend les catégories/,
 		);
@@ -122,14 +163,7 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("places the source paragraph before the obligatoires mention (#4215)", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-				initialSource="accord-entreprise"
-			/>,
-		);
+		renderStep2({ initialSource: "accord-entreprise" });
 		const sourceParagraph = screen
 			.getByText(/Source utilisée pour déterminer/)
 			.closest("p") as HTMLElement;
@@ -140,14 +174,7 @@ describe("SecondDeclarationStep2Form", () => {
 	});
 
 	it("keeps the source paragraph out of the reference period block (#4215)", () => {
-		render(
-			<SecondDeclarationStep2Form
-				declarationSiren="123456789"
-				declarationYear={2025}
-				initialFirstDeclarationCategories={mockCategories}
-				initialSource="accord-entreprise"
-			/>,
-		);
+		renderStep2({ initialSource: "accord-entreprise" });
 		const startDateField = screen.getByLabelText(/Date de début/);
 		const sourceParagraph = screen
 			.getByText(/Source utilisée pour déterminer/)
@@ -232,5 +259,22 @@ describe("SecondDeclarationStep2Form", () => {
 		renderStep2({ status: "revised_joint_evaluation_chosen" });
 		expect(screen.getByLabelText(/Date de début/)).toBeDisabled();
 		expect(screen.getByLabelText(/Date de fin/)).toBeDisabled();
+	});
+
+	it("renders the lock-protected inputs as readOnly instead of disabled", () => {
+		renderStep2ReadOnly();
+
+		const startDate = screen.getByLabelText(/Date de début/);
+		const womenCount = screen.getByLabelText(/Effectif femmes, catégorie 1/);
+
+		expect(startDate).toHaveAttribute("readonly");
+		expect(startDate).not.toBeDisabled();
+		expect(womenCount).toHaveAttribute("readonly");
+		expect(womenCount).not.toBeDisabled();
+	});
+
+	it("does not autosave the draft when the declaration is lock-read-only", () => {
+		renderStep2ReadOnly();
+		expect(setFieldMock).not.toHaveBeenCalled();
 	});
 });

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryAccordionItem.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryAccordionItem.tsx
@@ -15,6 +15,7 @@ type Props = {
 	fieldId: string;
 	category: EmployeeCategory & { id: number };
 	disabled: boolean;
+	readOnly: boolean;
 	isExpanded: boolean;
 	readOnlyLabel: boolean;
 	showDelete: boolean;
@@ -38,6 +39,7 @@ export function CategoryAccordionItem({
 	fieldId,
 	category,
 	disabled,
+	readOnly,
 	isExpanded,
 	readOnlyLabel,
 	showDelete,
@@ -110,6 +112,7 @@ export function CategoryAccordionItem({
 								disabled={disabled}
 								id={`cat-${index}-name`}
 								maxLength={CATEGORY_NAME_MAX_LENGTH}
+								readOnly={readOnly}
 								{...nameProps}
 								type="text"
 							/>
@@ -126,6 +129,7 @@ export function CategoryAccordionItem({
 						disabled={disabled}
 						onDecimalBlur={onDecimalBlur}
 						onPositiveNumberChange={onPositiveNumberChange}
+						readOnly={readOnly}
 					/>
 					{showDelete && (
 						<div className={stepStyles.deleteRow}>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryDataTable.tsx
@@ -22,6 +22,7 @@ type Props = {
 	) => (e: React.ChangeEvent<HTMLInputElement>) => void;
 	onDecimalBlur: (index: number, field: keyof EmployeeCategory) => () => void;
 	disabled?: boolean;
+	readOnly?: boolean;
 };
 
 type StringField = {
@@ -53,6 +54,7 @@ type EuroCellProps = {
 	ariaLabel: string;
 	id: string;
 	disabled: boolean;
+	readOnly: boolean;
 	value: string;
 	onBlur: () => void;
 	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -62,6 +64,7 @@ function EuroInputCell({
 	ariaLabel,
 	id,
 	disabled,
+	readOnly,
 	value,
 	onBlur,
 	onChange,
@@ -77,6 +80,7 @@ function EuroInputCell({
 					inputMode="decimal"
 					onBlur={onBlur}
 					onChange={onChange}
+					readOnly={readOnly}
 					type="text"
 					value={displayDecimal(value)}
 				/>
@@ -137,6 +141,7 @@ type RemunerationTableProps = {
 	cat: EmployeeCategory;
 	catIndex: number;
 	disabled: boolean;
+	readOnly: boolean;
 	pos: Props["onPositiveNumberChange"];
 	blur: Props["onDecimalBlur"];
 	idPrefix: string;
@@ -149,6 +154,7 @@ function RemunerationTable({
 	cat,
 	catIndex,
 	disabled,
+	readOnly,
 	pos,
 	blur,
 	idPrefix,
@@ -185,6 +191,7 @@ function RemunerationTable({
 							id={idFor("base-women")}
 							onBlur={blur(catIndex, fields.baseWomen)}
 							onChange={pos(catIndex, fields.baseWomen, false)}
+							readOnly={readOnly}
 							value={cat[fields.baseWomen]}
 						/>
 						<EuroInputCell
@@ -193,6 +200,7 @@ function RemunerationTable({
 							id={idFor("base-men")}
 							onBlur={blur(catIndex, fields.baseMen)}
 							onChange={pos(catIndex, fields.baseMen, false)}
+							readOnly={readOnly}
 							value={cat[fields.baseMen]}
 						/>
 						<td className={stepStyles.gapCell}>
@@ -214,6 +222,7 @@ function RemunerationTable({
 							id={idFor("variable-women")}
 							onBlur={blur(catIndex, fields.variableWomen)}
 							onChange={pos(catIndex, fields.variableWomen, false)}
+							readOnly={readOnly}
 							value={cat[fields.variableWomen]}
 						/>
 						<EuroInputCell
@@ -222,6 +231,7 @@ function RemunerationTable({
 							id={idFor("variable-men")}
 							onBlur={blur(catIndex, fields.variableMen)}
 							onChange={pos(catIndex, fields.variableMen, false)}
+							readOnly={readOnly}
 							value={cat[fields.variableMen]}
 						/>
 						<td className={stepStyles.gapCell}>
@@ -258,6 +268,7 @@ export function CategoryDataTable({
 	onPositiveNumberChange: pos,
 	onDecimalBlur: blur,
 	disabled = false,
+	readOnly = false,
 }: Props) {
 	const womenInt = cat.womenCount ? Number.parseInt(cat.womenCount, 10) : NaN;
 	const menInt = cat.menCount ? Number.parseInt(cat.menCount, 10) : NaN;
@@ -304,6 +315,7 @@ export function CategoryDataTable({
 									inputMode="numeric"
 									onChange={pos(catIndex, "womenCount", true)}
 									pattern="[0-9]*"
+									readOnly={readOnly}
 									type="text"
 									value={cat.womenCount}
 								/>
@@ -317,6 +329,7 @@ export function CategoryDataTable({
 									inputMode="numeric"
 									onChange={pos(catIndex, "menCount", true)}
 									pattern="[0-9]*"
+									readOnly={readOnly}
 									type="text"
 									value={cat.menCount}
 								/>
@@ -334,6 +347,7 @@ export function CategoryDataTable({
 				fields={ANNUAL_FIELDS}
 				idPrefix={idPrefix}
 				pos={pos}
+				readOnly={readOnly}
 				scope="annuel"
 				title="Rémunération annuelle brute moyenne"
 			/>
@@ -346,6 +360,7 @@ export function CategoryDataTable({
 				fields={HOURLY_FIELDS}
 				idPrefix={idPrefix}
 				pos={pos}
+				readOnly={readOnly}
 				scope="horaire"
 				title="Rémunération horaire brute moyenne"
 			/>

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/CategoryForm.tsx
@@ -32,6 +32,7 @@ import {
 	padDecimalToTwo,
 	sumCategoryWorkforce,
 } from "~/modules/domain";
+import common from "~/modules/declaration-remuneration/shared/common.module.scss";
 import { getDsfrCollapse } from "~/modules/shared";
 import { useZodForm } from "~/modules/shared/useZodForm";
 import stepStyles from "../Step5EmployeeCategories.module.scss";
@@ -85,6 +86,7 @@ type Props = {
 	referencePeriodPicker?: ReactNode;
 	descriptionText?: string;
 	disabled?: boolean;
+	readOnly?: boolean;
 	nextHref?: string;
 	mimoquageNextHref?: string;
 	hasDataOverride?: boolean;
@@ -143,6 +145,7 @@ export function CategoryForm({
 	referencePeriodPicker,
 	descriptionText = "Cet indicateur permet de mesurer l'écart de rémunération entre les femmes et les hommes au sein de chaque catégorie de salariés, en distinguant le salaire de base des composantes variables ou complémentaires.",
 	disabled = false,
+	readOnly = false,
 	nextHref,
 	mimoquageNextHref,
 	hasDataOverride,
@@ -385,6 +388,7 @@ export function CategoryForm({
 			onSubmit={handleFormSubmit}
 		>
 			<StepTitleRow
+				devFillDisabled={disabled || readOnly}
 				hasData={hasData}
 				isPendingSave={isPendingSaveOverride}
 				isSaving={isSavingOverride}
@@ -441,7 +445,7 @@ export function CategoryForm({
 							aria-describedby={sourceError ? "source-error" : undefined}
 							aria-invalid={Boolean(sourceError)}
 							className="fr-select"
-							disabled={disabled}
+							disabled={disabled || readOnly}
 							id="source-select"
 							{...form.register("source")}
 							onChange={(e) => {
@@ -481,68 +485,72 @@ export function CategoryForm({
 				</div>
 				{!readOnlyLabel && (
 					<CategoryImportExport
-						disabled={disabled}
+						disabled={disabled || readOnly}
 						onImport={handleImportCategories}
 					/>
 				)}
 			</div>
 
-			<div className="fr-accordions-group" data-fr-group="false">
-				{fields.map((field, index) => {
-					const cat = categories[index];
-					return (
-						<CategoryAccordionItem
-							baseId={baseId}
-							category={
-								cat ? { id: index, ...cat } : createEmptyCategory(index)
-							}
-							collapseRef={(node) => {
-								accordionCollapseRefs.current[index] = node;
-							}}
-							disabled={disabled}
-							fieldId={field.id}
-							headerRef={(node) => {
-								accordionHeaderRefs.current[index] = node;
-							}}
-							index={index}
-							isExpanded={expandedByFieldId[field.id] ?? true}
-							key={field.id}
-							nameError={
-								form.formState.errors.categories?.[index]?.name?.message
-							}
-							nameProps={{
-								...form.register(`categories.${index}.name`),
-								onChange: (e) => {
-									form.setValue(`categories.${index}.name`, e.target.value);
-									setHasData(false);
-								},
-							}}
-							onAccordionToggle={(e) => handleAccordionToggle(e, field.id)}
-							onAskRemove={askRemoveCategory}
-							onDecimalBlur={handleDecimalBlur}
-							onPositiveNumberChange={handlePositiveNumberChange}
-							readOnlyLabel={readOnlyLabel}
-							showDelete={!readOnlyLabel && fields.length > 1}
-						/>
-					);
-				})}
-			</div>
+			<fieldset className={readOnly ? common.readOnlyFieldset : undefined}>
+				<legend className="fr-sr-only">Catégories d&apos;emplois</legend>
+				<div className="fr-accordions-group" data-fr-group="false">
+					{fields.map((field, index) => {
+						const cat = categories[index];
+						return (
+							<CategoryAccordionItem
+								baseId={baseId}
+								category={
+									cat ? { id: index, ...cat } : createEmptyCategory(index)
+								}
+								collapseRef={(node) => {
+									accordionCollapseRefs.current[index] = node;
+								}}
+								disabled={disabled}
+								fieldId={field.id}
+								headerRef={(node) => {
+									accordionHeaderRefs.current[index] = node;
+								}}
+								index={index}
+								isExpanded={expandedByFieldId[field.id] ?? true}
+								key={field.id}
+								nameError={
+									form.formState.errors.categories?.[index]?.name?.message
+								}
+								nameProps={{
+									...form.register(`categories.${index}.name`),
+									onChange: (e) => {
+										form.setValue(`categories.${index}.name`, e.target.value);
+										setHasData(false);
+									},
+								}}
+								onAccordionToggle={(e) => handleAccordionToggle(e, field.id)}
+								onAskRemove={askRemoveCategory}
+								onDecimalBlur={handleDecimalBlur}
+								onPositiveNumberChange={handlePositiveNumberChange}
+								readOnly={readOnly}
+								readOnlyLabel={readOnlyLabel}
+								showDelete={!readOnlyLabel && !readOnly && fields.length > 1}
+							/>
+						);
+					})}
+				</div>
 
-			<div className={stepStyles.categoryFooter}>
-				<p className="fr-text--bold fr-mb-0">
-					Nombre de catégories : {fields.length}
-				</p>
-				{!readOnlyLabel && (
-					<button
-						className="fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left"
-						disabled={disabled}
-						onClick={addCategory}
-						type="button"
-					>
-						Ajouter une catégorie d&apos;emplois
-					</button>
-				)}
-			</div>
+				<div className={stepStyles.categoryFooter}>
+					<p className="fr-text--bold fr-mb-0">
+						Nombre de catégories : {fields.length}
+					</p>
+					{!readOnlyLabel && (
+						<button
+							className="fr-btn fr-btn--secondary fr-icon-add-line fr-btn--icon-left"
+							disabled={disabled || readOnly}
+							onClick={addCategory}
+							type="button"
+						>
+							Ajouter une catégorie d&apos;emplois
+						</button>
+					)}
+				</div>
+			</fieldset>
 
 			<DefinitionAccordion
 				id={accordionId}

--- a/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx
@@ -44,6 +44,7 @@ function renderItem(
 			onAskRemove={vi.fn()}
 			onDecimalBlur={() => vi.fn()}
 			onPositiveNumberChange={() => vi.fn()}
+			readOnly={false}
 			readOnlyLabel={false}
 			showDelete={false}
 			{...rest}

--- a/packages/app/src/server/api/routers/__tests__/declarationDraft.integration.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDraft.integration.test.ts
@@ -12,6 +12,8 @@ describe("declarationDraftRouter save/get roundtrip (real Postgres)", () => {
 	const USER_ID = "draft-integration-test-user";
 	const USER_EMAIL = "draft-integration@example.fr";
 	const USER_SIRET = `${SIREN}00015`;
+	const LOCK_USER_ID = "draft-integration-lock-user";
+	const LOCK_USER_EMAIL = "draft-lock@example.fr";
 
 	function createCaller() {
 		return declarationDraftRouter.createCaller({
@@ -36,22 +38,32 @@ describe("declarationDraftRouter save/get roundtrip (real Postgres)", () => {
 
 	afterAll(async () => {
 		if (!sql) return;
+		await sql`DELETE FROM app_declaration_lock WHERE locked_by_user_id IN (${USER_ID}, ${LOCK_USER_ID})`;
 		await sql`DELETE FROM app_declaration WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user_company WHERE user_id = ${LOCK_USER_ID}`;
 		await sql`DELETE FROM app_user_company WHERE user_id = ${USER_ID}`;
 		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${LOCK_USER_ID}`;
 		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
 		await sql.end();
 	});
 
 	beforeEach(async () => {
+		await sql`DELETE FROM app_declaration_lock WHERE locked_by_user_id IN (${USER_ID}, ${LOCK_USER_ID})`;
 		await sql`DELETE FROM app_declaration WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user_company WHERE user_id = ${LOCK_USER_ID}`;
 		await sql`DELETE FROM app_user_company WHERE user_id = ${USER_ID}`;
 		await sql`DELETE FROM app_company WHERE siren = ${SIREN}`;
+		await sql`DELETE FROM app_user WHERE id = ${LOCK_USER_ID}`;
 		await sql`DELETE FROM app_user WHERE id = ${USER_ID}`;
 
 		await sql`
 			INSERT INTO app_user (id, email)
 			VALUES (${USER_ID}, ${USER_EMAIL})
+		`;
+		await sql`
+			INSERT INTO app_user (id, email)
+			VALUES (${LOCK_USER_ID}, ${LOCK_USER_EMAIL})
 		`;
 		await sql`
 			INSERT INTO app_company (siren, name)
@@ -60,6 +72,10 @@ describe("declarationDraftRouter save/get roundtrip (real Postgres)", () => {
 		await sql`
 			INSERT INTO app_user_company (user_id, siren)
 			VALUES (${USER_ID}, ${SIREN})
+		`;
+		await sql`
+			INSERT INTO app_user_company (user_id, siren)
+			VALUES (${LOCK_USER_ID}, ${SIREN})
 		`;
 	});
 
@@ -122,5 +138,54 @@ describe("declarationDraftRouter save/get roundtrip (real Postgres)", () => {
 		expect(Date.now() - (draftUpdatedAt as Date).getTime()).toBeLessThan(
 			30 * 24 * 3600 * 1000,
 		);
+	});
+
+	it("rejects clear with CONFLICT when another co-declarant holds the active lock", async () => {
+		const caller = createCaller();
+
+		await caller.save({
+			siren: SIREN,
+			year: YEAR,
+			slice: { kind: "main", step: "step1", data: { workforce: 50 } },
+		});
+
+		const declarationRows = await sql<{ id: string }[]>`
+			SELECT id
+			FROM app_declaration
+			WHERE siren = ${SIREN} AND year = ${YEAR} AND cancelled_at IS NULL
+		`;
+		const declarationId = declarationRows[0]?.id;
+		expect(declarationId).toBeTruthy();
+
+		await sql`
+			INSERT INTO app_declaration_lock (
+				declaration_id,
+				locked_by_user_id,
+				locked_at,
+				last_heartbeat_at,
+				expires_at
+			)
+			VALUES (
+				${declarationId as string},
+				${LOCK_USER_ID},
+				NOW(),
+				NOW(),
+				NOW() + INTERVAL '10 minutes'
+			)
+		`;
+
+		await expect(
+			caller.clear({ siren: SIREN, year: YEAR }),
+		).rejects.toMatchObject({
+			code: "CONFLICT",
+			message: "Déclaration verrouillée par un autre utilisateur.",
+		});
+
+		const draftRows = await sql<{ draft: unknown }[]>`
+			SELECT draft
+			FROM app_declaration
+			WHERE siren = ${SIREN} AND year = ${YEAR} AND cancelled_at IS NULL
+		`;
+		expect(draftRows[0]?.draft).toEqual({ main: { step1: { workforce: 50 } } });
 	});
 });

--- a/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/declarationDraft.test.ts
@@ -395,7 +395,11 @@ describe("declarationDraftRouter", () => {
 
 	describe("clear", () => {
 		it("sets draft and draftUpdatedAt to null when no kind is given", async () => {
-			const { db, mocks } = createMockDb([[{ siren: SIREN }]]);
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ id: DECLARATION_ID, draft: { main: { step1: { workforce: 50 } } } }],
+				[ownLockHolder()],
+			]);
 			const caller = await createCaller(db);
 
 			const result = await caller.clear({ siren: SIREN, year: YEAR });
@@ -413,7 +417,8 @@ describe("declarationDraftRouter", () => {
 			};
 			const { db, mocks } = createMockDb([
 				[{ siren: SIREN }],
-				[{ draft: existingDraft }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[ownLockHolder()],
 			]);
 			const caller = await createCaller(db);
 
@@ -435,7 +440,8 @@ describe("declarationDraftRouter", () => {
 			const existingDraft = { main: { step1: { workforce: 50 } } };
 			const { db, mocks } = createMockDb([
 				[{ siren: SIREN }],
-				[{ draft: existingDraft }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[ownLockHolder()],
 			]);
 			const caller = await createCaller(db);
 
@@ -486,7 +492,8 @@ describe("declarationDraftRouter", () => {
 			};
 			const { db, mocks } = createMockDb([
 				[{ siren: SIREN }],
-				[{ draft: existingDraft }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[ownLockHolder()],
 			]);
 			const caller = await createCaller(db);
 
@@ -512,7 +519,8 @@ describe("declarationDraftRouter", () => {
 			};
 			const { db, mocks } = createMockDb([
 				[{ siren: SIREN }],
-				[{ draft: existingDraft }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[ownLockHolder()],
 			]);
 			const caller = await createCaller(db);
 
@@ -534,7 +542,8 @@ describe("declarationDraftRouter", () => {
 			const existingDraft = { main: { "1": { totalWomen: 50 } } };
 			const { db, mocks } = createMockDb([
 				[{ siren: SIREN }],
-				[{ draft: existingDraft }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[ownLockHolder()],
 			]);
 			const caller = await createCaller(db);
 
@@ -548,6 +557,24 @@ describe("declarationDraftRouter", () => {
 			expect(mocks.set).toHaveBeenCalledWith(
 				expect.objectContaining({ draft: null, draftUpdatedAt: null }),
 			);
+		});
+
+		it("throws CONFLICT when another co-declarant holds the declaration lock", async () => {
+			const existingDraft = { main: { step1: { workforce: 50 } } };
+			const { db, mocks } = createMockDb([
+				[{ siren: SIREN }],
+				[{ id: DECLARATION_ID, draft: existingDraft }],
+				[foreignLockHolder()],
+			]);
+			const caller = await createCaller(db);
+
+			await expect(caller.clear({ siren: SIREN, year: YEAR })).rejects.toMatchObject(
+				{
+					code: "CONFLICT",
+					message: "Déclaration verrouillée par un autre utilisateur.",
+				},
+			);
+			expect(mocks.update).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/app/src/server/api/routers/declarationDraft.ts
+++ b/packages/app/src/server/api/routers/declarationDraft.ts
@@ -168,22 +168,33 @@ export const declarationDraftRouter = createTRPCRouter({
 				isNull(declarations.cancelledAt),
 			);
 
+			const rows = await ctx.db
+				.select({ id: declarations.id, draft: declarations.draft })
+				.from(declarations)
+				.where(where)
+				.limit(1);
+
+			const existing = rows[0];
+
+			if (existing) {
+				const lock = await getActiveLock(ctx.db, existing.id);
+				if (lock && lock.userId !== ctx.session.user.id) {
+					throw new TRPCError({
+						code: "CONFLICT",
+						message: "Déclaration verrouillée par un autre utilisateur.",
+					});
+				}
+			}
+
 			if (kind === undefined) {
 				await ctx.db
 					.update(declarations)
 					.set({ draft: null, draftUpdatedAt: null })
 					.where(where);
 			} else {
-				const rows = await ctx.db
-					.select({ draft: declarations.draft })
-					.from(declarations)
-					.where(where)
-					.limit(1);
+				if (!existing || existing.draft === null) return { ok: true as const };
 
-				const row = rows[0];
-				if (!row || row.draft === null) return { ok: true as const };
-
-				const current = row.draft as DraftBlob;
+				const current = existing.draft as DraftBlob;
 				let newDraft: DraftBlob | null;
 
 				if (step !== undefined) {


### PR DESCRIPTION
## Summary
- make second-declaration step 2 fields read-only when another co-declarant holds the lock
- prevent draft autosave and clear while the declaration is locked by another user
- cover the lock behavior with unit and integration tests

## Tests
- pnpm exec vitest run src/modules/declaration-remuneration/steps/secondDeclaration/__tests__/SecondDeclarationStep2Form.test.tsx src/modules/declaration-remuneration/steps/step5/__tests__/CategoryAccordionItem.test.tsx src/server/api/routers/__tests__/declarationDraft.test.ts
- integration test added but not run locally: no container runtime available for Testcontainers

Closes #3797