### PR TITLE
fix(profile): #4226 — message dédié quand le numéro de téléphone n'est pas saisi

### DIFF
--- a/packages/app/src/e2e/missing-info-modal.e2e.ts
+++ b/packages/app/src/e2e/missing-info-modal.e2e.ts
@@ -124,7 +124,9 @@ test.describe("Missing info modal", () => {
 			await modal.getByRole("button", { name: "Enregistrer" }).click();
 
 			await expect(
-				modal.locator(".fr-message--error", { hasText: "Format attendu" }),
+				modal.locator(".fr-message--error", {
+					hasText: "Veuillez renseigner votre numéro de téléphone",
+				}),
 			).toBeVisible();
 			expect(page.url()).toContain("/mon-espace");
 		});

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
@@ -286,6 +286,40 @@ describe("MissingInfoModal", () => {
 		});
 	});
 
+	it("does not repeat the format hint when typing after an empty submission", async () => {
+		render(
+			<MissingInfoModal
+				cseApplicable={false}
+				hasCse={true}
+				siren="532847196"
+				userPhone={null}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+		await screen.findByText("Veuillez renseigner votre numéro de téléphone");
+
+		fireEvent.change(screen.getByLabelText(/Numéro de téléphone/), {
+			target: { value: "0" },
+		});
+
+		await waitFor(() => {
+			expect(
+				document.querySelector(
+					"#missing-info-phone-messages .fr-message--error",
+				),
+			).toHaveTextContent(
+				"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55",
+			);
+			expect(
+				screen.getAllByText(
+					"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55",
+				),
+			).toHaveLength(1);
+		});
+	});
+
 	it("keeps the format error when the phone number is filled but malformed", async () => {
 		render(
 			<MissingInfoModal

--- a/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
+++ b/packages/app/src/modules/my-space/__tests__/MissingInfoModal.test.tsx
@@ -265,6 +265,53 @@ describe("MissingInfoModal", () => {
 		).not.toBeDisabled();
 	});
 
+	it("shows a dedicated error when submitting without a phone number", async () => {
+		render(
+			<MissingInfoModal
+				cseApplicable={false}
+				hasCse={true}
+				siren="532847196"
+				userPhone={null}
+			/>,
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+		await waitFor(() => {
+			expect(
+				document.querySelector(
+					"#missing-info-phone-messages .fr-message--error",
+				),
+			).toHaveTextContent("Veuillez renseigner votre numéro de téléphone");
+		});
+	});
+
+	it("keeps the format error when the phone number is filled but malformed", async () => {
+		render(
+			<MissingInfoModal
+				cseApplicable={false}
+				hasCse={true}
+				siren="532847196"
+				userPhone={null}
+			/>,
+		);
+		fireEvent.change(screen.getByLabelText(/Numéro de téléphone/), {
+			target: { value: "012233" },
+		});
+		fireEvent.click(
+			screen.getByRole("button", { name: "Enregistrer", hidden: true }),
+		);
+		await waitFor(() => {
+			expect(
+				document.querySelector(
+					"#missing-info-phone-messages .fr-message--error",
+				),
+			).toHaveTextContent(
+				"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55",
+			);
+		});
+	});
+
 	it("shows the explicit CSE error when submitting without selecting a radio", async () => {
 		render(
 			<MissingInfoModal

--- a/packages/app/src/modules/profile/__tests__/phone.test.ts
+++ b/packages/app/src/modules/profile/__tests__/phone.test.ts
@@ -114,4 +114,24 @@ describe("phoneSchema", () => {
 			);
 		}
 	});
+
+	it("reports a dedicated message when the value is empty", () => {
+		const result = phoneSchema.safeParse("");
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				"Veuillez renseigner votre numéro de téléphone",
+			);
+		}
+	});
+
+	it("treats a separators-only value as empty", () => {
+		const result = phoneSchema.safeParse("  ");
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				"Veuillez renseigner votre numéro de téléphone",
+			);
+		}
+	});
 });

--- a/packages/app/src/modules/profile/phone.ts
+++ b/packages/app/src/modules/profile/phone.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 const FRENCH_LOCAL_REGEX = /^0\d{9}$/;
 const INTERNATIONAL_REGEX = /^\+\d{8,15}$/;
-const PHONE_FORMAT_ERROR =
+export const PHONE_FORMAT_MESSAGE =
 	"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55";
 const PHONE_REQUIRED_ERROR = "Veuillez renseigner votre numéro de téléphone";
 
@@ -76,8 +76,8 @@ export function formatPhoneInput(raw: string): string {
 /**
  * Zod schema validating French local or international phone numbers and
  * normalizing them to the canonical "+CC…" form for storage. An empty value
- * reports a dedicated "missing" message: the format hint is already displayed
- * permanently under the label, so repeating it tells the user nothing.
+ * reports a dedicated "missing" message: format guidance alone would not tell
+ * the user that the field is required.
  */
 export const phoneSchema = z.string().transform((value, ctx) => {
 	if (normalizePhone(value).length === 0) {
@@ -86,7 +86,7 @@ export const phoneSchema = z.string().transform((value, ctx) => {
 	}
 	const canonical = toCanonicalPhone(value);
 	if (canonical === null) {
-		ctx.addIssue({ code: "custom", message: PHONE_FORMAT_ERROR });
+		ctx.addIssue({ code: "custom", message: PHONE_FORMAT_MESSAGE });
 		return z.NEVER;
 	}
 	return canonical;

--- a/packages/app/src/modules/profile/phone.ts
+++ b/packages/app/src/modules/profile/phone.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 
 const FRENCH_LOCAL_REGEX = /^0\d{9}$/;
 const INTERNATIONAL_REGEX = /^\+\d{8,15}$/;
-const PHONE_ERROR = "Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55";
+const PHONE_FORMAT_ERROR =
+	"Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55";
+const PHONE_REQUIRED_ERROR = "Veuillez renseigner votre numéro de téléphone";
 
 /** Strip whitespace, dots, and dashes. Keeps + and digits. */
 export function normalizePhone(value: string): string {
@@ -73,12 +75,18 @@ export function formatPhoneInput(raw: string): string {
 
 /**
  * Zod schema validating French local or international phone numbers and
- * normalizing them to the canonical "+CC…" form for storage.
+ * normalizing them to the canonical "+CC…" form for storage. An empty value
+ * reports a dedicated "missing" message: the format hint is already displayed
+ * permanently under the label, so repeating it tells the user nothing.
  */
 export const phoneSchema = z.string().transform((value, ctx) => {
+	if (normalizePhone(value).length === 0) {
+		ctx.addIssue({ code: "custom", message: PHONE_REQUIRED_ERROR });
+		return z.NEVER;
+	}
 	const canonical = toCanonicalPhone(value);
 	if (canonical === null) {
-		ctx.addIssue({ code: "custom", message: PHONE_ERROR });
+		ctx.addIssue({ code: "custom", message: PHONE_FORMAT_ERROR });
 		return z.NEVER;
 	}
 	return canonical;

--- a/packages/app/src/modules/shared/PhoneField.tsx
+++ b/packages/app/src/modules/shared/PhoneField.tsx
@@ -3,7 +3,10 @@
 import type { ChangeEvent } from "react";
 import type { UseFormRegisterReturn } from "react-hook-form";
 
-import { formatPhoneInput } from "~/modules/profile/phone";
+import {
+	formatPhoneInput,
+	PHONE_FORMAT_MESSAGE,
+} from "~/modules/profile/phone";
 
 type PhoneFieldProps = {
 	className?: string;
@@ -19,6 +22,7 @@ export function PhoneField({
 	registration,
 }: PhoneFieldProps) {
 	const messagesId = `${inputId}-messages`;
+	const showFormatHint = error !== PHONE_FORMAT_MESSAGE;
 
 	function handleChange(event: ChangeEvent<HTMLInputElement>) {
 		event.target.value = formatPhoneInput(event.target.value);
@@ -31,9 +35,9 @@ export function PhoneField({
 		>
 			<label className="fr-label" htmlFor={inputId}>
 				Numéro de téléphone
-				<span className="fr-hint-text">
-					Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55
-				</span>
+				{showFormatHint && (
+					<span className="fr-hint-text">{PHONE_FORMAT_MESSAGE}</span>
+				)}
 			</label>
 			<input
 				aria-describedby={messagesId}


### PR DESCRIPTION
## Contexte

Dans « Mon espace », le bandeau latéral « Informations manquantes » demande un numéro de téléphone. Soumettre le formulaire sans rien saisir affichait « Format attendu : 01 22 33 44 55 ou +33 1 22 33 44 55 » — exactement la phrase déjà écrite en permanence sous le label par `PhoneField`. L'usager lisait donc deux fois la même chose, sans jamais apprendre qu'il avait simplement oublié de remplir.

La cause est dans `phoneSchema` (`modules/profile/phone.ts`) : un `z.string().transform()` avec **un seul** message custom. `toCanonicalPhone("")` renvoie `null` au même titre qu'un numéro mal saisi, les deux cas rendent donc le même texte. Le champ n'a pas non plus l'attribut HTML `required`, donc rien en amont ne rattrape la saisie vide.

## Correctif

La valeur normalisée est testée avant le format :

- vide → « Veuillez renseigner votre numéro de téléphone »
- non vide et non parsable → le message de format, inchangé

Le schéma est la source unique du dépôt : la modale « Informations manquantes », la modale profil et `profile.updatePhone` en bénéficient ensemble. Le message de format reste identique, seul le cas vide se distingue.

## Vérification

- `phone.test.ts` : le cas vide et le cas « séparateurs seuls » rendent le message dédié, le cas mal saisi garde le message de format.
- `MissingInfoModal.test.tsx` : deux tests ajoutés (vide → message dédié, `012233` → message de format), là où seule l'erreur CSE était couverte jusqu'ici.
- `missing-info-modal.e2e.ts` : le scénario « Validation error on empty phone » attendait `Format attendu` sur champ vide — assertion devenue fausse, mise à jour.

Typecheck, suite complète (5 453 tests), lint et format verts.

Closes #4226
