### PR TITLE
fix(mail): #4220 — retire le récapitulatif des éléments transmis de l'AR de seconde déclaration

### DIFF
--- a/packages/app/src/modules/mail/__tests__/buildReceiptAttachments.test.ts
+++ b/packages/app/src/modules/mail/__tests__/buildReceiptAttachments.test.ts
@@ -74,17 +74,16 @@ describe("buildReceiptAttachments", () => {
 	});
 
 	describe("buildSecondDeclarationAttachments", () => {
-		it("attaches the correction recap and the transmitted recap", async () => {
+		it("attaches only the second declaration recap and never renders the transmitted recap", async () => {
 			const attachments = await buildSecondDeclarationAttachments(SIREN, YEAR);
 
-			expect(attachments).toHaveLength(2);
-			expect(attachments.map((a) => a.filename)).toEqual([
-				`seconde-declaration-${SIREN}-${YEAR}.pdf`,
-				`recapitulatif-elements-transmis-${SIREN}-${YEAR + 1}.pdf`,
-			]);
-			expect(
-				attachments.every((a) => a.contentType === "application/pdf"),
-			).toBe(true);
+			expect(attachments).toHaveLength(1);
+			expect(attachments[0]).toMatchObject({
+				filename: `seconde-declaration-${SIREN}-${YEAR}.pdf`,
+				contentType: "application/pdf",
+			});
+			expect(mocks.buildTransmittedPdfData).not.toHaveBeenCalled();
+			expect(mocks.TransmittedPdfDocument).not.toHaveBeenCalled();
 		});
 
 		it("renders the declaration recap as a correction", async () => {
@@ -95,11 +94,6 @@ describe("buildReceiptAttachments", () => {
 				YEAR,
 				expect.any(Date),
 				"correction",
-			);
-			expect(mocks.buildTransmittedPdfData).toHaveBeenCalledWith(
-				SIREN,
-				YEAR,
-				expect.any(Date),
 			);
 		});
 	});

--- a/packages/app/src/modules/mail/buildReceiptAttachments.ts
+++ b/packages/app/src/modules/mail/buildReceiptAttachments.ts
@@ -1,9 +1,7 @@
 import "server-only";
 import { renderToBuffer } from "@react-pdf/renderer";
 import { buildPdfData } from "~/modules/declarationPdf/buildPdfData";
-import { buildTransmittedPdfData } from "~/modules/declarationPdf/buildTransmittedPdfData";
 import { DeclarationPdfDocument } from "~/modules/declarationPdf/DeclarationPdfDocument";
-import { TransmittedPdfDocument } from "~/modules/declarationPdf/TransmittedPdfDocument";
 import type { MailAttachment } from "./types";
 
 async function renderDeclarationPdf(
@@ -24,19 +22,6 @@ async function renderDeclarationPdf(
 	};
 }
 
-async function renderTransmittedPdf(
-	siren: string,
-	year: number,
-): Promise<MailAttachment> {
-	const data = await buildTransmittedPdfData(siren, year, new Date());
-	const buffer = await renderToBuffer(TransmittedPdfDocument({ data }));
-	return {
-		filename: `recapitulatif-elements-transmis-${siren}-${data.year + 1}.pdf`,
-		content: Buffer.from(buffer),
-		contentType: "application/pdf",
-	};
-}
-
 export async function buildDeclarationAttachments(
 	siren: string,
 	year: number,
@@ -49,8 +34,5 @@ export async function buildSecondDeclarationAttachments(
 	siren: string,
 	year: number,
 ): Promise<MailAttachment[]> {
-	return Promise.all([
-		renderDeclarationPdf(siren, year, "correction"),
-		renderTransmittedPdf(siren, year),
-	]);
+	return [await renderDeclarationPdf(siren, year, "correction")];
 }


### PR DESCRIPTION
Closes #4220

## Résumé

L'accusé de réception de la **seconde déclaration** contenait 2 pièces jointes PDF au lieu d'1 : le récapitulatif de seconde déclaration, et un « récapitulatif des éléments transmis » qui est structurellement vide à ce stade du parcours (il ne remonte que les avis CSE / fichier d'évaluation conjointe, alors que ce mail est précisément celui qui *demande* leur dépôt).

Même correctif que #4207, qui avait déjà réglé ce problème pour la **première** déclaration mais avait volontairement laissé la seconde déclaration inchangée (le PDF y était encore "utilisé").

`buildSecondDeclarationAttachments()` ne renvoie désormais que le récap de seconde déclaration. `renderTransmittedPdf` (fonction locale au fichier) devient sans appelant et est supprimée, avec ses 2 imports orphelins (`buildTransmittedPdfData`, `TransmittedPdfDocument` — toujours utilisés indépendamment par `api/transmitted-pdf/route.ts`, non touché).

## Périmètre

- 1 seul fichier source : `packages/app/src/modules/mail/buildReceiptAttachments.ts`
- Tests ajustés dans `packages/app/src/modules/mail/__tests__/buildReceiptAttachments.test.ts` (par `tu-dev`) : l'assertion `toHaveLength(2)` devenait rouge de façon légitime (comportement retiré volontairement).
- Non touché intentionnellement : `buildDeclarationAttachments` (1ère déclaration, déjà correcte depuis #4207), les textes des mails, `api/transmitted-pdf/route.ts`.

## Vérification

**Unitaire (revert-verify par `tu-dev`)** : le test corrigé a été revert sur `origin/alpha` puis rejoué → **RED** (`expected length 1 but got 2`, reproduisant exactement le symptôme du ticket), puis restauré avec le fix → **GREEN**. Coverage 100% sur le fichier modifié.

**Manuelle sur dev server** : dégradée — le worktree local part d'une base de données vierge (0 déclaration, 0 utilisateur) ; reconstruire un état complet « seconde déclaration soumise » (déclaration initiale + calcul d'écart + parcours de mise en conformité + dépôt CSE) via l'UI est disproportionné pour un ticket XS dont la propriété corrigée est le retour d'une fonction pure, déjà prouvé par le revert-verify ci-dessus. La vérification navigateur reste à la charge du gate `functional-validator` (étape 9a) qui dispose d'un environnement de test outillé.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (suite complète verte, 0 régression)
- [x] `pnpm lint:check` / `pnpm format:check`
- [x] Audit structurel (PASS)
- [ ] `functional-validator` (étape 9a, en cours)
