### PR TITLE
API SUIT — objet Parcours : regroupement des données déduites + OpenAPI 3.0.0

### DIFF
--- a/packages/app/src/modules/export/__tests__/exportApi.test.ts
+++ b/packages/app/src/modules/export/__tests__/exportApi.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { RELOCATED_ROOT_KEYS } from "./helpers/parcoursKeys";
+
 const mockFetchSubmitted = vi.fn().mockResolvedValue([]);
 const mockFetchIndicatorG = vi.fn().mockResolvedValue(new Map());
 const mockFetchCse = vi.fn().mockResolvedValue(new Map());
@@ -415,8 +417,8 @@ describe("GET /api/v1/export/declarations", () => {
 
 		expect(response.status).toBe(200);
 		const decl = (await response.json()).Declarations[0];
-		expect(decl.Effectif).toBe(70);
-		expect(decl.Indicateur_G_requis).toBe(false);
+		expect(decl.Parcours.Effectif).toBe(70);
+		expect(decl.Parcours.Indicateur_G_requis).toBe(false);
 	});
 
 	it("should send a null Effectif when the company is absent from the GIP file", async () => {
@@ -468,10 +470,10 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(response.status).toBe(200);
 		const body = await response.json();
 		expect(body.Nombre).toBe(1);
-		expect(body.Declarations[0].Effectif).toBeNull();
+		expect(body.Declarations[0].Parcours.Effectif).toBeNull();
 		// Workforce-0 (absent from GIP) is in the voluntary (< 50) tier → 7-indicator
 		// volunteering, so indicator G is required (#4043).
-		expect(body.Declarations[0].Indicateur_G_requis).toBe(true);
+		expect(body.Declarations[0].Parcours.Indicateur_G_requis).toBe(true);
 	});
 
 	it("should expose CSE opinion declarationNumber alongside type", async () => {
@@ -1171,13 +1173,13 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(decl).not.toHaveProperty("Parcours_conformite");
 		expect(decl.Parcours_apres_declaration_1).toBe("corrective_action");
 		expect(decl.Parcours_apres_declaration_2).toBe("joint_evaluation");
-		expect(decl.Parcours_de_conformite_requis).toBe(true);
-		expect(decl.Parcours_de_conformite_revision_requis).toBe(true);
+		expect(decl.Parcours.Parcours_de_conformite_requis).toBe(true);
+		expect(decl.Parcours.Parcours_de_conformite_revision_requis).toBe(true);
 		expect(decl).not.toHaveProperty("Phase_2_requise");
 		expect(decl).not.toHaveProperty("Phase_2_revision_requise");
-		expect(decl.Avis_CSE_requis).toBe(true);
-		expect(decl.Indicateur_G_requis).toBe(true);
-		expect(decl.Version_regles).toBe("2027.1");
+		expect(decl.Parcours.Avis_CSE_requis).toBe(true);
+		expect(decl.Parcours.Indicateur_G_requis).toBe(true);
+		expect(decl.Parcours.Version_regles).toBe("2027.1");
 		expect(decl.Date_soumission).toBe("2027-03-15T10:00:00.000Z");
 		expect(decl.Date_parcours_apres_declaration_1).toBe(
 			"2027-04-01T10:00:00.000Z",
@@ -1190,6 +1192,9 @@ describe("GET /api/v1/export/declarations", () => {
 		expect(decl.Date_avis_CSE).toBe("2027-10-01T13:00:00.000Z");
 		expect(decl.Date_fin_demarche).toBe("2027-10-15T14:00:00.000Z");
 		expect(decl.Seconde_declaration.Statut).toBe(true);
+		for (const key of RELOCATED_ROOT_KEYS) {
+			expect(decl).not.toHaveProperty(key);
+		}
 	});
 
 	it("should thread the job-category source into Source_categories_emplois (#3944)", async () => {

--- a/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
+++ b/packages/app/src/modules/export/__tests__/fetchDeclarations.test.ts
@@ -7,6 +7,7 @@ import {
 	buildIndicators,
 } from "../fetchDeclarations";
 import type { RawHistoryEntry } from "../queries";
+import { PARCOURS_KEYS, RELOCATED_ROOT_KEYS } from "./helpers/parcoursKeys";
 
 // Minimal DeclarationRow used by buildIndicators / assembleDeclaration
 const baseRow = {
@@ -326,13 +327,17 @@ describe("buildIndicatorG", () => {
 		expect(category).not.toHaveProperty("Taux_horaire_total_ecart");
 	});
 
-	it("nulls a component gap when one of its salary values is missing", () => {
-		const [category] = buildIndicatorG([
+	it("nulls a component gap when either of its salary values is missing", () => {
+		const [womenMissing] = buildIndicatorG([
 			gEntry({ annualBaseWomen: null }),
 		]).initial;
+		const [menMissing] = buildIndicatorG([
+			gEntry({ annualBaseMen: null }),
+		]).initial;
 
-		expect(category?.Rem_annuelle_base_ecart).toBeNull();
-		expect(category?.Rem_annuelle_variable_ecart).toBe(0.0099);
+		expect(womenMissing?.Rem_annuelle_base_ecart).toBeNull();
+		expect(menMissing?.Rem_annuelle_base_ecart).toBeNull();
+		expect(womenMissing?.Rem_annuelle_variable_ecart).toBe(0.0099);
 	});
 
 	it("nulls a component gap when the men value is zero", () => {
@@ -352,9 +357,9 @@ describe("assembleDeclaration", () => {
 		expect(Object.keys(result)[0]).toBe("id");
 		expect(result.SIREN).toBe("123456789");
 		expect(result.Raison_sociale).toBe("ACME Corp");
-		expect(result.Effectif).toBe(250);
+		expect(result.Parcours.Effectif).toBe(250);
 		expect(result.CSE_existant).toBe(true);
-		expect(result.Annee).toBe(2027);
+		expect(result.Parcours.Annee).toBe(2027);
 		expect(result.Effectif_F_rem_annuelle_globale).toBe(100);
 		expect(result.Effectif_H_rem_annuelle_globale).toBe(150);
 		expect(result.Declarant.Email).toBe("jean@acme.fr");
@@ -366,21 +371,131 @@ describe("assembleDeclaration", () => {
 		expect(result.Date_creation).toBe("2027-03-15T10:00:00.000Z");
 	});
 
-	it("exposes the GIP annual average workforce as Effectif, floored to the lower integer", () => {
+	it("exposes the GIP annual average workforce as Parcours.Effectif, floored to the lower integer", () => {
 		expect(
 			assembleDeclaration({ ...baseRow, workforceEma: "99.97" }, [], [])
-				.Effectif,
+				.Parcours.Effectif,
 		).toBe(99);
 		expect(
 			assembleDeclaration({ ...baseRow, workforceEma: "70.00" }, [], [])
-				.Effectif,
+				.Parcours.Effectif,
 		).toBe(70);
 	});
 
-	it("exposes a null Effectif when the company is absent from the GIP file", () => {
+	it("exposes a null Parcours.Effectif when the company is absent from the GIP file", () => {
 		expect(
-			assembleDeclaration({ ...baseRow, workforceEma: null }, [], []).Effectif,
+			assembleDeclaration({ ...baseRow, workforceEma: null }, [], []).Parcours
+				.Effectif,
 		).toBeNull();
+	});
+
+	it("groups the path-derived data under Parcours, in schema order (#4326)", () => {
+		const result = assembleDeclaration(baseRow, [], []);
+
+		expect(Object.keys(result.Parcours)).toEqual([...PARCOURS_KEYS]);
+		expect(result.Parcours).toEqual({
+			Annee: 2027,
+			Effectif: 250,
+			Tranche_effectif: "250+",
+			Regime_obligations: "mandatory_with_compliance",
+			Statut: "awaiting_compliance_path_choice",
+			Annulee: false,
+			Parcours_de_conformite_requis: false,
+			Parcours_de_conformite_revision_requis: false,
+			Avis_CSE_requis: false,
+			Indicateur_G_requis: true,
+			Version_regles: "2027.1",
+		});
+	});
+
+	it("no longer exposes the relocated keys at the payload root (#4326)", () => {
+		const result = assembleDeclaration(baseRow, [], []);
+
+		for (const key of RELOCATED_ROOT_KEYS) {
+			expect(result).not.toHaveProperty(key);
+			expect(result.Parcours).toHaveProperty(key);
+		}
+	});
+
+	it("keeps the declared per-sex headcounts at the root, outside Parcours (#4326)", () => {
+		const result = assembleDeclaration(baseRow, [], []);
+
+		expect(result.Effectif_F_rem_annuelle_globale).toBe(100);
+		expect(result.Effectif_H_rem_annuelle_globale).toBe(150);
+		expect(result.Parcours).not.toHaveProperty(
+			"Effectif_F_rem_annuelle_globale",
+		);
+		expect(result.Parcours).not.toHaveProperty(
+			"Effectif_H_rem_annuelle_globale",
+		);
+	});
+
+	it("buckets Tranche_effectif on the floored headcount, never on the raw GIP value", () => {
+		// 149.7 falls in no bucket once compared raw — getCompanySizeRange would
+		// fall back to "<50" and misreport a 149-employee company as voluntary.
+		const result = assembleDeclaration(
+			{ ...baseRow, workforceEma: "149.7" },
+			[],
+			[],
+		);
+
+		expect(result.Parcours.Effectif).toBe(149);
+		expect(result.Parcours.Tranche_effectif).toBe("100-149");
+	});
+
+	it("classifies Regime_obligations on the exact GIP value, not the floored one", () => {
+		expect(
+			assembleDeclaration({ ...baseRow, workforceEma: "149.7" }, [], [])
+				.Parcours.Regime_obligations,
+		).toBe("mandatory_with_compliance");
+		expect(
+			assembleDeclaration({ ...baseRow, workforceEma: "49.99" }, [], [])
+				.Parcours.Regime_obligations,
+		).toBe("voluntary");
+	});
+
+	it.each([
+		["49.99", 49, "<50", "voluntary"],
+		["70.00", 70, "50-99", "mandatory"],
+		["100.00", 100, "100-149", "mandatory_with_compliance"],
+		["150.00", 150, "150-249", "mandatory_with_compliance"],
+		["250.00", 250, "250+", "mandatory_with_compliance"],
+	])("maps a GIP workforce of %s to Effectif %i, bucket %s and regime %s", (workforceEma, effectif, tranche, regime) => {
+		const { Parcours } = assembleDeclaration(
+			{ ...baseRow, workforceEma },
+			[],
+			[],
+		);
+
+		expect(Parcours.Effectif).toBe(effectif);
+		expect(Parcours.Tranche_effectif).toBe(tranche);
+		expect(Parcours.Regime_obligations).toBe(regime);
+	});
+
+	it("leaves Tranche_effectif null and the regime voluntary when the company is absent from the GIP file", () => {
+		const { Parcours } = assembleDeclaration(
+			{ ...baseRow, workforceEma: null },
+			[],
+			[],
+		);
+
+		expect(Parcours.Effectif).toBeNull();
+		expect(Parcours.Tranche_effectif).toBeNull();
+		expect(Parcours.Regime_obligations).toBe("voluntary");
+	});
+
+	it("flags Parcours.Annulee alongside the root Date_annulation", () => {
+		const active = assembleDeclaration(baseRow, [], []);
+		const cancelled = assembleDeclaration(
+			{ ...baseRow, cancelledAt: new Date("2027-04-15T08:00:00Z") },
+			[],
+			[],
+		);
+
+		expect(active.Parcours.Annulee).toBe(false);
+		expect(active.Date_annulation).toBeNull();
+		expect(cancelled.Parcours.Annulee).toBe(true);
+		expect(cancelled.Date_annulation).toBe("2027-04-15T08:00:00.000Z");
 	});
 
 	it("nulls CSE_existant below the CSE threshold even when a legacy hasCse value exists", () => {
@@ -766,7 +881,7 @@ describe("assembleDeclaration", () => {
 		expect(result.Indicateurs.G).toHaveLength(1);
 		expect(result.Indicateurs.G?.[0]?.Effectif_F).toBe(12);
 		expect(result.SIREN).toBe("123456789");
-		expect(result.Effectif).toBe(250);
+		expect(result.Parcours.Effectif).toBe(250);
 	});
 
 	it("should expose Historique_statuts as empty array when no history (S7)", () => {
@@ -1030,7 +1145,7 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, significantInitial, []);
 
-		expect(result.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(true);
 	});
 
 	it("does not require the compliance process when the indicator G gap is below 5%", () => {
@@ -1038,8 +1153,8 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, smallInitial, []);
 
-		expect(result.Parcours_de_conformite_requis).toBe(false);
-		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_revision_requis).toBe(false);
 	});
 
 	it("does not require the compliance process below 100 employees even with a gap", () => {
@@ -1047,7 +1162,7 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, significantInitial, []);
 
-		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(false);
 	});
 
 	it("does not require the compliance process without indicator G", () => {
@@ -1055,7 +1170,7 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, [], []);
 
-		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(false);
 	});
 
 	it("does not require the compliance process when the indicator G categories carry no gap data", () => {
@@ -1063,7 +1178,7 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, [entry("initial", "0", "0")], []);
 
-		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(false);
 	});
 
 	it("requires the compliance process when the indicator G gap is negative and significant", () => {
@@ -1073,7 +1188,7 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, negativeSignificantInitial, []);
 
-		expect(result.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(true);
 	});
 
 	it("treats a company absent from the GIP file as 0 for the derived flags", () => {
@@ -1081,11 +1196,11 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, significantInitial, []);
 
-		expect(result.Effectif).toBeNull();
-		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours.Effectif).toBeNull();
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(false);
 		// Workforce-0 derives from the missing GIP effectif; it lands in the
 		// voluntary (< 50) tier, which files all 7 indicators (#4043).
-		expect(result.Indicateur_G_requis).toBe(true);
+		expect(result.Parcours.Indicateur_G_requis).toBe(true);
 	});
 
 	it("derives the flags from the GIP workforce, never from the Weez value (#3929)", () => {
@@ -1093,9 +1208,9 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, significantInitial, []);
 
-		expect(result.Effectif).toBe(70);
-		expect(result.Indicateur_G_requis).toBe(false);
-		expect(result.Parcours_de_conformite_requis).toBe(false);
+		expect(result.Parcours.Effectif).toBe(70);
+		expect(result.Parcours.Indicateur_G_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(false);
 	});
 
 	it("compares the indicator G threshold on the exact GIP value", () => {
@@ -1110,8 +1225,8 @@ describe("assembleDeclaration — compliance flags", () => {
 			[],
 		);
 
-		expect(below.Indicateur_G_requis).toBe(false);
-		expect(atThreshold.Indicateur_G_requis).toBe(true);
+		expect(below.Parcours.Indicateur_G_requis).toBe(false);
+		expect(atThreshold.Parcours.Indicateur_G_requis).toBe(true);
 	});
 
 	it("compares the compliance threshold on the exact GIP value", () => {
@@ -1126,8 +1241,8 @@ describe("assembleDeclaration — compliance flags", () => {
 			[],
 		);
 
-		expect(below.Parcours_de_conformite_requis).toBe(false);
-		expect(atThreshold.Parcours_de_conformite_requis).toBe(true);
+		expect(below.Parcours.Parcours_de_conformite_requis).toBe(false);
+		expect(atThreshold.Parcours.Parcours_de_conformite_requis).toBe(true);
 	});
 
 	it("requires the revision when a second declaration was submitted with a correction gap >= 5%", () => {
@@ -1143,8 +1258,8 @@ describe("assembleDeclaration — compliance flags", () => {
 			[],
 		);
 
-		expect(result.Parcours_de_conformite_requis).toBe(true);
-		expect(result.Parcours_de_conformite_revision_requis).toBe(true);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours.Parcours_de_conformite_revision_requis).toBe(true);
 	});
 
 	it("does not require the revision without a submitted second declaration", () => {
@@ -1160,8 +1275,8 @@ describe("assembleDeclaration — compliance flags", () => {
 			[],
 		);
 
-		expect(result.Parcours_de_conformite_requis).toBe(true);
-		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_requis).toBe(true);
+		expect(result.Parcours.Parcours_de_conformite_revision_requis).toBe(false);
 	});
 
 	it("does not require the revision when the correction gap is below 5%", () => {
@@ -1177,7 +1292,7 @@ describe("assembleDeclaration — compliance flags", () => {
 			[],
 		);
 
-		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_revision_requis).toBe(false);
 	});
 
 	it("requires the revision when the correction gap is negative and significant", () => {
@@ -1195,7 +1310,7 @@ describe("assembleDeclaration — compliance flags", () => {
 			[],
 		);
 
-		expect(result.Parcours_de_conformite_revision_requis).toBe(true);
+		expect(result.Parcours.Parcours_de_conformite_revision_requis).toBe(true);
 	});
 
 	it("does not require the revision when there are no correction categories", () => {
@@ -1208,6 +1323,6 @@ describe("assembleDeclaration — compliance flags", () => {
 
 		const result = assembleDeclaration(row, significantInitial, []);
 
-		expect(result.Parcours_de_conformite_revision_requis).toBe(false);
+		expect(result.Parcours.Parcours_de_conformite_revision_requis).toBe(false);
 	});
 });

--- a/packages/app/src/modules/export/__tests__/gipWorkforceExport.integration.test.ts
+++ b/packages/app/src/modules/export/__tests__/gipWorkforceExport.integration.test.ts
@@ -76,13 +76,16 @@ describe("GET /api/v1/export/declarations — GIP workforce integration (#3929)"
 		`;
 	});
 
-	async function fetchExport(): Promise<
-		Array<{
-			SIREN: string;
+	type ExportedDeclaration = {
+		SIREN: string;
+		Parcours: {
 			Effectif: number | null;
+			Tranche_effectif: string | null;
 			Indicateur_G_requis: boolean;
-		}>
-	> {
+		};
+	};
+
+	async function fetchExport(): Promise<ExportedDeclaration[]> {
 		const { GET } = await import("~/app/api/v1/export/declarations/route");
 		const response = await GET(
 			new Request(
@@ -94,41 +97,47 @@ describe("GET /api/v1/export/declarations — GIP workforce integration (#3929)"
 		return (await response.json()).Declarations;
 	}
 
-	function findBySiren(
-		declarations: Array<{ SIREN: string }>,
+	function parcoursOf(
+		declarations: ExportedDeclaration[],
 		siren: string,
-	): { SIREN: string; Effectif: number | null; Indicateur_G_requis: boolean } {
+	): ExportedDeclaration["Parcours"] {
 		const found = declarations.find((d) => d.SIREN === siren);
 		if (!found) throw new Error(`declaration for ${siren} missing from export`);
-		return found as never;
+		return found.Parcours;
 	}
 
-	it("sends the GIP annual average workforce as Effectif, not the Weez company workforce", async () => {
+	it("sends the GIP annual average workforce as Parcours.Effectif, not the Weez company workforce", async () => {
 		const declarations = await fetchExport();
 
-		expect(findBySiren(declarations, SIREN_IN_GIP).Effectif).toBe(70);
+		expect(parcoursOf(declarations, SIREN_IN_GIP).Effectif).toBe(70);
 	});
 
-	it("keeps the declaration of a company absent from the GIP file, with a null Effectif", async () => {
+	it("keeps the declaration of a company absent from the GIP file, with a null Parcours.Effectif", async () => {
 		const declarations = await fetchExport();
 
 		expect(declarations).toHaveLength(4);
-		const notInGip = findBySiren(declarations, SIREN_NOT_IN_GIP);
+		const notInGip = parcoursOf(declarations, SIREN_NOT_IN_GIP);
 		expect(notInGip.Effectif).toBeNull();
-		expect(notInGip.Indicateur_G_requis).toBe(false);
+		expect(notInGip.Tranche_effectif).toBeNull();
+		// Absent from GIP → obligation workforce 0 → voluntary tier, which files
+		// all 7 indicators (#4043).
+		expect(notInGip.Indicateur_G_requis).toBe(true);
 	});
 
-	it("floors the numeric(9,2) workforce so 99,97 is exported as 99", async () => {
+	it("floors the numeric(9,2) workforce so 99,97 is exported as 99 and bucketed on the floored value", async () => {
 		const declarations = await fetchExport();
 
-		expect(findBySiren(declarations, SIREN_FRACTIONAL).Effectif).toBe(99);
+		const fractional = parcoursOf(declarations, SIREN_FRACTIONAL);
+		expect(fractional.Effectif).toBe(99);
+		expect(fractional.Tranche_effectif).toBe("50-99");
 	});
 
 	it("does not pick up a GIP row from another campaign year", async () => {
 		const declarations = await fetchExport();
 
-		const otherYear = findBySiren(declarations, SIREN_OTHER_YEAR);
+		const otherYear = parcoursOf(declarations, SIREN_OTHER_YEAR);
 		expect(otherYear.Effectif).toBeNull();
-		expect(otherYear.Indicateur_G_requis).toBe(false);
+		expect(otherYear.Tranche_effectif).toBeNull();
+		expect(otherYear.Indicateur_G_requis).toBe(true);
 	});
 });

--- a/packages/app/src/modules/export/__tests__/helpers/parcoursKeys.ts
+++ b/packages/app/src/modules/export/__tests__/helpers/parcoursKeys.ts
@@ -1,0 +1,28 @@
+// Shared by the payload test (fetchDeclarations) and the schema test (openapi):
+// one list, so the OpenAPI document and the assembled declaration cannot drift.
+export const PARCOURS_KEYS = [
+	"Annee",
+	"Effectif",
+	"Tranche_effectif",
+	"Regime_obligations",
+	"Statut",
+	"Annulee",
+	"Parcours_de_conformite_requis",
+	"Parcours_de_conformite_revision_requis",
+	"Avis_CSE_requis",
+	"Indicateur_G_requis",
+	"Version_regles",
+] as const;
+
+// The keys #4326 moved out of the root and into Parcours. Tranche_effectif,
+// Regime_obligations and Annulee are new and never lived at the root.
+export const RELOCATED_ROOT_KEYS = [
+	"Annee",
+	"Effectif",
+	"Statut",
+	"Parcours_de_conformite_requis",
+	"Parcours_de_conformite_revision_requis",
+	"Avis_CSE_requis",
+	"Indicateur_G_requis",
+	"Version_regles",
+] as const;

--- a/packages/app/src/modules/export/__tests__/openapi.test.ts
+++ b/packages/app/src/modules/export/__tests__/openapi.test.ts
@@ -1,17 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { DECLARATION_FSM_STATUSES } from "~/modules/domain";
+import {
+	COMPANY_SIZE_RANGES,
+	DECLARATION_FSM_STATUSES,
+} from "~/modules/domain";
 import {
 	representationNotComputableExecutivesEnum,
 	representationNotComputableMembersEnum,
 } from "~/server/db/schema";
 import { openApiSpec } from "../openapi";
+import { PARCOURS_KEYS, RELOCATED_ROOT_KEYS } from "./helpers/parcoursKeys";
 
 describe("openApiSpec", () => {
 	it("should be a valid OpenAPI 3.1 structure", () => {
 		expect(openApiSpec.openapi).toBe("3.1.0");
 		expect(openApiSpec.info.title).toBeDefined();
-		expect(openApiSpec.info.version).toBe("2.1.0");
+		expect(openApiSpec.info.version).toBe("3.0.0");
 		expect(openApiSpec.paths).toBeDefined();
 	});
 
@@ -150,11 +154,63 @@ describe("openApiSpec", () => {
 		});
 	});
 
+	describe("Parcours object (#4326)", () => {
+		const declarationSchema =
+			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]
+				.content["application/json"].schema.properties.Declarations.items;
+		const parcoursSchema = declarationSchema.properties.Parcours;
+
+		it("declares Parcours as an object carrying the path-derived properties", () => {
+			expect(parcoursSchema.type).toBe("object");
+			expect(Object.keys(parcoursSchema.properties)).toEqual([
+				...PARCOURS_KEYS,
+			]);
+		});
+
+		it("documents every Parcours property with a French description", () => {
+			for (const key of PARCOURS_KEYS) {
+				expect(parcoursSchema.properties[key].description).toBeTruthy();
+			}
+		});
+
+		it("no longer documents the relocated keys at the schema root", () => {
+			for (const key of RELOCATED_ROOT_KEYS) {
+				expect(declarationSchema.properties).not.toHaveProperty(key);
+			}
+		});
+
+		it("declares Tranche_effectif as a nullable enum of the size buckets", () => {
+			const tranche = parcoursSchema.properties.Tranche_effectif;
+			const stringVariant = tranche.oneOf.find((v) => v.type === "string");
+
+			expect(tranche.oneOf.find((v) => v.type === "null")).toBeDefined();
+			expect(
+				stringVariant && "enum" in stringVariant && stringVariant.enum,
+			).toEqual(Object.keys(COMPANY_SIZE_RANGES));
+		});
+
+		it("declares Regime_obligations as the company size classification enum", () => {
+			const regime = parcoursSchema.properties.Regime_obligations;
+
+			expect(regime.type).toBe("string");
+			expect(regime.enum).toEqual([
+				"voluntary",
+				"mandatory",
+				"mandatory_with_compliance",
+			]);
+		});
+
+		it("declares Annulee as a boolean", () => {
+			expect(parcoursSchema.properties.Annulee.type).toBe("boolean");
+		});
+	});
+
 	describe("Statut field (declaration FSM status)", () => {
 		const declarationSchema =
 			openApiSpec.paths["/api/v1/export/declarations"].get.responses["200"]
 				.content["application/json"].schema.properties.Declarations.items;
-		const statutSchema = declarationSchema.properties.Statut;
+		const statutSchema =
+			declarationSchema.properties.Parcours.properties.Statut;
 
 		it("declares Statut as a string enum", () => {
 			expect(statutSchema.type).toBe("string");

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -14,10 +14,13 @@ export {
 } from "./queries";
 
 import {
+	classifyCompanySize,
 	computeGapRatio,
 	floorWorkforce,
 	getObligationWorkforce,
+	getOptionalCompanySizeRange,
 	hasGapsAboveThreshold,
+	isCancelled,
 	isComplianceProcessRequired,
 	isComplianceProcessRevisionRequired,
 	isCseRequired,
@@ -346,29 +349,41 @@ export function assembleDeclaration(
 
 	const flags = deriveExportFlags(row, indicatorGEntries);
 
+	// Two distinct readings of the workforce, on purpose: the obligation regime is
+	// classified on the exact GIP value (same input as the compliance flags above),
+	// while the segmentation bucket is computed on the floored value and never folds
+	// an unknown workforce into "<50" (see getOptionalCompanySizeRange contract).
+	const gipWorkforce = parseGipWorkforce(row.workforceEma);
+	const flooredWorkforce = floorWorkforce(gipWorkforce);
+
 	return {
 		id: row.declarationId,
 		SIREN: row.siren,
 		Raison_sociale: row.companyName,
-		Effectif: floorWorkforce(parseGipWorkforce(row.workforceEma)),
 		Code_NAF: row.nafCode,
 		Adresse: row.address,
 		// The CSE field only exists for companies at or above the CSE threshold; legacy sub-100 values are not exported.
-		CSE_existant: isCseRequired(
-			getObligationWorkforce(parseGipWorkforce(row.workforceEma)),
-		)
+		CSE_existant: isCseRequired(getObligationWorkforce(gipWorkforce))
 			? row.hasCse
 			: null,
-		Annee: row.year,
-		Statut: row.status,
 		Parcours_apres_declaration_1: row.firstDeclarationPathChoice,
 		Parcours_apres_declaration_2: row.secondDeclarationPathChoice,
-		Parcours_de_conformite_requis: flags.complianceProcessRequired,
-		Parcours_de_conformite_revision_requis:
-			flags.complianceProcessRevisionRequired,
-		Avis_CSE_requis: row.cseRequired,
-		Indicateur_G_requis: flags.indicatorGRequired,
-		Version_regles: row.rulesVersion,
+		Parcours: {
+			Annee: row.year,
+			Effectif: flooredWorkforce,
+			Tranche_effectif: getOptionalCompanySizeRange(flooredWorkforce) ?? null,
+			Regime_obligations: classifyCompanySize(
+				getObligationWorkforce(gipWorkforce),
+			),
+			Statut: row.status,
+			Annulee: isCancelled(row),
+			Parcours_de_conformite_requis: flags.complianceProcessRequired,
+			Parcours_de_conformite_revision_requis:
+				flags.complianceProcessRevisionRequired,
+			Avis_CSE_requis: row.cseRequired,
+			Indicateur_G_requis: flags.indicatorGRequired,
+			Version_regles: row.rulesVersion,
+		},
 		Date_creation: row.createdAt?.toISOString() ?? null,
 		Date_modification: row.updatedAt?.toISOString() ?? null,
 		Date_soumission: row.submittedAt?.toISOString() ?? null,

--- a/packages/app/src/modules/export/fetchDeclarations.ts
+++ b/packages/app/src/modules/export/fetchDeclarations.ts
@@ -349,10 +349,7 @@ export function assembleDeclaration(
 
 	const flags = deriveExportFlags(row, indicatorGEntries);
 
-	// Two distinct readings of the workforce, on purpose: the obligation regime is
-	// classified on the exact GIP value (same input as the compliance flags above),
-	// while the segmentation bucket is computed on the floored value and never folds
-	// an unknown workforce into "<50" (see getOptionalCompanySizeRange contract).
+	// Obligation regime uses the exact value; the segmentation bucket uses the floored one.
 	const gipWorkforce = parseGipWorkforce(row.workforceEma);
 	const flooredWorkforce = floorWorkforce(gipWorkforce);
 

--- a/packages/app/src/modules/export/openapi.ts
+++ b/packages/app/src/modules/export/openapi.ts
@@ -219,11 +219,6 @@ const declarationSchema = {
 			type: ["string", "null"],
 			example: "THALES LAS FRANCE SAS",
 		},
-		Effectif: {
-			type: ["integer", "null"],
-			description: "Effectif total",
-			example: 7403,
-		},
 		Code_NAF: {
 			type: ["string", "null"],
 			description: "Code NAF/APE",
@@ -237,18 +232,6 @@ const declarationSchema = {
 			type: ["boolean", "null"],
 			description: "Présence d'un CSE (>= 100 salariés)",
 		},
-		Annee: {
-			type: "integer",
-			description: "Année de la déclaration",
-			example: 2026,
-		},
-		Statut: {
-			type: "string",
-			description:
-				"Statut courant de la déclaration dans le moteur FSM. Dérivé de l'autorité DECLARATION_FSM_STATUSES — toute évolution du vocabulaire FSM se répercute ici automatiquement. Sémantique : « demarche_completed » signifie qu'aucune action supplémentaire n'est attendue sur Egapro ; il peut être atteint dès le choix du parcours « justify » lorsque l'entreprise n'a pas de CSE (la justification des écarts ne donne lieu à aucun dépôt sur la plateforme).",
-			enum: [...DECLARATION_FSM_STATUSES],
-			example: "demarche_completed",
-		},
 		Parcours_apres_declaration_1: {
 			type: ["string", "null"],
 			description:
@@ -259,29 +242,77 @@ const declarationSchema = {
 			description:
 				"Parcours après la seconde déclaration (justify, corrective_action, joint_evaluation)",
 		},
-		Parcours_de_conformite_requis: {
-			type: "boolean",
+		Parcours: {
+			type: "object",
 			description:
-				"Prédicat statique : indique si l'entreprise est soumise au parcours de conformité (effectif ≥ 100, indicateur G calculé, écart ≥ 5 %). Calculé à la soumission et figé — ne change jamais au fil de l'avancement de la démarche. Ne pas confondre avec « Statut » qui, lui, évolue à chaque transition FSM.",
-		},
-		Parcours_de_conformite_revision_requis: {
-			type: "boolean",
-			description:
-				"Indique si une révision du parcours de conformité est requise après la seconde déclaration.",
-		},
-		Avis_CSE_requis: {
-			type: "boolean",
-			description: "Indique si un avis CSE est requis pour cette déclaration.",
-		},
-		Indicateur_G_requis: {
-			type: "boolean",
-			description:
-				"Indique si l'indicateur G est requis (déclaration à 7 indicateurs).",
-		},
-		Version_regles: {
-			type: ["string", "null"],
-			description:
-				"Version du moteur de règles métier utilisée à la soumission.",
+				"Données déduites du parcours de la déclaration — calculées par Egapro, jamais saisies par l'entreprise.",
+			properties: {
+				Annee: {
+					type: "integer",
+					description: "Année de la déclaration",
+					example: 2026,
+				},
+				Effectif: {
+					type: ["integer", "null"],
+					description:
+						"Effectif total, arrondi à l'entier inférieur (floored). `null` si l'effectif GIP est inconnu.",
+					example: 7403,
+				},
+				Tranche_effectif: {
+					description:
+						"Bucket de segmentation calculé sur l'effectif floored. `null` si l'effectif GIP est inconnu — jamais replié sur « <50 ».",
+					oneOf: [
+						{
+							type: "string",
+							enum: ["<50", "50-99", "100-149", "150-249", "250+"],
+						},
+						{ type: "null" },
+					],
+				},
+				Regime_obligations: {
+					type: "string",
+					enum: ["voluntary", "mandatory", "mandatory_with_compliance"],
+					description:
+						"Paquet d'obligations attaché à la taille de l'entreprise, classifié sur l'effectif GIP exact (jamais floored). Une entreprise absente du fichier GIP relève du volontariat.",
+				},
+				Statut: {
+					type: "string",
+					description:
+						"Statut courant de la déclaration dans le moteur FSM. Dérivé de l'autorité DECLARATION_FSM_STATUSES — toute évolution du vocabulaire FSM se répercute ici automatiquement. Sémantique : « demarche_completed » signifie qu'aucune action supplémentaire n'est attendue sur Egapro ; il peut être atteint dès le choix du parcours « justify » lorsque l'entreprise n'a pas de CSE (la justification des écarts ne donne lieu à aucun dépôt sur la plateforme).",
+					enum: [...DECLARATION_FSM_STATUSES],
+					example: "demarche_completed",
+				},
+				Annulee: {
+					type: "boolean",
+					description:
+						"Indique si la déclaration a été annulée. `Date_annulation` (à la racine) porte la date d'annulation et prime sur `Statut`, lequel reste figé à sa valeur d'avant annulation.",
+				},
+				Parcours_de_conformite_requis: {
+					type: "boolean",
+					description:
+						"Prédicat statique : indique si l'entreprise est soumise au parcours de conformité (effectif ≥ 100, indicateur G calculé, écart ≥ 5 %). Calculé à la soumission et figé — ne change jamais au fil de l'avancement de la démarche. Ne pas confondre avec « Statut » qui, lui, évolue à chaque transition FSM.",
+				},
+				Parcours_de_conformite_revision_requis: {
+					type: "boolean",
+					description:
+						"Indique si une révision du parcours de conformité est requise après la seconde déclaration.",
+				},
+				Avis_CSE_requis: {
+					type: "boolean",
+					description:
+						"Indique si un avis CSE est requis pour cette déclaration.",
+				},
+				Indicateur_G_requis: {
+					type: "boolean",
+					description:
+						"Indique si l'indicateur G est requis (déclaration à 7 indicateurs).",
+				},
+				Version_regles: {
+					type: ["string", "null"],
+					description:
+						"Version du moteur de règles métier utilisée à la soumission.",
+				},
+			},
 		},
 		Date_creation: { type: ["string", "null"], format: "date-time" },
 		Date_modification: { type: ["string", "null"], format: "date-time" },
@@ -629,7 +660,7 @@ export const openApiSpec = {
 		title: "EGAPRO — API d'export",
 		description:
 			"API REST sécurisée permettant de consulter les déclarations d'égalité professionnelle et les fichiers associés (avis CSE, évaluations conjointes). L'accès nécessite une clé API transmise en Bearer token. L'authentification ainsi qu'un quota (rate limit) sont appliqués en amont par la passerelle EGAPRO.",
-		version: "2.1.0",
+		version: "3.0.0",
 		contact: {
 			name: "Équipe EGAPRO — DNUM",
 		},


### PR DESCRIPTION
Closes #4326

## Résumé

Regroupe dans `assembleDeclaration` les données **déduites** du parcours (année, effectif, régime d'obligations, tranche d'effectif, statut FSM, flags d'obligation, version des règles) dans un nouvel objet `Parcours`, distinct des ~60 champs **déclarés** par l'entreprise. Ajoute la tranche d'effectif (calculée sur l'effectif floored, jamais la valeur GIP brute — piège d'arrondi documenté dans le ticket) et le booléen `Annulee` (dérivé de `isCancelled`).

Rupture assumée : les 8 clés déplacées (`Effectif`, `Annee`, `Statut`, `Parcours_de_conformite_requis`, `Parcours_de_conformite_revision_requis`, `Avis_CSE_requis`, `Indicateur_G_requis`, `Version_regles`) n'existent plus à la racine du payload ni du schéma OpenAPI. `info.version` bump `2.1.0` → `3.0.0`, chemin inchangé (`/api/v1/export/declarations`).

## Test plan

- [x] `pnpm typecheck` vert
- [x] `pnpm test` vert (5467/5467 côté app)
- [x] `pnpm lint:check` / `pnpm format:check` verts
- [x] Nouveaux tests : piège d'arrondi (149,7 → `Effectif: 149`, `Tranche_effectif: "100-149"`), effectif inconnu (`null`/`null`/`"voluntary"`), `Annulee` vs `Date_annulation`, absence des 8 clés à la racine, schéma OpenAPI (`Parcours` + 11 propriétés, `info.version === "3.0.0"`)
- [x] Aucun fichier `.tsx`/serveur modifié — `rgaa-auditor` et `security-auditor` PASS automatique (pas de sujet)