### PR TITLE
fix(declaration-remuneration): #4223 — période de référence du récapitulatif de la 2ème déclaration

### DIFF
--- a/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
+++ b/packages/app/src/app/declaration-remuneration/recapitulatif/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { RecapitulatifPage } from "~/modules/declaration-remuneration/recapitulatif";
-import { getReferencePeriod, isDraft } from "~/modules/domain";
+import { getDeclarationReferencePeriod, isDraft } from "~/modules/domain";
 import { Breadcrumb } from "~/modules/layout";
 import { mapToEmployeeCategoryRows } from "~/server/api/routers/declarationHelpers";
 import { mapToStepData } from "~/server/api/routers/declarationStepMapping";
@@ -52,7 +52,12 @@ export default async function RecapitulatifRoute({ searchParams }: Props) {
 	const { step2Data, step3Data, step4Data, step2Gaps, step3Gaps } =
 		mapToStepData(d);
 
-	const referencePeriod = getReferencePeriod(d.year);
+	const referencePeriod = getDeclarationReferencePeriod(
+		d.year,
+		isCorrection,
+		d.secondDeclReferencePeriodStart,
+		d.secondDeclReferencePeriodEnd,
+	);
 
 	const step5Categories =
 		data.jobCategories.length > 0

--- a/packages/app/src/modules/declaration-representation/steps/Step5Review.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step5Review.tsx
@@ -5,8 +5,8 @@ import { useRouter } from "next/navigation";
 import { useCallback, useMemo } from "react";
 
 import {
+	formatIsoDate,
 	formatPercentage,
-	formatShortDate,
 	getRepresentationCampaignYear,
 } from "~/modules/domain";
 import { NewTabNotice } from "~/modules/layout/shared/NewTabNotice";
@@ -27,8 +27,8 @@ import styles from "./Step5Review.module.scss";
 
 const CONFIRMATION_HREF = "/declaration-representation/confirmation";
 
-function formatIsoDate(value: string | undefined): string {
-	return value === undefined ? "—" : formatShortDate(new Date(value));
+function formatOptionalIsoDate(value: string | undefined): string {
+	return value === undefined ? "—" : formatIsoDate(value);
 }
 
 function PublicationUrl({ url }: { url: string | undefined }) {
@@ -132,8 +132,8 @@ export function Step5Review() {
 					<dd>{year}</dd>
 					<dt>Période de référence</dt>
 					<dd>
-						{formatIsoDate(draft.referencePeriodStart)} -{" "}
-						{formatIsoDate(draft.referencePeriodEnd)}
+						{formatOptionalIsoDate(draft.referencePeriodStart)} -{" "}
+						{formatOptionalIsoDate(draft.referencePeriodEnd)}
 					</dd>
 				</dl>
 			</section>
@@ -154,7 +154,7 @@ export function Step5Review() {
 					<h2 className="fr-text--lg fr-text--bold fr-mb-0">Publication</h2>
 					<dl className={`fr-text--md ${styles.definitionList}`}>
 						<dt>Date de publication</dt>
-						<dd>{formatIsoDate(draft.publishDate)}</dd>
+						<dd>{formatOptionalIsoDate(draft.publishDate)}</dd>
 						<dt>Site Internet de publication</dt>
 						<dd>{draft.hasWebsite === true ? "Oui" : "Non"}</dd>
 						{draft.hasWebsite === true ? (

--- a/packages/app/src/modules/declaration-representation/steps/Step5Review.tsx
+++ b/packages/app/src/modules/declaration-representation/steps/Step5Review.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useMemo } from "react";
 
 import {
-	formatIsoDate,
+	formatOptionalIsoDate,
 	formatPercentage,
 	getRepresentationCampaignYear,
 } from "~/modules/domain";
@@ -26,10 +26,6 @@ import { Step5NextSteps } from "./Step5NextSteps";
 import styles from "./Step5Review.module.scss";
 
 const CONFIRMATION_HREF = "/declaration-representation/confirmation";
-
-function formatOptionalIsoDate(value: string | undefined): string {
-	return value === undefined ? "—" : formatIsoDate(value);
-}
 
 function PublicationUrl({ url }: { url: string | undefined }) {
 	if (url === undefined || url.trim() === "") return "—";

--- a/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
+++ b/packages/app/src/modules/declarationPdf/RepresentationPdfDocument.tsx
@@ -1,8 +1,8 @@
 import { Document, Page, Text, View } from "@react-pdf/renderer";
 import {
+	formatIsoDate,
 	formatLongDate,
 	formatPercentage,
-	formatShortDate,
 } from "~/modules/domain";
 import type {
 	RepresentationPdfData,
@@ -22,7 +22,7 @@ const VERDICT_LABELS = {
 } as const;
 
 function formatOptionalDate(value: string | null): string {
-	return value === null ? "Non renseignée" : formatShortDate(new Date(value));
+	return value === null ? "Non renseignée" : formatIsoDate(value);
 }
 
 function IndicatorCard({

--- a/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
+++ b/packages/app/src/modules/declarationPdf/__tests__/buildPdfData.test.ts
@@ -304,7 +304,7 @@ describe("buildPdfData", () => {
 		expect(result.source).toBeNull();
 	});
 
-	it("uses the second_declaration_submit date for a correction declaration", async () => {
+	it("uses the second_declaration_submit date and the captured reference period for a correction declaration", async () => {
 		queue({
 			declarations: [
 				{
@@ -316,6 +316,8 @@ describe("buildPdfData", () => {
 					totalWomen: 10,
 					totalMen: 10,
 					updatedAt: new Date("2026-03-01T00:00:00Z"),
+					secondDeclReferencePeriodStart: "2025-07-01",
+					secondDeclReferencePeriodEnd: "2026-06-30",
 				},
 			],
 			companies: [{ siren: "123456789", name: "Société Démo" }],
@@ -345,6 +347,63 @@ describe("buildPdfData", () => {
 
 		expect(result.isSecondDeclaration).toBe(true);
 		expect(result.transmittedAt).toBe("05/06/2026");
+		expect(result.referencePeriod).toBe("01/07/2025 - 30/06/2026");
+	});
+
+	it("falls back to the civil reference period for a correction predating mandatory capture", async () => {
+		queue({
+			declarations: [
+				{
+					id: "d4bis",
+					siren: "123456789",
+					year: 2026,
+					status: "submitted",
+					declarantId: null,
+					totalWomen: 10,
+					totalMen: 10,
+					updatedAt: new Date("2026-03-01T00:00:00Z"),
+					secondDeclReferencePeriodStart: null,
+					secondDeclReferencePeriodEnd: null,
+				},
+			],
+			companies: [{ siren: "123456789", name: "Société Démo" }],
+			gipMdsData: [],
+			jobCategories: [],
+			declarationStatusHistory: [[{ createdAt: SECOND_SUBMIT }]],
+		});
+		const buildPdfData = await importBuild();
+		const result = await buildPdfData("123456789", 2026, NOW, "correction");
+
+		expect(result.isSecondDeclaration).toBe(true);
+		expect(result.referencePeriod).toBe("01/01/2025 - 31/12/2025");
+	});
+
+	it("ignores a captured reference period on an initial declaration", async () => {
+		queue({
+			declarations: [
+				{
+					id: "d4ter",
+					siren: "123456789",
+					year: 2026,
+					status: "submitted",
+					declarantId: null,
+					totalWomen: 10,
+					totalMen: 10,
+					updatedAt: new Date("2026-03-01T00:00:00Z"),
+					secondDeclReferencePeriodStart: "2025-07-01",
+					secondDeclReferencePeriodEnd: "2026-06-30",
+				},
+			],
+			companies: [{ siren: "123456789", name: "Société Démo" }],
+			gipMdsData: [],
+			jobCategories: [],
+			declarationStatusHistory: [[{ createdAt: SUBMITTED }]],
+		});
+		const buildPdfData = await importBuild();
+		const result = await buildPdfData("123456789", 2026, NOW);
+
+		expect(result.isSecondDeclaration).toBe(false);
+		expect(result.referencePeriod).toBe("01/01/2025 - 31/12/2025");
 	});
 
 	it("falls back through submit then updatedAt when no matching status event exists", async () => {

--- a/packages/app/src/modules/declarationPdf/buildPdfData.ts
+++ b/packages/app/src/modules/declarationPdf/buildPdfData.ts
@@ -6,7 +6,7 @@ import { formatCategorySource } from "~/modules/declaration-remuneration";
 import {
 	formatShortDate,
 	formatWorkforceForUser,
-	getReferencePeriod,
+	getDeclarationReferencePeriod,
 	getReferenceYearFor,
 	isDraft,
 	parseGipWorkforce,
@@ -144,7 +144,12 @@ export async function buildPdfData(
 		workforceYear: getReferenceYearFor(year),
 		isSecondDeclaration: declarationType === "correction",
 		transmittedAt: formatShortDate(transmittedDate),
-		referencePeriod: getReferencePeriod(year),
+		referencePeriod: getDeclarationReferencePeriod(
+			year,
+			declarationType === "correction",
+			declaration.secondDeclReferencePeriodStart,
+			declaration.secondDeclReferencePeriodEnd,
+		),
 		declarant: {
 			name: [declarant?.firstName, declarant?.lastName]
 				.filter(Boolean)

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -95,6 +95,12 @@ describe("getDeclarationReferencePeriod", () => {
 		);
 	});
 
+	it("falls back to the civil period on undefined persisted bounds", () => {
+		expect(
+			getDeclarationReferencePeriod(CAMPAIGN_YEAR, true, undefined, undefined),
+		).toBe(CIVIL_PERIOD);
+	});
+
 	it("tracks the campaign year of the declaration when falling back", () => {
 		expect(getDeclarationReferencePeriod(2027, true, null, null)).toBe(
 			getReferencePeriod(2027),

--- a/packages/app/src/modules/domain/__tests__/campaign.test.ts
+++ b/packages/app/src/modules/domain/__tests__/campaign.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	getCurrentYear,
 	getDeclarationDeadline,
+	getDeclarationReferencePeriod,
 	getDefaultCampaignDeadlines,
 	getDefaultRepresentationCampaign,
 	getPathChoiceDeadline,
@@ -39,6 +40,64 @@ describe("getReferencePeriod", () => {
 	it("uses the workforce year of the campaign as the reference window", () => {
 		expect(getReferencePeriod(2027)).toBe(
 			`01/01/${getReferenceYearFor(2027)} - 31/12/${getReferenceYearFor(2027)}`,
+		);
+	});
+});
+
+describe("getDeclarationReferencePeriod", () => {
+	const CAMPAIGN_YEAR = 2026;
+	const CIVIL_PERIOD = "01/01/2025 - 31/12/2025";
+	// Deliberately off the civil year: the assertion only discriminates if the
+	// persisted window cannot be produced by getReferencePeriod.
+	const CAPTURED_START = "2025-07-01";
+	const CAPTURED_END = "2026-06-30";
+
+	it("returns the period captured at step 2 of a second declaration", () => {
+		expect(
+			getDeclarationReferencePeriod(
+				CAMPAIGN_YEAR,
+				true,
+				CAPTURED_START,
+				CAPTURED_END,
+			),
+		).toBe("01/07/2025 - 30/06/2026");
+	});
+
+	it("never reads the persisted period for an initial declaration", () => {
+		expect(
+			getDeclarationReferencePeriod(
+				CAMPAIGN_YEAR,
+				false,
+				CAPTURED_START,
+				CAPTURED_END,
+			),
+		).toBe(CIVIL_PERIOD);
+	});
+
+	it("falls back to the civil period for a second declaration predating mandatory capture", () => {
+		expect(getDeclarationReferencePeriod(CAMPAIGN_YEAR, true, null, null)).toBe(
+			CIVIL_PERIOD,
+		);
+	});
+
+	it("falls back to the civil period when a single bound is persisted", () => {
+		expect(
+			getDeclarationReferencePeriod(CAMPAIGN_YEAR, true, CAPTURED_START, null),
+		).toBe(CIVIL_PERIOD);
+		expect(
+			getDeclarationReferencePeriod(CAMPAIGN_YEAR, true, null, CAPTURED_END),
+		).toBe(CIVIL_PERIOD);
+	});
+
+	it("falls back to the civil period on blank persisted bounds", () => {
+		expect(getDeclarationReferencePeriod(CAMPAIGN_YEAR, true, "", "")).toBe(
+			CIVIL_PERIOD,
+		);
+	});
+
+	it("tracks the campaign year of the declaration when falling back", () => {
+		expect(getDeclarationReferencePeriod(2027, true, null, null)).toBe(
+			getReferencePeriod(2027),
 		);
 	});
 });

--- a/packages/app/src/modules/domain/__tests__/format.test.ts
+++ b/packages/app/src/modules/domain/__tests__/format.test.ts
@@ -6,6 +6,7 @@ import {
 	formatCurrency,
 	formatGap,
 	formatGapCompact,
+	formatIsoDate,
 	formatMonthDay,
 	formatPercentage,
 	formatShortDate,
@@ -147,6 +148,21 @@ describe("formatShortDate", () => {
 
 	it("returns dash for undefined", () => {
 		expect(formatShortDate(undefined)).toBe("—");
+	});
+});
+
+describe("formatIsoDate", () => {
+	it("formats a persisted ISO date as dd/mm/yyyy", () => {
+		expect(formatIsoDate("2026-03-10")).toBe("10/03/2026");
+	});
+
+	it("pads single-digit days and months", () => {
+		expect(formatIsoDate("2025-01-05")).toBe("05/01/2025");
+	});
+
+	it("keeps the persisted day across a month boundary", () => {
+		expect(formatIsoDate("2025-07-01")).toBe("01/07/2025");
+		expect(formatIsoDate("2026-06-30")).toBe("30/06/2026");
 	});
 });
 

--- a/packages/app/src/modules/domain/__tests__/format.test.ts
+++ b/packages/app/src/modules/domain/__tests__/format.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
 	computePercentage,
@@ -8,6 +8,7 @@ import {
 	formatGapCompact,
 	formatIsoDate,
 	formatMonthDay,
+	formatOptionalIsoDate,
 	formatPercentage,
 	formatShortDate,
 	formatShortDateTime,
@@ -163,6 +164,28 @@ describe("formatIsoDate", () => {
 	it("keeps the persisted day across a month boundary", () => {
 		expect(formatIsoDate("2025-07-01")).toBe("01/07/2025");
 		expect(formatIsoDate("2026-06-30")).toBe("30/06/2026");
+	});
+
+	describe("under a negative-offset timezone", () => {
+		afterEach(() => {
+			vi.unstubAllEnvs();
+		});
+
+		// Regression: `new Date("2025-07-01")` parsed as UTC midnight rendered back as "30/06/2025".
+		it("keeps the persisted day", () => {
+			vi.stubEnv("TZ", "America/New_York");
+			expect(formatIsoDate("2025-07-01")).toBe("01/07/2025");
+		});
+	});
+});
+
+describe("formatOptionalIsoDate", () => {
+	it("formats a persisted ISO date as dd/mm/yyyy", () => {
+		expect(formatOptionalIsoDate("2026-03-10")).toBe("10/03/2026");
+	});
+
+	it("returns dash for undefined", () => {
+		expect(formatOptionalIsoDate(undefined)).toBe("—");
 	});
 });
 

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -4,6 +4,7 @@
 export {
 	getCurrentYear,
 	getDeclarationDeadline,
+	getDeclarationReferencePeriod,
 	getDefaultCampaignDeadlines,
 	getDefaultRepresentationCampaign,
 	getPathChoiceDeadline,
@@ -159,6 +160,7 @@ export {
 	formatCurrency,
 	formatGap,
 	formatGapCompact,
+	formatIsoDate,
 	formatLongDate,
 	formatMonthDay,
 	formatPercentage,

--- a/packages/app/src/modules/domain/index.ts
+++ b/packages/app/src/modules/domain/index.ts
@@ -163,6 +163,7 @@ export {
 	formatIsoDate,
 	formatLongDate,
 	formatMonthDay,
+	formatOptionalIsoDate,
 	formatPercentage,
 	formatShortDate,
 	formatShortDateTime,

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -42,8 +42,8 @@ export function getReferencePeriod(campaignYear: number): string {
 export function getDeclarationReferencePeriod(
 	campaignYear: number,
 	isSecondDeclaration: boolean,
-	secondDeclReferencePeriodStart: string | null,
-	secondDeclReferencePeriodEnd: string | null,
+	secondDeclReferencePeriodStart: string | null | undefined,
+	secondDeclReferencePeriodEnd: string | null | undefined,
 ): string {
 	if (
 		isSecondDeclaration &&

--- a/packages/app/src/modules/domain/shared/campaign.ts
+++ b/packages/app/src/modules/domain/shared/campaign.ts
@@ -1,6 +1,6 @@
 import type { CampaignDeadlines, RepresentationCampaign } from "../types";
 import { readCampaignYearOverride } from "./campaignClock";
-import { formatLongDate } from "./format";
+import { formatIsoDate, formatLongDate } from "./format";
 
 /** Returns the current campaign year: the E2E recette override when a grid run
  * pinned one (see campaignClock.ts — test-only, inert in production), the
@@ -28,6 +28,31 @@ export function getRepresentationDeadline(year: number): string {
 export function getReferencePeriod(campaignYear: number): string {
 	const referenceYear = getReferenceYearFor(campaignYear);
 	return `01/01/${referenceYear} - 31/12/${referenceYear}`;
+}
+
+/**
+ * Declaration recap reference period, format "DD/MM/YYYY - DD/MM/YYYY".
+ *
+ * A second declaration lets the user enter a custom reference period at step 2
+ * (`secondDeclReferencePeriodStart`/`End`, persisted as `YYYY-MM-DD`) instead of
+ * the campaign's civil year. Recap surfaces must display that persisted period —
+ * falling back to the civil-year period for initial declarations and for second
+ * declarations predating mandatory capture (both columns null).
+ */
+export function getDeclarationReferencePeriod(
+	campaignYear: number,
+	isSecondDeclaration: boolean,
+	secondDeclReferencePeriodStart: string | null,
+	secondDeclReferencePeriodEnd: string | null,
+): string {
+	if (
+		isSecondDeclaration &&
+		secondDeclReferencePeriodStart &&
+		secondDeclReferencePeriodEnd
+	) {
+		return `${formatIsoDate(secondDeclReferencePeriodStart)} - ${formatIsoDate(secondDeclReferencePeriodEnd)}`;
+	}
+	return getReferencePeriod(campaignYear);
 }
 
 /** Returns the declaration modification deadline for a given year: `"1ᵉʳ juin 2027"`. */

--- a/packages/app/src/modules/domain/shared/format.ts
+++ b/packages/app/src/modules/domain/shared/format.ts
@@ -93,7 +93,13 @@ export function formatShortDate(date: Date | null | undefined): string {
 
 /** Format a persisted ISO date string (`YYYY-MM-DD`) in short French format: `"2026-03-10"` → `"10/03/2026"`. */
 export function formatIsoDate(value: string): string {
-	return formatShortDate(new Date(value));
+	const [year, month, day] = value.split("-");
+	return `${day}/${month}/${year}`;
+}
+
+/** Format an optional persisted ISO date string (`YYYY-MM-DD`) in short French format. Returns `"—"` for `undefined`. */
+export function formatOptionalIsoDate(value: string | undefined): string {
+	return value === undefined ? "—" : formatIsoDate(value);
 }
 
 /** Format a date with time in short French format: `new Date(…)` → `"10/03/2026 14:30"`. Returns `"—"` for nullish values. */

--- a/packages/app/src/modules/domain/shared/format.ts
+++ b/packages/app/src/modules/domain/shared/format.ts
@@ -91,6 +91,11 @@ export function formatShortDate(date: Date | null | undefined): string {
 	}).format(new Date(date));
 }
 
+/** Format a persisted ISO date string (`YYYY-MM-DD`) in short French format: `"2026-03-10"` → `"10/03/2026"`. */
+export function formatIsoDate(value: string): string {
+	return formatShortDate(new Date(value));
+}
+
 /** Format a date with time in short French format: `new Date(…)` → `"10/03/2026 14:30"`. Returns `"—"` for nullish values. */
 export function formatShortDateTime(date: Date | null | undefined): string {
 	if (!date) return "—";

--- a/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
+++ b/packages/app/src/server/api/routers/__tests__/adminDeclarations.getRecap.test.ts
@@ -37,6 +37,8 @@ const baseDeclarationRow = {
 	secondDeclarationPathChoice: null,
 	demarcheCompletedAt: null,
 	secondDeclarationSubmittedAt: null,
+	secondDeclReferencePeriodStart: null as string | null,
+	secondDeclReferencePeriodEnd: null as string | null,
 	createdAt: new Date("2026-03-01"),
 	updatedAt: new Date("2026-03-15"),
 	cancelledAt: null,
@@ -72,6 +74,17 @@ const baseJoinedRow: JoinedRow = {
 	declarantFirstName: "Alice",
 	declarantLastName: "Dupont",
 };
+
+// Deliberately off the civil year: the assertion only discriminates if the
+// persisted window cannot be produced by getReferencePeriod.
+const rowWithCapturedPeriod = (): JoinedRow => ({
+	...baseJoinedRow,
+	declaration: {
+		...baseDeclarationRow,
+		secondDeclReferencePeriodStart: "2025-07-01",
+		secondDeclReferencePeriodEnd: "2026-06-30",
+	},
+});
 
 function buildDb(options: {
 	row: JoinedRow | null;
@@ -204,6 +217,50 @@ describe("adminDeclarationsRouter — getRecap", () => {
 		const result = await caller.getRecap({ id: DECL_ID });
 
 		expect(result.isCorrection).toBe(true);
+	});
+
+	it("returns the reference period captured at step 2 of the second declaration", async () => {
+		const db = buildDb({ row: rowWithCapturedPeriod(), hasSecondSubmit: true });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getRecap({ id: DECL_ID });
+
+		expect(result.referencePeriod).toBe("01/07/2025 - 30/06/2026");
+	});
+
+	it("falls back to the civil period for a correction predating mandatory capture", async () => {
+		const db = buildDb({ row: baseJoinedRow, hasSecondSubmit: true });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getRecap({ id: DECL_ID });
+
+		expect(result.isCorrection).toBe(true);
+		expect(result.referencePeriod).toBe("01/01/2025 - 31/12/2025");
+	});
+
+	it("ignores a captured reference period when the declaration is not a correction", async () => {
+		const db = buildDb({ row: rowWithCapturedPeriod() });
+		const { adminDeclarationsRouter } = await import("../adminDeclarations");
+		const caller = adminDeclarationsRouter.createCaller({
+			db,
+			session: adminSession,
+			headers: new Headers(),
+		} as never);
+
+		const result = await caller.getRecap({ id: DECL_ID });
+
+		expect(result.isCorrection).toBe(false);
+		expect(result.referencePeriod).toBe("01/01/2025 - 31/12/2025");
 	});
 
 	it("exposes step5Source from the first job category when jobs exist", async () => {

--- a/packages/app/src/server/api/routers/adminDeclarations.ts
+++ b/packages/app/src/server/api/routers/adminDeclarations.ts
@@ -26,7 +26,7 @@ import { releaseLockSchema } from "~/modules/admin/schemas";
 import {
 	floorWorkforce,
 	getCurrentYear,
-	getReferencePeriod,
+	getDeclarationReferencePeriod,
 	isCancelled,
 	parseGipWorkforce,
 } from "~/modules/domain";
@@ -426,7 +426,12 @@ export const adminDeclarationsRouter = createTRPCRouter({
 				isCorrection ? "correction" : "initial",
 			);
 			const step5Source = jobs[0]?.source ?? null;
-			const referencePeriod = getReferencePeriod(d.year);
+			const referencePeriod = getDeclarationReferencePeriod(
+				d.year,
+				isCorrection,
+				d.secondDeclReferencePeriodStart,
+				d.secondDeclReferencePeriodEnd,
+			);
 			const declarantName = [row.declarantFirstName, row.declarantLastName]
 				.filter(Boolean)
 				.join(" ");


### PR DESCRIPTION
Closes #4223

## Résumé

La période de référence saisie par l'utilisateur à l'étape 2 de la seconde déclaration (`declarations.secondDeclReferencePeriodStart/End`) était bien persistée mais aucune des 3 surfaces de récapitulatif ne la relisait — elles recalculaient toutes `getReferencePeriod(year)` (période civile N-1), d'où l'écart rapporté (le PDF affichait `01/01/2025 - 31/12/2025` au lieu de la période réellement saisie).

Ajoute `getDeclarationReferencePeriod` dans `~/modules/domain` (+ `formatIsoDate`), branché sur les trois surfaces :
- `modules/declarationPdf/buildPdfData.ts`
- `app/declaration-remuneration/recapitulatif/page.tsx`
- `server/api/routers/adminDeclarations.ts` (`getRecap`)

Repli sur la période civile pour les déclarations initiales et les secondes déclarations historiques antérieures à la saisie obligatoire (colonnes nulles). Consolide au passage deux formateurs ISO→DD/MM/YYYY dupliqués (`Step5Review.tsx`, `RepresentationPdfDocument.tsx`) sur le nouveau helper.

## Vérification

**One-shot (pendant le dev)** — la procédure décrite dans `## Analyse du bug` requiert un parcours navigateur complet (mise en conformité → seconde déclaration → étape 2 → soumission → 3 surfaces). Cette procédure n'a pas pu être déroulée telle quelle : ce worktree tourne sur le port 3016, et la passerelle ProConnect de test n'enregistre que le callback sur le port 3000 (déjà occupé par un autre worktree) — contrainte d'environnement connue, signalée en amont.

En remplacement, vérification directe de la fonction pure `getDeclarationReferencePeriod` (appelée à l'identique par les 3 surfaces) :
- `avant` (comportement pré-fix, `getReferencePeriod(2026)`) → `01/01/2025 - 31/12/2025`
- `après` (correction, période persistée `01/07/2025`–`30/06/2026`) → `01/07/2025 - 30/06/2026`
- déclaration initiale (sans correction) → reste `01/01/2025 - 31/12/2025` (non régressé)
- seconde déclaration historique sans période persistée → repli civil (non régressé)

**Couverture permanente** — `tu-dev` a ajouté 14 tests (domain, `buildPdfData`, `adminDeclarations.getRecap`) avec preuve revert-verify (RED avant le fix, GREEN après). Suite complète : 5463/5463 verts. Conformément au verdict de l'analyse (`Couverture permanente : TU/intégration suffisante`), aucun test E2E n'est requis pour ce ticket — `e2e-dev` reste libre d'en juger autrement en fin de pipeline.

## Quality gates

- `validator` (typecheck + test + lint + format) : **PASS**
- `structural-auditor` : **MINOR** (2 WARN non bloquants sur du style JSDoc cohérent avec la convention existante des fichiers touchés)
- `rgaa-auditor` : **PASS** (0 non-conformité — aucun markup modifié, uniquement de la logique de formatage)
- `security-auditor` : **SECURE** (substitution de fonction pure, aucune nouvelle surface d'attaque)
- `design-validator` : **skip** — aucune référence Figma sur ce ticket, aucun changement visuel/markup (confirmé par `rgaa-auditor`)

## Test plan

- [x] Fonction pure `getDeclarationReferencePeriod` vérifiée en isolation (avant/après)
- [x] Suite unitaire + intégration verte (5463/5463)
- [ ] Fonctionnel navigateur — non exécutable dans ce worktree (contrainte ProConnect port 3016), à confirmer en review humaine ou via un worktree sur le port 3000