### PR TITLE
fix(my-space): #4221 — récapitulatif des éléments transmis en dernier

### DIFF
--- a/packages/app/src/modules/my-space/DocumentsPanel.tsx
+++ b/packages/app/src/modules/my-space/DocumentsPanel.tsx
@@ -57,6 +57,14 @@ function getRemunerationResources(
 		});
 	}
 
+	if (declaration.hasSubmittedSecondDeclaration) {
+		resources.push({
+			title: "Télécharger le récapitulatif de la seconde déclaration",
+			subtitle,
+			href: `/api/declaration-pdf?type=correction&year=${declaration.year}`,
+		});
+	}
+
 	if (
 		declaration.hasSubmittedCseOpinion ||
 		declaration.hasJointEvaluationFile
@@ -65,14 +73,6 @@ function getRemunerationResources(
 			title: "Télécharger le récapitulatif des éléments transmis",
 			subtitle,
 			href: `/api/transmitted-pdf?year=${declaration.year}`,
-		});
-	}
-
-	if (declaration.hasSubmittedSecondDeclaration) {
-		resources.push({
-			title: "Télécharger le récapitulatif de la seconde déclaration",
-			subtitle,
-			href: `/api/declaration-pdf?type=correction&year=${declaration.year}`,
 		});
 	}
 

--- a/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/DocumentsPanel.test.tsx
@@ -251,8 +251,8 @@ describe("DocumentsPanel", () => {
 		expect(links().map((link) => link.textContent)).toEqual([
 			PREFILL_TITLE,
 			RECAP_TITLE,
-			TRANSMITTED_TITLE,
 			SECOND_TITLE,
+			TRANSMITTED_TITLE,
 		]);
 	});
 
@@ -266,11 +266,39 @@ describe("DocumentsPanel", () => {
 		expect(links().map((link) => link.getAttribute("href"))).toEqual([
 			`/api/prefill-pdf?year=${DECLARATION_YEAR}`,
 			`/api/declaration-pdf?year=${DECLARATION_YEAR}`,
-			`/api/transmitted-pdf?year=${DECLARATION_YEAR}`,
 			`/api/declaration-pdf?type=correction&year=${DECLARATION_YEAR}`,
+			`/api/transmitted-pdf?year=${DECLARATION_YEAR}`,
 		]);
 		expect(panel.getAllByText(SUBTITLE)).toHaveLength(4);
 		expect(panel.getAllByText("PDF")).toHaveLength(4);
+	});
+
+	// "Last" is an absolute position: any resource added later must land ahead of
+	// the transmitted-elements recap, whichever other resources are present.
+	it.each<[string, Partial<Omit<DeclarationItem, "status">>]>([
+		["a CSE opinion alone", { hasSubmittedCseOpinion: true }],
+		["a joint evaluation file alone", { hasJointEvaluationFile: true }],
+		[
+			"prefill data ahead of it",
+			{ hasPrefillData: true, hasSubmittedCseOpinion: true },
+		],
+		[
+			"a second declaration ahead of it",
+			{ hasJointEvaluationFile: true, hasSubmittedSecondDeclaration: true },
+		],
+		[
+			"every other resource ahead of it",
+			{
+				hasJointEvaluationFile: true,
+				hasPrefillData: true,
+				hasSubmittedCseOpinion: true,
+				hasSubmittedSecondDeclaration: true,
+			},
+		],
+	])("closes the list with the transmitted-elements recap, with %s", (_case, overrides) => {
+		const { links } = renderPanel(overrides);
+
+		expect(links().at(-1)?.textContent).toBe(TRANSMITTED_TITLE);
 	});
 
 	it("omits the prefill card when no DSN data is available", () => {


### PR DESCRIPTION
Closes #4221

## Résumé

Le panneau « Documents » de Mon espace affichait le récapitulatif des éléments transmis (avis CSE / rapport d'évaluation conjointe) **avant** celui de la seconde déclaration — divergence purement cosmétique avec l'ordre déjà utilisé sur l'écran `cseOpinion/ConfirmationPage.tsx` (déclaration des indicateurs → seconde déclaration → éléments transmis).

Fix : interversion des deux blocs `push()` dans `getRemunerationResources` (`DocumentsPanel.tsx`) pour que « éléments transmis » soit toujours en **dernière position absolue** — toute ressource ajoutée ultérieurement au panneau se placera avant elle. Aucun changement de condition, de libellé ni de route.

## Vérification (bug-fix-workflow.md)

**Vérification one-shot** (avant tout commit de test), via les deux assertions d'ordre existantes de `DocumentsPanel.test.tsx`, éditées temporairement à l'ordre cible :
- **Avant fix** : RED — 2 tests en échec (`renders one card per available resource, in order` / `points each card at its own PDF route…`), l'ordre observé était `PREFILL, RECAP, TRANSMITTED, SECOND` au lieu de `PREFILL, RECAP, SECOND, TRANSMITTED`.
- **Après fix** : GREEN — 35/35 tests du fichier, ordre cible confirmé.

Le fichier de test a ensuite été restauré à son état d'origine ; sa mise à jour permanente a été faite par `tu-dev` (voir ci-dessous), avec revert-verify indépendant (RED sans le fix → GREEN avec).

## Tests

Délégués à `tu-dev` : mise à jour des deux assertions d'ordre + ajout d'un `it.each` (5 cas) verrouillant l'invariant « éléments transmis toujours en dernier », quelle que soit la combinaison de ressources présentes. Suite complète : 5618/5618 tests verts (typecheck + lint + format OK).

## Quality gates

- `validator` : **PASS**
- `structural-auditor` : **MINOR** (2 WARN mineurs, pré-existants/borderline, non bloquants)
- `security-auditor` : **SECURE** (aucun fichier serveur touché)
- `rgaa-auditor` : **DEGRADED** — le plugin ultra11y a été installé en cours de session et le registre de skills des sous-agents n'a pas pu être rafraîchi (3 tentatives). Le diff est une pure interversion de l'ordre de deux blocs, sans changement de markup/ARIA/structure DOM — risque RGAA très faible. La gate CI **`a11y-gate`** (bloquante, indépendante de ce cache local) reste l'autorité RGAA sur ce changement et s'exécutera normalement sur cette PR. Détail : commentaire ticket #4221.

Aucune référence Figma sur ce ticket (bug de logique d'ordre, pas un écart visuel Figma ↔ app) — étape de fidélité visuelle non applicable.