### PR TITLE
fix(declaration): #4262 — aligner le titre des documents récapitulatifs sur « démarche »

### DIFF
--- a/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
+++ b/packages/app/src/modules/cseOpinion/ConfirmationPage.tsx
@@ -48,7 +48,7 @@ export function ConfirmationPage({
 			</div>
 
 			<h2 className="fr-h5 fr-mb-3w">
-				Documents récapitulatifs de votre déclaration
+				Documents récapitulatifs de votre démarche
 			</h2>
 
 			<div className={`fr-mb-4w ${styles.downloadCards}`}>

--- a/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
+++ b/packages/app/src/modules/cseOpinion/__tests__/ConfirmationPage.test.tsx
@@ -92,7 +92,7 @@ describe("ConfirmationPage", () => {
 		);
 
 		expect(
-			screen.getByText("Documents récapitulatifs de votre déclaration"),
+			screen.getByText("Documents récapitulatifs de votre démarche"),
 		).toBeInTheDocument();
 		expect(
 			screen.getByText(/récapitulatif de la déclaration des indicateurs/),

--- a/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx
@@ -79,7 +79,7 @@ export async function ComplianceConfirmation() {
 			</div>
 
 			<h2 className="fr-h5 fr-mb-0">
-				Documents récapitulatifs de votre déclaration
+				Documents récapitulatifs de votre démarche
 			</h2>
 
 			<div className={styles.downloadCards}>

--- a/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
+++ b/packages/app/src/modules/declaration-remuneration/steps/__tests__/ComplianceConfirmation.test.tsx
@@ -125,7 +125,7 @@ describe("ComplianceConfirmation", () => {
 		// end-of-journey screen and from the maquette (#3460, #4029).
 		expect(
 			screen.getByRole("heading", {
-				name: "Documents récapitulatifs de votre déclaration",
+				name: "Documents récapitulatifs de votre démarche",
 			}),
 		).toBeInTheDocument();
 

--- a/packages/app/src/modules/declaration-representation/Confirmation.tsx
+++ b/packages/app/src/modules/declaration-representation/Confirmation.tsx
@@ -46,7 +46,7 @@ export function Confirmation({
 			</div>
 
 			{/* Visually hidden: bridges h1 → h3 (DownloadCard's own title) without adding a visible heading the Figma frame doesn't show. */}
-			<h2 className="fr-sr-only">Documents récapitulatifs de la déclaration</h2>
+			<h2 className="fr-sr-only">Documents récapitulatifs de votre démarche</h2>
 			<DownloadCard
 				dataYear={referenceYear}
 				href={`/api/representation-pdf?year=${referenceYear}`}

--- a/packages/app/src/modules/declaration-representation/__tests__/Confirmation.test.tsx
+++ b/packages/app/src/modules/declaration-representation/__tests__/Confirmation.test.tsx
@@ -88,7 +88,7 @@ describe("Confirmation — fin de démarche", () => {
 		expect(
 			screen.getByRole("heading", {
 				level: 2,
-				name: "Documents récapitulatifs de la déclaration",
+				name: "Documents récapitulatifs de votre démarche",
 			}),
 		).toBeInTheDocument();
 		expect(


### PR DESCRIPTION
Closes #4262

## Résumé

Sur les 3 écrans de fin de parcours (rémunération, avis CSE, représentation équilibrée), le titre `<h2>` du bloc de téléchargement affichait « déclaration », divergent entre les écrans (« de votre déclaration » / « de la déclaration ») alors que ces écrans closent une **démarche** plus large (déclaration, seconde déclaration, avis CSE, représentation). Les trois titres sont désormais **strictement identiques** : « Documents récapitulatifs de votre démarche ».

Fichiers modifiés :
- `packages/app/src/modules/declaration-remuneration/steps/ComplianceConfirmation.tsx:82`
- `packages/app/src/modules/cseOpinion/ConfirmationPage.tsx:51`
- `packages/app/src/modules/declaration-representation/Confirmation.tsx:49` (titre `fr-sr-only`, inchangé en classe/niveau — pont d'accessibilité h1→h3, cf. commentaire adjacent conservé)

Pas d'extraction de constante partagée : 3 littéraux de titre dans 3 modules distincts sans logique commune, conformément à l'analyse du bug.

### Point 2 du ticket — sans objet

Le bouton « Modifier mes dépôts » (2ᵉ demande du ticket) est **déjà supprimé** par le commit `8c5bf55b6` (#4146), ancêtre de `alpha`. Aucun changement de code sur ce point ; l'assertion de non-régression existante (`cseOpinion/__tests__/ConfirmationPage.test.tsx:204`) reste inchangée.

## Vérification

**One-shot (avant/après)** — `grep -rn "Documents récapitulatifs" packages/app/src` :

- **Avant** : 2× « de votre déclaration » + 1× « de la déclaration » (3 formulations divergentes)
- **Après** : 3× « de votre démarche » (identiques)

**Rendu dev server** (login `dev-auth`, données seedées fictives, SIREN de test `130025265`) — les 3 écrans ont été ouverts et capturés :

- `/declaration-remuneration/parcours-conformite/confirmation` → titre visible « Documents récapitulatifs de votre démarche »
- `/avis-cse/confirmation` → titre visible « Documents récapitulatifs de votre démarche »
- `/declaration-representation/confirmation` → écran rendu correctement (le titre `fr-sr-only` n'est, par construction, jamais visible à l'écran — vérifié via le grep ci-dessus et le test unitaire réaligné)

## Test plan

- [x] Typecheck vert (`pnpm typecheck`)
- [x] Suite complète verte : 5449 tests (3 assertions réalignées par `tu-dev`, revert-verify RED→GREEN prouvé, 0 régression)
- [x] Lint et format Biome : aucune erreur (1247 fichiers)
- [x] `structural-auditor` : PASS
- [x] `rgaa-auditor` : PASS (0 non-conformité, changement purement textuel)
- [x] `security-auditor` : n/a (aucun fichier serveur modifié)
- [x] `functional-validator` / `design-validator` (gate 9a/9a-bis) : à venir
