### PR TITLE
fix(my-space): #4256 — retire le fil d'Ariane de mon espace

### DIFF
--- a/packages/app/src/e2e/breadcrumb-spacing.e2e.ts
+++ b/packages/app/src/e2e/breadcrumb-spacing.e2e.ts
@@ -19,13 +19,13 @@ const VIEWPORTS = [
 	{ name: "mobile", width: 375, height: 800 },
 ];
 
-// `/mon-espace` is not redundant with the public pages: its CompanyInfoBanner is one of the
-// two components whose local `:global(.fr-breadcrumb)` override this fix deleted, so it is
-// the surface that regresses first if the shared rule stops applying.
+// `/mon-espace` used to be listed here as the surface that regresses first, its
+// CompanyInfoBanner carrying one of the two local `:global(.fr-breadcrumb)` overrides this
+// fix deleted. #4256 removed the breadcrumb from `/mon-espace/**` altogether, leaving the
+// public pages as the only surfaces the shared rule still has to apply to.
 const SCREENS = [
 	{ name: "legal notice", path: "/mentions-legales" },
 	{ name: "FAQ", path: "/faq" },
-	{ name: "my space", path: "/mon-espace" },
 ];
 
 test.describe("breadcrumb spacing", () => {

--- a/packages/app/src/e2e/declaration-history.e2e.ts
+++ b/packages/app/src/e2e/declaration-history.e2e.ts
@@ -38,6 +38,9 @@ test.describe("Declaration history page", () => {
 			page.getByText(`Démarche des indicateurs de rémunération ${year}`),
 		).toBeVisible();
 
+		// #4256: same removal as the company banner, on the other `/mon-espace/**` surface.
+		await expect(page.locator(".fr-breadcrumb")).toHaveCount(0);
+
 		const items = page.locator("main ul > li");
 		await expect(items).toHaveCount(3);
 	});

--- a/packages/app/src/e2e/login.e2e.ts
+++ b/packages/app/src/e2e/login.e2e.ts
@@ -36,6 +36,10 @@ test.describe("ProConnect authentication flow", () => {
 		).toBeVisible();
 
 		await expect(page.getByText(/130.?025.?265/).first()).toBeVisible();
+
+		// #4256: the company banner opens on the company name. Only a real render catches a
+		// breadcrumb re-injected by the layout rather than by CompanyInfoBanner itself.
+		await expect(page.locator(".fr-breadcrumb")).toHaveCount(0);
 	});
 
 	test("redirects to mon espace when already logged in", async ({ page }) => {

--- a/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
+++ b/packages/app/src/modules/declarationHistory/DeclarationHistoryPage.tsx
@@ -1,4 +1,3 @@
-import { Breadcrumb } from "~/modules/layout";
 import { HistoryListSection } from "./HistoryListSection";
 
 type Props = {
@@ -10,13 +9,7 @@ export function DeclarationHistoryPage({ siren, year }: Props) {
 	return (
 		<main id="content" tabIndex={-1}>
 			<div className="fr-container fr-py-4w">
-				<Breadcrumb
-					items={[
-						{ label: "Mon espace", href: "/mon-espace" },
-						{ label: "Historique des actions" },
-					]}
-				/>
-				<h1 className="fr-h1 fr-mt-3w">Historique des modifications</h1>
+				<h1 className="fr-h1">Historique des modifications</h1>
 				<p className="fr-text--lg fr-mb-4w">
 					Démarche des indicateurs de rémunération {year}
 				</p>

--- a/packages/app/src/modules/declarationHistory/__tests__/DeclarationHistoryPage.test.tsx
+++ b/packages/app/src/modules/declarationHistory/__tests__/DeclarationHistoryPage.test.tsx
@@ -22,13 +22,15 @@ describe("DeclarationHistoryPage", () => {
 		).toBeInTheDocument();
 	});
 
-	it("renders breadcrumb with Mon espace link", () => {
+	it("does not render a breadcrumb", () => {
 		render(<DeclarationHistoryPage siren="130025265" year={2026} />);
 
-		expect(screen.getByRole("link", { name: "Mon espace" })).toHaveAttribute(
-			"href",
-			"/mon-espace",
-		);
+		expect(
+			screen.queryByRole("navigation", { name: "vous êtes ici :" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("link", { name: "Mon espace" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders the history list section", () => {

--- a/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
+++ b/packages/app/src/modules/my-space/CompanyInfoBanner.tsx
@@ -4,7 +4,6 @@ import {
 	getWorkforceYear,
 	isCseRequired,
 } from "~/modules/domain";
-import { Breadcrumb } from "~/modules/layout";
 
 import { MODAL_ID as COMPANY_EDIT_MODAL_ID } from "./CompanyEditModal";
 import styles from "./CompanyInfoBanner.module.scss";
@@ -27,13 +26,6 @@ export function CompanyInfoBanner({ company }: Props) {
 	return (
 		<div className={`fr-pt-3w fr-pb-4w ${styles.banner}`}>
 			<div className="fr-container">
-				<Breadcrumb
-					items={[
-						{ label: "Mon espace", href: "/mon-espace/mes-entreprises" },
-						{ label: company.name },
-					]}
-				/>
-
 				<div className="fr-grid-row fr-grid-row--middle fr-mb-1w">
 					<div className="fr-col">
 						<h1 className="fr-h4 fr-mb-0">{company.name}</h1>

--- a/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/CompanyInfoBanner.test.tsx
@@ -47,11 +47,14 @@ describe("CompanyInfoBanner", () => {
 		expect(screen.getByText("532 847 196")).toBeInTheDocument();
 	});
 
-	it("renders a breadcrumb with a link to /mon-espace/mes-entreprises", () => {
+	it("does not render a breadcrumb", () => {
 		render(<CompanyInfoBanner company={baseCompany} />);
-		const link = screen.getByRole("link", { name: "Mon espace" });
-		expect(link).toBeInTheDocument();
-		expect(link).toHaveAttribute("href", "/mon-espace/mes-entreprises");
+		expect(
+			screen.queryByRole("navigation", { name: "vous êtes ici :" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("link", { name: "Mon espace" }),
+		).not.toBeInTheDocument();
 	});
 
 	it("renders the address when provided", () => {


### PR DESCRIPTION
Closes #4256

## Résumé

Retire le composant `Breadcrumb` des deux écrans de la partie « mon espace », conformément à la maquette de refonte (node Figma `8470-95271`) qui démarre directement le bandeau entreprise par le nom de l'entreprise, sans fil d'Ariane.

- `CompanyInfoBanner.tsx` : suppression du `Breadcrumb` (« Mon espace » → nom de l'entreprise) et de son import.
- `DeclarationHistoryPage.tsx` : suppression du `Breadcrumb` (« Mon espace » → « Historique des actions ») et de son import ; retrait de la classe `fr-mt-3w` sur le `<h1>` (le `fr-py-4w` du container suffit désormais).
- `~/modules/layout/Breadcrumb.tsx` et son export barrel sont conservés — le composant reste utilisé par les funnels de déclaration, l'avis CSE, le récapitulatif et les pages publiques.

## Vérification visuelle

Rendu comparé au screenshot du node Figma `8470-95271` : le bandeau démarre directement par le nom de l'entreprise, sans fil d'Ariane au-dessus — conforme.

## Note pour la suite (e2e-dev)

`src/e2e/breadcrumb-spacing.e2e.ts` référence `/mon-espace` dans son tableau `SCREENS` — cette entrée devient invalide (plus de `.fr-breadcrumb` sur la page) et doit être retirée du scénario. Non traité ici (hors scope code-dev) ; `/mentions-legales` et `/faq` restent couverts.

## Test plan

- [x] Typecheck vert
- [x] Suite vitest verte (tests `CompanyInfoBanner` et `DeclarationHistoryPage` mis à jour par tu-dev en guards de non-régression)
- [x] Lint / format verts
- [x] Audit structurel : MINOR (warning taille de fichier pré-existant, non introduit par ce diff)
- [x] Audit RGAA (ultra11y `review-a11y`) : PASS, 0 non-conformité
- [ ] `functional-validator` (à suivre)
- [ ] CI GitHub Actions
- [ ] SonarCloud Quality Gate