### PR TITLE
fix(declaration-remuneration): #4218 — message d'erreur spécifique sur l'upload de l'évaluation conjointe

### DIFF
--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/JointEvaluationForm.tsx
@@ -74,6 +74,8 @@ export function JointEvaluationForm({
 		selectedFiles,
 		uploadError,
 	} = useFileUploadForm({
+		emptySelectionError:
+			"Veuillez sélectionner le rapport de l'évaluation conjointe avant de soumettre.",
 		flowType: "joint_evaluation",
 		onAllUploaded,
 	});

--- a/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/jointEvaluation/__tests__/JointEvaluationForm.test.tsx
@@ -45,6 +45,9 @@ const { uploadFile: uploadFileMock } = (await import(
 	"~/modules/shared/uploadFile"
 )) as unknown as { uploadFile: ReturnType<typeof vi.fn> };
 
+const EMPTY_SELECTION_ERROR =
+	"Veuillez sélectionner le rapport de l'évaluation conjointe avant de soumettre.";
+
 const defaultProps = {
 	cseOpinionRequired: false,
 	declarationDate: "01/06/2026",
@@ -105,15 +108,16 @@ describe("JointEvaluationForm", () => {
 		expect(screen.getByText(/01\/06\/2026/)).toBeInTheDocument();
 	});
 
-	it("shows an error when submitting without a file", () => {
+	it("names the expected document in the error when submitting without a file", () => {
 		render(<JointEvaluationForm {...defaultProps} />);
 
 		const submitButton = screen.getByRole("button", { name: /transmettre/i });
 		fireEvent.click(submitButton);
 
+		expect(screen.getByText(EMPTY_SELECTION_ERROR)).toBeInTheDocument();
 		expect(
-			screen.getByText(/veuillez sélectionner au moins un fichier/i),
-		).toBeInTheDocument();
+			screen.queryByText(/veuillez sélectionner au moins un fichier/i),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders the info boxes", () => {
@@ -148,9 +152,7 @@ describe("JointEvaluationForm", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: /transmettre/i }));
 
-		expect(
-			screen.queryByText(/veuillez sélectionner un fichier/i),
-		).not.toBeInTheDocument();
+		expect(screen.queryByText(EMPTY_SELECTION_ERROR)).not.toBeInTheDocument();
 
 		expect(
 			container.querySelector("dialog#joint-evaluation-submit-modal"),

--- a/packages/app/src/modules/shared/__tests__/useFileUploadForm.test.tsx
+++ b/packages/app/src/modules/shared/__tests__/useFileUploadForm.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "vitest";
 
 import { FILENAME_ERROR_MESSAGES } from "../fileNameValidation";
-import type { UploadFileResult } from "../uploadFile";
+import type { UploadFailureReason, UploadFileResult } from "../uploadFile";
 import { useFileUploadForm } from "../useFileUploadForm";
 
 vi.mock("../uploadFile", () => ({
@@ -138,7 +138,7 @@ describe("useFileUploadForm", () => {
 		);
 	});
 
-	it("handleSubmit prevents default and shows an error when no file is selected", () => {
+	it("handleSubmit prevents default and shows the generic error when no emptySelectionError is provided", () => {
 		const { result } = renderHook(() =>
 			useFileUploadForm({ flowType: "joint_evaluation" }),
 		);
@@ -152,6 +152,45 @@ describe("useFileUploadForm", () => {
 		expect(result.current.uploadError).toBe(
 			"Veuillez sélectionner au moins un fichier avant de soumettre.",
 		);
+	});
+
+	it("handleSubmit shows the consumer's emptySelectionError when no file is selected", () => {
+		const { result } = renderHook(() =>
+			useFileUploadForm({
+				emptySelectionError: "Veuillez sélectionner le rapport.",
+				flowType: "joint_evaluation",
+			}),
+		);
+
+		act(() => {
+			result.current.handleSubmit(preventSubmit());
+		});
+
+		expect(result.current.uploadError).toBe(
+			"Veuillez sélectionner le rapport.",
+		);
+	});
+
+	it("clears a previous emptySelectionError once a file is selected and submitted", () => {
+		const { result } = renderHook(() =>
+			useFileUploadForm({
+				emptySelectionError: "Veuillez sélectionner le rapport.",
+				flowType: "joint_evaluation",
+			}),
+		);
+		attachDialog(result);
+
+		act(() => {
+			result.current.handleSubmit(preventSubmit());
+		});
+		act(() => {
+			result.current.handleFilesChange([makeFile()], null);
+		});
+		act(() => {
+			result.current.handleSubmit(preventSubmit());
+		});
+
+		expect(result.current.uploadError).toBeNull();
 	});
 
 	it("handleSubmit opens the native dialog when DSFR API is unavailable", () => {
@@ -358,17 +397,7 @@ describe("useFileUploadForm", () => {
 	});
 
 	const reasonCases: Array<{
-		reason:
-			| "scan_unavailable"
-			| "max_files"
-			| "unauthorized"
-			| "not_found"
-			| "too_large"
-			| "wrong_type"
-			| "empty"
-			| "missing_flow"
-			| "missing_filename"
-			| "server_error";
+		reason: Exclude<UploadFailureReason, "virus">;
 		serverError: string;
 		expected: string;
 	}> = [
@@ -419,9 +448,19 @@ describe("useFileUploadForm", () => {
 			expected: "Nom manquant",
 		},
 		{
+			reason: "invalid_filename",
+			serverError: "Nom de fichier invalide",
+			expected: "Nom de fichier invalide",
+		},
+		{
 			reason: "server_error",
 			serverError: "ignored",
 			expected: "Erreur lors de l'upload du fichier. Merci de réessayer.",
+		},
+		{
+			reason: "aborted",
+			serverError: "ignored",
+			expected: "L'upload a été interrompu. Merci de réessayer.",
 		},
 	];
 

--- a/packages/app/src/modules/shared/useFileUploadForm.ts
+++ b/packages/app/src/modules/shared/useFileUploadForm.ts
@@ -22,11 +22,7 @@ type Options = {
 	 * → upload) used by the other upload forms.
 	 */
 	autoUpload?: boolean;
-	/**
-	 * Message shown when submitting the staged flow with no file selected.
-	 * Defaults to a generic copy — consumers with a single expected document
-	 * (e.g. the joint evaluation report) should pass a more specific message.
-	 */
+	// Overrides the generic default for consumers expecting one specific document.
 	emptySelectionError?: string;
 };
 

--- a/packages/app/src/modules/shared/useFileUploadForm.ts
+++ b/packages/app/src/modules/shared/useFileUploadForm.ts
@@ -22,6 +22,12 @@ type Options = {
 	 * → upload) used by the other upload forms.
 	 */
 	autoUpload?: boolean;
+	/**
+	 * Message shown when submitting the staged flow with no file selected.
+	 * Defaults to a generic copy — consumers with a single expected document
+	 * (e.g. the joint evaluation report) should pass a more specific message.
+	 */
+	emptySelectionError?: string;
 };
 
 export function useFileUploadForm({
@@ -29,6 +35,7 @@ export function useFileUploadForm({
 	onUploaded,
 	onAllUploaded,
 	autoUpload = false,
+	emptySelectionError = "Veuillez sélectionner au moins un fichier avant de soumettre.",
 }: Options) {
 	const modalRef = useRef<HTMLDialogElement>(null);
 	const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
@@ -109,9 +116,7 @@ export function useFileUploadForm({
 	function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 		if (selectedFiles.length === 0) {
-			setUploadError(
-				"Veuillez sélectionner au moins un fichier avant de soumettre.",
-			);
+			setUploadError(emptySelectionError);
 			return;
 		}
 		setUploadError(null);


### PR DESCRIPTION
Closes #4218

## Résumé

Le message d'erreur affiché quand on soumet le formulaire d'upload de l'évaluation conjointe sans fichier sélectionné était un littéral générique en dur dans le hook partagé `useFileUploadForm` ("Veuillez sélectionner au moins un fichier avant de soumettre."), alors que cette page attend un document précis et unique (le rapport de l'évaluation conjointe).

## Changement

- `useFileUploadForm` : ajout d'une option optionnelle `emptySelectionError` (défaut inchangé : "Veuillez sélectionner au moins un fichier avant de soumettre.") utilisée dans la branche `handleSubmit` → soumission à vide. Le hook reste agnostique du flux métier ; la copy reste dans le composant consommateur.
- `JointEvaluationForm` : passe désormais `"Veuillez sélectionner le rapport de l'évaluation conjointe avant de soumettre."`.

Le second consommateur du hook (`Step2Upload` de l'avis CSE) utilise `autoUpload: true` et sa propre gestion de soumission — il n'est pas affecté par cette branche du code.

## Vérification

Vérification one-shot exécutée via le test de composant (procédure décrite dans l'analyse du bug, écran de mise en conformité difficilement atteignable en local sans déclaration seedée dans le bon état FSM) :
- **Avant** (code base, assertion sur le libellé spécifique) → RED : le message générique "Veuillez sélectionner au moins un fichier..." s'affiche au lieu du libellé attendu.
- **Après** (fix appliqué) → GREEN : le message affiché est exactement "Veuillez sélectionner le rapport de l'évaluation conjointe avant de soumettre.".

Reproduction confirmée en revert-verify par la couverture permanente ajoutée (voir Test plan).

## Test plan

- [x] `pnpm typecheck` vert
- [x] Suite vitest complète verte (447 fichiers / 5449 tests) — nouveaux cas sur `emptySelectionError` (défaut + override) dans `useFileUploadForm.test.tsx`, assertion mise à jour dans `JointEvaluationForm.test.tsx`
- [x] `validator` (typecheck + test + lint + format) : PASS
- [x] `structural-auditor` : PASS (après correction d'un commentaire JSDoc superflu)
- [x] `rgaa-auditor` : PASS — mécanisme d'affichage d'erreur inchangé (`aria-live="polite"` + `aria-describedby`), seule la copy change
- [ ] `functional-validator` (scénario PO rejoué sur dev server)
- [ ] CI GitHub Actions
- [ ] SonarCloud Quality Gate

Aucun fichier serveur touché → pas de `security-auditor`. Aucun changement Figma/visuel → pas de `design-validator`. Aucune référence à ce message dans `src/e2e/`.